### PR TITLE
Make files generation at install deterministic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ else:
                         messages=jscatalog,
                         plural_expr=catalog.plural_expr,
                         locale=str(catalog.locale)
-                    ), outfile)
+                    ), outfile, sort_keys=True)
                     outfile.write(');')
                 finally:
                     outfile.close()

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -837,7 +837,7 @@ class StandaloneHTMLBuilder(Builder):
                      u'# The remainder of this file is compressed using zlib.\n'
                      % (self.config.project, self.config.version)).encode('utf-8'))
             compressor = zlib.compressobj(9)
-            for domainname, domain in iteritems(self.env.domains):
+            for domainname, domain in sorted(self.env.domains.items()):
                 for name, dispname, type, docname, anchor, prio in \
                         sorted(domain.get_objects()):
                     if anchor.endswith(name):

--- a/sphinx/pycode/pgen2/pgen.py
+++ b/sphinx/pycode/pgen2/pgen.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 from six import iteritems
+from collections import OrderedDict
 
 # Pgen imports
 
@@ -57,7 +58,7 @@ class ParserGenerator(object):
     def make_first(self, c, name):
         rawfirst = self.first[name]
         first = {}
-        for label in rawfirst:
+        for label in sorted(rawfirst):
             ilabel = self.make_label(c, label)
             ##assert ilabel not in first # X X X failed on <> ... !=
             first[ilabel] = 1
@@ -138,8 +139,8 @@ class ParserGenerator(object):
                 totalset[label] = 1
                 overlapcheck[label] = {label: 1}
         inverse = {}
-        for label, itsfirst in iteritems(overlapcheck):
-            for symbol in itsfirst:
+        for label, itsfirst in sorted(overlapcheck.items()):
+            for symbol in sorted(itsfirst):
                 if symbol in inverse:
                     raise ValueError("rule %s is ambiguous; %s is in the"
                                      " first sets of %s as well as %s" %
@@ -349,6 +350,9 @@ class NFAState(object):
         assert isinstance(next, NFAState)
         self.arcs.append((label, next))
 
+    def __hash__(self):
+        return hash(tuple(x[0] for x in self.arcs))
+
 class DFAState(object):
 
     def __init__(self, nfaset, final):
@@ -357,7 +361,10 @@ class DFAState(object):
         assert isinstance(final, NFAState)
         self.nfaset = nfaset
         self.isfinal = final in nfaset
-        self.arcs = {} # map from label to DFAState
+        self.arcs = OrderedDict() # map from label to DFAState
+
+    def __hash__(self):
+        return hash(tuple(self.arcs))
 
     def addarc(self, next, label):
         assert isinstance(label, str)

--- a/sphinx/pycode/pgen2/pgen.py
+++ b/sphinx/pycode/pgen2/pgen.py
@@ -4,7 +4,10 @@
 from __future__ import print_function
 
 from six import iteritems
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError: # Fallback for Python 2.6
+    OrderedDict = dict
 
 # Pgen imports
 

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -275,9 +275,9 @@ class IndexBuilder(object):
         rv = {}
         otypes = self._objtypes
         onames = self._objnames
-        for domainname, domain in iteritems(self.env.domains):
+        for domainname, domain in sorted(iteritems(self.env.domains)):
             for fullname, dispname, type, docname, anchor, prio in \
-                    domain.get_objects():
+                    sorted(domain.get_objects()):
                 # XXX use dispname?
                 if docname not in fn2index:
                     continue


### PR DESCRIPTION
While working on the [“reproducible builds” effort](https://wiki.debian.org/ReproducibleBuilds), we have noticed that sphinx could not be built reproducibly.

This pull requests makes these installed files deterministic:
- automata (and their pickle dump), provided `PYTHONHASHSEED` is set and not equal to `random`.
- inventory
- Javascript translations

Once applied, sphinx (and software using sphinx) can be built reproducibly in our current experimental framework.
