### PR TITLE
Modify French translation of ``return``

### DIFF
--- a/sphinx/locale/fr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fr/LC_MESSAGES/sphinx.po
@@ -131,12 +131,12 @@ msgstr "Paramètres"
 #: sphinx/domains/c.py:61 sphinx/domains/cpp.py:3614
 #: sphinx/domains/javascript.py:128 sphinx/domains/python.py:136
 msgid "Returns"
-msgstr "Retourne"
+msgstr "Renvoie"
 
 #: sphinx/domains/c.py:63 sphinx/domains/javascript.py:130
 #: sphinx/domains/python.py:138
 msgid "Return type"
-msgstr "Type retourné"
+msgstr "Type renvoyé"
 
 #: sphinx/domains/c.py:177
 #, python-format


### PR DESCRIPTION
For example,

  https://www.afpy.org/doc/python/3.5/tutorial/controlflow.html

never uses the verb ``retourner`` but always ``renvoyer``.

NOTE:  it may be that in a sub-part of society composed of programmers, use of ``retourner`` is common. I don't know. I have found examples on the net with ``retourner`` but as a French speaker this definitely sounds like an anglicism. The link above leading to some partial French translation of Python docs at least comforts me in the idea that ``renvoyer`` is used too. There is some use of ``retourner`` in postal service, but it always means something pre-existing is sent back, which is not what ``return`` does in Python programming (as the thing does not have to be pre-existing).

I attached milestone 1.4.9 but due to above uncertainty (see however next comment), I have nil objection against postponing this (or rejecting it altogether :-) )