### PR TITLE
latex use wrapper of \includegraphics, do not redefine original

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -701,25 +701,22 @@
  \raggedright}
 {\end{list}}
 
-% Redefine includgraphics for avoiding images larger than the screen size
-% If the size is not specified.
-\let\py@Oldincludegraphics\includegraphics
+% Use \includegraphics wrapper for avoiding images larger than the screen size
+% if the size is not specified.
 
-\newbox\image@box%
-\newdimen\image@width%
-\renewcommand\includegraphics[2][\@empty]{%
-  \ifx#1\@empty%
-    \setbox\image@box=\hbox{\py@Oldincludegraphics{#2}}%
-    \image@width\wd\image@box%
-    \ifdim \image@width>\linewidth%
-      \setbox\image@box=\hbox{\py@Oldincludegraphics[width=\linewidth]{#2}}%
-      \box\image@box%
-    \else%
-      \py@Oldincludegraphics{#2}%
-    \fi%
-  \else%
-    \py@Oldincludegraphics[#1]{#2}%
-  \fi%
+\newbox\SPX@image@box
+\newcommand\SPXincludegraphics[2][\hfuzz]{%
+  \noindent
+  \ifx\hfuzz #1%
+    \setbox\SPX@image@box=\hbox{\includegraphics{#2}}%
+    \ifdim \wd\SPX@image@box>\linewidth
+      \includegraphics[width=\linewidth]{#2}%
+    \else
+      \box\SPX@image@box
+    \fi
+  \else
+    \includegraphics[#1]{#2}%
+  \fi
 }
 
 % to make pdf with correct encoded bookmarks in Japanese

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -405,7 +405,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.elements['date'] = format_date(builder.config.today_fmt or _('%b %d, %Y'),
                                                 language=builder.config.language)
         if builder.config.latex_logo:
-            self.elements['logo'] = '\\includegraphics{%s}\\par' % \
+            self.elements['logo'] = '\\SPXincludegraphics{%s}\\par' % \
                                     path.basename(builder.config.latex_logo)
         # setup babel
         self.babel = ExtBabel(builder.config.language)
@@ -1437,7 +1437,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if include_graphics_options:
             options = '[%s]' % ','.join(include_graphics_options)
         base, ext = path.splitext(uri)
-        self.body.append('\\includegraphics%s{{%s}%s}' % (options, base, ext))
+        self.body.append('\\SPXincludegraphics%s{{%s}%s}' % (options, base, ext))
         self.body.extend(post)
 
     def depart_image(self, node):

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -113,19 +113,19 @@ def test_writer(app, status, warning):
     result = (app.outdir / 'SphinxTests.tex').text(encoding='utf8')
 
     assert ('\\begin{figure-in-table}\n\\centering\n\\capstart\n'
-            '\\includegraphics{{img}.png}\n'
+            '\\SPXincludegraphics{{img}.png}\n'
             '\\figcaption{figure in table}\\label{markup:id7}\\end{figure-in-table}' in result)
 
     assert ('\\begin{wrapfigure}{r}{0pt}\n\\centering\n'
-            '\\includegraphics{{rimg}.png}\n\\caption{figure with align option}'
+            '\\SPXincludegraphics{{rimg}.png}\n\\caption{figure with align option}'
             '\\label{markup:id8}\\end{wrapfigure}' in result)
 
     assert ('\\begin{wrapfigure}{r}{0.500\\linewidth}\n\\centering\n'
-            '\\includegraphics{{rimg}.png}\n\\caption{figure with align \\& figwidth option}'
+            '\\SPXincludegraphics{{rimg}.png}\n\\caption{figure with align \\& figwidth option}'
             '\\label{markup:id9}\\end{wrapfigure}' in result)
 
     assert ('\\begin{wrapfigure}{r}{3cm}\n\\centering\n'
-            '\\includegraphics[width=3cm]{{rimg}.png}\n'
+            '\\SPXincludegraphics[width=3cm]{{rimg}.png}\n'
             '\\caption{figure with align \\& width option}'
             '\\label{markup:id10}\\end{wrapfigure}' in result)
 
@@ -571,12 +571,12 @@ def test_image_in_section(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert ('\chapter[Test section]'
-            '{\includegraphics[width=15pt,height=15pt]{{pic}.png} Test section}'
+    assert ('\\chapter[Test section]'
+            '{\\SPXincludegraphics[width=15pt,height=15pt]{{pic}.png} Test section}'
             in result)
-    assert ('\chapter[Other {[}blah{]} section]{Other {[}blah{]} '
-            '\includegraphics[width=15pt,height=15pt]{{pic}.png} section}' in result)
-    assert ('\chapter{Another section}' in result)
+    assert ('\\chapter[Other {[}blah{]} section]{Other {[}blah{]} '
+            '\\SPXincludegraphics[width=15pt,height=15pt]{{pic}.png} section}' in result)
+    assert ('\\chapter{Another section}' in result)
 
 
 @with_app(buildername='latex', confoverrides={'latex_logo': 'notfound.jpg'})


### PR DESCRIPTION
the \noindent is needed in case \parindent has positive value for full
line width images ; besides earlier code had \hbox in case image
original width was larger than line width, which could cause vertical
space discrepancy with the case of \includegraphics without the \hbox
(which always initiates a paragraph).
