### PR TITLE
Use latexmk for pdf (and dvi) targets

### DIFF
--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -178,28 +178,29 @@ The builder's "name" must be given to the **-b** command-line option of
    .. note::
 
       The produced LaTeX file uses several LaTeX packages that may not be
-      present in a "minimal" TeX distribution installation.  For TeXLive,
-      the following packages need to be installed:
+      present in a "minimal" TeX distribution installation. For example, on
+      Ubuntu, the following packages need to be installed for successful PDF
+      builds:
 
       * texlive-latex-recommended
       * texlive-fonts-recommended
       * texlive-latex-extra
+      * latexmk (for ``make latexpdf``)
 
-      You may also need latex-xcolor, but Sphinx does not require it (and
-      recent distributions have ``xcolor.sty`` included in latex-recommended).
-
-      Unicode engines will need their respective packages texlive-luatex or
+      Sphinx will use ``xcolor.sty`` if present: recent Ubuntu distributions
+      have ``xcolor.sty`` included in latex-recommended, earlier ones have it
+      in latex-xcolor. Unicode engines will need texlive-luatex or
       texlive-xetex.
 
       The testing of Sphinx LaTeX is done on Ubuntu trusty with the above
-      texlive packages. They are from a `TeXLive 2013 snapshot dated
-      20140215`__.
+      mentioned packages, which are from a TeXLive 2013 snapshot dated
+      February 2014.
 
-      __ http://packages.ubuntu.com/trusty/texlive-latex-recommended
-
-      .. versionchanged::
-         1.6 Formerly, testing was done for some years on Ubuntu precise
+      .. versionchanged:: 1.6
+         Formerly, testing had been done for some years on Ubuntu precise
          (based on TeXLive 2009).
+      .. versionchanged:: 1.6
+         Use of ``latexmk`` on GNU/Linux or Mac OS X.
 
    .. autoattribute:: name
 

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -2,8 +2,13 @@
 
 ALLDOCS = $(basename $(wildcard *.tex))
 ALLPDF = $(addsuffix .pdf,$(ALLDOCS))
+{% if latex_engine == 'xelatex' -%}
+ALLDVI =
+{% else -%}
 ALLDVI = $(addsuffix .dvi,$(ALLDOCS))
+{% endif -%}
 ALLPS  = $(addsuffix .ps,$(ALLDOCS))
+ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
 
 # Prefix for archive names
 ARCHIVEPRREFIX =
@@ -12,29 +17,52 @@ LATEXOPTS =
 # format: pdf or dvi
 FMT = pdf
 
-LATEX = latex
-PDFLATEX = {{ latex_engine }}
-MAKEINDEX = makeindex
+{% if latex_engine == 'platex' -%}
+# latexmkrc is read then overridden by latexmkjarc
+LATEX = latexmk -r latexmkjarc -dvi
+PDFLATEX = latexmk -r latexmkjarc -pdfdvi -dvi- -ps-
+{% elif latex_engine == 'pdflatex' -%}
+LATEX = latexmk -dvi
+PDFLATEX = latexmk -pdf -dvi- -ps-
+{% elif latex_engine == 'lualatex' -%}
+LATEX = latexmk -lualatex
+PDFLATEX = latexmk -pdflua -dvi- -ps-
+{% elif latex_engine == 'xelatex' -%}
+LATEX = latexmk -pdfxe -dvi- -ps-
+PDFLATEX = $(LATEX)
+{% endif %}
 
-{% if latex_engine == 'platex' %}
-all: all-pdf-ja
-all-pdf: all-pdf-ja
-{% else %}
-all: $(ALLPDF)
-all-pdf: $(ALLPDF)
+%.png %.gif %.jpg %.jpeg: FORCE_MAKE
+	extractbb '$@'
+
+{% if latex_engine == 'platex' -%}
+%.dvi: %.tex $(ALLIMGS) FORCE_MAKE
+	for f in *.pdf; do extractbb $$f; done
+	$(LATEX) $(LATEXOPTS) '$<'
+
+{% elif latex_engine != 'xelatex' -%}
+%.dvi: %.tex FORCE_MAKE
+	$(LATEX) $(LATEXOPTS) '$<'
+
 {% endif -%}
+%.ps: %.dvi
+	dvips '$<'
+
+{% if latex_engine == 'platex' -%}
+%.pdf: %.tex $(ALLIMGS) FORCE_MAKE
+	for f in *.pdf; do extractbb $$f; done
+{%- else -%}
+%.pdf: %.tex FORCE_MAKE
+{%- endif %}
+	$(PDFLATEX) $(LATEXOPTS) '$<'
+
 all-dvi: $(ALLDVI)
+
 all-ps: $(ALLPS)
 
-all-pdf-ja:
-	for f in *.pdf *.png *.gif *.jpg *.jpeg; do extractbb $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	-for f in *.idx; do mendex -U -f -d "`basename $$f .idx`.dic" -s python.ist $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.dvi; do dvipdfmx $$f; done
+all-pdf: $(ALLPDF)
+
+all: $(ALLPDF)
 
 zip: all-$(FMT)
 	mkdir $(ARCHIVEPREFIX)docs-$(FMT)
@@ -57,30 +85,8 @@ bz2: tar
 xz: tar
 	xz -9 -k $(ARCHIVEPREFIX)docs-$(FMT).tar
 
-# The number of LaTeX runs is quite conservative, but I don't expect it
-# to get run often, so the little extra time won't hurt.
-%.dvi: %.tex
-	$(LATEX) $(LATEXOPTS) '$<'
-	$(LATEX) $(LATEXOPTS) '$<'
-	$(LATEX) $(LATEXOPTS) '$<'
-	-$(MAKEINDEX) -s python.ist '$(basename $<).idx'
-	$(LATEX) $(LATEXOPTS) '$<'
-	$(LATEX) $(LATEXOPTS) '$<'
-
-%.pdf: %.tex
-	$(PDFLATEX) $(LATEXOPTS) '$<'
-	$(PDFLATEX) $(LATEXOPTS) '$<'
-	$(PDFLATEX) $(LATEXOPTS) '$<'
-	-$(MAKEINDEX) -s python.ist '$(basename $<).idx'
-	$(PDFLATEX) $(LATEXOPTS) '$<'
-	$(PDFLATEX) $(LATEXOPTS) '$<'
-
-%.ps: %.dvi
-	dvips '$<'
-
 clean:
-	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI)
+	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI) *.fls *.fdb_latexmk
 
 .PHONY: all all-pdf all-dvi all-ps clean zip tar gz bz2 xz
-.PHONY: all-pdf-ja
-
+.PHONY: FORCE_MAKE

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -4,8 +4,10 @@ ALLDOCS = $(basename $(wildcard *.tex))
 ALLPDF = $(addsuffix .pdf,$(ALLDOCS))
 {% if latex_engine == 'xelatex' -%}
 ALLDVI =
+ALLXDV = $(addsuffix .xdv,$(ALLDOCS))
 {% else -%}
 ALLDVI = $(addsuffix .dvi,$(ALLDOCS))
+ALLXDV =
 {% endif -%}
 ALLPS  = $(addsuffix .ps,$(ALLDOCS))
 ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
@@ -37,7 +39,7 @@ PDFLATEX = $(LATEX)
 
 {% if latex_engine == 'platex' -%}
 %.dvi: %.tex $(ALLIMGS) FORCE_MAKE
-	for f in *.pdf; do extractbb $$f; done
+	for f in *.pdf; do extractbb "$$f"; done
 	$(LATEX) $(LATEXOPTS) '$<'
 
 {% elif latex_engine != 'xelatex' -%}
@@ -50,7 +52,7 @@ PDFLATEX = $(LATEX)
 
 {% if latex_engine == 'platex' -%}
 %.pdf: %.tex $(ALLIMGS) FORCE_MAKE
-	for f in *.pdf; do extractbb $$f; done
+	for f in *.pdf; do extractbb "$$f"; done
 {%- else -%}
 %.pdf: %.tex FORCE_MAKE
 {%- endif %}
@@ -86,7 +88,7 @@ xz: tar
 	xz -9 -k $(ARCHIVEPREFIX)docs-$(FMT).tar
 
 clean:
-	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI) *.fls *.fdb_latexmk
+	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI) $(ALLXDV) *.fls *.fdb_latexmk
 
 .PHONY: all all-pdf all-dvi all-ps clean zip tar gz bz2 xz
 .PHONY: FORCE_MAKE

--- a/sphinx/texinputs/latexmkjarc
+++ b/sphinx/texinputs/latexmkjarc
@@ -1,0 +1,7 @@
+$latex = 'platex --halt-on-error --interaction=nonstopmode -kanji=utf8 %O %S';
+$dvipdf = 'dvipdfmx %O -o %D %S';
+$makeindex = 'rm -f %D; mendex -U -f -d %B.dic -s python.ist %S || echo "mendex exited with error code $? (ignoring)" && : >> %D';
+add_cus_dep( "glo", "gls", 0, "makeglo" );
+sub makeglo {
+ return system( "mendex -J -f -s gglo.ist -o '$_[0].gls' '$_[0].glo'" );
+}

--- a/sphinx/texinputs/latexmkrc
+++ b/sphinx/texinputs/latexmkrc
@@ -1,0 +1,9 @@
+$latex = 'latex --halt-on-error --interaction=nonstopmode %O %S';
+$pdflatex = 'pdflatex --halt-on-error --interaction=nonstopmode %O %S';
+$lualatex = 'lualatex --halt-on-error --interaction=nonstopmode %O %S';
+$xelatex = 'xelatex --no-pdf --halt-on-error --interaction=nonstopmode %O %S';
+$makeindex = 'makeindex -s python.ist %O -o %D %S';
+add_cus_dep( "glo", "gls", 0, "makeglo" );
+sub makeglo {
+ return system( "makeindex -s gglo.ist -o '$_[0].gls' '$_[0].glo'" );
+}


### PR DESCRIPTION
This will need some review because I don't know if latexmk is available on all platforms where Sphinx is available. I know latexmk comes with TeXLive installations and I think the TeXLive has its own perl so that latexmk runs (also on windows).

rel #3064, #2513

```
modified:   sphinx/texinputs/Makefile_t
new file:   sphinx/texinputs/latexmkrc
```
