### PR TITLE
include builtin thmemes automatically #1794

### DIFF
--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -133,6 +133,11 @@ class Theme(object):
             inherit = self.themeconf.get('theme', 'inherit')
         except configparser.NoOptionError:
             raise ThemeError('theme %r doesn\'t have "inherit" setting' % name)
+
+        if inherit in ['alabaster', 'sphinx_rtd_theme']:
+            # include 'alabaster' or 'sphinx_themes' automatically #1794
+            self.load_extra_theme(inherit)
+
         if inherit == 'none':
             self.base = None
         elif inherit not in self.themes:


### PR DESCRIPTION
I'm sorry for sending PR accidentally earlier.
I fixed the issue once again.

Fix #1794 
Add statements
- Checking if a base theme is built in
- If the theme is built in theme, load it.
