### PR TITLE
Use epub3 builder by default.  And the old epub builder is renamed to epub2.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Incompatible changes
 * Use make-mode of ``sphinx-quickstart`` by default.  To disable this, use
   ``-M`` option
 * Fix ``genindex.html`` to satisfy xhtml standard.
+* Use epub3 builder by default.  And the old epub builder is renamed to epub2.
 
 Features added
 --------------

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -140,6 +140,11 @@ The builder's "name" must be given to the **-b** command-line option of
 
    .. autoattribute:: supported_image_types
 
+   .. deprecated:: 1.5
+
+      Since Sphinx-1.5, the epub3 builder is used for the default builder of epub.
+      Now EpubBuilder is renamed to epub2.
+
 .. module:: sphinx.builders.epub3
 .. class:: Epub3Builder
 
@@ -149,9 +154,6 @@ The builder's "name" must be given to the **-b** command-line option of
    `<http://idpf.org/epub>`_ or `<https://en.wikipedia.org/wiki/EPUB>`_.
    The builder creates *EPUB 3* files.
 
-   This builder is still *experimental* because it can't generate valid EPUB 3
-   files.
-
    .. autoattribute:: name
 
    .. autoattribute:: format
@@ -159,6 +161,10 @@ The builder's "name" must be given to the **-b** command-line option of
    .. autoattribute:: supported_image_types
 
    .. versionadded:: 1.4
+
+   .. versionchanged:: 1.5
+
+      Since Sphinx-1.5, the epub3 builder is used for the default builder of epub.
 
 .. module:: sphinx.builders.latex
 .. class:: LaTeXBuilder

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -176,7 +176,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
     META-INF/container.xml.  Afterwards, all necessary files are zipped to an
     epub file.
     """
-    name = 'epub'
+    name = 'epub2'
 
     # don't copy the reST source
     copysource = False

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -95,7 +95,7 @@ class Epub3Builder(EpubBuilder):
     and META-INF/container.xml. Afterwards, all necessary files are zipped to
     an epub file.
     """
-    name = 'epub3'
+    name = 'epub'
 
     navigation_doc_template = NAVIGATION_DOC_TEMPLATE
     navlist_template = NAVLIST_TEMPLATE

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,7 +70,7 @@ def test_build_all():
 
     # note: no 'html' - if it's ok with dirhtml it's ok with html
     for buildername in ['dirhtml', 'singlehtml', 'latex', 'texinfo', 'pickle',
-                        'json', 'text', 'htmlhelp', 'qthelp', 'epub', 'epub3',
+                        'json', 'text', 'htmlhelp', 'qthelp', 'epub2', 'epub',
                         'applehelp', 'changes', 'xml', 'pseudoxml', 'man',
                         'linkcheck']:
         yield verify_build, buildername, srcdir


### PR DESCRIPTION
I think it't time to change the default epub builder.
@shibukawa @takuan-osho What do you think?
