### PR TITLE
Extend pdflatex config in sphinx.sty to subparagraphs

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -454,8 +454,12 @@
             {\py@TitleColor\thesubsection}{0.5em}{\py@TitleColor}{\py@NormalColor}
 \titleformat{\subsubsection}{\py@HeaderFamily}%
             {\py@TitleColor\thesubsubsection}{0.5em}{\py@TitleColor}{\py@NormalColor}
-\titleformat{\paragraph}{\small\py@HeaderFamily}%
-            {\py@TitleColor}{0em}{\py@TitleColor}{\py@NormalColor}
+% By default paragraphs (and subsubsections) will not be numbered because
+% sphinxmanual.cls and sphinxhowto.cls set secnumdepth to 2
+\titleformat{\paragraph}{\py@HeaderFamily}%
+            {\py@TitleColor\theparagraph}{0.5em}{\py@TitleColor}{\py@NormalColor}
+\titleformat{\subparagraph}{\py@HeaderFamily}%
+            {\py@TitleColor\thesubparagraph}{0.5em}{\py@TitleColor}{\py@NormalColor}
 
 % {fulllineitems} is the main environment for object descriptions.
 %


### PR DESCRIPTION
This addresses #2547. As the two Sphinx classes set secnumdepth to 2 by
default, the label for paragraphs with the numbering is still skipped by
default. But if user increases secnumdepth to 4 or higher it will show,
contrarily to earlier situation. Also formerly paragraph headings used
\small, which looks wrong because the body text did not use \small.

And subparagraphs were not at all configured with \titleformat, thus did
not use same font as other headings.
