### PR TITLE
Fix MathExtError arguments in imgmath

### DIFF
--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -185,7 +185,7 @@ def render_math(self, math):
 
     stdout, stderr = p.communicate()
     if p.returncode != 0:
-        raise MathExtError('%s exited with error',
+        raise MathExtError('%s exited with error' %
                            image_translator, stderr, stdout)
     depth = None
     if use_preview and image_format == 'png':  # depth is only useful for png


### PR DESCRIPTION
It's constructor is:

```
class MathExtError(SphinxError):
    def __init__(self, msg, stderr=None, stdout=None):
```
