### PR TITLE
Add "language" attribute to html in the "basic" theme

### DIFF
--- a/sphinx/themes/basic/changes/frameset.html
+++ b/sphinx/themes/basic/changes/frameset.html
@@ -1,6 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
   "http://www.w3.org/TR/html4/frameset.dtd">
-<html>
+<html
+  {% if language is not none %}
+  lang = "{{ language }}"
+  {% endif %} >
   <head>
     <title>{% trans version=version|e, docstitle=docstitle|e %}Changes in Version {{ version }} &mdash; {{ docstitle }}{% endtrans %}</title>
   </head>

--- a/sphinx/themes/basic/changes/rstsource.html
+++ b/sphinx/themes/basic/changes/rstsource.html
@@ -1,6 +1,9 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
   "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<html
+  {% if language is not none %}
+  lang = "{{ language }}"
+  {% endif %} >
   <head>
     <title>{% trans filename=filename, docstitle=docstitle|e %}{{ filename }} &mdash; {{ docstitle }}{% endtrans %}</title>
     <style type="text/css">

--- a/sphinx/themes/basic/changes/versionchanges.html
+++ b/sphinx/themes/basic/changes/versionchanges.html
@@ -5,7 +5,10 @@
 {% endmacro -%}
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
   "http://www.w3.org/TR/html4/loose.dtd">
-<html>
+<html
+  {% if language is not none %}
+  lang = "{{ language }}"
+  {% endif %} >
   <head>
     <link rel="stylesheet" href="default.css">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -107,7 +107,10 @@
     {%- endfor %}
 {%- endmacro %}
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml"
+  {% if language is not none %}
+  lang = "{{ language }}"
+  {% endif %} >
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
     {{ metatags }}


### PR DESCRIPTION
Some styling are affected by the language option. Specify a language in `<html>` if the user specifies.
