### PR TITLE
Wikisyntax Builder

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Other contributors, listed alphabetically, are:
 * Henrique Bastos -- SVG support for graphviz extension
 * Daniel Bültmann -- todo extension
 * Etienne Desautels -- apidoc module
+* Emilio Dorigatti -- wikisyntax builder
 * Michael Droettboom -- inheritance_diagram extension
 * Charles Duffy -- original graphviz extension
 * Kevin Dunn -- MathJax extension

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -476,4 +476,5 @@ BUILTIN_BUILDERS = {
     'gettext':    ('gettext', 'MessageCatalogBuilder'),
     'xml':        ('xml', 'XMLBuilder'),
     'pseudoxml':  ('xml', 'PseudoXMLBuilder'),
+    'wikisyntax': ('wikisyntax', 'WikisyntaxBuilder'),
 }

--- a/sphinx/builders/wikisyntax.py
+++ b/sphinx/builders/wikisyntax.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.builders.wikisyntax
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Wikisyntax Sphinx builder.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from sphinx.builders.text import TextBuilder
+from sphinx.writers.wikisyntax import WikisyntaxWriter
+
+
+class WikisyntaxBuilder(TextBuilder):
+    name = 'wikisyntax'
+    format = 'wikisyntax'
+    out_suffix = '.wiki'
+    allow_parallel = True
+
+    def prepare_writing(self, docnames):
+        self.writer = WikisyntaxWriter(self)

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -126,11 +126,8 @@ class TextWrapper(textwrap.TextWrapper):
             cur_line.append(reversed_chunks.pop())
 
 
-MAXWIDTH = 70
-STDINDENT = 3
-
-
-def my_wrap(text, width=MAXWIDTH, **kwargs):
+def my_wrap(text, width=None, **kwargs):
+    width = TextTranslator.MAXWIDTH if width is None else width
     w = TextWrapper(width=width, **kwargs)
     return w.wrap(text)
 
@@ -154,6 +151,9 @@ class TextWriter(writers.Writer):
 
 
 class TextTranslator(nodes.NodeVisitor):
+    MAXWIDTH = 70
+    STDINDENT = 3
+
     sectionchars = '*=-~"+`'
 
     def __init__(self, document, builder):
@@ -178,8 +178,9 @@ class TextTranslator(nodes.NodeVisitor):
     def add_text(self, text):
         self.states[-1].append((-1, text))
 
-    def new_state(self, indent=STDINDENT):
+    def new_state(self, indent=None):
         self.states.append([])
+        indent = self.STDINDENT if indent is None else indent
         self.stateindent.append(indent)
 
     def end_state(self, wrap=True, end=[''], first=None):
@@ -193,7 +194,7 @@ class TextTranslator(nodes.NodeVisitor):
             if not toformat:
                 return
             if wrap:
-                res = my_wrap(''.join(toformat), width=MAXWIDTH-maxindent)
+                res = my_wrap(''.join(toformat), width=self.MAXWIDTH-maxindent)
             else:
                 res = ''.join(toformat).splitlines()
             if end:
@@ -586,7 +587,7 @@ class TextTranslator(nodes.NodeVisitor):
     def visit_transition(self, node):
         indent = sum(self.stateindent)
         self.new_state(0)
-        self.add_text('=' * (MAXWIDTH - indent))
+        self.add_text('=' * (self.MAXWIDTH - indent))
         self.end_state()
         raise nodes.SkipNode
 

--- a/sphinx/writers/wikisyntax.py
+++ b/sphinx/writers/wikisyntax.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.writers.wikisyntax
+    ~~~~~~~~~~~~~~~~~~~
+
+    Custom docutils writer for wikisyntax
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+from docutils import writers, nodes
+from sphinx.writers.text import TextTranslator
+
+
+class WikisyntaxWriter(writers.Writer):
+    supported = ('text',)
+    settings_spec = ('No options here.', '', ())
+    settings_defaults = {}
+
+    output = None
+
+    def __init__(self, builder):
+        writers.Writer.__init__(self)
+        self.builder = builder
+        self.translator_class = self.builder.translator_class or WikisyntaxTranslator
+
+    def translate(self):
+        visitor = self.translator_class(self.document, self.builder)
+        self.document.walkabout(visitor)
+        self.output = visitor.body
+
+
+class WikisyntaxTranslator(TextTranslator):
+
+    MAXWIDTH = 200
+    STDINDENT = 1
+
+    def depart_document(self, node):
+        self.end_state()
+        self.body = self.nl.join(line and (':'*indent + line)
+                                 for indent, lines in self.states[0]
+                                 for line in lines)
+
+    def depart_title(self, node):
+        text = ''.join(x[1] for x in self.states.pop() if x[0] == -1)
+        delimiter = '=' * self.sectionlevel
+
+        self.stateindent.pop()
+        self.states[-1].append((0, ['%s %s %s' % (delimiter, text, delimiter)]))
+
+    def visit_desc_signature(self, node):
+        self.new_state(0)
+        self.add_text('<br />')
+        self.add_text("'''")
+
+    def visit_desc_parameterlist(self, node):
+        self.add_text("'''")
+        self.add_text('(')
+        self.first_param = 1
+
+    def depart_table(self, node):
+        text = []
+        text.append('<table border="1">')
+
+        text.append('<tr>')
+        for field in self.table[1]:
+            text.append('<th>%s</th>' % field.rstrip('\n'))
+        text.append('</tr>')
+
+        for row in self.table[3:]:
+            text.append('<tr>')
+            for field in row:
+                text.append('<td>%s</td>' % field.rstrip('\n'))
+            text.append('</tr>')
+        text.append('</table>')
+
+        self.add_text(''.join(text))
+        self.table = None
+        self.end_state(wrap=False)
+
+    def visit_transition(self, node):
+        self.new_state(0)
+        self.add_text('----')
+        self.end_state()
+        raise nodes.SkipNode
+
+    def depart_list_item(self, node):
+        if self.list_counter[-1] == -1:
+            self.end_state(first='* ')
+        elif self.list_counter[-1] == -2:
+            pass
+        else:
+            self.end_state(first='# ')
+
+    def visit_centered(self, node):
+        self.add_text('{center|')
+
+    def depart_centered(self, node):
+        self.add_text('}')
+
+    def visit_block_quote(self, node):
+        self.new_state()
+        self.add_text('<blockquote>')
+
+    def depart_block_quote(self, node):
+        self.add_text('</blockquote>')
+        self.end_state()
+
+    def visit_emphasis(self, node):
+        self.add_text("''")
+
+    def depart_emphasis(self, node):
+        self.add_text("''")
+
+    def visit_literal_emphasis(self, node):
+        self.add_text("''")
+
+    def depart_literal_emphasis(self, node):
+        self.add_text("''")
+
+    def visit_strong(self, node):
+        self.add_text("'''")
+
+    def depart_strong(self, node):
+        self.add_text("'''")
+
+    def visit_literal_strong(self, node):
+        self.add_text("'''")
+
+    def depart_literal_strong(self, node):
+        self.add_text("'''")
+
+    def visit_subscript(self, node):
+        self.add_text('<sub>')
+
+    def depart_subscript(self, node):
+        self.add_text('</sub>')
+
+    def visit_superscript(self, node):
+        self.add_text('<sup>')
+
+    def depart_superscript(self, node):
+        self.add_text('</sup>')
+
+    def visit_doctest_block(self, node):
+        self.new_state(0)
+
+    def depart_doctest_block(self, node):
+        _, doctest = self.states.pop()[0]
+        self.states.append([(0, [
+            '<syntaxhighlight lang="python">' + self.nl +
+            doctest + self.nl +
+            '</syntaxhighlight>'
+        ])])
+        self.end_state(wrap=False)

--- a/tests/roots/test-build-wikisyntax/conf.py
+++ b/tests/roots/test-build-wikisyntax/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'contents'
+source_suffix = '.rst'
+exclude_patterns = ['_build']

--- a/tests/roots/test-build-wikisyntax/contents.rst
+++ b/tests/roots/test-build-wikisyntax/contents.rst
@@ -1,0 +1,8 @@
+.. toctree::
+
+   ul
+   ol
+   table
+   transition
+   titles
+   inline

--- a/tests/roots/test-build-wikisyntax/doctest.rst
+++ b/tests/roots/test-build-wikisyntax/doctest.rst
@@ -1,0 +1,6 @@
+    Some doctests in an indented block:
+
+    >>> print "This is a doctest block."
+    This is a doctest block.
+
+    End of tests.

--- a/tests/roots/test-build-wikisyntax/inline.rst
+++ b/tests/roots/test-build-wikisyntax/inline.rst
@@ -1,0 +1,3 @@
+*emphasis*
+
+**strong emphasis**

--- a/tests/roots/test-build-wikisyntax/ol.rst
+++ b/tests/roots/test-build-wikisyntax/ol.rst
@@ -1,0 +1,7 @@
+Ordered List:
+
+1. first item
+2. second item
+3. third item
+
+End of list

--- a/tests/roots/test-build-wikisyntax/table.rst
+++ b/tests/roots/test-build-wikisyntax/table.rst
@@ -1,0 +1,8 @@
+=====  =====  ======
+  A      B    A or B
+=====  =====  ====== 
+False  False  False 
+True   False  True 
+False  True   True 
+True   True   True 
+=====  =====  ======

--- a/tests/roots/test-build-wikisyntax/titles.rst
+++ b/tests/roots/test-build-wikisyntax/titles.rst
@@ -1,0 +1,10 @@
+=========
+Big Title
+=========
+
+Intro
+
+Sub-Title
+---------
+
+Sub-Intro

--- a/tests/roots/test-build-wikisyntax/transition.rst
+++ b/tests/roots/test-build-wikisyntax/transition.rst
@@ -1,0 +1,5 @@
+Some text here.
+
+------------------
+
+Completely new paragraph

--- a/tests/roots/test-build-wikisyntax/ul.rst
+++ b/tests/roots/test-build-wikisyntax/ul.rst
@@ -1,0 +1,7 @@
+Unordered List:
+
+- item 1
+- item 2
+- item 3
+
+end of list

--- a/tests/test_build_text.py
+++ b/tests/test_build_text.py
@@ -10,7 +10,7 @@
 """
 
 from docutils.utils import column_width
-from sphinx.writers.text import MAXWIDTH
+from sphinx.writers.text import TextTranslator
 
 from util import with_app
 
@@ -31,7 +31,7 @@ def test_maxwitdh_with_prefix(app, status, warning):
 
     lines = result.splitlines()
     line_widths = [column_width(line) for line in lines]
-    assert max(line_widths) < MAXWIDTH
+    assert max(line_widths) < TextTranslator.MAXWIDTH
     assert lines[0].startswith('See also: ham')
     assert lines[1].startswith('  ham')
     assert lines[2] == ''
@@ -84,7 +84,7 @@ def test_nonascii_maxwidth(app, status, warning):
     result = (app.outdir / 'nonascii_maxwidth.txt').text(encoding='utf-8')
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     line_widths = [column_width(line) for line in lines]
-    assert max(line_widths) < MAXWIDTH
+    assert max(line_widths) < TextTranslator.MAXWIDTH
 
 
 @with_text_app()

--- a/tests/test_build_wikisyntax.py
+++ b/tests/test_build_wikisyntax.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""
+    test_build_wikisyntax
+    ~~~~~~~~~~~~~~~
+
+    Test the build process with Wikisyntax builder with the test root.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from util import with_app
+
+
+def with_wikisyntax_app(*args, **kw):
+    default_kw = {
+        'buildername': 'wikisyntax',
+        'testroot': 'build-wikisyntax',
+    }
+    default_kw.update(kw)
+    return with_app(*args, **default_kw)
+
+
+@with_wikisyntax_app()
+def test_ul(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'ul.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        'Unordered List:',
+        '',
+        '* item 1',
+        '',
+        '* item 2',
+        '',
+        '* item 3',
+        '',
+        'end of list',
+        '',
+    ])
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_ol(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'ol.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        'Ordered List:',
+        '',
+        '# first item',
+        '',
+        '# second item',
+        '',
+        '# third item',
+        '',
+        'End of list',
+        '',
+    ])
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_table(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'table.wiki').text(encoding='utf-8'))
+
+    expected = ''.join(s.strip() for s in """
+        <table border="1">
+            <tr>
+                <th>A</th>
+                <th>B</th>
+                <th>A or B</th>
+            </tr>
+            <tr>
+                <td>False</td>
+                <td>False</td>
+                <td>False</td>
+            </tr>
+            <tr>
+                <td>True</td>
+                <td>False</td>
+                <td>True</td>
+            </tr>
+            <tr>
+                <td>False</td>
+                <td>True</td>
+                <td>True</td>
+            </tr>
+            <tr>
+                <td>True</td>
+                <td>True</td>
+                <td>True</td>
+            </tr>
+        </table>""".split('\n')) + '\n'
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_transition(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'transition.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        'Some text here.',
+        '',
+        '----',
+        '',
+        'Completely new paragraph',
+        '',
+    ])
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_titles(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'titles.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        '= Big Title =',
+        'Intro',
+        '',
+        '== Sub-Title ==',
+        'Sub-Intro',
+        '',
+    ])
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_inline(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'inline.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        "''emphasis''",
+        '',
+        "'''strong emphasis'''",
+        '',
+    ])
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_inline(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'doctest.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        'Some doctests:',
+        '',
+        '<syntaxhighlight lang="python">',
+        '>>> print "This is a doctest block."',
+        'This is a doctest block.',
+        '</syntaxhighlight>',
+        '',
+        'End of tests.',
+        '',
+    ])
+
+    assert result == expected
+
+
+@with_wikisyntax_app()
+def test_inline(app, status, warnings):
+    app.builder.build_update()
+    result = str((app.outdir / 'doctest.wiki').text(encoding='utf-8'))
+
+    expected = '\n'.join([
+        ':<blockquote>',
+        '',
+        ':Some doctests in an indented block:',
+        '',
+        ':<syntaxhighlight lang="python">',
+        '>>> print "This is a doctest block."',
+        'This is a doctest block.',
+        '</syntaxhighlight>',
+        ':End of tests.',
+        '',
+        ':</blockquote>',
+        '',
+    ])
+
+    assert result == expected


### PR DESCRIPTION
I added a builder for the [wiki markup](https://en.wikipedia.org/wiki/Help:Wiki_markup). It is by no means feature-complete, it just handles the basics (italics, bold, tables, lists and titles). I subclassed `TextTranslator` as most of its structure can be re-used and took inspiration from `TextBuilder` to wire things together.
