### PR TITLE
Fix #2523: LaTeX raises error for labeled code-block

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -275,6 +275,8 @@
 }
 
 \renewcommand{\Verbatim}[1][1]{%
+  % quit horizontal mode if we are still in a paragraph
+  \par
   % list starts new par, but we don't want it to be set apart vertically
   \parskip\z@skip
   % first, let's check if there is a caption


### PR DESCRIPTION
Was caused because produced latex source may not have blank line before
\begin{Verbatim}. Solved by adding a \par to sphinx.sty.
