### PR TITLE
Split doctest extension docs into sections

### DIFF
--- a/doc/ext/doctest.rst
+++ b/doc/ext/doctest.rst
@@ -33,11 +33,14 @@ There are two kinds of test blocks:
 * *code-output-style* blocks consist of an ordinary piece of Python code, and
   optionally, a piece of output for that code.
 
-The doctest extension provides four directives.  The *group* argument is
-interpreted as follows: if it is empty, the block is assigned to the group named
-``default``.  If it is ``*``, the block is assigned to all groups (including the
-``default`` group).  Otherwise, it must be a comma-separated list of group
-names.
+
+Directives
+----------
+
+The *group* argument below is interpreted as follows: if it is empty, the block
+is assigned to the group named ``default``.  If it is ``*``, the block is
+assigned to all groups (including the ``default`` group).  Otherwise, it must be
+a comma-separated list of group names.
 
 .. rst:directive:: .. testsetup:: [group]
 
@@ -174,7 +177,10 @@ The following is an example for the usage of the directives.  The test via
       This parrot wouldn't voom if you put 3000 volts through it!
 
 
-There are also these config values for customizing the doctest extension:
+Configuration
+-------------
+
+The doctest extension uses the following configuration values:
 
 .. confval:: doctest_path
 


### PR DESCRIPTION
At the moment the docs have no sections at all. This commit adds sections "Directives" and "Configuration" to facilitate navigation. Also, it removes the outdated line about the number of directives
provided by the extension (there’s now 5 of them).
