### PR TITLE
Convert text into links at bottom of tutorial.rst and top of config.rst

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -56,7 +56,7 @@ General configuration
 
 .. confval:: extensions
 
-   A list of strings that are module names of Sphinx extensions.  These can be
+   A list of strings that are module names of :ref:`extensions`. These can be
    extensions coming with Sphinx (named ``sphinx.ext.*``) or custom ones.
 
    Note that you can extend :data:`sys.path` within the conf file if your

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -300,12 +300,17 @@ features of intersphinx.
 More topics to be covered
 -------------------------
 
-- Other extensions (math, viewcode, doctest)
+- :doc:`Other extensions <extensions>`:
+
+  * :doc:`ext/math`,
+  * :doc:`ext/viewcode`,
+  * :doc:`ext/doctest`,
+  * ...
 - Static files
-- Selecting a theme
-- Templating
+- :doc:`Selecting a theme <theming>`
+- :ref:`Templating <templating>`
 - Using extensions
-- Writing extensions
+- :ref:`Writing extensions <dev-extensions>`
 
 
 .. rubric:: Footnotes


### PR DESCRIPTION
Making a PR as I don't know if adding labels and using `:ref:` role would be better than using `:doc:` role which may create broken links if individual files are renamed ?

(rationale for adding links is that I found often myself looking for the Math Support page, and for the Extensions, when reading the "Build configuration" file page)
