### PR TITLE
Make javascript search work in python 3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ Features added
 Bugs fixed
 ----------
 
+* jsdump fix for python 3: fixes the HTML search on python > 3
 * #2676: (latex) Error with verbatim text in captions since Sphinx 1.4.4
 * #2629: memoir class crashes LaTeX. Fixed ``by latex_keep_old_macro_names=False`` (ref 2675)
 * #2684: `sphinx.ext.intersphinx` crashes with six-1.4.1

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -19,7 +19,7 @@ from sphinx.util.pycompat import u
 _str_re  = re.compile(r'"(\\\\|\\"|[^"])*"')
 _int_re  = re.compile(r'\d+')
 _name_re = re.compile(r'[a-zA-Z]\w*')
-_nameonly_re = re.compile(r'[a-zA-Z]\w*$')
+_nameonly_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*$')
 
 # escape \, ", control characters and everything outside ASCII
 ESCAPE_ASCII = re.compile(r'([\\"]|[^\ -~])')

--- a/tests/test_util_jsdump.py
+++ b/tests/test_util_jsdump.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+def test_jsdump():
+    from sphinx.util.jsdump import dumps
+
+    assert dumps({'1a': 1}) == '{"1a":1}'
+    assert dumps({'a1': 1}) == '{a1:1}'
+
+    assert dumps({u'a\xe8': 1}) == '{"a\\u00e8":1}'


### PR DESCRIPTION
The meaning of `\w` changed from python 2 to python 3.

> $ python3.5 -c "import re; print(re.compile(r'[a-zA-Z]\w*$').match(u'a\xe8'));"
> <_sre.SRE_Match object; span=(0, 2), match='aè'>
> 
> python -c "import re; print(re.compile(r'[a-zA-Z]\w*$').match(u'a\xe8'));"
> None

but the definition of what's an acceptable javascript identifier should not vary from case to case.
