### PR TITLE
Make sphinx_rtd_theme optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ requires = [
     'snowballstemmer>=1.1',
     'babel>=1.3,!=2.0',
     'alabaster>=0.7,<0.8',
-    'sphinx_rtd_theme>=0.1,<2.0',
 ]
 extras_require = {
     # Environment Marker works for wheel 0.24 or later

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -102,8 +102,12 @@ class Theme(object):
         if name not in self.themes:
             self.load_extra_theme(name)
             if name not in self.themes:
-                raise ThemeError('no theme named %r found '
-                                 '(missing theme.conf?)' % name)
+                if name == 'sphinx_rtd_theme':
+                    raise ThemeError('sphinx_rtd_theme has been unbundled since version '
+                                     '1.4.0. Please install it manually.')
+                else:
+                    raise ThemeError('no theme named %r found '
+                                     '(missing theme.conf?)' % name)
         self.name = name
 
         # Do not warn yet -- to be compatible with old Sphinxes, people *have*

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -27,7 +27,6 @@ from sphinx import package_dir
 from sphinx.errors import ThemeError
 
 import alabaster
-import sphinx_rtd_theme
 
 NODEFAULT = object()
 THEMECONF = 'theme.conf'
@@ -71,7 +70,13 @@ class Theme(object):
 
     @classmethod
     def load_extra_theme(cls, name):
-        if name in ('alabaster', 'sphinx_rtd_theme'):
+        themes = ['alabaster']
+        try:
+            import sphinx_rtd_theme
+            themes.append('sphinx_rtd_theme')
+        except ImportError:
+            pass
+        if name in themes:
             if name == 'alabaster':
                 themedir = alabaster.get_path()
                 # alabaster theme also requires 'alabaster' extension, it will be loaded


### PR DESCRIPTION
The proposed small PR makes `sphinx_rtd_theme` optional to avoid overhead of installing extra package(s) when the latter is not used. It also fixes #2086 and, possibly, #1845.
