### PR TITLE
Fix LaTeX output of \mathbb in math

### DIFF
--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -214,3 +214,4 @@ def setup_math(app, htmlinlinevisitors, htmldisplayvisitors):
     app.add_role('eq', eq_role)
     app.add_directive('math', MathDirective)
     app.connect('doctree-resolved', number_equations)
+    app.add_latex_package('amsfonts')

--- a/tests/root/math.txt
+++ b/tests/root/math.txt
@@ -19,4 +19,8 @@ This is inline math: :math:`a^2 + b^2 = c^2`.
 
    e^{ix} = \cos x + i\sin x
 
+.. math::
+
+   n \in \mathbb N
+
 Referencing equation :eq:`foo`.


### PR DESCRIPTION
If \mathbb is used in math, which is commonly used to represent sets, the output LaTeX won't compile. This commit fixes by adding `\RequirePackage{amsfonts}` to sphinx.sty.
