### PR TITLE
Add an option to number all displayed math

### DIFF
--- a/doc/ext/math.rst
+++ b/doc/ext/math.rst
@@ -28,6 +28,13 @@ Keep in mind that when you put math markup in **Python docstrings** read by
 :mod:`autodoc <sphinx.ext.autodoc>`, you either have to double all backslashes,
 or use Python raw strings (``r"raw"``).
 
+:mod:`.mathbase` provides the following config values:
+
+.. confval:: math_number_all
+
+   Set this option to ``True`` if you want all displayed math to be numbered.
+   The default is ``False``.
+
 :mod:`.mathbase` defines these new markup elements:
 
 .. rst:role:: math

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -242,7 +242,8 @@ def html_visit_displaymath(self, node):
     if node['nowrap']:
         latex = node['latex']
     else:
-        latex = wrap_displaymath(node['latex'], None)
+        latex = wrap_displaymath(node['latex'], None,
+                                 self.builder.config.math_number_all)
     try:
         fname, depth = render_math(self, latex)
     except MathExtError as exc:

--- a/sphinx/ext/pngmath.py
+++ b/sphinx/ext/pngmath.py
@@ -213,7 +213,8 @@ def html_visit_displaymath(self, node):
     if node['nowrap']:
         latex = node['latex']
     else:
-        latex = wrap_displaymath(node['latex'], None)
+        latex = wrap_displaymath(node['latex'], None,
+                                 self.builder.config.math_number_all)
     try:
         fname, depth = render_math(self, latex)
     except MathExtError as exc:

--- a/tests/roots/test-ext-imgmath/index.rst
+++ b/tests/roots/test-ext-imgmath/index.rst
@@ -1,6 +1,0 @@
-Test imgmath
-============
-
-.. math:: a^2+b^2=c^2
-
-Inline :math:`E=mc^2`

--- a/tests/roots/test-ext-math/conf.py
+++ b/tests/roots/test-ext-math/conf.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
 
-extensions = ['sphinx.ext.imgmath']
 master_doc = 'index'

--- a/tests/roots/test-ext-math/index.rst
+++ b/tests/roots/test-ext-math/index.rst
@@ -1,0 +1,10 @@
+Test Math
+=========
+
+.. math:: a^2+b^2=c^2
+
+Inline :math:`E=mc^2`
+
+Second math
+
+.. math:: e^{i\pi}+1=0

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-    test_ext_imgmath
-    ~~~~~~~~~~~~~~~~
+    test_ext_math
+    ~~~~~~~~~~~~~
 
-    Test sphinx.ext.imgmath extension.
+    Test math extensions.
 
     :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -14,7 +14,8 @@ import re
 from util import with_app, SkipTest
 
 
-@with_app('html', testroot='ext-imgmath')
+@with_app('html', testroot='ext-math',
+          confoverrides = {'extensions': ['sphinx.ext.imgmath']})
 def test_imgmath_png(app, status, warning):
     app.builder.build_all()
     if "LaTeX command 'latex' cannot be run" in warning.getvalue():
@@ -27,8 +28,9 @@ def test_imgmath_png(app, status, warning):
             '\s*alt="a\^2\+b\^2=c\^2"/>\s*</p>\s*</div>')
     assert re.search(html, content, re.S)
 
-@with_app('html', testroot='ext-imgmath',
-          confoverrides={'imgmath_image_format': 'svg'})
+@with_app('html', testroot='ext-math',
+          confoverrides={'extensions': ['sphinx.ext.imgmath'],
+                         'imgmath_image_format': 'svg'})
 def test_imgmath_svg(app, status, warning):
     app.builder.build_all()
     if "LaTeX command 'latex' cannot be run" in warning.getvalue():
@@ -39,4 +41,15 @@ def test_imgmath_svg(app, status, warning):
     content = (app.outdir / 'index.html').text()
     html = ('<div class="math">\s*<p>\s*<img src="_images/math/\w+.svg"'
             '\s*alt="a\^2\+b\^2=c\^2"/>\s*</p>\s*</div>')
+    assert re.search(html, content, re.S)
+
+@with_app('html', testroot='ext-math',
+          confoverrides={'math_number_all': True,
+                         'extensions': ['sphinx.ext.mathjax']})
+def test_math_number_all(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'index.html').text()
+    html = (r'<div class="math">\s*'
+            r'<span class="eqno">\(1\)</span>\\\[a\^2\+b\^2=c\^2\\\]</div>')
     assert re.search(html, content, re.S)


### PR DESCRIPTION
The second commit also refactors the math extension tests to include tests for this new option (more elegantly).
