### PR TITLE
Fix #1793: Add new line before first item of list

### DIFF
--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -711,6 +711,9 @@ class TextTranslator(nodes.NodeVisitor):
     def _visit_admonition(self, node):
         self.new_state(2)
 
+        if isinstance(node.children[0], nodes.Sequential):
+            self.add_text(self.nl)
+
     def _make_depart_admonition(name):
         def depart_admonition(self, node):
             self.end_state(first=admonitionlabels[name] + ': ')

--- a/tests/roots/test-build-text/listitems.txt
+++ b/tests/roots/test-build-text/listitems.txt
@@ -1,0 +1,4 @@
+.. seealso::
+
+    * item 1
+    * item 2

--- a/tests/test_build_text.py
+++ b/tests/test_build_text.py
@@ -99,3 +99,15 @@ def test_table_with_empty_cell(app, status, warning):
     assert lines[4] == "+-------+-------+"
     assert lines[5] == "| XXX   |       |"
     assert lines[6] == "+-------+-------+"
+
+
+@with_text_app()
+def test_list_items_in_admonition(app, status, warning):
+    app.builder.build_update()
+    result = (app.outdir / 'listitems.txt').text(encoding='utf-8')
+    lines = [line.rstrip() for line in result.splitlines()]
+    assert lines[0] == "See also:"
+    assert lines[1] == ""
+    assert lines[2] == "  * item 1"
+    assert lines[3] == ""
+    assert lines[4] == "  * item 2"


### PR DESCRIPTION
Add new line before first item of a `Sequential` in `admonition`.
