### PR TITLE
Pass command args into nose unit test runner from tests/run.py

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -48,4 +48,4 @@ tempdir.makedirs()
 print('Running Sphinx test suite (with Python %s)...' % sys.version.split()[0])
 sys.stdout.flush()
 
-nose.main()
+nose.main(argv=sys.argv)


### PR DESCRIPTION
This allows developers to selectively run tests, to enable debugging on test failures, etc. by calling python tests.run.py with arguments. See http://nose.readthedocs.io/en/latest/usage.html for usage instructions.

For example, this will run only the test_environment.py tests and will drop into pdb for any unhandled exceptions or unit test failures

```
cd tests/
python run.py --pdb test_environment
```
