### PR TITLE
Fix unwanted * between varargs and keyword only args

### DIFF
--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -350,7 +350,9 @@ def formatargspec(function, args, varargs=None, varkw=None, defaults=None,
         formatted.append('*' + format_arg_with_annotation(varargs))
 
     if kwonlyargs:
-        formatted.append('*')
+        if not varargs:
+            formatted.append('*')
+
         for kwarg in kwonlyargs:
             arg_fd = StringIO()
             arg_fd.write(format_arg_with_annotation(kwarg))

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1010,7 +1010,7 @@ def test_type_hints():
     from sphinx.util.inspect import getargspec
 
     try:
-        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8
+        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9
     except (ImportError, SyntaxError):
         raise SkipTest('Cannot import Python code with function annotations')
 
@@ -1037,12 +1037,15 @@ def test_type_hints():
     # Keyword-only arguments
     verify_arg_spec(f5, '(x: int, *, y: str, z: str) -> None')
 
+    # Keyword-only arguments with varargs
+    verify_arg_spec(f6, '(x: int, *args, y: str, z: str) -> None')
+
     # Space around '=' for defaults
-    verify_arg_spec(f6, '(x: int = None, y: dict = {}) -> None')
+    verify_arg_spec(f7, '(x: int = None, y: dict = {}) -> None')
 
     # Callable types
-    verify_arg_spec(f7, '(x: typing.Callable[[int, str], int]) -> None')
+    verify_arg_spec(f8, '(x: typing.Callable[[int, str], int]) -> None')
 
     # Tuple types
-    verify_arg_spec(f8, '(x: typing.Tuple[int, str],'
+    verify_arg_spec(f9, '(x: typing.Tuple[int, str],'
                         ' y: typing.Tuple[int, ...]) -> None')

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -35,14 +35,18 @@ def f5(x: int, *, y: str, z: str) -> None:
     pass
 
 
-def f6(x: int = None, y: dict = {}) -> None:
+def f6(x: int, *args, y: str, z: str) -> None:
     pass
 
 
-def f7(x: Callable[[int, str], int]) -> None:
+def f7(x: int = None, y: dict = {}) -> None:
+    pass
+
+
+def f8(x: Callable[[int, str], int]) -> None:
     # See https://github.com/ambv/typehinting/issues/149 for Callable[..., int]
     pass
 
 
-def f8(x: Tuple[int, str], y: Tuple[int, ...]) -> None:
+def f9(x: Tuple[int, str], y: Tuple[int, ...]) -> None:
     pass


### PR DESCRIPTION
The \* parameter must only be present when a holder for positional variable arguments is not present.
