### PR TITLE
allow apidoc using 'python -m sphinx.apidoc'

### DIFF
--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -373,3 +373,7 @@ Note: By default this script will not overwrite already created files.""")
             qs.generate(d, silent=True, overwrite=opts.force)
     elif not opts.notoc:
         create_modules_toc_file(modules, opts)
+
+# So program can be started with "python -m sphinx.apidoc ..."
+if __name__ == "__main__":
+    main()

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -2424,7 +2424,7 @@ class CPPObject(ObjectDescription):
         if len(ast.prefixedName.names) == 1:
             # TODO: we could warn, but it is somewhat equivalent to unscoped
             # enums, without the enum
-            return # no parent
+            return  # no parent
         parentPrefixedAstName = ASTNestedName(ast.prefixedName.names[:-1])
         parentPrefixedName = text_type(parentPrefixedAstName).lstrip(':')
         if parentPrefixedName not in objects:


### PR DESCRIPTION
When supporting multiple versions of python, it is useful to be able to call sphinx-apidoc using:

```
$PYTHON  -m sphinx.apidoc ...
```

or within a python script, using:

```
subprocess.call([sys.executable, "-m", "sphinx.apidoc", ...])
```

This picks up the version of sphinx associated with the current python environment, rather than having to guess the location of the correct sphinx-apidoc.py.

The patch just adds the **name** == "**main**" logic to the end of apidoc.py.
