### PR TITLE
Allow linebreaks in latex(pdf) codeblocks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,13 +14,16 @@ Features added
   - ``image.data_uri``
   - ``image.nonlocal_uri``
 
-* LaTeX writer allows page breaks in topic contents; and their horizontal
-  extent now fits in the line width (shadow in margin). Warning-type
-  admonitions allow page breaks and their vertical spacing has been made
-  more coherent with the one for Hint-type notices.
+* #2453: LaTeX writer allows page breaks in topic contents; and their
+  horizontal extent now fits in the line width (with shadow in margin). Also
+  warning-type admonitions allow page breaks and their vertical spacing has
+  been made more coherent with the one for hint-type notices (ref #2446).
 
-* The framing of literal code-blocks in LaTeX output (and not only the code
-  lines themselves) obey the indentation context in lists or quoted blocks.
+* #2459: the framing of literal code-blocks in LaTeX output (and not only the
+  code lines themselves) obey the indentation in lists or quoted blocks.
+
+* #2343: the long source lines in code-blocks are wrapped (without modifying
+   the line numbering) in LaTeX output (ref #1534, #2304).
 
 Bugs fixed
 ----------
@@ -40,6 +43,8 @@ Bugs fixed
 * #2309: Fix could not refer "indirect hyperlink targets" by ref-role
 * intersphinx fails if mapping URL contains any port
 * #2088: intersphinx crashes if the mapping URL requires basic auth
+* #2304: auto line breaks in latexpdf codeblocks
+* #1534: Word wrap long lines in Latex verbatim blocks
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -226,6 +226,58 @@
   \global\Sphinx@myfirstframedpassfalse
 }
 
+% For linebreaks inside Verbatim environment from package fancyvrb.
+\newbox\Sphinxcontinuationbox
+\newbox\Sphinxvisiblespacebox
+% These are user customizable e.g. from latex_elements's preamble key.
+% Use of \textvisiblespace for compatibility with XeTeX/LuaTeX/fontspec.
+\newcommand*\Sphinxvisiblespace {\textcolor{red}{\textvisiblespace}}
+\newcommand*\Sphinxcontinuationsymbol {\textcolor{red}{\llap{\tiny$\m@th\hookrightarrow$}}}
+\newcommand*\Sphinxcontinuationindent {3ex }
+\newcommand*\Sphinxafterbreak {\kern\Sphinxcontinuationindent\copy\Sphinxcontinuationbox}
+
+% Take advantage of the already applied Pygments mark-up to insert
+% potential linebreaks for TeX processing.
+%        {, <, #, %, $, ' and ": go to next line.
+%        _, }, ^, &, >, - and ~: stay at end of broken line.
+% Use of \textquotesingle for straight quote.
+\newcommand*\Sphinxbreaksatspecials {%
+    \def\PYGZus{\discretionary{\char`\_}{\Sphinxafterbreak}{\char`\_}}%
+    \def\PYGZob{\discretionary{}{\Sphinxafterbreak\char`\{}{\char`\{}}%
+    \def\PYGZcb{\discretionary{\char`\}}{\Sphinxafterbreak}{\char`\}}}%
+    \def\PYGZca{\discretionary{\char`\^}{\Sphinxafterbreak}{\char`\^}}%
+    \def\PYGZam{\discretionary{\char`\&}{\Sphinxafterbreak}{\char`\&}}%
+    \def\PYGZlt{\discretionary{}{\Sphinxafterbreak\char`\<}{\char`\<}}%
+    \def\PYGZgt{\discretionary{\char`\>}{\Sphinxafterbreak}{\char`\>}}%
+    \def\PYGZsh{\discretionary{}{\Sphinxafterbreak\char`\#}{\char`\#}}%
+    \def\PYGZpc{\discretionary{}{\Sphinxafterbreak\char`\%}{\char`\%}}%
+    \def\PYGZdl{\discretionary{}{\Sphinxafterbreak\char`\$}{\char`\$}}%
+    \def\PYGZhy{\discretionary{\char`\-}{\Sphinxafterbreak}{\char`\-}}%
+    \def\PYGZsq{\discretionary{}{\Sphinxafterbreak\textquotesingle}{\textquotesingle}}%
+    \def\PYGZdq{\discretionary{}{\Sphinxafterbreak\char`\"}{\char`\"}}%
+    \def\PYGZti{\discretionary{\char`\~}{\Sphinxafterbreak}{\char`\~}}%
+}
+
+% Some characters . , ; ? ! / are not pygmentized.
+% This macro makes them "active" and they will insert potential linebreaks
+\newcommand*\Sphinxbreaksatpunct {%
+   \lccode`\~`\.\lowercase{\def~}{\discretionary{\char`\.}{\Sphinxafterbreak}{\char`\.}}%
+   \lccode`\~`\,\lowercase{\def~}{\discretionary{\char`\,}{\Sphinxafterbreak}{\char`\,}}%
+   \lccode`\~`\;\lowercase{\def~}{\discretionary{\char`\;}{\Sphinxafterbreak}{\char`\;}}%
+   \lccode`\~`\:\lowercase{\def~}{\discretionary{\char`\:}{\Sphinxafterbreak}{\char`\:}}%
+   \lccode`\~`\?\lowercase{\def~}{\discretionary{\char`\?}{\Sphinxafterbreak}{\char`\?}}%
+   \lccode`\~`\!\lowercase{\def~}{\discretionary{\char`\!}{\Sphinxafterbreak}{\char`\!}}%
+   \lccode`\~`\/\lowercase{\def~}{\discretionary{\char`\/}{\Sphinxafterbreak}{\char`\/}}%
+   \catcode`\.\active
+   \catcode`\,\active
+   \catcode`\;\active
+   \catcode`\:\active
+   \catcode`\?\active
+   \catcode`\!\active
+   \catcode`\/\active
+   \lccode`\~`\~
+}
+
 \renewcommand{\Verbatim}[1][1]{%
   % list starts new par, but we don't want it to be set apart vertically
   \parskip\z@skip
@@ -251,6 +303,31 @@
   % for mid pages and last page portion of (long) split frame:
   \def\MidFrameCommand{\Sphinx@colorbox\fcolorbox }%
   \let\LastFrameCommand\MidFrameCommand
+  % fancyvrb's Verbatim puts each input line in (unbreakable) horizontal boxes.
+  % This customization wraps each line from the input in a \vtop, thus
+  % allowing it to wrap and display on two or more lines in the latex output.
+  %     - The codeline counter will be increased only once.
+  %     - The wrapped material will not break across pages, it is impossible
+  %       to achieve this without extensive rewrite of fancyvrb.
+  %     - The (not used in Sphinx) obeytabs option to Verbatim is
+  %       broken by this change (showtabs and tabspace work).
+  \sbox\Sphinxcontinuationbox {\Sphinxcontinuationsymbol}%
+  \sbox\Sphinxvisiblespacebox {\FV@SetupFont\Sphinxvisiblespace}%
+  \def\FancyVerbFormatLine ##1{\hsize\linewidth
+          \vtop{\raggedright\hyphenpenalty\z@\exhyphenpenalty\z@
+                \doublehyphendemerits\z@\finalhyphendemerits\z@
+                \strut ##1\strut}%
+          }%
+  % If the linebreak is at a space, the latter will be displayed as visible
+  % space at end of first line, and a continuation symbol starts next line.
+  % Stretch/shrink are however usually zero for typewriter font.
+  \def\FV@Space {%
+       \nobreak\hskip\z@ plus\fontdimen3\font minus\fontdimen4\font
+       \discretionary{\copy\Sphinxvisiblespacebox}{\Sphinxafterbreak}
+                     {\kern\fontdimen2\font}%
+       }%
+  % Allow breaks at special characters using \PYG... macros.
+  \Sphinxbreaksatspecials
   % The list environment is needed to control perfectly the vertical space.
   % Note: \OuterFrameSep used by framed.sty is later set to \topsep hence 0pt.
   % If caption, there is \literalcaptiontopvspace + \abovecaptionskip vertical space
@@ -269,7 +346,10 @@
     \advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize
     \@setminipage  }%
      \small
-    \OriginalVerbatim[#1]%
+     % For grid placement from \strut's in \FancyVerbFormatLine
+     \lineskip\z@skip
+     % Breaks at punctuation characters . , ; ? ! and / need catcode=\active
+     \OriginalVerbatim[#1,codes*=\Sphinxbreaksatpunct]%
 }
 \renewcommand{\endVerbatim}{%
   \endOriginalVerbatim


### PR DESCRIPTION
This addresses the issue raised in #1534 and #2304: currently long lines do not wrap in code blocks for LaTeX output, they cross the frame, go to the page margin and possibly beyond.

Currently, Sphinx uses LaTeX package `fancyvrb` for its `Verbatim` environment. This environment scans each input line and puts it in an unbreakable horizontal box (actually multiple nested ones). It does not do any syntax highlighting, the latter has been incorporated by Sphinx LaTeX writer directly via macros `\PYG...` in the produced latex file.

More recent packages exist, among them `minted` which however needs `-shell-escape`  for its latex runs as it appeals to `pygmentize`. Switching to `minted`  would mean presumably a complete revision of how the Sphinx LaTeX builder operates. There is a sub-part of `minted` which modifies `fancyvrb`'s `Verbatim` to allow line-breaks, and this does not require `-shell-escape` but only "`draft`" option, but this is not available separately so far and consists of at least 300 hundred lines of code possibly using more stuff from other LaTeX packages (for key-value handling for example).

I propose this patch which is a minimal modification of `fancyvrb`'s `Verbatim`: the macro `\FancyVerbFormatLine` is modified to wrap its arguments first in a paragraph building box. Then, linebreaks can occur at spaces (the `\FV@Space` is modified to allow such a line break.)

But having break-points only at spaces is not enough (in my testing of `minted` it did not do more than that in its modification of `fancyvrb`'s `Verbatim`) Thus it is proposed to exploit the already existing Pygmentization and modify (only in the Verbatim naturally) the `PYGZus`, etc... macros, which end up in the document LaTeX preamble; this modification is done to insert potential break points.  For some characters like the `?` or the `/` which do not seem to be treated by pygmentization another approach is used which consists of making them "catcode active" (only in the Verbatim naturally).

This depends on new macros `\Sphinxbreaksatspecials`  and `\Sphinxbreaksatpunct` which can be redefined to do nothing if the behaviour is not desired. Either from the user via something in the `'preamble'` key in `conf.py`, or possibly via a dedicated new option.

When a line-break occurs, a continuation symbol will be displayed at start of second line. This symbol and the amount of indentation from the left margin are set in macros the user can redefine in the `'preamble'`. For the space character a red visible space is printed at end of broken line. This can also be customized via certain `\Sphinx...` macros.

Some characters where breaks are allowed will stay on first line, others go to continuation line. See code comments.

The new `Verbatim` makes option `obeytabs` a no-op but I don't think this option was available via Sphinx (it specified to use tabs from the input as tabulation stops in the latex (pdf) output, like for example in an Emacs buffer; from looking the Sphinx docs, I got the impression no option was provided to handle tab-formatted source code, perhaps I am wrong).

The extra lines do not modify the numbering: the first of the lines is still the numbered one.

It may happen that at bottom of page, the extra lines spill over the verbatim frame (by the way, although fancyvrb has the ability to draw frames, for some reason sphinx.sty uses `framed`  environment for that; this is not impacted). It is impossible to allow page breaks at these locations if not rewriting core parts of `fancyvrb` latex code. At least the material is now visible by the reader it does not disappear to the right of the printed page. Notice that the exact same issue arises when using `minted` with "`draft`" option and `\fvset{breaklines=true}`

The core changes in this patch are only about ten lines in `sphinx.sty` to allow breaks at spaces. Further changes handle the breaks  at characters. Note that digits or letters will not allow linebreaks, but this could be added.

As an after effect the spacing with the top rule and bottom rule of the surrounding frame are improved.
