### PR TITLE
Fix: omit empty URL targets in objects.inv

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -843,7 +843,9 @@ class StandaloneHTMLBuilder(Builder):
                     if anchor.endswith(name):
                         # this can shorten the inventory by as much as 25%
                         anchor = anchor[:-len(name)] + '$'
-                    uri = self.get_target_uri(docname) + '#' + anchor
+                    uri = self.get_target_uri(docname)
+                    if anchor:
+                        uri += '#' + anchor
                     if dispname == name:
                         dispname = u'-'
                     f.write(compressor.compress(


### PR DESCRIPTION
Some URLs in `objects.inv` may have empty targets, but Sphinx still appends a # to the end of the URL.

For example:

```
>>> inv = fetch_inventory(app, 'http://sphinx-doc.org/', 'http://sphinx-doc.org/objects.inv')
>>> inv['std:label']['search']
(u'Sphinx',
 u'1.4a0',
 u'http://sphinx-doc.org/search.html#',
 u'Search Page')
```

This is especially a problem with std:doc URLs that normally don't have targets.
