### PR TITLE
Changed 'Go' translation 'Искать' to 'OK' (russian locale)

### DIFF
--- a/sphinx/locale/ru/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ru/LC_MESSAGES/sphinx.po
@@ -593,7 +593,7 @@ msgstr "Поиск"
 
 #: sphinx/themes/agogo/layout.html:54 sphinx/themes/basic/searchbox.html:15
 msgid "Go"
-msgstr "Искать"
+msgstr "OK"
 
 #: sphinx/themes/agogo/layout.html:81 sphinx/themes/basic/sourcelink.html:15
 msgid "Show Source"


### PR DESCRIPTION
'Искать' (literally, 'to search') has too many letters, and doesn't fit into Alabaster theme. Internationally recognized 'OK' word is a good fit for that button label.
