### PR TITLE
Add CSS class to signature descriptions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Other contributors, listed alphabetically, are:
 * Jeppe Pihl -- literalinclude improvements
 * Rob Ruana -- napoleon extension
 * Stefan Seefeld -- toctree improvements
+* Dave Shawley -- HTML writer improvements
 * Shibukawa Yoshiki -- pluggable search API and Japanese search
 * Taku Shimizu -- epub3 builder
 * Antonio Valentino -- qthelp builder

--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,10 @@ Bugs fixed
 * #2394: Fix Sphinx crashes when html_last_updated_fmt is invalid
 * #2408: dummy builder not available in Makefile and make.bat
 
+Features added
+--------------
+
+* Tag signature descriptions with the ``descsignature`` CSS class.
 
 Release 1.4 (released Mar 28, 2016)
 ===================================

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -127,7 +127,9 @@ class HTMLTranslator(BaseTranslator):
         self.body.append(self.starttag(node, 'code', '', CLASS='descname'))
 
     def depart_desc_name(self, node):
-        self.body.append('</code>')
+        # space after the name allows for content wrapping to occur
+        # before a parameter list
+        self.body.append('</code> ')
 
     def visit_desc_parameterlist(self, node):
         self.body.append('<span class="sig-paren">(</span>')

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -95,7 +95,7 @@ class HTMLTranslator(BaseTranslator):
 
     def visit_desc_signature(self, node):
         # the id is set automatically
-        self.body.append(self.starttag(node, 'dt'))
+        self.body.append(self.starttag(node, 'dt', CLASS='descsignature'))
         # anchor for per-desc interactive data
         if node.parent['objtype'] != 'describe' \
            and node['ids'] and node['first']:

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1010,3 +1010,11 @@ def test_html_extra_path(app, status, warning):
     assert (app.outdir / 'rimg.png').exists()
     assert not (app.outdir / '_build/index.html').exists()
     assert (app.outdir / 'background.png').exists()
+
+
+@with_app(buildername='html')
+def test_api_styles(app, status, warning):
+    app.builder.build_all()
+    content = (app.outdir / 'autodoc.html').text()
+
+    assert '<dt class="descsignature" id="test_autodoc.Class">' in content

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1018,3 +1018,4 @@ def test_api_styles(app, status, warning):
     content = (app.outdir / 'autodoc.html').text()
 
     assert '<dt class="descsignature" id="test_autodoc.Class">' in content
+    assert '<code class="descname">Class</code> ' in content


### PR DESCRIPTION
The generated HTML documentation for class signatures is difficult to theme.  An example from a library that I maintain is rendered as follows:

<img width="804" alt="screen shot 2016-04-04 at 7 30 47 am" src="https://cloud.githubusercontent.com/assets/350812/14246751/33b886f6-fa37-11e5-8e9a-53b4b2b2e283.png" style="border:solid black 1px">

Since signatures are not tagged with a CSS class it is difficult to customize them.  This PR adds the `descname` CSS class to signature description.  It also inserts a space before the opening parenthesis which allows word wrapping to take care of awkward long lines.

With a hanging indent applied in CSS, the same code is rendered as:

<img width="749" alt="screen shot 2016-04-04 at 7 31 39 am" src="https://cloud.githubusercontent.com/assets/350812/14246770/50f047ae-fa37-11e5-8689-dff9d294ef4e.png" style="border:solid black 1px">
