### PR TITLE
Fix UnicodeDecodeError in devhelp

### DIFF
--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -91,7 +91,7 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
                     write_toc(subnode, item)
             elif isinstance(node, nodes.reference):
                 parent.attrib['link'] = node['refuri']
-                parent.attrib['name'] = node.astext().encode('utf-8')
+                parent.attrib['name'] = node.astext()
 
         def istoctree(node):
             return isinstance(node, addnodes.compact_paragraph) and \


### PR DESCRIPTION
For some reason reference name was encoded to utf-8, which failed upon xml
serialization, which expect unicode strings in tree.

In my case it crashed on building documentation for Django-1.7.1
