### PR TITLE
Let "make help" provide better info for latexpdf target

### DIFF
--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -39,7 +39,7 @@ BUILDERS = [
     ("",      "devhelp",     "to make HTML files and a Devhelp project"),
     ("",      "epub",        "to make an epub"),
     ("",      "latex",       "to make LaTeX files, you can set PAPER=a4 or PAPER=letter"),
-    ("posix", "latexpdf",    "to make LaTeX files and run them through pdflatex"),
+    ("posix", "latexpdf",    "to make LaTeX and PDF files (default pdflatex)"),
     ("posix", "latexpdfja",  "to make LaTeX files and run them through platex/dvipdfmx"),
     ("",      "text",        "to make text files"),
     ("",      "man",         "to make manual pages"),


### PR DESCRIPTION
Possibly the string should mention `latex_engine`, but I don't see how to
make it not exceed 66 characters to fit on a single line.
