### PR TITLE
Skip trailing parentheses when parsing a cross-reference

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4017,6 +4017,8 @@ class CPPDomain(Domain):
         try:
             ast = parser.parse_xref_object()
             parser.skip_ws()
+            if parser.current_char == '(':
+                parser.skip_string('()')
             parser.assert_end()
         except DefinitionError as e:
             warner.warn('Unparseable C++ cross-reference: %r\n%s'


### PR DESCRIPTION
The proposed PR fixes #2178 by skipping trailing parentheses when parsing a cross-reference.

With this change a correct reference for `f()` is generated in the following example:

``` rst
.. cpp:function:: void f()

:cpp:any:`f()`
```
