### PR TITLE
#2597: Show warning messages as yellow

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,7 @@ Features added
   - booleans ``\ifsphinxverbatimwithframe`` and ``\ifsphinxverbatimwrapslines``.
 * latex, captions for literal blocks inside tables are handled, and long code
   lines wrapped to fit table cell (ref: #2704)
+* #2597: Show warning messages as darkred
 
 Bugs fixed
 ----------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -42,7 +42,7 @@ from sphinx.util import import_object
 from sphinx.util.tags import Tags
 from sphinx.util.osutil import ENOENT
 from sphinx.util.logging import is_suppressed_warning
-from sphinx.util.console import bold, lightgray, darkgray, darkgreen, \
+from sphinx.util.console import bold, lightgray, darkgray, darkred, darkgreen, \
     term_width_line
 from sphinx.util.i18n import find_catalog_source_files
 
@@ -334,7 +334,8 @@ class Sphinx(object):
             wfile.flush()
         self.messagelog.append(message)
 
-    def warn(self, message, location=None, prefix='WARNING: ', type=None, subtype=None):
+    def warn(self, message, location=None, prefix='WARNING: ',
+             type=None, subtype=None, colorfunc=darkred):
         """Emit a warning.
 
         If *location* is given, it should either be a tuple of (docname, lineno)
@@ -364,7 +365,7 @@ class Sphinx(object):
         if self.warningiserror:
             raise SphinxWarning(warntext)
         self._warncount += 1
-        self._log(warntext, self._warning, True)
+        self._log(colorfunc(warntext), self._warning, True)
 
     def info(self, message='', nonl=False):
         """Emit an informational message.

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -14,7 +14,7 @@ from docutils import nodes
 from sphinx.application import ExtensionError
 from sphinx.domains import Domain
 
-from util import with_app, raises_msg
+from util import with_app, raises_msg, strip_escseq
 
 
 @with_app()
@@ -60,20 +60,21 @@ def test_output(app, status, warning):
 
     old_count = app._warncount
     app.warn("Bad news!")
-    assert warning.getvalue() == "WARNING: Bad news!\n"
+    assert strip_escseq(warning.getvalue()) == "WARNING: Bad news!\n"
     assert app._warncount == old_count + 1
 
 
 @with_app()
 def test_extensions(app, status, warning):
     app.setup_extension('shutil')
-    assert warning.getvalue().startswith("WARNING: extension 'shutil'")
+    assert strip_escseq(warning.getvalue()).startswith("WARNING: extension 'shutil'")
 
 
 @with_app()
 def test_extension_in_blacklist(app, status, warning):
     app.setup_extension('sphinxjp.themecore')
-    assert warning.getvalue().startswith("WARNING: the extension 'sphinxjp.themecore' was")
+    msg = strip_escseq(warning.getvalue())
+    assert msg.startswith("WARNING: the extension 'sphinxjp.themecore' was")
 
 
 @with_app()

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -15,7 +15,7 @@ import re
 from six import PY3, iteritems
 
 from sphinx import __display_version__
-from util import remove_unicode_literals, gen_with_app, with_app
+from util import remove_unicode_literals, gen_with_app, with_app, strip_escseq
 from etree13 import ElementTree
 from html5lib import getTreeBuilder, HTMLParser
 
@@ -384,7 +384,7 @@ def check_extra_entries(outdir):
               tags=['testtag'])
 def test_html_output(app, status, warning):
     app.builder.build_all()
-    html_warnings = warning.getvalue().replace(os.sep, '/')
+    html_warnings = strip_escseq(warning.getvalue().replace(os.sep, '/'))
     html_warnings_exp = HTML_WARNINGS % {
         'root': re.escape(app.srcdir.replace(os.sep, '/'))}
     assert re.match(html_warnings_exp + '$', html_warnings), \

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -19,7 +19,7 @@ from six import PY3
 from sphinx.errors import SphinxError
 from sphinx.writers.latex import LaTeXTranslator
 
-from util import SkipTest, remove_unicode_literals, with_app
+from util import SkipTest, remove_unicode_literals, with_app, strip_escseq
 from test_build_html import ENV_WARNINGS
 
 
@@ -67,7 +67,7 @@ def run_latex(outdir):
 def test_latex(app, status, warning):
     LaTeXTranslator.ignore_missing_images = True
     app.builder.build_all()
-    latex_warnings = warning.getvalue().replace(os.sep, '/')
+    latex_warnings = strip_escseq(warning.getvalue().replace(os.sep, '/'))
     latex_warnings_exp = LATEX_WARNINGS % {
         'root': re.escape(app.srcdir.replace(os.sep, '/'))}
     assert re.match(latex_warnings_exp + '$', latex_warnings), \
@@ -142,7 +142,7 @@ def test_writer(app, status, warning):
 def test_latex_howto(app, status, warning):
     LaTeXTranslator.ignore_missing_images = True
     app.builder.build_all()
-    latex_warnings = warning.getvalue().replace(os.sep, '/')
+    latex_warnings = strip_escseq(warning.getvalue().replace(os.sep, '/'))
     latex_warnings_exp = LATEX_WARNINGS % {
         'root': re.escape(app.srcdir.replace(os.sep, '/'))}
     assert re.match(latex_warnings_exp + '$', latex_warnings), \

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -18,7 +18,7 @@ from six import PY3
 
 from sphinx.writers.texinfo import TexinfoTranslator
 
-from util import SkipTest, remove_unicode_literals, with_app
+from util import SkipTest, remove_unicode_literals, with_app, strip_escseq
 from test_build_html import ENV_WARNINGS
 
 
@@ -37,7 +37,7 @@ if PY3:
 def test_texinfo(app, status, warning):
     TexinfoTranslator.ignore_missing_images = True
     app.builder.build_all()
-    texinfo_warnings = warning.getvalue().replace(os.sep, '/')
+    texinfo_warnings = strip_escseq(warning.getvalue().replace(os.sep, '/'))
     texinfo_warnings_exp = TEXINFO_WARNINGS % {
         'root': re.escape(app.srcdir.replace(os.sep, '/'))}
     assert re.match(texinfo_warnings_exp + '$', texinfo_warnings), \

--- a/tests/util.py
+++ b/tests/util.py
@@ -309,3 +309,7 @@ def find_files(root, suffix=None):
         for f in [f for f in files if not suffix or f.endswith(suffix)]:
             fpath = dirpath / f
             yield os.path.relpath(fpath, root)
+
+
+def strip_escseq(text):
+    return re.sub('\x1b.*?m', '', text)


### PR DESCRIPTION
This PR changes warning messages as yellow (ref: #2597).

Here is an example:
![2016-05-30 19 55 48](https://cloud.githubusercontent.com/assets/748828/15647752/8889e2f2-26a0-11e6-9dcb-04a68cb04ace.png)
