### PR TITLE
Allow the '=' character in the -D option of sphinx-build.py

### DIFF
--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -204,7 +204,8 @@ def main(argv):
     confoverrides = {}
     for val in opts.define:
         try:
-            key, val = val.split('=')
+            key, *vals = val.split('=')
+            val='='.join(vals)
         except ValueError:
             print('Error: -D option argument must be in the form name=value.',
                   file=sys.stderr)


### PR DESCRIPTION
I couldn't manage to pass a string containing a "=" to sphinx via sphinx-build.py, which would give me much more flexibility configuring the build without having to create a new conf.py.
So this one-liner adds what I need.
