### PR TITLE
Fix #3018: LaTeX problem with page dimensions and chapter titles

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1676,6 +1676,12 @@ These options influence LaTeX output. See further :doc:`latex`.
         to use ``'47363sp'``. To obtain ``72px=1in``, use ``'1bp'``.
 
         .. versionadded:: 1.5
+     ``'geometry'``
+        "geometry" package inclusion, the default definition is:
+
+          ``'\\usepackage[margin=1in,marginparwidth=0.5in]{geometry}'``.
+
+        .. versionadded:: 1.5
      ``'babel'``
         "babel" package inclusion, default ``'\\usepackage{babel}'``.
      ``'fontpkg'``

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -6,6 +6,7 @@
    \let\sphinxpxdimen\pdfpxdimen\else\newdimen\sphinxpxdimen
 \fi \sphinxpxdimen=<%= pxunit %>\relax
 <%= passoptionstopackages %>
+<%= geometry %>
 <%= inputenc %>
 <%= utf8extra %>
 <%= cmappkg %>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -102,24 +102,6 @@
   \def\py@TitleColor{\color{TitleColor}}
 \fi
 
-% Increase printable page size (copied from fullpage.sty)
-\topmargin 0pt
-\advance \topmargin by -\headheight
-\advance \topmargin by -\headsep
-
-% attempt to work a little better for A4 users
-\textheight \paperheight
-\advance\textheight by -2in
-
-\oddsidemargin 0pt
-\evensidemargin 0pt
-%\evensidemargin -.25in  % for ``manual size'' documents
-\marginparwidth 0.5in
-
-\textwidth \paperwidth
-\advance\textwidth by -2in
-
-
 % Style parameters and macros used by most documents here
 \raggedbottom
 \sloppy

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -265,6 +265,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'classoptions':    '',
         'extraclassoptions': '',
         'passoptionstopackages': '',
+        'geometry':        '\\usepackage[margin=1in,marginparwidth=0.5in]'
+                           '{geometry}',
         'inputenc':        '',
         'utf8extra':       ('\\ifdefined\\DeclareUnicodeCharacter\n'
                             '  \\DeclareUnicodeCharacter{00A0}{\\nobreakspace}\n'

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -28,7 +28,7 @@ from test_build_html import ENV_WARNINGS
 LATEX_ENGINES = ['pdflatex', 'lualatex', 'xelatex']
 DOCCLASSES = ['howto', 'manual']
 STYLEFILES = ['article.sty', 'fancyhdr.sty', 'titlesec.sty', 'amsmath.sty', 'framed.sty',
-              'color.sty', 'fancyvrb.sty', 'threeparttable.sty']
+              'color.sty', 'fancyvrb.sty', 'threeparttable.sty', 'geometry.sty']
 
 LATEX_WARNINGS = ENV_WARNINGS + """\
 %(root)s/index.rst:\\d+: WARNING: unknown option: &option


### PR DESCRIPTION
New key `'geometry'` to `latex_elements`.
