### PR TITLE
Create PyGroupedField and use it for 'exceptions'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Other contributors, listed alphabetically, are:
 * Martin Mahner -- nature theme
 * Will Maier -- directory HTML builder
 * Jacob Mason -- websupport library (GSOC project)
+* Glenn Matthews -- python domain signature improvements
 * Roland Meister -- epub builder
 * Ezio Melotti -- collapsible sidebar JavaScript
 * Daniel Neuhäuser -- JavaScript domain, Python 3 support (GSOC)

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Bugs fixed
 
 * applehelp: Sphinx crashes if ``hiutil`` or ``codesign`` commands not found
 * Fix ``make clean`` abort issue when build dir contains regular files like ``DS_Store``.
+* Python domain signature parser now uses the xref mixin for 'exceptions',
+  allowing exception classes to be autolinked.
 
 Release 1.4.5 (released Jul 13, 2016)
 =====================================

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -106,6 +106,10 @@ class PyField(PyXrefMixin, Field):
     pass
 
 
+class PyGroupedField(PyXrefMixin, GroupedField):
+    pass
+
+
 class PyTypedField(PyXrefMixin, TypedField):
     pass
 
@@ -130,9 +134,9 @@ class PyObject(ObjectDescription):
                      names=('var', 'ivar', 'cvar'),
                      typerolename='obj', typenames=('vartype',),
                      can_collapse=True),
-        GroupedField('exceptions', label=l_('Raises'), rolename='exc',
-                     names=('raises', 'raise', 'exception', 'except'),
-                     can_collapse=True),
+        PyGroupedField('exceptions', label=l_('Raises'), rolename='exc',
+                       names=('raises', 'raise', 'exception', 'except'),
+                       can_collapse=True),
         Field('returnvalue', label=l_('Returns'), has_arg=False,
               names=('returns', 'return')),
         PyField('returntype', label=l_('Return type'), has_arg=False,

--- a/tests/root/objects.txt
+++ b/tests/root/objects.txt
@@ -93,7 +93,7 @@ Referring to :func:`nothing <>`.
                 * expression
    :returns: a new :class:`Time` instance
    :rtype: Time
-   :raises ValueError: if the values are out of range
+   :raises Error: if the values are out of range
    :ivar int hour: like *hour*
    :ivar minute: like *minute*
    :vartype minute: int

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -203,6 +203,7 @@ HTML_XPATH = {
         # docfields
         (".//a[@class='reference internal'][@href='#TimeInt']/em", 'TimeInt'),
         (".//a[@class='reference internal'][@href='#Time']", 'Time'),
+        (".//a[@class='reference internal'][@href='#errmod.Error']/strong", 'Error'),
         # C references
         (".//span[@class='pre']", 'CFunction()'),
         (".//a[@href='#c.Sphinx_DoSomething']", ''),


### PR DESCRIPTION
Add `PyGroupedField` class, analogous to `PyField` and `PyTypedField`, and change the Python domain signatures 'exceptions'/'raises' field to use this class, allowing auto-linking of exception classes:

before:

**Raises:** **ValueError** -- if the values are out of range

after:

**Raises:** **[ValueError](https://docs.python.org/2/library/exceptions.html#exceptions.ValueError)** -- if the values are out of range
