### PR TITLE
Fixed #1099 -- allow the linkcheck builder to retry on errors.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1762,7 +1762,7 @@ Options for the linkcheck builder
    The number of times the linkcheck builder will attempt to check a URL before
    declaring it broken. Defaults to 1 attempt.
 
-  .. versionadded:: 1.4
+   .. versionadded:: 1.4
 
 .. confval:: linkcheck_timeout
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1757,6 +1757,13 @@ Options for the linkcheck builder
 
    .. versionadded:: 1.1
 
+.. confval:: linkcheck_retries
+
+  The number of times the linkcheck builder will attempt to check a URL before
+  declaring it broken. Defaults to 1 attempt.
+
+  .. versionadded:: 1.4
+
 .. confval:: linkcheck_timeout
 
    A timeout value, in seconds, for the linkcheck builder.  **Only works in

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1759,8 +1759,8 @@ Options for the linkcheck builder
 
 .. confval:: linkcheck_retries
 
-  The number of times the linkcheck builder will attempt to check a URL before
-  declaring it broken. Defaults to 1 attempt.
+   The number of times the linkcheck builder will attempt to check a URL before
+   declaring it broken. Defaults to 1 attempt.
 
   .. versionadded:: 1.4
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -137,8 +137,20 @@ class CheckExternalLinksBuilder(Builder):
         if self.app.config.linkcheck_timeout:
             kwargs['timeout'] = self.app.config.linkcheck_timeout
 
-
         def check_uri():
+            # split off anchor
+            if '#' in uri:
+                req_url, hash = uri.split('#', 1)
+            else:
+                req_url = uri
+                hash = None
+
+            # handle non-ASCII URIs
+            try:
+                req_url.encode('ascii')
+            except UnicodeError:
+                req_url = encode_uri(req_url)
+
             try:
                 if hash and self.app.config.linkcheck_anchors:
                     # Read the whole document and see if #hash exists
@@ -202,19 +214,6 @@ class CheckExternalLinksBuilder(Builder):
             for rex in self.to_ignore:
                 if rex.match(uri):
                     return 'ignored', '', 0
-
-            # split off anchor
-            if '#' in uri:
-                req_url, hash = uri.split('#', 1)
-            else:
-                req_url = uri
-                hash = None
-
-            # handle non-ASCII URIs
-            try:
-                req_url.encode('ascii')
-            except UnicodeError:
-                req_url = encode_uri(req_url)
 
             # need to actually check the URI
             for _ in range(self.app.config.linkcheck_retries):

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -217,7 +217,7 @@ class CheckExternalLinksBuilder(Builder):
                 req_url = encode_uri(req_url)
 
             # need to actually check the URI
-            for _ in range(self.app.config.linkcheck_retries)
+            for _ in range(self.app.config.linkcheck_retries):
                 status, info, code = check_uri()
                 if status != "broken":
                     break

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -228,6 +228,8 @@ class CheckExternalLinksBuilder(Builder):
             elif status == "redirected":
                 self.redirected[uri] = (info, code)
 
+            return (status, info, code)
+
         while True:
             uri, docname, lineno = self.wqueue.get()
             if uri is None:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -244,6 +244,7 @@ class Config(object):
 
         # linkcheck options
         linkcheck_ignore = ([], None),
+        linkcheck_retries = (1, None),
         linkcheck_timeout = (None, None, [int]),
         linkcheck_workers = (5, None),
         linkcheck_anchors = (True, None),


### PR DESCRIPTION
This is useful because if you run linkcheck often, you are likely to see lots of transient network errors, which usually disappear if you simply try again.
