### PR TITLE
todo list: link only

### DIFF
--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -110,9 +110,12 @@ def process_todo_nodes(app, doctree, fromdocname):
 
         for todo_info in env.todo_all_todos:
             para = nodes.paragraph(classes=['todo-source'])
-            description = _('(The <<original entry>> is located in '
-                            ' %s, line %d.)') % \
-                          (todo_info['source'], todo_info['lineno'])
+            if app.config['todo_link_only']:
+                description = _('<<original entry>>')
+            else:
+                description = _('(The <<original entry>> is located in '
+                                ' %s, line %d.)') % \
+                            (todo_info['source'], todo_info['lineno'])
             desc1 = description[:description.find('<<')]
             desc2 = description[description.find('>>')+2:]
             para += nodes.Text(desc1, desc1)
@@ -166,6 +169,7 @@ def depart_todo_node(self, node):
 
 def setup(app):
     app.add_config_value('todo_include_todos', False, 'html')
+    app.add_config_value('todo_link_only', False, 'html')
 
     app.add_node(todolist)
     app.add_node(todo_node,


### PR DESCRIPTION
In the code I'm working on I have a bunch of todos in module and function documentations and I am experimenting with `.. todolist::`.

However I'm not very happy with the text shown under each to do box, in particular when the `.. todo::` directive is in a function. As in [todos_orig](https://cloud.githubusercontent.com/assets/1394820/6442724/32954a0e-c0f2-11e4-8a68-14536b446beb.jpg) screenshot if the todo is in:
- module docstring (first part in the figure): it prints the absolute path of the source file on **my computer** then the module name and the line number
- function docstring: (second part in the figure): it prints a list containing of the whole docstring (which is ugly).

This PR adds a new option `todo_link_only` that allows to print only the link of the `original entry`. The 
[todos_mod](https://cloud.githubusercontent.com/assets/1394820/6442723/32835efc-c0f2-11e4-873e-cd560491bc20.jpg) screenshot shows the same two entries of above, with the  `todo_link_only = True`.

If there is any interest in pushing this PR into sphinx I'll update the documentation and the test suite according to the modifications.
