### PR TITLE
Fix #2298: automodule fails to document a class attribute.

### DIFF
--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -1193,6 +1193,17 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):
             return
         ModuleLevelDocumenter.document_members(self, all_members)
 
+    def generate(self, more_content=None, real_modname=None,
+                 check_module=False, all_members=False):
+        # Do not pass real_modname and use the name from the __module__
+        # attribute of the class.
+        # If a class gets imported into the module real_modname
+        # the analyzer won't find the source of the class, if
+        # it looks in real_modname.
+        return super(ClassDocumenter, self).generate(more_content=more_content,
+                                                     check_module=check_module,
+                                                     all_members=all_members)
+
 
 class ExceptionDocumenter(ClassDocumenter):
     """

--- a/tests/roots/test-ext-viewcode/index.rst
+++ b/tests/roots/test-ext-viewcode/index.rst
@@ -28,6 +28,11 @@ viewcode
    :language: python
    :pyobject: func1
 
+.. autoclass:: spam.mod3.Class3
+   :members:
+
+.. automodule:: spam.mod3
+   :members:
 
 .. toctree::
 

--- a/tests/roots/test-ext-viewcode/spam/mod1.py
+++ b/tests/roots/test-ext-viewcode/spam/mod1.py
@@ -13,3 +13,10 @@ class Class1(object):
     """
     this is Class1
     """
+
+class Class3(object):
+    """
+    this is Class3
+    """
+    class_attr = 42
+    """this is the class attribute class_attr"""

--- a/tests/roots/test-ext-viewcode/spam/mod3.py
+++ b/tests/roots/test-ext-viewcode/spam/mod3.py
@@ -1,0 +1,2 @@
+from spam.mod1 import Class3
+__all__ = ('Class3',)

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -31,6 +31,12 @@ def test_viewcode(app, status, warning):
     assert result.count('href="_modules/spam/mod1.html#Class1"') == 2
     assert result.count('href="_modules/spam/mod2.html#Class2"') == 2
 
+    # test that the class attribute is correctly documented
+    assert result.count('this is Class3') == 2
+    assert 'this is the class attribute class_attr' in result
+    # the next assert fails, until the autodoc bug gets fixed
+    assert result.count('this is the class attribute class_attr') == 2
+
 
 @with_app(testroot='ext-viewcode', tags=['test_linkcode'])
 def test_linkcode(app, status, warning):


### PR DESCRIPTION
This pull request adds a test case for bug #2298 (commit de356149cd) and a fix (commit c44608234d).

I didn't create a new test module but extended test_ext_viewcode, because the sphinx dev guide recommends it for performance reasons. The test fails until the second commit get applied.

My fix is not the only possible fix, but a fairly simple one. It surely needs to be reviewed. Especially I'm not completely sure about its impact on extension classes written in C.
