### PR TITLE
Proposal: Add :align: option support to table directives

### DIFF
--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -9,7 +9,7 @@
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst.directives import images
+from docutils.parsers.rst.directives import images, tables
 
 
 class Figure(images.Figure):
@@ -30,4 +30,73 @@ class Figure(images.Figure):
         return [figure_node]
 
 
+def halign(argument):
+    return directives.choice(argument, ('left', 'center', 'right'))
+
+
+class RSTTable(tables.RSTTable):
+    """The table directive which supports ``align`` option.
+
+    An ``align`` option can adjust the alignment of the table. The value should
+    be one of ``left``, ``center`` of ``right``.
+    """
+
+    option_spec = tables.RSTTable.option_spec.copy()
+    option_spec['align'] = halign
+
+    def run(self):
+        result = tables.RSTTable.run(self)
+        if isinstance(result[0], nodes.system_message):
+            return result
+
+        if 'align' in self.options:
+            result[0]['align'] = self.options['align']
+
+        return result
+
+
+class CSVTable(tables.CSVTable):
+    """The csv-table directive which supports ``align`` option.
+
+    An ``align`` option can adjust the alignment of the table. The value should
+    be one of ``left``, ``center`` of ``right``.
+    """
+
+    option_spec = tables.CSVTable.option_spec.copy()
+    option_spec['align'] = halign
+
+    def run(self):
+        result = tables.CSVTable.run(self)
+        if isinstance(result[0], nodes.system_message):
+            return result
+
+        if 'align' in self.options:
+            result[0]['align'] = self.options['align']
+
+        return result
+
+
+class ListTable(tables.ListTable):
+    """The list-table directive which supports ``align`` option.
+
+    An ``align`` option can adjust the alignment of the table. The value should
+    be one of ``left``, ``center`` of ``right``.
+    """
+
+    option_spec = tables.ListTable.option_spec.copy()
+    option_spec['align'] = halign
+
+    def run(self):
+        result = tables.ListTable.run(self)
+        if isinstance(result[0], nodes.system_message):
+            return result
+
+        if 'align' in self.options:
+            result[0]['align'] = self.options['align']
+
+        return result
+
 directives.register_directive('figure', Figure)
+directives.register_directive('table', RSTTable)
+directives.register_directive('csv-table', CSVTable)
+directives.register_directive('list-table', ListTable)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -957,6 +957,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.table.rowcount > 30:
             self.table.longtable = True
         self.popbody()
+        if 'align' in node:
+            self.body.append('\\begin{table}[htb]')
+            if node['align'] == 'center':
+                self.body.append('\\centering')
+                align_end = ''
+            else:
+                self.body.append('\\begin{flush%s}' % node['align'])
+                align_end = '\\end{flush%s}' % node['align']
         if not self.table.longtable and self.table.caption is not None:
             self.body.append('\n\n\\begin{threeparttable}\n'
                              '\\capstart\\caption{')
@@ -1023,6 +1031,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.body.append(endmacro)
         if not self.table.longtable and self.table.caption is not None:
             self.body.append('\\end{threeparttable}\n\n')
+        if 'align' in node:
+            self.body.append(align_end)
+            self.body.append('\\end{table}')
         self.unrestrict_footnote(node)
         self.table = None
         self.tablebody = None


### PR DESCRIPTION
To resolve #2305, I would like to add the `:align:` option to docutils' table directives.
I believe this is helpful. But, at the same time, it makes them incompatible with docutils.

On the other hand, Sphinx provides `tabularcolumns`.
It extend table directives from outside.
Are there any policies to enhance docutils' notations?
