### PR TITLE
deprecate `html_translator_class`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,8 @@ Incompatible changes
 * Fix ``genindex.html`` to satisfy xhtml standard.
 * Use epub3 builder by default.  And the old epub builder is renamed to epub2.
 * Fix ``epub`` and ``epub3`` builders that contained links to ``genindex`` even if ``epub_use_index = False``.
+* `html_translator_class` is now deprecated.
+  Use `Sphinx.set_translator()` API instead.
 
 Features added
 --------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -910,6 +910,11 @@ that use Sphinx's HTMLWriter class.
 
    .. seealso::  :meth:`~sphinx.application.Sphinx.set_translator`
 
+   .. deprecated:: 1.5
+
+      Implement your translator as extension and use `Sphinx.set_translator`
+      instead.
+
 .. confval:: html_show_copyright
 
    If true, "(C) Copyright ..." is shown in the HTML footer. Default is

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1183,6 +1183,12 @@ class JSONHTMLBuilder(SerializingHTMLBuilder):
         SerializingHTMLBuilder.init(self)
 
 
+def validate_config_values(app):
+    if app.config.html_translator_class:
+        app.warn('html_translator_class is deprecated. '
+                 'Use Sphinx.set_translator() API instead.')
+
+
 def setup(app):
     # builders
     app.add_builder(StandaloneHTMLBuilder)
@@ -1190,6 +1196,8 @@ def setup(app):
     app.add_builder(SingleFileHTMLBuilder)
     app.add_builder(PickleHTMLBuilder)
     app.add_builder(JSONHTMLBuilder)
+
+    app.connect('builder-inited', validate_config_values)
 
     # config values
     app.add_config_value('html_theme', 'alabaster', 'html')


### PR DESCRIPTION
The `html_translator_class` confval was introducded at 50da49fa. It was released since Sphinx-0.1.61611. At that moment, there were no `set_translator`, `add_node` and other Sphinx APIs.

Nowadays, we have a Sphinx API to setup translator `Sphinx.set_translator()`. I believe it's time to deprecate the confval.
