### PR TITLE
(latex) separate loading of hyperref from sphinx.sty

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1720,13 +1720,8 @@ These options influence LaTeX output. See further :doc:`latex`.
         the "Bjarne" style uses numbers spelled out in English).  Other
         "fncychap" styles you can try are "Lenny", "Glenn", "Conny", "Rejne" and
         "Bjornstrup".  You can also set this to ``''`` to disable fncychap.
-     ``'packages'``
-        Extra user specified ``\\usepackage{<foo>}`` commands, default empty,
-        executed *after* the loading of :file:`sphinx.sty` and *before* the
-        loading of "hyperref".
      ``'preamble'``
-        Additional preamble content, default empty. Executed *after*
-        the loading of "hyperref" package. See :doc:`latex`.
+        Additional preamble content, default empty. See :doc:`latex`.
      ``'postamble'``
         Additional postamble content (before the indices), default empty.
      ``'figure_align'``

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1720,8 +1720,13 @@ These options influence LaTeX output. See further :doc:`latex`.
         the "Bjarne" style uses numbers spelled out in English).  Other
         "fncychap" styles you can try are "Lenny", "Glenn", "Conny", "Rejne" and
         "Bjornstrup".  You can also set this to ``''`` to disable fncychap.
+     ``'packages'``
+        Extra user specified ``\\usepackage{<foo>}`` commands, default empty,
+        executed *after* the loading of :file:`sphinx.sty` and *before* the
+        loading of "hyperref".
      ``'preamble'``
-        Additional preamble content, default empty. See :doc:`latex`.
+        Additional preamble content, default empty. Executed *after*
+        the loading of "hyperref" package. See :doc:`latex`.
      ``'postamble'``
         Additional postamble content (before the indices), default empty.
      ``'figure_align'``

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1692,6 +1692,10 @@ These options influence LaTeX output. See further :doc:`latex`.
         to use ``'47363sp'``. To obtain ``72px=1in``, use ``'1bp'``.
 
         .. versionadded:: 1.5
+     ``'passoptionstopackages'``
+        "PassOptionsToPackage" call, default empty.
+
+        .. versionadded:: 1.4
      ``'geometry'``
         "geometry" package inclusion, the default definition is:
 
@@ -1716,10 +1720,6 @@ These options influence LaTeX output. See further :doc:`latex`.
         the "Bjarne" style uses numbers spelled out in English).  Other
         "fncychap" styles you can try are "Lenny", "Glenn", "Conny", "Rejne" and
         "Bjornstrup".  You can also set this to ``''`` to disable fncychap.
-     ``'passoptionstopackages'``
-        "PassOptionsToPackage" call, default empty.
-
-        .. versionadded:: 1.4
      ``'preamble'``
         Additional preamble content, default empty. See :doc:`latex`.
      ``'postamble'``
@@ -1754,6 +1754,17 @@ These options influence LaTeX output. See further :doc:`latex`.
         .. versionadded:: 1.2
      ``'fontenc'``
         "fontenc" package inclusion, default ``'\\usepackage[T1]{fontenc}'``.
+     ``'hyperref'``
+        "hyperref" package inclusion; also loads package "hypcap" and issues
+        ``\urlstyle{same}``. This is done after :file:`sphinx.sty` file is
+        loaded and before executing the contents of ``'preamble'`` key.
+
+        .. attention::
+
+           Loading of packages "hyperref" and "hypcap" is mandatory.
+
+        .. versionadded:: 1.5
+           Previously this was done from inside :file:`sphinx.sty`.
      ``'maketitle'``
         "maketitle" call, default ``'\\maketitle'`` (but it has been
         redefined by the Sphinx ``manual`` and ``howto`` classes.) Override

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -20,6 +20,7 @@
 \usepackage{multirow}
 \usepackage{eqparbox}
 <%= usepackages %>
+<%= packages %>
 <%= hyperref %>
 <%= contentsname %>
 <%= numfig_format %>

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -20,7 +20,6 @@
 \usepackage{multirow}
 \usepackage{eqparbox}
 <%= usepackages %>
-<%= packages %>
 <%= hyperref %>
 <%= contentsname %>
 <%= numfig_format %>

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -20,6 +20,7 @@
 \usepackage{multirow}
 \usepackage{eqparbox}
 <%= usepackages %>
+<%= hyperref %>
 <%= contentsname %>
 <%= numfig_format %>
 <%= pageautorefname %>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -853,19 +853,6 @@
   \fi
 \fi
 
-% Include hyperref last.
-\RequirePackage[colorlinks,breaklinks,
-                linkcolor=InnerLinkColor,filecolor=OuterLinkColor,
-                menucolor=OuterLinkColor,urlcolor=OuterLinkColor,
-                citecolor=InnerLinkColor]{hyperref}
-% Fix anchor placement for figures with captions.
-% (Note: we don't use a package option here; instead, we give an explicit
-% \capstart for figures that actually have a caption.)
-\RequirePackage{hypcap}
-
-% Set up styles of URL: it should be placed after hyperref
-\urlstyle{same}
-
 % From docutils.writers.latex2e
 % inline markup (custom roles)
 % \DUrole{#1}{#2} tries \DUrole#1{#2}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -278,7 +278,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'fontpkg':         '\\usepackage{times}',
         'fncychap':        '\\usepackage[Bjarne]{fncychap}',
         'longtable':       '\\usepackage{longtable}',
-        'packages':        '',
         'hyperref':        ('% Include hyperref last.\n'
                             '\\usepackage[colorlinks,breaklinks,%\n'
                             '            '

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -278,6 +278,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'fontpkg':         '\\usepackage{times}',
         'fncychap':        '\\usepackage[Bjarne]{fncychap}',
         'longtable':       '\\usepackage{longtable}',
+        'packages':        '',
         'hyperref':        ('% Include hyperref last.\n'
                             '\\usepackage[colorlinks,breaklinks,%\n'
                             '            '

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -278,6 +278,18 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'fontpkg':         '\\usepackage{times}',
         'fncychap':        '\\usepackage[Bjarne]{fncychap}',
         'longtable':       '\\usepackage{longtable}',
+        'hyperref':        ('% Include hyperref last.\n'
+                            '\\usepackage[colorlinks,breaklinks,%\n'
+                            '            '
+                            'linkcolor=InnerLinkColor,filecolor=OuterLinkColor,%\n'
+                            '            '
+                            'menucolor=OuterLinkColor,urlcolor=OuterLinkColor,%\n'
+                            '            '
+                            'citecolor=InnerLinkColor]{hyperref}\n'
+                            '% Fix anchor placement for figures with captions.\n'
+                            '\\usepackage{hypcap}% it must be loaded after hyperref.\n'
+                            '% Set up styles of URL: it should be placed after hyperref.\n'
+                            '\\urlstyle{same}'),
         'usepackages':     '',
         'numfig_format':   '',
         'contentsname':    '',


### PR DESCRIPTION
new 'hyperref' key in `latex_elements`.

Rationale: user can  add loading of additional packages via `'usepackages'` and `'preamble'` keys to `latex_elements`, but `hyperref`'s loading was hard-coded in sphinx.sty and happens earlier, and this may cause conflicts with attemps by user to employ extra packages. Besides `'hyperref'` key will allow modifying options of `hyperref`.

It is probably better to leave this key un-documented for the time being. I think `'usepackages'` is undocumented currently ?
