### PR TITLE
Fix #3047: spacing before footnote in pdf output is not coherent

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -151,6 +151,20 @@ from package file :file:`sphinx.sty` and class file :file:`sphinxhowto.cls` or
   displaying source code examples).
 - the ``\sphinxAtStartFootnote`` is inserted between footnote numbers and their
   texts, by default it does ``\mbox{ }``.
+- the ``\sphinxBeforeFootnote`` command is executed before each footnote, its
+  default definition is::
+
+    \newcommand*{\sphinxBeforeFootnote}{\leavevmode\unskip}
+
+  You can ``\renewcommand`` it to do nothing in order to recover the earlier
+  behaviour of Sphinx, or alternatively add a ``\nobreak\space`` or a
+  ``\thinspace`` after the ``\unskip`` in the definition to insert some
+  (non-breakable) space.
+
+  .. versionadded:: 1.5
+     formerly, footnotes from explicit mark-up were preceded by a space
+     allowing a linebreak, but automatically generated footnotes had no such
+     space.
 - use ``\sphinxSetHeaderFamily`` to set the font used by headings
   (default is ``\sffamily\bfseries``).
 

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{footnotehyper-sphinx}%
- [2016/10/08 v0.9f hyperref aware footnote.sty for sphinx (JFB)]
+ [2016/10/16 v0.9f hyperref aware footnote.sty for sphinx (JFB)]
 %%
 %% Package: footnotehyper-sphinx
 %% Version: based on footnotehyper.sty v0.9f (2016/10/03)
@@ -17,6 +17,11 @@
 %% and to be compatible with hyperref constructions of bookmarks, and survive
 %% to \MakeUppercase command or such which may be used to typeset chapter
 %% titles for example.
+%% 5. the \sphinxBeforeFootnote is added: reST syntax implies that a space token
+%% is needed before footnote mark-up like [#]_ and it goes to latex file (and
+%% a line break can happen before the footnote mark), but for generated
+%% footnotes from latex_show_urls = 'footnote' there is no such space. The
+%% hook normalizes this, and by default uses a non-breakable space.
 %%
 %% Note: with \footnotemark[N]/\footnotetext[N] syntax, hyperref
 %% does not insert an hyperlink. This is _not_ improved here.
@@ -94,7 +99,8 @@
     \if@savingnotes\expandafter\fn@fntext\else\expandafter\H@@footnotetext\fi
     {\unvbox\z@}\endgroup
 }%
-\def\FNH@fixed@footnote {\ifx\@currenvir\fn@footnote
+%% \sphinxBeforeFootnote added 2016/10/16
+\def\FNH@fixed@footnote {\sphinxBeforeFootnote\ifx\@currenvir\fn@footnote
     \expandafter\FNH@footnoteenv\else\expandafter\fn@latex@@footnote\fi }%
 \def\FNH@footnoteenv {\@ifnextchar[\FNH@xfootnoteenv%]
     {\stepcounter\@mpfn
@@ -150,9 +156,13 @@
 }%
 %% \sphinxfootnotemark: usable in section titles and silently removed from TOCs
 \def\sphinxfootnotemark [#1]%
-   {\ifx\thepage\relax\else \protect\footnotemark[#1]\fi}%
+   {\ifx\thepage\relax\else \protect\sphinxBeforeFootnote
+                            \protect\footnotemark[#1]\fi}%
 \AtBeginDocument
    {\pdfstringdefDisableCommands{\def\sphinxfootnotemark [#1]{}}}%
+%% before 1.5, Sphinx left a (breakable) space before user generated footnotes
+%% but no space before automatically generated footnotes.
+\def\sphinxBeforeFootnote {\leavevmode\unskip}%
 \endinput
 %%
 %% End of file `footnotehyper-sphinx.sty'.

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -21,7 +21,7 @@
 %% is needed before footnote mark-up like [#]_ and it goes to latex file (and
 %% a line break can happen before the footnote mark), but for generated
 %% footnotes from latex_show_urls = 'footnote' there is no such space. The
-%% hook normalizes this, and by default uses a non-breakable space.
+%% hook normalizes this, and by default uses no space.
 %%
 %% Note: with \footnotemark[N]/\footnotetext[N] syntax, hyperref
 %% does not insert an hyperlink. This is _not_ improved here.


### PR DESCRIPTION
A `\sphinxBeforeFootnote` macro is inserted by footnote environment
and `\footnotemark` command. Its default is to remove the space before
the footnote mark. Formerly, footnotes from explicit mark-up were
preceded by a space allowing a linebreak, but automatically generated
footnotes had no such space.
