### PR TITLE
Ignore updates of catalog files for gettext builder

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Features added
 Bugs fixed
 ----------
 
+* Ignore updates of catalog files for gettext builder
+
 Documentation
 -------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,7 @@ Features added
 Bugs fixed
 ----------
 
-* Ignore updates of catalog files for gettext builder
+* #2469: Ignore updates of catalog files for gettext builder
 
 Documentation
 -------------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -231,7 +231,7 @@ class Sphinx(object):
     def _init_env(self, freshenv):
         if freshenv:
             self.env = BuildEnvironment(self.srcdir, self.doctreedir,
-                                        self.config)
+                                        self.config, self.buildername)
             self.env.find_files(self.config)
             for domain in self.domains.keys():
                 self.env.domains[domain] = self.domains[domain](self.env)

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -142,10 +142,11 @@ class BuildEnvironment:
 
     # --------- ENVIRONMENT INITIALIZATION -------------------------------------
 
-    def __init__(self, srcdir, doctreedir, config):
+    def __init__(self, srcdir, doctreedir, config, buildername):
         self.doctreedir = doctreedir
         self.srcdir = srcdir
         self.config = config
+        self.buildername = buildername
 
         # the method of doctree versioning; see set_versioning_method
         self.versioning_condition = None
@@ -395,6 +396,9 @@ class BuildEnvironment:
         )
         self.found_docs = set(get_matching_docs(
             self.srcdir, config.source_suffix, exclude_matchers=matchers))
+
+        if self.buildername == 'gettext':
+            return
 
         # add catalog mo file dependency
         for docname in self.found_docs:

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -338,6 +338,15 @@ def test_gettext_builder(app, status, warning):
     for expect_msg in [m for m in expect if m.id]:
         yield assert_in, expect_msg.id, [m.id for m in actual if m.id]
 
+    # --- don't rebuild by .mo mtime
+
+    app.builder.build_update()
+    updated = app.env.update(app.config, app.srcdir, app.doctreedir, app)
+    yield assert_equal, len(updated), 0
+
+    (app.srcdir / 'xx' / 'LC_MESSAGES' / 'bom.mo').utime(None)
+    updated = app.env.update(app.config, app.srcdir, app.doctreedir, app)
+    yield assert_equal, len(updated), 0
 
 @gen_with_intl_app('html', freshenv=True)
 def test_html_builder(app, status, warning):


### PR DESCRIPTION
We don't need to detect updates of catalog files
since they don't change the behavior of the gettext builder.
This change will make the incremental build faster.

Please let me know any problems, I'm going to fix them.
