### PR TITLE
Flatten genindex columns' height

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Release 1.4.7 (in development)
 Bugs fixed
 ----------
 
+* #2870: flatten genindex columns' heights.
 
 Release 1.4.6 (released Aug 20, 2016)
 =====================================

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -35,6 +35,27 @@ def _toint(val):
         return 0
 
 
+def _slice_index(values, slices):
+    seq = list(values)
+    length = 0
+    for value in values:
+        length += 1 + len(value[1][1])  # count includes subitems
+    items_per_slice = length // slices
+    offset = 0
+    for slice_number in range(slices):
+        count = 0
+        start = offset
+        if slices == slice_number + 1:  # last column
+            offset = len(seq)
+        else:
+            for value in values[offset:]:
+                count += 1 + len(value[1][1])
+                offset += 1
+                if count >= items_per_slice:
+                    break
+        yield seq[start:offset]
+
+
 def accesskey(context, key):
     """Helper to output each access key only once."""
     if '_accesskeys' not in context:
@@ -127,6 +148,7 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
                                                 extensions=extensions)
         self.environment.filters['tobool'] = _tobool
         self.environment.filters['toint'] = _toint
+        self.environment.filters['slice_index'] = _slice_index
         self.environment.globals['debug'] = contextfunction(pformat)
         self.environment.globals['accesskey'] = contextfunction(accesskey)
         self.environment.globals['idgen'] = idgen

--- a/sphinx/themes/basic/genindex.html
+++ b/sphinx/themes/basic/genindex.html
@@ -44,7 +44,7 @@
 {%- for key, entries in genindexentries %}
 <h2 id="{{ key }}">{{ key }}</h2>
 <table style="width: 100%" class="indextable genindextable"><tr>
-  {%- for column in entries|slice(2) if column %}
+  {%- for column in entries|slice_index(2) if column %}
   <td style="width: 33%" valign="top"><dl>
     {%- for entryname, (links, subitems, _) in column %}
       {{ indexentries(entryname, links) }}


### PR DESCRIPTION
Original slice filter(Jinja2 built-in) just split root items by index, and doesn't check child entry counts. I added new filter `slice_index` that treats children count.
# before

![2016-08-19 17 17 09](https://cloud.githubusercontent.com/assets/564612/17803340/d24fdf70-6630-11e6-9306-e22baf19491c.png)
# after

![2016-08-19 17 16 29](https://cloud.githubusercontent.com/assets/564612/17803346/dadae8a6-6630-11e6-8e44-878001031f43.png)
