### PR TITLE
Use xcolor over color for \fcolorbox where available for LaTeX output

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -18,7 +18,13 @@
 \RequirePackage{makeidx}
 \RequirePackage{framed}
 \RequirePackage{ifthen}
-\RequirePackage{color}
+%The xcolor package draws better fcolorboxes
+%around verbatim code
+\IfFileExists{xcolor.sty}{
+    \RequirePackage[xcdraw]{xcolor}
+}{
+    \RequirePackage{color}
+}
 % For highlighted code.
 \RequirePackage{fancyvrb}
 % For table captions.


### PR DESCRIPTION
The boxes drawn around verbatim code when outputting to LaTeX (using \fcolorbox) with the color package seem to display poorly on-screen (with some sides missing) in some PDF readers (e.g. Adobe Reader). Boxes drawn with xcolor display much better, hence the xcolor package will be used if available.

It seems that xcolor is pretty ubiquitous these days, but to avoid breaking any compatibility this patch will fall back to using color if xcolor is not available.

Here is a before and after with pdfTeX from MikTeX 2.9:
![colors](https://cloud.githubusercontent.com/assets/10561746/7843281/92b890ac-04a0-11e5-8200-c7e11b8b05c8.PNG)
![xcolors](https://cloud.githubusercontent.com/assets/10561746/7843282/92bddaee-04a0-11e5-8261-003a4f74f965.PNG)
