### PR TITLE
Fix #3031: incompatibility with LaTeX package ``tocloft``

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1739,13 +1739,17 @@ These options influence LaTeX output. See further :doc:`latex`.
      ``'fontenc'``
         "fontenc" package inclusion, default ``'\\usepackage[T1]{fontenc}'``.
      ``'maketitle'``
-        "maketitle" call, default ``'\\maketitle'``.  Override if you want to
+        "maketitle" call, default ``'\\maketitle'`` (but it has been
+        redefined by the Sphinx ``manual`` and ``howto`` classes.) Override
+        if you want to
         generate a differently-styled title page.
      ``'releasename'``
         value that prefixes ``'release'`` element on title page, default
         ``'Release'``.
      ``'tableofcontents'``
-        "tableofcontents" call, default ``'\\tableofcontents'``.  Override if
+        "tableofcontents" call, default ``'\\sphinxtableofcontents'`` (it is a
+        wrapper of unmodified ``tableofcontents``.)
+        Override if
         you want to generate a different table of contents or put content
         between the title page and the TOC.
      ``'transition'``

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1748,7 +1748,8 @@ These options influence LaTeX output. See further :doc:`latex`.
         ``'Release'``.
      ``'tableofcontents'``
         "tableofcontents" call, default ``'\\sphinxtableofcontents'`` (it is a
-        wrapper of unmodified ``tableofcontents``.)
+        wrapper of unmodified ``\tableofcontents``, which may itself be
+        customized by user loaded packages.)
         Override if
         you want to generate a different table of contents or put content
         between the title page and the TOC.

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1019,3 +1019,8 @@
 
 % stylesheet for highlighting with pygments
 \RequirePackage{sphinxhighlight}
+
+% make commands known to non-Sphinx document classes
+\providecommand*{\sphinxtableofcontents}{\tableofcontents}
+\providecommand*{\sphinxthebibliography}{\thebibliography}
+\providecommand*{\sphinxtheindex}{\theindex}

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -923,16 +923,15 @@
 % fix the double index and bibliography on the table of contents
 % in jsclasses (Japanese standard document classes)
 \ifx\@jsc@uplatextrue\undefined\else
-  \renewcommand{\theindex}{
-    \cleardoublepage
-    \phantomsection
-    \py@OldTheindex
-  }
-  \renewcommand{\thebibliography}[1]{
-    \cleardoublepage
-    \phantomsection
-    \py@OldThebibliography{1}
-  }
+  \renewenvironment{sphinxtheindex}
+    {\cleardoublepage\phantomsection
+     \begin{theindex}}
+    {\end{theindex}}
+
+  \renewenvironment{sphinxthebibliography}[1]
+    {\cleardoublepage\phantomsection
+     \begin{thebibliography}{\detokenize{#1}}}
+    {\end{thebibliography}}
 \fi
 
 % disable \@chappos in Appendix in pTeX

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -70,11 +70,10 @@
   %\gdef\@thanks{}\gdef\@author{}\gdef\@title{}
 }
 
-\let\py@OldTableofcontents=\tableofcontents
-\renewcommand{\tableofcontents}{
+\newcommand{\sphinxtableofcontents}{
   \begingroup
     \parskip = 0mm
-    \py@OldTableofcontents
+    \tableofcontents
   \endgroup
   \rule{\textwidth}{1pt}
   \vspace{12pt}
@@ -91,21 +90,18 @@
 % Contents.
 % For an article document class this environment is a section,
 % so no page break before it.
-\let\py@OldThebibliography=\thebibliography
-\renewcommand{\thebibliography}[1]{
+\newenvironment{sphinxthebibliography}[1]{%
   \phantomsection
-  \py@OldThebibliography{1}
-  \addcontentsline{toc}{section}{\bibname}
-}
+  \begin{thebibliography}{\detokenize{#1}}%
+  \addcontentsline{toc}{chapter}{\bibname}}{\end{thebibliography}}
+
 
 % Same for the indices.
 % The memoir class already does this, so we don't duplicate it in that case.
 %
-\@ifclassloaded{memoir}{}{
-  \let\py@OldTheindex=\theindex
-  \renewcommand{\theindex}{
+\@ifclassloaded{memoir}
+ {\newenvironment{sphinxtheindex}{\begin{theindex}}{\end{theindex}}}
+ {\newenvironment{sphinxtheindex}{%
     \phantomsection
-    \py@OldTheindex
-    \addcontentsline{toc}{section}{\indexname}
-  }
-}
+    \begin{theindex}%
+    \addcontentsline{toc}{chapter}{\indexname}}{\end{theindex}}}

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -93,7 +93,7 @@
 \newenvironment{sphinxthebibliography}[1]{%
   \phantomsection
   \begin{thebibliography}{\detokenize{#1}}%
-  \addcontentsline{toc}{chapter}{\bibname}}{\end{thebibliography}}
+  \addcontentsline{toc}{section}{\bibname}}{\end{thebibliography}}
 
 
 % Same for the indices.
@@ -104,4 +104,4 @@
  {\newenvironment{sphinxtheindex}{%
     \phantomsection
     \begin{theindex}%
-    \addcontentsline{toc}{chapter}{\indexname}}{\end{theindex}}}
+    \addcontentsline{toc}{section}{\indexname}}{\end{theindex}}}

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -82,15 +82,14 @@
   %\gdef\@thanks{}\gdef\@author{}\gdef\@title{}
 }
 
-\let\py@OldTableofcontents=\tableofcontents
-\renewcommand{\tableofcontents}{%
+\newcommand{\sphinxtableofcontents}{%
   % before resetting page counter, let's do the right thing.
   \if@openright\cleardoublepage\else\clearpage\fi
   \pagenumbering{roman}%
   \pagestyle{plain}%
   \begingroup
     \parskip \z@skip
-    \py@OldTableofcontents
+    \tableofcontents
   \endgroup
   % before resetting page counter, let's do the right thing.
   \if@openright\cleardoublepage\else\clearpage\fi
@@ -108,23 +107,19 @@
 % Fix the bibliography environment to add an entry to the Table of
 % Contents.
 % For a report document class this environment is a chapter.
-\let\py@OldThebibliography=\thebibliography
-\renewcommand{\thebibliography}[1]{
+\newenvironment{sphinxthebibliography}[1]{%
   \if@openright\cleardoublepage\else\clearpage\fi
   \phantomsection
-  \py@OldThebibliography{1}
-  \addcontentsline{toc}{chapter}{\bibname}
-}
+  \begin{thebibliography}{\detokenize{#1}}%
+  \addcontentsline{toc}{chapter}{\bibname}}{\end{thebibliography}}
 
 % Same for the indices.
 % The memoir class already does this, so we don't duplicate it in that case.
 %
-\@ifclassloaded{memoir}{}{
-  \let\py@OldTheindex=\theindex
-  \renewcommand{\theindex}{
+\@ifclassloaded{memoir}
+ {\newenvironment{sphinxtheindex}{\begin{theindex}}{\end{theindex}}}
+ {\newenvironment{sphinxtheindex}{%
     \if@openright\cleardoublepage\else\clearpage\fi
     \phantomsection
-    \py@OldTheindex
-    \addcontentsline{toc}{chapter}{\indexname}
-  }
-}
+    \begin{theindex}%
+    \addcontentsline{toc}{chapter}{\indexname}}{\end{theindex}}}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -291,7 +291,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         'makeindex':       '\\makeindex',
         'shorthandoff':    '',
         'maketitle':       '\\maketitle',
-        'tableofcontents': '\\tableofcontents',
+        'tableofcontents': '\\sphinxtableofcontents',
         'postamble':       '',
         'printindex':      '\\printindex',
         'transition':      '\n\n\\bigskip\\hrule{}\\bigskip\n\n',
@@ -587,7 +587,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def generate_indices(self):
         def generate(content, collapsed):
-            ret.append('\\begin{theindex}\n')
+            ret.append('\\begin{sphinxtheindex}\n')
             ret.append('\\def\\bigletter#1{{\\Large\\sffamily#1}'
                        '\\nopagebreak\\vspace{1mm}}\n')
             for i, (letter, entries) in enumerate(content):
@@ -604,7 +604,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                         ret.append('\\sphinxstyleindexextra{%s}' % self.encode(entry[4]))
                     ret.append('\\sphinxstyleindexpageref{%s:%s}\n' %
                                (entry[2], self.idescape(entry[3])))
-            ret.append('\\end{theindex}\n')
+            ret.append('\\end{sphinxtheindex}\n')
 
         ret = []
         # latex_domain_indices can be False/True or a list of index names
@@ -652,14 +652,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
             for bi in self.bibitems:
                 if len(widest_label) < len(bi[0]):
                     widest_label = bi[0]
-            self.body.append(u'\n\\begin{thebibliography}{%s}\n' % widest_label)
+            self.body.append(u'\n\\begin{sphinxthebibliography}{%s}\n' % widest_label)
             for bi in self.bibitems:
                 target = self.hypertarget(bi[2] + ':' + bi[3],
                                           withdoc=False)
                 self.body.append(u'\\bibitem[%s]{%s}{%s %s}\n' %
                                  (self.encode(bi[0]), self.idescape(bi[0]),
                                   target, bi[1]))
-            self.body.append(u'\\end{thebibliography}\n')
+            self.body.append(u'\\end{sphinxthebibliography}\n')
             self.bibitems = []
 
     def visit_start_of_file(self, node):


### PR DESCRIPTION
Use `\sphinxtableofcontents`,  and environments `sphinxtheindex`
and `sphinxthebibliography`.

Similarly  the redefined `\maketitle` should be called `\sphinxmaketitle`.
