### PR TITLE
Fix index generation

### DIFF
--- a/sphinx/themes/basic/genindex-single.html
+++ b/sphinx/themes/basic/genindex-single.html
@@ -37,7 +37,7 @@
 <table style="width: 100%" class="indextable"><tr>
   {%- for column in entries|slice(2) if column %}
   <td style="width: 33%" valign="top"><dl>
-    {%- for entryname, (links, subitems) in column %}
+    {%- for entryname, (links, subitems, _) in column %}
       {{ indexentries(entryname, links) }}
       {%- if subitems %}
       <dd><dl>


### PR DESCRIPTION
Commit e6a5a3a92e938fcd75866b4227db9e0524d58f7c (classifier of glossary terms can be used for index entries grouping key. The classifier also be used for translation. See also :ref:`glossary-directive`.) broke the generation of single-letter index pages.  Fix this by adding an extra item when iterating through entries.
