### PR TITLE
Fix #2027: ``make epub`` got errors if ``html_title`` is None

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -565,8 +565,7 @@ that use Sphinx's HTMLWriter class.
    The "title" for HTML documentation generated with Sphinx's own templates.
    This is appended to the ``<title>`` tag of individual pages, and used in the
    navigation bar as the "topmost" element.  It defaults to :samp:`'{<project>}
-   v{<revision>} documentation'` (with the values coming from the config
-   values).
+   v{<revision>} documentation'`.
 
 .. confval:: html_short_title
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -92,7 +92,7 @@ class Config(object):
         html_theme_options = ({}, 'html'),
         html_title = (lambda self: l_('%s %s documentation') %
                       (self.project, self.release),
-                      'html'),
+                      'html', [str]),
         html_short_title = (lambda self: self.html_title, 'html'),
         html_style = (None, 'html', [str]),
         html_logo = (None, 'html', [str]),

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -190,9 +190,9 @@ html_theme = 'alabaster'
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-#html_title = None
+# The name for this set of Sphinx documents.
+# "<project> v<release> documentation" by default.
+#html_title = u'%(project_str)s v%(release_str)s'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
Sphinx does not expect setting None value as `html_title` in
spite of documented.
This changed that to deny None value as `html_title`.
