### PR TITLE
classifier of glossary terms can be used for index entries grouping key.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -73,6 +73,8 @@ Features added
   sections using its title. Thanks to Tadhg O'Higgins.
 * #1854: Allow to choose Janome for Japanese splitter.
 * #1853: support custom text splitter on html search with `language='ja'`.
+* #2320: classifier of glossary terms can be used for index entries grouping key.
+  The classifier also be used for translation. See also :ref:`glossary-directive`.
 
 Bugs fixed
 ----------

--- a/doc/markup/para.rst
+++ b/doc/markup/para.rst
@@ -183,6 +183,24 @@ Glossary
 
    (When the glossary is sorted, the first term determines the sort order.)
 
+   If you want to specify "grouping key" for general index entries, you can put a "key"
+   as "term : key". For example::
+
+      .. glossary::
+
+         term 1 : A
+         term 2 : B
+            Definition of both terms.
+
+   Note that "key" is used for grouping key as is.
+   The "key" isn't normalized; key "A" and "a" become different groups.
+   The whole characters in "key" is used instead of a first character; it is used for
+   "Combining Character Sequence" and "Surrogate Pairs" grouping key.
+
+   In i18n situation, you can specify "localized term : key" even if original text only
+   have "term" part. In this case, translated "localized term" will be categorized in
+   "key" group.
+
    .. versionadded:: 0.6
       You can now give the glossary directive a ``:sorted:`` flag that will
       automatically sort the entries alphabetically.
@@ -190,6 +208,8 @@ Glossary
    .. versionchanged:: 1.1
       Now supports multiple terms and inline markup in terms.
 
+   .. versionchanged:: 1.4
+      Index key for glossary term should be considered *experimental*.
 
 Grammar production displays
 ---------------------------

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -400,7 +400,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         # XXX: modifies tree inline
         # Logic modeled from themes/basic/genindex.html
         for key, columns in tree:
-            for entryname, (links, subitems) in columns:
+            for entryname, (links, subitems, key_) in columns:
                 for (i, (ismain, link)) in enumerate(links):
                     m = self.refuri_re.match(link)
                     if m:

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -117,7 +117,7 @@ class I18nBuilder(Builder):
         if 'index' in self.env.config.gettext_additional_targets:
             # Extract translatable messages from index entries.
             for node, entries in traverse_translatable_index(doctree):
-                for typ, msg, tid, main in entries:
+                for typ, msg, tid, main, key_ in entries:
                     for m in split_index_msg(typ, msg):
                         if typ == 'pair' and m in pairindextypes.values():
                             # avoid built-in translated message was incorporated

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -512,7 +512,7 @@ class StandaloneHTMLBuilder(Builder):
         indexcounts = []
         for _k, entries in genindex:
             indexcounts.append(sum(1 + len(subitems)
-                                   for _, (_, subitems) in entries))
+                                   for _, (_, subitems, _) in entries))
 
         genindexcontext = dict(
             genindexentries = genindex,

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -299,7 +299,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                         write_index(subitem[0], subitem[1], [])
                     f.write('</UL>')
             for (key, group) in index:
-                for title, (refs, subitems) in group:
+                for title, (refs, subitems, key_) in group:
                     write_index(title, refs, subitems)
             f.write('</UL>\n')
         finally:

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -148,7 +148,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         keywords = []
         index = self.env.create_index(self, group_entries=False)
         for (key, group) in index:
-            for title, (refs, subitems) in group:
+            for title, (refs, subitems, key_) in group:
                 keywords.extend(self.build_keywords(title, refs, subitems))
         keywords = u'\n'.join(keywords)
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -206,7 +206,7 @@ class CObject(ObjectDescription):
         indextext = self.get_index_text(name)
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
-                                              targetname, ''))
+                                              targetname, '', None))
 
     def before_content(self):
         self.typename_set = False

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3677,7 +3677,7 @@ class CPPObject(ObjectDescription):
 
         name = text_type(ast.symbol.get_full_nested_name()).lstrip(':')
         indexText = self.get_index_text(name)
-        self.indexnode['entries'].append(('single', indexText, newestId, ''))
+        self.indexnode['entries'].append(('single', indexText, newestId, '', None))
 
         if newestId not in self.state.document.ids:
             # if the name is not unique, the first one will win

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -97,7 +97,7 @@ class JSObject(ObjectDescription):
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
                                               fullname.replace('$', '_S_'),
-                                              ''))
+                                              '', None))
 
     def get_index_text(self, objectname, name_obj):
         name, obj = name_obj

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -257,7 +257,7 @@ class PyObject(ObjectDescription):
         indextext = self.get_index_text(modname, name_cls)
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
-                                              fullname, ''))
+                                              fullname, '', None))
 
     def before_content(self):
         # needed for automatic qualification of members (reset in subclasses)
@@ -462,7 +462,7 @@ class PyModule(Directive):
             ret.append(targetnode)
             indextext = _('%s (module)') % modname
             inode = addnodes.index(entries=[('single', indextext,
-                                             'module-' + modname, '')])
+                                             'module-' + modname, '', None)])
             ret.append(inode)
         return ret
 

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -48,7 +48,7 @@ class ReSTMarkup(ObjectDescription):
         indextext = self.get_index_text(self.objtype, name)
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
-                                              targetname, ''))
+                                              targetname, '', None))
 
     def get_index_text(self, objectname, name):
         if self.objtype == 'directive':

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -191,7 +191,7 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner,
     if typ == 'pep':
         indexnode['entries'] = [
             ('single', _('Python Enhancement Proposals; PEP %s') % target,
-             targetid, '')]
+             targetid, '', None)]
         anchor = ''
         anchorindex = target.find('#')
         if anchorindex > 0:
@@ -212,7 +212,8 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner,
         rn += sn
         return [indexnode, targetnode, rn], []
     elif typ == 'rfc':
-        indexnode['entries'] = [('single', 'RFC; RFC %s' % target, targetid, '')]
+        indexnode['entries'] = [
+            ('single', 'RFC; RFC %s' % target, targetid, '', None)]
         anchor = ''
         anchorindex = target.find('#')
         if anchorindex > 0:
@@ -317,7 +318,7 @@ def index_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
             target = target[1:]
             title = title[1:]
             main = 'main'
-        entries = [('single', target, targetid, main)]
+        entries = [('single', target, targetid, main, None)]
     indexnode = addnodes.index()
     indexnode['entries'] = entries
     set_role_source_info(inliner, lineno, indexnode)

--- a/sphinx/themes/basic/genindex.html
+++ b/sphinx/themes/basic/genindex.html
@@ -46,7 +46,7 @@
 <table style="width: 100%" class="indextable genindextable"><tr>
   {%- for column in entries|slice(2) if column %}
   <td style="width: 33%" valign="top"><dl>
-    {%- for entryname, (links, subitems) in column %}
+    {%- for entryname, (links, subitems, _) in column %}
       {{ indexentries(entryname, links) }}
       {%- if subitems %}
       <dd><dl>

--- a/sphinx/transforms.py
+++ b/sphinx/transforms.py
@@ -27,7 +27,7 @@ from sphinx.util.nodes import (
 from sphinx.util.osutil import ustrftime
 from sphinx.util.i18n import find_catalog
 from sphinx.util.pycompat import indent
-from sphinx.domains.std import register_term_to_glossary
+from sphinx.domains.std import make_glossary_term, split_term_classifiers
 
 
 default_substitutions = set([
@@ -340,7 +340,12 @@ class Locale(Transform):
                 for _id in node['names']:
                     if _id in gloss_entries:
                         gloss_entries.remove(_id)
-                    register_term_to_glossary(env, patch, _id)
+
+                    parts = split_term_classifiers(msgstr)
+                    patch = publish_msgstr(
+                        env.app, parts[0], source, node.line, env.config, settings)
+                    patch = make_glossary_term(
+                        env, patch, parts[1], source, node.line, _id)
                     node['ids'] = patch['ids']
                     node['names'] = patch['names']
                     processed = True
@@ -521,7 +526,7 @@ class Locale(Transform):
             # Extract and translate messages for index entries.
             for node, entries in traverse_translatable_index(self.document):
                 new_entries = []
-                for type, msg, tid, main in entries:
+                for type, msg, tid, main, key_ in entries:
                     msg_parts = split_index_msg(type, msg)
                     msgstr_parts = []
                     for part in msg_parts:
@@ -530,7 +535,7 @@ class Locale(Transform):
                             msgstr = part
                         msgstr_parts.append(msgstr)
 
-                    new_entries.append((type, ';'.join(msgstr_parts), tid, main))
+                    new_entries.append((type, ';'.join(msgstr_parts), tid, main, None))
 
                 node['raw_entries'] = entries
                 node['entries'] = new_entries

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -213,7 +213,7 @@ def process_index_entry(entry, targetid):
         if entry.startswith(type+':'):
             value = entry[len(type)+1:].strip()
             value = pairindextypes[type] + '; ' + value
-            indexentries.append(('pair', value, targetid, main))
+            indexentries.append(('pair', value, targetid, main, None))
             break
     else:
         for type in indextypes:
@@ -221,7 +221,7 @@ def process_index_entry(entry, targetid):
                 value = entry[len(type)+1:].strip()
                 if type == 'double':
                     type = 'pair'
-                indexentries.append((type, value, targetid, main))
+                indexentries.append((type, value, targetid, main, None))
                 break
         # shorthand notation for single entries
         else:
@@ -233,7 +233,7 @@ def process_index_entry(entry, targetid):
                     value = value[1:].lstrip()
                 if not value:
                     continue
-                indexentries.append(('single', value, targetid, main))
+                indexentries.append(('single', value, targetid, main, None))
     return indexentries
 
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1531,7 +1531,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if not node.get('inline', True):
             self.body.append('\n')
         entries = node['entries']
-        for type, string, tid, ismain in entries:
+        for type, string, tid, ismain, key_ in entries:
             m = ''
             if ismain:
                 m = '|textbf'

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1302,7 +1302,7 @@ class TexinfoTranslator(nodes.NodeVisitor):
         else:
             self.body.append('\n')
         for entry in node['entries']:
-            typ, text, tid, text2 = entry
+            typ, text, tid, text2, key_ = entry
             text = self.escape_menu(text)
             self.body.append('@geindex %s\n' % text)
 


### PR DESCRIPTION
The classifier also be used for translation.
IMO this is a experimental feature of sphinx-1.4. For now I don't care about non-glossary-term index entries. Actually I have no use cases about "specifying grouping key for non-glossary-terms".

Please see also a change of para.rst.
