### PR TITLE
Fix #2461: re-allow footnotes in topics for latex PDF

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -146,15 +146,11 @@ class ShowUrlsTransform(object):
                 if node.astext() != uri:
                     index = node.parent.index(node)
                     if show_urls == 'footnote':
-                        if list(traverse_parent(node, nodes.topic)):
-                            # should not expand references in topics
-                            pass
-                        else:
-                            footnote_nodes = self.create_footnote(uri)
-                            for i, fn in enumerate(footnote_nodes):
-                                node.parent.insert(index + i + 1, fn)
+                        footnote_nodes = self.create_footnote(uri)
+                        for i, fn in enumerate(footnote_nodes):
+                            node.parent.insert(index + i + 1, fn)
 
-                            self.expanded = True
+                        self.expanded = True
                     else:  # all other true values (b/w compat)
                         textnode = nodes.Text(" (%s)" % uri)
                         node.parent.insert(index + 1, textnode)


### PR DESCRIPTION
The issue #2291 which was fixed at 9b958b6d (1.3.6) is now alleviated
in another way since PR #3022 (b8e0e93).
