### PR TITLE
make conf.py's html_favicon description match docs

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -202,8 +202,8 @@ html_theme = 'alabaster'
 # of the sidebar.
 #html_logo = None
 
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# The name of an image file (relative to this directory) to use as a favicon of
+# the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 #html_favicon = None
 


### PR DESCRIPTION
Clarify that the path is relative to the conf file, rather than the static path dir.
