### PR TITLE
Closes #1968: Show extended type hints for function annotations that use 'typing' module

### DIFF
--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -976,7 +976,7 @@ def test_type_hints():
 
     try:
         from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8
-    except ImportError:
+    except (ImportError, SyntaxError):
         raise SkipTest('Cannot import Python code with function annotations')
 
     def verify_arg_spec(f, expected):

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -11,8 +11,7 @@
 """
 
 # "raises" imported for usage by autodoc
-from unittest import SkipTest
-from util import TestApp, Struct, raises
+from util import TestApp, Struct, raises, SkipTest
 from nose.tools import with_setup, eq_
 
 from six import StringIO
@@ -978,7 +977,7 @@ def test_type_hints():
     try:
         from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8
     except ImportError:
-        raise SkipTest
+        raise SkipTest('Cannot import Python code with function annotations')
 
     def verify_arg_spec(f, expected):
         eq_(formatargspec(f, *getargspec(f)), expected)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -11,8 +11,9 @@
 """
 
 # "raises" imported for usage by autodoc
+from unittest import SkipTest
 from util import TestApp, Struct, raises
-from nose.tools import with_setup
+from nose.tools import with_setup, eq_
 
 from six import StringIO
 from docutils.statemachine import ViewList
@@ -968,3 +969,46 @@ class InstAttCls(object):
 
         self.ia2 = 'e'
         """Docstring for instance attribute InstAttCls.ia2."""
+
+
+def test_type_hints():
+    from sphinx.ext.autodoc import formatargspec
+    from sphinx.util.inspect import getargspec
+
+    try:
+        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8
+    except ImportError:
+        raise SkipTest
+
+    def verify_arg_spec(f, expected):
+        eq_(formatargspec(f, *getargspec(f)), expected)
+
+    # Class annotations
+    verify_arg_spec(f0, '(x: int, y: numbers.Integral) -> None')
+
+    # Generic types with concrete parameters
+    verify_arg_spec(f1, '(x: typing.List[int]) -> typing.List[int]')
+
+    # TypeVars and generic types with TypeVars
+    verify_arg_spec(f2, '(x: typing.List[T],'
+                        ' y: typing.List[T_co],'
+                        ' z: T) -> typing.List[T_contra]')
+
+    # Union types
+    verify_arg_spec(f3, '(x: typing.Union[str, numbers.Integral]) -> None')
+
+    # Quoted annotations
+    verify_arg_spec(f4, '(x: str, y: str) -> None')
+
+    # Keyword-only arguments
+    verify_arg_spec(f5, '(x: int, *, y: str, z: str) -> None')
+
+    # Space around '=' for defaults
+    verify_arg_spec(f6, '(x: int = None, y: dict = {}) -> None')
+
+    # Callable types
+    verify_arg_spec(f7, '(x: typing.Callable[[int, str], int]) -> None')
+
+    # Tuple types
+    verify_arg_spec(f8, '(x: typing.Tuple[int, str],'
+                        ' y: typing.Tuple[int, ...]) -> None')

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -1,0 +1,48 @@
+from typing import List, TypeVar, Union, Callable, Tuple
+
+from numbers import Integral
+
+
+def f0(x: int, y: Integral) -> None:
+    pass
+
+
+def f1(x: List[int]) -> List[int]:
+    pass
+
+
+T = TypeVar('T')
+T_co = TypeVar('T_co', covariant=True)
+T_contra = TypeVar('T_contra', contravariant=True)
+
+
+def f2(x: List[T], y: List[T_co], z: T) -> List[T_contra]:
+    pass
+
+
+def f3(x: Union[str, Integral]) -> None:
+    pass
+
+
+MyStr = str
+
+
+def f4(x: 'MyStr', y: MyStr) -> None:
+    pass
+
+
+def f5(x: int, *, y: str, z: str) -> None:
+    pass
+
+
+def f6(x: int = None, y: dict = {}) -> None:
+    pass
+
+
+def f7(x: Callable[[int, str], int]) -> None:
+    # See https://github.com/ambv/typehinting/issues/149 for Callable[..., int]
+    pass
+
+
+def f8(x: Tuple[int, str], y: Tuple[int, ...]) -> None:
+    pass


### PR DESCRIPTION
The results of the EuroPython 2015 sprint. See #1968.
