### PR TITLE
Fix #2667: latex crashes if resized images appeared in section title

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,7 @@ Bugs fixed
 * #2699: hyperlinks in help HTMLs are broken if `html_file_suffix` is set
 * #2723: extra spaces in latex pdf output from multirow cell
 * #2735: latexpdf ``Underfull \hbox (badness 10000)`` warnings from title page
+* #2667: latex crashes if resized images appeared in section title
 
 
 Release 1.4.4 (released Jun 12, 2016)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1417,7 +1417,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if include_graphics_options:
             options = '[%s]' % ','.join(include_graphics_options)
         base, ext = path.splitext(uri)
-        self.body.append('\\sphinxincludegraphics%s{{%s}%s}' % (options, base, ext))
+        if self.in_title and base:
+            # Lowercase tokens forcely because some fncychap themes capitalize
+            # the options of \sphinxincludegraphics unexpectly (ex. WIDTH=...).
+            self.body.append('\\lowercase{\\sphinxincludegraphics%s}{{%s}%s}' %
+                             (options, base, ext))
+        else:
+            self.body.append('\\sphinxincludegraphics%s{{%s}%s}' %
+                             (options, base, ext))
         self.body.extend(post)
 
     def depart_image(self, node):

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -577,11 +577,12 @@ def test_image_in_section(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert ('\\chapter[Test section]'
-            '{\\sphinxincludegraphics[width=15pt,height=15pt]{{pic}.png} Test section}'
+    assert ('\\chapter[Test section]{\\lowercase{\\sphinxincludegraphics'
+            '[width=15pt,height=15pt]}{{pic}.png} Test section}'
             in result)
     assert ('\\chapter[Other {[}blah{]} section]{Other {[}blah{]} '
-            '\\sphinxincludegraphics[width=15pt,height=15pt]{{pic}.png} section}' in result)
+            '\\lowercase{\\sphinxincludegraphics[width=15pt,height=15pt]}'
+            '{{pic}.png} section}' in result)
     assert ('\\chapter{Another section}' in result)
 
 


### PR DESCRIPTION
This is a fix for #2667 
