### PR TITLE
Email addresses should not be showed again if latex_show_urls is not None

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1403,9 +1403,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('\\href{%s}{' % self.encode_uri(uri))
             # if configured, put the URL after the link
             show_urls = self.builder.config.latex_show_urls
+            if uri.startswith('mailto:'):
+                uri = uri[7:]
             if node.astext() != uri and show_urls and show_urls != 'no':
-                if uri.startswith('mailto:'):
-                    uri = uri[7:]
                 if show_urls == 'footnote' and not \
                    (self.in_footnote or self.in_caption):
                     # obviously, footnotes in footnotes are not going to work

--- a/tests/root/conf.py
+++ b/tests/root/conf.py
@@ -51,6 +51,7 @@ latex_documents = [
      'Georg Brandl \\and someone else', 'manual'),
 ]
 
+latex_show_urls = 'footnote'
 latex_additional_files = ['svgimg.svg']
 
 texinfo_documents = [

--- a/tests/root/footnote.txt
+++ b/tests/root/footnote.txt
@@ -35,6 +35,18 @@ footnotes in table
     * - VIDIOC_CROPCAP
       - Information about VIDIOC_CROPCAP
 
+URLs as footnotes
+-----------------
+
+`homepage <http://sphinx.org>`_
+
+URLs should not be footnotes
+----------------------------
+
+GitHub Page: `https://github.com/sphinx-doc/sphinx <https://github.com/sphinx-doc/sphinx>`_
+
+Mailing list: `sphinx-dev@googlegroups.com <mailto:sphinx-dev@googlegroups.com>`_
+
 footenotes
 --------------------
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -318,6 +318,9 @@ def test_footnote(app, status, warning):
     assert ('\\end{threeparttable}\n\n'
             '\\footnotetext[4]{\nfootnotes in table caption\n}'
             '\\footnotetext[5]{\nfootnotes in table\n}' in result)
+    assert r'\href{http://sphinx.org}{homepage}\footnote{http://sphinx.org}' in result
+    assert r'\footnote{https://github.com/sphinx-doc/sphinx}' not in result
+    assert r'\footnote{sphinx-dev@googlegroups.com}' not in result
 
 
 @with_app(buildername='latex', testroot='references-in-caption')


### PR DESCRIPTION
The latex output shows email addresses even the external links itself is an email address. For example, I have an email address `me@example.com`, then the latex output would show it as `me@example.com (me@example.com)`. This commit fixes this issue by removing the "mailto:" prefix before comparing the text and uri.

---

However, I don't know which test file I should add a test for this case. Can anyone help me out with it? Thanks!
