### PR TITLE
Fix LocalTimeZone.utcoffset return value when SOURCE_DATE_EPOCH is set

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -135,7 +135,7 @@ tzdelta = datetime.fromtimestamp(timestamp) - \
 source_date_epoch = getenv('SOURCE_DATE_EPOCH')
 if source_date_epoch is not None:
     timestamp = float(source_date_epoch)
-    tzdelta = 0
+    tzdelta = timedelta(0)
 
 
 class LocalTimeZone(tzinfo):


### PR DESCRIPTION
Subclasses of `tzinfo` should follow the parent class and return offset either as None (when unknown) or as `timedelta`.

Otherwise `datetime.fromtimestamp()` will raise a `TypeError: tzinfo.utcoffset() must return None or timedelta, not 'int'`.

Cc @JojoBoulix.
