### PR TITLE
latex: Separate stylesheets of pygments to .sty file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Incompatible changes
   ``height`` attribute of an image.
 * latex, if ``width`` or ``height`` attribute of an image is given with no unit,
   use ``px`` rather than ignore it.
+* latex: Separate stylesheets of pygments to independent .sty file
 
 
 Features added

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -19,7 +19,7 @@ from docutils.io import FileOutput
 from docutils.utils import new_document
 from docutils.frontend import OptionParser
 
-from sphinx import package_dir, addnodes
+from sphinx import package_dir, addnodes, highlighting
 from sphinx.util import texescape
 from sphinx.errors import SphinxError
 from sphinx.locale import _
@@ -92,6 +92,16 @@ class LaTeXBuilder(Builder):
                 docname = docname[:-5]
             self.titles.append((docname, entry[2]))
 
+    def write_stylesheet(self):
+        highlighter = highlighting.PygmentsBridge(
+            'latex', self.config.pygments_style, self.config.trim_doctest_flags)
+        stylesheet = path.join(self.outdir, 'sphinxhighlight.sty')
+        with open(stylesheet, 'w') as f:
+            f.write('\\NeedsTeXFormat{LaTeX2e}[1995/12/01]\n')
+            f.write('\\ProvidesPackage{sphinxhighlight}'
+                    '[2016/05/29 stylesheet for highlighting with pygments]\n\n')
+            f.write(highlighter.get_stylesheet())
+
     def write(self, *ignored):
         docwriter = LaTeXWriter(self)
         docsettings = OptionParser(
@@ -100,6 +110,7 @@ class LaTeXBuilder(Builder):
             read_config_files=True).get_default_values()
 
         self.init_document_data()
+        self.write_stylesheet()
 
         for entry in self.document_data:
             docname, targetname, title, author, docclass = entry[:5]

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1024,3 +1024,6 @@
 \newcommand{\sphinxstyleliteralstrong}[1]{\textbf{\texttt{#1}}}
 \newcommand*{\sphinxstyleabbreviation}{\textsc}
 \newcommand*{\sphinxstyleliteralintitle}{\texttt}
+
+% stylesheet for highlighting with pygments
+\RequirePackage{sphinxhighlight}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -544,7 +544,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def astext(self):
         return (HEADER % self.elements +
-                self.highlighter.get_stylesheet() +
                 u''.join(self.body) +
                 '\n' + self.elements['footer'] + '\n' +
                 self.generate_indices() +


### PR DESCRIPTION
To improve readability of generated LaTeX source code, separate
stylesheets of pygments into independent .sty file.
