### PR TITLE
(latex) avoid in a better way duplicate name page.1 hyperref warning

### DIFF
--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -41,6 +41,7 @@
 %
 \renewcommand{\maketitle}{%
   \begin{titlepage}%
+    \hypersetup{pageanchor=false}% avoid duplicate destination page.1 warning
     \let\footnotesize\small
     \let\footnoterule\relax
     \noindent\rule{\textwidth}{1pt}\ifsphinxpdfoutput\newline\null\fi\par
@@ -96,7 +97,6 @@
   \pagenumbering{arabic}%
   \ifdefined\fancyhf\pagestyle{normal}\fi
 }
-\pagenumbering{alph}% avoid hyperref "duplicate destination" warnings
 
 % This is needed to get the width of the section # area wide enough in the
 % library reference.  Doing it here keeps it the same for all the manuals.


### PR DESCRIPTION
The  `\pagenumbering{alph}` trick has the inconvenient that it is
mandatory to reset later the page numbering to arabic else errors will
arise as soon as the document has more than 26 pages. This resetting is
done by Sphinx code for `\tableofcontents` now called
`\sphinxtableofcontents` but not by original `\tableofcontents`.
Thus, user putting `\tableofcontents` in `'tableofcontents'` key
would get errors now without that fix.

The titlepage environment creates a group and clears the page before
exiting, thus this solution is quite analogous to the one recommended by
hyperref author at http://tex.stackexchange.com/a/333219/4686.
