### PR TITLE
Allow silencing directive/role/node override warnings.

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -144,6 +144,10 @@ class Sphinx(object):
         if 'alabaster' not in self.config.extensions:
             self.config.extensions.append('alabaster')
 
+        # collect values a first time before extension setup because they may
+        # be needing for things like suppressing warnings.
+        self.config.init_values(self.warn)
+
         # load all user-given extension modules
         for extension in self.config.extensions:
             self.setup_extension(extension)
@@ -584,7 +588,8 @@ class Sphinx(object):
            hasattr(nodes.GenericNodeVisitor, 'visit_' + node.__name__):
             self.warn('while setting up extension %s: node class %r is '
                       'already registered, its visitors will be overridden' %
-                      (self._setting_up_extension, node.__name__))
+                      (self._setting_up_extension, node.__name__),
+                      type='node_overridden', subtype=node.__name__)
         nodes._add_node_class_names([node.__name__])
         for key, val in iteritems(kwds):
             try:
@@ -636,7 +641,8 @@ class Sphinx(object):
         if name in directives._directives:
             self.warn('while setting up extension %s: directive %r is '
                       'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], name))
+                      (self._setting_up_extension[-1], name),
+                      type='directive_overridden', subtype=name)
         directives.register_directive(
             name, self._directive_helper(obj, content, arguments, **options))
 
@@ -645,7 +651,8 @@ class Sphinx(object):
         if name in roles._roles:
             self.warn('while setting up extension %s: role %r is '
                       'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], name))
+                      (self._setting_up_extension[-1], name),
+                      type='role_overridden', subtype=name)
         roles.register_local_role(name, role)
 
     def add_generic_role(self, name, nodeclass):
@@ -655,7 +662,8 @@ class Sphinx(object):
         if name in roles._roles:
             self.warn('while setting up extension %s: role %r is '
                       'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], name))
+                      (self._setting_up_extension[-1], name),
+                      type='role_overridden', subtype=name)
         role = roles.GenericRole(name, nodeclass)
         roles.register_local_role(name, role)
 


### PR DESCRIPTION
As described in the comments of cdf0f8253c613dce89b41be50ffb791ff64d0450, Django is overriding `versionchanged` and `versionadded` and these warnings cause our builds to fail. This allows us to add:

```
suppress_warnings = [
    'directive_overridden.versionadded',
    'directive_overridden.versionchanged',
]
```

to our config to suppress them.

If this looks okay, I'll add docs to http://www.sphinx-doc.org/en/stable/config.html#confval-suppress_warnings (anything else needed?).

Not sure if tests are needed since the linked commit didn't have any.
