### PR TITLE
transforms: Don't try to call has_child on parent nodes that are None

### DIFF
--- a/sphinx/transforms.py
+++ b/sphinx/transforms.py
@@ -121,13 +121,13 @@ class AutoNumbering(Transform):
                 if has_child(node, nodes.caption):
                     self.document.note_implicit_target(node)
             elif isinstance(node, nodes.image):
-                if has_child(node.parent, nodes.caption):
+                if node.parent and has_child(node.parent, nodes.caption):
                     self.document.note_implicit_target(node.parent)
             elif isinstance(node, nodes.table):
                 if has_child(node, nodes.title):
                     self.document.note_implicit_target(node)
             elif isinstance(node, nodes.literal_block):
-                if has_child(node.parent, nodes.caption):
+                if node.parent and has_child(node.parent, nodes.caption):
                     self.document.note_implicit_target(node.parent)
 
 


### PR DESCRIPTION
Otherwise the build can fail with the following error:

```
  File "/usr/lib/python2.7/dist-packages/sphinx/environment.py", line 791, in read_doc
    pub.publish()
  File "/usr/lib/python2.7/dist-packages/docutils/core.py", line 218, in publish
    self.apply_transforms()
  File "/usr/lib/python2.7/dist-packages/docutils/core.py", line 199, in apply_transforms
    self.document.transformer.apply_transforms()
  File "/usr/lib/python2.7/dist-packages/docutils/transforms/__init__.py", line 171, in apply_transforms
    transform.apply(**kwargs)
  File "/usr/lib/python2.7/dist-packages/sphinx/transforms.py", line 124, in apply
    if has_child(node.parent, nodes.caption):
  File "/usr/lib/python2.7/dist-packages/sphinx/transforms.py", line 117, in has_child
    return any(isinstance(child, cls) for child in node)
TypeError: 'NoneType' object is not iterable
```

The error can be reproduced with [lp:autopilot/legacy](https://code.launchpad.net/~autopilot/autopilot/legacy) branch from Launchpad.
