### PR TITLE
ext.viewcode needs to use the Python3Lexer from pygments when in Python3

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import sys
 import traceback
 
 from six import iteritems, text_type
@@ -139,7 +140,10 @@ def collect_pages(app):
         # construct a page name for the highlighted source
         pagename = '_modules/' + modname.replace('.', '/')
         # highlight the source using the builder's highlighter
-        highlighted = highlighter.highlight_block(code, 'python', linenos=False)
+        lang = 'python'
+        if sys.version_info[0] == 3:
+            lang = 'python3'
+        highlighted = highlighter.highlight_block(code, lang, linenos=False)
         # split the code into lines
         lines = highlighted.splitlines()
         # split off wrap markup from the first line of the actual code


### PR DESCRIPTION
Implement fix for bug 1 reported at https://github.com/sphinx-doc/sphinx/issues/2279

In a Python 3 environment, we need to use the Python3Lexer. Luckily all the code is already there,
see https://github.com/sphinx-doc/sphinx/blob/master/sphinx/highlighting.py#L167  where
`pygments.lexers.get_lexer_by_name()` does the correct job.

You may want however to add Python3Lexer to the list of lexers there: https://github.com/sphinx-doc/sphinx/blob/master/sphinx/highlighting.py#L37 in order to be more explicit.
