### PR TITLE
Display correctly the Builtin themes in the PDF build of Sphinx doc

### DIFF
--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -81,6 +81,8 @@ that has to return the directory with themes in it::
 Builtin themes
 --------------
 
+.. cssclass:: longtable
+
 +--------------------+--------------------+
 | **Theme overview** |                    |
 +--------------------+--------------------+


### PR DESCRIPTION
Add longtable as class, which will allow pagebreaks in pdf output. (section 12.2 Builtin themes)

I checked ok with html output. I imagine `.. cssclass:: longtable` causes no harm in other outputs ?
