### PR TITLE
Set <blockquote> in the classic theme to fit with <p>.

### DIFF
--- a/sphinx/themes/classic/static/classic.css_t
+++ b/sphinx/themes/classic/static/classic.css_t
@@ -223,7 +223,7 @@ a.headerlink:hover {
     color: white;
 }
 
-div.body p, div.body dd, div.body li {
+div.body p, div.body dd, div.body li, div.body blockquote {
     text-align: justify;
     line-height: 130%;
 }


### PR DESCRIPTION
A blockquote looks better if its text style is close to <p>.

---

Currently blockquote texts are not justified and it looks really strange compared with other parts. Plus, if more than 1 elements in a blockquote, such as a praragraph plus a list, the paragraph would be surrounded by <p> and this blockquote would look different from other blockquotes.
