### PR TITLE
add extension blacklist to avoid error when loading deprecated extensions

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -69,6 +69,10 @@ events = {
 CONFIG_FILENAME = 'conf.py'
 ENV_PICKLE_FILENAME = 'environment.pickle'
 
+# list of deprecated extensions. Keys are extension name.
+# Values are Sphinx version that merge the extension.
+EXTENSION_BLACKLIST = {"sphinxjp.themecore": "1.2"}
+
 
 class Sphinx(object):
 
@@ -459,6 +463,11 @@ class Sphinx(object):
         """Import and setup a Sphinx extension module. No-op if called twice."""
         self.debug('[app] setting up extension: %r', extension)
         if extension in self._extensions:
+            return
+        if extension in EXTENSION_BLACKLIST:
+            self.warn('the extension %r was already merged with Sphinx since version %s; '
+                      'this extension is ignored.' % (
+                          extension, EXTENSION_BLACKLIST[extension]))
             return
         self._setting_up_extension.append(extension)
         try:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -32,7 +32,6 @@ CONFIG_EXIT_ERROR = "The configuration file (or one of the modules it imports) "
 CONFIG_TYPE_WARNING = "The config value `{name}' has type `{current.__name__}', " \
                       "defaults to `{default.__name__}.'"
 
-
 string_classes = [text_type]
 if PY2:
     string_classes.append(binary_type)  # => [str, unicode]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -71,6 +71,12 @@ def test_extensions(app, status, warning):
 
 
 @with_app()
+def test_extension_in_blacklist(app, status, warning):
+    app.setup_extension('sphinxjp.themecore')
+    assert warning.getvalue().startswith("WARNING: the extension 'sphinxjp.themecore' was")
+
+
+@with_app()
 def test_domain_override(app, status, warning):
     class A(Domain):
         name = 'foo'


### PR DESCRIPTION
"sphinxjp.themecore" is already merged into Sphinx, but some old document possibly uses this extension. It raises difficult error messages for novice users.

This PR prints warning instead of import error.
