### PR TITLE
C++, fix #1689

### DIFF
--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -62,6 +62,8 @@ def test_type_definitions():
     check("type",
           "public MyContainer::const_iterator",
           "MyContainer::const_iterator")
+    # test decl specs on right
+    check("type", "bool const b")
 
     check('member',
           '  const  std::string  &  name = 42',


### PR DESCRIPTION
C++, add support for 'const', 'volatile', etc. on the right-hand side of the type.
