### PR TITLE
Fix wrong import for gmtime

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -14,7 +14,7 @@ import os
 import re
 import warnings
 from os import path
-from time import time
+from time import time, gmtime
 from datetime import datetime
 from collections import namedtuple
 
@@ -188,7 +188,7 @@ def format_date(format, date=None, language=None, warn=None):
         # See https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal
         source_date_epoch = os.getenv('SOURCE_DATE_EPOCH')
         if source_date_epoch is not None:
-            date = time.gmtime(float(source_date_epoch))
+            date = gmtime(float(source_date_epoch))
         else:
             date = datetime.now()
 


### PR DESCRIPTION
Fixes 

```
Traceback (most recent call last):
 ...
  File ".../python2.7/site-packages/sphinx/builders/manpage.py", line 86, in write
    docwriter.write(largetree, destination)
  File ".../python2.7/site-packages/docutils/writers/__init__.py", line 80, in write
    self.translate()
  File ".../python2.7/site-packages/sphinx/writers/manpage.py", line 37, in translate
    visitor = self.translator_class(self.builder, self.document)
  File "...python2.7/site-packages/sphinx/writers/manpage.py", line 102, in __init__
    language=builder.config.language)
  File ".../python2.7/site-packages/sphinx/util/i18n.py", line 172, in format_date
    date = time.gmtime(float(source_date_epoch))
AttributeError: 'builtin_function_or_method' object has no attribute 'gmtime'
```
