### PR TITLE
Fix #2707: (latex) the column width is badly computed for tabular

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Incompatible changes
 * LaTeX package newfloat (which was shipped with Sphinx since 1.3.4) is no
   longer a dependency of sphinx.sty (ref #2660)
 
+
 Features added
 --------------
 
@@ -33,9 +34,13 @@ Features added
 * public names for latex environments and parameters used by note, warning,
   and other admonition types, allowing full customizability from the
   ``'preamble'`` key (ref: feature request #2674, #2685)
+* latex better computes column widths of some tables (as a result, there will
+  be slight changes as tables now correctly fill the line with; ref: #2708)
 
 Bugs fixed
 ----------
+
+* #2707: (latex) the column width is badly computed for tabular
 
 Documentation
 -------------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1052,9 +1052,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append(self.table.colspec)
         else:
             if self.table.has_problematic:
-                colspec = ('p{\\dimexpr(\\linewidth-\\arrayrulewidth)/%d'
-                           '-2\\tabcolsep-\\arrayrulewidth\\relax}|' % \
-                self.table.colcount) * self.table.colcount
+                colspec = ('*{%d}{p{\\dimexpr(\\linewidth-\\arrayrulewidth)/%d'
+                           '-2\\tabcolsep-\\arrayrulewidth\\relax}|}' % \
+                           (self.table.colcount, self.table.colcount))
                 self.body.append('{|' + colspec + '}\n')
             elif self.table.longtable:
                 self.body.append('{|' + ('l|' * self.table.colcount) + '}\n')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1052,9 +1052,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append(self.table.colspec)
         else:
             if self.table.has_problematic:
-                colwidth = 0.95 / self.table.colcount
-                colspec = ('p{%.3f\\linewidth}|' % colwidth) * \
-                    self.table.colcount
+                colspec = ('p{\\dimexpr(\\linewidth-\\arrayrulewidth)/%d'
+                           '-2\\tabcolsep-\\arrayrulewidth\\relax}|' % \
+                self.table.colcount) * self.table.colcount
                 self.body.append('{|' + colspec + '}\n')
             elif self.table.longtable:
                 self.body.append('{|' + ('l|' * self.table.colcount) + '}\n')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1053,7 +1053,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         else:
             if self.table.has_problematic:
                 colspec = ('*{%d}{p{\\dimexpr(\\linewidth-\\arrayrulewidth)/%d'
-                           '-2\\tabcolsep-\\arrayrulewidth\\relax}|}' % \
+                           '-2\\tabcolsep-\\arrayrulewidth\\relax}|}' %
                            (self.table.colcount, self.table.colcount))
                 self.body.append('{|' + colspec + '}\n')
             elif self.table.longtable:


### PR DESCRIPTION
MEMO: the used formula is correct as long as package array is loaded.
Package array (which modifies how the width of vertical rules is counted
in the total width of the tabular) is a dependency of packages tabulary,
and eqparbox, and possibly others which are currently loaded by
sphinx.sty. Even if usage of package tabulary is dropped in future
version of sphinx.sty, there would still remain the dependency on array
via eqparbox, and the formula configured in latex.py will remain
correct.
