### PR TITLE
Have generated Makefile set -W to ensure warnings are handled

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Features added
   :confval:`linkcheck_anchors_ignore`
 * #3083: let Unicode no-break space act like LaTeX ``~`` (fixed #3019)
 * #3116: allow word wrap in PDF output for inline literals (ref #3110)
+* #3120: Have newly-generated projects fail to build when warnings present by default
 
 Bugs fixed
 ----------

--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -10,7 +10,7 @@ BUILDDIR      = {{ rbuilddir }}
 # Internal variables.
 PAPEROPT_a4     = -D latex_elements.papersize=a4
 PAPEROPT_letter = -D latex_elements.papersize=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) {{ rsrcdir }}
+ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) {{ rsrcdir }}
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) {{ rsrcdir }}
 


### PR DESCRIPTION
Several build warnings aren't just minor trifles, they can result in
hefty gaps and omissions in generated documentation - see
https://github.com/pybee/batavia/pull/352 for an example

Unfortunately this also includes some actual cosmetic things (like title
underline length) which is likely to increase friction, but I feel the
tradeoff should be worthwhile