### PR TITLE
Use caption of toctree by default

### DIFF
--- a/sphinx/templates/quickstart/master_doc.rst_t
+++ b/sphinx/templates/quickstart/master_doc.rst_t
@@ -6,10 +6,9 @@
 Welcome to {{ project }}'s documentation!
 ==========={{ project_underline }}=================
 
-Contents:
-
 .. toctree::
    :maxdepth: {{ mastertocmaxdepth }}
+   :caption: Contents:
 
 {{ mastertoctree }}
 


### PR DESCRIPTION
The current quickstart generates following contents:

```
Welcome to test's documentation!
================================

Contents:

.. toctree::
   :maxdepth: 2

   foo
```

This "Contents:" heading inserts individual pages to LaTeX document by default. I believe this is very ugly and bad default behavior.

So this PR uses `:caption:` to represent "Caption:" heading. It removes meaningless pages. And this does not effect to other builders. 
