### PR TITLE
``sphinx.util.osutil.filecopy()`` skips copying if the file has not been changed (ref: #2510, #2753)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Incompatible changes
   ``index.rst.txt``).
 * ``sphinx.util.copy_static_entry()`` is now deprecated.
   Use ``sphinx.util.fileutil.copy_asset()`` instead.
+* ``sphinx.util.osutil.filecopy()`` skips copying if the file has not been changed
+  (ref: #2510, #2753)
 
 
 Features added

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -17,6 +17,7 @@ import time
 import errno
 import locale
 import shutil
+import filecmp
 from os import path
 import contextlib
 
@@ -141,13 +142,16 @@ def copytimes(source, dest):
 
 
 def copyfile(source, dest):
-    """Copy a file and its modification times, if possible."""
-    shutil.copyfile(source, dest)
-    try:
-        # don't do full copystat because the source may be read-only
-        copytimes(source, dest)
-    except OSError:
-        pass
+    """Copy a file and its modification times, if possible.
+
+    Note: ``copyfile`` skips copying if the file has not been changed"""
+    if not path.exists(dest) or not filecmp.cmp(source, dest):
+        shutil.copyfile(source, dest)
+        try:
+            # don't do full copystat because the source may be read-only
+            copytimes(source, dest)
+        except OSError:
+            pass
 
 
 no_fn_re = re.compile(r'[^a-zA-Z0-9_-]')


### PR DESCRIPTION
This PR modifies `filecopy()`; the basic copy utility. So this change effects the many file copying work in sphinx.
So please review this before merging.

ref: #2510, #2753 
