### PR TITLE
Fix label missing bug in longtable environment

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1029,6 +1029,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('}')
             for id in self.pop_hyperlink_ids('table'):
                 self.body.append(self.hypertarget(id, anchor=False))
+            if node['ids']:
+                self.body.append(self.hypertarget(node['ids'][0], anchor=False))
             self.body.append(u'\\\\\n')
         if self.table.longtable:
             self.body.append('\\hline\n')


### PR DESCRIPTION
`:name:` attribute for table related directives creates `label` for references in TeX file. 
But in case of `longtable`, which is created for a over 30 rows including table, 
the `label` was missing. This PR will fix the bug.
