### PR TITLE
Fix #2873: code-block overflow in latex (due to commas)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Bugs fixed
 * #2917: inline code is hyphenated on HTML
 * #1462: autosummary warns for namedtuple with attribute with trailing underscore
 * Could not reference equations if ``:nowrap:`` option specified
+* #2873: code-block overflow in latex (due to commas)
 
 Release 1.4.6 (released Aug 20, 2016)
 =====================================

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -290,6 +290,7 @@
     \def\PYGZti{\discretionary{\char`\~}{\sphinxafterbreak}{\char`\~}}%
 }
 
+\def\sphinx@verbatim@nolig@list {\do \`}%
 % Some characters . , ; ? ! / are not pygmentized.
 % This macro makes them "active" and they will insert potential linebreaks
 \newcommand*\sphinxbreaksatpunct {%
@@ -387,6 +388,8 @@
      % For grid placement from \strut's in \FancyVerbFormatLine
      \lineskip\z@skip
      % Breaks at punctuation characters . , ; ? ! and / need catcode=\active
+     % and the active comma should not be overwritten by \@noligs
+     \let\verbatim@nolig@list \sphinx@verbatim@nolig@list
      \OriginalVerbatim[#1,codes*=\sphinxbreaksatpunct]%
 }
 \renewcommand{\endVerbatim}{%


### PR DESCRIPTION
The potential linebreaks at commas in code lines were not inserted due
to latex kernel macro `\@noligs` which is issued by fancyvrb.sty
during its line processing. From the default ``<>,'-`, only the
backtick is left to be handled by `\@noligs` because the others are
either already replaced by a macro by Pygments, or (only the comma) made
active by sphinx.sty to insert potential linebreaks.
