### PR TITLE
gettext: use canonical relative paths for .pot

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -23,7 +23,7 @@ from six import iteritems
 from sphinx.builders import Builder
 from sphinx.util import split_index_msg
 from sphinx.util.nodes import extract_messages, traverse_translatable_index
-from sphinx.util.osutil import safe_relpath, ensuredir, SEP
+from sphinx.util.osutil import safe_relpath, ensuredir, canon_path
 from sphinx.util.i18n import find_catalog
 from sphinx.util.console import darkgreen, purple, bold
 from sphinx.locale import pairindextypes
@@ -165,8 +165,7 @@ class MessageCatalogBuilder(I18nBuilder):
             for dirpath, dirs, files in walk(tmpl_abs_path):
                 for fn in files:
                     if fn.endswith('.html'):
-                        filename = path.join(dirpath, fn)
-                        filename = filename.replace(path.sep, SEP)
+                        filename = canon_path(path.join(dirpath, fn))
                         template_files.add(filename)
         return template_files
 
@@ -216,8 +215,8 @@ class MessageCatalogBuilder(I18nBuilder):
                     if self.config.gettext_location:
                         # generate "#: file1:line1\n#: file2:line2 ..."
                         pofile.write("#: %s\n" % "\n#: ".join(
-                            "%s:%s" % (safe_relpath(source, self.outdir).
-                                       replace('\\', '/'), line)
+                            "%s:%s" % (canon_path(
+                                safe_relpath(source, self.outdir)), line)
                             for source, line, _ in positions))
                     if self.config.gettext_uuid:
                         # generate "# uuid1\n# uuid2\n ..."

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -216,7 +216,8 @@ class MessageCatalogBuilder(I18nBuilder):
                     if self.config.gettext_location:
                         # generate "#: file1:line1\n#: file2:line2 ..."
                         pofile.write("#: %s\n" % "\n#: ".join(
-                            "%s:%s" % (safe_relpath(source, self.outdir), line)
+                            "%s:%s" % (safe_relpath(source, self.outdir).
+                                       replace('\\', '/'), line)
                             for source, line, _ in positions))
                     if self.config.gettext_uuid:
                         # generate "# uuid1\n# uuid2\n ..."

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -38,6 +38,10 @@ SEP = "/"
 
 def os_path(canonicalpath):
     return canonicalpath.replace(SEP, path.sep)
+    
+def canon_path(nativepath):
+    """Return path in OS-independent form"""
+    return nativepath.replace(path.sep, SEP)
 
 
 def relative_uri(base, to):

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -38,7 +38,8 @@ SEP = "/"
 
 def os_path(canonicalpath):
     return canonicalpath.replace(SEP, path.sep)
-    
+
+
 def canon_path(nativepath):
     """Return path in OS-independent form"""
     return nativepath.replace(path.sep, SEP)


### PR DESCRIPTION
This removes unnecessary changes when rebuilding .pot files on Windows
