### PR TITLE
Sphinx 1.3 can't load extra theme.

### DIFF
--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -86,7 +86,7 @@ class Theme(object):
             if not path.isdir(themedir):
                 continue
             for theme in os.listdir(themedir):
-                if theme != 'name':
+                if theme != name:
                     continue
                 if not path.isfile(path.join(themedir, theme, THEMECONF)):
                     continue


### PR DESCRIPTION
Hi. Sphinx authors.

First, thanks for the awesome tool.

After upgrading to 1.3, i encountered errors such as the following.
I have fixed the bug. Please feel free to merge it.

```
$ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.3
Initializing Basicstrap theme directives
loading pickled environment... not yet created

Theme error:
no theme named 'basicstrap' found (missing theme.conf?)
make: *** [html] Error 1
```

Thx.
