### PR TITLE
Fix auto summary signature

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -544,6 +544,9 @@ class Sphinx(object):
                 return result
         return None
 
+    def has_event_listener(self, event):
+        return event in self._listeners
+
     # registering addon parts
 
     def add_builder(self, builder):

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -298,8 +298,9 @@ class Autosummary(Directive):
             if not sig:
                 sig = ''
             else:
-                max_chars = max(10, max_item_chars - len(display_name))
-                sig = mangle_signature(sig, max_chars=max_chars)
+                if not env.app.has_event_listener('autodoc-process-signature'):
+                    max_chars = max(10, max_item_chars - len(display_name))
+                    sig = mangle_signature(sig, max_chars=max_chars)
                 sig = sig.replace('*', r'\*')
 
             # -- Grab the summary


### PR DESCRIPTION
The autosummary tag does not respect the autodoc-process-signature event as it mangles the signature after the event is performed. This PR only performs the mangle if there is no handler attached for that event. 
From issue #2572 
