### PR TITLE
#1286: add configuration option to allow linking to section titles without explicit labels

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Other contributors, listed alphabetically, are:
 * Roland Meister -- epub builder
 * Ezio Melotti -- collapsible sidebar JavaScript
 * Daniel Neuhäuser -- JavaScript domain, Python 3 support (GSOC)
+* Tadhg O'Higgins -- linking to section titles without labels
 * Christopher Perkins -- autosummary integration
 * Benjamin Peterson -- unittests
 * T. Powers -- HTML output improvements

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 * C++, added new scope management directives ``namespace-push`` and ``namespace-pop``.
 * Intersphinx: Added support for fetching Intersphinx inventories with URLs
   using HTTP basic auth
+* #1286: add configuration option to allow linking to section titles without
+  explicit labels.
 
 Bugs fixed
 ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -171,6 +171,21 @@ General configuration
 
    .. versionadded:: 1.0
 
+.. confval:: section_titles_as_targets
+
+   The default is ``False``.
+
+   If ``False``, explicit labels are necessary to use ``:ref:`` to link to section
+   titles.
+
+   If ``True``, ``:ref:`` will be able to target section titles without explicit
+   labels. This requires targeted section titles to be unique throughout the
+   documentation, otherwise unexpected behavior is likely to occur.
+
+   See :ref:`ref-role`.
+
+    .. versionadded:: 1.4
+
 .. confval:: primary_domain
 
    .. index:: default; domain

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -173,16 +173,17 @@ General configuration
 
 .. confval:: section_titles_as_targets
 
-   The default is ``False``.
+   This setting allows :ref:`ref-role` to link to sections that do not have
+   explicit labels.
 
    If ``False``, explicit labels are necessary to use ``:ref:`` to link to section
    titles.
 
-   If ``True``, ``:ref:`` will be able to target section titles without explicit
+   If ``True``, :ref:`ref-role` will be able to target section titles without explicit
    labels. This requires targeted section titles to be unique throughout the
    documentation, otherwise unexpected behavior is likely to occur.
 
-   See :ref:`ref-role`.
+   The default is ``False``.
 
     .. versionadded:: 1.4
 

--- a/doc/markup/inline.rst
+++ b/doc/markup/inline.rst
@@ -154,6 +154,21 @@ Cross-referencing arbitrary locations
    section headings are changed, and for all builders that support
    cross-references.
 
+   .. versionadded:: 1.4
+
+   If ``section_titles_as_targets`` is set to ``True`` in ``conf.py``, you may
+   reference section titles without labels. Example::
+
+        A Plain Title
+        -------------
+
+        This is the text of the section.
+
+        It refers to the section itself, see :ref:`A Plain Title`.
+
+     The ``:ref:`` role would then generate a link to the section, with the link
+     title being "A Plain Title".  This works just as well when section and
+     reference are in different source files.
 
 Cross-referencing documents
 ---------------------------

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -74,7 +74,7 @@ class Config(object):
         modindex_common_prefix = ([], 'html'),
         rst_epilog = (None, 'env'),
         rst_prolog = (None, 'env'),
-        section_titles_as_targets = (None, 'env'),
+        section_titles_as_targets = (False, 'env'),
         trim_doctest_flags = (True, 'env'),
         primary_domain = ('py', 'env'),
         needs_sphinx = (None, None),

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -74,6 +74,7 @@ class Config(object):
         modindex_common_prefix = ([], 'html'),
         rst_epilog = (None, 'env'),
         rst_prolog = (None, 'env'),
+        section_titles_as_targets = (None, 'env'),
         trim_doctest_flags = (True, 'env'),
         primary_domain = ('py', 'env'),
         needs_sphinx = (None, None),

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -530,7 +530,8 @@ class StandardDomain(Domain):
         labels, anonlabels = self.data['labels'], self.data['anonlabels']
         for name, explicit in iteritems(document.nametypes):
             if not explicit:
-                continue
+                if not env.config.section_titles_as_targets:
+                    continue
             labelid = document.nameids[name]
             if labelid is None:
                 continue

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -529,8 +529,7 @@ class StandardDomain(Domain):
     def process_doc(self, env, docname, document):
         labels, anonlabels = self.data['labels'], self.data['anonlabels']
         for name, explicit in iteritems(document.nametypes):
-            if not explicit:
-                if not env.config.section_titles_as_targets:
+            if not explicit and not env.config.section_titles_as_targets:
                     continue
             labelid = document.nameids[name]
             if labelid is None:

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -35,6 +35,45 @@ def test_process_doc_handle_figure_caption():
     assert domain.data['labels']['testname'] == (
         'testdoc', 'testid', 'caption text')
 
+def test_process_doc_handle_explicit_ref_default():
+    env = mock.Mock(domaindata={})
+    env.config.section_titles_as_targets = False
+    section_node = nodes.section(
+        '',
+        nodes.title('title text', 'title text'),
+        names="test_section")
+    document = mock.Mock(
+        nametypes={'test_section': None},
+        nameids={'test_section': 'test_section_id'},
+        ids={'test_section_id': section_node},
+    )
+
+    domain = StandardDomain(env)
+    if 'test_section' in domain.data['labels']:
+        del domain.data['labels']['test_section']
+    domain.process_doc(env, 'testdoc', document)
+    assert "test_section" not in domain.data["labels"]
+
+def test_process_doc_handle_explicit_ref_section_titles_as_targets():
+    env = mock.Mock(domaindata={})
+    env.config.section_titles_as_targets = True
+    section_node = nodes.section(
+        '',
+        nodes.title('title text', 'title text'),
+        names="test_section")
+    document = mock.Mock(
+        nametypes={'test_section': None},
+        nameids={'test_section': 'test_section_id'},
+        ids={'test_section_id': section_node},
+    )
+
+    domain = StandardDomain(env)
+    if 'test_section' in domain.data['labels']:
+        del domain.data['labels']['test_section']
+    domain.process_doc(env, 'testdoc', document)
+    assert 'test_section' in domain.data['labels']
+    assert domain.data['labels']['test_section'] == (
+        'testdoc', 'test_section_id', 'title text')
 
 def test_process_doc_handle_image_parent_figure_caption():
     env = mock.Mock(domaindata={})


### PR DESCRIPTION
There are a number of reasons why it should be possible to use :ref: to target section titles without requiring explicit labels:
-   The labels are often redundant (i.e. the same text as the titles).
-   If they are redundant, they clutter up the source significantly.
-   They make linking between documents more difficult, as the author must remember both to add the label to the target and, later, what the label was.
-   By making cross-referencing more difficult, they make it harder for authors to create navigable documentation.

A number of these were mentioned in issue #1286 and I hope this PR will reverse the WONTFIX decision.

My own use case is a cast of characters, each of which has a section. Adding an explicit label for each one is entirely redundant, and the argument that mandating explicit labels protect against future section title changes simply doesn't apply.

I'm sure many similar use cases exist, and that these are sufficient to warrant the addition of a configuration option to allow the non-explicit behavior, particularly since, as far as I can tell, the code change is quite simple.

This PR introduces a new configuration option named section_titles_as_targets and sets its default as False, preserving the existing behavior. If that option is set to True, the new behavior applies and the if statement that excludes non-explicit links in domains/std.py is effectively ignored.
