### PR TITLE
Fix #701 by allowing `title <hyperlink>`_ toctree entries

### DIFF
--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -16,7 +16,7 @@ from docutils.parsers.rst.directives.misc import Include as BaseInclude
 
 from sphinx import addnodes
 from sphinx.locale import versionlabels, _
-from sphinx.util import url_re, docname_join
+from sphinx.util import url_re, inline_link_re, docname_join
 from sphinx.util.nodes import explicit_title_re, set_source_info, \
     process_index_entry
 from sphinx.util.matching import patfilter
@@ -96,6 +96,11 @@ class TocTree(Directive):
                 # absolutize filenames
                 docname = docname_join(env.docname, docname)
                 if url_re.match(ref) or ref == 'self':
+                    entries.append((title, ref))
+                elif inline_link_re.match(ref):
+                    # match inline link toctree entries `Title <link>`_
+                    lm = inline_link_re.match(ref)
+                    title = lm.group(1) or None
                     entries.append((title, ref))
                 elif docname not in env.found_docs:
                     ret.append(self.state.document.reporter.warning(

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -37,8 +37,8 @@ from docutils.writers import UnfilteredWriter
 from docutils.frontend import OptionParser
 
 from sphinx import addnodes
-from sphinx.util import url_re, get_matching_docs, docname_join, split_into, \
-    FilenameUniqDict, get_figtype, import_object
+from sphinx.util import url_re, inline_link_re, get_matching_docs, docname_join, \
+    split_into, FilenameUniqDict, get_figtype, import_object
 from sphinx.util.nodes import clean_astext, make_refnode, WarningStream, is_translatable
 from sphinx.util.osutil import SEP, getcwd, fs_encoding
 from sphinx.util.i18n import find_catalog_files
@@ -1410,6 +1410,18 @@ class BuildEnvironment:
                 try:
                     refdoc = None
                     if url_re.match(ref):
+                        if title is None:
+                            title = ref
+                        reference = nodes.reference('', '', internal=False,
+                                                    refuri=ref, anchorname='',
+                                                    *[nodes.Text(title)])
+                        para = addnodes.compact_paragraph('', '', reference)
+                        item = nodes.list_item('', para)
+                        toc = nodes.bullet_list('', item)
+                    elif inline_link_re.match(ref):
+                        # get link from inline web link `Title <link>`_
+                        lm = inline_link_re.match(ref)
+                        ref = lm.group(2)
                         if title is None:
                             title = ref
                         reference = nodes.reference('', '', internal=False,

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -46,9 +46,10 @@ from sphinx.util.matching import patfilter  # noqa
 # Generally useful regular expressions.
 ws_re = re.compile(r'\s+')
 url_re = re.compile(r'(?P<schema>.+)://.*')
-
+inline_link_re = re.compile(r'^`(.*?)\s*<(.*)>`_$')
 
 # High-level utility functions.
+
 
 def docname_join(basedocname, docname):
     return posixpath.normpath(


### PR DESCRIPTION
This PR is a stab at allowing toctree entries to contain relative links (#701) by allowing hyperlinks.

Currently, toctree's allow explicit web links via a special syntax that looks like

```
.. toctree::

    intro
    Some title <http://www.google.com>         <- special syntax
```

but replacing the explicit web link with a relative one "../some/path" results in sphinx trying to find a document and failing. Essentially, plain relative links can't be added in a toctree.

One suggestion in #701 was a special syntax `<href:../some/path>`. However, after looking over the code, it seems cleaner to support standard rst [inline hyperlinks](http://sphinx-doc.org/rest.html#hyperlinks).

```
.. toctree::

    `Some title <any/link>`_
    `<title/will/be/this/link>`_
```

Just like inline hyperlinks in text, If no title is explicitly given, the link text is used as the title (i.e. body of the anchor tag). Separately defined `.. _a link: http://example.com/` target's aren't supported though.

I'd mostly just like to see #701 addressed, whether it is this approach or something else the maintainers like.
