### PR TITLE
Fix something I don't understand

### DIFF
--- a/sphinx/themes/basic/genindex-single.html
+++ b/sphinx/themes/basic/genindex-single.html
@@ -37,7 +37,7 @@
 <table style="width: 100%" class="indextable"><tr>
   {%- for column in entries|slice(2) if column %}
   <td style="width: 33%" valign="top"><dl>
-    {%- for entryname, (links, subitems) in column %}
+    {%- for entryname, (links, subitems, _) in column %}
       {{ indexentries(entryname, links) }}
       {%- if subitems %}
       <dd><dl>


### PR DESCRIPTION
Without this new release fails with 

```
generating indices... genindex
Exception occurred:
  File ".tox/docs/lib/python2.7/site-packages/sphinx/themes/basic/genindex-single.html", line 40, in block "body"
    {%- for entryname, (links, subitems) in column %}
ValueError: too many values to unpack
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sphinx-doc/sphinx/2396)

<!-- Reviewable:end -->
