### PR TITLE
Move luatex85 loading check from sphinx.sty to sphinx{howto,manual}.cls

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -8,12 +8,6 @@
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesPackage{sphinx}[2010/01/15 LaTeX package (Sphinx markup)]
 
-\ifx\directlua\undefined\else
-% if compiling with lualatex 0.85 or later load compatibility patch issued by
-% the LaTeX team for older packages relying on \pdf<name> named primitives.
-    \IfFileExists{luatex85.sty}{\RequirePackage{luatex85}}{}
-\fi
-
 \@ifclassloaded{memoir}{}{\RequirePackage{fancyhdr}}
 
 \RequirePackage{textcomp}

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -5,6 +5,12 @@
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{sphinxhowto}[2009/06/02 Document class (Sphinx HOWTO)]
 
+\ifx\directlua\undefined\else
+% if compiling with lualatex 0.85 or later load compatibility patch issued by
+% the LaTeX team for older packages relying on \pdf<name> named primitives.
+    \IfFileExists{luatex85.sty}{\RequirePackage{luatex85}}{}
+\fi
+
 % 'oneside' option overriding the 'twoside' default
 \newif\if@oneside
 \DeclareOption{oneside}{\@onesidetrue}

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -5,6 +5,12 @@
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{sphinxmanual}[2009/06/02 Document class (Sphinx manual)]
 
+\ifx\directlua\undefined\else
+% if compiling with lualatex 0.85 or later load compatibility patch issued by
+% the LaTeX team for older packages relying on \pdf<name> named primitives.
+    \IfFileExists{luatex85.sty}{\RequirePackage{luatex85}}{}
+\fi
+
 % chapters starting at odd pages (overridden by 'openany' document option)
 \PassOptionsToClass{openright}{\sphinxdocclass}
 


### PR DESCRIPTION
Recent commit 5c823a770ce9807abc769b074ed09329099f5277 added to `sphinx.sty` conditional loading of `luatex85` which will help legacy packages using `pdf...` primitives to be still usable under future `LuaTeX 0.90` soon to be released as part of TeXLive 2016 (actually in pretest). Currently some packages like `hyperref` already have been updated to do `\RequirePackage{luatex85}`, but many legacy packages in TL2016 probably will not have it.

The loading of `luatex85` should be as early as possible as the user may use in `conf.py` keys from `latex_elements` to load packages before `sphinx.sty`. Thus I move this to the two classes `sphinxhowto.cls` and `sphinxmanual.cls`. If the user loads non-Sphinx class, it is assumed either the class or the user will know how to do the right thing. I hesitated about possibly putting it rather into `HEADER` in `latex.py`.
