### PR TITLE
sphinx.ext.graphviz: use <object> instead of <img> to embed svg

### DIFF
--- a/doc/ext/graphviz.rst
+++ b/doc/ext/graphviz.rst
@@ -111,7 +111,18 @@ There are also these new config values:
 .. confval:: graphviz_output_format
 
    The output format for Graphviz when building HTML files.  This must be either
-   ``'png'`` or ``'svg'``; the default is ``'png'``.
+   ``'png'`` or ``'svg'``; the default is ``'png'``. If ``'svg'`` is used, in
+   order to make the URL links work properly, an appropriate ``target``
+   attribute must be set, such as ``"_top"`` and ``"_blank"``. For example, the
+   link in the following graph should work in the svg output: ::
+
+       .. graphviz::
+
+            digraph example {
+                a [label="sphinx", href="http://sphinx-doc.org", target="_top"];
+                b [label="other"];
+                a -> b;
+            }
 
    .. versionadded:: 1.0
       Previously, output always was PNG.

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -223,7 +223,8 @@ def render_dot_html(self, node, code, options, prefix='graphviz',
             alt = node.get('alt', self.encode(code).strip())
         imgcss = imgcls and 'class="%s"' % imgcls or ''
         if format == 'svg':
-            svgtag = '<img src="%s" alt="%s" %s/>\n' % (fname, alt, imgcss)
+            svgtag = '''<object data="%s" type="image/svg+xml">
+            <p class="warning">%s</p></object>\n''' % (fname, alt)
             self.body.append(svgtag)
         else:
             mapfile = open(outfn + '.map', 'rb')


### PR DESCRIPTION
If svg files are embedded in `<img>` in html, all interactive features are
lost, which graphviz is able to produce. This commit replace `<img>` with
`<object>` for svg files.
