### PR TITLE
Fix performTermsSearch function for multiple words search.

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -357,54 +357,54 @@ var Search = {
   /**
    * search for full-text terms in the index
    */
-	performTermsSearch : function(searchterms, excluded, terms, titleterms) {
-    var filenames = this._index.filenames;
-    var titles = this._index.titles;
+  performTermsSearch : function(searchterms, excluded, terms, titleterms) {
+  var filenames = this._index.filenames;
+  var titles = this._index.titles;
 
-    var i, j, file, files;
-    var fileMap = {};
-    var scoreMap = {};  
-    var results = [];
+  var i, j, file, files;
+  var fileMap = {};
+  var scoreMap = {};
+  var results = [];
 
-    // perform the search on the required terms
-    for (i = 0; i < searchterms.length; i++) {
-      var word = searchterms[i];
+  // perform the search on the required terms
+  for (i = 0; i < searchterms.length; i++) {
+    var word = searchterms[i];
 	  
-	  files = [];
-	  _files1 = terms[word];
-	  _files2 = titleterms[word];
-	  // no match but word was a required one
-	  if (_files1 === undefined && _files2 === undefined) {
-		break;
-	  }
-	  // found search word in contents
-	  if (_files1 !== undefined) {
-		if (_files1.length === undefined)
-		  _files1 = [_files1];
-		files = files.concat(_files1);
+    files = [];
+    _files1 = terms[word];
+    _files2 = titleterms[word];
+    // no match but word was a required one
+    if (_files1 === undefined && _files2 === undefined) {
+      break;
+    }
+    // found search word in contents
+    if (_files1 !== undefined) {
+      if (_files1.length === undefined)
+        _files1 = [_files1];
+        files = files.concat(_files1);
 
-		// set score for the word in each file to Scorer.term
-		for (j = 0; j < _files1.length; j++) {
-		  file = _files1[j];
-		  if (!(file in scoreMap))
-			scoreMap[file] = {}
-		  scoreMap[file][word] = Scorer.term;
-		}
-	  }
-	  if (_files2 !== undefined) {
-		// found the word in document title
-		if (_files2.length === undefined)
-		  _files2 = [_files2];
-		files = files.concat(_files2);
+        // set score for the word in each file to Scorer.term
+        for (j = 0; j < _files1.length; j++) {
+          file = _files1[j];
+          if (!(file in scoreMap))
+            scoreMap[file] = {}
+          scoreMap[file][word] = Scorer.term;
+        }
+      }
+      if (_files2 !== undefined) {
+        // found the word in document title
+        if (_files2.length === undefined)
+          _files2 = [_files2];
+        files = files.concat(_files2);
 
-		// set score for the word in each file to Scorer.title
-		for (j = 0; j < _files2.length; j++) {
-		  file = _files2[j];
-		  if (!(file in scoreMap))
-			scoreMap[file] = {}
-		  scoreMap[file][word] = Scorer.title;
-		}
-	  }
+        // set score for the word in each file to Scorer.title
+        for (j = 0; j < _files2.length; j++) {
+          file = _files2[j];
+          if (!(file in scoreMap))
+            scoreMap[file] = {}
+          scoreMap[file][word] = Scorer.title;
+        }
+      }
 
       // create the mapping
       for (j = 0; j < files.length; j++) {
@@ -427,9 +427,9 @@ var Search = {
       // ensure that none of the excluded terms is in the search result
       for (i = 0; i < excluded.length; i++) {
         if (terms[excluded[i]] == file ||
-			titleterms[excluded[i]] == file ||
-			$u.contains(terms[excluded[i]] || [], file) ||
-			$u.contains(titleterms[excluded[i]] || [], file)) {
+            titleterms[excluded[i]] == file ||
+            $u.contains(terms[excluded[i]] || [], file) ||
+            $u.contains(titleterms[excluded[i]] || [], file)) {
           valid = false;
           break;
         }
@@ -437,14 +437,14 @@ var Search = {
 
       // if we have still a valid result we can add it to the result list
       if (valid) {
-		// select one (max) score for the file.
-		// for better ranking, we should calculate ranking by using words statistics like basic tf-idf...
-		score = 0;
-		for (i = 0; i < fileMap[file].length; i++) {
-		  w = fileMap[file][i];
-		  if (score < scoreMap[file][w])
-			score = scoreMap[file][w]
-		}
+        // select one (max) score for the file.
+        // for better ranking, we should calculate ranking by using words statistics like basic tf-idf...
+        score = 0;
+        for (i = 0; i < fileMap[file].length; i++) {
+          w = fileMap[file][i];
+          if (score < scoreMap[file][w])
+            score = scoreMap[file][w]
+        }
         results.push([filenames[file], titles[file], '', null, score]);
       }
     }

--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -193,8 +193,9 @@ var Search = {
     }
 
     // lookup as search terms in fulltext
-    results = results.concat(this.performTermsSearch(searchterms, excluded, terms, Scorer.term))
-                     .concat(this.performTermsSearch(searchterms, excluded, titleterms, Scorer.title));
+    //results = results.concat(this.performTermsSearch(searchterms, excluded, terms, Scorer.term))
+    //                 .concat(this.performTermsSearch(searchterms, excluded, titleterms, Scorer.title));
+	results = results.concat(this.performTermsSearch(searchterms, excluded, terms, titleterms));
 
     // let the scorer override scores with a custom scoring function
     if (Scorer.score) {
@@ -358,6 +359,7 @@ var Search = {
   /**
    * search for full-text terms in the index
    */
+/*   
   performTermsSearch : function(searchterms, excluded, terms, score) {
     var filenames = this._index.filenames;
     var titles = this._index.titles;
@@ -404,6 +406,104 @@ var Search = {
 
       // if we have still a valid result we can add it to the result list
       if (valid) {
+        results.push([filenames[file], titles[file], '', null, score]);
+      }
+    }
+    return results;
+  },
+*/
+
+  /**
+   * search for full-text terms in the index
+   */
+	performTermsSearch : function(searchterms, excluded, terms, titleterms) {
+    var filenames = this._index.filenames;
+    var titles = this._index.titles;
+
+    var i, j, file, files;
+    var fileMap = {};
+    var scoreMap = {};  
+    var results = [];
+
+    // perform the search on the required terms
+    for (i = 0; i < searchterms.length; i++) {
+      var word = searchterms[i];
+	  
+	  files = [];
+	  _files1 = terms[word];
+	  _files2 = titleterms[word];
+	  // no match but word was a required one
+	  if (_files1 === undefined && _files2 === undefined) {
+		break;
+	  }
+	  // found search word in contents
+	  if (_files1 !== undefined) {
+		if (_files1.length === undefined)
+		  _files1 = [_files1];
+		files = files.concat(_files1);
+
+		// set score for the word in each file to Scorer.term
+		for (j = 0; j < _files1.length; j++) {
+		  file = _files1[j];
+		  if (!(file in scoreMap))
+			scoreMap[file] = {}
+		  scoreMap[file][word] = Scorer.term;
+		}
+	  }
+	  if (_files2 !== undefined) {
+		// found the word in document title
+		if (_files2.length === undefined)
+		  _files2 = [_files2];
+		files = files.concat(_files2);
+
+		// set score for the word in each file to Scorer.title
+		for (j = 0; j < _files2.length; j++) {
+		  file = _files2[j];
+		  if (!(file in scoreMap))
+			scoreMap[file] = {}
+		  scoreMap[file][word] = Scorer.title;
+		}
+	  }
+
+      // create the mapping
+      for (j = 0; j < files.length; j++) {
+        file = files[j];
+        if (file in fileMap)
+          fileMap[file].push(word);
+        else
+          fileMap[file] = [word];
+      }
+    }
+
+    // now check if the files don't contain excluded terms
+    for (file in fileMap) {
+      var valid = true;
+
+      // check if all requirements are matched
+      if (fileMap[file].length != searchterms.length)
+          continue;
+
+      // ensure that none of the excluded terms is in the search result
+      for (i = 0; i < excluded.length; i++) {
+        if (terms[excluded[i]] == file ||
+			titleterms[excluded[i]] == file ||
+			$u.contains(terms[excluded[i]] || [], file) ||
+			$u.contains(titleterms[excluded[i]] || [], file)) {
+          valid = false;
+          break;
+        }
+      }
+
+      // if we have still a valid result we can add it to the result list
+      if (valid) {
+		// select one (max) score for the file.
+		// for better ranking, we should calculate ranking by using words statistics like basic tf-idf...
+		score = 0;
+		for (i = 0; i < fileMap[file].length; i++) {
+		  w = fileMap[file][i];
+		  if (score < scoreMap[file][w])
+			score = scoreMap[file][w]
+		}
         results.push([filenames[file], titles[file], '', null, score]);
       }
     }

--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -358,29 +358,29 @@ var Search = {
    * search for full-text terms in the index
    */
   performTermsSearch : function(searchterms, excluded, terms, titleterms) {
-  var filenames = this._index.filenames;
-  var titles = this._index.titles;
+    var filenames = this._index.filenames;
+    var titles = this._index.titles;
 
-  var i, j, file, files;
-  var fileMap = {};
-  var scoreMap = {};
-  var results = [];
+    var i, j, file, files;
+    var fileMap = {};
+    var scoreMap = {};
+    var results = [];
 
-  // perform the search on the required terms
-  for (i = 0; i < searchterms.length; i++) {
-    var word = searchterms[i];
+    // perform the search on the required terms
+    for (i = 0; i < searchterms.length; i++) {
+      var word = searchterms[i];
 	  
-    files = [];
-    _files1 = terms[word];
-    _files2 = titleterms[word];
-    // no match but word was a required one
-    if (_files1 === undefined && _files2 === undefined) {
-      break;
-    }
-    // found search word in contents
-    if (_files1 !== undefined) {
-      if (_files1.length === undefined)
-        _files1 = [_files1];
+      files = [];
+      _files1 = terms[word];
+      _files2 = titleterms[word];
+      // no match but word was a required one
+      if (_files1 === undefined && _files2 === undefined) {
+        break;
+      }
+      // found search word in contents
+      if (_files1 !== undefined) {
+        if (_files1.length === undefined)
+          _files1 = [_files1];
         files = files.concat(_files1);
 
         // set score for the word in each file to Scorer.term

--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -193,8 +193,6 @@ var Search = {
     }
 
     // lookup as search terms in fulltext
-    //results = results.concat(this.performTermsSearch(searchterms, excluded, terms, Scorer.term))
-    //                 .concat(this.performTermsSearch(searchterms, excluded, titleterms, Scorer.title));
 	results = results.concat(this.performTermsSearch(searchterms, excluded, terms, titleterms));
 
     // let the scorer override scores with a custom scoring function
@@ -355,63 +353,6 @@ var Search = {
 
     return results;
   },
-
-  /**
-   * search for full-text terms in the index
-   */
-/*   
-  performTermsSearch : function(searchterms, excluded, terms, score) {
-    var filenames = this._index.filenames;
-    var titles = this._index.titles;
-
-    var i, j, file, files;
-    var fileMap = {};
-    var results = [];
-
-    // perform the search on the required terms
-    for (i = 0; i < searchterms.length; i++) {
-      var word = searchterms[i];
-      // no match but word was a required one
-      if ((files = terms[word]) === undefined)
-        break;
-      if (files.length === undefined) {
-        files = [files];
-      }
-      // create the mapping
-      for (j = 0; j < files.length; j++) {
-        file = files[j];
-        if (file in fileMap)
-          fileMap[file].push(word);
-        else
-          fileMap[file] = [word];
-      }
-    }
-
-    // now check if the files don't contain excluded terms
-    for (file in fileMap) {
-      var valid = true;
-
-      // check if all requirements are matched
-      if (fileMap[file].length != searchterms.length)
-          continue;
-
-      // ensure that none of the excluded terms is in the search result
-      for (i = 0; i < excluded.length; i++) {
-        if (terms[excluded[i]] == file ||
-          $u.contains(terms[excluded[i]] || [], file)) {
-          valid = false;
-          break;
-        }
-      }
-
-      // if we have still a valid result we can add it to the result list
-      if (valid) {
-        results.push([filenames[file], titles[file], '', null, score]);
-      }
-    }
-    return results;
-  },
-*/
 
   /**
    * search for full-text terms in the index


### PR DESCRIPTION
When I query multiple words "A B", searchtools.js returns documents that contain both A and B within document title or contain both A and B within contents. However, documents that contain A in title and B in contents, or vise versa,  are not returned. 
I think this behavior could be confusing. 
For example, when I query "pycon sphinxcon", the document below will not be returned even though it contains both terms. 

```
PyCon 
=============

SphinxCon
```

Such documents will be returned with this patch. I hope that will make search results more intuitive. In a formal tone (if you like that,)  this will improve recall rate in information retrieval area :)
