### PR TITLE
Support gzip encoding in HEAD requests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Bugs fixed
 
 * #2778: Fix autodoc crashes if obj.__dict__ is a property method and raises exception
 * Fix duplicated toc in epub3 output.
+* #2775: Fix failing linkcheck with servers not supporting identidy encoding
 
 Release 1.4.5 (released Jul 13, 2016)
 =====================================

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -56,6 +56,11 @@ opener.addheaders = [('User-agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) '
 
 class HeadRequest(Request):
     """Subclass of urllib2.Request that sends a HEAD request."""
+    def __init__(self, *args, **kwargs):
+        Request.__init__(self, *args, **kwargs)
+        # we do not parse the response in HEAD, so accepting anything is okay
+        self.headers['Accept-encoding'] = '*'
+
     def get_method(self):
         return 'HEAD'
 


### PR DESCRIPTION
Completely support would be more problematic and this already covers
most usual case.

Fixes #2775
