### PR TITLE
Fix extensions overrides

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -261,11 +261,6 @@ class Config(object):
         self.overrides = overrides
         self.values = Config.config_values.copy()
         config = {}
-        if 'extensions' in overrides:  # XXX do we need this?
-            if isinstance(overrides['extensions'], string_types):
-                config['extensions'] = overrides.pop('extensions').split(',')
-            else:
-                config['extensions'] = overrides.pop('extensions')
         if dirname is not None:
             config_file = path.join(dirname, filename)
             config['__file__'] = config_file
@@ -279,7 +274,12 @@ class Config(object):
                     raise ConfigError(CONFIG_SYNTAX_ERROR % err)
                 except SystemExit:
                     raise ConfigError(CONFIG_EXIT_ERROR)
-
+        # override extensions after loading the configuration (otherwise it's pointless...)
+        if 'extensions' in overrides:
+            if isinstance(overrides['extensions'], string_types):
+                config['extensions'] = overrides.pop('extensions').split(',')
+            else:
+                config['extensions'] = overrides.pop('extensions')
         self._raw_config = config
         # these two must be preinitialized because extensions can add their
         # own config values


### PR DESCRIPTION
Just a quick rearrangement of existing code for extension overrides in the Config **init** function so that extension overrides actually work. I hate to say I didn't even test this before making the change, but it seemed like a fairly obviously problem when you're trying to override extensions. The overridden extensions get overridden by the original config file during **init** so that defeats the purpose of an override. Just need to change the order of the code to fix it.
