### PR TITLE
ext.autodoc: fix formatting instance annotations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Bugs fixed
 
 * #2778: Fix autodoc crashes if obj.__dict__ is a property method and raises exception
 * Fix duplicated toc in epub3 output.
+* #2775: Fix failing linkcheck with servers not supporting identidy encoding
 
 Release 1.4.5 (released Jul 13, 2016)
 =====================================

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Bugs fixed
 * #2778: Fix autodoc crashes if obj.__dict__ is a property method and raises exception
 * Fix duplicated toc in epub3 output.
 * #2775: Fix failing linkcheck with servers not supporting identidy encoding
+* #2833: Fix formatting instance annotations in ext.autodoc.
 
 Release 1.4.5 (released Jul 13, 2016)
 =====================================

--- a/EXAMPLES
+++ b/EXAMPLES
@@ -61,6 +61,7 @@ Documentation using the classic theme
 * Quex: http://quex.sourceforge.net/doc/html/main.html
 * Ring programming language: http://ring-lang.sourceforge.net/doc/index.html
 * Scapy: http://www.secdev.org/projects/scapy/doc/
+* Seaborn: https://stanford.edu/~mwaskom/software/seaborn/
 * Segway: http://noble.gs.washington.edu/proj/segway/doc/1.1.0/segway.html
 * SimPy: http://simpy.readthedocs.org/en/latest/
 * SymPy: http://docs.sympy.org/

--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -545,10 +545,10 @@ a visibility statement (``public``, ``private`` or ``protected``).
 
    Full and partial template specialisations can be declared::
 
-      .. cpp::class:: template<> \
+      .. cpp:class:: template<> \
                       std::array<bool, 256>
 
-      .. cpp::class:: template<typename T> \
+      .. cpp:class:: template<typename T> \
                       std::array<T, 42>
 
 
@@ -680,9 +680,9 @@ a visibility statement (``public``, ``private`` or ``protected``).
 
    Describe an enumerator, optionally with its value defined, e.g.,::
 
-      .. cpp::enumerator:: MyEnum::myEnumerator
+      .. cpp:enumerator:: MyEnum::myEnumerator
 
-      .. cpp::enumerator:: MyEnum::myOtherEnumerator = 42
+      .. cpp:enumerator:: MyEnum::myOtherEnumerator = 42
 
 
 Namespacing

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -56,6 +56,11 @@ opener.addheaders = [('User-agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) '
 
 class HeadRequest(Request):
     """Subclass of urllib2.Request that sends a HEAD request."""
+    def __init__(self, *args, **kwargs):
+        Request.__init__(self, *args, **kwargs)
+        # we do not parse the response in HEAD, so accepting anything is okay
+        self.headers['Accept-encoding'] = '*'
+
     def get_method(self):
         return 'HEAD'
 

--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -261,12 +261,13 @@ def format_annotation(annotation):
 
     Displaying complex types from ``typing`` relies on its private API.
     """
+    if not isinstance(annotation, type):
+        return repr(annotation)
+
     qualified_name = (annotation.__module__ + '.' + annotation.__qualname__
                       if annotation else repr(annotation))
 
-    if not isinstance(annotation, type):
-        return repr(annotation)
-    elif annotation.__module__ == 'builtins':
+    if annotation.__module__ == 'builtins':
         return annotation.__qualname__
     elif typing:
         if isinstance(annotation, typing.TypeVar):

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1025,7 +1025,7 @@ def test_type_hints():
     from sphinx.util.inspect import getargspec
 
     try:
-        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8
+        from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9
     except (ImportError, SyntaxError):
         raise SkipTest('Cannot import Python code with function annotations')
 
@@ -1061,3 +1061,6 @@ def test_type_hints():
     # Tuple types
     verify_arg_spec(f8, '(x: typing.Tuple[int, str],'
                         ' y: typing.Tuple[int, ...]) -> None')
+
+    # Instance annotations
+    verify_arg_spec(f9, '(x: CustomAnnotation, y: 123) -> None')

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -46,3 +46,11 @@ def f7(x: Callable[[int, str], int]) -> None:
 
 def f8(x: Tuple[int, str], y: Tuple[int, ...]) -> None:
     pass
+
+
+class CustomAnnotation:
+    def __repr__(self):
+        return 'CustomAnnotation'
+
+def f9(x: CustomAnnotation(), y: 123) -> None:
+    pass


### PR DESCRIPTION
Currently `format_annotation` fails on instances, because instances don't have `__module__` and `__qualname__` attributes.  Defer building the `qualified_name` of an annotation until we have established that the annotation is a type.
