### PR TITLE
Use make-mode of ``sphinx-quickstart`` by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,8 @@ Incompatible changes
 * Fix :download: role on epub/qthelp builder. They ignore the role because they don't support it.
 * ``sphinx.ext.viewcode`` doesn't work on epub building by default. ``viewcode_enable_epub`` option
 * ``sphinx.ext.viewcode`` disabled on singlehtml builder.
+* Use make-mode of ``sphinx-quickstart`` by default.  To disable this, use
+  ``-M`` option
 
 Features added
 --------------

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -585,6 +585,7 @@ def main(argv=sys.argv):
     group.add_option('-M', '--no-use-make-mode', action='store_false', dest='make_mode',
                      help='not use make-mode for Makefile/make.bat')
     group.add_option('-m', '--use-make-mode', action='store_true', dest='make_mode',
+                     default=True,
                      help='use make-mode for Makefile/make.bat')
 
     # parse options


### PR DESCRIPTION
This is a change you said once.  Should this be included at v1.5?
