### PR TITLE
Fix #2810: Problems with pdflatex in an Italian document

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -93,7 +93,7 @@ class ExtBabel(Babel):
         if shortlang in ('de', 'ngerman', 'sl', 'slovene', 'pt', 'portuges',
                          'es', 'spanish', 'nl', 'dutch', 'pl', 'polish', 'it',
                          'italian'):
-            return '\\shorthandoff{"}'
+            return '\\if\\catcode`\\"\\active\\shorthandoff{"}\\fi'
         elif shortlang in ('tr', 'turkish'):
             return '\\shorthandoff{=}'
         return ''


### PR DESCRIPTION
Depending on the version of the italian module for LaTeX Babel, the
double-quote character may have been or not declared as a babel
shorthand. The babel `\shorthandoff` macro emits an error which aborts
compilation if the character isn't a shorthand. This commits wraps the
macro in a conditional to test if the character is active or not.

```
modified:   sphinx/writers/latex.py
```
