### PR TITLE
Reduce the number of scattered quickstart config string replacements

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -354,13 +354,13 @@ EPUB_CONFIG = u'''
 # -- Options for Epub output ----------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'%(project_str)s'
+epub_title = project
 epub_author = author
 epub_publisher = author
-epub_copyright = u'%(copyright_str)s'
+epub_copyright = copyright
 
 # The basename for the epub file. It defaults to the project name.
-#epub_basename = u'%(project_str)s'
+#epub_basename = project
 
 # The HTML theme for the epub output. Since the default themes are not optimized
 # for small screen space, using the same theme for HTML and epub output is

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -287,7 +287,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('%(master_str)s', '%(project_fn)s.tex', u'%(project_doc_texescaped_str)s',
+  (master_doc, '%(project_fn)s.tex', u'%(project_doc_texescaped_str)s',
    u'%(author_texescaped_str)s', 'manual'),
 ]
 
@@ -317,7 +317,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('%(master_str)s', '%(project_manpage)s', u'%(project_doc_str)s',
+    (master_doc, '%(project_manpage)s', u'%(project_doc_str)s',
      [author], 1)
 ]
 
@@ -331,7 +331,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('%(master_str)s', '%(project_fn)s', u'%(project_doc_str)s',
+  (master_doc, '%(project_fn)s', u'%(project_doc_str)s',
    author, '%(project_fn)s', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -116,6 +116,7 @@ master_doc = '%(master_str)s'
 # General information about the project.
 project = u'%(project_str)s'
 copyright = u'%(copyright_str)s'
+author = u'%(author_str)s'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -317,7 +318,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('%(master_str)s', '%(project_manpage)s', u'%(project_doc_str)s',
-     [u'%(author_str)s'], 1)
+     [author], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -331,7 +332,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('%(master_str)s', '%(project_fn)s', u'%(project_doc_str)s',
-   u'%(author_str)s', '%(project_fn)s', 'One line description of project.',
+   author, '%(project_fn)s', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -354,8 +355,8 @@ EPUB_CONFIG = u'''
 
 # Bibliographic Dublin Core info.
 epub_title = u'%(project_str)s'
-epub_author = u'%(author_str)s'
-epub_publisher = u'%(author_str)s'
+epub_author = author
+epub_publisher = author
 epub_copyright = u'%(copyright_str)s'
 
 # The basename for the epub file. It defaults to the project name.


### PR DESCRIPTION
I originally thought of this when making a change to add myself as an author on a project. I discovered that the answer to "author" is stuck into several places within the generated config, rather than assigning it to a variable once, and then reusing that (allowing a single line change later when the authors change).

I extended this to other string replacements in the generated config, currently excluding the `%(project_fn)s` replacement.
