### PR TITLE
Explicitly mention sphinx-users mailing list

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -27,7 +27,7 @@ are also available.{%endtrans%}</p>
 
 <h3>{%trans%}Questions? Suggestions?{%endtrans%}</h3>
 
-<p>{%trans%}Join the <a href="http://groups.google.com/group/sphinx-users">Google group</a>:{%endtrans%}</p>
+<p>{%trans%}Join the <a href="http://groups.google.com/group/sphinx-users">sphinx-users</a> mailing list on Google Groups:{%endtrans%}</p>
 <form action="http://groups.google.com/group/sphinx-users/boxsubscribe"
       style="padding-left: 0.5em">
   <input type="text" name="email" value="your@email" style="font-size: 90%; width: 120px"


### PR DESCRIPTION
This should now answer searches for "mailing list" and "sphinx-", in case users just skim the Web site.

I have checked this in a Web browser and it looks good IMO (box not overfull.)
