### PR TITLE
Enable to build PDF docs on Ubuntu precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ addons:
   apt:
     packages:
     - graphviz
+    - texlive-latex-recommended
+    - texlive-latex-extra
+    - texlive-fonts-recommended
+    - texlive-fonts-extra
 install:
   - pip install -U pip
   - pip install docutils==$DOCUTILS

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 * #2635: Latex code directives produce inconsistent frames based on viewing resolution
 * #2639: Sphinx now bundles iftex.sty
 * Failed to build PDF with framed.sty 0.95
+* Sphinx now bundles needspace.sty
 
 
 Release 1.4.3 (released Jun 5, 2016)

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 * latex: allow one more nesting depth for code-blocks (ref #777, PR #2624)
 * #2635: Latex code directives produce inconsistent frames based on viewing resolution
 * #2639: Sphinx now bundles iftex.sty
+* Failed to build PDF with framed.sty 0.95
 
 
 Release 1.4.3 (released Jun 5, 2016)

--- a/sphinx/texinputs/needspace.sty
+++ b/sphinx/texinputs/needspace.sty
@@ -1,0 +1,35 @@
+
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{needspace}[2010/09/12 v1.3d reserve vertical space]
+
+\newcommand{\needspace}[1]{%
+  \begingroup
+    \setlength{\dimen@}{#1}%
+    \vskip\z@\@plus\dimen@
+    \penalty -100\vskip\z@\@plus -\dimen@
+    \vskip\dimen@
+    \penalty 9999%
+    \vskip -\dimen@
+    \vskip\z@skip % hide the previous |\vskip| from |\addvspace|
+  \endgroup
+}
+
+\newcommand{\Needspace}{\@ifstar{\@sneedsp@}{\@needsp@}}
+
+\newcommand{\@sneedsp@}[1]{\par \penalty-100\begingroup
+  \setlength{\dimen@}{#1}%
+  \dimen@ii\pagegoal \advance\dimen@ii-\pagetotal
+  \ifdim \dimen@>\dimen@ii
+    \break
+  \fi\endgroup}
+
+\newcommand{\@needsp@}[1]{\par \penalty-100\begingroup
+  \setlength{\dimen@}{#1}%
+  \dimen@ii\pagegoal \advance\dimen@ii-\pagetotal
+  \ifdim \dimen@>\dimen@ii
+    \ifdim \dimen@ii>\z@
+      \vfil
+    \fi
+    \break
+  \fi\endgroup}
+

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -841,7 +841,7 @@
 % Define literal-block environment
 \RequirePackage{newfloat}
 \DeclareFloatingEnvironment{literal-block}
-\ifx\thechapter\undefined
+\ifx\c@chapter\undefined
   \SetupFloatingEnvironment{literal-block}{within=section,placement=h}
 \else
   \SetupFloatingEnvironment{literal-block}{within=chapter,placement=h}

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -416,7 +416,7 @@
 \newenvironment{SphinxShadowBox}
   {\def\FrameCommand {\Sphinx@ShadowFBox }%
    % configure framed.sty not to add extra vertical spacing
-   \OuterFrameSep \z@skip
+   \ifdefined\OuterFrameSep \OuterFrameSep\z@skip \fi
    % the \trivlist will add the vertical spacing on top and bottom which is
    % typical of center environment as used in Sphinx <= 1.4.1
    % the \noindent has the effet of an extra blank line on top, to
@@ -532,7 +532,7 @@
    % configure framed.sty's parameters to obtain same vertical spacing
    % as for "light" boxes. We need for this to manually insert parskip glue and
    % revert a skip done by framed before the frame.
-    \setlength{\OuterFrameSep}{0pt}
+    \ifdefined\OuterFrameSep \OuterFrameSep\z@skip \fi
     \vspace{\FrameHeightAdjust}
    % copied/adapted from framed.sty's snugshade
    \def\FrameCommand##1{\hskip\@totalleftmargin


### PR DESCRIPTION
I try to build PDF docs on Ubuntu precise (through Travis CI).
But current stable branch has some troubles to build it.
This resolves the errors.

At same time, this enables to build continuously on Travis CI.

@jfbu Could you review this please?
