### PR TITLE
[Napoleon] Fix NumPy handling of *args and **kwargs parameters

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -212,10 +212,7 @@ class GoogleDocstring(UnicodeMixin):
                 _name = match.group(1)
                 _type = match.group(2)
 
-        if _name[:2] == '**':
-            _name = r'\*\*'+_name[2:]
-        elif _name[:1] == '*':
-            _name = r'\*'+_name[1:]
+        _name = self._escape_args_and_kwargs(_name)
 
         if prefer_type and not _type:
             _type, _name = _name, _type
@@ -296,6 +293,14 @@ class GoogleDocstring(UnicodeMixin):
         else:
             min_indent = self._get_min_indent(lines)
             return [line[min_indent:] for line in lines]
+
+    def _escape_args_and_kwargs(self, name):
+        if name[:2] == '**':
+            return r'\*\*' + name[2:]
+        elif name[:1] == '*':
+            return r'\*' + name[1:]
+        else:
+            return name
 
     def _format_admonition(self, admonition, lines):
         lines = self._strip_empty(lines)
@@ -771,6 +776,7 @@ class NumpyDocstring(GoogleDocstring):
         else:
             _name, _type = line, ''
         _name, _type = _name.strip(), _type.strip()
+        _name = self._escape_args_and_kwargs(_name)
         if prefer_type and not _type:
             _type, _name = _name, _type
         indent = self._get_indent(line)

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -732,8 +732,8 @@ class NumpyDocstringTest(BaseDocstringTest):
         Single line summary
 
         :Parameters: * **arg1** (*str*) -- Extended description of arg1
-                     * ***args** -- Variable length argument list.
-                     * ****kwargs** -- Arbitrary keyword arguments.
+                     * **\\*args** -- Variable length argument list.
+                     * **\\*\\*kwargs** -- Arbitrary keyword arguments.
         """
     ), (
         """


### PR DESCRIPTION
This fixes an issue where *args and **kwargs parameter names are not parsed correctly in NumPy-style docstrings. This same issue was resolved previously in #1670, but only for Google-style docstrings. That fix 9df7b53782bd999387f33f43e9433a8a41bc75b6 added a test for NumPy but the stars were not escaped in the expected result.

This PR corrects the test and escapes the *args and **kwargs parameters in NumPy docstrings.
