### PR TITLE
Fix #1615: Support XeTeX and LuaTeX for the LaTeX builder

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -249,7 +249,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'classoptions':    '',
         'extraclassoptions': '',
         'inputenc':        '\\usepackage[utf8]{inputenc}',
-        'utf8extra':       '\\DeclareUnicodeCharacter{00A0}{\\nobreakspace}',
+        'utf8extra':       ('\\ifdefined\\DeclareUnicodeCharacter\n'
+                            '  \\DeclareUnicodeCharacter{00A0}{\\nobreakspace}\n'
+                            '\\else\\fi'),
         'cmappkg':         '\\usepackage{cmap}',
         'fontenc':         '\\usepackage[T1]{fontenc}',
         'babel':           '\\usepackage{babel}',

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -77,17 +77,20 @@ def test_latex(app, status, warning):
     cwd = os.getcwd()
     os.chdir(app.outdir)
     try:
-        try:
-            p = Popen(['pdflatex', '--interaction=nonstopmode',
-                       'SphinxTests.tex'], stdout=PIPE, stderr=PIPE)
-        except OSError:
-            raise SkipTest  # most likely pdflatex was not found
-        else:
-            stdout, stderr = p.communicate()
-            if p.returncode != 0:
-                print(stdout)
-                print(stderr)
-                assert False, 'latex exited with return code %s' % p.returncode
+        for latex in ('pdflatex', 'xelatex', 'lualatex'):
+            try:
+                os.mkdir(latex)
+                p = Popen([latex, '--interaction=nonstopmode',
+                        '-output-directory=%s' % latex, 'SphinxTests.tex'],
+                        stdout=PIPE, stderr=PIPE)
+            except OSError:
+                raise SkipTest  # most likely pdflatex was not found
+            else:
+                stdout, stderr = p.communicate()
+                if p.returncode != 0:
+                    print(stdout)
+                    print(stderr)
+                    assert False, 'latex exited with return code %s' % p.returncode
     finally:
         os.chdir(cwd)
 


### PR DESCRIPTION
XeTeX and LuaTeX have better Unicode support than the old PDFTeX. This may become really important for multilingual support (which may relate to some east Asian language bugs in the issue tracker). Using LuaTeX or XeTeX may also be able to replace the `latexpdfja` target in the default Makefile with a more general target in the future, e.g., `latexpdfunicode` (I'm not super sure on this point).

In addition, LuaTeX is the designated successor of PDFTeX and has already been included in TeXLive at this point.
