### PR TITLE
Remove all memory addresses in object_description()

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -20,7 +20,7 @@ from sphinx.util import force_decode
 # relatively import this module
 inspect = __import__('inspect')
 
-memory_address_re = re.compile(r' at 0x[0-9a-f]{8,16}(?=>$)')
+memory_address_re = re.compile(r' at 0x[0-9a-f]{8,16}(?=>)')
 
 
 if PY3:


### PR DESCRIPTION
Change `object_desription()` to remove all hexadecimal addresses, not only those at the end of the string.

The `repr()` of some objects is generated by taking the `repr()` of one object and then adding stuff to it. Therefore, memory addresses like `<object foo at 0xabcdef>` do not need to occur at the end of the string.
