### PR TITLE
fix #2856: use same regex word splitter in Python and JS

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -145,7 +145,7 @@ var Search = {
     var searchterms = [];
     var excluded = [];
     var hlterms = [];
-    var tmp = query.split(/\s+/);
+    var tmp = query.split(/\W+/);
     var objectterms = [];
     for (i = 0; i < tmp.length; i++) {
       if (tmp[i] !== "") {


### PR DESCRIPTION
Before:

`PIN-code` is treated as is (because JS splitter splits by white spaces.

After:

`PIN-code` is broken into `PIN` and `code` (each word should be `/\w+/`).

---

Sphinx's Python code makes search index with `PIN` and `code`, not `PIN-code`. So now, Python and JS treats words in same way. It makes easy the searching feature to use.
