### PR TITLE
fix inspect: return defargs[0] if obj.__dict__ is a property and raises exception

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -110,12 +110,23 @@ def safe_getattr(obj, name, *defargs):
     except Exception:
         # sometimes accessing a property raises an exception (e.g.
         # NotImplementedError), so let's try to read the attribute directly
-        if name in obj.__dict__:
+
+        # We should also be aware that if `__dict__` has been overridden,
+        # this may also raise an exception.
+
+        try:
+            obj_dict = obj.__dict__
+        except Exception as exc:
+            obj_dict = {}
+
+        if name in obj_dict:
             return obj.__dict__[name]
+
         # this is a catch-all for all the weird things that some modules do
         # with attribute access
         if defargs:
             return defargs[0]
+
         raise AttributeError(name)
 
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -110,19 +110,12 @@ def safe_getattr(obj, name, *defargs):
     except Exception:
         # sometimes accessing a property raises an exception (e.g.
         # NotImplementedError), so let's try to read the attribute directly
-
         try:
             # In case the object does weird things with attribute access
             # such that accessing `obj.__dict__` may raise an exception
-            obj_dict = obj.__dict__
+            return obj.__dict__[name]
         except Exception:
-            # This is a broad `except` clause, but we're being specific about
-            # where we catch it
             pass
-        else:
-            # We don't want to catch any exceptions here
-            if name in obj_dict:
-                return obj_dict[name]
 
         # this is a catch-all for all the weird things that some modules do
         # with attribute access

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -111,16 +111,18 @@ def safe_getattr(obj, name, *defargs):
         # sometimes accessing a property raises an exception (e.g.
         # NotImplementedError), so let's try to read the attribute directly
 
-        # We should also be aware that if `__dict__` has been overridden,
-        # this may also raise an exception.
-
         try:
+            # In case the object does weird things with attribute access
+            # such that accessing `obj.__dict__` may raise an exception
             obj_dict = obj.__dict__
         except Exception:
-            obj_dict = {}
-
-        if name in obj_dict:
-            return obj.__dict__[name]
+            # This is a broad `except` clause, but we're being specific about
+            # where we catch it
+            pass
+        else:
+            # We don't want to catch any exceptions here
+            if name in obj_dict:
+                return obj_dict[name]
 
         # this is a catch-all for all the weird things that some modules do
         # with attribute access

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -116,7 +116,7 @@ def safe_getattr(obj, name, *defargs):
 
         try:
             obj_dict = obj.__dict__
-        except Exception as exc:
+        except Exception:
             obj_dict = {}
 
         if name in obj_dict:

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+    test_util_inspect
+    ~~~~~~~~~~~~~~~
+
+    Tests util.inspect functions.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+from unittest import TestCase
+
+from sphinx.util import inspect
+
+
+class TestSafeGetAttr(TestCase):
+    def test_safe_getattr_with_default(self):
+        class Foo(object):
+            def __getattr__(self, item):
+                raise Exception
+
+        obj = Foo()
+
+        result = inspect.safe_getattr(obj, 'bar', 'baz')
+
+        assert result == 'baz'
+
+    def test_safe_getattr_with_exception(self):
+        class Foo(object):
+            def __getattr__(self, item):
+                raise Exception
+
+        obj = Foo()
+
+        with self.assertRaisesRegexp(AttributeError, 'bar'):
+            inspect.safe_getattr(obj, 'bar')
+
+    def test_safe_getattr_with_property_exception(self):
+        class Foo(object):
+            @property
+            def bar(self):
+                raise Exception
+
+        obj = Foo()
+
+        with self.assertRaisesRegexp(AttributeError, 'bar'):
+            inspect.safe_getattr(obj, 'bar')
+
+    def test_safe_getattr_with___dict___override(self):
+        class Foo(object):
+            @property
+            def __dict__(self):
+                raise Exception
+
+        obj = Foo()
+
+        with self.assertRaisesRegexp(AttributeError, 'bar'):
+            inspect.safe_getattr(obj, 'bar')

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -32,8 +32,12 @@ class TestSafeGetAttr(TestCase):
 
         obj = Foo()
 
-        with self.assertRaisesRegexp(AttributeError, 'bar'):
+        try:
             inspect.safe_getattr(obj, 'bar')
+        except AttributeError as exc:
+            self.assertEqual(exc.args[0], 'bar')
+        else:
+            self.fail('AttributeError not raised')
 
     def test_safe_getattr_with_property_exception(self):
         class Foo(object):
@@ -43,8 +47,12 @@ class TestSafeGetAttr(TestCase):
 
         obj = Foo()
 
-        with self.assertRaisesRegexp(AttributeError, 'bar'):
+        try:
             inspect.safe_getattr(obj, 'bar')
+        except AttributeError as exc:
+            self.assertEqual(exc.args[0], 'bar')
+        else:
+            self.fail('AttributeError not raised')
 
     def test_safe_getattr_with___dict___override(self):
         class Foo(object):
@@ -54,5 +62,9 @@ class TestSafeGetAttr(TestCase):
 
         obj = Foo()
 
-        with self.assertRaisesRegexp(AttributeError, 'bar'):
+        try:
             inspect.safe_getattr(obj, 'bar')
+        except AttributeError as exc:
+            self.assertEqual(exc.args[0], 'bar')
+        else:
+            self.fail('AttributeError not raised')


### PR DESCRIPTION
The fallback implemented in #2731 cannot return `obj.__dict__[name]` if the `__dict__` method has been redefined in such a way that it raises an exception when trying to access it.

This pull request adds a try-except block to work around this.

Any suggestions for a better implementation welcome!
