### PR TITLE
Feature: table caption placement flag

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Release 1.4.4 (in development)
 ==============================
 
+Features added
+--------------
+
+* Added ability to place table titles below table in latex using ``:title-below:`` option
+
 Bugs fixed
 ----------
 

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -9,7 +9,7 @@
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst.directives import images
+from docutils.parsers.rst.directives import images, tables
 
 
 class Figure(images.Figure):
@@ -34,5 +34,20 @@ class Figure(images.Figure):
 
         return [figure_node]
 
+class RSTTable(tables.RSTTable):
+    """Adds an option to the table directive which allows for the title to below
+    displayed below the table.
+    """ 
+    option_spec = tables.Table.option_spec
+    option_spec.update({'title-below': directives.flag})
+    
+    def run(self):
+        result = tables.RSTTable.run(self)
+        (table_node,) = result
+        
+        table_node['title-below'] = 'title-below' in self.options
+        
+        return [table_node]   
 
+directives.register_directive('table', RSTTable)
 directives.register_directive('figure', Figure)

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -34,20 +34,21 @@ class Figure(images.Figure):
 
         return [figure_node]
 
+
 class RSTTable(tables.RSTTable):
     """Adds an option to the table directive which allows for the title to below
     displayed below the table.
-    """ 
+    """
     option_spec = tables.Table.option_spec
     option_spec.update({'title-below': directives.flag})
-    
+
     def run(self):
         result = tables.RSTTable.run(self)
         (table_node,) = result
-        
+
         table_node['title-below'] = 'title-below' in self.options
-        
-        return [table_node]   
+
+        return [table_node]
 
 directives.register_directive('table', RSTTable)
 directives.register_directive('figure', Figure)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -998,11 +998,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.table.longtable = True
         self.popbody()
         if not self.table.longtable and self.table.caption is not None:
-            self.body.append('\n\n\\begin{threeparttable}\n'
-                             '\\capstart\\caption{')
-            for caption in self.table.caption:
-                self.body.append(caption)
-            self.body.append('}')
+            self.body.append('\n\n\\begin{threeparttable}\n')
+            if not 'title-below' in node:
+                self.body.append('\\capstart\\caption{')
+                for caption in self.table.caption:
+                    self.body.append(caption)
+                self.body.append('}')
             for id in self.pop_hyperlink_ids('table'):
                 self.body.append(self.hypertarget(id, anchor=False))
             if node['ids']:
@@ -1033,7 +1034,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 self.body.append('{|' + ('l|' * self.table.colcount) + '}\n')
             else:
                 self.body.append('{|' + ('L|' * self.table.colcount) + '}\n')
-        if self.table.longtable and self.table.caption is not None:
+        if self.table.longtable and self.table.caption is not None and not 'title-below' in node:
             self.body.append(u'\\caption{')
             for caption in self.table.caption:
                 self.body.append(caption)
@@ -1060,8 +1061,18 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('\\hline\n')
             self.body.extend(self.tableheaders)
         self.body.extend(self.tablebody)
+        if self.table.longtable and 'title-below' in node:
+            self.body.append(u'\\caption{')
+            for caption in self.table.caption:
+                self.body.append(caption)
+            self.body.append('}')
         self.body.append(endmacro)
         if not self.table.longtable and self.table.caption is not None:
+            if 'title-below' in node:
+                self.body.append('\\capstart\\caption{')
+                for caption in self.table.caption:
+                    self.body.append(caption)
+                self.body.append('}\n')
             self.body.append('\\end{threeparttable}\n\n')
         self.unrestrict_footnote(node)
         self.table = None

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -999,7 +999,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.popbody()
         if not self.table.longtable and self.table.caption is not None:
             self.body.append('\n\n\\begin{threeparttable}\n')
-            if not 'title-below' in node:
+            if 'title-below' not in node:
                 self.body.append('\\capstart\\caption{')
                 for caption in self.table.caption:
                     self.body.append(caption)
@@ -1034,14 +1034,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 self.body.append('{|' + ('l|' * self.table.colcount) + '}\n')
             else:
                 self.body.append('{|' + ('L|' * self.table.colcount) + '}\n')
-        if self.table.longtable and self.table.caption is not None and not 'title-below' in node:
-            self.body.append(u'\\caption{')
-            for caption in self.table.caption:
-                self.body.append(caption)
-            self.body.append('}')
-            for id in self.pop_hyperlink_ids('table'):
-                self.body.append(self.hypertarget(id, anchor=False))
-            self.body.append(u'\\\\\n')
+        if self.table.longtable and self.table.caption is not None:
+            if 'title-below' not in node:
+                self.body.append(u'\\caption{')
+                for caption in self.table.caption:
+                    self.body.append(caption)
+                self.body.append('}')
+                for id in self.pop_hyperlink_ids('table'):
+                    self.body.append(self.hypertarget(id, anchor=False))
+                self.body.append(u'\\\\\n')
         if self.table.longtable:
             self.body.append('\\hline\n')
             self.body.extend(self.tableheaders)


### PR DESCRIPTION
#1723 Asked for the ability to add the caption (title) of a table below the table instead of above it. I figured I would give it a go.

I patched the RSTTable directive from docutils adding an option `title-below`. I edited the latex writer to change where the caption is placed in the `.tex` file if the flag is there.

Not sure if this is the prefered implementation, but I would appreciate some feedback.
