### PR TITLE
Add todo_include_todo into generated quickstart config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Other contributors, listed alphabetically, are:
 * Blaise Laflamme -- pyramid theme
 * Thomas Lamb -- linkcheck builder
 * Łukasz Langa -- partial support for autodoc
+* Ian Lee -- quickstart improvements
 * Robert Lehmann -- gettext builder (GSOC project)
 * Dan MacKinlay -- metadata fixes
 * Martin Mahner -- nature theme

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Features added
 * The ``language`` config value is now available in the HTML templates.
 * The ``env-updated`` event can now return a value, which is interpreted
   as an iterable of additional docnames that need to be rewritten.
+* Add ``todo_include_todos`` config option to quickstart conf file, handled as
+  described in documentation.
 
 Bugs fixed
 ----------

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -363,6 +363,7 @@ Note: By default this script will not overwrite already created files.""")
             epub = True,
             ext_autodoc = True,
             ext_viewcode = True,
+            ext_todo = True,
             makefile = True,
             batchfile = True,
             mastertocmaxdepth = opts.maxdepth,

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -53,6 +53,7 @@ DEFAULT_VALUE = {
     'epub': False,
     'ext_autodoc': False,
     'ext_doctest': False,
+    'ext_todo': False,
     'makefile': True,
     'batchfile': True,
     }
@@ -166,6 +167,9 @@ pygments_style = 'sphinx'
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = %(ext_todo)s
 
 
 # -- Options for HTML output ----------------------------------------------
@@ -1284,6 +1288,8 @@ def generate(d, overwrite=True, silent=False):
         d['extensions'] = '\n' + indent + extensions + ',\n'
     else:
         d['extensions'] = extensions
+    print(d['extensions'])
+    d['ext_todo'] = text_type(d['ext_todo'])
     d['copyright'] = time.strftime('%Y') + ', ' + d['author']
     d['author_texescaped'] = text_type(d['author']).\
         translate(texescape.tex_escape_map)

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -1288,8 +1288,6 @@ def generate(d, overwrite=True, silent=False):
         d['extensions'] = '\n' + indent + extensions + ',\n'
     else:
         d['extensions'] = extensions
-    print(d['extensions'])
-    d['ext_todo'] = text_type(d['ext_todo'])
     d['copyright'] = time.strftime('%Y') + ', ' + d['author']
     d['author_texescaped'] = text_type(d['author']).\
         translate(texescape.tex_escape_map)

--- a/test-reqs.txt
+++ b/test-reqs.txt
@@ -1,3 +1,5 @@
+nose
+mock
 six>=1.4
 Jinja2>=2.3
 Pygments>=2.0

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -150,6 +150,7 @@ def test_quickstart_defaults(tempdir):
     assert ns['copyright'] == '%s, Georg Brandl' % time.strftime('%Y')
     assert ns['version'] == '0.1'
     assert ns['release'] == '0.1'
+    assert ns['todo_include_todos'] is False
     assert ns['html_static_path'] == ['_static']
     assert ns['latex_documents'] == [
         ('index', 'SphinxTest.tex', 'Sphinx Test Documentation',
@@ -178,7 +179,7 @@ def test_quickstart_all_answers(tempdir):
         'autodoc': 'y',
         'doctest': 'yes',
         'intersphinx': 'no',
-        'todo': 'n',
+        'todo': 'y',
         'coverage': 'no',
         'pngmath': 'N',
         'mathjax': 'no',
@@ -198,7 +199,9 @@ def test_quickstart_all_answers(tempdir):
     assert conffile.isfile()
     ns = {}
     execfile_(conffile, ns)
-    assert ns['extensions'] == ['sphinx.ext.autodoc', 'sphinx.ext.doctest']
+    assert ns['extensions'] == [
+        'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo'
+    ]
     assert ns['templates_path'] == ['.templates']
     assert ns['source_suffix'] == '.txt'
     assert ns['master_doc'] == 'contents'
@@ -207,6 +210,7 @@ def test_quickstart_all_answers(tempdir):
         time.strftime('%Y')
     assert ns['version'] == '2.0'
     assert ns['release'] == '2.0.1'
+    assert ns['todo_include_todos'] is True
     assert ns['html_static_path'] == ['.static']
     assert ns['latex_documents'] == [
         ('contents', 'STASI.tex', u'STASI™ Documentation',


### PR DESCRIPTION
Create a `todo_include_todo` entry in the quickstart generated config. Documentation describing this option is at: http://sphinx-doc.org/ext/todo.html
