### PR TITLE
latex: keep Verbatim under same name, use SphinxVerbatim for own

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Incompatible changes
 * LaTeX package fancybox is not longer a dependency of sphinx.sty
 * Use ``'locales'`` as a default value of `locale_dirs`
 * LaTeX package ifthen is not any longer a dependency of sphinx.sty
+* LaTeX writer produces source not modifying original fancyvrb's Verbatim but using new name SphinxVerbatim for its custom wrapper
 
 Features added
 --------------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -159,11 +159,10 @@
 % Support large numbered footnotes in minipage (cf. admonitions)
 \def\thempfootnote{\arabic{mpfootnote}}
 
-% Redefine the Verbatim environment to allow border and background colors
-% and to handle the top caption in a non separable by pagebreak way.
-% The original environment is still used for verbatims within tables.
-\let\OriginalVerbatim=\Verbatim
-\let\endOriginalVerbatim=\endVerbatim
+% Preparations for SphinxVerbatim environment, which is a wrapper of fancyvrb
+% Verbatim with framing allowing pagebreaks, with border and background colors
+% and possibly also a top caption, non separable by pagebreak. The original
+% fancyvrb Verbatim is still used within tables.
 
 \newcommand\Sphinx@colorbox [2]{%
 % #1 will be \fcolorbox or, for first part of frame: \Sphinx@fcolorbox
@@ -279,7 +278,7 @@
    \lccode`\~`\~
 }
 
-\renewcommand{\Verbatim}[1][1]{%
+\newenvironment{SphinxVerbatim}[1][1]{%
   % quit horizontal mode if we are still in a paragraph
   \par
   % list starts new par, but we don't want it to be set apart vertically
@@ -328,8 +327,10 @@
        \discretionary{\copy\Sphinxvisiblespacebox}{\Sphinxafterbreak}
                      {\kern\fontdimen2\font}%
        }%
-  % go around fancyvrb's check of @currenvir (for case of minipage below)
-  \renewcommand*{\VerbatimEnvironment}{\gdef\FV@EnvironName{Verbatim}}%
+  % go around fancyvrb's check of \@currenvir
+  \renewcommand*{\VerbatimEnvironment}{\gdef\FV@EnvironName{SphinxVerbatim}}%
+  % go around fancyvrb's check of current list depth
+  \def\@toodeep {\advance\@listdepth\@ne}%
   % Allow breaks at special characters using \PYG... macros.
   \Sphinxbreaksatspecials
   % The list environment is needed to control perfectly the vertical space.
@@ -354,10 +355,10 @@
      % For grid placement from \strut's in \FancyVerbFormatLine
      \lineskip\z@skip
      % Breaks at punctuation characters . , ; ? ! and / need catcode=\active
-     \OriginalVerbatim[#1,codes*=\Sphinxbreaksatpunct]%
+     \Verbatim[#1,codes*=\Sphinxbreaksatpunct]%
 }
-\renewcommand{\endVerbatim}{%
-  \endOriginalVerbatim
+{%
+  \endVerbatim
   \par\unskip\@minipagefalse\endMakeFramed
   \ifSphinx@inframed\end{minipage}\fi
   \endtrivlist

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1899,14 +1899,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
             hlcode = hlcode.replace(u'€', u'@texteuro[]')
             # must use original Verbatim environment and "tabular" environment
             if self.table:
-                hlcode = hlcode.replace('\\begin{Verbatim}',
-                                        '\\begin{OriginalVerbatim}')
                 self.table.has_problematic = True
                 self.table.has_verbatim = True
+            else:
+                hlcode = hlcode.replace('\\begin{Verbatim}',
+                                        '\\begin{SphinxVerbatim}')
             # get consistent trailer
             hlcode = hlcode.rstrip()[:-14]  # strip \end{Verbatim}
             self.body.append('\n' + hlcode + '\\end{%sVerbatim}\n' %
-                             (self.table and 'Original' or ''))
+                             ((not self.table) and 'Sphinx' or ''))
             if ids:
                 self.body.append('\\let\\SphinxLiteralBlockLabel\empty\n')
             raise nodes.SkipNode

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -228,11 +228,11 @@ def test_literalinclude_file_whole_of_emptyline(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8').replace('\r\n', '\n')
     includes = (
-        '\\begin{Verbatim}[commandchars=\\\\\\{\\},numbers=left,firstnumber=1,stepnumber=1]\n'
+        '\\begin{SphinxVerbatim}[commandchars=\\\\\\{\\},numbers=left,firstnumber=1,stepnumber=1]\n'
         '\n'
         '\n'
         '\n'
-        '\\end{Verbatim}\n')
+        '\\end{SphinxVerbatim}\n')
     assert includes in latex
 
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -137,9 +137,9 @@ def test_latex_escaping():
            r'\(\Gamma\)\textbackslash{}\(\infty\)\$')
     # in verbatim code fragments
     yield (verify, u'::\n\n @Γ\\∞${}', None,
-           u'\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n'
+           u'\\begin{SphinxVerbatim}[commandchars=\\\\\\{\\}]\n'
            u'@\\(\\Gamma\\)\\PYGZbs{}\\(\\infty\\)\\PYGZdl{}\\PYGZob{}\\PYGZcb{}\n'
-           u'\\end{Verbatim}')
+           u'\\end{SphinxVerbatim}')
     # in URIs
     yield (verify_re, u'`test <http://example.com/~me/>`_', None,
            r'\\href{http://example.com/~me/}{test}.*')


### PR DESCRIPTION
It is better practice not to overwrite original Verbatim environment from fancyvrb.
