### PR TITLE
fix inter document link

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -30,7 +30,7 @@
       module indices{%endtrans%}</li>
     <li>{%trans%}<b>Code handling:</b> automatic highlighting using the <a
       href="http://pygments.org">Pygments</a> highlighter{%endtrans%}</li>
-    <li>{%trans path=pathto('extensions')%}<b>Extensions:</b> automatic testing of code snippets, inclusion of
+    <li>{%trans path=pathto('ext/builtins')%}<b>Extensions:</b> automatic testing of code snippets, inclusion of
       docstrings from Python modules (API docs), and
       <a href="{{ path }}#builtin-sphinx-extensions">more</a>{%endtrans%}</li>
     <li>{%trans path=pathto('develop')%}<b>Contributed extensions:</b> more than


### PR DESCRIPTION
By #2929, document path is little changed and index.html's link points old URL. It is my mistake
