### PR TITLE
C++, add support for user-defined literals

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,7 @@ Bugs fixed
 * C++, add support for final classes.
 * C++, fix parsing of types prefixed with 'enum'.
 * #2023: Dutch search support uses Danish stemming info
+* C++, add support for user-defined literals.
 
 Documentation
 -------------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -821,6 +821,31 @@ class ASTOperatorType(ASTBase):
             signode += addnodes.desc_addname(identifier, identifier)
 
 
+class ASTOperatorLiteral(ASTBase):
+    def __init__(self, identifier):
+        self.identifier = identifier
+
+    def is_operator(self):
+        return True
+
+    def get_id_v1(self):
+        raise NoOldIdError()
+
+    def get_id_v2(self):
+        return u'li' + self.identifier.get_id_v2()
+
+    def __unicode__(self):
+        return u'operator""' + text_type(self.identifier)
+
+    def describe_signature(self, signode, mode, env, prefix, symbol):
+        _verify_description_mode(mode)
+        identifier = text_type(self)
+        if mode == 'lastIsName':
+            signode += addnodes.desc_name(identifier, identifier)
+        else:
+            signode += addnodes.desc_addname(identifier, identifier)
+
+
 class ASTTemplateArgConstant(ASTBase):
     def __init__(self, value):
         self.value = value
@@ -2524,6 +2549,14 @@ class DefinitionParser(object):
                     self.fail('Expected "]" after  "operator ' + op + '["')
                 op += '[]'
             return ASTOperatorBuildIn(op)
+
+        # user-defined literal?
+        if self.skip_string('""'):
+            self.skip_ws()
+            if not self.match(_identifier_re):
+                self.fail("Expected user-defined literal suffix.")
+            identifier = ASTIdentifier(self.matched_text)
+            return ASTOperatorLiteral(identifier)
 
         # oh well, looks like a cast operator definition.
         # In that case, eat another type.

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -347,6 +347,9 @@ def test_operators():
     check('function', 'void operator ! ()',
           "not-operator", "ntv", output='void operator!()')
 
+    check('function', 'void operator "" _udl()',
+           None, 'li4_udlv', output='void operator""_udl()')
+
 #def test_print():
 #    # used for getting all the ids out for checking
 #    for a in ids:


### PR DESCRIPTION
Adds support for C++11 [user-defined literals](http://en.cppreference.com/w/cpp/language/user_literal).

Currently, parsing a literal operator like this 

``` c++
std::string operator "" _s(const char*, std::size_t)
```

produces an error:

```
DefinitionError: Error when parsing function declaration:
If no return type {
Invalid definition: Expecting "(" in parameters_and_qualifiers. [error at 12]
  std::string operator "" _s(const char*, std::size_t)
  ------------^
} else if return type {
Invalid definition: Expected identifier in nested name. [error at 21]
  std::string operator "" _s(const char*, std::size_t)
  ---------------------^
}
```

This pull request fixes that.
The `id_v2` is generated base on [standard operator mangling](http://mentorembedded.github.io/cxx-abi/abi.html#mangling-operator).
