### PR TITLE
C++, add support for concepts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Features added
 * #2463, #2516: Add keywords of "meta" directive to search index
 * ``:maxdepth:`` option of toctree affects ``secnumdepth`` (ref: #2547)
 * #2575: Now ``sphinx.ext.graphviz`` allows ``:align:`` option
+* C++, added concept directive
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Features added
 * ``:maxdepth:`` option of toctree affects ``secnumdepth`` (ref: #2547)
 * #2575: Now ``sphinx.ext.graphviz`` allows ``:align:`` option
 * C++, added concept directive
+* C++, added support for Concepts Lite template introduction syntax
 
 Bugs fixed
 ----------

--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -685,6 +685,33 @@ a visibility statement (``public``, ``private`` or ``protected``).
       .. cpp::enumerator:: MyEnum::myOtherEnumerator = 42
 
 
+.. rst:directive:: .. cpp:concept:: template<typename Param> name
+                   .. cpp:concept:: template<typename Param> name()
+
+   Describe a concept, which must be a template. A concept can be declared as a
+   variable concept or as a function concept. Examples::
+
+      .. cpp:concept:: template<typename It> Iterator
+
+         Proxy to an element of a notional sequence that can be compared,
+         indirected, or incremented.
+
+      .. cpp:concept:: template<typename Cont> Container()
+
+         Holder of elements, to which it can provide access via Iterators.
+
+   They will render as follows:
+
+   .. cpp:concept:: template<typename It> Iterator
+
+      Proxy to an element of a notional sequence that can be compared,
+      indirected, or incremented.
+
+   .. cpp:concept:: template<typename Cont> Container()
+
+      Holder of elements, to which it can provide access via Iterators.
+
+
 Namespacing
 ~~~~~~~~~~~~~~~~~
 
@@ -790,6 +817,7 @@ These roles link to the given declaration types:
               cpp:member
               cpp:var
               cpp:type
+              cpp:concept
               cpp:enum
               cpp:enumerator
 

--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -916,6 +916,27 @@ References to partial specialisations must always include the template parameter
 Currently the lookup only succeed if the template parameter identifiers are equal strings.
 
 
+Template Introductions
+.......................
+
+As an alternative, template parameters can be specified with the template
+introduction syntax of Concepts Lite:
+
+.. rst:directive:: .. cpp:concept:: template<typename It> Iterator
+                   .. cpp:function:: Iterator{It} void advance(It& it)
+
+   .. cpp:concept:: template<typename It> Iterator
+   .. cpp:function:: Iterator{It} void advance(It& it)
+
+This is a shorter way of declaring ``template<typename It> void advance(It&
+it)`` with the added benefit that the constraints on the ``It`` template
+parameter are made explicit, and the :cpp:concept:`Iterator` concept is linked
+to.
+
+Note however that no checking is performed with respect to parameter
+compatibility. E.g. ``Iterator{A, B, C}`` will be accepted as an introduction
+even though it would not be valid C++.
+
 
 The Standard Domain
 -------------------

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -411,6 +411,26 @@ def test_templates():
           None, "I00ElsRNSt13basic_ostreamI4Char6TraitsEE"
           "RK18c_string_view_baseIK4Char6TraitsE")
 
+    # template introductions
+    raises(DefinitionError, parse, 'enum', 'abc::ns::foo{id_0, id_1, id_2} A')
+    raises(DefinitionError, parse, 'enumerator', 'abc::ns::foo{id_0, id_1, id_2} A')
+    check('class', 'abc::ns::foo{id_0, id_1, id_2} xyz::bar',
+          None, 'I000EN3xyz3barE')
+    check('class', 'abc::ns::foo{id_0, id_1, ...id_2} xyz::bar',
+          None, 'I00DpEN3xyz3barE')
+    check('type', 'abc::ns::foo{id_0, id_1, id_2} xyz::bar = ghi::qux',
+          None, 'I000EN3xyz3barE')
+    check('type', 'abc::ns::foo{id_0, id_1, ...id_2} xyz::bar = ghi::qux',
+          None, 'I00DpEN3xyz3barE')
+    check('function', 'abc::ns::foo{id_0, id_1, id_2} void xyz::bar()',
+          None, 'I000EN3xyz3barEv')
+    check('function', 'abc::ns::foo{id_0, id_1, ...id_2} void xyz::bar()',
+          None, 'I00DpEN3xyz3barEv')
+    check('member', 'abc::ns::foo{id_0, id_1, id_2} ghi::qux xyz::bar',
+          None, 'I000EN3xyz3barE')
+    check('member', 'abc::ns::foo{id_0, id_1, ...id_2} ghi::qux xyz::bar',
+          None, 'I00DpEN3xyz3barE')
+
 
 #def test_print():
 #    # used for getting all the ids out for checking

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -133,6 +133,21 @@ def test_type_definitions():
     check('type', 'A = B', None, '1A')
 
 
+def test_concept_definitions():
+    check('concept', '  template  <  typename  Param  >  A  ::  B  ::  Concept  ',
+          None, 'I0EN1A1B7ConceptE',
+          output='template<typename Param> concept bool A::B::Concept')
+    check('concept', 'template<typename A, typename B, typename ...C> Foo',
+          None, 'I00DpE3Foo',
+          output='template<typename A, typename B, typename ...C> concept bool Foo')
+    check('concept', '  template  <  typename  Param  >  A  ::  B  ::  Concept  (  )  ',
+          None, 'I0EN1A1B7ConceptEv',
+          output='template<typename Param> concept bool A::B::Concept()')
+    check('concept', 'template<typename A, typename B, typename ...C> Foo()',
+          None, 'I00DpE3Foov',
+          output='template<typename A, typename B, typename ...C> concept bool Foo()')
+
+
 def test_member_definitions():
     check('member', '  const  std::string  &  name = 42',
           "name__ssCR", "4name", output='const std::string &name = 42')


### PR DESCRIPTION
I have been using the `cpp:type` directive to document my concepts so far, but I figure something better can be achieved. Two commits for two concept-related and connected features:
- a `cpp:concept` directive and role, allowing for both variable and function concept syntax
- support for parsing [Concepts Lite](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0121r0.pdf) template introductions, e.g.:
  
  ``` rst
  .. concept:: template<typename It> Iterator
  .. function:: Iterator{It} void advance(It& it)
  
    Shorter than ``template<typename It> void advance(It& it)``,
    and references the concept.
  ```

I've hit a few snags however and I don't consider this PR 100% ready, I'm in need of some hints and advice. In particular:
- I can't figure out how e.g. the `class` directive takes into account the current namespace (for un-rooted nested names), so in the current state the `concept` directive doesn't
- to avoid disruption I've made it so parsing of an introduction backtracks on error, this makes it impossible to report a sensible message to the user. to do otherwise would mean that `{}`-brackets are reserved for introductions in many contexts and I don't know if that's acceptable
- a `Concept{Param0, Param1, Param2} decl` declaration will mangle identically to `template<typename Param0, typename Param1, typename Param2> decl` (i.e. `I000E` for the template parameters) even though in C++ (with Concepts Lite) two such declarations are different and are allowed to overload (for functions)
  
  the most sensible fix in my mind is for introductions to add a mangling bit, e.g. the above declaration mangling to `IC000E` or something instead to distinguish it from an unconstrained declaration
- concepts usually document notation, associated types, and associated expressions. it's a bit tricky to do so with info fields, compare [this Boost.Range concept](http://www.boost.org/doc/libs/1_60_0/libs/range/doc/html/range/concepts/single_pass_range.html) to [this recreation in Sphinx](http://mickk-on-cpp.github.io/sphinx-demo/single-pass-range/). I considered adding `GroupedField`s (leading to [this](http://mickk-on-cpp.github.io/sphinx-demo/single-pass-range-grouped-fields/), not part of the PR), but they have their own issues:
  - `rng (Rng)` is appropriate for Python, but looks out of place for C++
  - something like `:associated-type typename range_iterator<bar>\:\:type:` is tedious to escape
  - field arguments are not typeset as code (more obvious depending on the theme), and using inline markup to fix that means you can't escape the colons anymore
  
  this seems more like a job for a directive than an info field, but does that make sense?

Something that may be desirable but I have no idea how realistic it is or not to implement in a subsequent PR would be to generalise non-type template parameters so that constrained parameters are parsed, too:

``` rst
.. concept:: template<typename Int> Integral
.. concept:: template<typename It> Iterator
.. function:: template<Iterator It, Integral Int> void advance(It& it, Int offset)
```

The handling of template parameters is a bit… daunting to me however.

Things I consider out of scope:
- concise templates, e.g. `void advance(Iterator& it)`
- anything to do with `requires`, as I feel any constraint substantially more complicated than a template introduction should belong in the content/info fields/etc. and not the declaration
