### PR TITLE
verbose output for travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ python:
   - "3.5"
   - "pypy"
 env:
-  - DOCUTILS=0.11
-  - DOCUTILS=0.12
+  global:
+    - TEST=-v
+  matrix:
+    - DOCUTILS=0.11
+    - DOCUTILS=0.12
 install:
   - pip install -U pip
   - pip install docutils==$DOCUTILS


### PR DESCRIPTION
To get skipped test details, travis testing should emit all test names and reason of skipping.
Output example: https://travis-ci.org/sphinx-doc/sphinx/jobs/123833997
