### PR TITLE
Fix #1770: regard empty file as an empty string

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -219,7 +219,7 @@ class LiteralInclude(Directive):
 
         lines = self.read_with_encoding(filename, document,
                                         codec_info, encoding)
-        if not isinstance(lines[0], string_types):
+        if lines and not isinstance(lines[0], string_types):
             return lines
 
         diffsource = self.options.get('diff')


### PR DESCRIPTION
If an empty file is given, regard it as an empty string.
