### PR TITLE
Fix #2060: ``:manpage:`` role uses incorrect style (node)

### DIFF
--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -212,6 +212,10 @@ class termsep(nodes.Structural, nodes.Element):
     """Separates two terms within a <term> node."""
 
 
+class manpage(nodes.Inline, nodes.TextElement):
+    """Node for references to manpages."""
+
+
 # make the new nodes known to docutils; needed because the HTML writer will
 # choke at some point if these are not added
 nodes._add_node_class_names(k for k in globals().keys()

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -29,7 +29,7 @@ generic_docroles = {
     'kbd': nodes.literal,
     'mailheader': addnodes.literal_emphasis,
     'makevar': addnodes.literal_strong,
-    'manpage': addnodes.literal_emphasis,
+    'manpage': addnodes.manpage,
     'mimetype': addnodes.literal_emphasis,
     'newsgroup': addnodes.literal_emphasis,
     'program': addnodes.literal_strong,  # XXX should be an x-ref

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -640,6 +640,12 @@ class HTMLTranslator(BaseTranslator):
         self.body.append('<br />')
         raise nodes.SkipNode
 
+    def visit_manpage(self, node):
+        return self.visit_literal_emphasis(node)
+
+    def depart_manpage(self, node):
+        return self.depart_literal_emphasis(node)
+
     def depart_title(self, node):
         close_tag = self.context[-1]
         if (self.permalink_text and self.builder.add_permalinks and

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1666,6 +1666,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def depart_abbreviation(self, node):
         self.body.append(self.context.pop())
 
+    def visit_manpage(self, node):
+        return self.visit_literal_emphasis(node)
+
+    def depart_manpage(self, node):
+        return self.depart_literal_emphasis(node)
+
     def visit_title_reference(self, node):
         self.body.append(r'\emph{')
 

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -375,6 +375,12 @@ class ManualPageTranslator(BaseTranslator):
     def depart_abbreviation(self, node):
         pass
 
+    def visit_manpage(self, node):
+        return self.visit_strong(node)
+
+    def depart_manpage(self, node):
+        return self.depart_strong(node)
+
     # overwritten: handle section titles better than in 0.6 release
     def visit_title(self, node):
         if isinstance(node.parent, addnodes.seealso):

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1476,6 +1476,12 @@ class TexinfoTranslator(nodes.NodeVisitor):
     def depart_abbreviation(self, node):
         self.body.append(self.context.pop())
 
+    def visit_manpage(self, node):
+        return self.visit_literal_emphasis(node)
+
+    def depart_manpage(self, node):
+        return self.depart_literal_emphasis(node)
+
     def visit_download_reference(self, node):
         pass
 

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -861,6 +861,12 @@ class TextTranslator(nodes.NodeVisitor):
         if node.hasattr('explanation'):
             self.add_text(' (%s)' % node['explanation'])
 
+    def visit_manpage(self, node):
+        return self.visit_literal_emphasis(node)
+
+    def depart_manpage(self, node):
+        return self.depart_literal_emphasis(node)
+
     def visit_title_reference(self, node):
         self.add_text('*')
 

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -20,3 +20,4 @@ def test_all(app, status, warning):
 
     content = (app.outdir / 'SphinxTests.1').text()
     assert r'\fBprint \fP\fIi\fP\fB\en\fP' in content
+    assert r'\fBmanpage\en\fP' in content


### PR DESCRIPTION
It should be use bold style to reference man pages in man format.
On other formats, it is still represented as emphasis.

To keep style of other format, I added new node; `sphinx.addnodes.manpage`.
It makes doctree a little complicated, but it separates styles and data structure.
