### PR TITLE
Indent quickstart toctree by four spaces

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -447,7 +447,7 @@ Welcome to %(project)s's documentation!
 Contents:
 
 .. toctree::
-   :maxdepth: %(mastertocmaxdepth)s
+    :maxdepth: %(mastertocmaxdepth)s
 
 %(mastertoctree)s
 


### PR DESCRIPTION
Most editors default to four space tabs so when someone quickstarts a Sphinx project and begins editing their toctree, they will likely see an error like this:

```
index.rst:15: WARNING: toctree contains reference to nonexisting document u' installation.rst'
```

Did you notice the space? Neither did I at first! It's easy to miss so this error is confusing.

I know it's a small change but I think this will help a lot of people.
