### PR TITLE
Fix #2735: latexpdf ``Underfull \hbox`` warnings from title page

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,7 @@ Bugs fixed
 * #2718: Sphinx crashes if the document file is not readable
 * #2699: hyperlinks in help HTMLs are broken if `html_file_suffix` is set
 * #2723: extra spaces in latex pdf output from multirow cell
+* #2735: latexpdf ``Underfull \hbox (badness 10000)`` warnings from title page
 
 
 Release 1.4.4 (released Jun 12, 2016)

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -35,19 +35,19 @@
 % Change the title page to look a bit better, and fit in with the fncychap
 % ``Bjarne'' style a bit better.
 %
-\renewcommand{\maketitle}{
-  \rule{\textwidth}{1pt}
+\renewcommand{\maketitle}{%
+  \noindent\rule{\textwidth}{1pt}\newline\null\par
   \ifsphinxpdfoutput
     \begingroup
     % These \defs are required to deal with multi-line authors; it
     % changes \\ to ', ' (comma-space), making it pass muster for
     % generating document info in the PDF file.
-    \def\\{, }
-    \def\and{and }
+    \def\\{, }%
+    \def\and{and }%
     \pdfinfo{
       /Author (\@author)
       /Title (\@title)
-    }
+    }%
     \endgroup
   \fi
   \begin{flushright}

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -43,18 +43,18 @@
   \begin{titlepage}%
     \let\footnotesize\small
     \let\footnoterule\relax
-    \rule{\textwidth}{1pt}%
+    \noindent\rule{\textwidth}{1pt}\newline\null\par
     \ifsphinxpdfoutput
       \begingroup
       % These \defs are required to deal with multi-line authors; it
       % changes \\ to ', ' (comma-space), making it pass muster for
       % generating document info in the PDF file.
-      \def\\{, }
-      \def\and{and }
+      \def\\{, }%
+      \def\and{and }%
       \pdfinfo{
         /Author (\@author)
         /Title (\@title)
-      }
+      }%
       \endgroup
     \fi
     \begin{flushright}%


### PR DESCRIPTION
This came from the spurious space tokens following a fullwidth rule at
top of `\maketitle` in `sphinxhowto.cls` and `sphinxmanual.cls`.
The `\newline\null\par` incantation recreates the extra empty line
which originated in these spurious space tokens, but it avoids the
Underfull latex warning. Nothing is changed to layout from this fix.
