### PR TITLE
better default LaTeX settings for Japanese

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,9 @@ Incompatible changes
   to improve readability.
 * latex: To provide good default settings to Japanese docs, Sphinx uses ``jsbooks``
   as a docclass by default if the `language` is ``ja``.
+* latex: To provide good default settings to Japanese docs, Sphinx uses
+  ``jreport`` and ``jsbooks`` as a docclass by default if the `language` is
+  ``ja``.
 
 
 Features added

--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,9 @@ Incompatible changes
 * QtHelpBuilder doens't generate search page (ref: #2352)
 * QtHelpBuilder uses ``nonav`` theme instead of default one
   to improve readability.
+* latex: To provide good default settings to Japanese docs, Sphinx uses ``jsbooks``
+  as a docclass by default if the `language` is ``ja``.
+
 
 Features added
 --------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1711,7 +1711,8 @@ These options influence LaTeX output. See further :doc:`latex`.
 
    .. versionchanged:: 1.5
 
-      In Japanese docs, ``'jsbooks'`` is used to manual by default
+      In Japanese docs(`language` is ``ja``), ``'jreport'`` is used for
+      ``'howto'`` and ``'jsbooks'`` is used for ``'manual'`` by default.
 
 .. confval:: latex_additional_files
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1709,6 +1709,10 @@ These options influence LaTeX output. See further :doc:`latex`.
 
    .. versionadded:: 1.0
 
+   .. versionchanged:: 1.5
+
+      In Japanese docs, ``'jsbooks'`` is used to manual by default
+
 .. confval:: latex_additional_files
 
    A list of file names, relative to the configuration directory, to copy to the

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -284,8 +284,11 @@ def setup(app):
     app.add_config_value('latex_font_size', '10pt', None)
     app.add_config_value('latex_elements', {}, None)
     app.add_config_value('latex_additional_files', [], None)
+
+    japanese_default = {'manual': 'jsbook',
+                        'howto': 'jreport'}
     app.add_config_value('latex_docclass',
-                         lambda self: {'manual': 'jsbook'} if self.language == 'ja' else {},
+                         lambda self: japanese_default if self.language == 'ja' else {},
                          None)
     # now deprecated - use latex_elements
     app.add_config_value('latex_preamble', '', None)

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -284,6 +284,8 @@ def setup(app):
     app.add_config_value('latex_font_size', '10pt', None)
     app.add_config_value('latex_elements', {}, None)
     app.add_config_value('latex_additional_files', [], None)
-    app.add_config_value('latex_docclass', {}, None)
+    app.add_config_value('latex_docclass',
+                         lambda self: {'manual': 'jsbook'} if self.language == 'ja' else {},
+                         None)
     # now deprecated - use latex_elements
     app.add_config_value('latex_preamble', '', None)


### PR DESCRIPTION
At this moment, Japanese users have to set the `latex_docclass` manually to build their LaTeX docs.

This changes the default settings of `latex_docclass` to `jsbooks` (if `language` is `ja`).
This is introduced at sphinx-users.jp. So it is usually used for Japanese docs. I believe this is good default settings for all Japanese users.
(ref: http://sphinx-users.jp/cookbook/pdf/latex.html (in Japanese))
