### PR TITLE
Add initial ability to name a TOC Tree

### DIFF
--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -39,6 +39,7 @@ class TocTree(Directive):
     final_argument_whitespace = False
     option_spec = {
         'maxdepth': int,
+        'name': str,
         'glob': directives.flag,
         'hidden': directives.flag,
         'includehidden': directives.flag,
@@ -50,6 +51,7 @@ class TocTree(Directive):
         env = self.state.document.settings.env
         suffix = env.config.source_suffix
         glob = 'glob' in self.options
+        name = self.options.get('name')
 
         ret = []
         # (title, ref) pairs, where ref may be a document, or an external link,
@@ -105,6 +107,7 @@ class TocTree(Directive):
         # includefiles only entries that are documents
         subnode['includefiles'] = includefiles
         subnode['maxdepth'] = self.options.get('maxdepth', -1)
+        subnode['name'] = name
         subnode['glob'] = glob
         subnode['hidden'] = 'hidden' in self.options
         subnode['includehidden'] = 'includehidden' in self.options

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -1353,7 +1353,15 @@ class BuildEnvironment:
                                   separate=False, subtree=False):
             """Return TOC entries for a toctree node."""
             refs = [(e[0], e[1]) for e in toctreenode['entries']]
+            name = toctreenode.attributes.get('name')
             entries = []
+            if name:
+                entries.extend(
+                        nodes.reference('', '', internal=False,
+                                                    refuri='', anchorname='',
+                                                    *[nodes.Text(name)])
+                )
+
             for (title, ref) in refs:
                 try:
                     refdoc = None


### PR DESCRIPTION
This is an initial attempt at adding a `:name:` attribute to toctrees. This lets users have multiple TOC Trees with names. The main use of this is to provide sidebar headers for the different TOCTrees in the Read the Docs themes, but could also be used to include an optional name in the doc output.

Mostly looking for feedback, and general ideas around the concept. 
## Example

![screenshot 2015-01-31 18 56 24](https://cloud.githubusercontent.com/assets/25510/5990838/e1f6a5d6-a97a-11e4-968c-8d18d3dced49.png)
## Needs
- [ ] Tests 
