### PR TITLE
remove header and footer from resulting epub

### DIFF
--- a/sphinx/themes/epub/layout.html
+++ b/sphinx/themes/epub/layout.html
@@ -15,14 +15,7 @@
 {# add only basic navigation links #}
 {% block sidebar1 %}{% endblock %}
 {% block sidebar2 %}{% endblock %}
+{% block relbar1 %}{% endblock %}
 {% block relbar2 %}{% endblock %}
 {% block linktags %}{% endblock %}
-
-{# redefine relbar1 and footer to only call super if options are true #}
-{%- block relbar1 %}
-{% if theme_relbar1|tobool %}{{ super() }}{% endif %}
-{%- endblock %}
-{%- block footer %}
-{% if theme_footer|tobool %}{{ super() }}{% endif %}
-{%- endblock %}
-
+{% block footer %}{% endblock %}


### PR DESCRIPTION
Almost all epub files doesn't have header/fotter from source HTML. It removes them.

Before:

![2016-08-30 20 58 12](https://cloud.githubusercontent.com/assets/564612/18088336/17d765f0-6ef5-11e6-856d-d922ea62adb3.png)

After:

![2016-08-30 20 59 17](https://cloud.githubusercontent.com/assets/564612/18088338/1e9a5cee-6ef5-11e6-83b0-9ffd73900827.png)
