### PR TITLE
Modify a spelling mistake

### DIFF
--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -533,7 +533,7 @@ class SearchJapanese(SearchLanguage):
     language_name = 'Japanese'
     splitters = {
         'default': 'sphinx.search.ja.DefaultSplitter',
-        'mecab': 'sphinx.sarch.ja.MecabSplitter',
+        'mecab': 'sphinx.search.ja.MecabSplitter',
         'janome': 'sphinx.search.ja.JanomeSplitter',
     }
 


### PR DESCRIPTION
Due to a spelling mistake in `sphinx/search/ja.py` that is `'mecab': 'sphinx.sarch.ja.MecabSplitter'` the HTML build with using MeCab splitter failed with the following error:

```
Extension error:
Splitter module 'sphinx.sarch.ja.MecabSplitter' can't be imported
```

This patch will correct the wrong spell `sarch` to `search`.
