### PR TITLE
Fix #2635. To avoid pdf viewer issue, draw code frames latest.

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -218,11 +218,19 @@
                   \hb@xt@\z@{\hss\begin{minipage}{\wd\@tempboxa}%
                                   \SphinxVerbatimTitle
                                  \end{minipage}\hss}\fi
-            \hrule\@height\fboxrule\relax
-            \hbox{\vrule\@width\fboxrule\relax
+            % draw frame border _latest_ to avoid pdf viewer issue
+            \kern\fboxrule
+            \hbox{\kern\fboxrule
                   \vbox{\vskip\fboxsep\copy\@tempboxa\vskip\fboxsep}%
-                  \vrule\@width\fboxrule\relax}%
-            \hrule\@height\fboxrule\relax}%
+                  \kern-\wd\@tempboxa\kern-\fboxrule
+                  \vrule\@width\fboxrule
+                  \kern\wd\@tempboxa
+                  \vrule\@width\fboxrule}%
+            \kern-\dimexpr\fboxsep+\ht\@tempboxa+\dp\@tempboxa
+                                  +\fboxsep+\fboxrule\relax
+            \hrule\@height\fboxrule
+            \kern\dimexpr\fboxsep+\ht\@tempboxa+\dp\@tempboxa+\fboxsep\relax
+            \hrule\@height\fboxrule}%
    }}%
   \endgroup
   \global\Sphinx@myfirstframedpassfalse


### PR DESCRIPTION
As latest Sphinx controls Verbatim up to finest details, it got possible
to arrange for framing to be drawn _after_ the code lines. This provides
work-around for issue with some pdf viewer at some resolutions on some
devices.

Reasoning is heuristic that  due to rounding effects or anti-aliasing method, portions of already drawn frame were erased.
