### PR TITLE
Add support for per-suffix parsers

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -55,6 +55,7 @@ class Config(object):
         source_encoding = ('utf-8-sig', 'env'),
         exclude_patterns = ([], 'env'),
         default_role = (None, 'env'),
+        parsers = ({}, 'env'),
         add_function_parentheses = (True, 'env'),
         add_module_names = (True, 'env'),
         trim_footnote_reference_space = (False, 'env'),


### PR DESCRIPTION
This adds the ability to do something like `parsers = {'.md': 'markdown.parsers'}` to use `markdown.parsers.Parser` to parse .md files. Custom parsers specified in this manner are _only_ used to parse files matching the suffix; otherwise the default (reST) parser is used.

This should help with #825, by allowing for a mixture of reST and MD.
