### PR TITLE
Version-lock unlocked dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ requires = [
     'Pygments>=2.0',
     'docutils>=0.11',
     'snowballstemmer>=1.1',
-    'babel',
-    'alabaster',
-    'sphinx_rtd_theme',
+    'babel>=1.3',
+    'alabaster>=0.7,<0.8',
+    'sphinx_rtd_theme>=0.1,<0.2',
 ]
 extras_require = {
     # Environment Marker works for wheel 0.24 or later


### PR DESCRIPTION
As the author of one of the new theme dependencies (`alabaster`), having a wholly unqualified requirement scared me a bit re: ability to make non-bugfix releases without downstream users' sites changing underneath them in unexpected (visual) ways (without them consciously upgrading Sphinx versions).

`alabaster` uses semantic versioning so the lock reflects this.

For consistency, I updated the other new theme dependency similarly, and made `babel` match its fellow non-theme dependencies in having an optimistic (vs semantic) version lock, but I can revert these changes if desired.
