### PR TITLE
Add the option to force syntax highlighting

### DIFF
--- a/doc/markup/code.rst
+++ b/doc/markup/code.rst
@@ -72,7 +72,8 @@ installed) and handled in a smart way:
     <http://pygments.org/docs/lexers/>`_.
 
 * If highlighting with the selected language fails (i.e. Pygments emits an
-  "Error" token), the block is not highlighted in any way.
+  "Error" token), the block is not highlighted in any way, unless the
+  highlighting language is passed with ``force_`` prepended to it.
 
 Line numbers
 ^^^^^^^^^^^^

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -170,25 +170,22 @@ class PygmentsBridge(object):
             if lang in lexers:
                 lexer = lexers[lang]
             else:
-                lexer_err = False
+                if lang.startswith("force_"):
+                    lang = lang.split("force_", 1)[1]
+                    raiseonerror = False
+                else:
+                    raiseonerror = True
                 try:
                     lexer = lexers[lang] = get_lexer_by_name(lang, **(opts or {}))
                 except ClassNotFound as err:
-                    if lang.startswith("force_"):
-                        try:
-                            lexer = lexers[lang] = get_lexer_by_name(lang.split("force_", 1)[1], **(opts or {}))
-                        except ClassNotFound as err:
-                            lexer_err = err
-                    else:
-                        lexer_err = err
-                else:
-                    lexer.add_filter('raiseonerror')
-                if lexer_err:
                     if warn:
                         warn('Pygments lexer name %r is not known' % lang)
                         lexer = lexers['none']
                     else:
-                        raise lexer_err
+                        raise
+                else:
+                    if raiseonerror:
+                        lexer.add_filter('raiseonerror')
 
         # trim doctest options if wanted
         if isinstance(lexer, PythonConsoleLexer) and self.trim_doctest_flags:

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -177,7 +177,7 @@ class PygmentsBridge(object):
                     raiseonerror = True
                 try:
                     lexer = lexers[lang] = get_lexer_by_name(lang, **(opts or {}))
-                except ClassNotFound as err:
+                except ClassNotFound:
                     if warn:
                         warn('Pygments lexer name %r is not known' % lang)
                         lexer = lexers['none']


### PR DESCRIPTION
Often times, I will want to write pseudo-Python when documenting things, as it is useful when trying to explain something to be able to deviate slightly from Python syntax (to use a more mathematically precise notation, for example). Unfortunately, when I do this, Sphinx refuses to highlight any of the included Python at all, even though Pygments is capable of that. Since I think this feature would be very useful, I wrote some code that adds to Sphinx the ability to process syntax highlighting languages of the form `force_<lang>` (e.g. `force_python`), which will cause Sphinx to tell Pygments not to raise an error if the parsing fails in one spot. I have also included an update to the Sphinx documentation detailing this change.
