### PR TITLE
Allow overriding 'numfig_format' for LaTeX output in latex_elements

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -248,12 +248,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     return '\\usepackage{%s}' % (packagename,)
             usepackages = (declare_package(*p) for p in builder.usepackages)
             self.elements['usepackages'] += "\n".join(usepackages)
+        self.elements['numfig_format'] = self.generate_numfig_format(builder)
         # allow the user to override them all
         self.elements.update(builder.config.latex_elements)
         if self.elements['extraclassoptions']:
             self.elements['classoptions'] += ',' + \
                                              self.elements['extraclassoptions']
-        self.elements['numfig_format'] = self.generate_numfig_format(builder)
 
         self.highlighter = highlighting.PygmentsBridge(
             'latex',


### PR DESCRIPTION
Currently, we can't get rid of such a blurb in the .tex output:

```
\addto\captionsenglish{\renewcommand{\figurename}{Fig. }}
\addto\captionsenglish{\renewcommand{\tablename}{Table }}
\floatname{literal-block}{Listing }
```

This is because `LaTeXWriter.elements['numfig_format']` is set too late in the writer configuration process. This pull request fixes that. I tried the patch against v1.3.1 (from pip); I don't expect any problems from this simple line swap so I didn't run extensive tests.

I didn't add an entry to CHANGES yet, because there is no section yet for the next release 1.3.3. Who can do this for me? :) I'd suggest the following entry:

```
* Make "numfig_format" overridable in latex_elements.
```
