### PR TITLE
Restructuring glossary term node to fix #2251

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,9 +21,11 @@ Incompatible changes
   refers to :confval:`exclude_patterns` to exclude extra files and directories.
 * #2300: enhance autoclass:: to use the docstring of __new__ if __init__ method's is missing
   of empty
-* #2251: term nodes in a glossary directive are wrapped with ``termset`` node to handle
-  multiple term correctly. ``termsep`` node is removed and ``termset`` is added.
-  By this change, every writers must have visit_termset and depart_termset method.
+* #2251: Previously, under glossary directives, multiple terms for one definition are
+  converted into single ``term`` node and the each terms in the term node are separated
+  by ``termsep`` node. In new implementation, each terms are converted into individual
+  ``term`` nodes and ``termsep`` node is removed.
+  By this change, output layout of every builders are changed a bit.
 
 Features added
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,9 @@ Incompatible changes
   refers to :confval:`exclude_patterns` to exclude extra files and directories.
 * #2300: enhance autoclass:: to use the docstring of __new__ if __init__ method's is missing
   of empty
+* #2251: term nodes in a glossary directive are wrapped with ``termset`` node to handle
+  multiple term correctly. ``termsep`` node is removed and ``termset`` is added.
+  By this change, every writers must have visit_termset and depart_termset method.
 
 Features added
 --------------
@@ -84,6 +87,7 @@ Bugs fixed
 * #2074: make gettext should use canonical relative paths for .pot. Thanks to
   anatoly techtonik.
 * #2311: Fix sphinx.ext.inheritance_diagram raises AttributeError
+* #2251: Line breaks in .rst files are transferred to .pot files in a wrong way.
 
 
 Documentation

--- a/doc/extdev/nodes.rst
+++ b/doc/extdev/nodes.rst
@@ -54,4 +54,4 @@ You should not need to generate the nodes below in extensions.
 .. autoclass:: start_of_file
 .. autoclass:: productionlist
 .. autoclass:: production
-.. autoclass:: termset
+.. autoclass:: termsep

--- a/doc/extdev/nodes.rst
+++ b/doc/extdev/nodes.rst
@@ -54,4 +54,4 @@ You should not need to generate the nodes below in extensions.
 .. autoclass:: start_of_file
 .. autoclass:: productionlist
 .. autoclass:: production
-.. autoclass:: termsep
+.. autoclass:: termset

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -208,8 +208,8 @@ class abbreviation(nodes.Inline, nodes.TextElement):
     """Node for abbreviations with explanations."""
 
 
-class termsep(nodes.Structural, nodes.Element):
-    """Separates two terms within a <term> node."""
+class termset(nodes.Structural, nodes.Element):
+    """A set of <term> node"""
 
 
 class manpage(nodes.Inline, nodes.TextElement):

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import warnings
+
 from docutils import nodes
 
 
@@ -208,8 +210,17 @@ class abbreviation(nodes.Inline, nodes.TextElement):
     """Node for abbreviations with explanations."""
 
 
-class termset(nodes.Structural, nodes.Element):
-    """A set of <term> node"""
+class termsep(nodes.Structural, nodes.Element):
+    """Separates two terms within a <term> node.
+
+    .. versionchanged:: 1.4
+       sphinx.addnodes.termsep is deprecated. It will be removed at Sphinx-1.5.
+    """
+
+    def __init__(self, *args, **kw):
+        warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
+                      DeprecationWarning, stacklevel=2)
+        super(termsep, self).__init__(*args, **kw)
 
 
 class manpage(nodes.Inline, nodes.TextElement):

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -235,14 +235,6 @@ def register_term_to_glossary(env, node, new_id=None):
     node['names'].append(new_id)
 
 
-def make_termset_from_termnodes(termnodes):
-    # make a single "termset" node with all the terms
-    termset = addnodes.termset('', *termnodes)
-    termset.source, termset.line = termnodes[0].source, termnodes[0].line
-    termset.rawsource = termset.astext()
-    return termset
-
-
 class Glossary(Directive):
     """
     Directive to create a glossary with cross-reference targets for :term:
@@ -337,16 +329,15 @@ class Glossary(Directive):
                 termtexts.append(term.astext())
                 termnodes.append(term)
 
-            termset = make_termset_from_termnodes(termnodes)
-            termset += system_messages
+            termnodes.extend(system_messages)
 
             defnode = nodes.definition()
             if definition:
                 self.state.nested_parse(definition, definition.items[0][1],
                                         defnode)
-
+            termnodes.append(defnode)
             items.append((termtexts,
-                          nodes.definition_list_item('', termset, defnode)))
+                          nodes.definition_list_item('', *termnodes)))
 
         if 'sorted' in self.options:
             items.sort(key=lambda x:

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -214,7 +214,7 @@ class OptionXRefRole(XRefRole):
         return title, target
 
 
-def make_termnodes_from_paragraph_node(env, node, new_id=None):
+def register_term_to_glossary(env, node, new_id=None):
     gloss_entries = env.temp_data.setdefault('gloss_entries', set())
     objects = env.domaindata['std']['objects']
 
@@ -229,25 +229,18 @@ def make_termnodes_from_paragraph_node(env, node, new_id=None):
     # add an index entry too
     indexnode = addnodes.index()
     indexnode['entries'] = [('single', termtext, new_id, 'main')]
-    new_termnodes = []
-    new_termnodes.append(indexnode)
-    new_termnodes.extend(node.children)
-    new_termnodes.append(addnodes.termsep())
-    for termnode in new_termnodes:
-        termnode.source, termnode.line = node.source, node.line
-
-    return new_id, termtext, new_termnodes
+    indexnode.source, indexnode.line = node.source, node.line
+    node.append(indexnode)
+    node['ids'].append(new_id)
+    node['names'].append(new_id)
 
 
-def make_term_from_paragraph_node(termnodes, ids):
-    # make a single "term" node with all the terms, separated by termsep
-    # nodes (remove the dangling trailing separator)
-    term = nodes.term('', '', *termnodes[:-1])
-    term.source, term.line = termnodes[0].source, termnodes[0].line
-    term.rawsource = term.astext()
-    term['ids'].extend(ids)
-    term['names'].extend(ids)
-    return term
+def make_termset_from_termnodes(termnodes):
+    # make a single "termset" node with all the terms
+    termset = addnodes.termset('', *termnodes)
+    termset.source, termset.line = termnodes[0].source, termnodes[0].line
+    termset.rawsource = termset.astext()
+    return termset
 
 
 class Glossary(Directive):
@@ -330,7 +323,6 @@ class Glossary(Directive):
             termtexts = []
             termnodes = []
             system_messages = []
-            ids = []
             for line, source, lineno in terms:
                 # parse the term with inline markup
                 res = self.state.inline_text(line, lineno)
@@ -338,17 +330,15 @@ class Glossary(Directive):
 
                 # get a text-only representation of the term and register it
                 # as a cross-reference target
-                tmp = nodes.paragraph('', '', *res[0])
-                tmp.source = source
-                tmp.line = lineno
-                new_id, termtext, new_termnodes = \
-                    make_termnodes_from_paragraph_node(env, tmp)
-                ids.append(new_id)
-                termtexts.append(termtext)
-                termnodes.extend(new_termnodes)
+                term = nodes.term('', '', *res[0])
+                term.source = source
+                term.line = lineno
+                register_term_to_glossary(env, term)
+                termtexts.append(term.astext())
+                termnodes.append(term)
 
-            term = make_term_from_paragraph_node(termnodes, ids)
-            term += system_messages
+            termset = make_termset_from_termnodes(termnodes)
+            termset += system_messages
 
             defnode = nodes.definition()
             if definition:
@@ -356,7 +346,7 @@ class Glossary(Directive):
                                         defnode)
 
             items.append((termtexts,
-                          nodes.definition_list_item('', term, defnode)))
+                          nodes.definition_list_item('', termset, defnode)))
 
         if 'sorted' in self.options:
             items.sort(key=lambda x:

--- a/sphinx/transforms.py
+++ b/sphinx/transforms.py
@@ -27,10 +27,7 @@ from sphinx.util.nodes import (
 from sphinx.util.osutil import ustrftime
 from sphinx.util.i18n import find_catalog
 from sphinx.util.pycompat import indent
-from sphinx.domains.std import (
-    make_term_from_paragraph_node,
-    make_termnodes_from_paragraph_node,
-)
+from sphinx.domains.std import register_term_to_glossary
 
 
 default_substitutions = set([
@@ -340,18 +337,10 @@ class Locale(Transform):
             # glossary terms update refid
             if isinstance(node, nodes.term):
                 gloss_entries = env.temp_data.setdefault('gloss_entries', set())
-                ids = []
-                termnodes = []
                 for _id in node['names']:
                     if _id in gloss_entries:
                         gloss_entries.remove(_id)
-                    _id, _, new_termnodes = \
-                        make_termnodes_from_paragraph_node(env, patch, _id)
-                    ids.append(_id)
-                    termnodes.extend(new_termnodes)
-
-                if termnodes and ids:
-                    patch = make_term_from_paragraph_node(termnodes, ids)
+                    register_term_to_glossary(env, patch, _id)
                     node['ids'] = patch['ids']
                     node['names'] = patch['names']
                     processed = True

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -13,6 +13,7 @@ import sys
 import posixpath
 import os
 import copy
+import warnings
 
 from six import string_types
 from docutils import nodes
@@ -629,11 +630,11 @@ class HTMLTranslator(BaseTranslator):
     def depart_abbreviation(self, node):
         self.body.append('</abbr>')
 
-    def visit_termset(self, node):
-        pass
-
-    def depart_termset(self, node):
-        pass
+    def visit_termsep(self, node):
+        warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
+                      DeprecationWarning)
+        self.body.append('<br />')
+        raise nodes.SkipNode
 
     def visit_manpage(self, node):
         return self.visit_literal_emphasis(node)

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -629,9 +629,11 @@ class HTMLTranslator(BaseTranslator):
     def depart_abbreviation(self, node):
         self.body.append('</abbr>')
 
-    def visit_termsep(self, node):
-        self.body.append('<br />')
-        raise nodes.SkipNode
+    def visit_termset(self, node):
+        pass
+
+    def depart_termset(self, node):
+        pass
 
     def visit_manpage(self, node):
         return self.visit_literal_emphasis(node)
@@ -691,6 +693,15 @@ class HTMLTranslator(BaseTranslator):
                           'described at http://sphinx-doc.org/ext/math.html',
                           (self.builder.current_docname, node.line))
         raise nodes.SkipNode
+
+    # overwritten to do not add '</dt>' in 'visit_definition' state.
+    def visit_definition(self, node):
+        self.body.append(self.starttag(node, 'dd', ''))
+        self.set_first_last(node)
+
+    # overwritten to add '</dt>' in 'depart_term' state.
+    def depart_term(self, node):
+        self.body.append('</dt>\n')
 
     def unknown_visit(self, node):
         raise NotImplementedError('Unknown node: ' + node.__class__.__name__)

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -630,6 +630,23 @@ class HTMLTranslator(BaseTranslator):
     def depart_abbreviation(self, node):
         self.body.append('</abbr>')
 
+    # overwritten (but not changed) to keep pair of visit/depart_term
+    def visit_term(self, node):
+        self.body.append(self.starttag(node, 'dt', ''))
+
+    # overwritten to add '</dt>' in 'depart_term' state.
+    def depart_term(self, node):
+        self.body.append('</dt>\n')
+
+    # overwritten to do not add '</dt>' in 'visit_definition' state.
+    def visit_definition(self, node):
+        self.body.append(self.starttag(node, 'dd', ''))
+        self.set_first_last(node)
+
+    # overwritten (but not changed) to keep pair of visit/depart_definition
+    def depart_definition(self, node):
+        self.body.append('</dd>\n')
+
     def visit_termsep(self, node):
         warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
                       DeprecationWarning)
@@ -694,15 +711,6 @@ class HTMLTranslator(BaseTranslator):
                           'described at http://sphinx-doc.org/ext/math.html',
                           (self.builder.current_docname, node.line))
         raise nodes.SkipNode
-
-    # overwritten to do not add '</dt>' in 'visit_definition' state.
-    def visit_definition(self, node):
-        self.body.append(self.starttag(node, 'dd', ''))
-        self.set_first_last(node)
-
-    # overwritten to add '</dt>' in 'depart_term' state.
-    def depart_term(self, node):
-        self.body.append('</dt>\n')
 
     def unknown_visit(self, node):
         raise NotImplementedError('Unknown node: ' + node.__class__.__name__)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1222,9 +1222,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.unrestrict_footnote(node)
         self.in_term -= 1
 
-    def visit_termsep(self, node):
-        self.body.append(', ')
-        raise nodes.SkipNode
+    def visit_termset(self, node):
+        pass
+
+    def depart_termset(self, node):
+        pass
 
     def visit_classifier(self, node):
         self.body.append('{[}')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -15,6 +15,7 @@
 import re
 import sys
 from os import path
+import warnings
 
 from six import itervalues, text_type
 from docutils import nodes, writers
@@ -1222,11 +1223,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.unrestrict_footnote(node)
         self.in_term -= 1
 
-    def visit_termset(self, node):
-        pass
-
-    def depart_termset(self, node):
-        pass
+    def visit_termsep(self, node):
+        warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
+                      DeprecationWarning)
+        self.body.append(', ')
+        raise nodes.SkipNode
 
     def visit_classifier(self, node):
         self.body.append('{[}')

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import warnings
+
 from docutils import nodes
 from docutils.writers.manpage import (
     MACRO_DEF,
@@ -200,11 +202,11 @@ class ManualPageTranslator(BaseTranslator):
     def depart_versionmodified(self, node):
         self.depart_paragraph(node)
 
-    def visit_termset(self, node):
-        pass
-
-    def depart_termset(self, node):
-        pass
+    def visit_termsep(self, node):
+        warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
+                      DeprecationWarning)
+        self.body.append(', ')
+        raise nodes.SkipNode
 
     # overwritten -- we don't want source comments to show up
     def visit_comment(self, node):

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -200,9 +200,11 @@ class ManualPageTranslator(BaseTranslator):
     def depart_versionmodified(self, node):
         self.depart_paragraph(node)
 
-    def visit_termsep(self, node):
-        self.body.append(', ')
-        raise nodes.SkipNode
+    def visit_termset(self, node):
+        pass
+
+    def depart_termset(self, node):
+        pass
 
     # overwritten -- we don't want source comments to show up
     def visit_comment(self, node):

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -952,10 +952,10 @@ class TexinfoTranslator(nodes.NodeVisitor):
     def depart_term(self, node):
         pass
 
-    def visit_termsep(self, node):
-        self.body.append('\n%s ' % self.at_item_x)
+    def visit_termset(self, node):
+        pass
 
-    def depart_termsep(self, node):
+    def depart_termset(self, node):
         pass
 
     def visit_classifier(self, node):

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -12,6 +12,7 @@
 import re
 import textwrap
 from os import path
+import warnings
 
 from six import itervalues
 from six.moves import range
@@ -952,10 +953,12 @@ class TexinfoTranslator(nodes.NodeVisitor):
     def depart_term(self, node):
         pass
 
-    def visit_termset(self, node):
-        pass
+    def visit_termsep(self, node):
+        warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
+                      DeprecationWarning)
+        self.body.append('\n%s ' % self.at_item_x)
 
-    def depart_termset(self, node):
+    def depart_termsep(self, node):
         pass
 
     def visit_classifier(self, node):

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -640,9 +640,11 @@ class TextTranslator(nodes.NodeVisitor):
         if not self._classifier_count_in_li:
             self.end_state(end=None)
 
-    def visit_termsep(self, node):
-        self.add_text(', ')
-        raise nodes.SkipNode
+    def visit_termset(self, node):
+        pass
+
+    def depart_termset(self, node):
+        pass
 
     def visit_classifier(self, node):
         self.add_text(' : ')

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -12,6 +12,7 @@ import os
 import re
 import textwrap
 from itertools import groupby
+import warnings
 
 from six.moves import zip_longest
 
@@ -640,11 +641,11 @@ class TextTranslator(nodes.NodeVisitor):
         if not self._classifier_count_in_li:
             self.end_state(end=None)
 
-    def visit_termset(self, node):
-        pass
-
-    def depart_termset(self, node):
-        pass
+    def visit_termsep(self, node):
+        warnings.warn('sphinx.addnodes.termsep will be removed at Sphinx-1.5',
+                      DeprecationWarning)
+        self.add_text(', ')
+        raise nodes.SkipNode
 
     def visit_classifier(self, node):
         self.add_text(' : ')


### PR DESCRIPTION
This change introduces incompatibility for doctree structure and output structure of 'html', 'latex', 'man', 'texinfo' and 'text' builders.

For example, PDF visibility via latexpdf will be changed a bit.

Before:

```
\item[{\index{Term 4 : E|textbf}Term 4 : E, \index{Term 5 : e|textbf}Term 5 : e}] \leavevmode\phantomsection\label{index:term-term-4-e}
description 4 and 5
```

![image](https://cloud.githubusercontent.com/assets/151623/13031674/cdab51e4-d318-11e5-8b75-2ef56b4a5603.png)

After:

```
\item[{Term 4 : E\index{Term 4 : E|textbf}}] \leavevmode\phantomsection\label{index:term-term-4-e}\item[{Term 5 : e\index{Term 5 : e|textbf}}] \leavevmode\phantomsection\label{index:term-term-5-e}
description 4 and 5
```

![image](https://cloud.githubusercontent.com/assets/151623/13031656/628fd02e-d318-11e5-9de7-f1e75635ccd6.png)

IMO, it's not bad.
