### PR TITLE
Fix 1792: Make custom theme directories absolute paths

### DIFF
--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -24,6 +24,7 @@ except ImportError:
     pkg_resources = False
 
 from sphinx import package_dir
+from sphinx.util.osutil import abspath
 from sphinx.errors import ThemeError
 
 import alabaster
@@ -42,7 +43,7 @@ class Theme(object):
     @classmethod
     def init_themes(cls, confdir, theme_path, warn=None):
         """Search all theme paths for available themes."""
-        cls.themepath = list(theme_path)
+        cls.themepath = [abspath(path.join(confdir, x)) for x in theme_path]
         cls.themepath.append(path.join(package_dir, 'themes'))
 
         for themedir in cls.themepath[::-1]:


### PR DESCRIPTION
This change allows to use a relative path such as `../../_templates` for `html_theme_path` in `conf.py`
