### PR TITLE
Use `locales` as a default value of `locale_dirs`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Incompatible changes
 --------------------
 
 * LaTeX package fancybox is not longer a dependency of sphinx.sty
+* Use `'locales'` as a default value of `locale_dirs`
 
 Features added
 --------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -513,7 +513,10 @@ documentation on :ref:`intl` for details.
    :file:`./locale/{language}/LC_MESSAGES/sphinx.mo`.  The text domain of
    individual documents depends on :confval:`gettext_compact`.
 
-   The default is ``[]``.
+   The default is ``['locales']``.
+
+   .. versionchanged:: 1.5
+      Use ``locales`` directory as a default value
 
 .. confval:: gettext_compact
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -57,7 +57,7 @@ class Config(object):
         today_fmt = (None, 'env', string_classes),
 
         language = (None, 'env', string_classes),
-        locale_dirs = ([], 'env'),
+        locale_dirs = (['locales'], 'env'),
         figure_language_filename = (u'{root}.{language}{ext}', 'env', [str]),
 
         master_doc = ('contents', 'env'),


### PR DESCRIPTION
We have to set up `locale_dirs` before any translations. This patch gives it to good default value.

@shimizukawa What do you think?
