### PR TITLE
Allow entering builder class via application init

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -74,7 +74,7 @@ class Sphinx(object):
     def __init__(self, srcdir, confdir, outdir, doctreedir, buildername,
                  confoverrides=None, status=sys.stdout, warning=sys.stderr,
                  freshenv=False, warningiserror=False, tags=None, verbosity=0,
-                 parallel=0):
+                 builderclass=None, parallel=0):
         self.verbosity = verbosity
         self.next_listener_id = 0
         self._extensions = {}
@@ -121,6 +121,9 @@ class Sphinx(object):
 
         # status code for command-line application
         self.statuscode = 0
+
+        if builderclass:
+            self.add_builder(builderclass)
 
         if not path.isdir(outdir):
             self.info('making output directory...')


### PR DESCRIPTION
This cleans up a lot. I am accessing sphinx via python. Currently, I'd have to enter a fake `buildername` then add a builder class and `_init` it afterwards:

``` python
app = Sphinx(
    confdir=SPHINX_CONF_DIR,
    outdir=SPHINX_OUT_DIR,
    doctreedir=DOCTREE_DIR,
    buildername='html',
)
app.add_builder(CustomBuilder)
app._init_builder('custombuilder')
```

With this patch I can pass the builder class through the init,

``` python
app = Sphinx(
    confdir=SPHINX_CONF_DIR,
    outdir=SPHINX_OUT_DIR,
    doctreedir=DOCTREE_DIR,
    buildername='custombuilder',
    builderclass=CustomBuilder
)
```

The new keyword argument `builderclass` is optional and doesn't existing code or functionality.

Fixes #2488
