### PR TITLE
Custom word splitting regex

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Other contributors, listed alphabetically, are:
 * Blaise Laflamme -- pyramid theme
 * Thomas Lamb -- linkcheck builder
 * Łukasz Langa -- partial support for autodoc
+* Hana Lee -- custom regex for search
 * Ian Lee -- quickstart improvements
 * Robert Lehmann -- gettext builder (GSOC project)
 * Dan MacKinlay -- metadata fixes

--- a/CHANGES
+++ b/CHANGES
@@ -87,6 +87,7 @@ Features added
 * Python domain signature parser now uses the xref mixin for 'exceptions',
   allowing exception classes to be autolinked.
 * #2513: Add `latex_engine` to switch the LaTeX engine by conf.py
+* Added feature to pass in custom word splitting regex in html_search_options (English only)
 
 Bugs fixed
 ----------

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -67,6 +67,8 @@ var Stemmer = function() {
         """
         Initialize the class with the options the user has given.
         """
+        if 'wordre' in options:
+            self._word_re = re.compile(options['wordre'])
 
     def split(self, input):
         """

--- a/sphinx/search/en.py
+++ b/sphinx/search/en.py
@@ -224,6 +224,7 @@ class SearchEnglish(SearchLanguage):
     stopwords = english_stopwords
 
     def init(self, options):
+        super(SearchEnglish, self).init(options)
         if PYSTEMMER:
             class Stemmer(object):
                 def __init__(self):


### PR DESCRIPTION
Added feature to pass in custom word splitting regex in `html_search_options` (English only)

Use by setting `wordre` in `html_search_options` in `conf.py` (example below)

`html_search_options = {
  'wordre': r'[\w\.\\:\/-]+(?u)'
}`

Sample regex above allows users to search for strings containing these punctuation characters: `\`, `/`, `:`, `.`, and `-`.
