### PR TITLE
Use non make-mode of ``sphinx-quickstart`` by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Incompatible changes
   ``epub_description`` and ``epub_contributor``.
 * Remove themes/basic/defindex.html; no longer used
 * Sphinx does not ship anymore (but still uses) LaTeX style file ``fncychap``
+* Use non make-mode of ``sphinx-quickstart`` by default
 
 Features added
 --------------

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -585,7 +585,6 @@ def main(argv=sys.argv):
     group.add_option('-M', '--no-use-make-mode', action='store_false', dest='make_mode',
                      help='not use make-mode for Makefile/make.bat')
     group.add_option('-m', '--use-make-mode', action='store_true', dest='make_mode',
-                     default=True,
                      help='use make-mode for Makefile/make.bat')
 
     # parse options


### PR DESCRIPTION
#2936 tells us incompleteness of make-mode.

So I revert the default mode to non make-mode in 1.5.
