### PR TITLE
Fix #3086: revert 1.5a2 change to latex bibliographic entries key widths

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -907,7 +907,7 @@
 
   \renewenvironment{sphinxthebibliography}[1]
     {\cleardoublepage\phantomsection
-     \begin{thebibliography}{\detokenize{#1}}}
+     \begin{thebibliography}{1}}
     {\end{thebibliography}}
 \fi
 

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -91,7 +91,7 @@
 % For an article document class this environment is a section,
 % so no page break before it.
 \newenvironment{sphinxthebibliography}[1]{%
-  \begin{thebibliography}{\detokenize{#1}}%
+  \begin{thebibliography}{1}%
   \addcontentsline{toc}{section}{\bibname}}{\end{thebibliography}}
 
 

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -109,7 +109,7 @@
 % For a report document class this environment is a chapter.
 \newenvironment{sphinxthebibliography}[1]{%
   \if@openright\cleardoublepage\else\clearpage\fi
-  \begin{thebibliography}{\detokenize{#1}}%
+  \begin{thebibliography}{1}%
   \addcontentsline{toc}{chapter}{\bibname}}{\end{thebibliography}}
 
 % Same for the indices.


### PR DESCRIPTION
Using the maximal key width may lead to unsatisfying results; probably safer to revert to the way Sphinx did it formerly.
