### PR TITLE
Fix a vertical space in indented code-blocks for latexpdf

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -238,6 +238,7 @@
   \setlength\parskip{0pt}%
   \setlength\itemsep{0ex}%
   \setlength\topsep{0ex}%
+  \setlength\parsep{0pt}% let's not forget this one!
   \setlength\partopsep{0pt}%
   \setlength\leftmargin{0pt}%
   }%


### PR DESCRIPTION
Add a missing \setlength\parsep{0pt} in Verbatim environment defined
in sphinx.sty. This is old code, but the parsep setting was clearly missing.

Without it there is a little extra white space below top frame, which shows
up in case of an indented code-block.

```
modified:   sphinx/texinputs/sphinx.sty
```
