### PR TITLE
latex, make use of ``\small`` for code listings customizable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,7 @@ Features added
 * latex, allow image dimensions using px unit (default is 96px=1in)
 * Show warnings if invalid dimension units found
 * #2650: Add ``--warning-is-error`` option to setup.py command
+* latex, make the use of ``\small`` for code listings customizable (ref #2721)
 
 
 Bugs fixed

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -120,6 +120,14 @@ Let us illustrate here what can be modified by the second method.
      were not wrapped), they now use ``sphinxVerbatimintable``.
   .. versionadded:: 1.5
      the two customizable lengths, the ``sphinxVerbatimintable``.
+- by default the Sphinx style file ``sphinx.sty`` includes the command
+  ``\fvset{fontsize=\small}`` as part of its configuration of
+  ``fancyvrb.sty``. The user may override this for example via
+  ``\fvset{fontsize=auto}`` which will use for listings the ambient
+  font size. Refer to ``fancyvrb.sty``'s documentation for further keys.
+
+  .. versionadded:: 1.5
+     formerly, the use of ``\small`` for code listings was not customizable.
 - miscellaneous colours: *TitleColor*, *InnerLinkColor*, *OuterLinkColor*,
   *VerbatimColor* (this is a background colour), *VerbatimBorderColor*.
 - the ``\sphinxAtStartFootnote`` is inserted between footnote numbers and their

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -42,6 +42,7 @@
 }
 % For highlighted code.
 \RequirePackage{fancyvrb}
+\fvset{fontsize=\small}
 % For table captions.
 \RequirePackage{threeparttable}
 % Handle footnotes in tables.
@@ -400,7 +401,6 @@
      \MakeFramed {% adapted over from framed.sty's snugshade environment
         \advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize\@setminipage
         }%
-     \small
      % For grid placement from \strut's in \FancyVerbFormatLine
      \lineskip\z@skip
      % will fetch its optional arguments if any


### PR DESCRIPTION
Until now, latex forces use of `\small` in code-blocks. This is explainable by the fact that
1. the default setting of courier for typewriter font gives big glyphs
2. until recently Sphinx did not know how to wrap code lines

This PR maintains same result as current Sphinx, but the user can override the default.
