### PR TITLE
Restore pycompat API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,8 @@ Bugs fixed
 * bizstyle theme: nested long title pages make long breadcrumb that breaks page layout.
 * bizstyle theme: all breadcrumb items become 'Top' on some mobile browser
   (iPhone5s safari).
+* ``sphinx.util.pycompat`` has been restored in its backwards-compatibility;
+  slated for removal in Sphinx 1.4.
 
 
 Release 1.3b2 (released Dec 5, 2014)

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -111,6 +111,7 @@ import warnings
 
 from six import class_types
 from six.moves import zip_longest
+import io
 from itertools import product
 
 class _DeprecationWrapper(object):
@@ -135,4 +136,6 @@ sys.modules[__name__] = _DeprecationWrapper(sys.modules[__name__], dict(
     open = open,
     base_exception = BaseException,
     relpath = __import__('os').path.relpath,
+    StringIO = io.StringIO,
+    BytesIO = io.BytesIO,
 ))

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -121,9 +121,10 @@ class _DeprecationWrapper(object):
 
     def __getattr__(self, attr):
         if attr in self._deprecated:
-            warnings.warn("sphinx.util.pycompat.%s is deprecated, "
-                          "please use the standard library version." % attr,
-                          DeprecationWarning)
+            warnings.warn("sphinx.util.pycompat.%s is deprecated and will be "
+                          "removed in Sphinx 1.4, please use the standard "
+                          "library version instead." % attr,
+                          DeprecationWarning, stacklevel=2)
             return self._deprecated[attr]
         return getattr(self._mod, attr)
 

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -135,6 +135,7 @@ sys.modules[__name__] = _DeprecationWrapper(sys.modules[__name__], dict(
     any = any,
     next = next,
     open = open,
+    class_types = class_types,
     base_exception = BaseException,
     relpath = __import__('os').path.relpath,
     StringIO = io.StringIO,

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -76,7 +76,7 @@ else:
             return self.__unicode__().encode('utf8')
 
 
-def execfile_(filepath, _globals):
+def execfile_(filepath, _globals, open=open):
     from sphinx.util.osutil import fs_encoding
     # get config source -- 'b' is a no-op under 2.x, while 'U' is
     # ignored under 3.x (but 3.x compile() accepts \r\n newlines)
@@ -103,3 +103,33 @@ def execfile_(filepath, _globals):
         else:
             raise
     exec_(code, _globals)
+
+# ------------------------------------------------------------------------------
+# Internal module backwards-compatibility
+
+import functools
+import warnings
+
+def _deprecated(func):
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        warnings.warn("sphinx.util.pycompat.{0.__name__} is deprecated, "
+                      "please use the standard library version.".format(func),
+                      DeprecationWarning, stacklevel=2)
+        func(*args, **kwargs)
+    return wrapped
+
+from six import class_types
+from six.moves import zip_longest
+from itertools import product
+
+zip_longest = _deprecated(zip_longest)
+product = _deprecated(product)
+
+all = _deprecated(all)
+any = _deprecated(any)
+next = _deprecated(next)
+open = _deprecated(open)
+
+base_exception = BaseException
+relpath = _deprecated(__import__('os').path.relpath)


### PR DESCRIPTION
As discussed in #1726, restore all helper functions in `sphinx.util.pycompat`.  I have also added a deprecation warning to the functions.
