### PR TITLE
rename ``'sphinxpackageoptions'`` to ``'sphinxsetup'``

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1695,7 +1695,7 @@ These options influence LaTeX output. See further :doc:`latex`.
         to use ``'47363sp'``. To obtain ``72px=1in``, use ``'1bp'``.
 
         .. versionadded:: 1.5
-     ``'sphinxpackageoptions'``
+     ``'sphinxsetup'``
         A comma separated list of ``key=value`` package options for the Sphinx
         LaTeX style, default empty. See :doc:`latex`.
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -78,7 +78,7 @@ configured, for example::
 The Sphinx LaTeX style package options
 --------------------------------------
 
-The ``'sphinxpackageoptions'`` key to :confval:`latex_elements` provides a
+The ``'sphinxsetup'`` key to :confval:`latex_elements` provides a
 more convenient interface to various style parameters. It is a comma separated
 string of ``key=value`` instructions::
 
@@ -99,10 +99,10 @@ If non-empty, it will be passed as argument to the ``\sphinxsetup`` command::
    - Most options described next could also have been positioned as
      :file:`sphinx.sty` package options. But for those where the key value
      contains some LaTeX code the use of ``\sphinxsetup`` is mandatory. Hence
-     the whole ``'sphinxpackageoptions'`` string is passed as argument to
+     the whole ``'sphinxsetup'`` string is passed as argument to
      ``\sphinxsetup``.
 
-   - As an alternative to the ``'sphinxpackageoptions'`` key, it is possibly
+   - As an alternative to the ``'sphinxsetup'`` key, it is possibly
      to insert explicitely the ``\\sphinxsetup{key=value,..}`` inside the
      ``'preamble'`` key. It is even possible to use the ``\sphinxsetup`` in
      the body of the document, via the :rst:dir:`raw` directive, to modify
@@ -355,7 +355,7 @@ Let us now list some macros from the package file
   English is the document language). Their default definitions use either the
   *sphinxheavybox* (for the first listed directives) or the *sphinxlightbox*
   environments, configured to use the parameters (colours, border thickness)
-  specific to each type, which can be set via ``'sphinxpackageoptions'`` string.
+  specific to each type, which can be set via ``'sphinxsetup'`` string.
 
   .. versionchanged:: 1.5
      use of public environment names, separate customizability of the parameters.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -54,7 +54,6 @@ DEFAULT_SETTINGS = {
     'extraclassoptions': '',
     'maxlistdepth':    '',
     'sphinxpkgoptions':     '',
-    'sphinxpackageoptions': '',
     'sphinxsetup':     '',
     'passoptionstopackages': '',
     'geometry':       ('\\usepackage[margin=1in,marginparwidth=0.5in]'
@@ -474,9 +473,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.elements['sphinxpkgoptions']:
             self.elements['sphinxpkgoptions'] = ('[%s]' %
                                                  self.elements['sphinxpkgoptions'])
-        if self.elements['sphinxpackageoptions']:
+        if self.elements['sphinxsetup']:
             self.elements['sphinxsetup'] = ('\\sphinxsetup{%s}' %
-                                            self.elements['sphinxpackageoptions'])
+                                            self.elements['sphinxsetup'])
         if self.elements['extraclassoptions']:
             self.elements['classoptions'] += ',' + \
                                              self.elements['extraclassoptions']


### PR DESCRIPTION
initially (at #3104) I did not choose ``'sphinxsetup'`` because ``'sphinxlatexsetup'`` would have been more precise but not completely. But in my practice these last few days, ``'sphinxpackageoptions'`` is too long and I can not remember it. For LaTeX user, ``\<foo>setup`` is commonly encountered for configuration macro of packages.