### PR TITLE
Add missing trailing space in italian translation

### DIFF
--- a/sphinx/locale/it/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/it/LC_MESSAGES/sphinx.po
@@ -819,7 +819,7 @@ msgstr "Ricerca completata, trovata/e %s pagina/e corrispondenti."
 
 #: sphinx/themes/basic/static/searchtools.js_t:338
 msgid ", in "
-msgstr ", in"
+msgstr ", in "
 
 #: sphinx/themes/classic/static/sidebar.js_t:83
 msgid "Expand sidebar"


### PR DESCRIPTION
This is the same change proposed in PR#3143 but relative to the stable branch.