### PR TITLE
Fix #777 (part Ia): Latex output "too deeply nested"

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -334,6 +334,8 @@
        }%
   % go around fancyvrb's check of @currenvir (for case of minipage below)
   \renewcommand*{\VerbatimEnvironment}{\gdef\FV@EnvironName{Verbatim}}%
+  % go around fancyvrb's check of current list depth
+  \def\@toodeep {\advance\@listdepth\@ne}%
   % Allow breaks at special characters using \PYG... macros.
   \Sphinxbreaksatspecials
   % The list environment is needed to control perfectly the vertical space.


### PR DESCRIPTION
Allow code-blocks at maximal nesting depth of lists/quotes in LaTeX
(which by default is 6), by patching fancyvrb's original Verbatim way of
checking list depth which resulted in a loss of 1 possible level.

Memo 1: latex can have by default a maximum of 4 nested enumerated
lists, 4 nested labeled lists, and in total 6 nested lists. This
includes quoted blocks as they use the `\list` macro.

Memo 2: fancyvrb's rationale for using the \@list... macros (in its
\FV@ListNesting) is to set vertical positioning. To set a Verbatim at
level N it uses vertical parameters for list level N+1, hence can't work
at max level. But in Sphinx, this happens inside a \vbox for framing,
hence the vertical positioning set by fancyvrb turns out to be inoperant
anyhow. The execution of \@list<level> also sets the \leftmargin, but
fancyvrb resets it to zero later (#1=\z@ in \FV@ListNesting). To sum up,
fancyvrb's \FV@ListNesting does nothing but has the after effect to
raise an error if the code-block is at level equal to max - 1.

The effect of this commit is to make inoperant fancyvrb's check of
nesting depth, hence now the code-block can appear at maximal depth.

This is second commit improving in Sphinx the maximal depth for
code-blocks in nested lists or quote blocks. It used to be 4 (with
LaTeX's defaults for lists), it is now at 6 (or at the max depth
allowed by the document class).
