### PR TITLE
Use "align" environment to wrap math equations instead of "gather"

### DIFF
--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -34,16 +34,19 @@ def wrap_displaymath(math, label, numbering):
     for i, part in enumerate(parts):
         if not part.strip():
             continue
-        if label is not None and i == 0:
-            ret.append('\\begin{split}%s\\end{split}' % part +
-                       (label and '\\label{'+label+'}' or ''))
-        else:
-            ret.append(r'\begin{split}%s\end{split}' % part)
-            if not numbering:
-                ret.append(r'\notag')
+        ret.append(r'\begin{split}%s\end{split}' % part)
     if not ret:
         return ''
-    return '\\begin{gather}\n' + '\\\\'.join(ret) + '\n\\end{gather}'
+    if label is not None or numbering:
+        env_begin = r'\begin{align}'
+        if label is not None:
+            env_begin += r'\label{%s}' % label
+        env_end = r'\end{align}'
+    else:
+        env_begin = r'\begin{align*}'
+        env_end = r'\end{align*}'
+    return ('%s\\begin{aligned}\n%s\\end{aligned}%s') % (
+        env_begin, '\\\\\n'.join(ret), env_end)
 
 
 def math_role(role, rawtext, text, lineno, inliner, options={}, content=[]):

--- a/tests/roots/test-ext-math/conf.py
+++ b/tests/roots/test-ext-math/conf.py
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
 
 master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'test.tex', 'Math Extension Testing', 'Sphinx', 'report')]

--- a/tests/roots/test-ext-math/index.rst
+++ b/tests/roots/test-ext-math/index.rst
@@ -8,3 +8,11 @@ Inline :math:`E=mc^2`
 Second math
 
 .. math:: e^{i\pi}+1=0
+
+Multi math equations
+
+.. math::
+
+   S &= \pi r^2
+
+   V &= \frac{4}{3} \pi r^3

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -53,3 +53,10 @@ def test_math_number_all(app, status, warning):
     html = (r'<div class="math">\s*'
             r'<span class="eqno">\(1\)</span>\\\[a\^2\+b\^2=c\^2\\\]</div>')
     assert re.search(html, content, re.S)
+
+@with_app('latex', testroot='ext-math',
+          confoverrides={'extensions': ['sphinx.ext.mathjax']})
+def test_math_number_all(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'test.tex').text()


### PR DESCRIPTION
Using align brings the benefit when multiple math equations are in one math directive, alignment is provided. We also use "aligned" to wrap the equations since in this way all the equations will be given only one label/tag, while previously only the first equation is labeled.
