### PR TITLE
Implemented a first set of Sphinx targets in a PowerShell based "makefile".

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -60,6 +60,7 @@ DEFAULT_VALUE = {
     'ext_todo': False,
     'makefile': True,
     'batchfile': True,
+    'poshfile': True,
 }
 
 EXTENSIONS = ('autodoc', 'doctest', 'intersphinx', 'todo', 'coverage',
@@ -215,6 +216,7 @@ def ask_user(d):
     * ext_*:     extensions to use (bools)
     * makefile:  make Makefile
     * batchfile: make command file
+    * poshfile:  make PowerShell file
     """
 
     print(bold('Welcome to the Sphinx %s quickstart utility.') % __display_version__)
@@ -368,6 +370,11 @@ directly.''')
     elif 'batchfile' not in d:
         do_prompt(d, 'batchfile', 'Create Windows command file? (y/n)',
                   'y', boolean)
+    if 'no_poshfile' in d:
+        d['poshfile'] = False
+    elif 'poshfile' not in d:
+        do_prompt(d, 'poshfile', 'Create PowerShell file? (y/n)',
+                  'y', boolean)
     print()
 
 
@@ -447,9 +454,11 @@ def generate(d, overwrite=True, silent=False, templatedir=None):
     if d.get('make_mode') is True:
         makefile_template = 'quickstart/Makefile.new_t'
         batchfile_template = 'quickstart/make.bat.new_t'
+        poshfile_template = 'quickstart/make.ps1_t'
     else:
         makefile_template = 'quickstart/Makefile_t'
         batchfile_template = 'quickstart/make.bat_t'
+        poshfile_template = 'quickstart/make.ps1_t'
 
     if d['makefile'] is True:
         d['rsrcdir'] = d['sep'] and 'source' or '.'
@@ -464,13 +473,19 @@ def generate(d, overwrite=True, silent=False, templatedir=None):
         write_file(path.join(d['path'], 'make.bat'),
                    template.render(batchfile_template, d), u'\r\n')
 
+    if d['poshfile'] is True:
+        d['rsrcdir'] = d['sep'] and 'source' or '.'
+        d['rbuilddir'] = d['sep'] and 'build' or d['dot'] + 'build'
+        write_file(path.join(d['path'], 'make.ps1'),
+                   template.render(poshfile_template, d), u'\r\n')
+
     if silent:
         return
     print()
     print(bold('Finished: An initial directory structure has been created.'))
     print('''
 You should now populate your master file %s and create other documentation
-source files. ''' % masterfile + ((d['makefile'] or d['batchfile']) and '''\
+source files. ''' % masterfile + ((d['makefile'] or d['batchfile'] or d['poshfile']) and '''\
 Use the Makefile to build the docs, like so:
    make builder
 ''' or '''\
@@ -596,6 +611,12 @@ def main(argv=sys.argv):
     group.add_option('--no-batchfile', action='store_true', dest='no_batchfile',
                      default=False,
                      help='not create batchfile')
+    group.add_option('--poshfile', action='store_true', dest='poshfile',
+                     default=False,
+                     help='create PowerShell file')
+    group.add_option('--no-poshfile', action='store_true', dest='no_poshfile',
+                     default=False,
+                     help='not create PowerShell file')
     group.add_option('-M', '--no-use-make-mode', action='store_false', dest='make_mode',
                      help='not use make-mode for Makefile/make.bat')
     group.add_option('-m', '--use-make-mode', action='store_true', dest='make_mode',
@@ -640,6 +661,8 @@ def main(argv=sys.argv):
                 d['makefile'] = False
             if 'no_batchfile' in d:
                 d['batchfile'] = False
+            if 'no_poshfile' in d:
+                d['poshfile'] = False
 
             if not valid_dir(d):
                 print()

--- a/sphinx/templates/quickstart/make.ps1_t
+++ b/sphinx/templates/quickstart/make.ps1_t
@@ -17,7 +17,7 @@
 # 
 # 
 # ==========================================================================
-# Copyright © 2016 Patrick Lehmann - Dresden, Germany
+# Copyright Â© 2016 Patrick Lehmann - Dresden, Germany
 # ==========================================================================
 [CmdletBinding()]
 param(

--- a/sphinx/templates/quickstart/make.ps1_t
+++ b/sphinx/templates/quickstart/make.ps1_t
@@ -1,0 +1,198 @@
+# .SYNOPSIS
+# Please use '.\make.ps1 -<target>' where <target> is one of:
+#   html, dirhtml, singlehtml, pickle, json, linkcheck
+# 
+# .DESCRIPTION
+# This is a front-end script for Sphinx.
+# 
+# .EXAMPLE
+#  .\make.ps1 -clean
+# Cleanup the build directory.
+# .EXAMPLE
+#  .\make.ps1 -html
+# Build documentation as HTML pages.
+# .EXAMPLE
+#  .\make.ps1 -clean -html -linkcheck
+# Combine multiple commands in a single call
+# 
+# 
+# ==========================================================================
+# Copyright © 2016 Patrick Lehmann - Dresden, Germany
+# ==========================================================================
+[CmdletBinding()]
+param(
+  # Make all targets
+  [switch]$all =        $false,
+  # Make standalone HTML files
+  [switch]$html =       $false,
+  # Make HTML files named index.html in directories
+  [switch]$dirhtml =    $false,
+  # Make a single large HTML file
+  [switch]$singlehtml = $false,
+  # Make pickle files
+  [switch]$pickle =     $false,
+  # Make json files
+  [switch]$json =       $false,  
+  # Check all external links for integrity
+  [switch]$linkcheck =  $false,
+  # Clean up directory before running Sphinx.
+  [switch]$clean =      $false,
+  # Show the embedded help page(s).
+  [switch]$help =       $false
+)
+
+# resolve paths
+$WorkingDir =     Get-Location
+$SphinxRootDir =  Convert-Path (Resolve-Path ($PSScriptRoot))
+
+# set default values
+$EnableVerbose =  $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
+$EnableDebug =    $PSCmdlet.MyInvocation.BoundParameters["Debug"]
+if ($EnableVerbose -eq $null)  { $EnableVerbose =  $false }
+if ($EnableDebug   -eq $null)  { $EnableDebug =    $false }
+if ($EnableDebug   -eq $true)  { $EnableVerbose =  $true  }
+
+# Display help if no command was selected
+$Help = $Help -or (-not ($all -or $html -or $dirhtml -or $singlehtml -or $pickle -or $linkcheck -or $clean -or $help))
+
+function Exit-Script
+{ <#
+    .PARAMETER ExitCode
+    ExitCode of this script run
+  #>
+  [CmdletBinding()]
+  param([int]$ExitCode = 0)
+  
+  # restore environment
+  # rm env:GHDL -ErrorAction SilentlyContinue
+  
+  cd $WorkingDir
+  
+  # unload modules
+  # Remove-Module precompile -Verbose:$false
+
+  # exit with exit code
+  exit $ExitCode
+}
+
+if ($Help)
+{ Get-Help $MYINVOCATION.InvocationName -Detailed
+  Exit-Script
+}
+
+if ($All)
+{ $clean =      $true
+  $html =       $true
+  $dirhtml =    $true
+  $singlehtml = $true
+}
+
+$SphinxBuild =    if (-not $env:SPHINXBUILD) { "sphinx-build" } else { $env:SPHINXBUILD }
+$BuildDir =       "$SphinxRootDir\{{ rbuilddir }}"
+$SourceDir =      "$SphinxRootDir\{{ rsrcdir }}"
+# $BuildDir =       "$SphinxRootDir\_build"   # for local testing, can be removed in the future
+# $SourceDir =      "$SphinxRootDir\."        # for local testing, can be removed in the future
+$AllSphinxOpts =  "-d $BuildDir\doctrees ${env:SPHINXOPTS} $SourceDir"
+$I18NSphinxOpts = "${env:SPHINXOPTS} $SourceDir"
+# ------------------------------------------------------------------------------
+# TODO: add paper options
+# ------------------------------------------------------------------------------
+# if NOT "%PAPER%" == "" (
+#   set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
+#   set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
+# )
+
+# Check if sphinx-build is available and fallback to Python version if any
+# ------------------------------------------------------------------------------
+# TODO: add testings if sphinxbuild can be called and/or is installed
+# ------------------------------------------------------------------------------
+#  %SPHINXBUILD% 1>NUL 2>NUL
+#  if errorlevel 9009 goto sphinx_python
+#  goto sphinx_ok
+#  
+#  :sphinx_python
+#  
+#  set SPHINXBUILD=python -m sphinx.__init__
+#  %SPHINXBUILD% 2> nul
+#  if errorlevel 9009 (
+#    echo.
+#    echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+#    echo.installed, then set the SPHINXBUILD environment variable to point
+#    echo.to the full path of the 'sphinx-build' executable. Alternatively you
+#    echo.may add the Sphinx directory to PATH.
+#    echo.
+#    echo.If you don't have Sphinx installed, grab it from
+#    echo.http://sphinx-doc.org/
+#    exit /b 1
+#  )
+
+$EnableDebug
+
+if ($clean)
+{ $EnableVerbose -and (Write-Host "Cleaning build directory '$BuildDir'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  dir -Path $BuildDir * -Directory | rmdir -Recurse"           ) | Out-Null
+	dir -Path $BuildDir * -Directory | rmdir -Recurse
+  Write-Host "Cleaning finished." -Foreground Green
+}
+
+if ($html)
+{ $expr = "$SphinxBuild -b html $AllSphinxOpts $BuildDir\html"
+  $EnableVerbose -and (Write-Host "Building target 'html' into '$BuildDir\html'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  $expr" -Foreground Cyan ) | Out-Null
+	Invoke-Expression $expr
+  if ($LastExitCode -ne 0)
+  { Exit-Script 1 }
+  Write-Host "Build finished. The HTML pages are in $BuildDir\html." -Foreground Green
+}
+
+if ($dirhtml)
+{ $expr = "$SphinxBuild -b dirhtml $AllSphinxOpts $BuildDir\dirhtml"
+  $EnableVerbose -and (Write-Host "Building target 'dirhtml' into '$BuildDir\dirhtml'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  $expr" -Foreground Cyan ) | Out-Null
+  Invoke-Expression $expr
+  if ($LastExitCode -ne 0)
+  { Exit-Script 1 }
+  Write-Host "Build finished. The HTML pages are in $BuildDir\dirhtml." -Foreground Green
+}
+
+if ($singlehtml)
+{ $expr = "$SphinxBuild -b singlehtml $AllSphinxOpts $BuildDir\singlehtml"
+  $EnableVerbose -and (Write-Host "Building target 'singlehtml' into '$BuildDir\singlehtml'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  $expr" -Foreground Cyan ) | Out-Null 
+  Invoke-Expression $expr
+  if ($LastExitCode -ne 0)
+  { Exit-Script 1 }
+  Write-Host "Build finished. The HTML page are in $BuildDir\singlehtml." -Foreground Green
+}
+
+if ($pickle)
+{ $expr = "$SphinxBuild -b pickle $AllSphinxOpts $BuildDir\pickle"
+  $EnableVerbose -and (Write-Host "Building target 'pickle' into '$BuildDir\pickle'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  $expr" -Foreground Cyan ) | Out-Null 
+  Invoke-Expression $expr
+  if ($LastExitCode -ne 0)
+  { Exit-Script 1 }
+  Write-Host "Build finished. Now you can process the pickle files." -Foreground Green
+}
+
+if ($json)
+{ $expr = "$SphinxBuild -b json $AllSphinxOpts $BuildDir\json"
+  $EnableVerbose -and (Write-Host "Building target 'json' into '$BuildDir\json'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  $expr" -Foreground Cyan ) | Out-Null 
+  Invoke-Expression $expr
+  if ($LastExitCode -ne 0)
+  { Exit-Script 1 }
+  Write-Host "Build finished. Now you can process the json files." -Foreground Green
+}
+
+if ($linkcheck)
+{ $expr = "$SphinxBuild -b linkcheck $AllSphinxOpts $BuildDir\linkcheck"
+  $EnableVerbose -and (Write-Host "Building target 'html' into '$BuildDir\html'..." -Foreground DarkCyan  ) | Out-Null
+	$EnableDebug   -and (Write-Host "  $expr" -Foreground Cyan ) | Out-Null 
+  Invoke-Expression $expr
+  if ($LastExitCode -ne 0)
+  { Exit-Script 1 }
+  Write-Host "Link check complete. Look for any errors in the above output or in $BuildDir\linkcheck\output.txt." -Foreground Green
+}
+
+Exit-Script


### PR DESCRIPTION
This pull request:
* Adds a PowerShell (PoSh) option for a new "makefile" format in quickstart.py
* Adds a new template file for a PowerShell based "makefile".
* Addresses issue #3145

Implemented target/commands:
* `-clean` - cleanup the build directory
* `-help` - show the embedded help page
* `all` - build all targets
* `html` - build html
* `dirhtml` - build dirhtml
* `singlehtml` - build a single html file
* `json` - create json files
* `pickle` - create pickle files
* `linkcheck` - check links

Usage examples:
* `.\make.ps1 -help`
* `.\make.ps1 -clean`
* `.\make.ps1 -clean -html -linkcheck`