### PR TITLE
Fix #2723: extra spaces in latex pdf output from multirow cell

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1121,28 +1121,28 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 self.remember_multirow[self.table.col] -= 1
                 if self.remember_multirowcol.get(self.table.col, 0):
                     extracols = self.remember_multirowcol[self.table.col]
-                    self.body.append(' \\multicolumn{')
+                    self.body.append('\\multicolumn{')
                     self.body.append(str(extracols + 1))
-                    self.body.append('}{|l|}{}')
+                    self.body.append('}{|l|}{}\\relax ')
                     self.table.col += extracols
-                self.body.append(' & ')
+                self.body.append('&')
         else:
-            self.body.append(' & ')
+            self.body.append('&')
         self.table.col += 1
         context = ''
         if 'morecols' in node:
-            self.body.append(' \\multicolumn{')
+            self.body.append('\\multicolumn{')
             self.body.append(str(node.get('morecols') + 1))
             if self.table.col == 1:
-                self.body.append('}{|l|}{')
+                self.body.append('}{|l|}{\\relax ')
             else:
-                self.body.append('}{l|}{')
-            context += '}'
+                self.body.append('}{l|}{\\relax ')
+            context += '\\unskip}\\relax '
         if 'morerows' in node:
-            self.body.append(' \\multirow{')
+            self.body.append('\\multirow{')
             self.body.append(str(node.get('morerows') + 1))
-            self.body.append('}{*}{')
-            context += '}'
+            self.body.append('}{*}{\\relax ')
+            context += '\\unskip}\\relax '
             self.remember_multirow[self.table.col] = node.get('morerows')
         if 'morecols' in node:
             if 'morerows' in node:
@@ -1160,16 +1160,16 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 pass
             else:
                 self.body.append('\\textsf{\\relax ')
-                context += '}'
+                context += '\\unskip}\\relax '
         while self.remember_multirow.get(self.table.col + 1, 0):
             self.table.col += 1
             self.remember_multirow[self.table.col] -= 1
-            context += ' & '
+            context += '&'
             if self.remember_multirowcol.get(self.table.col, 0):
                 extracols = self.remember_multirowcol[self.table.col]
-                context += ' \\multicolumn{'
+                context += '\\multicolumn{'
                 context += str(extracols + 1)
-                context += '}{l|}{}'
+                context += '}{l|}{}\\relax '
                 self.table.col += extracols
         if len(node.traverse(nodes.paragraph)) >= 2:
             self.table.has_problematic = True


### PR DESCRIPTION
Adds some `\relax`/`\unskip` and removes spaces from `visit_entry`
generated latex code. Earlier, multirow cell inherited one extra space
token at begin and one at end, making left or right alignment with other
cells fail because the native LaTeX space removal mechanism for table
cells could not apply there.

Memo: the `\eqparbox` part of `visit_entry` from e41f831f is left
untouched; separate analysis required.
