### PR TITLE
Fix #2199: Use ``imagesize`` package to obtain size of images

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,7 @@ Features added
 * #1779: Add EPUB 3 builder
 * #1751: Add :confval:`todo_link_only` to avoid file path and line indication on
   :rst:dir:`todolist`. Thanks to Francesco Montesano.
+* #2199: Use ``imagesize`` package to obtain size of images
 
 Bugs fixed
 ----------

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ requires = [
     'snowballstemmer>=1.1',
     'babel>=1.3,!=2.0',
     'alabaster>=0.7,<0.8',
+    'imagesize',
 ]
 extras_require = {
     # Environment Marker works for wheel 0.24 or later

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.util.images
+    ~~~~~~~~~~~
+
+    Image utility functions for Sphinx.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import imagesize
+
+try:
+    from PIL import Image        # check for the Python Imaging Library
+except ImportError:
+    try:
+        import Image
+    except ImportError:
+        Image = None
+
+
+def get_image_size(filename):
+    try:
+        size = imagesize.get(filename)
+        if size[0] == -1:
+            size = None
+
+        if Image:  # fallback to PIL
+            im = Image.open(filename)
+            size = im.size
+            try:
+                im.fp.close()
+            except Exception:
+                pass
+
+        return size
+    except:
+        return None

--- a/test-reqs.txt
+++ b/test-reqs.txt
@@ -11,3 +11,4 @@ sqlalchemy>=0.9
 whoosh>=2.0
 alabaster
 sphinx_rtd_theme
+imagesize


### PR DESCRIPTION
Fix #2199. This PR adds  `imagesize` package to dependency list of sphinx.
It is written in python. so we do not need to build PIL to obtain size of images.

@birkenfeld @shimizukawa any rules to add new dependencies?
