### PR TITLE
fix #1822 regression from 1.3b3

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -276,8 +276,6 @@ class Autosummary(Directive):
                 self.warn('failed to import object %s' % real_name)
                 items.append((display_name, '', '', real_name))
                 continue
-            if not documenter.check_module():
-                continue
 
             # try to also get a source code analyzer for attribute docs
             try:


### PR DESCRIPTION
it reverts part of 21b8384 that was a backward-incompatible attempt to fix #1061. 
Maybe this issue should be solved by using a backward-compatible :imported: flag as suggested by  @shimizukawa, see #1822 for details
