### PR TITLE
FIX : fix syntax error in python 3.5

### DIFF
--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -164,7 +164,7 @@ class PygmentsBridge(object):
                 lexer = lexers[lang]
             else:
                 try:
-                    lexer = lexers[lang] = get_lexer_by_name(lang, **opts or {})
+                    lexer = lexers[lang] = get_lexer_by_name(lang, **(opts or {}))
                 except ClassNotFound:
                     if warn:
                         warn('Pygments lexer name %r is not known' % lang)


### PR DESCRIPTION
Be explicit about grouping between `**` in call and the `or` expression.

matplotlib has started running tests against python 3.5 nightly builds and we are seeing test failures with the exception

```
Exception occurred:
  File "/home/travis/virtualenv/python3.5-dev/lib/python3.5/site-packages/sphinx/builders/html.py", line 40, in <module>
    from sphinx.highlighting import PygmentsBridge
  File "/home/travis/virtualenv/python3.5-dev/lib/python3.5/site-packages/sphinx/highlighting.py", line 167
    lexer = lexers[lang] = get_lexer_by_name(lang, **opts or {})
                                                           ^
SyntaxError: invalid syntax
The full traceback has been saved in /tmp/sphinx-err-5svuzooo.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!

```

See https://s3.amazonaws.com/archive.travis-ci.org/jobs/61716973/log.txt for the full example.

This is not tested in 3.5 yet, but works as expected on 3.4 with the addition of the `()`.  If I get time tomorrow I am going to patch the sphinx installation on travis to make sure it fixes it.

I could find no mention of this syntax change for 3.5, I am unclear if I am failing to find the documentation, this is an intended change which is not documented, or if this is really a bug in python.
