### PR TITLE
Sync shipped tabulary with upstream one.

### DIFF
--- a/sphinx/texinputs/tabulary.sty
+++ b/sphinx/texinputs/tabulary.sty
@@ -14,7 +14,7 @@
 %%
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{tabulary}
-          [2008/12/01 v0.9 tabulary package (DPC)]
+          [2014/06/11 v0.10 tabulary package (DPC) + footnote patch (sphinx)]
 \RequirePackage{array}
 \catcode`\Z=14
 \DeclareOption{debugshow}{\catcode`\Z=9\relax}
@@ -354,6 +354,7 @@ Z \message{^^JTotal:\the\@tempdima^^J}%
     \expandafter\let\expandafter\color\expandafter\relax
     \expandafter\let\expandafter\CT@column@color\expandafter\relax
     \expandafter\let\expandafter\CT@row@color\expandafter\relax
+    \expandafter\let\expandafter\CT@cell@color\expandafter\relax
     \@mkpream{#1}}
 \let\TY@@mkpream\@mkpream
 \def\TY@classz{%
@@ -396,6 +397,7 @@ Z \message{^^JTotal:\the\@tempdima^^J}%
   \CT@setup
   \CT@column@color
   \CT@row@color
+  \CT@cell@color
   \CT@do@color
 \endgroup
         \@tempdima\ht\z@


### PR DESCRIPTION
The update incorporates
\changes{v0.10}{2014/06/21}
      {support \cs{cellcolor} see
      http://tex.stackexchange.com/a/185851/1090}
from tabulary commented source.

Memo: Sphinx ships a custom tabulary to fix a footnote issue, in
relation with package footnote:

   sphinx.sty does \makesavenoteenv{tabulary} but this needs also
   a patch inside tabulary package

It would be better, as package footnote has some bugs, for Sphinx to
ship with package footnotehyper which fixes theses bugs and can easily
be extended to ensure the compatibility with tabulary. This would be
better than shipping a custom tabulary.
