### PR TITLE
Fix epub result: skip creating links from image tags to original image files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Bugs fixed
   underscore
 * #2900: Fix epub content.opf: add auto generated orphan files to spine.
 * #2899: Fix ``hasdoc()`` function in Jinja2 template. It can detect ``genindex``, ``search`` collectly.
+* #2901: Fix epub result: skip creating links from image tags to original image files.
 
 Release 1.4.6 (released Aug 20, 2016)
 =====================================

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -190,7 +190,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
     add_permalinks = False
     # don't add sidebar etc.
     embedded = True
-
+    # dont' create links to original images from images
+    html_scaled_image_link = False
     # don't generate search index or include search page
     search = False
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -74,6 +74,8 @@ class StandaloneHTMLBuilder(Builder):
     link_suffix = '.html'  # defaults to matching out_suffix
     indexer_format = js_index
     indexer_dumps_unicode = True
+    # create links to original images from images [True/False]
+    html_scaled_image_link = True
     supported_image_types = ['image/svg+xml', 'image/png',
                              'image/gif', 'image/jpeg']
     searchindex_filename = 'searchindex.js'
@@ -678,7 +680,7 @@ class StandaloneHTMLBuilder(Builder):
         """
         Builder.post_process_images(self, doctree)
 
-        if self.config.html_scaled_image_link:
+        if self.config.html_scaled_image_link and self.html_scaled_image_link:
             for node in doctree.traverse(nodes.image):
                 scale_keys = ('scale', 'width', 'height')
                 if not any((key in node) for key in scale_keys) or \


### PR DESCRIPTION
It improves epub-check score
