### PR TITLE
Fix #2667: latex crashes if resized images appeared in section title

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,7 @@ Bugs fixed
 * #2718: Sphinx crashes if the document file is not readable
 * #2699: hyperlinks in help HTMLs are broken if `html_file_suffix` is set
 * #2723: extra spaces in latex pdf output from multirow cell
+* #2667: latex crashes if resized images appeared in section title
 
 
 Release 1.4.4 (released Jun 12, 2016)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1417,7 +1417,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if include_graphics_options:
             options = '[%s]' % ','.join(include_graphics_options)
         base, ext = path.splitext(uri)
-        self.body.append('\\sphinxincludegraphics%s{{%s}%s}' % (options, base, ext))
+        if self.in_title and base:
+            # Lowercase tokens forcely because some fncychap themes capitalize
+            # the options of \sphinxincludegraphics unexpectly (ex. WIDTH=...).
+            self.body.append('\\lowercase{\\sphinxincludegraphics%s}{{%s}%s}' %
+                             (options, base, ext))
+        else:
+            self.body.append('\\sphinxincludegraphics%s{{%s}%s}' %
+                             (options, base, ext))
         self.body.extend(post)
 
     def depart_image(self, node):

--- a/tests/roots/test-ext-todo/bar.rst
+++ b/tests/roots/test-ext-todo/bar.rst
@@ -1,0 +1,4 @@
+bar
+===
+
+.. todo:: todo in bar

--- a/tests/roots/test-ext-todo/conf.py
+++ b/tests/roots/test-ext-todo/conf.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+extensions = ['sphinx.ext.todo']
+master_doc = 'index'

--- a/tests/roots/test-ext-todo/foo.rst
+++ b/tests/roots/test-ext-todo/foo.rst
@@ -1,0 +1,4 @@
+foo
+===
+
+.. todo:: todo in foo

--- a/tests/roots/test-ext-todo/index.rst
+++ b/tests/roots/test-ext-todo/index.rst
@@ -1,0 +1,9 @@
+test for sphinx.ext.todo
+========================
+
+.. toctree::
+
+   foo
+   bar
+
+.. todolist::

--- a/tests/test_ext_todo.py
+++ b/tests/test_ext_todo.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+    test_ext_todo
+    ~~~~~~~~~~~~~
+
+    Test sphinx.ext.todo extension.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+from util import with_app
+
+
+@with_app('html', testroot='ext-todo', freshenv=True,
+          confoverrides={'todo_include_todos': True, 'todo_emit_warnings': True})
+def test_todo(app, status, warning):
+    todos = []
+
+    def on_todo_defined(app, node):
+        todos.append(node)
+
+    app.connect('todo-defined', on_todo_defined)
+    app.builder.build_all()
+
+    # check todolist
+    content = (app.outdir / 'index.html').text()
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in foo</p>')
+    assert re.search(html, content, re.S)
+
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in bar</p>')
+    assert re.search(html, content, re.S)
+
+    # check todo
+    content = (app.outdir / 'foo.html').text()
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in foo</p>')
+    assert re.search(html, content, re.S)
+
+    # check emitted warnings
+    assert 'WARNING: TODO entry found: todo in foo' in warning.getvalue()
+    assert 'WARNING: TODO entry found: todo in bar' in warning.getvalue()
+
+    # check handled event
+    assert len(todos) == 2
+    assert set(todo[1].astext() for todo in todos) == set(['todo in foo', 'todo in bar'])
+
+
+@with_app('html', testroot='ext-todo', freshenv=True,
+          confoverrides={'todo_include_todos': False, 'todo_emit_warnings': True})
+def test_todo_not_included(app, status, warning):
+    todos = []
+
+    def on_todo_defined(app, node):
+        todos.append(node)
+
+    app.connect('todo-defined', on_todo_defined)
+    app.builder.build_all()
+
+    # check todolist
+    content = (app.outdir / 'index.html').text()
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in foo</p>')
+    assert not re.search(html, content, re.S)
+
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in bar</p>')
+    assert not re.search(html, content, re.S)
+
+    # check todo
+    content = (app.outdir / 'foo.html').text()
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in foo</p>')
+    assert not re.search(html, content, re.S)
+
+    # check emitted warnings
+    assert 'WARNING: TODO entry found: todo in foo' in warning.getvalue()
+    assert 'WARNING: TODO entry found: todo in bar' in warning.getvalue()
+
+    # check handled event
+    assert len(todos) == 2
+    assert set(todo[1].astext() for todo in todos) == set(['todo in foo', 'todo in bar'])


### PR DESCRIPTION
This is a fix for #2667 
