### PR TITLE
Add suffix to doc context. Fixes #1873.

### DIFF
--- a/doc/templating.rst
+++ b/doc/templating.rst
@@ -399,3 +399,8 @@ are in HTML form), these variables are also available:
 
    * ``includehidden`` (``False`` by default): if true, the TOC tree will also
      contain hidden entries.
+
+.. data:: page_source_suffix
+
+   The suffix of the file that was rendered. Since we support a list of :confval:`source_suffix`,
+   this will allow you to properly link to the original source file.

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -408,6 +408,9 @@ class StandaloneHTMLBuilder(Builder):
         # metadata for the document
         meta = self.env.metadata.get(docname)
 
+        # Suffix for the document
+        source_suffix = '.' + self.env.doc2path(docname).split('.')[-1]
+
         # local TOC and global TOC tree
         self_toc = self.env.get_toc_for(docname, self)
         toc = self.render_partial(self_toc)['fragment']
@@ -425,6 +428,7 @@ class StandaloneHTMLBuilder(Builder):
             toc = toc,
             # only display a TOC if there's more than one item to show
             display_toc = (self.env.toc_num_entries[docname] > 1),
+            page_source_suffix = source_suffix,
         )
 
     def write_doc(self, docname, doctree):


### PR DESCRIPTION
Not sure the best way to get the suffix from the docname, but this seems to work well. Happy to clean this up if there's a better way to do it.

Refs https://github.com/sphinx-doc/sphinx/issues/1873
