### PR TITLE
Fix #1149: ``sphinx.ext.graphviz``: show graph image in inline by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,7 @@ Incompatible changes
   conf.py that will be provided on sphinx-quickstart.
 * #2027, #2208: The ``html_title`` accepts string values only. And The None value cannot be
   accepted.
-
+* ``sphinx.ext.graphviz``: show graph image in inline by default
 
 Features added
 --------------

--- a/tests/roots/test-ext-graphviz/conf.py
+++ b/tests/roots/test-ext-graphviz/conf.py
@@ -2,4 +2,12 @@
 
 extensions = ['sphinx.ext.graphviz']
 master_doc = 'index'
+<<<<<<< 492f60c37185dccee1e42c01fb5d87ed42f45608
 exclude_patterns = ['_build']
+=======
+
+latex_documents = [
+    (master_doc, 'SphinxTests.tex', 'Sphinx Tests Documentation',
+     'Georg Brandl', 'manual'),
+]
+>>>>>>> ``sphinx.ext.graphviz``: show graph image in inline by default

--- a/tests/roots/test-ext-graphviz/index.rst
+++ b/tests/roots/test-ext-graphviz/index.rst
@@ -5,3 +5,9 @@ graphviz
    :caption: caption of graph
 
    bar -> baz
+
+.. |graph| digraph:: bar
+
+           bar -> baz
+
+Hello |graph| graphviz world

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -15,12 +15,31 @@ from util import with_app, SkipTest
 
 
 @with_app('html', testroot='ext-graphviz')
-def test_graphviz(app, status, warning):
+def test_graphviz_html(app, status, warning):
     app.builder.build_all()
     if "dot command 'dot' cannot be run" in warning.getvalue():
         raise SkipTest('graphviz "dot" is not available')
 
     content = (app.outdir / 'index.html').text()
-    html = ('<p class="graphviz">\s*<img .*?/>\s*</p>\s*'
-            '<p class="caption"><span class="caption-text">caption of graph</span>')
+    html = ('<div class="figure" .*?>\s*<img .*?/>\s*<p class="caption">'
+            '<span class="caption-text">caption of graph</span>.*</p>\s*</div>')
     assert re.search(html, content, re.S)
+
+    html = 'Hello <img .*?/>\n graphviz world'
+    assert re.search(html, content, re.S)
+
+
+@with_app('latex', testroot='ext-graphviz')
+def test_graphviz_latex(app, status, warning):
+    app.builder.build_all()
+    if "dot command 'dot' cannot be run" in warning.getvalue():
+        raise SkipTest('graphviz "dot" is not available')
+
+    content = (app.outdir / 'SphinxTests.tex').text()
+    macro = ('\\\\begin{figure}\[htbp\]\n\\\\centering\n\\\\capstart\n\n'
+             '\\\\includegraphics{graphviz-\w+.pdf}\n'
+             '\\\\caption{caption of graph}\\\\end{figure}')
+    assert re.search(macro, content, re.S)
+
+    macro = 'Hello \\\\includegraphics{graphviz-\w+.pdf} graphviz world'
+    assert re.search(macro, content, re.S)


### PR DESCRIPTION
To support subsutituion syntax, make graphviz node inline (ref: #1149).
Now graphviz directive behaves like `image` directive when no captions.
If specified, it generates `figure` node and `caption` node like
`figure` directive.
