### PR TITLE
Use new style python classes

### DIFF
--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -14,7 +14,7 @@ import warnings
 from docutils import nodes
 
 
-class translatable:
+class translatable(object):
     """Node which supports translation.
 
     The translation goes forward with following steps:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -34,7 +34,7 @@ CONFIG_TYPE_WARNING = "The config value `{name}' has type `{current.__name__}', 
                       "defaults to `{default.__name__}.'"
 
 
-class ENUM:
+class ENUM(object):
     """represents the config value should be a one of candidates.
 
     Example:

--- a/sphinx/environment.py
+++ b/sphinx/environment.py
@@ -92,7 +92,7 @@ class NoUri(Exception):
     pass
 
 
-class BuildEnvironment:
+class BuildEnvironment(object):
     """
     The environment in which the ReST files are translated.
     Stores an inventory of cross-file targets and provides doctree

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -137,7 +137,7 @@ def autosummary_table_visit_html(self, node):
 
 # -- autodoc integration -------------------------------------------------------
 
-class FakeDirective:
+class FakeDirective(object):
     env = {}
     genopt = Options()
 

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -33,7 +33,7 @@ pydriver = driver.Driver(pygrammar, convert=nodes.convert)
 
 
 # an object with attributes corresponding to token and symbol names
-class sym:
+class sym(object):
     pass
 for k, v in iteritems(pygrammar.symbol2number):
     setattr(sym, k, v)

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -55,7 +55,7 @@ if PY3:
         return text_type(tree)
     from html import escape as htmlescape  # noqa: >= Python 3.2
 
-    class UnicodeMixin:
+    class UnicodeMixin(object):
         """Mixin class to handle defining the proper __str__/__unicode__
         methods in Python 2 or 3."""
 


### PR DESCRIPTION
Is there any reason to use old style classes?
If none, let's move to new style one.
