### PR TITLE
Highlighting fallbacks by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,9 +12,11 @@ Features added
 Bugs fixed
 ----------
 * Remove ``image/gif`` from supported_image_types of LaTeX writer (#2272)
-* Fix code-block literals raises highlighting warnings by default
 * Fix ValueError is raised if LANGUAGE is empty string
 * Fix unpack warning is shown when the directives generated from ``Sphinx.add_crossref_type`` is used
+* The default highlight language is now ``default``.  This means that source code
+  is highlighted as Python 3 (which is mostly a superset of Python 2) if possible.
+  To get the old behavior back, add ``highlight_language = "python"`` to conf.py.
 
 Documentation
 -------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -333,9 +333,11 @@ Project information
    .. versionadded:: 0.5
 
    .. versionchanged:: 1.4
-      The default is now ``'python3'``, since it is mostly a superset of
-      ``'python'``.  If you prefer Python 2 only highlighting, you can set
-      it back to ``'python'``.
+      The default is now ``'default'``. It is similar to ``'python3'``;
+      it is mostly a superset of ``'python'``. but it fallbacks to
+      ``'none'`` without warning if failed.  ``'python3'`` and other
+      languages will emit warning if failed.  If you prefer Python 2
+      only highlighting, you can set it back to ``'python'``.
 
 .. confval:: highlight_options
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -65,7 +65,7 @@ class Config(object):
         trim_footnote_reference_space = (False, 'env'),
         show_authors = (False, 'env'),
         pygments_style = (None, 'html', [str]),
-        highlight_language = ('python3', 'env'),
+        highlight_language = ('default', 'env'),
         highlight_options = ({}, 'env'),
         templates_path = ([], 'html'),
         template_bridge = (None, 'html', [str]),

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -11,6 +11,7 @@
 
 from pygments.lexer import RegexLexer
 from pygments.token import Text, Name
+from pygments.filters import ErrorToken
 from pygments.formatters.html import HtmlFormatter
 
 from sphinx.highlighting import PygmentsBridge
@@ -86,3 +87,28 @@ def test_trim_doctest_flags():
         assert ret == '>>> 1+2 \n3\n'
     finally:
         PygmentsBridge.html_formatter = HtmlFormatter
+
+
+def test_default_highlight():
+    bridge = PygmentsBridge('html')
+
+    # default: highlights as python3
+    ret = bridge.highlight_block('print "Hello sphinx world"', 'default')
+    assert ret == ('<div class="highlight"><pre><span></span><span class="nb">print</span> '
+                   '<span class="s2">&quot;Hello sphinx world&quot;</span>\n</pre></div>\n')
+
+    # default: fallbacks to none if highlighting failed
+    ret = bridge.highlight_block('reST ``like`` text', 'default')
+    assert ret == '<div class="highlight"><pre><span></span>reST ``like`` text\n</pre></div>\n'
+
+    # python3: highlights as python3
+    ret = bridge.highlight_block('print "Hello sphinx world"', 'python3')
+    assert ret == ('<div class="highlight"><pre><span></span><span class="nb">print</span> '
+                   '<span class="s2">&quot;Hello sphinx world&quot;</span>\n</pre></div>\n')
+
+    # python3: raises error if highlighting failed
+    try:
+        ret = bridge.highlight_block('reST ``like`` text', 'python3')
+        assert False, "highlight_block() does not raise any exceptions"
+    except ErrorToken:
+        pass  # raise parsing error


### PR DESCRIPTION
In 423bf7b, I tried to add fallback mechanism to `python3`. But it breaks
the python3 highlighting on python2 environment.

This adds `'default'` to highlighting languages; it works like
`'python3'`, but fallbacks if failed Highlighting. And this removes
try-parse step from `'python3'` language. Now, it highlights regardless of
runtime environments.

@birkenfeld I think this resolves all of highlighting problem we are facing.
What do you think this change?
