### PR TITLE
[stable] linkcheck: Fall back to a GET request on 403 status

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Bugs fixed
 
 * #2870: flatten genindex columns' heights.
 * #2856: Search on generated HTML site doesnt find some symbols
+* #2882: Fall back to a GET request on 403 status in linkcheck
 
 Release 1.4.6 (released Aug 20, 2016)
 =====================================

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -183,10 +183,10 @@ class CheckExternalLinksBuilder(Builder):
                         f = opener.open(req, **kwargs)
                         f.close()
                     except HTTPError as err:
-                        if err.code != 405:
+                        if err.code not in (403, 405):
                             raise
                         # retry with GET if that fails, some servers
-                        # don't like HEAD requests and reply with 405
+                        # don't like HEAD requests and reply with 403 or 405
                         req = Request(req_url)
                         f = opener.open(req, **kwargs)
                         f.close()


### PR DESCRIPTION
stable branch version of 2f46c7899ca03597bd5b563b085f2bd8c685899a, ref https://github.com/sphinx-doc/sphinx/pull/2389#issuecomment-241316457

Should this be mentioned in CHANGES? Should I add an example link somewhere in `tests/root` ?
