### PR TITLE
Fix #2405 and #2414 related to PDF hyperlinks to numbered code listings

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -190,6 +190,7 @@
     \def\SphinxVerbatimTitle
        {\captionof{#1}{\SphinxLiteralBlockLabel #2}\smallskip }%
 }
+% \SphinxLiteralBlockLabel will be set dynamically to hold the label for links
 \newcommand*\SphinxLiteralBlockLabel {}
 
 % \SphinxCustomFBox is copied from framed.sty's \CustomFBox, but
@@ -248,17 +249,17 @@
   % list starts new par, but we don't want it to be set apart vertically
   \bgroup\parskip\z@skip
   \smallskip
-  % use customized framed environment
-  % first, check if has caption
+  % first, let's check if there is a caption
   \ifx\SphinxVerbatimTitle\empty
-      % no caption. Require space if at bottom of page
-      \needspace{\literalblockwithoutcaptionneedspace}%
-      % if there is a label insert hypertarget.
+      % there was no caption. Check if nevertheless a label was set.
       \ifx\SphinxLiteralBlockLabel\empty\else
+      % we require some space to be sure hyperlink target from \phantomsection
+      % will not be separated from upcoming verbatim by a page break
+          \needspace{\literalblockwithoutcaptionneedspace}%
           \phantomsection\SphinxLiteralBlockLabel
       \fi
   \fi
-  % non empty \SphinxVerbatimTitle has label inside if there is one.
+  % non-empty \SphinxVerbatimTitle has label inside it (in case there is one)
   \let\SphinxFrameTitle\SphinxVerbatimTitle
   \global\Sphinx@myfirstframedpasstrue
   % The list environement is needed to control perfectly the vertical
@@ -280,8 +281,6 @@
   \endlist
   % close group to restore \parskip (and \SphinxFrameTitle)
   \egroup
-  % reset to empty \SphinxVerbatimTitle
-  \global\let\SphinxVerbatimTitle\empty
 }
 
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -247,7 +247,7 @@
 
 \renewcommand{\Verbatim}[1][1]{%
   % list starts new par, but we don't want it to be set apart vertically
-  \bgroup\parskip\z@skip
+  \parskip\z@skip
   \smallskip
   % first, let's check if there is a caption
   \ifx\SphinxVerbatimTitle\empty
@@ -279,8 +279,7 @@
   \endOriginalVerbatim
   \endMakeFramed
   \endlist
-  % close group to restore \parskip (and \SphinxFrameTitle)
-  \egroup
+  % LaTeX environments always revert local changes on exit, here e.g. \parskip
 }
 
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -186,8 +186,11 @@
 \newcommand*\SphinxVerbatimTitle {}
 \newcommand*\SphinxSetupCaptionForVerbatim [2]
 {%
-    \def\SphinxVerbatimTitle{\captionof{#1}{#2}\smallskip }%
+    \needspace{\literalblockneedspace}\vspace{\literalblockcaptiontopvspace}%
+    \def\SphinxVerbatimTitle
+       {\captionof{#1}{\SphinxLiteralBlockLabel #2}\smallskip }%
 }
+\newcommand*\SphinxLiteralBlockLabel {}
 
 % \SphinxCustomFBox is copied from framed.sty's \CustomFBox, but
 % #1=title/caption is to be set _above_ the top rule, not _below_
@@ -246,6 +249,16 @@
   \bgroup\parskip\z@skip
   \smallskip
   % use customized framed environment
+  % first, check if has caption
+  \ifx\SphinxVerbatimTitle\empty
+      % no caption. Require space if at bottom of page
+      \needspace{\literalblockwithoutcaptionneedspace}%
+      % if there is a label insert hypertarget.
+      \ifx\SphinxLiteralBlockLabel\empty\else
+          \phantomsection\SphinxLiteralBlockLabel
+      \fi
+  \fi
+  % non empty \SphinxVerbatimTitle has label inside if there is one.
   \let\SphinxFrameTitle\SphinxVerbatimTitle
   \global\Sphinx@myfirstframedpasstrue
   % The list environement is needed to control perfectly the vertical
@@ -625,5 +638,6 @@
 \RequirePackage{needspace}
 % if the left page space is less than \literalblockneedsapce, insert page-break
 \newcommand{\literalblockneedspace}{5\baselineskip}
+\newcommand{\literalblockwithoutcaptionneedspace}{1.5\baselineskip}
 % margin before the caption of literal-block
 \newcommand{\literalblockcaptiontopvspace}{0.5\baselineskip}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1445,8 +1445,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.in_container_literal_block:
             self.body.append('\\needspace{\\literalblockneedspace}')
             self.body.append('\\vspace{\\literalblockcaptiontopvspace}\n')
-            self.body.append(self.context.pop())
-            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{')
+            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{'
+                             + self.context.pop())
         elif self.in_minipage and isinstance(node.parent, nodes.figure):
             self.body.append('\\captionof{figure}{')
         else:
@@ -1992,14 +1992,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
             for id in self.pop_hyperlink_ids('code-block'):
                 ids += self.hypertarget(id, anchor=False)
             if node['ids']:
-                ids += self.hypertarget(node['ids'][0])
+                # suppress with anchor=False \phantomsection generation
+                ids += self.hypertarget(node['ids'][0], anchor=False)
             self.body.append('\n')
-            self.context.append(ids + '\n')
+            if ids:
+                self.context.append(ids) # will be used in visit_caption
 
     def depart_container(self, node):
         if node.get('literal_block'):
             self.in_container_literal_block -= 1
-            # self.body.append(self.context.pop()) moved to visit_caption
 
     def visit_decoration(self, node):
         pass

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1445,8 +1445,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.in_container_literal_block:
             self.body.append('\\needspace{\\literalblockneedspace}')
             self.body.append('\\vspace{\\literalblockcaptiontopvspace}\n')
-            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{'
-                             + self.context.pop())
+            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{' + self.context.pop())
         elif self.in_minipage and isinstance(node.parent, nodes.figure):
             self.body.append('\\captionof{figure}{')
         else:
@@ -1995,7 +1994,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 # suppress with anchor=False \phantomsection generation
                 ids += self.hypertarget(node['ids'][0], anchor=False)
             self.body.append('\n')
-            self.context.append(ids) # will be used in visit_caption
+            # context.pop will be done in visit_caption
+            self.context.append(ids)
 
     def depart_container(self, node):
         if node.get('literal_block'):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1804,8 +1804,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             if node['ids']:
                 # suppress with anchor=False \phantomsection insertion
                 ids += self.hypertarget(node['ids'][0], anchor=False)
-            # define label for use in caption, or directly if none exist.
-            # LaTeX code will add the \phantomsection in latter case.
+            # LaTeX code will insert \phantomsection prior to \label
             if ids:
                 self.body.append('\n\\def\\SphinxLiteralBlockLabel{' + ids + '}')
             code = node.astext()

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2009,6 +2009,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def depart_container(self, node):
         if node.get('literal_block'):
             self.in_container_literal_block -= 1
+            self.body.append('\\let\\SphinxVerbatimTitle\\empty\n')
             self.body.append('\\let\\SphinxLiteralBlockLabel\\empty\n')
 
     def visit_decoration(self, node):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1445,7 +1445,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.in_container_literal_block:
             self.body.append('\\needspace{\\literalblockneedspace}')
             self.body.append('\\vspace{\\literalblockcaptiontopvspace}\n')
-            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{' + self.context.pop())
+            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{'
+                             '' + self.context.pop())
         elif self.in_minipage and isinstance(node.parent, nodes.figure):
             self.body.append('\\captionof{figure}{')
         else:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1995,8 +1995,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 # suppress with anchor=False \phantomsection generation
                 ids += self.hypertarget(node['ids'][0], anchor=False)
             self.body.append('\n')
-            if ids:
-                self.context.append(ids) # will be used in visit_caption
+            self.context.append(ids) # will be used in visit_caption
 
     def depart_container(self, node):
         if node.get('literal_block'):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1444,8 +1444,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.in_caption += 1
         if self.in_container_literal_block:
             self.body.append('\\needspace{\\literalblockneedspace}')
-            self.body.append('\\vspace{\\literalblockcaptiontopvspace}%')
-            self.body.append('\n\\SphinxSetupCaptionForVerbatim{literal-block}{')
+            self.body.append('\\vspace{\\literalblockcaptiontopvspace}\n')
+            self.body.append(self.context.pop())
+            self.body.append('\\SphinxSetupCaptionForVerbatim{literal-block}{')
         elif self.in_minipage and isinstance(node.parent, nodes.figure):
             self.body.append('\\captionof{figure}{')
         else:
@@ -1998,7 +1999,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def depart_container(self, node):
         if node.get('literal_block'):
             self.in_container_literal_block -= 1
-            self.body.append(self.context.pop())
+            # self.body.append(self.context.pop()) moved to visit_caption
 
     def visit_decoration(self, node):
         pass

--- a/tests/roots/test-directive-code/caption.rst
+++ b/tests/roots/test-directive-code/caption.rst
@@ -1,5 +1,13 @@
-Dedent
-======
+Caption
+=======
+
+References
+----------
+
+See :numref:`caption *test* rb` and :numref:`caption **test** py`.
+
+See :ref:`Ruby <name *test* rb>` and :ref:`Python <name **test** py>`.
+
 
 Code blocks
 -----------
@@ -19,3 +27,26 @@ Literal Include
    :language: python
    :caption: caption **test** py
    :lines: 10-11
+
+
+Named Code blocks
+-----------------
+
+.. code-block:: ruby
+   :name: name *test* rb
+   :caption: caption *test* rbnamed
+
+   def ruby?
+       false
+   end
+
+
+Named Literal Include
+---------------------
+
+.. literalinclude:: literal.inc
+   :language: python
+   :name: name **test** py
+   :caption: caption **test** pynamed
+   :lines: 10-11
+

--- a/tests/roots/test-directive-code/conf.py
+++ b/tests/roots/test-directive-code/conf.py
@@ -2,3 +2,5 @@
 
 master_doc = 'index'
 exclude_patterns = ['_build']
+numfig = True
+

--- a/tests/roots/test-directive-code/namedblocks.rst
+++ b/tests/roots/test-directive-code/namedblocks.rst
@@ -1,0 +1,28 @@
+Named Blocks
+============
+
+References to named blocks
+--------------------------
+
+See :ref:`the ruby code <some ruby code>` and
+also :ref:`the python code <some python code>`.
+
+
+Named Code block
+----------------
+
+.. code-block:: ruby
+   :name: some ruby code
+
+   def ruby?
+       false
+   end
+
+
+Named Literal Include
+---------------------
+
+.. literalinclude:: literal.inc
+   :language: python
+   :name: some python code
+

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -64,7 +64,7 @@ def test_code_block_caption_html(app, status, warning):
 def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{\label{caption:caption-test-rb}caption \\emph{test} rb}'
+    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\emph{test} rb}'
     assert caption in latex
 
 
@@ -229,7 +229,7 @@ def test_literalinclude_caption_html(app, status, warning):
 def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{\label{caption:caption-test-py}caption \\textbf{test} py}'
+    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\textbf{test} py}'
     assert caption in latex
 
 

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -54,6 +54,7 @@ def test_code_block_caption_html(app, status, warning):
     app.builder.build(['caption'])
     html = (app.outdir / 'caption.html').text(encoding='utf-8')
     caption = (u'<div class="code-block-caption">'
+               u'<span class="caption-number">Listing 1 </span>'
                u'<span class="caption-text">caption <em>test</em> rb'
                u'</span><a class="headerlink" href="#caption-test-rb" '
                u'title="Permalink to this code">\xb6</a></div>')
@@ -65,7 +66,28 @@ def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
     caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\emph{test} rb}'
+    label = '\\def\\SphinxLiteralBlockLabel{\\label{caption:caption-test-rb}}'
+    link  = '\hyperref[caption:caption-test-rb]' \
+            '{Listing \\ref{caption:caption-test-rb}}'
     assert caption in latex
+    assert label in latex
+    assert link in latex
+
+
+@with_app('latex', testroot='directive-code')
+def test_code_block_namedlink_latex(app, status, warning):
+    app.builder.build_all()
+    latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
+    label1 = '\def\SphinxLiteralBlockLabel{\label{caption:name-test-rb}}'
+    link1  = '\\hyperref[caption:name\\string-test\\string-rb]'\
+             '{\\crossref{\\DUrole{std,std-ref}{Ruby}}'
+    label2 = '\def\SphinxLiteralBlockLabel{\label{namedblocks:some-ruby-code}}'
+    link2  = '\\hyperref[namedblocks:some\\string-ruby\\string-code]'\
+             '{\\crossref{\\DUrole{std,std-ref}{the ruby code}}}'
+    assert label1 in latex
+    assert link1  in latex
+    assert label2 in latex
+    assert link2  in latex
 
 
 @with_app('xml', testroot='directive-code')
@@ -219,6 +241,7 @@ def test_literalinclude_caption_html(app, status, warning):
     app.builder.build('index')
     html = (app.outdir / 'caption.html').text(encoding='utf-8')
     caption = (u'<div class="code-block-caption">'
+               u'<span class="caption-number">Listing 2 </span>'
                u'<span class="caption-text">caption <strong>test</strong> py'
                u'</span><a class="headerlink" href="#caption-test-py" '
                u'title="Permalink to this code">\xb6</a></div>')
@@ -230,7 +253,28 @@ def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
     caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\textbf{test} py}'
+    label = '\\def\\SphinxLiteralBlockLabel{\\label{caption:caption-test-py}}'
+    link  = '\hyperref[caption:caption-test-py]' \
+            '{Listing \\ref{caption:caption-test-py}}'
     assert caption in latex
+    assert label in latex
+    assert link in latex
+
+
+@with_app('latex', testroot='directive-code')
+def test_literalinclude_namedlink_latex(app, status, warning):
+    app.builder.build('index')
+    latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
+    label1 = '\def\SphinxLiteralBlockLabel{\label{caption:name-test-py}}'
+    link1  = '\\hyperref[caption:name\\string-test\\string-py]'\
+             '{\\crossref{\\DUrole{std,std-ref}{Python}}'
+    label2 = '\def\SphinxLiteralBlockLabel{\label{namedblocks:some-python-code}}'
+    link2  = '\\hyperref[namedblocks:some\\string-python\\string-code]'\
+             '{\\crossref{\\DUrole{std,std-ref}{the python code}}}'
+    assert label1 in latex
+    assert link1  in latex
+    assert label2 in latex
+    assert link2  in latex
 
 
 @with_app('xml', testroot='directive-code')

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -64,7 +64,7 @@ def test_code_block_caption_html(app, status, warning):
 def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\emph{test} rb}'
+    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{\label{caption:caption-test-rb}caption \\emph{test} rb}'
     assert caption in latex
 
 
@@ -229,7 +229,7 @@ def test_literalinclude_caption_html(app, status, warning):
 def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{caption \\textbf{test} py}'
+    caption = '\\SphinxSetupCaptionForVerbatim{literal-block}{\label{caption:caption-test-py}caption \\textbf{test} py}'
     assert caption in latex
 
 


### PR DESCRIPTION
This needs review because I am not sure whether my modification to LaTeX writer `latex.py` does not break something.
