### PR TITLE
Fix #1480: LaTeX: Support math in section titles

### DIFF
--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -56,6 +56,17 @@ def eq_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     return [node], []
 
 
+def is_in_section_title(node):
+    """Determine whether the node is in a section title"""
+    from sphinx.util.nodes import traverse_parent
+
+    for ancestor in traverse_parent(node):
+        if isinstance(ancestor, nodes.title) and \
+           isinstance(ancestor.parent, nodes.section):
+            return True
+    return False
+
+
 class MathDirective(Directive):
 
     has_content = True
@@ -91,7 +102,12 @@ class MathDirective(Directive):
 
 
 def latex_visit_math(self, node):
-    self.body.append('\\(' + node['latex'] + '\\)')
+    if is_in_section_title(node):
+        protect = r'\protect'
+    else:
+        protect = ''
+    equation = protect + r'\(' + node['latex'] + protect + r'\)'
+    self.body.append(equation)
     raise nodes.SkipNode
 
 

--- a/tests/root/math.txt
+++ b/tests/root/math.txt
@@ -1,5 +1,5 @@
-Test math extensions
-====================
+Test math extensions :math:`E = m c^2`
+======================================
 
 This is inline math: :math:`a^2 + b^2 = c^2`.
 


### PR DESCRIPTION
Fix #1480
