### PR TITLE
Add configuration option tab_width.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -92,6 +92,14 @@ General configuration
    .. versionadded:: 0.5
       Previously, Sphinx accepted only UTF-8 encoded sources.
 
+.. confval:: tab_width
+
+   The number of spaces tab characters in reST source files will be expanded to.
+   The default is 8.
+
+   .. versionadded:: 1.5
+      Previously tabs were always expanded to 8 spaces.
+
 .. confval:: source_parsers
 
    If given, a dictionary of parser classes for different source suffices.  The

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -71,6 +71,7 @@ class Config(object):
         add_function_parentheses = (True, 'env'),
         add_module_names = (True, 'env'),
         trim_footnote_reference_space = (False, 'env'),
+        tab_width = (8, 'env'),
         show_authors = (False, 'env'),
         pygments_style = (None, 'html', string_classes),
         highlight_language = ('default', 'env'),

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -685,6 +685,7 @@ class BuildEnvironment:
         self.settings['trim_footnote_reference_space'] = \
             self.config.trim_footnote_reference_space
         self.settings['gettext_compact'] = self.config.gettext_compact
+        self.settings['tab_width'] = self.config.tab_width
 
         self.patch_lookup_functions()
 

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -142,6 +142,9 @@ release = u'%(release_str)s'
 # Usually you set "language" from the command line for these cases.
 language = %(language)r
 
+# The number of spaces tab characters in reST source files will be expanded to.
+# tab_width = 8
+
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 #


### PR DESCRIPTION
This change add a configuration option tab_width to Sphinx. This option will be passed to the docutils parser when parsing reST files.
