### PR TITLE
Now all builders and domains work as built-in extensions

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -32,9 +32,8 @@ from sphinx.roles import XRefRole
 from sphinx.config import Config
 from sphinx.errors import SphinxError, SphinxWarning, ExtensionError, \
     VersionRequirementError, ConfigError
-from sphinx.domains import ObjType, BUILTIN_DOMAINS
+from sphinx.domains import ObjType
 from sphinx.domains.std import GenericObject, Target, StandardDomain
-from sphinx.builders import BUILTIN_BUILDERS
 from sphinx.environment import BuildEnvironment
 from sphinx.io import SphinxStandaloneReader
 from sphinx.util import pycompat  # noqa: imported for side-effects
@@ -65,6 +64,31 @@ events = {
     'html-page-context': 'pagename, context, doctree or None',
     'build-finished': 'exception',
 }
+builtin_extensions = (
+    'sphinx.builders.applehelp',
+    'sphinx.builders.changes',
+    'sphinx.builders.epub',
+    'sphinx.builders.epub3',
+    'sphinx.builders.devhelp',
+    'sphinx.builders.dummy',
+    'sphinx.builders.gettext',
+    'sphinx.builders.html',
+    'sphinx.builders.htmlhelp',
+    'sphinx.builders.latex',
+    'sphinx.builders.linkcheck',
+    'sphinx.builders.manpage',
+    'sphinx.builders.qthelp',
+    'sphinx.builders.texinfo',
+    'sphinx.builders.text',
+    'sphinx.builders.websupport',
+    'sphinx.builders.xml',
+    'sphinx.domains.c',
+    'sphinx.domains.cpp',
+    'sphinx.domains.javascript',
+    'sphinx.domains.python',
+    'sphinx.domains.rst',
+    'sphinx.domains.std',
+)
 
 CONFIG_FILENAME = 'conf.py'
 ENV_PICKLE_FILENAME = 'environment.pickle'
@@ -87,9 +111,9 @@ class Sphinx(object):
         self._additional_source_parsers = {}
         self._listeners = {}
         self._setting_up_extension = ['?']
-        self.domains = BUILTIN_DOMAINS.copy()
+        self.domains = {}
         self.buildername = buildername
-        self.builderclasses = BUILTIN_BUILDERS.copy()
+        self.builderclasses = {}
         self.builder = None
         self.env = None
         self.enumerable_nodes = {}
@@ -151,6 +175,10 @@ class Sphinx(object):
         # of code expect a confdir to be set
         if self.confdir is None:
             self.confdir = self.srcdir
+
+        # load all built-in extension modules
+        for extension in builtin_extensions:
+            self.setup_extension(extension)
 
         # extension loading support for alabaster theme
         # self.config.html_theme is not set from conf.py at here
@@ -274,11 +302,6 @@ class Sphinx(object):
             raise SphinxError('Builder name %s not registered' % buildername)
 
         builderclass = self.builderclasses[buildername]
-        if isinstance(builderclass, tuple):
-            # builtin builder
-            mod, cls = builderclass
-            builderclass = getattr(
-                __import__('sphinx.builders.' + mod, None, None, [cls]), cls)
         self.builder = builderclass(self)
         self.emit('builder-inited')
 
@@ -570,13 +593,9 @@ class Sphinx(object):
             raise ExtensionError('Builder class %s has no "name" attribute'
                                  % builder)
         if builder.name in self.builderclasses:
-            if isinstance(self.builderclasses[builder.name], tuple):
-                raise ExtensionError('Builder %r is a builtin builder' %
-                                     builder.name)
-            else:
-                raise ExtensionError(
-                    'Builder %r already exists (in module %s)' % (
-                        builder.name, self.builderclasses[builder.name].__module__))
+            raise ExtensionError(
+                'Builder %r already exists (in module %s)' % (
+                    builder.name, self.builderclasses[builder.name].__module__))
         self.builderclasses[builder.name] = builder
 
     def add_config_value(self, name, default, rebuild, types=()):

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -451,29 +451,3 @@ class Builder(object):
         except AttributeError:
             optname = '%s_%s' % (default, option)
             return getattr(self.config, optname)
-
-BUILTIN_BUILDERS = {
-    'dummy':      ('dummy', 'DummyBuilder'),
-    'html':       ('html', 'StandaloneHTMLBuilder'),
-    'dirhtml':    ('html', 'DirectoryHTMLBuilder'),
-    'singlehtml': ('html', 'SingleFileHTMLBuilder'),
-    'pickle':     ('html', 'PickleHTMLBuilder'),
-    'json':       ('html', 'JSONHTMLBuilder'),
-    'web':        ('html', 'PickleHTMLBuilder'),
-    'htmlhelp':   ('htmlhelp', 'HTMLHelpBuilder'),
-    'devhelp':    ('devhelp', 'DevhelpBuilder'),
-    'qthelp':     ('qthelp', 'QtHelpBuilder'),
-    'applehelp':  ('applehelp', 'AppleHelpBuilder'),
-    'epub':       ('epub', 'EpubBuilder'),
-    'epub3':      ('epub3', 'Epub3Builder'),
-    'latex':      ('latex', 'LaTeXBuilder'),
-    'text':       ('text', 'TextBuilder'),
-    'man':        ('manpage', 'ManualPageBuilder'),
-    'texinfo':    ('texinfo', 'TexinfoBuilder'),
-    'changes':    ('changes', 'ChangesBuilder'),
-    'linkcheck':  ('linkcheck', 'CheckExternalLinksBuilder'),
-    'websupport': ('websupport', 'WebSupportBuilder'),
-    'gettext':    ('gettext', 'MessageCatalogBuilder'),
-    'xml':        ('xml', 'XMLBuilder'),
-    'pseudoxml':  ('xml', 'PseudoXMLBuilder'),
-}

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -13,11 +13,13 @@ from __future__ import print_function
 import codecs
 import pipes
 
-from os import path
+from os import path, environ
+import shlex
 
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.config import string_classes
 from sphinx.util import copy_static_entry
-from sphinx.util.osutil import copyfile, ensuredir
+from sphinx.util.osutil import copyfile, ensuredir, make_filename
 from sphinx.util.console import bold
 from sphinx.util.pycompat import htmlescape
 from sphinx.util.matching import compile_matchers
@@ -255,3 +257,35 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
                     raise AppleHelpCodeSigningFailed(output)
                 else:
                     self.info('done')
+
+
+def setup(app):
+    app.setup_extension('sphinx.builders.html')
+    app.add_builder(AppleHelpBuilder)
+
+    app.add_config_value('applehelp_bundle_name',
+                         lambda self: make_filename(self.project), 'applehelp')
+    app.add_config_value('applehelp_bundle_id', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_dev_region', 'en-us', 'applehelp')
+    app.add_config_value('applehelp_bundle_version', '1', 'applehelp')
+    app.add_config_value('applehelp_icon', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_kb_product',
+                         lambda self: '%s-%s' % (make_filename(self.project), self.release),
+                         'applehelp')
+    app.add_config_value('applehelp_kb_url', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_remote_url', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_index_anchors', False, 'applehelp', string_classes)
+    app.add_config_value('applehelp_min_term_length', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_stopwords',
+                         lambda self: self.language or 'en', 'applehelp')
+    app.add_config_value('applehelp_locale', lambda self: self.language or 'en', 'applehelp')
+    app.add_config_value('applehelp_title', lambda self: self.project + ' Help', 'applehelp')
+    app.add_config_value('applehelp_codesign_identity',
+                         lambda self: environ.get('CODE_SIGN_IDENTITY', None),
+                         'applehelp'),
+    app.add_config_value('applehelp_codesign_flags',
+                         lambda self: shlex.split(environ.get('OTHER_CODE_SIGN_FLAGS', '')),
+                         'applehelp'),
+    app.add_config_value('applehelp_indexer_path', '/usr/bin/hiutil', 'applehelp')
+    app.add_config_value('applehelp_codesign_path', '/usr/bin/codesign', 'applehelp')
+    app.add_config_value('applehelp_disable_external_tools', False, None)

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -154,3 +154,7 @@ class ChangesBuilder(Builder):
 
     def finish(self):
         pass
+
+
+def setup(app):
+    app.add_builder(ChangesBuilder)

--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -18,6 +18,7 @@ from os import path
 from docutils import nodes
 
 from sphinx import addnodes
+from sphinx.util.osutil import make_filename
 from sphinx.builders.html import StandaloneHTMLBuilder
 
 try:
@@ -130,3 +131,10 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
         # Dump the XML file
         with comp_open(path.join(outdir, outname + '.devhelp'), 'w') as f:
             tree.write(f, 'utf-8')
+
+
+def setup(app):
+    app.setup_extension('sphinx.builders.html')
+    app.add_builder(DevhelpBuilder)
+
+    app.add_config_value('devhelp_basename', lambda self: make_filename(self.project), None)

--- a/sphinx/builders/dummy.py
+++ b/sphinx/builders/dummy.py
@@ -34,3 +34,7 @@ class DummyBuilder(Builder):
 
     def finish(self):
         pass
+
+
+def setup(app):
+    app.add_builder(DummyBuilder)

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -29,7 +29,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.util.i18n import format_date
-from sphinx.util.osutil import ensuredir, copyfile, EEXIST
+from sphinx.util.osutil import ensuredir, copyfile, make_filename, EEXIST
 from sphinx.util.smartypants import sphinx_smarty_pants as ssp
 from sphinx.util.console import brown
 
@@ -761,3 +761,33 @@ class EpubBuilder(StandaloneHTMLBuilder):
             fp = path.join(outdir, file)
             epub.write(fp, file, zipfile.ZIP_DEFLATED)
         epub.close()
+
+
+def setup(app):
+    app.setup_extension('sphinx.builders.html')
+    app.add_builder(EpubBuilder)
+
+    # config values
+    app.add_config_value('epub_basename', lambda self: make_filename(self.project), None)
+    app.add_config_value('epub_theme', 'epub', 'html')
+    app.add_config_value('epub_theme_options', {}, 'html')
+    app.add_config_value('epub_title', lambda self: self.html_title, 'html')
+    app.add_config_value('epub_author', 'unknown', 'html')
+    app.add_config_value('epub_language', lambda self: self.language or 'en', 'html')
+    app.add_config_value('epub_publisher', 'unknown', 'html')
+    app.add_config_value('epub_copyright', lambda self: self.copyright, 'html')
+    app.add_config_value('epub_identifier', 'unknown', 'html')
+    app.add_config_value('epub_scheme', 'unknown', 'html')
+    app.add_config_value('epub_uid', 'unknown', 'env')
+    app.add_config_value('epub_cover', (), 'env')
+    app.add_config_value('epub_guide', (), 'env')
+    app.add_config_value('epub_pre_files', [], 'env')
+    app.add_config_value('epub_post_files', [], 'env')
+    app.add_config_value('epub_exclude_files', [], 'env')
+    app.add_config_value('epub_tocdepth', 3, 'env')
+    app.add_config_value('epub_tocdup', True, 'env')
+    app.add_config_value('epub_tocscope', 'default', 'env')
+    app.add_config_value('epub_fix_images', False, 'env')
+    app.add_config_value('epub_max_image_width', 0, 'env')
+    app.add_config_value('epub_show_urls', 'inline', 'html')
+    app.add_config_value('epub_use_index', lambda self: self.html_use_index, 'html')

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -13,6 +13,7 @@
 import codecs
 from os import path
 
+from sphinx.config import string_classes
 from sphinx.builders.epub import EpubBuilder
 
 
@@ -209,3 +210,12 @@ class Epub3Builder(EpubBuilder):
 
         # Add nav.xhtml to epub file
         self.files.append(outname)
+
+
+def setup(app):
+    app.setup_extension('sphinx.builders.epub')
+    app.add_builder(Epub3Builder)
+
+    app.add_config_value('epub3_description', '', 'epub3', string_classes)
+    app.add_config_value('epub3_contributor', 'unknown', 'epub3', string_classes)
+    app.add_config_value('epub3_page_progression_direction', 'ltr', 'epub3', string_classes)

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -233,3 +233,13 @@ class MessageCatalogBuilder(I18nBuilder):
                         replace('"', r'\"'). \
                         replace('\n', '\\n"\n"')
                     pofile.write('msgid "%s"\nmsgstr ""\n\n' % message)
+
+
+def setup(app):
+    app.add_builder(MessageCatalogBuilder)
+
+    app.add_config_value('gettext_compact', True, 'gettext')
+    app.add_config_value('gettext_location', True, 'gettext')
+    app.add_config_value('gettext_uuid', False, 'gettext')
+    app.add_config_value('gettext_auto_build', True, 'env')
+    app.add_config_value('gettext_additional_targets', [], 'env')

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -33,7 +33,8 @@ from sphinx.util.osutil import SEP, os_path, relative_uri, ensuredir, \
     movefile, copyfile
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.matching import patmatch, compile_matchers
-from sphinx.locale import _
+from sphinx.config import string_classes
+from sphinx.locale import _, l_
 from sphinx.search import js_index
 from sphinx.theming import Theme
 from sphinx.builders import Builder
@@ -1160,3 +1161,52 @@ class JSONHTMLBuilder(SerializingHTMLBuilder):
 
     def init(self):
         SerializingHTMLBuilder.init(self)
+
+
+def setup(app):
+    # builders
+    app.add_builder(StandaloneHTMLBuilder)
+    app.add_builder(DirectoryHTMLBuilder)
+    app.add_builder(SingleFileHTMLBuilder)
+    app.add_builder(PickleHTMLBuilder)
+    app.add_builder(JSONHTMLBuilder)
+
+    # config values
+    app.add_config_value('html_theme', 'alabaster', 'html')
+    app.add_config_value('html_theme_path', [], 'html')
+    app.add_config_value('html_theme_options', {}, 'html')
+    app.add_config_value('html_title',
+                         lambda self: l_('%s %s documentation') % (self.project, self.release),
+                         'html', string_classes)
+    app.add_config_value('html_short_title', lambda self: self.html_title, 'html')
+    app.add_config_value('html_style', None, 'html', string_classes)
+    app.add_config_value('html_logo', None, 'html', string_classes)
+    app.add_config_value('html_favicon', None, 'html', string_classes)
+    app.add_config_value('html_static_path', [], 'html')
+    app.add_config_value('html_extra_path', [], 'html')
+    app.add_config_value('html_last_updated_fmt', None, 'html', string_classes)
+    app.add_config_value('html_use_smartypants', True, 'html')
+    app.add_config_value('html_translator_class', None, 'html', string_classes)
+    app.add_config_value('html_sidebars', {}, 'html')
+    app.add_config_value('html_additional_pages', {}, 'html')
+    app.add_config_value('html_use_modindex', True, 'html')  # deprecated
+    app.add_config_value('html_domain_indices', True, 'html', [list])
+    app.add_config_value('html_add_permalinks', u'\u00B6', 'html')
+    app.add_config_value('html_use_index', True, 'html')
+    app.add_config_value('html_split_index', False, 'html')
+    app.add_config_value('html_copy_source', True, 'html')
+    app.add_config_value('html_show_sourcelink', True, 'html')
+    app.add_config_value('html_sourcelink_suffix', '.txt', 'html')
+    app.add_config_value('html_use_opensearch', '', 'html')
+    app.add_config_value('html_file_suffix', None, 'html', string_classes)
+    app.add_config_value('html_link_suffix', None, 'html', string_classes)
+    app.add_config_value('html_show_copyright', True, 'html')
+    app.add_config_value('html_show_sphinx', True, 'html')
+    app.add_config_value('html_context', {}, 'html')
+    app.add_config_value('html_output_encoding', 'utf-8', 'html')
+    app.add_config_value('html_compact_lists', True, 'html')
+    app.add_config_value('html_secnumber_suffix', '. ', 'html')
+    app.add_config_value('html_search_language', None, 'html', string_classes)
+    app.add_config_value('html_search_options', {}, 'html')
+    app.add_config_value('html_search_scorer', '', None)
+    app.add_config_value('html_scaled_image_link', True, 'html')

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -18,6 +18,7 @@ from os import path
 from docutils import nodes
 
 from sphinx import addnodes
+from sphinx.util.osutil import make_filename
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.util.pycompat import htmlescape
 
@@ -296,3 +297,10 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                 for title, (refs, subitems, key_) in group:
                     write_index(title, refs, subitems)
             f.write('</UL>\n')
+
+
+def setup(app):
+    app.setup_extension('sphinx.builders.html')
+    app.add_builder(HTMLHelpBuilder)
+
+    app.add_config_value('htmlhelp_basename', lambda self: make_filename(self.project), None)

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -21,12 +21,13 @@ from docutils.frontend import OptionParser
 
 from sphinx import package_dir, addnodes, highlighting
 from sphinx.util import texescape
+from sphinx.config import string_classes
 from sphinx.errors import SphinxError
 from sphinx.locale import _
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
 from sphinx.util.nodes import inline_all_toctrees
-from sphinx.util.osutil import SEP, copyfile
+from sphinx.util.osutil import SEP, copyfile, make_filename
 from sphinx.util.console import bold, darkgreen
 from sphinx.writers.latex import LaTeXWriter
 
@@ -233,3 +234,31 @@ class LaTeXBuilder(Builder):
             elif not path.isfile(logotarget):
                 copyfile(path.join(self.confdir, self.config.latex_logo), logotarget)
         self.info('done')
+
+
+def setup(app):
+    app.add_builder(LaTeXBuilder)
+
+    app.add_config_value('latex_documents',
+                         lambda self: [(self.master_doc, make_filename(self.project) + '.tex',
+                                        self.project, '', 'manual')],
+                         None)
+    app.add_config_value('latex_logo', None, None, string_classes)
+    app.add_config_value('latex_appendices', [], None)
+    app.add_config_value('latex_keep_old_macro_names', True, None)
+    # now deprecated - use latex_toplevel_sectioning
+    app.add_config_value('latex_use_parts', False, None)
+    app.add_config_value('latex_toplevel_sectioning', None, None, [str])
+    app.add_config_value('latex_use_modindex', True, None)  # deprecated
+    app.add_config_value('latex_domain_indices', True, None, [list])
+    app.add_config_value('latex_show_urls', 'no', None)
+    app.add_config_value('latex_show_pagerefs', False, None)
+    # paper_size and font_size are still separate values
+    # so that you can give them easily on the command line
+    app.add_config_value('latex_paper_size', 'letter', None)
+    app.add_config_value('latex_font_size', '10pt', None)
+    app.add_config_value('latex_elements', {}, None)
+    app.add_config_value('latex_additional_files', [], None)
+    app.add_config_value('latex_docclass', {}, None)
+    # now deprecated - use latex_elements
+    app.add_config_value('latex_preamble', '', None)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -300,3 +300,13 @@ class CheckExternalLinksBuilder(Builder):
     def finish(self):
         for worker in self.workers:
             self.wqueue.put((None, None, None), False)
+
+
+def setup(app):
+    app.add_builder(CheckExternalLinksBuilder)
+
+    app.add_config_value('linkcheck_ignore', [], None)
+    app.add_config_value('linkcheck_retries', 1, None)
+    app.add_config_value('linkcheck_timeout', None, None, [int])
+    app.add_config_value('linkcheck_workers', 5, None)
+    app.add_config_value('linkcheck_anchors', True, None)

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -19,6 +19,7 @@ from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
 from sphinx.util.nodes import inline_all_toctrees
+from sphinx.util.osutil import make_filename
 from sphinx.util.console import bold, darkgreen
 from sphinx.writers.manpage import ManualPageWriter
 
@@ -88,3 +89,13 @@ class ManualPageBuilder(Builder):
 
     def finish(self):
         pass
+
+
+def setup(app):
+    app.add_builder(ManualPageBuilder)
+
+    app.add_config_value('man_pages',
+                         lambda self: [(self.master_doc, make_filename(self.project).lower(),
+                                        '%s %s' % (self.project, self.release), [], 1)],
+                         None)
+    app.add_config_value('man_show_urls', False, None)

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -21,6 +21,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.util import force_decode
+from sphinx.util.osutil import make_filename
 from sphinx.util.pycompat import htmlescape
 
 
@@ -291,3 +292,10 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
                 keywords.extend(self.build_keywords(subitem[0], subitem[1], []))
 
         return keywords
+
+
+def setup(app):
+    app.setup_extension('sphinx.builders.html')
+    app.add_builder(QtHelpBuilder)
+
+    app.add_config_value('qthelp_basename', lambda self: make_filename(self.project), None)

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -22,7 +22,7 @@ from sphinx.locale import _
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
 from sphinx.util.nodes import inline_all_toctrees
-from sphinx.util.osutil import SEP, copyfile
+from sphinx.util.osutil import SEP, copyfile, make_filename
 from sphinx.util.console import bold, darkgreen
 from sphinx.writers.texinfo import TexinfoWriter
 
@@ -225,3 +225,20 @@ class TexinfoBuilder(Builder):
         except (IOError, OSError) as err:
             self.warn("error writing file %s: %s" % (fn, err))
         self.info(' done')
+
+
+def setup(app):
+    app.add_builder(TexinfoBuilder)
+
+    app.add_config_value('texinfo_documents',
+                         lambda self: [(self.master_doc, make_filename(self.project).lower(),
+                                        self.project, '', make_filename(self.project),
+                                        'The %s reference manual.' %
+                                        make_filename(self.project),
+                                        'Python')],
+                         None)
+    app.add_config_value('texinfo_appendices', [], None)
+    app.add_config_value('texinfo_elements', {}, None)
+    app.add_config_value('texinfo_domain_indices', True, None, [list])
+    app.add_config_value('texinfo_show_urls', 'footnote', None)
+    app.add_config_value('texinfo_no_detailmenu', False, None)

--- a/sphinx/builders/text.py
+++ b/sphinx/builders/text.py
@@ -67,3 +67,10 @@ class TextBuilder(Builder):
 
     def finish(self):
         pass
+
+
+def setup(app):
+    app.add_builder(TextBuilder)
+
+    app.add_config_value('text_sectionchars', '*=-~"+`', 'env')
+    app.add_config_value('text_newlines', 'unix', 'env')

--- a/sphinx/builders/websupport.py
+++ b/sphinx/builders/websupport.py
@@ -165,3 +165,7 @@ class WebSupportBuilder(PickleHTMLBuilder):
 
     def dump_search_index(self):
         self.indexer.finish_indexing()
+
+
+def setup(app):
+    app.add_builder(WebSupportBuilder)

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -95,3 +95,10 @@ class PseudoXMLBuilder(XMLBuilder):
     out_suffix = '.pseudoxml'
 
     _writer_class = PseudoXMLWriter
+
+
+def setup(app):
+    app.add_builder(XMLBuilder)
+    app.add_builder(PseudoXMLBuilder)
+
+    app.add_config_value('xml_pretty', True, 'env')

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -10,14 +10,13 @@
 """
 
 import re
-from os import path, environ, getenv
-import shlex
+from os import path, getenv
 
 from six import PY2, PY3, iteritems, string_types, binary_type, text_type, integer_types
 
 from sphinx.errors import ConfigError
 from sphinx.locale import l_
-from sphinx.util.osutil import make_filename, cd
+from sphinx.util.osutil import cd
 from sphinx.util.pycompat import execfile_, NoneType
 from sphinx.util.i18n import format_date
 
@@ -94,183 +93,6 @@ class Config(object):
                           'table': l_('Table %s'),
                           'code-block': l_('Listing %s')},
                          'env'),
-
-        # HTML options
-        html_theme = ('alabaster', 'html'),
-        html_theme_path = ([], 'html'),
-        html_theme_options = ({}, 'html'),
-        html_title = (lambda self: l_('%s %s documentation') %
-                      (self.project, self.release),
-                      'html', string_classes),
-        html_short_title = (lambda self: self.html_title, 'html'),
-        html_style = (None, 'html', string_classes),
-        html_logo = (None, 'html', string_classes),
-        html_favicon = (None, 'html', string_classes),
-        html_static_path = ([], 'html'),
-        html_extra_path = ([], 'html'),
-        # the real default is locale-dependent
-        html_last_updated_fmt = (None, 'html', string_classes),
-        html_use_smartypants = (True, 'html'),
-        html_translator_class = (None, 'html', string_classes),
-        html_sidebars = ({}, 'html'),
-        html_additional_pages = ({}, 'html'),
-        html_use_modindex = (True, 'html'),  # deprecated
-        html_domain_indices = (True, 'html', [list]),
-        html_add_permalinks = (u'\u00B6', 'html'),
-        html_use_index = (True, 'html'),
-        html_split_index = (False, 'html'),
-        html_copy_source = (True, 'html'),
-        html_show_sourcelink = (True, 'html'),
-        html_sourcelink_suffix = ('.txt', 'html'),
-        html_use_opensearch = ('', 'html'),
-        html_file_suffix = (None, 'html', string_classes),
-        html_link_suffix = (None, 'html', string_classes),
-        html_show_copyright = (True, 'html'),
-        html_show_sphinx = (True, 'html'),
-        html_context = ({}, 'html'),
-        html_output_encoding = ('utf-8', 'html'),
-        html_compact_lists = (True, 'html'),
-        html_secnumber_suffix = ('. ', 'html'),
-        html_search_language = (None, 'html', string_classes),
-        html_search_options = ({}, 'html'),
-        html_search_scorer = ('', None),
-        html_scaled_image_link = (True, 'html'),
-
-        # HTML help only options
-        htmlhelp_basename = (lambda self: make_filename(self.project), None),
-
-        # Qt help only options
-        qthelp_basename = (lambda self: make_filename(self.project), None),
-
-        # Devhelp only options
-        devhelp_basename = (lambda self: make_filename(self.project), None),
-
-        # Apple help options
-        applehelp_bundle_name = (lambda self: make_filename(self.project),
-                                 'applehelp'),
-        applehelp_bundle_id = (None, 'applehelp', string_classes),
-        applehelp_dev_region = ('en-us', 'applehelp'),
-        applehelp_bundle_version = ('1', 'applehelp'),
-        applehelp_icon = (None, 'applehelp', string_classes),
-        applehelp_kb_product = (lambda self: '%s-%s' %
-                                (make_filename(self.project), self.release),
-                                'applehelp'),
-        applehelp_kb_url = (None, 'applehelp', string_classes),
-        applehelp_remote_url = (None, 'applehelp', string_classes),
-        applehelp_index_anchors = (False, 'applehelp', string_classes),
-        applehelp_min_term_length = (None, 'applehelp', string_classes),
-        applehelp_stopwords = (lambda self: self.language or 'en', 'applehelp'),
-        applehelp_locale = (lambda self: self.language or 'en', 'applehelp'),
-        applehelp_title = (lambda self: self.project + ' Help', 'applehelp'),
-        applehelp_codesign_identity = (lambda self:
-                                       environ.get('CODE_SIGN_IDENTITY', None),
-                                       'applehelp'),
-        applehelp_codesign_flags = (lambda self:
-                                    shlex.split(
-                                        environ.get('OTHER_CODE_SIGN_FLAGS',
-                                                    '')),
-                                    'applehelp'),
-        applehelp_indexer_path = ('/usr/bin/hiutil', 'applehelp'),
-        applehelp_codesign_path = ('/usr/bin/codesign', 'applehelp'),
-        applehelp_disable_external_tools = (False, None),
-
-        # Epub options
-        epub_basename = (lambda self: make_filename(self.project), None),
-        epub_theme = ('epub', 'html'),
-        epub_theme_options = ({}, 'html'),
-        epub_title = (lambda self: self.html_title, 'html'),
-        epub3_description = ('', 'epub3', string_classes),
-        epub_author = ('unknown', 'html'),
-        epub3_contributor = ('unknown', 'epub3', string_classes),
-        epub_language = (lambda self: self.language or 'en', 'html'),
-        epub_publisher = ('unknown', 'html'),
-        epub_copyright = (lambda self: self.copyright, 'html'),
-        epub_identifier = ('unknown', 'html'),
-        epub_scheme = ('unknown', 'html'),
-        epub_uid = ('unknown', 'env'),
-        epub_cover = ((), 'env'),
-        epub_guide = ((), 'env'),
-        epub_pre_files = ([], 'env'),
-        epub_post_files = ([], 'env'),
-        epub_exclude_files = ([], 'env'),
-        epub_tocdepth = (3, 'env'),
-        epub_tocdup = (True, 'env'),
-        epub_tocscope = ('default', 'env'),
-        epub_fix_images = (False, 'env'),
-        epub_max_image_width = (0, 'env'),
-        epub_show_urls = ('inline', 'html'),
-        epub_use_index = (lambda self: self.html_use_index, 'html'),
-        epub3_page_progression_direction = ('ltr', 'epub3', string_classes),
-
-        # LaTeX options
-        latex_documents = (lambda self: [(self.master_doc,
-                                          make_filename(self.project) + '.tex',
-                                          self.project,
-                                          '', 'manual')],
-                           None),
-        latex_logo = (None, None, string_classes),
-        latex_appendices = ([], None),
-        latex_keep_old_macro_names = (True, None),
-        # now deprecated - use latex_toplevel_sectioning
-        latex_use_parts = (False, None),
-        latex_toplevel_sectioning = (None, None, [str]),
-        latex_use_modindex = (True, None),  # deprecated
-        latex_domain_indices = (True, None, [list]),
-        latex_show_urls = ('no', None),
-        latex_show_pagerefs = (False, None),
-        # paper_size and font_size are still separate values
-        # so that you can give them easily on the command line
-        latex_paper_size = ('letter', None),
-        latex_font_size = ('10pt', None),
-        latex_elements = ({}, None),
-        latex_additional_files = ([], None),
-        latex_docclass = ({}, None),
-        # now deprecated - use latex_elements
-        latex_preamble = ('', None),
-
-        # text options
-        text_sectionchars = ('*=-~"+`', 'env'),
-        text_newlines = ('unix', 'env'),
-
-        # manpage options
-        man_pages = (lambda self: [(self.master_doc,
-                                    make_filename(self.project).lower(),
-                                    '%s %s' % (self.project, self.release),
-                                    [], 1)],
-                     None),
-        man_show_urls = (False, None),
-
-        # Texinfo options
-        texinfo_documents = (lambda self: [(self.master_doc,
-                                            make_filename(self.project).lower(),
-                                            self.project, '',
-                                            make_filename(self.project),
-                                            'The %s reference manual.' %
-                                            make_filename(self.project),
-                                            'Python')],
-                             None),
-        texinfo_appendices = ([], None),
-        texinfo_elements = ({}, None),
-        texinfo_domain_indices = (True, None, [list]),
-        texinfo_show_urls = ('footnote', None),
-        texinfo_no_detailmenu = (False, None),
-
-        # linkcheck options
-        linkcheck_ignore = ([], None),
-        linkcheck_retries = (1, None),
-        linkcheck_timeout = (None, None, [int]),
-        linkcheck_workers = (5, None),
-        linkcheck_anchors = (True, None),
-
-        # gettext options
-        gettext_compact = (True, 'gettext'),
-        gettext_location = (True, 'gettext'),
-        gettext_uuid = (False, 'gettext'),
-        gettext_auto_build = (True, 'env'),
-        gettext_additional_targets = ([], 'env'),
-
-        # XML options
-        xml_pretty = (True, 'env'),
     )
 
     def __init__(self, dirname, filename, overrides, tags):

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -273,20 +273,3 @@ class Domain(object):
         if primary:
             return type.lname
         return _('%s %s') % (self.label, type.lname)
-
-
-from sphinx.domains.c import CDomain                     # noqa
-from sphinx.domains.cpp import CPPDomain                 # noqa
-from sphinx.domains.std import StandardDomain            # noqa
-from sphinx.domains.python import PythonDomain           # noqa
-from sphinx.domains.javascript import JavaScriptDomain   # noqa
-from sphinx.domains.rst import ReSTDomain                # noqa
-
-BUILTIN_DOMAINS = {
-    'std': StandardDomain,
-    'py': PythonDomain,
-    'c': CDomain,
-    'cpp': CPPDomain,
-    'js': JavaScriptDomain,
-    'rst': ReSTDomain,
-}

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -302,3 +302,7 @@ class CDomain(Domain):
     def get_objects(self):
         for refname, (docname, type) in list(self.data['objects'].items()):
             yield (refname, refname, type, docname, 'c.' + refname, 1)
+
+
+def setup(app):
+    app.add_domain(CDomain)

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4185,3 +4185,7 @@ class CPPDomain(Domain):
             docname = symbol.docname
             newestId = symbol.declaration.get_newest_id()
             yield (name, name, objectType, docname, newestId, 1)
+
+
+def setup(app):
+    app.add_domain(CPPDomain)

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -234,3 +234,7 @@ class JavaScriptDomain(Domain):
         for refname, (docname, type) in list(self.data['objects'].items()):
             yield refname, refname, type, docname, \
                 refname.replace('$', '_S_'), 1
+
+
+def setup(app):
+    app.add_domain(JavaScriptDomain)

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -771,3 +771,7 @@ class PythonDomain(Domain):
         for refname, (docname, type) in iteritems(self.data['objects']):
             if type != 'module':  # modules are already handled
                 yield (refname, refname, type, docname, refname, 1)
+
+
+def setup(app):
+    app.add_domain(PythonDomain)

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -156,3 +156,7 @@ class ReSTDomain(Domain):
     def get_objects(self):
         for (typ, name), docname in iteritems(self.data['objects']):
             yield name, name, typ, docname, typ + '-' + name, 1
+
+
+def setup(app):
+    app.add_domain(ReSTDomain)

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -767,3 +767,7 @@ class StandardDomain(Domain):
         else:
             figtype, _ = self.enumerable_nodes.get(node.__class__, (None, None))
             return figtype
+
+
+def setup(app):
+    app.add_domain(StandardDomain)


### PR DESCRIPTION
I removed all special treatment for built in builders and domains from `sphinx.applciation` and `sphinx.config`.
I think this is a first step to refactor of sphinx-core.

What do you think?
