### PR TITLE
fix HTTP BasicAuth for intersphinx mappings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * #2476: Omit MathJax markers if :nowrap: is given
 * #2465: latex builder fails in case no caption option is provided to toctree directive
 * Sphinx crashes if self referenced toctree found
+* #2481: spelling mistake for mecab search splitter. Thanks to Naoki Sato.
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #2447: VerbatimBorderColor wrongly used also for captions of PDF
 * #2456: C++, fix crash related to document merging (e.g., singlehtml and Latex builders).
 * #2446: latex(pdf) sets local tables of contents (or more generally topic nodes) in unbreakable boxes, causes overflow at bottom
+* #2476: Omit MathJax markers if :nowrap: is given
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Features added
   - ``app.add_directive``
   - ``app.add_role``
   - ``app.add_generic_role``
+  - ``app.add_source_parser``
   - ``image.data_uri``
   - ``image.nonlocal_uri``
 

--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * #2456: C++, fix crash related to document merging (e.g., singlehtml and Latex builders).
 * #2446: latex(pdf) sets local tables of contents (or more generally topic nodes) in unbreakable boxes, causes overflow at bottom
 * #2476: Omit MathJax markers if :nowrap: is given
+* #2465: latex builder fails in case no caption option is provided to toctree directive
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,15 @@ Release 1.4.2 (in development)
 Features added
 --------------
 
-* Now :confval:`suppress_warnings` accepts following configurations: ``app.add_node``, ``app.add_directive``, ``app.add_role`` and ``app.add_generic_role`` (ref: #2451)
+* Now :confval:`suppress_warnings` accepts following configurations (ref: #2451, #2466):
+
+  - ``app.add_node``
+  - ``app.add_directive``
+  - ``app.add_role``
+  - ``app.add_generic_role``
+  - ``image.data_uri``
+  - ``image.nonlocal_uri``
+
 * LaTeX writer allows page breaks in topic contents; and their horizontal
   extent now fits in the line width (shadow in margin). Warning-type
   admonitions allow page breaks (if very long) and their vertical spacing

--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Bugs fixed
 * #2446: latex(pdf) sets local tables of contents (or more generally topic nodes) in unbreakable boxes, causes overflow at bottom
 * #2476: Omit MathJax markers if :nowrap: is given
 * #2465: latex builder fails in case no caption option is provided to toctree directive
+* Sphinx crashes if self referenced toctree found
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
 * #2465: latex builder fails in case no caption option is provided to toctree directive
 * Sphinx crashes if self referenced toctree found
 * #2481: spelling mistake for mecab search splitter. Thanks to Naoki Sato.
+* #2309: Fix could not refer "indirect hyperlink targets" by ref-role
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -222,6 +222,7 @@ General configuration
    * app.add_directive
    * app.add_role
    * app.add_generic_role
+   * app.add_source_parser
    * image.data_uri
    * image.nonlocal_uri
    * ref.term

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -222,6 +222,8 @@ General configuration
    * app.add_directive
    * app.add_role
    * app.add_generic_role
+   * image.data_uri
+   * image.nonlocal_uri
    * ref.term
    * ref.ref
    * ref.numref

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -788,6 +788,11 @@ class Sphinx(object):
 
     def add_source_parser(self, suffix, parser):
         self.debug('[app] adding search source_parser: %r, %r', (suffix, parser))
+        if suffix in self._additional_source_parsers:
+            self.warn('while setting up extension %s: source_parser for %r is '
+                      'already registered, it will be overridden' %
+                      (self._setting_up_extension[-1], suffix),
+                      type='app', subtype='add_source_parser')
         self._additional_source_parsers[suffix] = parser
 
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -137,7 +137,7 @@ class LaTeXBuilder(Builder):
         tree = self.env.get_doctree(indexfile)
         contentsname = None
         for toctree in tree.traverse(addnodes.toctree):
-            if toctree['caption']:
+            if 'caption' in toctree:
                 contentsname = toctree['caption']
                 break
 

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -532,6 +532,9 @@ class StandardDomain(Domain):
             if labelid is None:
                 continue
             node = document.ids[labelid]
+            if node.tagname == 'target' and 'refid' in node:  # indirect hyperlink targets
+                node = document.ids.get(node['refid'])
+                labelid = node['names'][0]
             if name.isdigit() or 'refuri' in node or \
                node.tagname.startswith('desc_'):
                 # ignore footnote labels, labels automatically generated from a

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -75,7 +75,7 @@ default_settings = {
 # or changed to properly invalidate pickle files.
 #
 # NOTE: increase base version by 2 to have distinct numbers for Py2 and 3
-ENV_VERSION = 47 + (sys.version_info[0] - 2)
+ENV_VERSION = 48 + (sys.version_info[0] - 2)
 
 
 dummy_reporter = Reporter('', 4, 4)

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -1911,6 +1911,10 @@ class BuildEnvironment:
         traversed = set()
 
         def traverse_toctree(parent, docname):
+            if parent == docname:
+                self.warn(docname, 'self referenced toctree found. Ignored.')
+                return
+
             # traverse toctree by pre-order
             yield parent, docname
             traversed.add(docname)

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -908,11 +908,13 @@ class BuildEnvironment:
             node['candidates'] = candidates = {}
             imguri = node['uri']
             if imguri.startswith('data:'):
-                self.warn_node('image data URI found. some builders might not support', node)
+                self.warn_node('image data URI found. some builders might not support', node,
+                               type='image', subtype='data_uri')
                 candidates['?'] = imguri
                 continue
             elif imguri.find('://') != -1:
-                self.warn_node('nonlocal image URI found: %s' % imguri, node)
+                self.warn_node('nonlocal image URI found: %s' % imguri, node,
+                               type='image', subtype='nonlocal_uri')
                 candidates['?'] = imguri
                 continue
             rel_imgpath, full_imgpath = self.relfn2path(imguri, docname)

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -177,7 +177,7 @@ def _read_from_url(url):
         password_mgr = request.HTTPPasswordMgrWithDefaultRealm()
         password_mgr.add_password(None, url, username, password)
         handler = request.HTTPBasicAuthHandler(password_mgr)
-        opener = request.build_opener(default_handlers + [handler])
+        opener = request.build_opener(*(default_handlers + [handler]))
     else:
         opener = default_opener
 

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -29,9 +29,7 @@ def html_visit_math(self, node):
 def html_visit_displaymath(self, node):
     self.body.append(self.starttag(node, 'div', CLASS='math'))
     if node['nowrap']:
-        self.body.append(self.builder.config.mathjax_display[0] +
-                         self.encode(node['latex']) +
-                         self.builder.config.mathjax_display[1])
+        self.body.append(self.encode(node['latex']))
         self.body.append('</div>')
         raise nodes.SkipNode
 

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -533,7 +533,7 @@ class SearchJapanese(SearchLanguage):
     language_name = 'Japanese'
     splitters = {
         'default': 'sphinx.search.ja.DefaultSplitter',
-        'mecab': 'sphinx.sarch.ja.MecabSplitter',
+        'mecab': 'sphinx.search.ja.MecabSplitter',
         'janome': 'sphinx.search.ja.JanomeSplitter',
     }
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -278,7 +278,7 @@ class HTMLTranslator(BaseTranslator):
         figtype = self.builder.env.domains['std'].get_figtype(node)
         if figtype:
             if len(node['ids']) == 0:
-                msg = 'Any IDs not assiend for %s node' % node.tagname
+                msg = 'Any IDs not assigned for %s node' % node.tagname
                 self.builder.env.warn_node(msg, node)
             else:
                 append_fignumber(figtype, node['ids'][0])

--- a/tests/root/contents.txt
+++ b/tests/root/contents.txt
@@ -62,3 +62,7 @@ Test for issue #1700
 
 :ref:`mastertoc`
 
+Test for indirect hyperlink targets
+===================================
+
+:ref:`indirect hyperref <other-label>`

--- a/tests/root/markup.txt
+++ b/tests/root/markup.txt
@@ -107,6 +107,9 @@ Admonitions
 .. tip::
    Tip text.
 
+Indirect hyperlink targets
+
+.. _other-label: some-label_
 
 Inline markup
 -------------
@@ -142,6 +145,7 @@ Adding \n to test unescaping.
 * :token:`try statement <try_stmt>`
 * :ref:`admonition-section`
 * :ref:`here <some-label>`
+* :ref:`there <other-label>`
 * :ref:`my-figure`
 * :ref:`my-figure-name`
 * :ref:`my-table`

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -31,16 +31,16 @@ http://www.python.org/logo.png
 reading included file u'.*?wrongenc.inc' seems to be wrong, try giving an \
 :encoding: option\\n?
 %(root)s/includes.txt:4: WARNING: download file not readable: .*?nonexisting.png
-(%(root)s/markup.txt:359: WARNING: invalid single index entry u'')?
+(%(root)s/markup.txt:363: WARNING: invalid single index entry u'')?
 (%(root)s/undecodable.txt:3: WARNING: undecodable source characters, replacing \
 with "\\?": b?'here: >>>(\\\\|/)xbb<<<'
 )?"""
 
 HTML_WARNINGS = ENV_WARNINGS + """\
 %(root)s/images.txt:20: WARNING: no matching candidate for image URI u'foo.\\*'
-%(root)s/markup.txt:271: WARNING: Could not lex literal_block as "c". Highlighting skipped.
+%(root)s/markup.txt:275: WARNING: Could not lex literal_block as "c". Highlighting skipped.
 %(root)s/footnote.txt:60: WARNING: citation not found: missing
-%(root)s/markup.txt:160: WARNING: unknown option: &option
+%(root)s/markup.txt:164: WARNING: unknown option: &option
 """
 
 if PY3:
@@ -151,6 +151,8 @@ HTML_XPATH = {
             "[@class='reference internal']/code/span[@class='pre']", '^with$'),
         (".//a[@href='#grammar-token-try_stmt']"
             "[@class='reference internal']/code/span", '^statement$'),
+        (".//a[@href='#some-label'][@class='reference internal']/span", '^here$'),
+        (".//a[@href='#some-label'][@class='reference internal']/span", '^there$'),
         (".//a[@href='subdir/includes.html']"
             "[@class='reference internal']/span", 'Including in subdir'),
         (".//a[@href='objects.html#cmdoption-python-c']"
@@ -274,6 +276,9 @@ HTML_XPATH = {
          'http://sphinx-doc.org/'),
         (".//a[@class='reference external'][@href='http://sphinx-doc.org/latest/']",
          'Latest reference'),
+        # Indirect hyperlink targets across files
+        (".//a[@href='markup.html#some-label'][@class='reference internal']/span",
+         '^indirect hyperref$'),
     ],
     'bom.html': [
         (".//title", " File with UTF-8 BOM"),

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -24,10 +24,10 @@ from test_build_html import ENV_WARNINGS
 
 
 LATEX_WARNINGS = ENV_WARNINGS + """\
-%(root)s/markup.txt:160: WARNING: unknown option: &option
+%(root)s/markup.txt:164: WARNING: unknown option: &option
 %(root)s/footnote.txt:60: WARNING: citation not found: missing
 %(root)s/images.txt:20: WARNING: no matching candidate for image URI u'foo.\\*'
-%(root)s/markup.txt:271: WARNING: Could not lex literal_block as "c". Highlighting skipped.
+%(root)s/markup.txt:275: WARNING: Could not lex literal_block as "c". Highlighting skipped.
 """
 
 if PY3:

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -23,7 +23,7 @@ from test_build_html import ENV_WARNINGS
 
 
 TEXINFO_WARNINGS = ENV_WARNINGS + """\
-%(root)s/markup.txt:160: WARNING: unknown option: &option
+%(root)s/markup.txt:164: WARNING: unknown option: &option
 %(root)s/footnote.txt:60: WARNING: citation not found: missing
 %(root)s/images.txt:20: WARNING: no matching candidate for image URI u'foo.\\*'
 %(root)s/images.txt:29: WARNING: no matching candidate for image URI u'svgimg.\\*'

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -24,7 +24,7 @@ def setup_module():
     global app, env
     app = TestApp(srcdir='root-envtest')
     env = app.env
-    env.set_warnfunc(lambda *args: warnings.append(args))
+    env.set_warnfunc(lambda *args, **kwargs: warnings.append(args))
 
 
 def teardown_module():


### PR DESCRIPTION
request.build_opener requires *args, not a list of handlers as first argument. This fixes basic authentication for me (see also: #2088).
