### PR TITLE
Fix annotations formatting for plain typing.Callable

### DIFF
--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -315,6 +315,7 @@ def format_annotation(annotation):
                 isinstance(annotation, typing.CallableMeta) and \
                 getattr(annotation, '__args__', None) is not None and \
                 hasattr(annotation, '__result__'):
+            # Skipped in the case of plain typing.Callable
             args = annotation.__args__
             if args is Ellipsis:
                 args_str = '...'

--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -313,7 +313,7 @@ def format_annotation(annotation):
                 return '%s[%s]' % (qualified_name, param_str)
         elif hasattr(typing, 'CallableMeta') and \
                 isinstance(annotation, typing.CallableMeta) and \
-                hasattr(annotation, '__args__') and \
+                getattr(annotation, '__args__', None) is not None and \
                 hasattr(annotation, '__result__'):
             args = annotation.__args__
             if args is Ellipsis:

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1069,7 +1069,7 @@ def test_type_hints():
     from sphinx.util.inspect import getargspec
 
     try:
-        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10
+        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11
     except (ImportError, SyntaxError):
         raise SkipTest('Cannot import Python code with function annotations')
 
@@ -1104,10 +1104,11 @@ def test_type_hints():
 
     # Callable types
     verify_arg_spec(f8, '(x: typing.Callable[[int, str], int]) -> None')
+    verify_arg_spec(f9, '(x: typing.Callable) -> None')
 
     # Tuple types
-    verify_arg_spec(f9, '(x: typing.Tuple[int, str],'
-                        ' y: typing.Tuple[int, ...]) -> None')
+    verify_arg_spec(f10, '(x: typing.Tuple[int, str],'
+                         ' y: typing.Tuple[int, ...]) -> None')
 
     # Instance annotations
-    verify_arg_spec(f10, '(x: CustomAnnotation, y: 123) -> None')
+    verify_arg_spec(f11, '(x: CustomAnnotation, y: 123) -> None')

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -48,7 +48,11 @@ def f8(x: Callable[[int, str], int]) -> None:
     pass
 
 
-def f9(x: Tuple[int, str], y: Tuple[int, ...]) -> None:
+def f9(x: Callable) -> None:
+    pass
+
+
+def f10(x: Tuple[int, str], y: Tuple[int, ...]) -> None:
     pass
 
 
@@ -56,5 +60,6 @@ class CustomAnnotation:
     def __repr__(self):
         return 'CustomAnnotation'
 
-def f10(x: CustomAnnotation(), y: 123) -> None:
+
+def f11(x: CustomAnnotation(), y: 123) -> None:
     pass


### PR DESCRIPTION
The typing.Callable class may be used without generic arguments, in which case it is equivalent to collections.abc.Callable.
