### PR TITLE
Give sphinx.sty a more accurate latex version date as latex package

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2010/01/15 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2016/06/10 LaTeX package (Sphinx markup)]
 
 \@ifclassloaded{memoir}{}{\RequirePackage{fancyhdr}}
 


### PR DESCRIPTION
Although naturally Sphinx version number is main reference it may help if people encountering latex issues can state an accurate date for sphinx.sty as latex package, from the log output of a make latexpdf run.
