### PR TITLE
Sphinx.add_source_parser takes only two arguments

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -358,7 +358,7 @@ package.
 
    .. versionadded:: 1.1
 
-.. method:: Sphinx.add_source_parser(name, suffix, parser)
+.. method:: Sphinx.add_source_parser(suffix, parser)
 
    Register a parser class for specified *suffix*.
 


### PR DESCRIPTION
https://github.com/sphinx-doc/sphinx/blob/master/sphinx/application.py#L794
