### PR TITLE
Fix link target path for SVG inheritance diagrams

### DIFF
--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -360,10 +360,7 @@ def html_visit_inheritance_diagram(self, node):
     urls = {}
     for child in node:
         if child.get('refuri') is not None:
-            if graphviz_output_format == 'SVG':
-                urls[child['reftitle']] = "../" + child.get('refuri')
-            else:
-                urls[child['reftitle']] = child.get('refuri')
+            urls[child['reftitle']] = child.get('refuri')
         elif child.get('refid') is not None:
             if graphviz_output_format == 'SVG':
                 urls[child['reftitle']] = '../' + current_filename + '#' + child.get('refid')


### PR DESCRIPTION
The link target path for the SVG version of the inheritance diagram was incorrect (see examples below). This PR fixes it.

Examples:
http://docs.astropy.org/en/stable/coordinates/#class-inheritance-diagram
http://photutils.readthedocs.org/en/latest/photutils/aperture.html#class-inheritance-diagram

This fixes https://github.com/astropy/photutils/issues/345.

Does it need a changelog entry?
