### PR TITLE
Keeping original signatures for functions/methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,28 +1,15 @@
-=================
-README for Sphinx
-=================
 
-This is the Sphinx documentation generator, see http://sphinx-doc.org/.
+This is the fork of Sphinx documentation generator, see http://sphinx-doc.org/.
+In this version implemented proposal from https://github.com/sphinx-doc/issues/759.
+
 
 
 Installing
 ==========
 
-Install from PyPI to use stable version::
-
-   pip install -U sphinx
-
-Install from PyPI to use beta version::
-
-   pip install -U --pre sphinx
-
-Install from newest dev version in stable branch::
-
-   pip install git+https://github.com/sphinx-doc/sphinx@stable
-
 Install from newest dev version in master branch::
 
-   pip install git+https://github.com/sphinx-doc/sphinx
+   pip install git+https://github.com/hypnocat/sphinx
 
 Install from cloned source::
 
@@ -38,6 +25,8 @@ Reading the docs
 
 After installing::
 
+
+   echo "autodoc_dumb_docstring=True" >> conf.py   
    cd doc
    make html
 
@@ -46,36 +35,3 @@ Then, direct your browser to ``_build/html/index.html``.
 Or read them online at <http://sphinx-doc.org/>.
 
 
-Testing
-=======
-
-To run the tests with the interpreter available as ``python``, use::
-
-    make test
-
-If you want to use a different interpreter, e.g. ``python3``, use::
-
-    PYTHON=python3 make test
-
-Continuous testing runs on travis:
-
-.. image:: https://travis-ci.org/sphinx-doc/sphinx.svg?branch=master
-   :target: https://travis-ci.org/sphinx-doc/sphinx
-
-
-Contributing
-============
-
-#. Check for open issues or open a fresh issue to start a discussion around a
-   feature idea or a bug.
-#. If you feel uncomfortable or uncertain about an issue or your changes, feel
-   free to email sphinx-dev@googlegroups.com.
-#. Fork the repository on GitHub https://github.com/sphinx-doc/sphinx
-   to start making your changes to the **master** branch for next major
-   version, or **stable** branch for next minor version.
-#. Write a test which shows that the bug was fixed or that the feature works
-   as expected.  Use ``make test`` to run the test suite.
-#. Send a pull request and bug the maintainer until it gets merged and
-   published.  Make sure to add yourself to AUTHORS
-   <https://github.com/sphinx-doc/sphinx/blob/master/AUTHORS> and the change to
-   CHANGES <https://github.com/sphinx-doc/sphinx/blob/master/CHANGES>.

--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -30,7 +30,7 @@ from sphinx.application import ExtensionError
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.compat import Directive
 from sphinx.util.inspect import getargspec, isdescriptor, safe_getmembers, \
-    safe_getattr, object_description, is_builtin_class_method
+    safe_getattr, object_description, is_builtin_class_method, dumb_signature
 from sphinx.util.docstrings import prepare_docstring
 
 
@@ -1064,6 +1064,8 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):
         args = formatargspec(*argspec)
         # escape backslashes for reST
         args = args.replace('\\', '\\\\')
+        if self.env.config.autodoc_dumb_docstring:
+            args = dumb_signature(self.object)
         return args
 
     def document_members(self, all_members=False):
@@ -1116,7 +1118,11 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):
             return None
         if argspec[0] and argspec[0][0] in ('cls', 'self'):
             del argspec[0][0]
-        return formatargspec(*argspec)
+
+        if self.env.config.autodoc_dumb_docstring:
+            return dumb_signature(initmeth)
+        else:
+            return formatargspec(*argspec)
 
     def format_signature(self):
         if self.doc_as_attr:
@@ -1286,6 +1292,8 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):
         args = formatargspec(*argspec)
         # escape backslashes for reST
         args = args.replace('\\', '\\\\')
+        if self.env.config.autodoc_dumb_docstring:
+            args = dumb_signature(self.object)
         return args
 
     def document_members(self, all_members=False):
@@ -1520,6 +1528,7 @@ def setup(app):
     app.add_config_value('autodoc_member_order', 'alphabetic', True)
     app.add_config_value('autodoc_default_flags', [], True)
     app.add_config_value('autodoc_docstring_signature', True, True)
+    app.add_config_value('autodoc_dumb_docstring', False, True)
     app.add_config_value('autodoc_mock_imports', [], True)
     app.add_event('autodoc-process-docstring')
     app.add_event('autodoc-process-signature')

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -161,13 +161,23 @@ def is_builtin_class_method(obj, attr_name):
 
 
 def dumb_signature(functional_object):
-    src = inspect.getsourcelines(functional_object)
-    for l in src[0]:
+    src = inspect.getsourcelines(functional_object)[0]
+
+    for i, l in enumerate(src):
         if 'def' in l:
-            src = l
             break
+    acc = ''
+    for l in src[i:]:
+        acc += l.strip()
+        if '):' in acc:
+            break
+
     r = re.compile(r'\((.*)\)')
-    s = r.findall(src)[0]
+    s = r.findall(acc)
+    if not s:
+        return '()'
+    s = s[0]
     for d in [r'^self,', r'^self', r'^cls,', r'^cls']:
-        s = re.sub(d,'',s)
+        s = re.sub(d, '', s)
+        s = s.strip()
     return '(' + s + ')'

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -158,3 +158,16 @@ def is_builtin_class_method(obj, attr_name):
     if not hasattr(builtins, safe_getattr(cls, '__name__', '')):
         return False
     return getattr(builtins, safe_getattr(cls, '__name__', '')) is cls
+
+
+def dumb_signature(functional_object):
+    src = inspect.getsourcelines(functional_object)
+    for l in src[0]:
+        if 'def' in l:
+            src = l
+            break
+    r = re.compile(r'\((.*)\)')
+    s = r.findall(src)[0]
+    for d in [r'^self,', r'^self', r'^cls,', r'^cls']:
+        s = re.sub(d,'',s)
+    return '(' + s + ')'


### PR DESCRIPTION
Implements https://github.com/sphinx-doc/sphinx/issues/759
Mentioned in https://github.com/sphinx-doc/sphinx/issues/1859

Sometimes users need _exact_ signatures, and do not want to
[override function declaration in autodoc for sphinx](http://stackoverflow.com/questions/12082570/override-function-declaration-in-autodoc-for-sphinx)
This PR is first attempt to implement this feature.
