### PR TITLE
Fix relative paths in intersphinx links

### DIFF
--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -257,7 +257,7 @@ def missing_reference(app, env, node, contnode):
             proj, version, uri, dispname = inventory[objtype][target]
             if '://' not in uri and node.get('refdoc'):
                 # get correct path in case of subdirectories
-                uri = path.join(relative_path(node['refdoc'], env.srcdir), uri)
+                uri = path.join(relative_path(node['refdoc'], '.'), uri)
             newnode = nodes.reference('', '', internal=False, refuri=uri,
                                       reftitle=_('(in %s v%s)') % (proj, version))
             if node.get('refexplicit'):

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -86,6 +86,8 @@ def test_missing_reference(tempdir, app, status, warning):
     app.config.intersphinx_mapping = {
         'https://docs.python.org/': inv_file,
         'py3k': ('https://docs.python.org/py3k/', inv_file),
+        'py3krel': ('py3k', inv_file),  # relative path
+        'py3krelparent': ('../../py3k', inv_file),  # relative path, parent dir
     }
     app.config.intersphinx_cache_limit = 0
 
@@ -152,6 +154,19 @@ def test_missing_reference(tempdir, app, status, warning):
     rn = missing_reference(app, app.env, node, contnode)
     assert rn is None
     assert contnode[0].astext() == 'py3k:unknown'
+
+    # check relative paths
+    rn = reference_check('py', 'mod', 'py3krel:module1', 'foo')
+    assert rn['refuri'] == 'py3k/foo.html#module-module1'
+
+    rn = reference_check('py', 'mod', 'py3krelparent:module1', 'foo')
+    assert rn['refuri'] == '../../py3k/foo.html#module-module1'
+
+    rn = reference_check('py', 'mod', 'py3krel:module1', 'foo', refdoc='sub/dir/test')
+    assert rn['refuri'] == '../../py3k/foo.html#module-module1'
+
+    rn = reference_check('py', 'mod', 'py3krelparent:module1', 'foo', refdoc='sub/dir/test')
+    assert rn['refuri'] == '../../../../py3k/foo.html#module-module1'
 
 
 @with_app()


### PR DESCRIPTION
Computing link paths relative to `env.srcdir` does not work as intended, because document names do not include the name of the source directory. Using `'.'` or `''` as the base directory fixes it.

Should fix #1060.
