### PR TITLE
MecabBinder should support both of Python 2 and 3.

### DIFF
--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -21,7 +21,7 @@ import os
 import re
 import sys
 
-from six import iteritems
+from six import iteritems, PY3
 
 try:
     import MeCab
@@ -43,13 +43,16 @@ class MecabBinder(object):
         self.dict_encode = options.get('dic_enc', 'utf-8')
 
     def split(self, input):
-        input2 = input.encode(self.dict_encode)
+        input2 = input if PY3 else input.encode(self.dict_encode)
         if native_module:
             result = self.native.parse(input2)
         else:
             result = self.ctypes_libmecab.mecab_sparse_tostr(
                 self.ctypes_mecab, input.encode(self.dict_encode))
-        return result.decode(self.dict_encode).split(' ')
+        if PY3:
+            return result.split(' ')
+        else:
+            return result.decode(self.dict_encode).split(' ')
 
     def init_native(self, options):
         param = '-Owakati'


### PR DESCRIPTION
MecabBinder for html (Japanese) search does not work with MeCab bindings for Python3.
e.g. https://pypi.python.org/pypi/mecab-python3

This patch fix the issue. Thanks.
