### PR TITLE
[BUG] fix calling convention for add_source_parser debug arguments

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -831,7 +831,7 @@ class Sphinx(object):
         languages[cls.lang] = cls
 
     def add_source_parser(self, suffix, parser):
-        self.debug('[app] adding search source_parser: %r, %r', (suffix, parser))
+        self.debug('[app] adding search source_parser: %r, %r', suffix, parser)
         if suffix in self._additional_source_parsers:
             self.warn('while setting up extension %s: source_parser for %r is '
                       'already registered, it will be overridden' %


### PR DESCRIPTION
The debug message string for `add_source_parser` has two placeholders, so the arguments passed to `debug` need to be unpacked so that all the placeholders are filled.

Without this change, a build with, e.g.

```
app.add_source_parser('.py', BokehScriptParser)
```

will fail and abort early with `SPHINXOPTS=-vv` set.
