### PR TITLE
Texts in the classic html theme should be hyphenated.

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -189,6 +189,13 @@ div.genindex-jumpbox {
 
 /* -- general body styles --------------------------------------------------- */
 
+div.body p, div.body dd, div.body li, div.body blockquote {
+    -moz-hyphens: auto;
+    -ms-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto;
+}
+
 a.headerlink {
     visibility: hidden;
 }


### PR DESCRIPTION
To avoid "river of white".

This currently works well in Firefox, but Chromium seems not supporting it well yet (but does not hurt anyway).
