### PR TITLE
Time formats no longer allowed in today_fmt

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -161,6 +161,11 @@ def babel_format_date(date, format, locale, warn=None, formatter=babel.dates.for
     if locale is None:
         locale = 'en'
 
+    # Check if we have the tzinfo attribute. If not we cannot do any time
+    # related formats.
+    if not hasattr(date, 'tzinfo'):
+        formatter = babel.dates.format_date
+
     try:
         return formatter(date, format, locale=locale)
     except (ValueError, babel.core.UnknownLocaleError):
@@ -201,12 +206,17 @@ def format_date(format, date=None, language=None, warn=None):
         for token in tokens:
             if token in date_format_mappings:
                 babel_format = date_format_mappings.get(token, '')
+
+                # Check if we have to use a different babel formatter then
+                # format_datetime, because we only want to format a date
+                # or a time.
                 if token == '%x':
                     function = babel.dates.format_date
                 elif token == '%X':
                     function = babel.dates.format_time
                 else:
                     function = babel.dates.format_datetime
+
                 result.append(babel_format_date(date, babel_format, locale=language,
                                                 formatter=function))
             else:

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -192,7 +192,8 @@ def format_date(format, date=None, language=None, warn=None):
         warnings.warn('LDML format support will be dropped at Sphinx-1.5',
                       DeprecationWarning)
 
-        return babel_format_date(date, format, locale=language, warn=warn, formatter=babel.dates.format_datetime)
+        return babel_format_date(date, format, locale=language, warn=warn,
+                                 formatter=babel.dates.format_datetime)
     else:
         # consider the format as ustrftime's and try to convert it to babel's
         result = []
@@ -206,7 +207,8 @@ def format_date(format, date=None, language=None, warn=None):
                     function = babel.dates.format_time
                 else:
                     function = babel.dates.format_datetime
-                result.append(babel_format_date(date, babel_format, locale=language, formatter=function))
+                result.append(babel_format_date(date, babel_format, locale=language,
+                                                formatter=function))
             else:
                 result.append(token)
 

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -200,6 +200,18 @@ def test_format_date():
     format = 'Mon Mar 28 12:37:08 2016, commit 4367aef'
     assert i18n.format_date(format, date=date) == format
 
+    format = '%B %d, %Y, %H:%M:%S %I %p'
+    datet = datetime.datetime(2016, 2, 7, 5, 11, 17, 0)
+    assert i18n.format_date(format, date=datet) == 'February 07, 2016, 05:11:17 05 AM'
+
+    format = '%x'
+    assert i18n.format_date(format, date=datet) == 'Feb 7, 2016'
+    format = '%X'
+    assert i18n.format_date(format, date=datet) == '5:11:17 AM'
+    assert i18n.format_date(format, date=date) == 'Feb 7, 2016'
+    format = '%c'
+    assert i18n.format_date(format, date=datet) == 'Feb 7, 2016, 5:11:17 AM'
+    assert i18n.format_date(format, date=date) == 'Feb 7, 2016'
 
 def test_get_filename_for_language():
     app = TestApp()


### PR DESCRIPTION
Sphinx 1.3.x allowed to specify time formatters in today_fmt like %H and %M.

Allow these time formatters again.
This requires to use babel.dates.format_datetime instead of babel.dates.format_date
for formating. The approach of babel compared to ustrftime to use different functions
for time, date and datetime formating creates an ambiguousness for translating %c, %x, %X
from ustrftime to babel. Hence we look out for %x and %X to use the appropriate babel
function in this case.
Change of behaviour: People using the short, medium, long or full babel formats in
today_fmt will now get the respective datetime format instead of just the date format.
