### PR TITLE
2894 Fixed argument parsing for quickstart main

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -590,7 +590,7 @@ def main(argv=sys.argv):
 
     # parse options
     try:
-        opts, args = parser.parse_args()
+        opts, args = parser.parse_args(argv[1:])
     except SystemExit as err:
         return err.code
 


### PR DESCRIPTION
  The main() funciton in quickstart was ignoring the argv passed as a
  param, and instead was using the default sys.argv when it was parsing
  arguments. Fixed this so usage matches other modules like apidoc
