### PR TITLE
HTML escape item names in search results.

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -242,12 +242,12 @@ var Search = {
           }
           listItem.append($('<a/>').attr('href',
             DOCUMENTATION_OPTIONS.URL_ROOT + dirname +
-            highlightstring + item[2]).html(item[1]));
+            highlightstring + item[2]).text(item[1]));
         } else {
           // normal html builders
           listItem.append($('<a/>').attr('href',
             item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX +
-            highlightstring + item[2]).html(item[1]));
+            highlightstring + item[2]).text(item[1]));
         }
         if (item[3]) {
           listItem.append($('<span> (' + item[3] + ')</span>'));


### PR DESCRIPTION
When the name of an item contains characters that need HTML escaping,
the search results need to escape the text so that it appears correctly.

Everything else is escaped correctly for item names apart from this.

This happens with the Dylan language where it is valid for identifiers
to contain characters such as '<' and '>'.

Fixes #2019.
- sphinx-themes/basic/static/searchtools.js_t
  (Search.dispalyNextItem): Use .text() rather than .html() so that
  the item name gets HTML escaped correctly.
