### PR TITLE
Python domain can link multiple types in a type field

### DIFF
--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -371,6 +371,13 @@ using the following syntax::
    :type point: tuple(float, float)
    :type point: tuple[float, float]
 
+Multiple types in a type field will be linked automatically if separated by
+the word "or"::
+
+   :type an_arg: int or None
+   :vartype a_var: str or int
+   :rtype: float or str
+
 .. _python-roles:
 
 Cross-referencing Python objects

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -103,7 +103,7 @@ class PyXrefMixin(object):
 
     def make_xrefs(self, rolename, domain, target, innernode=nodes.emphasis,
                    contnode=None):
-        delims = '(\s*[\[\]\(\),]\s*)'
+        delims = '(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+)'
         delims_re = re.compile(delims)
         sub_targets = re.split(delims, target)
 


### PR DESCRIPTION
Multiple types in a type field can now be linked when separated with the word "or":

> :type an_arg: int or None
> :vartype a_var: str or int
> :rtype: float or str

I opted to put this in sphinx rather than Napoleon because multiple type fields for a single parameter or variable only uses the last specified type. For example

> :type arg: int
> :type arg: None

is rendered as `arg (None): Description`.

Fixes #2703 
