### PR TITLE
Autodoc: Allow mocked module decorators to pass-through functions unchanged

### DIFF
--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -93,6 +93,9 @@ class _MockModule(object):
         self.__all__ = []
 
     def __call__(self, *args, **kwargs):
+        if args and type(args[0]) in [FunctionType, MethodType]:
+            # Appears to be a decorator, pass through unchanged
+            return args[0]
         return _MockModule()
 
     def _append_submodule(self, submod):

--- a/tests/root/autodoc_missing_imports.py
+++ b/tests/root/autodoc_missing_imports.py
@@ -5,5 +5,14 @@ import missing_package1.missing_module1
 from missing_package2 import missing_module2
 from missing_package3.missing_module3 import missing_name
 
+@missing_name
+def decoratedFunction():
+  """decoratedFunction docstring"""
+  return None
+
 class TestAutodoc(object):
     """TestAutodoc docstring."""
+    @missing_name
+    def decoratedMethod(self):
+        """TestAutodoc::decoratedMethod docstring"""
+        return None

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -832,6 +832,17 @@ def test_generate():
     assert_result_contains('   .. py:method:: CustomDataDescriptor.meth()',
                            'module', 'test_autodoc')
 
+    # test mocked module imports
+    options.members = ['TestAutodoc']
+    options.undoc_members = False
+    assert_result_contains('.. py:class:: TestAutodoc',
+                           'module', 'autodoc_missing_imports')
+    assert_result_contains('   .. py:method:: TestAutodoc.decoratedMethod()',
+                           'module', 'autodoc_missing_imports')
+    options.members = ['decoratedFunction']
+    assert_result_contains('.. py:function:: decoratedFunction()',
+                           'module', 'autodoc_missing_imports')
+
 # --- generate fodder ------------
 __all__ = ['Class']
 


### PR DESCRIPTION
## Summary

Autodoc's `autodoc_mock_imports` feature is useful for both ignoring imports and any module-level statements or class definitions that use those imports.

One category of imported objects that are most commonly used at the module level are decorators. I propose support for mocking imports that are used as decorators in autodoc'd modules.
## Current Behavior

When a mocked import in an autodoc'd class is a decorator used on functions or methods in that module, the function, class, or method it decorates will be replaced with a _MockModule instance and the original definition discarded. This makes it impossible to autodoc anything decorated in projects where the decorator is from a mocked import.
## Proposed Behavior

_MockModule should do a simple inspection on **call**()s to guess whether the mock instance is being called as a decorator and if so, pass through the original object unchanged.
## Example Use Case

The [Fabric project](https://github.com/fabric/fabric) defines execution tasks in Python by decorating module-level functions with a decorator. If 'fabric' (and its submodules) is added to the list of mocked modules in conf.py, it becomes impossible to use autodoc to generate documentation on this config.

Note: This would also make Fabric's Sphinx helper [unwrap_tasks()](http://docs.fabfile.org/en/1.12/api/core/docs.html#fabric.docs.unwrap_tasks) unnecessary, simplifying conf.py for Fabric users
