### PR TITLE
LaTeX captions of literal blocks now glued to framed verbatim

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -151,50 +151,50 @@
 \let\endOriginalVerbatim=\endVerbatim
 
 % Play with vspace to be able to keep the indentation.
-\newlength\distancetoright
-\def\mycolorbox#1{%
-  \setlength\distancetoright{\linewidth}%
-  \advance\distancetoright -\@totalleftmargin %
+\newlength\Sphinx@scratchlength
+\newcommand\Sphinxcolorbox [1]{%
+  \setlength\Sphinx@scratchlength{\linewidth}%
+  \advance\Sphinx@scratchlength -\@totalleftmargin %
   \fcolorbox{VerbatimBorderColor}{VerbatimColor}{%
-  \begin{minipage}{\distancetoright}%
+  \begin{minipage}{\Sphinx@scratchlength}%
     #1
   \end{minipage}%
   }%
 }
 % used for split frames for continuation on next and final page
-\def\MidFrameCommand{\mycolorbox}
+\def\MidFrameCommand{\Sphinxcolorbox}
 \let\LastFrameCommand\MidFrameCommand
 
 % We customize \FrameCommand (for non split frames) and \FirstFrameCommand
 % (split frames), in order for the framed environment to insert a Title above
 % the frame, which can not be separated by a pagebreak.
 
-% The title is specified from outside as macro \MyVerbatimTitle.
-% \MyVerbatimTitle is reset to empty after each use of Verbatim environment.
+% The title is specified from outside as macro \SphinxVerbatimTitle.
+% \SphinxVerbatimTitle is reset to empty after each use of Verbatim environment.
 
 % It is also possible to use directly framed environment (i.e. not indirectly
-% via the Verbatim environment next), then it is \MyFrameTitle which specifies
+% via the Verbatim environment next), then it is \SphinxFrameTitle which specifies
 % the title.
-\newcommand*\MyFrameTitle {}
-\newcommand*\MyVerbatimTitle {}
-\newcommand*\setupcaptionforverbatim [2]
+\newcommand*\SphinxFrameTitle {}
+\newcommand*\SphinxVerbatimTitle {}
+\newcommand*\SphinxSetupCaptionForVerbatim [2]
 {%
-    \def\MyVerbatimTitle{\captionof{#1}{#2}\smallskip }%
+    \def\SphinxVerbatimTitle{\captionof{#1}{#2}\smallskip }%
 }
 
-% \MyCustomFBox is copied from framed.sty's \CustomFBox, but
+% \SphinxCustomFBox is copied from framed.sty's \CustomFBox, but
 % #1=title/caption is to be set _above_ the top rule, not _below_
 % #1 must be "vertical material", it may be left empty.
 
 % The amsmath patches \stepcounter to inhibit stepping under
 % \firstchoice@false. We use it because framed.sty typesets multiple
 % times its contents.
-\newif\if@MyFirstFramedPass
+\newif\ifSphinx@myfirstframedpass
 
-\long\def\MyCustomFBox#1#2#3#4#5#6#7{%
+\long\def\SphinxCustomFBox#1#2#3#4#5#6#7{%
   % we set up amsmath (amstext.sty) conditional to inhibit counter stepping
   % except in first pass
-  \if@MyFirstFramedPass\firstchoice@true
+  \ifSphinx@myfirstframedpass\firstchoice@true
                   \else\firstchoice@false\fi
   \leavevmode\begingroup
   \setbox\@tempboxa\hbox{%
@@ -218,29 +218,29 @@
     }%
   }%
   \endgroup
-  \global\@MyFirstFramedPassfalse
+  \global\Sphinx@myfirstframedpassfalse
 }
 
 % for non split frames:
 \def\FrameCommand{%
    % this is inspired from framed.sty v 0.96 2011/10/22 lines 185--190
-   % \fcolorbox (see \mycolorbox above) from color.sty uses \fbox.
-   \def\fbox{\MyCustomFBox{\MyFrameTitle}{}%
+   % \fcolorbox (see \Sphinxcolorbox above) from color.sty uses \fbox.
+   \def\fbox{\SphinxCustomFBox{\SphinxFrameTitle}{}%
                  \fboxrule\fboxrule\fboxrule\fboxrule}%
    % \fcolorbox from xcolor.sty may use rather \XC@fbox.
    \let\XC@fbox\fbox
-   \mycolorbox
+   \Sphinxcolorbox
 }
 % for first portion of split frames:
 \let\FirstFrameCommand\FrameCommand
 
 \renewcommand{\Verbatim}[1][1]{%
   % list starts new par, but we don't want it to be set apart vertically
-  \bgroup\parskip=0pt
+  \bgroup\parskip\z@skip
   \smallskip
   % use customized framed environment
-  \let\MyFrameTitle\MyVerbatimTitle
-  \global\@MyFirstFramedPasstrue
+  \let\SphinxFrameTitle\SphinxVerbatimTitle
+  \global\Sphinx@myfirstframedpasstrue
   % The list environement is needed to control perfectly the vertical
   % space.
   \list{}{%
@@ -258,10 +258,10 @@
   \endOriginalVerbatim
   \endMakeFramed
   \endlist
-  % close group to restore \parskip (and \MyFrameTitle)
+  % close group to restore \parskip (and \SphinxFrameTitle)
   \egroup
-  % reset to empty \MyVerbatimTitle
-  \global\let\MyVerbatimTitle\empty
+  % reset to empty \SphinxVerbatimTitle
+  \global\let\SphinxVerbatimTitle\empty
 }
 
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -163,10 +163,75 @@
 }
 \def\FrameCommand{\mycolorbox}
 
+% Go deep into framed.sty to insert a Title above the frame
+% Will be used for literal-block captions.
+% \MyCustomFBox, \MyFrameTitle, \MyVerbatimTitle, \setupverbatimcaption
+
+% The amsmath patches \stepcounter to inhibit stepping via \firstchoice@false
+% We will use that, because framed.sty typesets multiple times its contents,
+% and we want to put the \captionof in it.
+\newif\if@MyFirstFramedPass
+
+% \MyCustomFBox is for use by \FirstFrameCommand
+% It is copied from framed.sty's \CustomFBox, with the difference that
+% #1=title/caption is to be set _above_ the top rule, not _below_
+% #1 must be "vertical material" and may be left empty.
+% #1=\captionof{literal-block}{foo} is ok for example.
+\long\def\MyCustomFBox#1#2#3#4#5#6#7{%
+  % we set up amsmath (amstext.sty) conditional to inhibit counter stepping
+  % except in first pass
+  \if@MyFirstFramedPass\firstchoice@true
+                  \else\firstchoice@false\fi
+  \leavevmode\begingroup
+  \setbox\@tempboxa\hbox{%
+    \color@begingroup
+      \kern\fboxsep{#7}\kern\fboxsep
+    \color@endgroup}%
+  \hbox{%
+    \lower\dimexpr#4+\fboxsep+\dp\@tempboxa\hbox{%
+      \vbox{%
+        #1% TITLE
+        \hrule\@height#3\relax
+        \hbox{%
+          \vrule\@width#5\relax
+          \vbox{%
+            \vskip\fboxsep
+            \copy\@tempboxa
+            \vskip\fboxsep}%
+          \vrule\@width#6\relax}%
+        #2%
+        \hrule\@height#4\relax}%
+    }%
+  }%
+  \endgroup
+  \global\@MyFirstFramedPassfalse
+}
+
+\newcommand*\MyFrameTitle {}
+\newcommand*\MyVerbatimTitle {}
+\newcommand*\setupcaptionforverbatim [2]
+{% make \smallskip customizable ?
+    \def\MyVerbatimTitle{\captionof{#1}{#2}\smallskip }%
+}
+
+\def\FirstFrameCommand{%
+   % this is inspired from framed.sty v 0.96 2011/10/22 lines 185--190
+   % \fcolorbox (see \mycolorbox above) from color.sty uses \fbox.
+   \def\fbox{\MyCustomFBox{\MyFrameTitle}{}%
+                 \fboxrule\fboxrule\fboxrule\fboxrule}%
+   % \fcolorbox from xcolor.sty may use rather \XC@fbox.
+   \let\XC@fbox\fbox
+   \mycolorbox
+}
+
+% Unneeded %'s after control words removed.
 \renewcommand{\Verbatim}[1][1]{%
   % list starts new par, but we don't want it to be set apart vertically
-  \bgroup\parskip=0pt%
-  \smallskip%
+  \bgroup\parskip=0pt
+  \smallskip
+  % use customized framed environment
+  \let\MyFrameTitle\MyVerbatimTitle
+  \global\@MyFirstFramedPasstrue
   % The list environement is needed to control perfectly the vertical
   % space.
   \list{}{%
@@ -177,15 +242,17 @@
   \setlength\leftmargin{0pt}%
   }%
   \item\MakeFramed {\FrameRestore}%
-     \small%
+     \small
     \OriginalVerbatim[#1]%
 }
 \renewcommand{\endVerbatim}{%
-    \endOriginalVerbatim%
-  \endMakeFramed%
-  \endlist%
-  % close group to restore \parskip
-  \egroup%
+  \endOriginalVerbatim
+  \endMakeFramed
+  \endlist
+  % close group to restore \parskip (and \MyFrameTitle)
+  \egroup
+  % reset to empty \MyVerbatimTitle
+  \global\let\MyVerbatimTitle\empty
 }
 
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -161,22 +161,28 @@
   \end{minipage}%
   }%
 }
-\def\FrameCommand{\mycolorbox}
+\def\MidFrameCommand{\mycolorbox}
+\let\LastFrameCommand\MidFrameCommand
 
-% Go deep into framed.sty to insert a Title above the frame
-% Will be used for literal-block captions.
-% \MyCustomFBox, \MyFrameTitle, \MyVerbatimTitle, \setupverbatimcaption
+% We now customize \FrameCommand (for non split frames) and \FirstFrameCommand
+% (split frames), in order for the framed environment in order for it to
+% handle a Title above the frame, which can not be separated by a pagebreak.
+\newcommand*\MyFrameTitle {}
+\newcommand*\MyVerbatimTitle {}
+% cf visit_caption(self, node) in sphinx/writers/latex.py
+\newcommand*\setupcaptionforverbatim [2]
+{% make the \smallskip customizable ?
+    \def\MyVerbatimTitle{\captionof{#1}{#2}\smallskip }%
+}
 
-% The amsmath patches \stepcounter to inhibit stepping via \firstchoice@false
-% We will use that, because framed.sty typesets multiple times its contents,
-% and we want to put the \captionof in it.
+% \MyCustomFBox is copied from framed.sty's \CustomFBox, but
+% #1=title/caption is to be set _above_ the top rule, not _below_
+% #1 must be "vertical material", it may be left empty.
+
+% The amsmath patches \stepcounter to inhibit stepping under \firstchoice@false
+% We use that too, because framed.sty typesets multiple times its contents,
 \newif\if@MyFirstFramedPass
 
-% \MyCustomFBox is for use by \FirstFrameCommand
-% It is copied from framed.sty's \CustomFBox, with the difference that
-% #1=title/caption is to be set _above_ the top rule, not _below_
-% #1 must be "vertical material" and may be left empty.
-% #1=\captionof{literal-block}{foo} is ok for example.
 \long\def\MyCustomFBox#1#2#3#4#5#6#7{%
   % we set up amsmath (amstext.sty) conditional to inhibit counter stepping
   % except in first pass
@@ -207,14 +213,7 @@
   \global\@MyFirstFramedPassfalse
 }
 
-\newcommand*\MyFrameTitle {}
-\newcommand*\MyVerbatimTitle {}
-\newcommand*\setupcaptionforverbatim [2]
-{% make \smallskip customizable ?
-    \def\MyVerbatimTitle{\captionof{#1}{#2}\smallskip }%
-}
-
-\def\FirstFrameCommand{%
+\def\FrameCommand{% used for non-split frames
    % this is inspired from framed.sty v 0.96 2011/10/22 lines 185--190
    % \fcolorbox (see \mycolorbox above) from color.sty uses \fbox.
    \def\fbox{\MyCustomFBox{\MyFrameTitle}{}%
@@ -223,6 +222,8 @@
    \let\XC@fbox\fbox
    \mycolorbox
 }
+% first portion of split frames:
+\let\FirstFrameCommand\FrameCommand
 
 % Unneeded %'s after control words removed.
 \renewcommand{\Verbatim}[1][1]{%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -225,7 +225,6 @@
 % first portion of split frames:
 \let\FirstFrameCommand\FrameCommand
 
-% Unneeded %'s after control words removed.
 \renewcommand{\Verbatim}[1][1]{%
   % list starts new par, but we don't want it to be set apart vertically
   \bgroup\parskip=0pt

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -161,17 +161,24 @@
   \end{minipage}%
   }%
 }
+% used for split frames for continuation on next and final page
 \def\MidFrameCommand{\mycolorbox}
 \let\LastFrameCommand\MidFrameCommand
 
-% We now customize \FrameCommand (for non split frames) and \FirstFrameCommand
-% (split frames), in order for the framed environment in order for it to
-% handle a Title above the frame, which can not be separated by a pagebreak.
+% We customize \FrameCommand (for non split frames) and \FirstFrameCommand
+% (split frames), in order for the framed environment to insert a Title above
+% the frame, which can not be separated by a pagebreak.
+
+% The title is specified from outside as macro \MyVerbatimTitle.
+% \MyVerbatimTitle is reset to empty after each use of Verbatim environment.
+
+% It is also possible to use directly framed environment (i.e. not indirectly
+% via the Verbatim environment next), then it is \MyFrameTitle which specifies
+% the title.
 \newcommand*\MyFrameTitle {}
 \newcommand*\MyVerbatimTitle {}
-% cf visit_caption(self, node) in sphinx/writers/latex.py
 \newcommand*\setupcaptionforverbatim [2]
-{% make the \smallskip customizable ?
+{%
     \def\MyVerbatimTitle{\captionof{#1}{#2}\smallskip }%
 }
 
@@ -179,8 +186,9 @@
 % #1=title/caption is to be set _above_ the top rule, not _below_
 % #1 must be "vertical material", it may be left empty.
 
-% The amsmath patches \stepcounter to inhibit stepping under \firstchoice@false
-% We use that too, because framed.sty typesets multiple times its contents,
+% The amsmath patches \stepcounter to inhibit stepping under
+% \firstchoice@false. We use it because framed.sty typesets multiple
+% times its contents.
 \newif\if@MyFirstFramedPass
 
 \long\def\MyCustomFBox#1#2#3#4#5#6#7{%
@@ -213,7 +221,8 @@
   \global\@MyFirstFramedPassfalse
 }
 
-\def\FrameCommand{% used for non-split frames
+% for non split frames:
+\def\FrameCommand{%
    % this is inspired from framed.sty v 0.96 2011/10/22 lines 185--190
    % \fcolorbox (see \mycolorbox above) from color.sty uses \fbox.
    \def\fbox{\MyCustomFBox{\MyFrameTitle}{}%
@@ -222,7 +231,7 @@
    \let\XC@fbox\fbox
    \mycolorbox
 }
-% first portion of split frames:
+% for first portion of split frames:
 \let\FirstFrameCommand\FrameCommand
 
 \renewcommand{\Verbatim}[1][1]{%

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1384,7 +1384,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.in_container_literal_block:
             self.body.append('\\needspace{\\literalblockneedspace}')
             self.body.append('\\vspace{\\literalblockcaptiontopvspace}%')
-            self.body.append('\n\\setupcaptionforverbatim{literal-block}{')
+            self.body.append('\n\\SphinxSetupCaptionForVerbatim{literal-block}{')
             return
         self.body.append('\\caption{')
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1383,8 +1383,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.in_caption += 1
         if self.in_container_literal_block:
             self.body.append('\\needspace{\\literalblockneedspace}')
-            self.body.append('\\vspace{\\literalblockcaptiontopvspace}')
-            self.body.append('\\captionof{literal-block}{')
+            self.body.append('\\vspace{\\literalblockcaptiontopvspace}%')
+            self.body.append('\n\\setupcaptionforverbatim{literal-block}{')
             return
         self.body.append('\\caption{')
 

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -229,5 +229,5 @@ def test_literalinclude_caption_html(app, status, warning):
 def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\setupcaptionforverbatim{literal-block}{caption \\textbf{test} py}'
+    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\textbf{test} py}'
     assert caption in latex

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -64,7 +64,7 @@ def test_code_block_caption_html(app, status, warning):
 def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\captionof{literal-block}{caption \\emph{test} rb}'
+    caption = '\\setupcaptionforverbatim{literal-block}{caption \\emph{test} rb}'
     assert caption in latex
 
 
@@ -229,5 +229,5 @@ def test_literalinclude_caption_html(app, status, warning):
 def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\captionof{literal-block}{caption \\textbf{test} py}'
+    caption = '\\setupcaptionforverbatim{literal-block}{caption \\textbf{test} py}'
     assert caption in latex

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -64,7 +64,7 @@ def test_code_block_caption_html(app, status, warning):
 def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\setupcaptionforverbatim{literal-block}{caption \\emph{test} rb}'
+    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\emph{test} rb}'
     assert caption in latex
 
 


### PR DESCRIPTION
This could fix https://github.com/sphinx-doc/sphinx/issues/2262

Tested on top of 1.3.5 release.

The 1.3.5 Verbatim environment in sphinx.sty has many places allowing a
page break after the caption: from the \smallskip, and from the list,
and from the \MakeFramed because framed.sty explains it encourages page
breaks above it.

This commit sets up the caption from _inside_ the framed environment.

Test project on
https://github.com/sphinx-doc/sphinx/files/101910/2262.zip
compiles correctly. I have also tested with xcolor as its use has been
introduced in later commit 476f8093.

More extensive tests needed.

```
modified:   sphinx/texinputs/sphinx.sty
modified:   sphinx/writers/latex.py
```
