### PR TITLE
fix unclear documentation for html_last_updated_fmt

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -624,9 +624,10 @@ that use Sphinx's HTMLWriter class.
 
 .. confval:: html_last_updated_fmt
 
-   If this is not the empty string, a 'Last updated on:' timestamp is inserted
-   at every page bottom, using the given :func:`strftime` format.  Default is
-   ``'%b %d, %Y'`` (or a locale-dependent equivalent).
+   If this is not None, a 'Last updated on:' timestamp is inserted
+   at every page bottom, using the given :func:`strftime` format.
+   The empty string is equivalent to '%b %d, %Y' (or a
+   locale-dependent equivalent).
 
 .. confval:: html_use_smartypants
 

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -213,9 +213,10 @@ html_static_path = ['%(dot)sstatic']
 # directly to the root of the documentation.
 #html_extra_path = []
 
-# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
-# using the given strftime format.
-#html_last_updated_fmt = '%%b %%d, %%Y'
+# If not None, a 'Last updated on:' timestamp is inserted at every page
+# bottom, using the given strftime format.
+# The empty string is equivalent to '%%b %%d, %%Y'.
+#html_last_updated_fmt = None
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.


### PR DESCRIPTION
I got confused by the original statement, since it seems to say that the "Last updated" is only inserted if html_last_updated_fmt is not ''. I wanted to undo a formerly generated "Last updated" and assigned '' to this variable, but was surprised that sphinx would still generate the "Last updated" thing. In fact, the default is None (and that should be given as the (example) value in the conf.py). That one can use '' or '%b %d, %Y' (or any other format string) should be in the corresponding documentation.
