### PR TITLE
Enhance latex text styling customizability

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,10 @@ Features added
 * Show warnings if no domains match with `primary_domain` (ref: #2001)
 * C++, show warnings when the kind of role is misleading for the kind
   of target it refers to (e.g., using the `class` role for a function).
+* latex writer abstracts more of text styling into customizable macros, e.g.
+  the ``visit_emphasis`` will output ``\sphinxstyleemphasis`` rather than
+  ``\\emph`` (which may be in use elsewhere or in an added LaTeX package). See
+  list at end of ``sphinx.sty`` (ref: #2686)
 
 Bugs fixed
 ----------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -887,3 +887,19 @@
   \DeclareRobustCommand{\code}[1]{{\@noligs\scantokens{\texttt{#1}}}}
   \def\sphinxcode{\code}%
 \fi
+
+% additional customizable styling
+\let\sphinxstyleindexentry\texttt
+\newcommand{\sphinxstyleindexextra}[1]{ \emph{(#1)}}
+\newcommand*{\sphinxstyleindexpageref}{, \pageref}
+\newcommand{\sphinxstyletopictitle}[1]{\textbf{#1}\par\medskip}
+\let\sphinxstylesidebartitle\sphinxstyletopictitle
+\let\sphinxstyleothertitle\textbf
+\newcommand{\sphinxstylesidebarsubtitle}[1]{~\\\textbf{#1} \smallskip}
+\let\sphinxstylethead\textsf
+\let\sphinxstyleemphasis\emph
+\newcommand{\sphinxstyleliteralemphasis}[1]{\emph{\texttt{#1}}}
+\let\sphinxstylestrong\textbf
+\newcommand{\sphinxstyleliteralstrong}[1]{\textbf{\texttt{#1}}}
+\let\sphinxstyleabbreviation\textsc
+\let\sphinxstyleliteralintitle\texttt

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -638,11 +638,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 for entry in entries:
                     if not entry[3]:
                         continue
-                    ret.append('\\item {\\texttt{%s}}' % self.encode(entry[0]))
+                    # ret.append('\\item {\\texttt{%s}}' % self.encode(entry[0]))
+                    ret.append('\\item {\\sphinxstyleindexentry{%s}}' % self.encode(entry[0]))
                     if entry[4]:
                         # add "extra" info
-                        ret.append(' \\emph{(%s)}' % self.encode(entry[4]))
-                    ret.append(', \\pageref{%s:%s}\n' %
+                        # ret.append(' \\emph{(%s)}' % self.encode(entry[4]))
+                        ret.append('\\sphinxstyleindexextra{%s}' % self.encode(entry[4]))
+                    # ret.append(', \\pageref{%s:%s}\n' %
+                    ret.append('\\sphinxstyleindexpageref{%s:%s}\n' %
                                (entry[2], self.idescape(entry[3])))
             ret.append('\\end{theindex}\n')
 
@@ -830,9 +833,16 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.context[-1] += self.hypertarget(id, anchor=False)
                 self.next_section_ids.clear()
 
-        elif isinstance(parent, (nodes.topic, nodes.sidebar)):
-            self.body.append(r'\textbf{')
-            self.context.append('}\n\n\medskip\n\n')
+        elif isinstance(parent, nodes.topic):
+            # self.body.append(r'\textbf{')
+            self.body.append(r'\sphinxstyletopictitle{')
+            # self.context.append('}\n\n\medskip\n\n')
+            self.context.append('}\n')
+        elif isinstance(parent, nodes.sidebar):
+            # self.body.append(r'\textbf{')
+            self.body.append(r'\sphinxstylesidebartitle{')
+            # self.context.append('}\n\n\medskip\n\n')
+            self.context.append('}\n')
         elif isinstance(parent, nodes.Admonition):
             self.body.append('{')
             self.context.append('}\n')
@@ -844,7 +854,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 'encountered title node not in section, topic, table, '
                 'admonition or sidebar',
                 (self.curfilestack[-1], node.line or ''))
-            self.body.append('\\textbf{')
+#            self.body.append('\\textbf{')
+            self.body.append('\\sphinxstyleothertitle{')
             self.context.append('}\n')
         self.in_title = 1
 
@@ -858,8 +869,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_subtitle(self, node):
         if isinstance(node.parent, nodes.sidebar):
-            self.body.append('~\\\\\n\\textbf{')
-            self.context.append('}\n\\smallskip\n')
+            # self.body.append('~\\\\\n\\textbf{')
+            # self.context.append('}\n\\smallskip\n')
+            self.body.append('\\sphinxstylesidebarsubtitle{')
+            self.context.append('}\n')
         else:
             self.context.append('')
 
@@ -1194,7 +1207,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             if len(node) == 1 and isinstance(node[0], nodes.paragraph) and node.astext() == '':
                 pass
             else:
-                self.body.append('\\textsf{\\relax ')
+                # self.body.append('\\textsf{\\relax ')
+                self.body.append('\\sphinxstylethead{\\relax ')
                 context += '}'
         while self.remember_multirow.get(self.table.col + 1, 0):
             self.table.col += 1
@@ -1756,36 +1770,43 @@ class LaTeXTranslator(nodes.NodeVisitor):
         pass
 
     def visit_emphasis(self, node):
-        self.body.append(r'\emph{')
+        # self.body.append(r'\emph{')
+        self.body.append(r'\sphinxstyleemphasis{')
 
     def depart_emphasis(self, node):
         self.body.append('}')
 
     def visit_literal_emphasis(self, node):
-        self.body.append(r'\emph{\texttt{')
+        # self.body.append(r'\emph{\texttt{')
+        self.body.append(r'\sphinxstyleliteralemphasis{')
         self.no_contractions += 1
 
     def depart_literal_emphasis(self, node):
-        self.body.append('}}')
+        # self.body.append('}}')
+        self.body.append('}')
         self.no_contractions -= 1
 
     def visit_strong(self, node):
-        self.body.append(r'\textbf{')
+        # self.body.append(r'\textbf{')
+        self.body.append(r'\sphinxstylestrong{')
 
     def depart_strong(self, node):
         self.body.append('}')
 
     def visit_literal_strong(self, node):
-        self.body.append(r'\textbf{\texttt{')
+        # self.body.append(r'\textbf{\texttt{')
+        self.body.append(r'\sphinxstyleliteralstrong{')
         self.no_contractions += 1
 
     def depart_literal_strong(self, node):
-        self.body.append('}}')
+        # self.body.append('}}')
+        self.body.append('}')
         self.no_contractions -= 1
 
     def visit_abbreviation(self, node):
         abbr = node.astext()
-        self.body.append(r'\textsc{')
+        # self.body.append(r'\textsc{')
+        self.body.append(r'\sphinxstyleabbreviation{')
         # spell out the explanation once
         if node.hasattr('explanation') and abbr not in self.handled_abbrs:
             self.context.append('} (%s)' % self.encode(node['explanation']))
@@ -1829,7 +1850,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_literal(self, node):
         self.no_contractions += 1
         if self.in_title:
-            self.body.append(r'\texttt{')
+            # self.body.append(r'\texttt{')
+            self.body.append(r'\sphinxstyleliteralintitle{')
         else:
             self.body.append(r'\sphinxcode{')
 

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -65,7 +65,8 @@ def test_code_block_caption_html(app, status, warning):
 def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\sphinxSetupCaptionForVerbatim{literal-block}{caption \\emph{test} rb}'
+    caption = '\\sphinxSetupCaptionForVerbatim{literal-block}' \
+              '{caption \\sphinxstyleemphasis{test} rb}'
     label = '\\def\\sphinxLiteralBlockLabel{\\label{caption:caption-test-rb}}'
     link  = '\hyperref[caption:caption-test-rb]' \
             '{Listing \\ref{caption:caption-test-rb}}'
@@ -252,7 +253,8 @@ def test_literalinclude_caption_html(app, status, warning):
 def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
-    caption = '\\sphinxSetupCaptionForVerbatim{literal-block}{caption \\textbf{test} py}'
+    caption = '\\sphinxSetupCaptionForVerbatim{literal-block}' \
+              '{caption \\sphinxstylestrong{test} py}'
     label = '\\def\\sphinxLiteralBlockLabel{\\label{caption:caption-test-py}}'
     link  = '\hyperref[caption:caption-test-py]' \
             '{Listing \\ref{caption:caption-test-py}}'

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -101,7 +101,7 @@ def test_inline():
            '<p><code class="samp docutils literal"><span class="pre">a</span>'
            '<em><span class="pre">b</span></em>'
            '<span class="pre">c</span></code></p>',
-           '\\sphinxcode{a\\emph{b}c}')
+           '\\sphinxcode{a\\sphinxstyleemphasis{b}c}')
 
     # interpolation of arrows in menuselection
     yield (verify, ':menuselection:`a --> b`',
@@ -131,7 +131,7 @@ def test_inline():
     # verify classes for inline roles
     yield (verify, ':manpage:`mp(1)`',
            '<p><em class="manpage">mp(1)</em></p>',
-           '\\emph{\\texttt{mp(1)}}')
+           '\\sphinxstyleliteralemphasis{mp(1)}')
 
 
 def test_latex_escaping():


### PR DESCRIPTION
This addresses #2686. For reviewing, I have left original lines in `latex.py` as comments, as they have to be compared with the new definitions at bottom of `sphinx.sty`. These commented lines will be removed afterwards. I am perplexed in particular by the styling of sidebar subtitle, the original code is 

```
        self.body.append('~\\\\\n\\textbf{')
        self.context.append('}\n\\smallskip\n')
```

However `\smallskip` in LaTeX (contrarily to TeX) does not quit horizontal mode. It says to add a small space near the location (i never remember if above or below the line in the paragraph). Here the paragraph is not ended, there is only one `\n` before and also after `\smallskip`. Thus if some text comes next, perhaps unexpected result ensues. Besides the `~\\\\\n` becoming `~\\` and an end of line is also strange. Anyway currently I have code this as 

``` latex
\newcommand{\sphinxstylesidebarsubtitle}[1]{~\\\textbf{#1} \smallskip}
```

in `sphinx.sty` (the space before `\smallskip` because that's how the end of line from original python code would be treated by TeX tokenization). But I would rather suppress the useless `~` and add a `\par` before the `\smallskip`.
