### PR TITLE
Use try / except in read_doc to avoid racing condition

### DIFF
--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -40,7 +40,7 @@ from sphinx import addnodes
 from sphinx.util import url_re, get_matching_docs, docname_join, split_into, \
     FilenameUniqDict, get_figtype, import_object, split_index_msg, split_docinfo
 from sphinx.util.nodes import clean_astext, make_refnode, WarningStream, is_translatable
-from sphinx.util.osutil import SEP, getcwd, fs_encoding
+from sphinx.util.osutil import SEP, getcwd, fs_encoding, ensuredir
 from sphinx.util.i18n import find_catalog_files
 from sphinx.util.console import bold, purple
 from sphinx.util.matching import compile_matchers
@@ -859,9 +859,7 @@ class BuildEnvironment:
         # save the parsed doctree
         doctree_filename = self.doc2path(docname, self.doctreedir,
                                          '.doctree')
-        dirname = path.dirname(doctree_filename)
-        if not path.isdir(dirname):
-            os.makedirs(dirname)
+        ensuredir(path.dirname(doctree_filename))
         f = open(doctree_filename, 'wb')
         try:
             pickle.dump(doctree, f, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
It's port of [bb's PR 319](https://bitbucket.org/birkenfeld/sphinx/pull-requests/319) FTR parallel build sometimes triggers:

```
(Error in parallel process)
Traceback (most recent call last):
  File ".../Sphinx-1.3b2dev_20141124-py2.7.egg/sphinx/util/parallel.py", line 69, in _process
    ret = func(arg)
  File ".../Sphinx-1.3b2dev_20141124-py2.7.egg/sphinx/environment.py", line 614, in read_process
    self.read_doc(docname, app)
  File ".../Sphinx-1.3b2dev_20141124-py2.7.egg/sphinx/environment.py", line 822, in read_doc
    os.makedirs(dirname)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/var/lib/jenkins/jobs/yt-docs-3.0/workspace/doc/build/doctrees/analyzing'
```
