### PR TITLE
Fix: #1815 Emit warns and use quiet setting to suppress info

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -237,11 +237,11 @@ class CheckExternalLinksBuilder(Builder):
         elif status == 'working':
             self.info(darkgreen('ok        ')  + uri + info)
         elif status == 'broken':
-            self.info(red('broken    ') + uri + red(' - ' + info))
+            if not self.app.quiet:
+                self.info(red('broken    ') + uri + red(' - ' + info))
             self.write_entry('broken', docname, lineno, uri + ': ' + info)
-            if self.app.quiet:
-                self.warn('broken link: %s' % uri,
-                          '%s:%s' % (self.env.doc2path(docname), lineno))
+            self.warn('broken link: %s' % uri,
+                      '%s:%s' % (self.env.doc2path(docname), lineno))
         elif status == 'redirected':
             text, color = {
                 301: ('permanently', darkred),

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -262,9 +262,9 @@ Results of doctest builder run on %s
         self.outfile.write(text)
 
     def _warn_out(self, text):
-        self.info(text, nonl=True)
-        if self.app.quiet:
-            self.warn(text)
+        if not self.app.quiet:
+            self.info(text, nonl=True)
+        self.warn(text)
         if isinstance(text, binary_type):
             text = force_decode(text, None)
         self.outfile.write(text)


### PR DESCRIPTION
Call warn function instead of info when a warning event occurs and
use the app.quiet flag to only call the info function when there is
additional data that can be disabled and the user has not requested it
be suppressed.

Since the Application object warn() method called by the Builder objects
decides whether to simply log the warning or raise an exception if the
user has enabled 'warniserror', it's necessary to ensure any warning
events always use the warn() method.

This inverts the current logic of always calling info() for warnings
and only calling warn() if the `app.quiet` flag is true and removes an
unnecessary info call where it is outputting identical information to
the corresponding call to warn().
