### PR TITLE
Error message improvement: sphinx_rtd_theme not found error

### DIFF
--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -103,7 +103,8 @@ class Theme(object):
             if name not in self.themes:
                 if name == 'sphinx_rtd_theme':
                     raise ThemeError('sphinx_rtd_theme is no longer a hard dependency '
-                                     'since version 1.4.0. Please install it manually.')
+                                     'since version 1.4.0. Please install it manually.'
+                                     '(pip install sphinx_rtd_theme)')
                 else:
                     raise ThemeError('no theme named %r found '
                                      '(missing theme.conf?)' % name)


### PR DESCRIPTION
Explicitly adding the pip command required to install the spinx_rtd_theme to the error message.

It's not immediately obvious to new users how to fix this error - the "Please install it manually" is ambiguous and googling or reading the documentation doesn't return the fix!
