### PR TITLE
Fix support for nested classes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Other contributors, listed alphabetically, are:
 * Jacob Mason -- websupport library (GSOC project)
 * Glenn Matthews -- python domain signature improvements
 * Roland Meister -- epub builder
+* Samuel Messner -- fixes to Python domain
 * Ezio Melotti -- collapsible sidebar JavaScript
 * Daniel Neuhäuser -- JavaScript domain, Python 3 support (GSOC)
 * Christopher Perkins -- autosummary integration

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Bugs fixed
 * #2432: Fix unwanted * between varargs and keyword only args. Thanks to Alex Grönholm.
 * #3062: Failed to build PDF using 1.5a2 (undefined ``\hypersetup`` for
   Japanese documents since PR#3030)
+* #3065: Nested classes break contextual qualifying
 
 Release 1.5 alpha2 (released Oct 17, 2016)
 ==========================================

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -755,7 +755,8 @@ class BuildEnvironment(object):
         """Backwards compatible alias.  Will be removed."""
         self.warn(self.docname, 'env.currclass is being referenced by an '
                   'extension; this API will be removed in the future')
-        return self.ref_context.get('py:class')
+        class_stack = self.ref_context.get('py:class_stack')
+        return class_stack[-1] if class_stack else None
 
     def new_serialno(self, category=''):
         """Return a serial number, e.g. for index entry targets.

--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -1091,7 +1091,8 @@ class ClassLevelDocumenter(Documenter):
                 mod_cls = self.env.temp_data.get('autodoc:class')
                 # ... or from a class directive
                 if mod_cls is None:
-                    mod_cls = self.env.ref_context.get('py:class')
+                    class_stack = self.env.ref_context.get('py:class_stack')
+                    mod_cls = class_stack[-1] if class_stack else None
                 # ... if still None, there's no way to know
                 if mod_cls is None:
                     return None, []

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -451,7 +451,8 @@ def get_import_prefixes_from_env(env):
     if currmodule:
         prefixes.insert(0, currmodule)
 
-    currclass = env.ref_context.get('py:class')
+    class_stack = env.ref_context.get('py:class_stack')
+    currclass = class_stack[-1] if class_stack else None
     if currclass:
         if currmodule:
             prefixes.insert(0, currmodule + "." + currclass)

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -359,7 +359,7 @@ class Locale(Transform):
             for new in new_refs:
                 key = get_ref_key(new)
                 # Copy attributes to keep original node behavior. Especially
-                # copying 'reftarget', 'py:module', 'py:class' are needed.
+                # copying 'reftarget', 'py:module', 'py:class_stack' are needed.
                 for k, v in xref_reftarget_map.get(key, {}).items():
                     # Note: This implementation overwrite all attributes.
                     # if some attributes `k` should not be overwritten,

--- a/tests/root/objects.txt
+++ b/tests/root/objects.txt
@@ -50,6 +50,8 @@ Referring to :func:`nothing <>`.
 
 .. class:: Cls
 
+   .. class:: NestedClass
+
    .. method:: meth1
 
    .. staticmethod:: meths

--- a/tests/roots/test-nested-classes/conf.py
+++ b/tests/roots/test-nested-classes/conf.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'

--- a/tests/roots/test-nested-classes/index.rst
+++ b/tests/roots/test-nested-classes/index.rst
@@ -1,0 +1,5 @@
+.. class:: Parent()
+
+    .. class:: Parent.Child1()
+    .. class:: Parent.Child2()
+    .. method:: Parent.method()

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -134,7 +134,7 @@ def test_parse_name():
     verify('method', 'util.TestApp.cleanup',
            ('util', ['TestApp', 'cleanup'], None, None))
     directive.env.ref_context['py:module'] = 'util'
-    directive.env.ref_context['py:class'] = 'Foo'
+    directive.env.ref_context['py:class_stack'] = ['Foo']
     directive.env.temp_data['autodoc:class'] = 'TestApp'
     verify('method', 'cleanup', ('util', ['TestApp', 'cleanup'], None, None))
     verify('method', 'TestApp.cleanup',
@@ -142,7 +142,7 @@ def test_parse_name():
 
     # and clean up
     del directive.env.ref_context['py:module']
-    del directive.env.ref_context['py:class']
+    del directive.env.ref_context['py:class_stack']
     del directive.env.temp_data['autodoc:class']
 
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -119,6 +119,7 @@ def test_object_inventory():
     assert 'func_without_module2' in refs
     assert 'mod.func_in_module' in refs
     assert 'mod.Cls' in refs
+    assert 'mod.Cls.NestedClass' in refs
     assert 'mod.Cls.meth1' in refs
     assert 'mod.Cls.meth2' in refs
     assert 'mod.Cls.meths' in refs


### PR DESCRIPTION
This pull request fixes issue #3065, and thereby allows classes to nest arbitrarily without breaking context. Class context has been replaced with a stack, as opposed to a single value, to fix this.

The changes, among other things, replace `env['py:class']` with `env['py:class_stack']`. I couldn't find any documentation on the `env` properties, and I got no answer in the IRC channel, so I assumed it wasn't part of the public API. If it was, however, I can add maintaining the old `py:class` property to the changes. I'm also wondering a bit about whether this should perhaps be a pull request to `stable`, as that's what the readme implied, but... I had forked `master`, and that's what everyone else was doing, so I did the same. If that's wrong, let me know and I'll see if I can re-do.

In the pull request is also included a test for the changes. I've verified it fails without these commits, and passes with them.
