### PR TITLE
Add hidden directive to ObjectDescription class

### DIFF
--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -54,6 +54,7 @@ class ObjectDescription(Directive):
     final_argument_whitespace = True
     option_spec = {
         'noindex': directives.flag,
+        'hidden': directives.flag,
     }
 
     # types of doc fields that this directive handles, see sphinx.util.docfields
@@ -123,7 +124,7 @@ class ObjectDescription(Directive):
 
         * find out if called as a domain-specific directive, set self.domain
         * create a `desc` node to fit all description inside
-        * parse standard options, currently `noindex`
+        * parse standard options, currently `noindex` and `hidden`
         * create an index node if needed as self.indexnode
         * parse all given signatures (as returned by self.get_signatures())
           using self.handle_signature(), which should either return a name
@@ -144,6 +145,7 @@ class ObjectDescription(Directive):
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
         node['noindex'] = noindex = ('noindex' in self.options)
+        node['hidden'] = hidden = ('hidden' in self.options)
 
         self.names = []  # type: List[unicode]
         signatures = self.get_signatures()
@@ -152,7 +154,8 @@ class ObjectDescription(Directive):
             # and add a reference target for it
             signode = addnodes.desc_signature(sig, '')
             signode['first'] = False
-            node.append(signode)
+            if not hidden:
+                node.append(signode)
             try:
                 # name can also be a tuple, e.g. (classname, objname);
                 # this is strictly domain-specific (i.e. no assumptions may

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -152,6 +152,7 @@ class PyObject(ObjectDescription):
     """
     option_spec = {
         'noindex': directives.flag,
+        'hidden': directives.flag,
         'module': directives.unchanged,
         'annotation': directives.unchanged,
     }
@@ -494,6 +495,7 @@ class PyModule(Directive):
         'platform': lambda x: x,
         'synopsis': lambda x: x,
         'noindex': directives.flag,
+        'hidden': directives.flag,
         'deprecated': directives.flag,
     }
 

--- a/tests/roots/test-domain-cpp/domain.rst
+++ b/tests/roots/test-domain-cpp/domain.rst
@@ -1,0 +1,15 @@
+test-domain-cpp
+===============
+
+.. cpp:class:: Foobar
+
+Methods
+-------
+
+.. cpp:class:: Foo
+    :noindex:
+    :hidden:
+
+    .. cpp:function:: bar()
+
+        Bar method

--- a/tests/roots/test-domain-js/conf.py
+++ b/tests/roots/test-domain-js/conf.py
@@ -1,0 +1,4 @@
+
+master_doc = 'index'
+project = 'test-domain-js'
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-js/index.rst
+++ b/tests/roots/test-domain-js/index.rst
@@ -1,0 +1,15 @@
+test-domain-js
+==============
+
+.. js:class:: Foobar
+
+Methods
+-------
+
+.. js:class:: Foo
+    :noindex:
+    :hidden:
+
+    .. js:function:: bar()
+
+        Bar method

--- a/tests/roots/test-domain-py/conf.py
+++ b/tests/roots/test-domain-py/conf.py
@@ -1,0 +1,4 @@
+
+master_doc = 'index'
+project = 'test-domain-py'
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-py/index.rst
+++ b/tests/roots/test-domain-py/index.rst
@@ -1,0 +1,15 @@
+test-domain-py
+==============
+
+.. py:class:: Foobar
+
+Methods
+-------
+
+.. py:class:: Foo
+    :noindex:
+    :hidden:
+
+    .. py:method:: bar()
+
+        Bar method

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -562,3 +562,13 @@ def test_build_domain_cpp_with_add_function_parentheses_is_False(app, status, wa
     t = (app.outdir / f).text()
     for s in parenPatterns:
         check(s, t, f)
+
+
+@with_app('html', testroot='domain-cpp')
+def test_hidden_directive(app, status, warning):
+    app.builder.build(['domain-cpp'])
+    result = (app.outdir / 'domain.html').text(encoding='utf-8')
+    assert '<dt id="_CPPv26Foobar">' in result
+    assert '<dt id="_CPPv2N3Foo3barEv">' in result
+    pattern = re.compile(r'<dt id="_CPPv\d+Foo">')
+    assert pattern.search(result) is None

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+    test_domain_js
+    ~~~~~~~~~~~~~~
+
+    Tests the JavaScript Domain
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+
+from util import with_app
+
+
+@with_app('html', testroot='domain-js')
+def test_hidden_directive(app, status, warning):
+    app.builder.build(['domain-js'])
+    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    assert '<dt id="Foobar">' in result
+    assert '<dt id="Foo">' not in result
+    # js domain doesn't handle nested directives
+    assert '<dt id="bar">' in result

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -14,6 +14,8 @@ from six import text_type
 from sphinx import addnodes
 from sphinx.domains.python import py_sig_re, _pseudo_parse_arglist
 
+from util import with_app
+
 
 def parse(sig):
     m = py_sig_re.match(sig)
@@ -44,3 +46,12 @@ def test_function_signatures():
 
     rv = parse('func(a=[][, b=None])')
     assert text_type(rv) == u'a=[], [b=None]'
+
+
+@with_app('html', testroot='domain-py')
+def test_hidden_directive(app, status, warning):
+    app.builder.build(['domain-py'])
+    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    assert '<dt id="Foobar">' in result
+    assert '<dt id="Foo">' not in result
+    assert '<dt id="Foo.bar">' in result


### PR DESCRIPTION
Refs #2812

This implements a `hidden` directive on the underlying class for domain objects.
The hidden directive must be reimplemented on domains that override the
`option_spec`, but it will be available to the domains in Sphinx core.
