### PR TITLE
Fix an issue with ``\pysigline`` in LaTeX style file.

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -564,12 +564,12 @@
 \newlength{\py@argswidth}
 \newcommand{\py@sigparams}[2]{%
   \parbox[t]{\py@argswidth}{#1\sphinxcode{)}#2}}
-\newcommand{\pysigline}[1]{\item[#1]\nopagebreak}
+\newcommand{\pysigline}[1]{\item[{#1}]\nopagebreak}
 \newcommand{\pysiglinewithargsret}[3]{%
   \settowidth{\py@argswidth}{#1\sphinxcode{(}}%
   \addtolength{\py@argswidth}{-2\py@argswidth}%
   \addtolength{\py@argswidth}{\linewidth}%
-  \item[#1\sphinxcode{(}\py@sigparams{#2}{#3}]}
+  \item[{#1\sphinxcode{(}\py@sigparams{#2}{#3}}]}
 
 % Production lists
 %
@@ -787,7 +787,7 @@
 %
 \newenvironment{definitions}{%
   \begin{description}%
-  \def\term##1{\item[##1]\mbox{}\\*[0mm]}
+  \def\term##1{\item[{##1}]\mbox{}\\*[0mm]}
 }{%
   \end{description}%
 }


### PR DESCRIPTION
This issue was initially reported as
http://tex.stackexchange.com/questions/201270/argument-of-item-has-an-extra

The commit also fixes two other potential problematic code locations in
sphinx.sty
