### PR TITLE
Fix #1658

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -660,12 +660,14 @@ class StandardDomain(Domain):
             # most obvious thing: we are a flag option without program
             if target.startswith(('-', '/', '+')):
                 progname = node.get('std:program')
-            else:
+            elif ' -' in target or ' /' in target:
                 try:
                     progname, target = re.split(r' (?=-|--|/|\+)', target, 1)
                 except ValueError:
                     return None
                 progname = ws_re.sub('-', progname.strip())
+            else:
+                progname = None
             docname, labelid = self.data['progoptions'].get((progname, target),
                                                             ('', ''))
             if not docname:


### PR DESCRIPTION
Check if an option contains `-` or `/`. This behavior is same as commits before 6ba8883

The document says that options without `-` and `/` are allowed,
A warning says that options should contains `-` or `/`.
Which is right behavior?
