### PR TITLE
C++, add support for virtual base classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -66,6 +66,7 @@ Bugs fixed
   transforming.
 * C++, fix parsing of 'signed char' and 'unsigned char' as types.
 * C++, add missing support for 'friend' functions.
+* C++, add support for virtual bases.
 
 Documentation
 -------------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3020,7 +3020,7 @@ class DefinitionParser(object):
                     visibility = self.matched_text
                     self.skip_ws()
                 if self.skip_string('virtual'):
-                    if virtual == True:
+                    if virtual:
                         self.fail('Duplicate virtual keyword found')
                     virtual = True
                 baseName = self._parse_nested_name()

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -304,6 +304,9 @@ def test_bases():
     check('class', 'A : public B', "A", "1A")
     check('class', 'A : B, C', "A", "1A")
     check('class', 'A : B, protected C, D', "A", "1A")
+    check('class', 'A : virtual private B', 'A', '1A', output='A : virtual B')
+    check('class', 'A : B, virtual C', 'A', '1A')
+    check('class', 'A : public virtual B', 'A', '1A')
 
 
 def test_operators():


### PR DESCRIPTION
Virtual base classes used to error due to expecting a nested name but a keyword was received instead. This patch fixes the problem by allowing the `virtual` specifier on base classes. 

There's a bit of an oddity when it comes to the `virtual` specifier in the base classes. They can either come before or after the access specifier (e.g. `class X : virtual public Y` or `class X : public virtual Y` are both valid). So both ways are parsed. The output chooses the latter way to represent it since this is the most common way I've seen it spelled out.
