### PR TITLE
WOFF web font support missing from epub builder.

### DIFF
--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -152,6 +152,7 @@ MEDIA_TYPES = {
     '.jpeg': 'image/jpeg',
     '.otf': 'application/x-font-otf',
     '.ttf': 'application/x-font-ttf',
+    '.woff': 'application/font-woff',
 }
 
 VECTOR_GRAPHICS_EXTENSIONS = ('.svg',)


### PR DESCRIPTION
Was receiving this error:

```
WARNING: unknown mimetype for _static/fonts/fontawesome-webfont.woff, ignoring
```

Took a long time to figure out but it appears the filetype must be whitelisted.

Woff is well supported, see the mime type below:
- http://caniuse.com/#feat=woff
- http://stackoverflow.com/a/5142316/450917

Would probably make sense to add a few others, but this appears to be the most common format, so I'll stop here. 
