### PR TITLE
Fix #2517: wrong bookmark encoding in PDF if using LuaLaTeX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,7 @@ Bugs fixed
 * #2522: Sphinx touches mo files under installed directory that caused permission error.
 * #2536: C++, fix crash when an immediately nested scope has the same name as the current scope.
 * #2555: Fix crash on any-references with unicode.
+* #2517: wrong bookmark encoding in PDF if using LuaLaTeX
 
 
 Release 1.4.1 (released Apr 12, 2016)

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -699,7 +699,10 @@
 
 % to make pdf with correct encoded bookmarks in Japanese
 % this should precede the hyperref package
-\ifx\kanjiskip\undefined\else
+\ifx\kanjiskip\undefined
+% for non-Japanese: make sure bookmarks are ok also with lualatex
+  \PassOptionsToPackage{pdfencoding=unicode}{hyperref}
+\else
   \usepackage{atbegshi}
   \ifx\ucs\undefined
     \ifnum 42146=\euc"A4A2


### PR DESCRIPTION
Load hyperref with option pdfencoding=unicode for correctly encoded bookmarks
if using lualatex (does not alter case of pdflatex or xelatex). Skip this however if
pLaTeX is used.
