### PR TITLE
Time formats no longer allowed in today_fmt

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -183,7 +183,8 @@ def format_date(format, date=None, language=None):
 
     if '%' not in format:
         # consider the format as babel's
-        return babel_format_date(date, format, locale=language, formatter=babel.dates.format_datetime)
+        return babel_format_date(date, format, locale=language,
+                                 formatter=babel.dates.format_datetime)
     else:
         warnings.warn('ustrftime format support will be dropped at Sphinx-1.5',
                       DeprecationWarning)
@@ -200,7 +201,8 @@ def format_date(format, date=None, language=None):
                     function = babel.dates.format_time
                 else:
                     function = babel.dates.format_datetime
-                result.append(babel_format_date(date, babel_format, locale=language, formatter=function))
+                result.append(babel_format_date(date, babel_format, locale=language,
+                                                formatter=function))
             else:
                 result.append(token)
 

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -126,15 +126,21 @@ def find_catalog_source_files(locale_dirs, locale, domains=None, gettext_compact
 
     return catalogs
 
-# date_format mappings: ustrftime() to bable.dates.format_date()
+# date_format mappings: ustrftime() to bable.dates.format_datetime()
 date_format_mappings = {
     '%a': 'EEE',     # Weekday as locale’s abbreviated name.
     '%A': 'EEEE',    # Weekday as locale’s full name.
     '%b': 'MMM',     # Month as locale’s abbreviated name.
     '%B': 'MMMM',    # Month as locale’s full name.
+    '%c': 'medium',  # Locale’s appropriate date and time representation.
     '%d': 'dd',      # Day of the month as a zero-padded decimal number.
+    '%H': 'HH',      # Hour (24-hour clock) as a decimal number [00,23].
+    '%I': 'hh',      # Hour (12-hour clock) as a decimal number [01,12].
     '%j': 'DDD',     # Day of the year as a zero-padded decimal number.
     '%m': 'MM',      # Month as a zero-padded decimal number.
+    '%M': 'mm',      # Minute as a decimal number [00,59].
+    '%p': 'a',       # Locale’s equivalent of either AM or PM.
+    '%S': 'ss',      # Second as a decimal number.
     '%U': 'WW',      # Week number of the year (Sunday as the first day of the week)
                      # as a zero padded decimal number. All days in a new year preceding
                      # the first Sunday are considered to be in week 0.
@@ -143,21 +149,23 @@ date_format_mappings = {
                      # as a decimal number. All days in a new year preceding the first
                      # Monday are considered to be in week 0.
     '%x': 'medium',  # Locale’s appropriate date representation.
+    '%X': 'medium',  # Locale’s appropriate time representation.
     '%y': 'YY',      # Year without century as a zero-padded decimal number.
     '%Y': 'YYYY',    # Year with century as a decimal number.
+    '%Z': 'zzzz',    # Time zone name (no characters if no time zone exists).
     '%%': '%',
 }
 
 
-def babel_format_date(date, format, locale):
+def babel_format_date(date, format, locale, formatter=babel.dates.format_date):
     if locale is None:
         locale = 'en'
 
     try:
-        return babel.dates.format_date(date, format, locale=locale)
+        return formatter(date, format, locale=locale)
     except (ValueError, babel.core.UnknownLocaleError):
         # fallback to English
-        return babel.dates.format_date(date, format, locale='en')
+        return formatter(date, format, locale='en')
 
 
 def format_date(format, date=None, language=None):
@@ -175,7 +183,7 @@ def format_date(format, date=None, language=None):
 
     if '%' not in format:
         # consider the format as babel's
-        return babel_format_date(date, format, locale=language)
+        return babel_format_date(date, format, locale=language, formatter=babel.dates.format_datetime)
     else:
         warnings.warn('ustrftime format support will be dropped at Sphinx-1.5',
                       DeprecationWarning)
@@ -186,7 +194,13 @@ def format_date(format, date=None, language=None):
         for token in tokens:
             if token in date_format_mappings:
                 babel_format = date_format_mappings.get(token, '')
-                result.append(babel_format_date(date, babel_format, locale=language))
+                if token == '%x':
+                    function = babel.dates.format_date
+                elif token == '%X':
+                    function = babel.dates.format_time
+                else:
+                    function = babel.dates.format_datetime
+                result.append(babel_format_date(date, babel_format, locale=language, formatter=function))
             else:
                 result.append(token)
 

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -161,6 +161,11 @@ def babel_format_date(date, format, locale, formatter=babel.dates.format_date):
     if locale is None:
         locale = 'en'
 
+    # Check if we have the tzinfo attribute. If not we cannot do any time
+    # related formats.
+    if not hasattr(date, 'tzinfo'):
+        formatter = babel.dates.format_date
+
     try:
         return formatter(date, format, locale=locale)
     except (ValueError, babel.core.UnknownLocaleError):
@@ -195,12 +200,17 @@ def format_date(format, date=None, language=None):
         for token in tokens:
             if token in date_format_mappings:
                 babel_format = date_format_mappings.get(token, '')
+
+                # Check if we have to use a different babel formatter then
+                # format_datetime, because we only want to format a date
+                # or a time.
                 if token == '%x':
                     function = babel.dates.format_date
                 elif token == '%X':
                     function = babel.dates.format_time
                 else:
                     function = babel.dates.format_datetime
+
                 result.append(babel_format_date(date, babel_format, locale=language,
                                                 formatter=function))
             else:

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -185,6 +185,18 @@ def test_format_date():
     assert i18n.format_date(format, date=date, language='ja') == u'2月 07, 2016'
     assert i18n.format_date(format, date=date, language='de') == 'Februar 07, 2016'
 
+    format = '%B %d, %Y, %H:%M:%S %I %p'
+    datet = datetime.datetime(2016, 2, 7, 5, 11, 17, 0)
+    assert i18n.format_date(format, date=datet) == 'February 07, 2016, 05:11:17 05 AM'
+
+    format = '%x'
+    assert i18n.format_date(format, date=datet) == 'Feb 7, 2016'
+    format = '%X'
+    assert i18n.format_date(format, date=datet) == '5:11:17 AM'
+    assert i18n.format_date(format, date=date) == 'Feb 7, 2016'
+    format = '%c'
+    assert i18n.format_date(format, date=datet) == 'Feb 7, 2016, 5:11:17 AM'
+    assert i18n.format_date(format, date=date) == 'Feb 7, 2016'
 
 def test_get_filename_for_language():
     app = TestApp()


### PR DESCRIPTION
Sphinx 1.3.x allowed to specify time formatters in today_fmt like %H and %M.

Allow these time formatters again.
This requires to use babel.dates.format_datetime instead of babel.dates.format_date
for formating. The approach of babel compared to ustrftime to use different functions
for time, date and datetime formating creates an ambiguousness for translating %c, %x, %X
from ustrftime to babel. Hence we look out for %x and %X to use the appropriate babel
function in this case.
Change of behaviour: People using the short, medium, long or full babel formats in
today_fmt will now get the respective datetime format instead of just the date format.
