### PR TITLE
Make alabaster and sphinx_rtd_theme dependencies optional

### DIFF
--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -26,9 +26,6 @@ except ImportError:
 from sphinx import package_dir
 from sphinx.errors import ThemeError
 
-import alabaster
-import sphinx_rtd_theme
-
 NODEFAULT = object()
 THEMECONF = 'theme.conf'
 
@@ -73,10 +70,12 @@ class Theme(object):
     def load_extra_theme(cls, name):
         if name in ('alabaster', 'sphinx_rtd_theme'):
             if name == 'alabaster':
+                import alabaster
                 themedir = alabaster.get_path()
                 # alabaster theme also requires 'alabaster' extension, it will be loaded
                 # at sphinx.application module.
             elif name == 'sphinx_rtd_theme':
+                import sphinx_rtd_theme
                 themedir = sphinx_rtd_theme.get_html_theme_path()
             else:
                 raise NotImplementedError('Programming Error')


### PR DESCRIPTION
There is no need to pull these dependencies if i.e. the documentation is using the classic theme.

There will be no change in behavior for projects using alabaster or sphinx_rtd_theme.

Note: this PR does not remove these dependencies from setuptools `requires` list, as this can potentially break some reverse dependencies. If you think we should do this, please let me know and I will amend the PR. This change will be useful for us (Debian) anyway as we will be able to remove `sphinx-rtd-theme` from our our list of dependencies.
