### PR TITLE
Fix #2877: Rename ``latex_elements['footer']`` to ``latex_elements['postpreamble']``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,8 @@ Incompatible changes
   Use `Sphinx.set_translator()` API instead.
 * Drop python 2.6 and 3.3 support
 * Drop epub3 builder's ``epub3_page_progression_direction`` option (use ``epub3_writing_mode``).
+* #2877: Rename ``latex_elements['footer']`` to
+  ``latex_elements['postpreamble']``
 
 Features added
 --------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1686,6 +1686,8 @@ These options influence LaTeX output. See further :doc:`latex`.
         .. versionadded:: 1.4
      ``'preamble'``
         Additional preamble content, default empty. See :doc:`latex`.
+     ``'postamble'``
+        Additional postamble content (before the indices), default empty.
      ``'figure_align'``
         Latex figure float alignment, default 'htbp' (here, top, bottom, page).
         Whenever an image doesn't fit into the current page, it will be
@@ -1696,6 +1698,9 @@ These options influence LaTeX output. See further :doc:`latex`.
         .. versionadded:: 1.3
      ``'footer'``
         Additional footer content (before the indices), default empty.
+
+        .. deprecated:: 1.5
+           User ``'postamble'`` key instead.
 
    * Keys that don't need be overridden unless in special cases are:
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -258,6 +258,15 @@ def validate_config_values(app):
             app.warn("latex_font_size is deprecated. Use latex_elements['pointsize'] instead.")
             app.config.latex_elements['pointsize'] = app.config.latex_font_size
 
+    if 'footer' in app.config.latex_elements:
+        if 'postamble' in app.config.latex_elements:
+            app.warn("latex_elements['footer'] conflicts with "
+                     "latex_elements['postamble'], ignored.")
+        else:
+            app.warn("latex_elements['footer'] is deprecated. "
+                     "Use latex_elements['preamble'] instead.")
+            app.config.latex_elements['postamble'] = app.config.latex_elements['footer']
+
 
 def setup(app):
     app.add_builder(LaTeXBuilder)

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -34,7 +34,7 @@
 \renewcommand{\releasename}{<%= releasename %>}
 <%= makeindex %>
 <%= body %>
-<%= footer %>
+<%= postamble %>
 <%= indices %>
 \renewcommand{\indexname}{<%= indexname %>}
 <%= printindex %>

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -290,7 +290,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'shorthandoff':    '',
         'maketitle':       '\\maketitle',
         'tableofcontents': '\\tableofcontents',
-        'footer':          '',
+        'postamble':       '',
         'printindex':      '\\printindex',
         'transition':      '\n\n\\bigskip\\hrule{}\\bigskip\n\n',
         'figure_align':    'htbp',


### PR DESCRIPTION
`postpreamble` is my coined word. If possible, I would like to rename it more suite name.
refs: #2877 
