### PR TITLE
Add ``--warning-is-error`` option to setup.py command

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,7 +52,7 @@ Features added
 * #2597: Show warning messages as darkred
 * latex, allow image dimensions using px unit (default is 96px=1in)
 * Show warnings if invalid dimension units found
-* #2650: Add ``--warning-is-error`` option to setup.py command
+* #2663: Add ``--warning-is-error`` option to setup.py command
 
 
 Bugs fixed

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -73,6 +73,7 @@ class BuildDoc(Command):
         ('build-dir=', None, 'Build directory'),
         ('config-dir=', 'c', 'Location of the configuration directory'),
         ('builder=', 'b', 'The builder to use. Defaults to "html"'),
+        ('warning-is-error', 'W', 'Turn warning into errors'),
         ('project=', None, 'The documented project\'s name'),
         ('version=', None, 'The short X.Y version'),
         ('release=', None, 'The full version, including alpha/beta/rc tags'),
@@ -82,13 +83,15 @@ class BuildDoc(Command):
         ('copyright', None, 'The copyright string'),
         ('pdb', None, 'Start pdb on exception'),
     ]
-    boolean_options = ['fresh-env', 'all-files', 'link-index']
+    boolean_options = ['fresh-env', 'all-files', 'warning-is-error',
+                       'link-index']
 
     def initialize_options(self):
         self.fresh_env = self.all_files = False
         self.pdb = False
         self.source_dir = self.build_dir = None
         self.builder = 'html'
+        self.warning_is_error = False
         self.project = ''
         self.version = ''
         self.release = ''
@@ -162,7 +165,8 @@ class BuildDoc(Command):
         app = Sphinx(self.source_dir, self.config_dir,
                      self.builder_target_dir, self.doctree_dir,
                      self.builder, confoverrides, status_stream,
-                     freshenv=self.fresh_env)
+                     freshenv=self.fresh_env,
+                     warningiserror=self.warning_is_error)
 
         try:
             app.build(force_all=self.all_files)

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -108,3 +108,25 @@ def test_build_sphinx_return_nonzero_status(pkgroot, proc):
     print(out)
     print(err)
     assert proc.returncode != 0, 'expect non-zero status for setup.py'
+
+
+@with_setup_command(root)
+def test_build_sphinx_warning_return_zero_status(pkgroot, proc):
+    srcdir = (pkgroot / 'doc')
+    (srcdir / 'contents.txt').write_text(
+        'See :ref:`unexisting-reference-label`')
+    out, err = proc.communicate()
+    print(out)
+    print(err)
+    assert proc.returncode == 0
+
+
+@with_setup_command(root, '--warning-is-error')
+def test_build_sphinx_warning_is_error_return_nonzero_status(pkgroot, proc):
+    srcdir = (pkgroot / 'doc')
+    (srcdir / 'contents.txt').write_text(
+        'See :ref:`unexisting-reference-label`')
+    out, err = proc.communicate()
+    print(out)
+    print(err)
+    assert proc.returncode != 0, 'expect non-zero status for setup.py'


### PR DESCRIPTION
Clone of PR #2649 against the `master` branch.

Original description:

Motivation for this feature comes from building the documentation automatically with a CI system. In such a scenario, it would be very useful if Sphinx's setup.py command would be able to return a nonzero exit status also for warnings.

Added two tests:
- `test_build_sphinx_warning_return_zero_status` checks if `setup.py build_sphinx` returns zero exit status when documentation contains warnings
- `test_build_sphinx_warning_is_error_return_nonzero_status` checks if `setup.py build_sphinx --warning-is-error` returns nonzero exit status when documentation contains warnings
