### PR TITLE
latex multilingual and contentsname setup to after getting user setup

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -175,7 +175,7 @@ class ExtBabel(Babel):
                          'italian'):
             return '\\if\\catcode`\\"\\active\\shorthandoff{"}\\fi'
         elif shortlang in ('tr', 'turkish'):
-            return '\\shorthandoff{=}'
+            return '\\if\\catcode`\\=\\active\\shorthandoff{=}\\fi'
         return ''
 
     def uses_cyrillic(self):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -437,6 +437,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     # disable fncychap in Japanese documents
                     self.elements['fncychap'] = ''
 
+        # set 'babel' to improbable value to detect if user has used it
+        self.elements['babel'] = '3.1415'
+
         if getattr(builder, 'usepackages', None):
             def declare_package(packagename, options=None):
                 if options:
@@ -462,12 +465,17 @@ class LaTeXTranslator(nodes.NodeVisitor):
             if tocdepth >= SECNUMDEPTH:
                 # Increase secnumdepth if tocdepth is depther than default SECNUMDEPTH
                 self.elements['secnumdepth'] = '\\setcounter{secnumdepth}{%d}' % tocdepth
-        if getattr(document.settings, 'contentsname', None):
-            self.elements['contentsname'] = \
-                self.babel_renewcommand('\\contentsname', document.settings.contentsname)
         # allow the user to override them all
         self.check_latex_elements()
         self.elements.update(builder.config.latex_elements)
+
+        if self.elements['babel'] != '3.1415':
+            self.elements['multilingual'] = self.elements['babel']
+
+        if getattr(document.settings, 'contentsname', None):
+            self.elements['contentsname'] = \
+                self.babel_renewcommand('\\contentsname', document.settings.contentsname)
+
         if self.elements['maxlistdepth']:
             self.elements['sphinxpkgoptions'] += (',maxlistdepth=%s' %
                                                   self.elements['maxlistdepth'])

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -438,7 +438,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.elements['fncychap'] = ''
 
         # set 'babel' to improbable value to detect if user has used it
-        self.elements['babel'] = '3.1415'
+        if self.elements['babel']:
+            self.elements['babel'] = '3.1415'
+        else:
+            self.elements['babel'] = '2.7182'
 
         if getattr(builder, 'usepackages', None):
             def declare_package(packagename, options=None):
@@ -470,7 +473,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.elements.update(builder.config.latex_elements)
 
         if self.elements['babel'] != '3.1415':
-            self.elements['multilingual'] = self.elements['babel']
+            if self.elements['babel'] != '2.7182':
+                self.elements['multilingual'] = self.elements['babel']
+            else:
+                self.elements['babel'] = ''
 
         if getattr(document.settings, 'contentsname', None):
             self.elements['contentsname'] = \

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -590,7 +590,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         return self.idescape(ref).replace('-', '\\string-')
 
     def babel_renewcommand(self, command, definition):
-        if self.elements['babel']:
+        if self.elements['multilingual']:
             prefix = '\\addto\\captions%s{' % self.babel.get_language()
             suffix = '}'
         else:  # babel is disabled (mainly for Japanese environment)


### PR DESCRIPTION
This may fix both of #3123 and #3069. I simply moved <strike>relevant</strike> code to after

    self.elements.update(builder.config.latex_elements)

(edit) *to fix #3069 and I added a check for user config of babel for #3123* (we must obey ``'babel'`` key for backwards compatibility as it is documented)

Not confident that no after-effect.