### PR TITLE
Reduce epub checker warnings/errors for epub3 builder.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,11 @@ Bugs fixed
 
 * applehelp: Sphinx crashes if ``hiutil`` or ``codesign`` commands not found
 * Fix ``make clean`` abort issue when build dir contains regular files like ``DS_Store``.
+* Reduce epubcheck warnings/errors:
+
+  * Fix DOCTYPE to html5
+  * Change extension from .html to .xhtml.
+  * Disable search page on epub results
 
 Release 1.4.5 (released Jul 13, 2016)
 =====================================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ epub_fix_images = False
 epub_max_image_width = 0
 epub_show_urls = 'inline'
 epub_use_index = False
-epub_guide = (('toc', 'contents.html', u'Table of Contents'),)
+epub_guide = (('toc', 'contents.xhtml', u'Table of Contents'),)
 
 latex_documents = [('contents', 'sphinx.tex', 'Sphinx Documentation',
                     'Georg Brandl', 'manual', 1)]

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -113,7 +113,7 @@ COVER_TEMPLATE = u'''\
     <meta name="cover" content="%(cover)s"/>
 '''
 
-COVERPAGE_NAME = u'epub-cover.html'
+COVERPAGE_NAME = u'epub-cover.xhtml'
 
 FILE_TEMPLATE = u'''\
     <item id="%(id)s"
@@ -127,6 +127,10 @@ GUIDE_TEMPLATE = u'''\
     <reference type="%(type)s" title="%(title)s" href="%(uri)s" />'''
 
 TOCTREE_TEMPLATE = u'toctree-l%d'
+
+DOCTYPE = u'''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+'''
 
 LINK_TARGET_TEMPLATE = u' [%(uri)s]'
 
@@ -143,7 +147,7 @@ GUIDE_TITLES = {
 }
 
 MEDIA_TYPES = {
-    '.html': 'application/xhtml+xml',
+    '.xhtml': 'application/xhtml+xml',
     '.css': 'text/css',
     '.png': 'image/png',
     '.gif': 'image/gif',
@@ -198,6 +202,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
     spine_template = SPINE_TEMPLATE
     guide_template = GUIDE_TEMPLATE
     toctree_template = TOCTREE_TEMPLATE
+    doctype = DOCTYPE
     link_target_template = LINK_TARGET_TEMPLATE
     css_link_target_class = CSS_LINK_TARGET_CLASS
     guide_titles = GUIDE_TITLES
@@ -207,7 +212,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def init(self):
         StandaloneHTMLBuilder.init(self)
         # the output files for epub must be .html only
-        self.out_suffix = '.html'
+        self.out_suffix = '.xhtml'
+        self.link_suffix = '.xhtml'
         self.playorder = 0
         self.tocid = 0
 
@@ -277,7 +283,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """
         refnodes.insert(0, {
             'level': 1,
-            'refuri': self.esc(self.config.master_doc + '.html'),
+            'refuri': self.esc(self.config.master_doc + self.out_suffix),
             'text': ssp(self.esc(
                 self.env.titles[self.config.master_doc].astext()))
         })
@@ -481,6 +487,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """
         if pagename.startswith('genindex'):
             self.fix_genindex(addctx['genindexentries'])
+        addctx['doctype'] = self.doctype
         StandaloneHTMLBuilder.handle_page(self, pagename, addctx, templatename,
                                           outfilename, event_arg)
 

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -189,6 +189,9 @@ class EpubBuilder(StandaloneHTMLBuilder):
     # don't add sidebar etc.
     embedded = True
 
+    # don't generate search index or include search page
+    search = False
+
     mimetype_template = MIMETYPE_TEMPLATE
     container_template = CONTAINER_TEMPLATE
     toc_template = TOC_TEMPLATE

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -82,6 +82,9 @@ PACKAGE_DOC_TEMPLATE = u'''\
 </package>
 '''
 
+DOCTYPE = u'''<!DOCTYPE html>
+'''
+
 # The epub3 publisher
 
 
@@ -99,6 +102,7 @@ class Epub3Builder(EpubBuilder):
     navlist_template = NAVLIST_TEMPLATE
     navlist_indent = NAVLIST_INDENT
     content_template = PACKAGE_DOC_TEMPLATE
+    doctype = DOCTYPE
 
     # Finish by building the epub file
     def handle_finish(self):

--- a/sphinx/themes/epub/layout.html
+++ b/sphinx/themes/epub/layout.html
@@ -10,8 +10,7 @@
 {%- extends "basic/layout.html" %}
 
 {%- block doctype -%}
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+{{ doctype }}
 {%- endblock -%}
 {# add only basic navigation links #}
 {% block sidebar1 %}{% endblock %}


### PR DESCRIPTION
- Fix DOCTYPE to html5
- Change extension from .html to .xhtml.

Sphinx's document's result:
- before: 95 warnings& 1238 errors
- after: 623 errors
