### PR TITLE
 Let exceptions be a PyTypedField

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Other contributors, listed alphabetically, are:
 * Martin Mahner -- nature theme
 * Will Maier -- directory HTML builder
 * Jacob Mason -- websupport library (GSOC project)
+* Glenn Matthews -- python domain signature improvements
 * Roland Meister -- epub builder
 * Ezio Melotti -- collapsible sidebar JavaScript
 * Daniel Neuhäuser -- JavaScript domain, Python 3 support (GSOC)

--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,7 @@ Features added
 * math: Add hyperlink marker to each equations in HTML output
 * Add new theme ``nonav`` that doesn't include any navigation links.
   This is for any help generator like qthelp.
+* Python domain signature parser now recognizes 'exceptions' as a typed field
 
 Bugs fixed
 ----------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -22,7 +22,7 @@ from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
 from sphinx.util.compat import Directive
-from sphinx.util.docfields import Field, GroupedField, TypedField
+from sphinx.util.docfields import Field, TypedField
 
 
 # REs for Python signatures
@@ -130,7 +130,7 @@ class PyObject(ObjectDescription):
                      names=('var', 'ivar', 'cvar'),
                      typerolename='obj', typenames=('vartype',),
                      can_collapse=True),
-        GroupedField('exceptions', label=l_('Raises'), rolename='exc',
+        PyTypedField('exceptions', label=l_('Raises'), rolename='exc',
                      names=('raises', 'raise', 'exception', 'except'),
                      can_collapse=True),
         Field('returnvalue', label=l_('Returns'), has_arg=False,

--- a/tests/root/objects.txt
+++ b/tests/root/objects.txt
@@ -93,7 +93,7 @@ Referring to :func:`nothing <>`.
                 * expression
    :returns: a new :class:`Time` instance
    :rtype: Time
-   :raises ValueError: if the values are out of range
+   :raises Error: if the values are out of range
    :ivar int hour: like *hour*
    :ivar minute: like *minute*
    :vartype minute: int

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -207,6 +207,7 @@ HTML_XPATH = {
         # docfields
         (".//a[@class='reference internal'][@href='#TimeInt']/em", 'TimeInt'),
         (".//a[@class='reference internal'][@href='#Time']", 'Time'),
+        (".//a[@class='reference internal'][@href='#errmod.Error']/strong", 'Error'),
         # C references
         (".//span[@class='pre']", 'CFunction()'),
         (".//a[@href='#c.Sphinx_DoSomething']", ''),


### PR DESCRIPTION
Add `PyGroupedField` class, analogous to `PyField` and `PyTypedField`, and change the Python domain signatures 'exceptions'/'raises' field to use this class, allowing auto-linking of exception classes:

before:

**Raises:** **ValueError** -- if the values are out of range

after:

**Raises:** **[ValueError](https://docs.python.org/2/library/exceptions.html#exceptions.ValueError)** -- if the values are out of range
