### PR TITLE
add option to control if inline literal word-wraps in latex

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -151,6 +151,16 @@ Here are the currently available options together with their default values.
        before or after, but this is accessible currently only by re-defining some
        macros with complicated LaTeX syntax from :file:`sphinx.sty`.
 
+``inlineliteralwraps``
+    default ``true``. Allows linebreaks inside inline literals: but extra
+    potential break-points (additionally to those allowed by LaTeX at spaces
+    or for hyphenation) are currently inserted only after the characters ``. ,
+    ; ? ! /``. Due to TeX internals, white space in the line will be stretched
+    (or shrinked) in order to accomodate the linebreak.
+
+    .. versionadded:: 1.5
+       set this option to ``false`` to recover former behaviour.
+
 ``verbatimvisiblespace``
     default ``\textcolor{red}{\textvisiblespace}``. When a long code line is
     split, space characters located at end of the line before the break are

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -85,6 +85,7 @@
 % verbatim
 \DeclareBoolOption[true]{verbatimwithframe}
 \DeclareBoolOption[true]{verbatimwrapslines}
+\DeclareBoolOption[true]{inlineliteralwraps}
 % \textvisiblespace for compatibility with fontspec+XeTeX/LuaTeX
 \DeclareStringOption[\textcolor{red}{\textvisiblespace}]{verbatimvisiblespace}
 \DeclareStringOption % must use braces to hide the brackets
@@ -243,7 +244,9 @@
 % in 'alltt' \@noligs is done already, and the \scantokens must be avoided.
 \long\protected\def\sphinxcode#1{{\def\@tempa{alltt}%
   \ifx\@tempa\@currenvir\else
-   \sphinxbreaksviaactive\let\sphinxafterbreak\empty
+   \ifspx@opt@inlineliteralwraps
+      \sphinxbreaksviaactive\let\sphinxafterbreak\empty
+   \fi
    \@noligs\endlinechar\m@ne\everyeof{\noexpand}%
    \expandafter\scantokens
   \fi {\texttt{#1}}}}


### PR DESCRIPTION
word-wrapping at a few characters for inline literals was added at #3116. This adds option to turn this off and recover former behaviour.