### PR TITLE
Tune sphinx_rtd_theme version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ requires = [
     'snowballstemmer>=1.1',
     'babel>=1.3',
     'alabaster>=0.7,<0.8',
-    'sphinx_rtd_theme>=0.1,<0.2',
+    'sphinx_rtd_theme>=0.1,<2.0',
 ]
 extras_require = {
     # Environment Marker works for wheel 0.24 or later


### PR DESCRIPTION
With some recent changes that are slightly backwards compatible, we were going
to bump the version of the RTD theme. We wanted to drop the current version
pattern for the semver scheme, but Sphinx's requirement on the RTD theme is
pinned at >=0.1,<0.2. For now, we're stuck releasing on the current scheme.

This relaxes the versioning requirement for the theme, with 2.0 being the
following release that could contain backwards incompatible API changes. We'd
likely wait to bump to 1.0 until the next Sphinx release, as to not break
experience for users.

Happy to tune this more, if anyone has any thoughts here.

Refs snide/sphinx_rtd_theme#244
