### PR TITLE
FIX: Ensure list is sent to OptParse

### DIFF
--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -125,7 +125,7 @@ def main(argv):
 
     # parse options
     try:
-        opts, args = parser.parse_args(argv[1:])
+        opts, args = parser.parse_args(list(argv[1:]))
     except SystemExit as err:
         return err.code
 


### PR DESCRIPTION
`argv` can be a tuple at this point, which can cause `optparse` to crap out with a strange error:

```
  File "/home/larsoner/custombuilds/sphinx/sphinx/__init__.py", line 51, in main
    sys.exit(build_main(argv))
  File "/home/larsoner/custombuilds/sphinx/sphinx/__init__.py", line 92, in build_main
    return cmdline.main(argv)
  File "/home/larsoner/custombuilds/sphinx/sphinx/cmdline.py", line 128, in main
    opts, args = parser.parse_args(argv[1:])
  File "/usr/lib/python2.7/optparse.py", line 1400, in parse_args
    stop = self._process_args(largs, rargs, values)
  File "/usr/lib/python2.7/optparse.py", line 1444, in _process_args
    self._process_short_opts(rargs, values)
  File "/usr/lib/python2.7/optparse.py", line 1518, in _process_short_opts
    arg = rargs.pop(0)
```

This PR ensures optparse gets the list it wants.
