### PR TITLE
Fix #2865: let LaTeX image inclusion obey ``scale`` before textwidth fit

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -814,23 +814,27 @@
  \raggedright}
 {\end{list}}
 
-% Re-define \includegraphics to resize images larger than the line width
-% if the size is not specified.
+% Redefine \includegraphics to resize images larger than the line width,
+% except if height or width option present.
+%
+% If scale is present, rescale before fitting to line width. (since 1.5)
+%
 % Warning: future version of Sphinx will not modify original \includegraphics,
-% Below custom code will be direct definition of \sphinxincludegraphics, with
-% \py@Oldincludegraphics replaced by direct use of original \includegraphics.
+% below code will be definition only of \sphinxincludegraphics.
 \let\py@Oldincludegraphics\includegraphics
 \newbox\spx@image@box
-\renewcommand*{\includegraphics}[2][\@empty]{%
-  \ifx\@empty #1% attention, #1 could be bb.., bad if first after \ifx
-    \setbox\spx@image@box=\hbox{\py@Oldincludegraphics{#2}}%
-    \ifdim \wd\spx@image@box>\linewidth
-      \py@Oldincludegraphics[width=\linewidth]{#2}%
-    \else
-      \leavevmode\box\spx@image@box
-    \fi
-  \else
+\renewcommand*{\includegraphics}[2][]{%
+  \in@{height}{#1}\ifin@\else\in@{width}{#1}\fi
+  \ifin@ % height or width present
     \py@Oldincludegraphics[#1]{#2}%
+  \else % no height nor width (but #1 may be "scale=...")
+    \setbox\spx@image@box\hbox{\py@Oldincludegraphics[#1,draft]{#2}}%
+    \ifdim \wd\spx@image@box>\linewidth
+      \setbox\spx@image@box\box\voidb@x % clear memory
+      \py@Oldincludegraphics[#1,width=\linewidth]{#2}%
+    \else
+      \py@Oldincludegraphics[#1]{#2}%
+    \fi
   \fi
 }
 % Writer will put \sphinxincludegraphics in LaTeX source, and with this,

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1368,11 +1368,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         post = []
         include_graphics_options = []
         is_inline = self.is_inline(node)
-        if 'scale' in attrs:
-            # start with ``scale`` option so that it gets executed first by
-            # ``\sphinxincludegraphics`` before limiting width to textwidth.
-            include_graphics_options.append('scale=%s'
-                                            % (float(attrs['scale']) / 100.0))
         if 'width' in attrs:
             w = self.latex_image_length(attrs['width'])
             if w:
@@ -1381,6 +1376,17 @@ class LaTeXTranslator(nodes.NodeVisitor):
             h = self.latex_image_length(attrs['height'])
             if h:
                 include_graphics_options.append('height=%s' % h)
+        if 'scale' in attrs:
+            if include_graphics_options:
+                # unfortunately passing "height=1cm,scale=2.0" to \includegraphics
+                # does not result in a height of 2cm. We must scale afterwards.
+                pre.append('\\scalebox{%f}{' % (attrs['scale'] / 100.0,))
+                post.append('}')
+            else:
+                # if no "width" nor "height", \sphinxincludegraphics will fit
+                # to the available text width if oversized after rescaling.
+                include_graphics_options.append('scale=%s'
+                                                % (float(attrs['scale']) / 100.0))
         if 'align' in attrs:
             align_prepost = {
                 # By default latex aligns the top of an image.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1369,10 +1369,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
         include_graphics_options = []
         is_inline = self.is_inline(node)
         if 'scale' in attrs:
-            # Could also be done with ``scale`` option to
-            # ``\includegraphics``; doing it this way for consistency.
-            pre.append('\\scalebox{%f}{' % (attrs['scale'] / 100.0,))
-            post.append('}')
+            # start with ``scale`` option so that it gets executed first by
+            # ``\sphinxincludegraphics`` before limiting width to textwidth.
+            include_graphics_options.append('scale=%s'
+                                            % (float(attrs['scale']) / 100.0))
         if 'width' in attrs:
             w = self.latex_image_length(attrs['width'])
             if w:


### PR DESCRIPTION
<strike>This PR induces a difference: earlier, the fit to text width of too wide images was done only if the image directive had no scale, width, or height option. Now, the fit to text width is done always. If for example height is specified but would result in a too wide image, the rescaling of width to text width will keep the aspect ratio so the final height will be smaller than requested. Earlier there would have been no fit of width and height would have been respected.</strike>

The PR has been amended: no fit to line width if the `height` or `width` attribute was used, to maintain backwards compatibility.

Currently this PR still redefines meaning of `\includegraphics` but this should be removed at earliest opportunity as it is a bug of Sphinx.
