### PR TITLE
Suppress "document isn't included in any toctree" warning if the document is included (ref: #2603)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Bugs fixed
 * ``width`` option of figure directive does not work if ``align`` option specified at same time (ref: #2595)
 * #2590: The ``inputenc`` package breaks compiling under lualatex and xelatex
 * #2540: date on latex front page use different font
+* Suppress "document isn't included in any toctree" warning if the document is included (ref: #2603)
 
 
 Release 1.4.2 (released May 29, 2016)

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -405,6 +405,7 @@ class Include(BaseInclude):
             return BaseInclude.run(self)
         rel_filename, filename = env.relfn2path(self.arguments[0])
         self.arguments[0] = filename
+        env.note_included(filename)
         return BaseInclude.run(self)
 
 


### PR DESCRIPTION
When any document is not linked to any toctree, but included as parts of document,
current sphinx warns it as "document isn't included in any toctree".
I think this warning does not help the users.

This PR suppresses the warning if the document is included.
