### PR TITLE
Make sure extensions specified with -D override extensions in config …

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -114,11 +114,6 @@ class Config(object):
         self.overrides = overrides
         self.values = Config.config_values.copy()
         config = {}
-        if 'extensions' in overrides:  # XXX do we need this?
-            if isinstance(overrides['extensions'], string_types):
-                config['extensions'] = overrides.pop('extensions').split(',')
-            else:
-                config['extensions'] = overrides.pop('extensions')
         if dirname is not None:
             config_file = path.join(dirname, filename)
             config['__file__'] = config_file
@@ -137,6 +132,12 @@ class Config(object):
         # these two must be preinitialized because extensions can add their
         # own config values
         self.setup = config.get('setup', None)
+
+        if 'extensions' in overrides:
+            if isinstance(overrides['extensions'], string_types):
+                config['extensions'] = overrides.pop('extensions').split(',')
+            else:
+                config['extensions'] = overrides.pop('extensions')
         self.extensions = config.get('extensions', [])
 
         # correct values of copyright year that are not coherent with


### PR DESCRIPTION
…file.

Previously, a comma separated list of extensions was read and parsed
correctly. However, the value was then stored in config hashtable,
which was overwritten when the config file was parsed.

Now, the config file is parsed first, and the the entry in the config
hashtable is updated with the overriding extension, if it exists.

Signed-off-by: mulhern amulhern@redhat.com
