### PR TITLE
writers/manpage: no implicit bold in definition list terms

### DIFF
--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -168,6 +168,10 @@ class ManualPageTranslator(BaseTranslator):
     def depart_versionmodified(self, node):
         self.depart_paragraph(node)
 
+    # overwritten -- remove implicit bold
+    def visit_term(self, node):
+        self.body.append("\n")
+
     def visit_termsep(self, node):
         self.body.append(', ')
         raise nodes.SkipNode


### PR DESCRIPTION
This patch resolves #1498. Please, can you review the changes?

The original `visit_term` method in docutils manpage writer emits the `\n.B` string. The `.B` is a troff macro enabling bold face. With this change, the macro is removed.
