### PR TITLE
Load compatibility patch for LuaTeX 0.85+

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -8,6 +8,12 @@
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesPackage{sphinx}[2010/01/15 LaTeX package (Sphinx markup)]
 
+\ifx\directlua\undefined\else
+% if compiling with lualatex 0.85 or later load compatibility patch issued by
+% the LaTeX team for older packages relying on \pdf<name> named primitives.
+    \IfFileExists{luatex85.sty}{\RequirePackage{luatex85}}{}
+\fi
+
 \@ifclassloaded{memoir}{}{\RequirePackage{fancyhdr}}
 
 \RequirePackage{textcomp}


### PR DESCRIPTION
See http://ctan.org/pkg/luatex85 for more info. Old packages relying on
pdf naming of primitives will break under LuaTeX 0.85+, which will be
generally available starting with TeXLive 2016 release.

On the pretest release of TeXLive 2016, all tests of Sphinx from `make test` which invoke LuaLaTeX fail. With this patch they all complete successfully. This is backwards compatible. 
