### PR TITLE
Add typing to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ requires = [
     'alabaster>=0.7,<0.8',
     'imagesize',
     'requests',
+    'typing',
 ]
 extras_require = {
     # Environment Marker works for wheel 0.24 or later

--- a/test-reqs.txt
+++ b/test-reqs.txt
@@ -13,3 +13,4 @@ alabaster
 sphinx_rtd_theme
 imagesize
 requests
+typing


### PR DESCRIPTION
typing seems to be required. Some tests failed because I didn't have this dependency.
