### PR TITLE
Fix a small bug in docs on "HTML theming support"

### DIFF
--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -51,7 +51,7 @@ The third form provides your theme path dynamically to Sphinx if the
 called ``sphinx_themes`` in your setup.py file and write a ``get_path`` function
 that has to return the directory with themes in it::
 
-    // in your 'setup.py'
+    # 'setup.py'
 
     setup(
         ...
@@ -63,7 +63,7 @@ that has to return the directory with themes in it::
         ...
     )
 
-    // in 'your_package.py'
+    # 'your_package.py'
 
     from os import path
     package_dir = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
A python code example from http://www.sphinx-doc.org/en/stable/theming.html#using-a-theme
contains javascript-style comments.
