### PR TITLE
Fix -D extensions=a,b

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -261,11 +261,6 @@ class Config(object):
         self.overrides = overrides
         self.values = Config.config_values.copy()
         config = {}
-        if 'extensions' in overrides:  # XXX do we need this?
-            if isinstance(overrides['extensions'], string_types):
-                config['extensions'] = overrides.pop('extensions').split(',')
-            else:
-                config['extensions'] = overrides.pop('extensions')
         if dirname is not None:
             config_file = path.join(dirname, filename)
             config['__file__'] = config_file
@@ -285,6 +280,12 @@ class Config(object):
         # own config values
         self.setup = config.get('setup', None)
         self.extensions = config.get('extensions', [])
+
+        if 'extensions' in overrides:
+            extensions = overrides.pop('extensions')
+            if isinstance(extensions, string_types):
+                extensions = extensions.split(',')
+            config['extensions'].extend(extensions)
 
     def check_types(self, warn):
         # check all values for deviation from the default value's type, since

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,13 +76,13 @@ def test_extensions_override(dir):
     assert cfg.extensions == ['a', 'b']
 
     cfg = Config(dir, 'conf.py', {'extensions': 'c'}, None)
-    assert cfg.extensions == ['a', 'b']
+    assert cfg.extensions == ['a', 'b', 'c']
 
     cfg = Config(dir, 'conf.py', {'extensions': 'c,d'}, None)
-    assert cfg.extensions == ['a', 'b']
+    assert cfg.extensions == ['a', 'b', 'c', 'd']
 
     cfg = Config(dir, 'conf.py', {'extensions': ['c', 'd']}, None)
-    assert cfg.extensions == ['a', 'b']
+    assert cfg.extensions == ['a', 'b', 'c', 'd']
 
 
 @with_app()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,24 @@ def test_core_config(app, status, warning):
     assert cfg['project'] == cfg.project == 'Sphinx Tests'
 
 
+@with_tempdir
+def test_extensions_override(dir):
+    # test the error for syntax errors in the config file
+    (dir / 'conf.py').write_text(u'extensions = ["a", "b"]\n', encoding='ascii')
+
+    cfg = Config(dir, 'conf.py', {}, None)
+    assert cfg.extensions == ['a', 'b']
+
+    cfg = Config(dir, 'conf.py', {'extensions': 'c'}, None)
+    assert cfg.extensions == ['a', 'b']
+
+    cfg = Config(dir, 'conf.py', {'extensions': 'c,d'}, None)
+    assert cfg.extensions == ['a', 'b']
+
+    cfg = Config(dir, 'conf.py', {'extensions': ['c', 'd']}, None)
+    assert cfg.extensions == ['a', 'b']
+
+
 @with_app()
 def test_extension_values(app, status, warning):
     cfg = app.config


### PR DESCRIPTION
Previously, supplying `-D extensions=myextension` would do nothing, despite special-case code for it in `sphinx.config`. My first commit here shows this.

My second commit changes the behavior to do something useful.
When given `-D extensions=myextension`, myextension will be appended to the extensions list.
I've preserved the old behavior of "a comma-delimited string is equivalent to a list".

For a use case, see https://github.com/scrooloose/syntastic/pull/1454.
Essentially we needed to add an extension (a custom builder) to projects' sphinx-build without editting their conf.py, for linting.
I think this is in line with the existing (albeit broken) code.
