### PR TITLE
Equation links are now clickable in html output

### DIFF
--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -35,7 +35,10 @@ def html_visit_displaymath(self, node):
 
     # necessary to e.g. set the id property correctly
     if node['number']:
-        self.body.append('<span class="eqno">(%s)</span>' % node['number'])
+        self.body.append('<span class="eqno"><a class="equationlink" '
+                         'href="#%s" title="Permalink to this '
+                         'equation">(%s)</a></span>' % (node['ids'][0],
+                             node['number']))
     self.body.append(self.builder.config.mathjax_display[0])
     parts = [prt for prt in node['latex'].split('\n\n') if prt.strip()]
     if len(parts) > 1:  # Add alignment if there are more than 1 equation


### PR DESCRIPTION
If you have an html document with lots of equation it would be very convenient for a user to get the actual links to those equations. This pull request allows for this by making links out of the equation numbers.

Here an example where I applied the changes:
http://sfstoolbox.org/en/latest/
