### PR TITLE
Fix #3092: Add :confval:`viewcode_tab_width` to expand tabs in HTML

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Features added
 --------------
 
 * #2513: A better default settings for XeLaTeX
+* #3092: ``sphinx.ext.viewcode``: Add :confval:`viewcode_tab_width` to expand
+  tabs in source code
 
 Bugs fixed
 ----------

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import string
 import traceback
 
 from six import iteritems, text_type
@@ -62,6 +63,8 @@ def doctree_read(app, doctree):
             code = analyzer.code.decode(analyzer.encoding)
         else:
             code = analyzer.code
+        if app.config.viewcode_tab_width:
+            code = string.expandtabs(code, app.config.viewcode_tab_width)
         if entry is None or entry[0] != code:
             analyzer.find_tags()
             entry = code, analyzer.tags, {}, refname
@@ -224,6 +227,7 @@ def setup(app):
     app.connect('env-merge-info', env_merge_info)
     app.connect('html-collect-pages', collect_pages)
     app.connect('missing-reference', missing_reference)
+    app.add_config_value('viewcode_tab_width', None, 'html', [int])
     # app.add_config_value('viewcode_include_modules', [], 'env')
     # app.add_config_value('viewcode_exclude_modules', [], 'env')
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}


### PR DESCRIPTION
As a trial, I added `viewcode_tab_width` to expand tabs in source code.
I don't know this is helpful or not.

Could you review this please?

If approved, I will update the document later.
