### PR TITLE
Rendering the toctree in html does not use fix_refuris

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -721,8 +721,11 @@ class StandaloneHTMLBuilder(Builder):
     def _get_local_toctree(self, docname, collapse=True, **kwds):
         if 'includehidden' not in kwds:
             kwds['includehidden'] = False
-        return self.render_partial(self.env.get_toctree_for(
-            docname, self, collapse, **kwds))['fragment']
+            
+        toc = self.env.get_toctree_for(
+            docname, self, collapse, **kwds)
+        self.fix_refuris(toc)    
+        return self.render_partial(toc)['fragment']
 
     def get_outfilename(self, pagename):
         return path.join(self.outdir, os_path(pagename) + self.out_suffix)


### PR DESCRIPTION
When generating HTML with a theme that just uses  {{ toctree }}  The output html has invalid links:
eg:  
{% set toctree = toctree(maxdepth=2, collapse=False, includehidden=True) %}
{% if toctree %}
      {{ toctree }}
 {% endif %}

Produces these links

<a href="index.html#document-xyz#somewhere">

When using the local TOC  the fix_refuris is called for the links to fix these.

I think fix_refuris should be uses too when rendering the 'global' toctree.
