### PR TITLE
rename ``'postamble'`` to ``'atendofbody'`` (ref #2877)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -150,7 +150,7 @@ Incompatible changes
 * Drop python 2.6 and 3.3 support
 * Drop epub3 builder's ``epub3_page_progression_direction`` option (use ``epub3_writing_mode``).
 * #2877: Rename ``latex_elements['footer']`` to
-  ``latex_elements['postamble']``
+  ``latex_elements['atendofbody']``
 
 Features added
 --------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1740,8 +1740,10 @@ These options influence LaTeX output. See further :doc:`latex`.
         "Bjornstrup".  You can also set this to ``''`` to disable fncychap.
      ``'preamble'``
         Additional preamble content, default empty. See :doc:`latex`.
-     ``'postamble'``
-        Additional postamble content (before the indices), default empty.
+     ``'atendofbody'``
+        Additional document content (right before the indices), default empty.
+
+        .. versionadded:: 1.5
      ``'figure_align'``
         Latex figure float alignment, default 'htbp' (here, top, bottom, page).
         Whenever an image doesn't fit into the current page, it will be
@@ -1754,7 +1756,7 @@ These options influence LaTeX output. See further :doc:`latex`.
         Additional footer content (before the indices), default empty.
 
         .. deprecated:: 1.5
-           User ``'postamble'`` key instead.
+           User ``'atendofbody'`` key instead.
 
    * Keys that don't need be overridden unless in special cases are:
 

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -45,7 +45,7 @@
 \renewcommand{\releasename}{<%= releasename %>}
 <%= makeindex %>
 <%= body %>
-<%= postamble %>
+<%= atendofbody %>
 <%= indices %>
 \renewcommand{\indexname}{<%= indexname %>}
 <%= printindex %>

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -89,7 +89,7 @@ DEFAULT_SETTINGS = {
     'shorthandoff':    '',
     'maketitle':       '\\maketitle',
     'tableofcontents': '\\sphinxtableofcontents',
-    'postamble':       '',
+    'atendofbody':     '',
     'printindex':      '\\printindex',
     'transition':      '\n\n\\bigskip\\hrule{}\\bigskip\n\n',
     'figure_align':    'htbp',


### PR DESCRIPTION
sorry for very late PR @tk0miya. Other possibility ``'afterbody'``. 