### PR TITLE
Fix #777 partially: Latex output "too deeply nested"

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -857,3 +857,7 @@
   {\ifx\equation$%$% this is trick to identify tabulary first pass
        \firstchoice@false\else\firstchoice@true\fi
    \Sphinx@originalcaption }
+
+% will be used to accompany quote environment and help avoid "too deeply nested"
+\newcommand*\SphinxDecreaseListDepth {\global\advance\@listdepth\m@ne}
+\newcommand*\SphinxIncreaseListDepth {\global\advance\@listdepth\@ne}

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -341,20 +341,19 @@
   % - if caption: vertical space above caption = (\abovecaptionskip + D) with
   %   D = \baselineskip-\FrameHeightAdjust, and then \smallskip above frame.
   % - if no caption: (\smallskip + D) above frame. By default D=6pt.
-  \list{}{%
-  \setlength\parskip{0pt}%
-  \setlength\itemsep{0ex}%
-  \setlength\topsep{0ex}%
-  \setlength\parsep{0pt}% let's not forget this one!
-  \setlength\partopsep{0pt}%
-  \setlength\leftmargin{0pt}%
-  }%
-  \item
+  % Use trivlist rather than list to avoid possible "too deeply nested" error.
+  \itemsep   \z@skip
+  \topsep    \z@skip
+  \partopsep \z@skip% trivlist will set \parsep to \parskip = zero (see above)
+  % \leftmargin will be set to zero by trivlist
+  \rightmargin\z@
+  \parindent  \z@% becomes \itemindent. Default zero, but perhaps overwritten.
+  \trivlist\item\relax
   % use a minipage if we are already inside a framed environment
-  \relax\ifSphinx@inframed\noindent\begin{minipage}{\linewidth}\fi
+     \ifSphinx@inframed\noindent\begin{minipage}{\linewidth}\fi
      \MakeFramed {% adapted over from framed.sty's snugshade environment
-    \advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize
-    \@setminipage  }%
+     \advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize
+     \@setminipage  }%
      \small
      % For grid placement from \strut's in \FancyVerbFormatLine
      \lineskip\z@skip
@@ -365,8 +364,7 @@
   \endOriginalVerbatim
   \par\unskip\@minipagefalse\endMakeFramed
   \ifSphinx@inframed\end{minipage}\fi
-  \endlist
-  % LaTeX environments always revert local changes on exit, here e.g. \parskip
+  \endtrivlist
 }
 
 % define macro to frame contents and add shadow on right and bottom

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1283,12 +1283,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.body.append('\n')
 
     def visit_field_list(self, node):
-        self.body.append('\\begin{quote}\\begin{description}\n')
+        self.body.append('\\begin{quote}\\SphinxDecreaseListDepth'
+                         '\\begin{description}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_field_list(self, node):
-        self.body.append('\\end{description}\\end{quote}\n')
+        self.body.append('\\end{description}\\end{quote}'
+                         '\\SphinxIncreaseListDepth\n')
 
     def visit_field(self, node):
         pass
@@ -1927,7 +1929,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     isinstance(child, nodes.enumerated_list):
                 done = 1
         if not done:
-            self.body.append('\\begin{quote}\n')
+            self.body.append('\\begin{quote}\\SphinxDecreaseListDepth\n')
             if self.table:
                 self.table.has_problematic = True
 
@@ -1939,7 +1941,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     isinstance(child, nodes.enumerated_list):
                 done = 1
         if not done:
-            self.body.append('\\end{quote}\n')
+            self.body.append('\\end{quote}\\SphinxIncreaseListDepth\n')
 
     # option node handling copied from docutils' latex writer
 


### PR DESCRIPTION
The first commit has Sphinx Verbatim use \trivlist rather than \list. This saves one level of nesting for LaTeX's check of depth (which can not exceed <strike>5</strike> 6, but see https://github.com/sphinx-doc/sphinx/pull/2624#issuecomment-225112978 below which explains why code-blocks could not appear so far deeper than level 4).

The second commit handles quoted paragraphs which are rendered by LaTeX's quote environment. The level of nesting is compensated to avoid the LaTeX error check. This is more experimental as the impact for nested quotes is that always margins for first level are re-used:(*) theoretically the document class can specify margins at each level.

(*) I mean each quote is has the same extra indent compared to previous level, rather than a varying extra indent.

Nothing is attempted for lists. Perhaps the simplest would be simply to patch LaTeX's \list to skip the nesting level check. Perhaps this would be better approach ? then nothing of the above would be needed anymore.
