### PR TITLE
Fall back to node's astext() during i18n message extraction.

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -121,6 +121,8 @@ def extract_messages(doctree):
                 msg += '\n   :alt: %s' % node['alt']
         else:
             msg = node.rawsource.replace('\n', ' ').strip()
+            if not msg:
+                msg = node.astext()
 
         # XXX nodes rendering empty are likely a bug in sphinx.addnodes
         if msg:


### PR DESCRIPTION
Using recommonmark/Markdown support,
I was unable to use the existing i18n tooling because it is depending on `rawsource`.
This makes it fall back to using astext() for nodes without a `rawsource`.

This makes it so I am able to translate messages with the i18n support with Commonmark.
