### PR TITLE
Fix bug with copying of initial_data for Domains

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * #2789: `sphinx.ext.intersphinx` generates wrong hyperlinks if the inventory is given
 * parsing errors for caption of code-blocks are displayed in document (ref: #2845)
 * #2846: ``singlehtml`` builder does not include figure numbers
+* #2816: Fix data from builds cluttering the ``Domain.initial_data`` class attributes
 
 Release 1.4.5 (released Jul 13, 2016)
 =====================================

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -10,6 +10,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import copy
+
 from six import iteritems
 
 from sphinx.errors import SphinxError
@@ -145,7 +147,7 @@ class Domain(object):
         self.env = env
         if self.name not in env.domaindata:
             assert isinstance(self.initial_data, dict)
-            new_data = self.initial_data.copy()
+            new_data = copy.deepcopy(self.initial_data)
             new_data['version'] = self.data_version
             self.data = env.domaindata[self.name] = new_data
         else:


### PR DESCRIPTION
`Domain.__init__` makes a _shallow_ copy of the class's `initial_data` attribute for use by individual instances.  However, in many cases (such as the Standard Domain, the C Domain, and others) the `initial_data` data structure contains nested mutable containers.  The result is that after a doc build the domain `initial_data` is no longer pristine, and can interfere when building multiple docs within the same process.

See https://trac.sagemath.org/ticket/21044#comment:7
