### PR TITLE
Fix epub/epub3 builder's behavior about genindex.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -43,6 +43,7 @@ Incompatible changes
   ``-M`` option
 * Fix ``genindex.html`` to satisfy xhtml standard.
 * Use epub3 builder by default.  And the old epub builder is renamed to epub2.
+* Fix ``epub`` and ``epub3`` builders that contained links to ``genindex`` even if ``epub_use_index = False``.
 
 Features added
 --------------

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -55,8 +55,8 @@
     </td><td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{%trans%}Search page{%endtrans%}</a><br/>
          <span class="linkdescr">{%trans%}search the documentation{%endtrans%}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{%trans%}General Index{%endtrans%}</a><br/>
-         <span class="linkdescr">{%trans%}all functions, classes, terms{%endtrans%}</span></p>
+      {%- if hasdoc('genindex') %}<p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{%trans%}General Index{%endtrans%}</a><br/>
+         <span class="linkdescr">{%trans%}all functions, classes, terms{%endtrans%}</span></p>{%- endif %}
     </td></tr>
   </table>
 

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -220,6 +220,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         self.link_suffix = '.xhtml'
         self.playorder = 0
         self.tocid = 0
+        self.use_index = self.get_builder_config('use_index', 'epub')
 
     def get_theme_config(self):
         return self.config.epub_theme, self.config.epub_theme_options
@@ -493,6 +494,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
         attributes.
         """
         if pagename.startswith('genindex'):
+            if not self.use_index:
+                return
             self.fix_genindex(addctx['genindexentries'])
         addctx['doctype'] = self.doctype
         StandaloneHTMLBuilder.handle_page(self, pagename, addctx, templatename,
@@ -561,6 +564,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
                               'toc.ncx', 'META-INF/container.xml',
                               self.config.epub_basename + '.epub'] + \
             self.config.epub_exclude_files
+        if not self.use_index:
+            self.ignored_files.append('genindex' + self.out_suffix)
         for root, dirs, files in os.walk(outdir):
             for fn in files:
                 filename = path.join(root, fn)[olen:]
@@ -595,7 +600,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
             spine.append(self.spine_template % {
                 'idref': self.esc(self.make_id(info[0] + self.out_suffix))
             })
-        if self.get_builder_config('use_index', 'epub'):
+        if self.use_index:
             spine.append(self.spine_template % {
                 'idref': self.esc(self.make_id('genindex' + self.out_suffix))
             })

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -121,6 +121,7 @@ class StandaloneHTMLBuilder(Builder):
         if self.config.language is not None:
             if self._get_translations_js():
                 self.script_files.append('_static/translations.js')
+        self.use_index = self.get_builder_config('use_index', 'html')
 
     def _get_translations_js(self):
         candidates = [path.join(package_dir, 'locale', self.config.language,
@@ -307,7 +308,7 @@ class StandaloneHTMLBuilder(Builder):
         self.relations = self.env.collect_relations()
 
         rellinks = []
-        if self.get_builder_config('use_index', 'html'):
+        if self.use_index:
             rellinks.append(('genindex', _('General Index'), 'I', _('index')))
         for indexname, indexcls, content, collapse in self.domain_indices:
             # if it has a short name
@@ -476,7 +477,7 @@ class StandaloneHTMLBuilder(Builder):
         self.info(bold('generating indices...'), nonl=1)
 
         # the global general index
-        if self.get_builder_config('use_index', 'html'):
+        if self.use_index:
             self.write_genindex()
 
         # the global domain-specific indices
@@ -1088,6 +1089,7 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         self.init_translator_class()
         self.init_templates()
         self.init_highlighter()
+        self.use_index = self.get_builder_config('use_index', 'html')
 
     def get_target_uri(self, docname, typ=None):
         if docname == 'index':


### PR DESCRIPTION
Even if `epub_use_index = False`, these builders generates `genindex.html/xhtml` and contains links to the document.

My PR fixes the following issues:
- No index is generated and no links for him when `epub_use_index = False`.
- Remove direct links to `genindex.html/xhtml` from Sphinx's document.
