### PR TITLE
perform a lower() on german index terms #2083

### DIFF
--- a/sphinx/search/de.py
+++ b/sphinx/search/de.py
@@ -311,4 +311,5 @@ class SearchGerman(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('german')
 
     def stem(self, word):
+        word = word.lower()
         return self.stemmer.stemWord(word)


### PR DESCRIPTION
This will fix issues with the german search index generation (#2083) in the first place but I suppose, other languages would benefit from a similar change in the corresponding locale files, too.
