### PR TITLE
FIX: Only check if members is True

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -276,7 +276,7 @@ class Autosummary(Directive):
                 self.warn('failed to import object %s' % real_name)
                 items.append((display_name, '', '', real_name))
                 continue
-            if not documenter.check_module():
+            if documenter.options.members and not documenter.check_module():
                 continue
 
             # try to also get a source code analyzer for attribute docs


### PR DESCRIPTION
Closes #1891.
Closes #1822.

`check_module` should only be called if `members` is currently activated, otherwise formely working use cases like those in #1891 are broken. This is also consistent with the docs:

> In an automodule directive with the members option set, only module members whose **module** attribute is equal to the module name as given to automodule will be documented. This is to prevent documentation of imported classes or functions. Set the imported-members option if you want to prevent this behavior and document all available members. Note that attributes from imported modules will not be documented, because attribute documentation is discovered by parsing the source file of the current module.

Ready for review/merge from my end.
