### PR TITLE
Limit the scope of inheritance traversal for ext.inheritance_diagram

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Other co-maintainers:
 Other contributors, listed alphabetically, are:
 
 * Alastair Houghton -- Apple Help builder
+* Alexander Todorov -- inheritance_diagram tests and improvements
 * Andi Albrecht -- agogo theme
 * Jakob Lykke Andersen -- Rewritten C++ domain
 * Henrique Bastos -- SVG support for graphviz extension

--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,7 @@ Bugs fixed
 
 Testing
 --------
+* Add tests for the ``sphinx.ext.inheritance_diagram`` extension.
 
 Release 1.6.3 (in development)
 ==============================

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Features added
 * C++, add a ``cpp:expr`` role for inserting inline C++ expressions or types.
 * #3638: Allow to change a label of reference to equation using
   ``math_eqref_format``
+* Add ``top-classes`` option for the ``sphinx.ext.inheritance_diagram``
+  extension to limit the scope of inheritance graphs.
 
 Features removed
 ----------------
@@ -52,7 +54,9 @@ Bugs fixed
 
 Testing
 --------
+
 * Add tests for the ``sphinx.ext.inheritance_diagram`` extension.
+
 
 Release 1.6.3 (in development)
 ==============================

--- a/doc/ext/inheritance.rst
+++ b/doc/ext/inheritance.rst
@@ -42,6 +42,58 @@ It adds this directive:
    .. versionchanged:: 1.5
       Added ``caption`` option
 
+   It also supports a ``top-classes`` option which requires one or more class
+   names separated by comma. If specified inheritance traversal will stop at the
+   specified class names. Given the following Python module::
+
+        """
+               A
+              / \
+             B   C
+            / \ / \
+           E   D   F
+        """
+
+        class A(object):
+            pass
+
+        class B(A):
+            pass
+
+        class C(A):
+            pass
+
+        class D(B, C):
+            pass
+
+        class E(B):
+            pass
+
+        class F(C):
+            pass
+
+   If you have specified a module in the inheritance diagram like this::
+
+        .. inheritance-diagram::
+            dummy.test
+            :top-classes: dummy.test.B, dummy.test.C
+
+   any base classes which are ancestors to ``top-classes`` and are also defined
+   in the same module will be rendered as stand alone nodes. In this example
+   class A will be rendered as stand alone node in the graph. This is a known
+   issue due to how this extension works internally.
+
+   If you don't want class A (or any other ancestors) to be visible then specify
+   only the classes you would like to generate the diagram for like this::
+
+        .. inheritance-diagram::
+            dummy.test.D
+            dummy.test.E
+            dummy.test.F
+            :top-classes: dummy.test.B, dummy.test.C
+
+   .. versionchanged:: 1.7
+      Added ``top-classes`` option to limit the scope of inheritance graphs.
 
 New config values are:
 

--- a/tests/roots/test-inheritance/basic_diagram.rst
+++ b/tests/roots/test-inheritance/basic_diagram.rst
@@ -1,0 +1,5 @@
+Basic Diagram
+==============
+
+.. inheritance-diagram::
+    dummy.test

--- a/tests/roots/test-inheritance/conf.py
+++ b/tests/roots/test-inheritance/conf.py
@@ -1,0 +1,6 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.inheritance_diagram']
+source_suffix = '.rst'

--- a/tests/roots/test-inheritance/contents.rst
+++ b/tests/roots/test-inheritance/contents.rst
@@ -1,0 +1,4 @@
+.. toctree::
+    :glob:
+
+    *

--- a/tests/roots/test-inheritance/diagram_module_w_2_top_classes.rst
+++ b/tests/roots/test-inheritance/diagram_module_w_2_top_classes.rst
@@ -1,0 +1,6 @@
+Diagram using module with 2 top classes
+=======================================
+
+.. inheritance-diagram::
+    dummy.test
+    :top-classes: dummy.test.B, dummy.test.C

--- a/tests/roots/test-inheritance/diagram_w_1_top_class.rst
+++ b/tests/roots/test-inheritance/diagram_w_1_top_class.rst
@@ -1,0 +1,7 @@
+Diagram using 1 top class
+=========================
+
+.. inheritance-diagram::
+    dummy.test
+    :top-classes: dummy.test.B
+

--- a/tests/roots/test-inheritance/diagram_w_2_top_classes.rst
+++ b/tests/roots/test-inheritance/diagram_w_2_top_classes.rst
@@ -1,0 +1,9 @@
+Diagram using 2 top classes
+===========================
+
+.. inheritance-diagram::
+    dummy.test.F
+    dummy.test.D
+    dummy.test.E
+    :top-classes: dummy.test.B, dummy.test.C
+

--- a/tests/roots/test-inheritance/diagram_w_parts.rst
+++ b/tests/roots/test-inheritance/diagram_w_parts.rst
@@ -1,0 +1,7 @@
+Diagram using the parts option
+==============================
+
+.. inheritance-diagram::
+    dummy.test
+    :parts: 1
+

--- a/tests/roots/test-inheritance/dummy/test.py
+++ b/tests/roots/test-inheritance/dummy/test.py
@@ -1,0 +1,30 @@
+"""
+
+    Test with a class diagram like this::
+
+           A
+          / \
+         B   C
+        / \ / \
+       E   D   F
+
+"""
+
+class A(object):
+    pass
+
+class B(A):
+    pass
+
+class C(A):
+    pass
+
+class D(B, C):
+    pass
+
+class E(B):
+    pass
+
+class F(C):
+    pass
+

--- a/tests/test_ext_inheritance.py
+++ b/tests/test_ext_inheritance.py
@@ -13,6 +13,7 @@ import os
 import pytest
 from sphinx.ext.inheritance_diagram import InheritanceDiagram
 
+
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
 @pytest.mark.usefixtures('if_graphviz_found')
 def test_inheritance_diagram(app, status, warning):
@@ -51,7 +52,8 @@ def test_inheritance_diagram(app, status, warning):
                         ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
                         ('dummy.test.C', 'dummy.test.C', ['dummy.test.A'], None),
                         ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
-                        ('dummy.test.D', 'dummy.test.D', ['dummy.test.B', 'dummy.test.C'], None),
+                        ('dummy.test.D', 'dummy.test.D',
+                            ['dummy.test.B', 'dummy.test.C'], None),
                         ('dummy.test.B', 'dummy.test.B', ['dummy.test.A'], None)
                     ]
 
@@ -64,4 +66,68 @@ def test_inheritance_diagram(app, status, warning):
                         ('E', 'dummy.test.E', ['B'], None),
                         ('D', 'dummy.test.D', ['B', 'C'], None),
                         ('B', 'dummy.test.B', ['A'], None)
+                    ]
+
+    # inheritance diagram with 1 top class
+    # :top-classes: dummy.test.B
+    # rendering should be
+    #       A
+    #        \
+    #     B   C
+    #    / \ / \
+    #   E   D   F
+    #
+    for cls in graphs['diagram_w_1_top_class'].class_info:
+        assert cls in [
+                        ('dummy.test.A', 'dummy.test.A', [], None),
+                        ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
+                        ('dummy.test.C', 'dummy.test.C', ['dummy.test.A'], None),
+                        ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
+                        ('dummy.test.D', 'dummy.test.D',
+                            ['dummy.test.B', 'dummy.test.C'], None),
+                        ('dummy.test.B', 'dummy.test.B', [], None)
+                    ]
+
+
+    # inheritance diagram with 2 top classes
+    # :top-classes: dummy.test.B, dummy.test.C
+    # Note: we're specifying separate classes, not the entire module here
+    # rendering should be
+    #
+    #     B   C
+    #    / \ / \
+    #   E   D   F
+    #
+    for cls in graphs['diagram_w_2_top_classes'].class_info:
+        assert cls in [
+                        ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
+                        ('dummy.test.C', 'dummy.test.C', [], None),
+                        ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
+                        ('dummy.test.D', 'dummy.test.D',
+                            ['dummy.test.B', 'dummy.test.C'], None),
+                        ('dummy.test.B', 'dummy.test.B', [], None)
+                    ]
+
+    # inheritance diagram with 2 top classes and specifiying the entire module
+    # rendering should be
+    #
+    #       A
+    #     B   C
+    #    / \ / \
+    #   E   D   F
+    #
+    # Note: dummy.test.A is included in the graph before its descendants are even processed
+    # b/c we've specified to load the entire module. The way InheritanceGraph works it is very
+    # hard to exclude parent classes once after they have been included in the graph.
+    # If you'd like to not show class A in the graph don't specify the entire module.
+    # this is a known issue.
+    for cls in graphs['diagram_module_w_2_top_classes'].class_info:
+        assert cls in [
+                        ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
+                        ('dummy.test.C', 'dummy.test.C', [], None),
+                        ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
+                        ('dummy.test.D', 'dummy.test.D',
+                            ['dummy.test.B', 'dummy.test.C'], None),
+                        ('dummy.test.B', 'dummy.test.B', [], None),
+                        ('dummy.test.A', 'dummy.test.A', [], None),
                     ]

--- a/tests/test_ext_inheritance.py
+++ b/tests/test_ext_inheritance.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+    test_inheritance
+    ~~~~~~~~~~~~~~~~
+
+    Tests for :mod:`sphinx.ext.inheritance_diagram` module.
+
+    :copyright: Copyright 2015 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import os
+import pytest
+from sphinx.ext.inheritance_diagram import InheritanceDiagram
+
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
+@pytest.mark.usefixtures('if_graphviz_found')
+def test_inheritance_diagram(app, status, warning):
+    # monkey-patch InheritaceDiagram.run() so we can get access to its
+    # results.
+    orig_run = InheritanceDiagram.run
+    graphs = {}
+
+    def new_run(self):
+        result = orig_run(self)
+        node = result[0]
+        source = os.path.basename(node.document.current_source).replace(".rst", "")
+        graphs[source] = node['graph']
+        return result
+
+    InheritanceDiagram.run = new_run
+
+    try:
+        app.builder.build_all()
+    finally:
+        InheritanceDiagram.run = orig_run
+
+    assert app.statuscode == 0
+
+    html_warnings = warning.getvalue()
+    assert html_warnings == ""
+
+    # note: it is better to split these asserts into separate test functions
+    # but I can't figure out how to build only a specific .rst file
+
+    # basic inheritance diagram showing all classes
+    for cls in graphs['basic_diagram'].class_info:
+        # use in b/c traversing order is different sometimes
+        assert cls in [
+                        ('dummy.test.A', 'dummy.test.A', [], None),
+                        ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
+                        ('dummy.test.C', 'dummy.test.C', ['dummy.test.A'], None),
+                        ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
+                        ('dummy.test.D', 'dummy.test.D', ['dummy.test.B', 'dummy.test.C'], None),
+                        ('dummy.test.B', 'dummy.test.B', ['dummy.test.A'], None)
+                    ]
+
+    # inheritance diagram using :parts: 1 option
+    for cls in graphs['diagram_w_parts'].class_info:
+        assert cls in [
+                        ('A', 'dummy.test.A', [], None),
+                        ('F', 'dummy.test.F', ['C'], None),
+                        ('C', 'dummy.test.C', ['A'], None),
+                        ('E', 'dummy.test.E', ['B'], None),
+                        ('D', 'dummy.test.D', ['B', 'C'], None),
+                        ('B', 'dummy.test.B', ['A'], None)
+                    ]


### PR DESCRIPTION
Hi guys,
I am generating inheritance diagrams in my documentation and they tend to result in fairly large images which are hard to read on screen b/c the ancestry tree is rather big. This new option gives me the ability to stop processing the inheritance tree after I reach particular classes. Anything above them will not be included in the graph.

I've split this PR in two commits:
1) Adds test cases for the inheritance_diagram extension because they were missing 
2) Adds my new functionality along with tests and documentation updates

There is 1 known issue due to how inheritance_diagram works (see the docs) but I think it's OK. Let me know how would you want to proceed with this PR.
