### PR TITLE
Add EPUB 3 builder

### DIFF
--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -140,6 +140,26 @@ The builder's "name" must be given to the **-b** command-line option of
 
    .. autoattribute:: supported_image_types
 
+.. module:: sphinx.builders.epub3
+.. class:: Epub3Builder
+
+   This builder produces the same output as the standalone HTML builder, but
+   also generates an *epub* file for ebook readers.  See :ref:`epub-faq` for
+   details about it.  For definition of the epub format, have a look at
+   `<http://idpf.org/epub>`_ or `<http://en.wikipedia.org/wiki/EPUB>`_.
+   The builder creates *EPUB 3* files.
+
+   This builder is still *experimental* because it can't generate valid EPUB 3
+   files.
+
+   .. autoattribute:: name
+
+   .. autoattribute:: format
+
+   .. autoattribute:: supported_image_types
+
+   .. versionadded:: 1.4
+
 .. module:: sphinx.builders.latex
 .. class:: LaTeXBuilder
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1145,10 +1145,24 @@ the `Dublin Core metadata <http://dublincore.org/>`_.
    The title of the document.  It defaults to the :confval:`html_title` option
    but can be set independently for epub creation.
 
+.. confval:: epub3_description
+
+   The description of the document. The default value is ``''``.
+
+   .. versionadded:: 1.4
+
 .. confval:: epub_author
 
    The author of the document.  This is put in the Dublin Core metadata.  The
    default value is ``'unknown'``.
+
+.. confval:: epub3_contributor
+
+   The name of a person, organization, etc. that played a secondary role in
+   the creation of the content of an EPUB Publication. The default value is
+   ``'unknown'``.
+
+   .. versionadded:: 1.4
 
 .. confval:: epub_language
 
@@ -1304,6 +1318,14 @@ the `Dublin Core metadata <http://dublincore.org/>`_.
    creation.
 
    .. versionadded:: 1.2
+
+.. confval:: epub3_page_progression_direction
+
+   The global direction in which the content flows.
+   Allowed values are ltr (left-to-right), rtl (right-to-left) and default.
+   The default value is ``'ltr'``.
+
+   .. versionadded:: 1.4
 
 .. _latex-options:
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -462,6 +462,7 @@ BUILTIN_BUILDERS = {
     'qthelp':     ('qthelp', 'QtHelpBuilder'),
     'applehelp':  ('applehelp', 'AppleHelpBuilder'),
     'epub':       ('epub', 'EpubBuilder'),
+    'epub3':      ('epub3', 'Epub3Builder'),
     'latex':      ('latex', 'LaTeXBuilder'),
     'text':       ('text', 'TextBuilder'),
     'man':        ('manpage', 'ManualPageBuilder'),

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -39,9 +39,9 @@ from sphinx.util.console import brown
 # output but that may be customized by (re-)setting module attributes,
 # e.g. from conf.py.
 
-_mimetype_template = 'application/epub+zip'  # no EOL!
+MIMETYPE_TEMPLATE = 'application/epub+zip'  # no EOL!
 
-_container_template = u'''\
+CONTAINER_TEMPLATE = u'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <container version="1.0"
       xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
@@ -52,7 +52,7 @@ _container_template = u'''\
 </container>
 '''
 
-_toc_template = u'''\
+TOC_TEMPLATE = u'''\
 <?xml version="1.0"?>
 <ncx version="2005-1" xmlns="http://www.daisy.org/z3986/2005/ncx/">
   <head>
@@ -70,7 +70,7 @@ _toc_template = u'''\
 </ncx>
 '''
 
-_navpoint_template = u'''\
+NAVPOINT_TEMPLATE = u'''\
 %(indent)s  <navPoint id="%(navpoint)s" playOrder="%(playorder)d">
 %(indent)s    <navLabel>
 %(indent)s      <text>%(text)s</text>
@@ -78,10 +78,10 @@ _navpoint_template = u'''\
 %(indent)s    <content src="%(refuri)s" />
 %(indent)s  </navPoint>'''
 
-_navpoint_indent = '  '
-_navPoint_template = 'navPoint%d'
+NAVPOINT_INDENT = '  '
+NODE_NAVPOINT_TEMPLATE = 'navPoint%d'
 
-_content_template = u'''\
+CONTENT_TEMPLATE = u'''\
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="2.0"
       unique-identifier="%(uid)s">
@@ -108,40 +108,40 @@ _content_template = u'''\
 </package>
 '''
 
-_cover_template = u'''\
+COVER_TEMPLATE = u'''\
     <meta name="cover" content="%(cover)s"/>
 '''
 
-_coverpage_name = u'epub-cover.html'
+COVERPAGE_NAME = u'epub-cover.html'
 
-_file_template = u'''\
+FILE_TEMPLATE = u'''\
     <item id="%(id)s"
           href="%(href)s"
           media-type="%(media_type)s" />'''
 
-_spine_template = u'''\
+SPINE_TEMPLATE = u'''\
     <itemref idref="%(idref)s" />'''
 
-_guide_template = u'''\
+GUIDE_TEMPLATE = u'''\
     <reference type="%(type)s" title="%(title)s" href="%(uri)s" />'''
 
-_toctree_template = u'toctree-l%d'
+TOCTREE_TEMPLATE = u'toctree-l%d'
 
-_link_target_template = u' [%(uri)s]'
+LINK_TARGET_TEMPLATE = u' [%(uri)s]'
 
-_footnote_label_template = u'#%d'
+FOOTNOTE_LABEL_TEMPLATE = u'#%d'
 
-_footnotes_rubric_name = u'Footnotes'
+FOOTNOTES_RUBRIC_NAME = u'Footnotes'
 
-_css_link_target_class = u'link-target'
+CSS_LINK_TARGET_CLASS = u'link-target'
 
 # XXX These strings should be localized according to epub_language
-_guide_titles = {
+GUIDE_TITLES = {
     'toc': u'Table of Contents',
     'cover': u'Cover'
 }
 
-_media_types = {
+MEDIA_TYPES = {
     '.html': 'application/xhtml+xml',
     '.css': 'text/css',
     '.png': 'image/png',
@@ -153,12 +153,12 @@ _media_types = {
     '.ttf': 'application/x-font-ttf',
 }
 
-_vector_graphics_extensions = ('.svg',)
+VECTOR_GRAPHICS_EXTENSIONS = ('.svg',)
 
 # Regular expression to match colons only in local fragment identifiers.
 # If the URI contains a colon before the #,
 # it is an external link that should not change.
-_refuri_re = re.compile("([^#:]*#)(.*)")
+REFURI_RE = re.compile("([^#:]*#)(.*)")
 
 
 # The epub publisher
@@ -182,6 +182,25 @@ class EpubBuilder(StandaloneHTMLBuilder):
     add_permalinks = False
     # don't add sidebar etc.
     embedded = True
+
+    mimetype_template = MIMETYPE_TEMPLATE
+    container_template = CONTAINER_TEMPLATE
+    toc_template = TOC_TEMPLATE
+    navpoint_template = NAVPOINT_TEMPLATE
+    navpoint_indent = NAVPOINT_INDENT
+    node_navpoint_template = NODE_NAVPOINT_TEMPLATE
+    content_template = CONTENT_TEMPLATE
+    cover_template = COVER_TEMPLATE
+    coverpage_name = COVERPAGE_NAME
+    file_template = FILE_TEMPLATE
+    spine_template = SPINE_TEMPLATE
+    guide_template = GUIDE_TEMPLATE
+    toctree_template = TOCTREE_TEMPLATE
+    link_target_template = LINK_TARGET_TEMPLATE
+    css_link_target_class = CSS_LINK_TARGET_CLASS
+    guide_titles = GUIDE_TITLES
+    media_types = MEDIA_TYPES
+    refuri_re = REFURI_RE
 
     def init(self):
         StandaloneHTMLBuilder.init(self)
@@ -224,7 +243,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 return result
             classes = doctree.parent.attributes['classes']
             for level in range(8, 0, -1):  # or range(1, 8)?
-                if (_toctree_template % level) in classes:
+                if (self.toctree_template % level) in classes:
                     result.append({
                         'level': level,
                         'refuri': self.esc(refuri),
@@ -285,7 +304,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """
         for node in tree.traverse(nodes.reference):
             if 'refuri' in node:
-                m = _refuri_re.match(node['refuri'])
+                m = self.refuri_re.match(node['refuri'])
                 if m:
                     node['refuri'] = self.fix_fragment(m.group(1), m.group(2))
             if 'refid' in node:
@@ -331,11 +350,11 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 return fn.parent, fn.parent.index(fn) + 1
             for node in tree.traverse(nodes.rubric):
                 if len(node.children) == 1 and \
-                        node.children[0].astext() == _footnotes_rubric_name:
+                        node.children[0].astext() == FOOTNOTES_RUBRIC_NAME:
                     return node.parent, node.parent.index(node) + 1
             doc = tree.traverse(nodes.document)[0]
             rub = nodes.rubric()
-            rub.append(nodes.Text(_footnotes_rubric_name))
+            rub.append(nodes.Text(FOOTNOTES_RUBRIC_NAME))
             doc.append(rub)
             return doc, doc.index(rub) + 1
 
@@ -351,12 +370,12 @@ class EpubBuilder(StandaloneHTMLBuilder):
                     uri.startswith('ftp:')) and uri not in node.astext():
                 idx = node.parent.index(node) + 1
                 if show_urls == 'inline':
-                    uri = _link_target_template % {'uri': uri}
+                    uri = self.link_target_template % {'uri': uri}
                     link = nodes.inline(uri, uri)
-                    link['classes'].append(_css_link_target_class)
+                    link['classes'].append(self.css_link_target_class)
                     node.parent.insert(idx, link)
                 elif show_urls == 'footnote':
-                    label = _footnote_label_template % nr
+                    label = FOOTNOTE_LABEL_TEMPLATE % nr
                     nr += 1
                     footnote_ref = make_footnote_ref(doc, label)
                     node.parent.insert(idx, footnote_ref)
@@ -383,13 +402,13 @@ class EpubBuilder(StandaloneHTMLBuilder):
         for key, columns in tree:
             for entryname, (links, subitems) in columns:
                 for (i, (ismain, link)) in enumerate(links):
-                    m = _refuri_re.match(link)
+                    m = self.refuri_re.match(link)
                     if m:
                         links[i] = (ismain,
                                     self.fix_fragment(m.group(1), m.group(2)))
                 for subentryname, subentrylinks in subitems:
                     for (i, (ismain, link)) in enumerate(subentrylinks):
-                        m = _refuri_re.match(link)
+                        m = self.refuri_re.match(link)
                         if m:
                             subentrylinks[i] = (ismain,
                                                 self.fix_fragment(m.group(1), m.group(2)))
@@ -397,7 +416,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def is_vector_graphics(self, filename):
         """Does the filename extension indicate a vector graphic format?"""
         ext = path.splitext(filename)[-1]
-        return ext in _vector_graphics_extensions
+        return ext in VECTOR_GRAPHICS_EXTENSIONS
 
     def copy_image_files_pil(self):
         """Copy images using the PIL.
@@ -478,7 +497,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         self.info('writing %s file...' % outname)
         f = codecs.open(path.join(outdir, outname), 'w', 'utf-8')
         try:
-            f.write(_mimetype_template)
+            f.write(self.mimetype_template)
         finally:
             f.close()
 
@@ -493,7 +512,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 raise
         f = codecs.open(path.join(outdir, outname), 'w', 'utf-8')
         try:
-            f.write(_container_template)
+            f.write(self.container_template)
         finally:
             f.close()
 
@@ -538,17 +557,17 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 if filename in self.ignored_files:
                     continue
                 ext = path.splitext(filename)[-1]
-                if ext not in _media_types:
+                if ext not in self.media_types:
                     # we always have JS and potentially OpenSearch files, don't
                     # always warn about them
                     if ext not in ('.js', '.xml'):
                         self.warn('unknown mimetype for %s, ignoring' % filename)
                     continue
                 filename = filename.replace(os.sep, '/')
-                projectfiles.append(_file_template % {
+                projectfiles.append(self.file_template % {
                     'href': self.esc(filename),
                     'id': self.esc(self.make_id(filename)),
-                    'media_type': self.esc(_media_types[ext])
+                    'media_type': self.esc(self.media_types[ext])
                 })
                 self.files.append(filename)
 
@@ -559,20 +578,20 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 continue
             if item['refuri'] in self.ignored_files:
                 continue
-            spine.append(_spine_template % {
+            spine.append(self.spine_template % {
                 'idref': self.esc(self.make_id(item['refuri']))
             })
         for info in self.domain_indices:
-            spine.append(_spine_template % {
+            spine.append(self.spine_template % {
                 'idref': self.esc(self.make_id(info[0] + self.out_suffix))
             })
         if self.get_builder_config('use_index', 'epub'):
-            spine.append(_spine_template % {
+            spine.append(self.spine_template % {
                 'idref': self.esc(self.make_id('genindex' + self.out_suffix))
             })
 
         # add the optional cover
-        content_tmpl = _content_template
+        content_tmpl = self.content_template
         html_tmpl = None
         if self.config.epub_cover:
             image, html_tmpl = self.config.epub_cover
@@ -580,22 +599,22 @@ class EpubBuilder(StandaloneHTMLBuilder):
             mpos = content_tmpl.rfind('</metadata>')
             cpos = content_tmpl.rfind('\n', 0, mpos) + 1
             content_tmpl = content_tmpl[:cpos] + \
-                _cover_template % {'cover': self.esc(self.make_id(image))} + \
+                COVER_TEMPLATE % {'cover': self.esc(self.make_id(image))} + \
                 content_tmpl[cpos:]
             if html_tmpl:
-                spine.insert(0, _spine_template % {
-                    'idref': self.esc(self.make_id(_coverpage_name))})
-                if _coverpage_name not in self.files:
-                    ext = path.splitext(_coverpage_name)[-1]
-                    self.files.append(_coverpage_name)
-                    projectfiles.append(_file_template % {
-                        'href': self.esc(_coverpage_name),
-                        'id': self.esc(self.make_id(_coverpage_name)),
-                        'media_type': self.esc(_media_types[ext])
+                spine.insert(0, self.spine_template % {
+                    'idref': self.esc(self.make_id(self.coverpage_name))})
+                if self.coverpage_name not in self.files:
+                    ext = path.splitext(self.coverpage_name)[-1]
+                    self.files.append(self.coverpage_name)
+                    projectfiles.append(self.file_template % {
+                        'href': self.esc(self.coverpage_name),
+                        'id': self.esc(self.make_id(self.coverpage_name)),
+                        'media_type': self.esc(self.media_types[ext])
                     })
                 ctx = {'image': self.esc(image), 'title': self.config.project}
                 self.handle_page(
-                    path.splitext(_coverpage_name)[0], ctx, html_tmpl)
+                    path.splitext(self.coverpage_name)[0], ctx, html_tmpl)
 
         guide = []
         auto_add_cover = True
@@ -609,21 +628,21 @@ class EpubBuilder(StandaloneHTMLBuilder):
                     auto_add_cover = False
                 if type == 'toc':
                     auto_add_toc = False
-                guide.append(_guide_template % {
+                guide.append(self.guide_template % {
                     'type': self.esc(type),
                     'title': self.esc(title),
                     'uri': self.esc(uri)
                 })
         if auto_add_cover and html_tmpl:
-            guide.append(_guide_template % {
+            guide.append(self.guide_template % {
                 'type': 'cover',
-                'title': _guide_titles['cover'],
-                'uri': self.esc(_coverpage_name)
+                'title': self.guide_titles['cover'],
+                'uri': self.esc(self.coverpage_name)
             })
         if auto_add_toc and self.refnodes:
-            guide.append(_guide_template % {
+            guide.append(self.guide_template % {
                 'type': 'toc',
-                'title': _guide_titles['toc'],
+                'title': self.guide_titles['toc'],
                 'uri': self.esc(self.refnodes[0]['refuri'])
             })
         projectfiles = '\n'.join(projectfiles)
@@ -644,10 +663,10 @@ class EpubBuilder(StandaloneHTMLBuilder):
         if incr:
             self.playorder += 1
         self.tocid += 1
-        node['indent'] = _navpoint_indent * level
-        node['navpoint'] = self.esc(_navPoint_template % self.tocid)
+        node['indent'] = self.navpoint_indent * level
+        node['navpoint'] = self.esc(self.node_navpoint_template % self.tocid)
         node['playorder'] = self.playorder
-        return _navpoint_template % node
+        return self.navpoint_template % node
 
     def insert_subnav(self, node, subnav):
         """Insert nested navpoints for given node.
@@ -730,7 +749,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         level = min(level, self.config.epub_tocdepth)
         f = codecs.open(path.join(outdir, outname), 'w', 'utf-8')
         try:
-            f.write(_toc_template % self.toc_metadata(level, navpoints))
+            f.write(self.toc_template % self.toc_metadata(level, navpoints))
         finally:
             f.close()
 

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.builders.epub3
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Build epub3 files.
+    Originally derived from epub.py.
+
+    :copyright: Copyright 2007-2015 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import codecs
+from os import path
+
+from sphinx.builders.epub import EpubBuilder
+
+
+# (Fragment) templates from which the metainfo files content.opf, toc.ncx,
+# mimetype, and META-INF/container.xml are created.
+# This template section also defines strings that are embedded in the html
+# output but that may be customized by (re-)setting module attributes,
+# e.g. from conf.py.
+
+NAVIGATION_DOC_TEMPLATE = u'''\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"\
+ xmlns:epub="http://www.idpf.org/2007/ops" lang="%(lang)s" xml:lang="%(lang)s">
+  <head>
+    <title>%(toc_locale)s</title>
+  </head>
+  <body>
+    <nav epub:type="toc">
+      <h1>%(toc_locale)s</h1>
+      <ol>
+%(navlist)s
+      </ol>
+    </nav>
+  </body>
+</html>
+'''
+
+NAVLIST_TEMPLATE = u'''\
+%(indent)s  <li>
+%(indent)s    <a href="%(refuri)s">%(text)s</a>
+%(indent)s  </li>
+'''
+NAVLIST_INDENT = '      '
+
+
+PACKAGE_DOC_TEMPLATE = u'''\
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="%(lang)s"
+      unique-identifier="%(uid)s">
+  <metadata xmlns:opf="http://www.idpf.org/2007/opf"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:language>%(lang)s</dc:language>
+    <dc:title>%(title)s</dc:title>
+    <dc:description>%(description)s</dc:description>
+    <dc:creator>%(author)s</dc:creator>
+    <dc:contributor>%(contributor)s</dc:contributor>
+    <dc:publisher>%(publisher)s</dc:publisher>
+    <dc:rights>%(copyright)s</dc:rights>
+    <dc:identifier id="%(uid)s">%(id)s</dc:identifier>
+    <dc:date>%(date)s</dc:date>
+    <meta property="dcterms:modified">%(date)s</meta>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <item id="nav" href="nav.xhtml"\
+ media-type="application/xhtml+xml" properties="nav"/>
+%(files)s
+  </manifest>
+  <spine toc="ncx" page-progression-direction="%(page_progression_direction)s">
+    <itemref idref="nav" />
+%(spine)s
+  </spine>
+  <guide>
+%(guide)s
+  </guide>
+</package>
+'''
+
+# The epub3 publisher
+
+
+class Epub3Builder(EpubBuilder):
+    """
+    Builder that outputs epub3 files.
+
+    It creates the metainfo files content.opf, nav.xhtml, toc.ncx, mimetype,
+    and META-INF/container.xml. Afterwards, all necessary files are zipped to
+    an epub file.
+    """
+    name = 'epub3'
+
+    navigation_doc_template = NAVIGATION_DOC_TEMPLATE
+    navlist_template = NAVLIST_TEMPLATE
+    navlist_indent = NAVLIST_INDENT
+    content_template = PACKAGE_DOC_TEMPLATE
+
+    # Finish by building the epub file
+    def handle_finish(self):
+        """Create the metainfo files and finally the epub."""
+        self.get_toc()
+        self.build_mimetype(self.outdir, 'mimetype')
+        self.build_container(self.outdir, 'META-INF/container.xml')
+        self.build_content(self.outdir, 'content.opf')
+        self.build_navigation_doc(self.outdir, 'nav.xhtml')
+        self.build_toc(self.outdir, 'toc.ncx')
+        self.build_epub(self.outdir, self.config.epub_basename + '.epub')
+
+    def content_metadata(self, files, spine, guide):
+        """Create a dictionary with all metadata for the content.opf
+        file properly escaped.
+        """
+        metadata = super(Epub3Builder, self).content_metadata(
+            files, spine, guide)
+        metadata['description'] = self.esc(self.config.epub3_description)
+        metadata['contributor'] = self.esc(self.config.epub3_contributor)
+        metadata['page_progression_direction'] = self.esc(
+            self.config.epub3_page_progression_direction)
+        return metadata
+
+    def new_navlist(self, node, level):
+        """Create a new entry in the toc from the node at given level."""
+        # XXX Modifies the node
+        self.tocid += 1
+        node['indent'] = self.navlist_indent * level
+        navpoint = self.navlist_template % node
+        return navpoint
+
+    def build_navlist(self, nodes):
+        """Create the toc navigation structure.
+
+        This method is almost same as build_navpoints method in epub.py.
+        This is because the logical navigation structure of epub3 is not
+        different from one of epub2.
+
+        The difference from build_navpoints method is templates which are used
+        when generating navigation documents.
+        """
+        navstack = []
+        navlist = []
+        level = 1
+        lastnode = None
+        for node in nodes:
+            if not node['text']:
+                continue
+            file = node['refuri'].split('#')[0]
+            if file in self.ignored_files:
+                continue
+            if node['level'] > self.config.epub_tocdepth:
+                continue
+            if node['level'] == level:
+                navlist.append(self.new_navlist(node, level))
+            elif node['level'] == level + 1:
+                navstack.append(navlist)
+                navlist = []
+                level += 1
+                if lastnode and self.config.epub_tocdup:
+                    navlist.append(self.new_navlist(node, level))
+                    navlist[-1] = '<ol>\n' + navlist[-1]
+            else:
+                while node['level'] < level:
+                    subnav = '\n'.join(navlist)
+                    navlist = navstack.pop()
+                    navlist[-1] = self.insert_subnav(navlist[-1], subnav)
+                    level -= 1
+                    navlist[-1] = navlist[-1] + '</ol>'
+                navlist.append(self.new_navlist(node, level))
+            lastnode = node
+        while level != 1:
+            subnav = '\n'.join(navlist)
+            navlist = navstack.pop()
+            navlist[-1] = self.insert_subnav(navlist[-1], subnav)
+            level -= 1
+            navlist[-1] = navlist[-1] + '</ol>'
+        return '\n'.join(navlist)
+
+    def navigation_doc_metadata(self, navlist):
+        """Create a dictionary with all metadata for the nav.xhtml file
+        properly escaped.
+        """
+        metadata = {}
+        metadata['lang'] = self.esc(self.config.epub_language)
+        metadata['toc_locale'] = self.esc(self.guide_titles['toc'])
+        metadata['navlist'] = navlist
+        return metadata
+
+    def build_navigation_doc(self, outdir, outname):
+        """Write the metainfo file nav.xhtml."""
+        self.info('writing %s file...' % outname)
+
+        if self.config.epub_tocscope == 'default':
+            doctree = self.env.get_and_resolve_doctree(
+                self.config.master_doc, self,
+                prune_toctrees=False, includehidden=False)
+            refnodes = self.get_refnodes(doctree, [])
+            self.toc_add_files(refnodes)
+        else:
+            # 'includehidden'
+            refnodes = self.refnodes
+        navlist = self.build_navlist(refnodes)
+        f = codecs.open(path.join(outdir, outname), 'w', 'utf-8')
+        try:
+            f.write(self.navigation_doc_template %
+                    self.navigation_doc_metadata(navlist))
+        finally:
+            f.close()
+            # Add nav.xhtml to epub file
+            self.files.append(outname)

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -169,7 +169,9 @@ class Config(object):
         epub_theme = ('epub', 'html'),
         epub_theme_options = ({}, 'html'),
         epub_title = (lambda self: self.html_title, 'html'),
+        epub3_description = ('', 'epub3', [str]),
         epub_author = ('unknown', 'html'),
+        epub3_contributor = ('unknown', 'epub3', [str]),
         epub_language = (lambda self: self.language or 'en', 'html'),
         epub_publisher = ('unknown', 'html'),
         epub_copyright = (lambda self: self.copyright, 'html'),
@@ -188,6 +190,7 @@ class Config(object):
         epub_max_image_width = (0, 'env'),
         epub_show_urls = ('inline', 'html'),
         epub_use_index = (lambda self: self.html_use_index, 'html'),
+        epub3_page_progression_direction = ('ltr', 'epub3', [str]),
 
         # LaTeX options
         latex_documents = (lambda self: [(self.master_doc,

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -503,6 +503,7 @@ help:
 \t@echo "  applehelp  to make an Apple Help Book"
 \t@echo "  devhelp    to make HTML files and a Devhelp project"
 \t@echo "  epub       to make an epub"
+\t@echo "  epub3      to make an epub3"
 \t@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
 \t@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
 \t@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
@@ -595,6 +596,12 @@ epub:
 \t$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 \t@echo
 \t@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+
+.PHONY: epub3
+epub3:
+\t$(SPHINXBUILD) -b epub3 $(ALLSPHINXOPTS) $(BUILDDIR)/epub3
+\t@echo
+\t@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
 .PHONY: latex
 latex:
@@ -719,6 +726,7 @@ if "%%1" == "help" (
 \techo.  qthelp     to make HTML files and a qthelp project
 \techo.  devhelp    to make HTML files and a Devhelp project
 \techo.  epub       to make an epub
+\techo.  epub3      to make an epub3
 \techo.  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
 \techo.  text       to make text files
 \techo.  man        to make manual pages
@@ -838,6 +846,14 @@ if "%%1" == "epub" (
 \tif errorlevel 1 exit /b 1
 \techo.
 \techo.Build finished. The epub file is in %%BUILDDIR%%/epub.
+\tgoto end
+)
+
+if "%%1" == "epub3" (
+\t%%SPHINXBUILD%% -b epub3 %%ALLSPHINXOPTS%% %%BUILDDIR%%/epub3
+\tif errorlevel 1 exit /b 1
+\techo.
+\techo.Build finished. The epub3 file is in %%BUILDDIR%%/epub3.
 \tgoto end
 )
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,7 +70,7 @@ def test_build_all():
 
     # note: no 'html' - if it's ok with dirhtml it's ok with html
     for buildername in ['dirhtml', 'singlehtml', 'latex', 'texinfo', 'pickle',
-                        'json', 'text', 'htmlhelp', 'qthelp', 'epub',
+                        'json', 'text', 'htmlhelp', 'qthelp', 'epub', 'epub3',
                         'applehelp', 'changes', 'xml', 'pseudoxml', 'man',
                         'linkcheck']:
         yield verify_build, buildername, srcdir


### PR DESCRIPTION
The content of this pull request is the same as [the pull request when Sphinx was on Bitbucket](https://bitbucket.org/birkenfeld/sphinx/pull-request/245/add-epub-3-builder/diff).

This pull request provides
- EPUB 3 builder
- configuration for EPUB 3 in Makefile

This pull request does not provide
- HTML5 output because docutils can not output HTML5.

The reason why original EPUB builder and this EPUB 3 builder are separated is as follows:
- This EPUB 3 builder implementation is still experimental because it can’t generate HTML5 based content files.
- If original EPUB builder and this immature EPUB 3 builder were integrated, Sphinx couldn’t generate valid EPUB files and EPUB readers couldn’t read them.
