### PR TITLE
Fix #2712: latex has two distinct python functions to convert dimensions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,10 @@ Incompatible changes
   it was shipped with Sphinx since 1.3.4).
 * latex, literal blocks in tables do not use OriginalVerbatim but
   sphinxVerbatimintable which handles captions and wraps lines(ref #2704).
+* latex, if ``width`` or ``height`` attribute of images are given with no unit,
+  use ``bp`` rather than ignore it.
+* latex, convert ``pt`` to TeX equivalent ``bp`` if found in ``width`` or
+  ``height`` attribute of images.
 
 
 Features added
@@ -47,11 +51,14 @@ Features added
   lines wrapped to fit table cell (ref: #2704)
 * #2597: Show warning messages as darkred
 * latex, allow image dimensions using px unit (default is 96px=1in)
+* latex, allow ``figwidth`` with px unit (also xelatex/platex; ref #2712)
 
 Bugs fixed
 ----------
 
 * #2707: (latex) the column width is badly computed for tabular
+* #2712: latex has two distinct python functions to convert dimensions and
+  they behave differently
 
 Documentation
 -------------

--- a/CHANGES
+++ b/CHANGES
@@ -13,10 +13,10 @@ Incompatible changes
   it was shipped with Sphinx since 1.3.4).
 * latex, literal blocks in tables do not use OriginalVerbatim but
   sphinxVerbatimintable which handles captions and wraps lines(ref #2704).
-* latex, if ``width`` or ``height`` attribute of images are given with no unit,
+* latex, if ``width`` or ``height`` attribute of an image is given with no unit,
   use ``bp`` rather than ignore it.
 * latex, convert ``pt`` to TeX equivalent ``bp`` if found in ``width`` or
-  ``height`` attribute of images.
+  ``height`` attribute of an image.
 
 
 Features added

--- a/CHANGES
+++ b/CHANGES
@@ -14,8 +14,8 @@ Incompatible changes
 * latex, literal blocks in tables do not use OriginalVerbatim but
   sphinxVerbatimintable which handles captions and wraps lines(ref #2704).
 * latex, if ``width`` or ``height`` attribute of an image is given with no unit,
-  use ``bp`` rather than ignore it.
-* latex, convert ``pt`` to TeX equivalent ``bp`` if found in ``width`` or
+  use ``px`` rather than ignore it.
+* latex, replace ``pt`` by TeX equivalent ``bp`` if found in ``width`` or
   ``height`` attribute of an image.
 
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1602,8 +1602,9 @@ These options influence LaTeX output. See further :doc:`latex`.
         Point size option of the document class (``'10pt'``, ``'11pt'`` or
         ``'12pt'``), default ``'10pt'``.
      ``'pxunit'``
-        the value of the ``px`` when used in image attributes ``width`` and
-        ``height``. The default value is ``'49336sp'`` which achieves
+        the value of the ``px`` when used in :rst:dir:`image` attributes
+        ``width`` and ``height`` or the :rst:dir:`figure` attribute
+        ``figwidth``. The default value is ``'49336sp'`` which achieves
         ``96px=1in`` (``1in = 72.27*65536 = 4736286.72sp``, and all dimensions
         in TeX are internally integer multiples of ``sp``). To obtain for
         example ``100px=1in``, one can use ``'0.01in'`` but it is more precise

--- a/doc/rest.rst
+++ b/doc/rest.rst
@@ -363,8 +363,9 @@ directory on building (e.g. the ``_static`` directory for HTML output.)
 
 Interpretation of image size options (``width`` and ``height``) is as follows:
 if the size has no unit or the unit is pixels, the given size will only be
-respected for output channels that support pixels (i.e. not in LaTeX output).
-Other units (like ``pt`` for points) will be used for HTML and LaTeX output.
+respected for output channels that support pixels. Other units (like ``pt``
+for points) will be used for HTML and LaTeX output (the latter replaces ``pt``
+by ``bp`` as this is the TeX unit such that ``72bp=1in``).
 
 Sphinx extends the standard docutils behavior by allowing an asterisk for the
 extension::
@@ -385,6 +386,9 @@ Note that image file names should not contain spaces.
 
 .. versionchanged:: 0.6
    Image paths can now be absolute.
+
+.. versionchanged:: 1.5
+   latex target supports pixels (default is ``96px=1in``).
 
 
 Footnotes

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1368,11 +1368,13 @@ class LaTeXTranslator(nodes.NodeVisitor):
             # fallback
             return length_str
         amount, unit = match.groups()[:2]
-        if unit in ('', 'pt'):
+        if not unit:
+            length_str = '%s\\sphinxpxdimen' % amount
+        elif unit == "pt":
             length_str = '%sbp' % amount  # convert to 'bp'
-        # px unit not accepted by all engines
+        # px unit not natively accepted by all engines, use \sphinxpxdimen
         elif unit == "px":
-            length_str = "%.3f\\sphinxpxdimen" % (float(amount))
+            length_str = "%s\\sphinxpxdimen" % amount
         # relate % to current line width (fits with lists or quotes)
         elif unit == "%":
             length_str = "%.3f\\linewidth" % (float(amount) / 100.0)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -270,25 +270,6 @@ class Table(object):
         self.longtable = False
 
 
-# this is not used but maintained for <1.5 compat. See latex_dim_to_latexdim.
-def width_to_latex_length(length_str):
-    """Convert `length_str` with rst length to LaTeX length.
-
-    This function is copied from docutils' latex writer
-    """
-    match = re.match('(\d*\.?\d*)\s*(\S*)', length_str)
-    if not match:
-        return length_str
-    value, unit = match.groups()[:2]
-    if unit in ('', 'pt'):
-        length_str = '%sbp' % value  # convert to 'bp'
-    # percentage: relate to current line width
-    elif unit == '%':
-        length_str = '%.3f\\linewidth' % (float(value)/100.0)
-
-    return length_str
-
-
 def escape_abbr(text):
     """Adjust spacing after abbreviations."""
     return re.sub('\.(?=\s|$)', '.\\@', text)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -578,10 +578,10 @@ def test_image_in_section(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert ('\\chapter[Test section]'
-            '{\\sphinxincludegraphics[width=15pt,height=15pt]{{pic}.png} Test section}'
+            '{\\sphinxincludegraphics[width=15bp,height=15bp]{{pic}.png} Test section}'
             in result)
     assert ('\\chapter[Other {[}blah{]} section]{Other {[}blah{]} '
-            '\\sphinxincludegraphics[width=15pt,height=15pt]{{pic}.png} section}' in result)
+            '\\sphinxincludegraphics[width=15bp,height=15bp]{{pic}.png} section}' in result)
     assert ('\\chapter{Another section}' in result)
 
 


### PR DESCRIPTION
and they behave differently. This includes PR #2711. As I don't know how extensions may have used the Python functions `width_to_latex_length(length_str)` and `latex_image_length(self, width_str)` from class `LaTeXTranslator`, they are still defined. The former with earlier meaning, the latter is now wrapper to `latex_dim_to_latexdim(self, length_str)` function from class `LaTeXTranslator`. Only this is used in `latex.py`.
