### PR TITLE
Add default alt attribute for img tags in SVG format.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,7 +47,8 @@ Bugs fixed
 * #2723: extra spaces in latex pdf output from multirow cell
 * #2735: latexpdf ``Underfull \hbox (badness 10000)`` warnings from title page
 * #2667: latex crashes if resized images appeared in section title
-
+* #2763: (html) Provide default value for required ``alt`` attribute for image
+  tags of SVG source, required to validate and now consistent w/ other formats.
 
 Release 1.4.4 (released Jun 12, 2016)
 =====================================

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -458,15 +458,14 @@ class HTMLTranslator(BaseTranslator):
             node['uri'] = posixpath.join(self.builder.imgpath,
                                          self.builder.images[olduri])
 
-        if node['uri'].lower().endswith('svg') or \
-           node['uri'].lower().endswith('svgz'):
-            atts = {'src': node['uri']}
+        uri = node['uri']
+        if uri.lower().endswith('svg') or uri.lower().endswith('svgz'):
+            atts = {'src': uri}
             if 'width' in node:
                 atts['width'] = node['width']
             if 'height' in node:
                 atts['height'] = node['height']
-            if 'alt' in node:
-                atts['alt'] = node['alt']
+            atts['alt'] = node.get('alt', uri)
             if 'align' in node:
                 self.body.append('<div align="%s" class="align-%s">' %
                                  (node['align'], node['align']))


### PR DESCRIPTION
Fix #2763
