### PR TITLE
allows some files in quickstart destination dir.

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -1403,13 +1403,20 @@ For more information, visit <http://sphinx-doc.org/>.
 """
 
 
-def valid_dir(dir):
+def valid_dir(d):
+    dir = d['path']
     if not path.exists(dir):
         return True
     if not path.isdir(dir):
         return False
     for f in os.listdir(dir):
-        if f in ['Makefile', 'index.rst', 'conf.py', 'make.bat']:
+        invalid_dirs = ['Makefile', 'make.bat', 'conf.py'
+                        '_static', '_templates', 'source']
+        if f in invalid_dirs:
+            return False
+        master = d['master']
+        ext = d['suffix']
+        if f == master + ext:
             return False
     return True
 
@@ -1523,7 +1530,7 @@ def main(argv=sys.argv):
             if 'no_batchfile' in d:
                 d['batchfile'] = False
 
-            if not valid_dir(d['path']):
+            if not valid_dir(d):
                 print()
                 print(bold('Error: specified path is not a directory, or sphinx'
                            ' files already exist.'))

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -1403,6 +1403,17 @@ For more information, visit <http://sphinx-doc.org/>.
 """
 
 
+def valid_dir(dir):
+    if not path.exists(dir):
+        return True
+    if not path.isdir(dir):
+        return False
+    for f in os.listdir(dir):
+        if f in ['Makefile', 'index.rst', 'conf.py', 'make.bat']:
+            return False
+    return True
+
+
 class MyFormatter(optparse.IndentedHelpFormatter):
     def format_usage(self, usage):
         return usage
@@ -1512,11 +1523,10 @@ def main(argv=sys.argv):
             if 'no_batchfile' in d:
                 d['batchfile'] = False
 
-            if path.exists(d['path']) and (
-                    not path.isdir(d['path']) or os.listdir(d['path'])):
+            if not valid_dir(d['path']):
                 print()
-                print(bold('Error: specified path is not a directory, or not a'
-                           ' empty directory.'))
+                print(bold('Error: specified path is not a directory, or sphinx'
+                           ' files already exist.'))
                 print('sphinx-quickstart only generate into a empty directory.'
                       ' Please specify a new root path.')
                 return

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -1409,15 +1409,23 @@ def valid_dir(d):
         return True
     if not path.isdir(dir):
         return False
-    for f in os.listdir(dir):
-        invalid_dirs = ['Makefile', 'make.bat', 'conf.py'
-                        '_static', '_templates', 'source']
-        if f in invalid_dirs:
+
+    invalid_dirs = ['Makefile', 'make.bat']
+    if set(invalid_dirs) & set(os.listdir(dir)):
+        return False
+
+    master = d['master']
+    suffix = d['suffix']
+    source = ['_static', '_templates', 'conf.py', master+suffix]
+    if d['sep']:
+        dir = os.path.join('source', dir)
+        if not path.exists(dir):
+            return True
+        if not path.isdir(dir):
             return False
-        master = d['master']
-        ext = d['suffix']
-        if f == master + ext:
-            return False
+    if set(source) & set(os.listdir(dir)):
+        return False
+
     return True
 
 


### PR DESCRIPTION
If quickstart destination directory includes some files such as `.git` or `.hg` which quickstart not overwrite files, quickstart will fail with below message.

```
Error: specified path is not a directory, or not a empty directory.
sphinx-quickstart only generate into a empty directory. Please specify a new root path.
```

This PR adds `valid_dir()` and check overwritten files exist or not.
