### PR TITLE
Make Xapian search work with Python 3

### DIFF
--- a/sphinx/websupport/search/xapiansearch.py
+++ b/sphinx/websupport/search/xapiansearch.py
@@ -11,6 +11,8 @@
 
 import xapian
 
+from six import string_types
+
 from sphinx.util.osutil import ensuredir
 from sphinx.websupport.search import BaseSearch
 
@@ -73,7 +75,10 @@ class XapianSearch(BaseSearch):
         results = []
 
         for m in matches:
-            context = self.extract_context(m.document.get_data())
+            data = m.document.get_data()
+            if not isinstance(data, string_types):
+                data = data.decode("utf-8")
+            context = self.extract_context(data)
             results.append((m.document.get_value(self.DOC_PATH),
                             m.document.get_value(self.DOC_TITLE),
                             ''.join(context)))


### PR DESCRIPTION
Xapian bindings 1.3.x support Python 3. However, the Sphinx tests currently fail with them:

``` pytb
======================================================================
ERROR: test_searchadapters.test_xapian
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/«PKGBUILDDIR»/tests/util.py", line 125, in skipper
    return test(*args, **kwds)
  File "/«PKGBUILDDIR»/tests/util.py", line 125, in skipper
    return test(*args, **kwds)
  File "/«PKGBUILDDIR»/tests/test_searchadapters.py", line 63, in test_xapian
    search_adapter_helper('xapian')
  File "/«PKGBUILDDIR»/tests/test_searchadapters.py", line 37, in search_adapter_helper
    results = s.query(u'Epigraph')
  File "/«PKGBUILDDIR»/sphinx/websupport/search/__init__.py", line 77, in query
    return self.handle_query(q)
  File "/«PKGBUILDDIR»/sphinx/websupport/search/xapiansearch.py", line 76, in handle_query
    context = self.extract_context(m.document.get_data())
  File "/«PKGBUILDDIR»/sphinx/websupport/search/__init__.py", line 104, in extract_context
    res = self.context_re.search(text)
TypeError: cannot use a string pattern on a bytes-like object
----------------------------------------------------------------------
```

I know nothing about this part of Sphinx code, but this pull request at least makes the tests pass.
