### PR TITLE
Add support for SOURCE_DATE_EPOCH environment variable

### DIFF
--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -12,7 +12,6 @@
 
 import os
 import re
-import time
 import codecs
 import zipfile
 from os import path
@@ -29,7 +28,7 @@ from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.util.osutil import ensuredir, copyfile, EEXIST
+from sphinx.util.osutil import ensuredir, copyfile, ustrftime, EEXIST
 from sphinx.util.smartypants import sphinx_smarty_pants as ssp
 from sphinx.util.console import brown
 
@@ -511,7 +510,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         metadata['copyright'] = self.esc(self.config.epub_copyright)
         metadata['scheme'] = self.esc(self.config.epub_scheme)
         metadata['id'] = self.esc(self.config.epub_identifier)
-        metadata['date'] = self.esc(time.strftime('%Y-%m-%d'))
+        metadata['date'] = self.esc(ustrftime('%Y-%m-%d'))
         metadata['files'] = files
         metadata['spine'] = spine
         metadata['guide'] = guide

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -151,15 +151,23 @@ no_fn_re = re.compile(r'[^a-zA-Z0-9_-]')
 def make_filename(string):
     return no_fn_re.sub('', string) or 'sphinx'
 
-if PY2:
+
+def ustrftime(format, *args):
     # strftime for unicode strings
-    def ustrftime(format, *args):
+    if not args:
+        # If time is not specified, try to use $SOURCE_DATE_EPOCH variable
+        # See https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal
+        source_date_epoch = os.getenv('SOURCE_DATE_EPOCH')
+        if source_date_epoch is not None:
+            time_struct = time.gmtime(float(source_date_epoch))
+            args = [time_struct]
+    if PY2:
         # if a locale is set, the time strings are encoded in the encoding
         # given by LC_TIME; if that is available, use it
         enc = locale.getlocale(locale.LC_TIME)[1] or 'utf-8'
         return time.strftime(text_type(format).encode(enc), *args).decode(enc)
-else:
-    ustrftime = time.strftime
+    else:
+        return time.strftime(format, *args)
 
 
 def safe_relpath(path, start=None):


### PR DESCRIPTION
In Debian, we use this variable to prevent build tools from inserting build timestamps into generated files, and use some deterministic date instead (i.e. date in the changelog).

Support for this variable has already been added to help2man, and submitted to doxygen, epydoc, gcc and txt2man projects.

See https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal for the full story.

I have added support for this to `ustrftime` function so that it applies to all places where we use the current time, i.e. handling of `|today|` and the Last Updated string.
