### PR TITLE
Fix #2640: 1.4.2 LaTeX crashes if code-block inside warning directive

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -329,6 +329,8 @@
        \discretionary{\copy\Sphinxvisiblespacebox}{\Sphinxafterbreak}
                      {\kern\fontdimen2\font}%
        }%
+  % go around fancyvrb's check of @currenvir (for case of minipage below)
+  \renewcommand*{\VerbatimEnvironment}{\xdef\FV@EnvironName{Verbatim}}%
   % Allow breaks at special characters using \PYG... macros.
   \Sphinxbreaksatspecials
   % The list environment is needed to control perfectly the vertical space.


### PR DESCRIPTION
The subtle cause of the bug was that original Verbatim environment was
used inside a minipage environment, and fancyvrb's code for checking
when \end{Verbatim} is reached does not work if \@currenvir is minipage.
