### PR TITLE
sidebar text overflow

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -52,6 +52,7 @@ div.sphinxsidebar {
     width: {{ theme_sidebarwidth|toint }}px;
     margin-left: -100%;
     font-size: 90%;
+    word-wrap: break-word;
 }
 
 div.sphinxsidebar ul {


### PR DESCRIPTION
Fix for text overflow in the sidebar
Breaking words should be the default behavior i guess..

example of the issue:
![wrap](https://cloud.githubusercontent.com/assets/7109776/6801833/8c76b608-d22b-11e4-9907-88017fecfd12.png)
