### PR TITLE
Create PyGroupedField and use it for 'exceptions'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Other contributors, listed alphabetically, are:
 * Martin Mahner -- nature theme
 * Will Maier -- directory HTML builder
 * Jacob Mason -- websupport library (GSOC project)
+* Glenn Matthews -- python domain signature improvements
 * Roland Meister -- epub builder
 * Ezio Melotti -- collapsible sidebar JavaScript
 * Daniel Neuhäuser -- JavaScript domain, Python 3 support (GSOC)

--- a/CHANGES
+++ b/CHANGES
@@ -75,6 +75,8 @@ Features added
 * #2680: `sphinx.ext.todo` now emits warnings if `todo_emit_warnings` enabled.
   Also, it emits an additional event named `todo-defined` to handle the TODO
   entries in 3rd party extensions.
+* Python domain signature parser now uses the xref mixin for 'exceptions',
+  allowing exception classes to be autolinked.
 
 
 Bugs fixed

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -106,6 +106,10 @@ class PyField(PyXrefMixin, Field):
     pass
 
 
+class PyGroupedField(PyXrefMixin, GroupedField):
+    pass
+
+
 class PyTypedField(PyXrefMixin, TypedField):
     pass
 
@@ -130,9 +134,9 @@ class PyObject(ObjectDescription):
                      names=('var', 'ivar', 'cvar'),
                      typerolename='obj', typenames=('vartype',),
                      can_collapse=True),
-        GroupedField('exceptions', label=l_('Raises'), rolename='exc',
-                     names=('raises', 'raise', 'exception', 'except'),
-                     can_collapse=True),
+        PyGroupedField('exceptions', label=l_('Raises'), rolename='exc',
+                       names=('raises', 'raise', 'exception', 'except'),
+                       can_collapse=True),
         Field('returnvalue', label=l_('Returns'), has_arg=False,
               names=('returns', 'return')),
         PyField('returntype', label=l_('Return type'), has_arg=False,

--- a/tests/root/objects.txt
+++ b/tests/root/objects.txt
@@ -93,7 +93,7 @@ Referring to :func:`nothing <>`.
                 * expression
    :returns: a new :class:`Time` instance
    :rtype: Time
-   :raises ValueError: if the values are out of range
+   :raises Error: if the values are out of range
    :ivar int hour: like *hour*
    :ivar minute: like *minute*
    :vartype minute: int

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -207,6 +207,7 @@ HTML_XPATH = {
         # docfields
         (".//a[@class='reference internal'][@href='#TimeInt']/em", 'TimeInt'),
         (".//a[@class='reference internal'][@href='#Time']", 'Time'),
+        (".//a[@class='reference internal'][@href='#errmod.Error']/strong", 'Error'),
         # C references
         (".//span[@class='pre']", 'CFunction()'),
         (".//a[@href='#c.Sphinx_DoSomething']", ''),


### PR DESCRIPTION
(resubmit of #2783 against master)

Add `PyGroupedField` class, analogous to `PyField` and `PyTypedField`, and change the Python domain signatures 'exceptions'/'raises' field to use this class, allowing auto-linking of exception classes:

before:

**Raises:** **ValueError** -- if the values are out of range

after:

**Raises:** **[ValueError](https://docs.python.org/2/library/exceptions.html#exceptions.ValueError)** -- if the values are out of range
