### PR TITLE
Add possibility to specify a config file.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -8,14 +8,14 @@ The build configuration file
 .. module:: conf
    :synopsis: Build configuration file.
 
-The :term:`configuration directory` must contain a file named :file:`conf.py`.
-This file (containing Python code) is called the "build configuration file" and
-contains all configuration needed to customize Sphinx input and output behavior.
+The build configuration file contains all parameters that are needed by Sphinx
+and its extensions during the documentation build process.  It is provided to
+``sphinx-build`` via the ``-c`` command line flag.  By default, Sphinx looks
+for a file named ``conf.py`` either in the :term:`configuration directory` or
+in the :term:`source directory`.
 
-The configuration file is executed as Python code at build time (using
-:func:`execfile`, and with the current directory set to its containing
-directory), and therefore can execute arbitrarily complex code.  Sphinx then
-reads simple names from the file's namespace as its configuration.
+The configuration file is executed at build time using :func:`execfile` and
+may therefore contain valid Python code of arbitrary complexity.
 
 Important points to note:
 
@@ -30,10 +30,10 @@ Important points to note:
 * Remember that document names use ``/`` as the path separator and don't contain
   the file name extension.
 
-* Since :file:`conf.py` is read as a Python file, the usual rules apply for
-  encodings and Unicode support: declare the encoding using an encoding cookie
-  (a comment like ``# -*- coding: utf-8 -*-``) and use Unicode string literals
-  when you include non-ASCII characters in configuration values.
+* Since the configuration file is read as a Python file, the usual rules apply
+  for encodings and Unicode support: declare the encoding using an encoding
+  cookie (a comment like ``# -*- coding: utf-8 -*-``) and use Unicode string
+  literals when you include non-ASCII characters in configuration values.
 
 * The contents of the config namespace are pickled (so that Sphinx can find out
   when configuration changes), so it may not contain unpickleable values --
@@ -47,8 +47,8 @@ Important points to note:
   ``tags.has('tag')`` to query, ``tags.add('tag')`` and ``tags.remove('tag')``
   to change. Only tags set via the ``-t`` command-line option or via
   ``tags.add('tag')`` can be queried using ``tags.has('tag')``.
-  Note that the current builder tag is not available in ``conf.py``, as it is
-  created *after* the builder is initialized.
+  Note that the current builder tag is not available in the config file, as it
+  is created *after* the builder is initialized.
 
 
 General configuration

--- a/doc/ext/example_google.py
+++ b/doc/ext/example_google.py
@@ -268,7 +268,7 @@ class ExampleClass(object):
         ``napoleon_include_special_with_doc`` is set to True.
 
         This behavior can be enabled by changing the following setting in
-        Sphinx's conf.py::
+        Sphinx's config file::
 
             napoleon_include_special_with_doc = True
 
@@ -286,7 +286,7 @@ class ExampleClass(object):
         in the output.
 
         This behavior can be changed such that private members *are* included
-        by changing the following setting in Sphinx's conf.py::
+        by changing the following setting in Sphinx's config file::
 
             napoleon_include_private_with_doc = True
 

--- a/doc/ext/example_numpy.py
+++ b/doc/ext/example_numpy.py
@@ -327,7 +327,7 @@ class ExampleClass(object):
         ``napoleon_include_special_with_doc`` is set to True.
 
         This behavior can be enabled by changing the following setting in
-        Sphinx's conf.py::
+        Sphinx's config file::
 
             napoleon_include_special_with_doc = True
 
@@ -345,7 +345,7 @@ class ExampleClass(object):
         in the output.
 
         This behavior can be changed such that private members *are* included
-        by changing the following setting in Sphinx's conf.py::
+        by changing the following setting in Sphinx's config file::
 
             napoleon_include_private_with_doc = True
 

--- a/doc/ext/graphviz.rst
+++ b/doc/ext/graphviz.rst
@@ -112,8 +112,8 @@ There are also these new config values:
    search path.
 
    Since this setting is not portable from system to system, it is normally not
-   useful to set it in ``conf.py``; rather, giving it on the
-   :program:`sphinx-build` command line via the :option:`-D <sphinx-build -D>`
+   useful to set it in the :doc:`configuration file</config>`; rather, giving it
+   on the :program:`sphinx-build` command line via the :option:`-D <sphinx-build -D>`
    option should be preferable, like this::
 
       sphinx-build -b html -D graphviz_dot=C:\graphviz\bin\dot.exe . _build/html

--- a/doc/ext/ifconfig.rst
+++ b/doc/ext/ifconfig.rst
@@ -12,8 +12,8 @@ This extension is quite simple, and features only one directive:
 
    Include content of the directive only if the Python expression given as an
    argument is ``True``, evaluated in the namespace of the project's
-   configuration (that is, all registered variables from :file:`conf.py` are
-   available).
+   configuration (that is, all registered variables from the
+   :doc:`configuration file</config>` are available).
 
    For example, one could write ::
 
@@ -23,7 +23,7 @@ This extension is quite simple, and features only one directive:
 
    To make a custom config value known to Sphinx, use
    :func:`~sphinx.application.Sphinx.add_config_value` in the setup function in
-   :file:`conf.py`, e.g.::
+   the :doc:`configuration file</config>`, e.g.::
 
       def setup(app):
           app.add_config_value('releaselevel', '', 'env')

--- a/doc/ext/math.rst
+++ b/doc/ext/math.rst
@@ -130,9 +130,9 @@ built:
    search path.
 
    Since this setting is not portable from system to system, it is normally not
-   useful to set it in ``conf.py``; rather, giving it on the
-   :program:`sphinx-build` command line via the :option:`-D <sphinx-build -D>`
-   option should be preferable, like this::
+   useful to set it in the :doc:`configuration file</config>`; rather, giving
+   it on the :program:`sphinx-build` command line via the
+   :option:`-D <sphinx-build -D>` option should be preferable, like this::
 
       sphinx-build -b html -D imgmath_latex=C:\tex\latex.exe . _build/html
 

--- a/doc/ext/napoleon.rst
+++ b/doc/ext/napoleon.rst
@@ -64,7 +64,7 @@ Getting Started
 ---------------
 
 1. After :doc:`setting up Sphinx <../tutorial>` to build your docs, enable
-   napoleon in the Sphinx `conf.py` file::
+   napoleon in the Sphinx :doc:`configuration file</config>`::
 
        # conf.py
 
@@ -245,9 +245,9 @@ Configuration
 =============
 
 Listed below are all the settings used by napoleon and their default
-values. These settings can be changed in the Sphinx `conf.py` file. Make
-sure that both "sphinx.ext.autodoc" and "sphinx.ext.napoleon" are
-enabled in `conf.py`::
+values. These settings can be changed in the Sphinx
+:doc:`configuration file</config>` file. Make sure that both
+"sphinx.ext.autodoc" and "sphinx.ext.napoleon" are enabled::
 
     # conf.py
 

--- a/doc/ext/thirdparty.rst
+++ b/doc/ext/thirdparty.rst
@@ -23,7 +23,7 @@ Extensions local to a project should be put within the project's directory
 structure.  Set Python's module search path, ``sys.path``, accordingly so that
 Sphinx can find them.
 E.g., if your extension ``foo.py`` lies in the ``exts`` subdirectory of the
-project root, put into :file:`conf.py`::
+project root, put into the :doc:`configuration file</config>`::
 
    import sys, os
 

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -225,8 +225,9 @@ package.
    * If you provide *parse_node*, it must be a function that takes a string and
      a docutils node, and it must populate the node with children parsed from
      the string.  It must then return the name of the item to be used in
-     cross-referencing and index entries.  See the :file:`conf.py` file in the
-     source for this documentation for an example.
+     cross-referencing and index entries.  See the
+     :doc:`configuration file</config>` in the source for this documentation
+     for an example.
    * The *objname* (if not given, will default to *directivename*) names the
      type of object.  It is used when listing objects, e.g. in search results.
 
@@ -438,8 +439,8 @@ Sphinx core events
 
 These events are known to the core.  The arguments shown are given to the
 registered event handlers.  Use :meth:`.connect` in an extension's ``setup``
-function (note that ``conf.py`` can also have a ``setup`` function) to connect
-handlers to the events.  Example:
+function (note that the :doc:`configuration file</config>` can also have a
+``setup`` function) to connect handlers to the events.  Example:
 
 .. code-block:: python
 

--- a/doc/extdev/envapi.rst
+++ b/doc/extdev/envapi.rst
@@ -21,7 +21,7 @@ Build environment API
 
    .. attribute:: confdir
 
-      Directory containing ``conf.py``.
+      Directory containing the :doc:`configuration file</config>`.
 
    .. attribute:: doctreedir
 

--- a/doc/extdev/tutorial.rst
+++ b/doc/extdev/tutorial.rst
@@ -50,8 +50,8 @@ extension.  These are:
 
 **Config**
    The config object (usually called ``config``) provides the values of
-   configuration values set in :file:`conf.py` as attributes.  It is an instance
-   of :class:`.Config`.
+   configuration values set in the :doc:`configuration file</config>` as
+   attributes.  It is an instance of :class:`.Config`.
 
    The config is available as ``app.config`` or ``env.config``.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -291,7 +291,7 @@ The following notes may be helpful if you want to create Texinfo files:
   now displayed like ```literal'``\s.
 
   The standard formatting can be re-enabled by adding the following to
-  your :file:`conf.py`::
+  your :doc:`configuration file<config>`::
 
      texinfo_elements = {'preamble': """
      @definfoenclose strong,*,*

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -15,9 +15,9 @@ Glossary
       See :ref:`builders` for an overview over Sphinx's built-in builders.
 
    configuration directory
-      The directory containing :file:`conf.py`.  By default, this is the same as
-      the :term:`source directory`, but can be set differently with the **-c**
-      command-line option.
+      The directory containing a build configuration file. By default, Sphinx will
+      look in the :term:`source directory` for a file named :file:`conf.py`, but
+      any other path can be set by the **-c** command-line option.
 
    directive
       A reStructuredText markup element that allows marking a block of content

--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -79,7 +79,7 @@ This section describe a easy way to translate with sphinx-intl.
 #. Install `sphinx-intl`_ by :command:`pip install sphinx-intl` or
    :command:`easy_install sphinx-intl`.
 
-#. Add configurations to your `conf.py`::
+#. Add configurations to your :doc:`configuration file<config>`::
 
       locale_dirs = ['locale/']   # path is example but recommended.
       gettext_compact = False     # optional.
@@ -112,8 +112,9 @@ This section describe a easy way to translate with sphinx-intl.
 
 #. make translated document.
 
-   You need a :confval:`language` parameter in ``conf.py`` or you may also
-   specify the parameter on the command line:
+   You need a :confval:`language` parameter in the
+   :doc:`configuration file<config>` or you may also specify the parameter on
+   the command line:
 
    .. code-block:: console
 

--- a/doc/invocation.rst
+++ b/doc/invocation.rst
@@ -283,11 +283,12 @@ The :program:`sphinx-build` script has several options:
 
 .. option:: -c path
 
-   Don't look for the :file:`conf.py` in the source directory, but use the given
-   configuration directory instead.  Note that various other files and paths
-   given by configuration values are expected to be relative to the
-   configuration directory, so they will have to be present at this location
-   too.
+   Don't look for the :doc:`configuration file<config>` in the source
+   directory, but use the given file path instead. If the path is a directory,
+   look for a file ``conf.py`` in that directory.  Note that various other
+   files and paths given by configuration values are expected to be relative to
+   the configuration directory, so they will have to be present at this
+   location too.
 
    .. versionadded:: 0.3
 
@@ -299,8 +300,8 @@ The :program:`sphinx-build` script has several options:
 
 .. option:: -D setting=value
 
-   Override a configuration value set in the :file:`conf.py` file.  The value
-   must be a number, string, list or dictionary value.
+   Override a configuration value set in the :doc:`configuration file<config>`.
+   The value must be a number, string, list or dictionary value.
 
    For lists, you can separate elements with a comma like this: ``-D
    html_theme_path=path1,path2``.

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -27,11 +27,13 @@ The *latex* target does not benefit from pre-prepared themes like the
 Basic customization
 -------------------
 
-It is available from ``conf.py`` via usage of the
-:ref:`latex-options` as described in :doc:`config` (backslashes must be doubled
-in Python string literals to reach latex.) For example::
+The LaTeX extensions provides several configuration options in the :doc:`build
+configuration file <config>`.  They are described in the :ref:`LaTeX section
+<latex-options>`. When specifying LaTeX macros and commands, please remember
+that backslashes must be doubled in Python String literals. See the following
+example::
 
-    # inside conf.py
+    # inside the config file
     latex_engine = 'xelatex'
     latex_elements = {
         'fontenc': '\\usepackage{fontspec}',
@@ -342,13 +344,14 @@ Let us now list some macros from the package file
   ``optional``. By default and for backwards compatibility the ``\sphinx<foo>``
   expands to ``\<foo>`` hence the user can choose to customize rather the latter
   (the non-prefixed macros will be left undefined if option
-  :confval:`latex_keep_old_macro_names` is set to ``False`` in :file:`conf.py`.)
+  :confval:`latex_keep_old_macro_names` is set to ``False`` in the
+  :doc:`config file <config>`)
 
   .. versionchanged:: 1.4.5
      use of ``\sphinx`` prefixed macro names to limit possibilities of conflict
      with user added packages: if
      :confval:`latex_keep_old_macro_names` is set to ``False`` in
-     :file:`conf.py` only the prefixed names are defined.
+     the :doc:`config file <config>` only the prefixed names are defined.
 - more text styling commands: ``\sphinxstyle<bar>`` with ``<bar>`` one of
   ``indexentry``, ``indexextra``, ``indexpageref``, ``topictitle``,
   ``sidebartitle``, ``othertitle``, ``sidebarsubtitle``, ``thead``,

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -15,7 +15,7 @@ Description
 :program:`sphinx-build` generates documentation from the files in
 ``<sourcedir>`` and places it in the ``<outdir>``.
 
-:program:`sphinx-build` looks for ``<sourcedir>/conf.py`` for the configuration
+:program:`sphinx-build` looks in ``<sourcedir>/conf.py`` for the configuration
 settings.  :manpage:`sphinx-quickstart(1)` may be used to generate template
 files, including ``conf.py``.
 
@@ -96,9 +96,11 @@ Options
                       from disk.
 -d <path>             Path to cached files; defaults to <outdir>/.doctrees.
 -j <N>                Build in parallel with N processes where possible.
--c <path>             Locate the conf.py file in the specified path instead of
-                      <sourcedir>.
--C                    Specify that no conf.py file at all is to be used.
+-c <file>             Use <file> as the config file.
+                      If <file> is directory, sphinx tries to load a conf.py
+                      from there.
+                      If this option is not given at all, behaviour is the same as for -c <sourcedir>.
+-C                    Specifies that no config file is used at all.
                       Configuration can only be set with the -D option.
 -D <setting=value>    Override a setting from the configuration file.
 -t <tag>              Define *tag* for use in "only" blocks.

--- a/doc/markup/misc.rst
+++ b/doc/markup/misc.rst
@@ -176,7 +176,7 @@ Including content based on tags
       .. only:: html and draft
 
    Undefined tags are false, defined tags (via the ``-t`` command-line option or
-   within :file:`conf.py`, see :ref:`here <conf-tags>`) are true.  Boolean
+   within the configuration file, see :ref:`here <conf-tags>`) are true.  Boolean
    expressions, also using parentheses (like ``html and (latex or draft)``) are
    supported.
 
@@ -269,6 +269,7 @@ following directive exists:
        builders derived from the html builder distinguish between the builder
        format and the builder name.
 
-       Note that the current builder tag is not available in ``conf.py``, it is
-       only available after the builder is initialized.
+       Note that the current builder tag is not available in the
+       :doc:`configuration file</config>`, it is only available after the
+       builder is initialized.
 

--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -22,7 +22,7 @@ Using an existing theme is easy.  If the theme is builtin to Sphinx, you only
 need to set the :confval:`html_theme` config value.  With the
 :confval:`html_theme_options` config value you can set theme-specific options
 that change the look and feel.  For example, you could have the following in
-your :file:`conf.py`::
+your :doc:`configuration file<config>`::
 
     html_theme = "classic"
     html_theme_options = {
@@ -38,10 +38,11 @@ If the theme does not come with Sphinx, it can be in two static forms: either a
 directory (containing :file:`theme.conf` and other needed files), or a zip file
 with the same contents.  Either of them must be put where Sphinx can find it;
 for this there is the config value :confval:`html_theme_path`.  It gives a list
-of directories, relative to the directory containing :file:`conf.py`, that can
-contain theme directories or zip files.  For example, if you have a theme in the
-file :file:`blue.zip`, you can put it right in the directory containing
-:file:`conf.py` and use this configuration::
+of directories, relative to the directory containing
+:doc:`configuration file<config>`, that can contain theme directories or zip
+files.  For example, if you have a theme in the file :file:`blue.zip`, you can
+put it right in the directory containing the :doc:`configuration file<config>`
+and use this configuration::
 
     html_theme = "blue"
     html_theme_path = ["."]
@@ -344,9 +345,9 @@ is built with the classic theme, the output directory will contain a
 ``_static/classic.css`` file where all template tags have been processed.
 
 
-.. [1] It is not an executable Python file, as opposed to :file:`conf.py`,
-       because that would pose an unnecessary security risk if themes are
-       shared.
+.. [1] It is not an executable Python file, as opposed to the
+       :doc:`configuration file<config>`, because that would pose an
+       unnecessary security risk if themes are shared.
 
 Third Party Themes
 ------------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -24,12 +24,13 @@ Setting up the documentation sources
 
 The root directory of a Sphinx collection of reStructuredText document sources
 is called the :term:`source directory`.  This directory also contains the Sphinx
-configuration file :file:`conf.py`, where you can configure all aspects of how
-Sphinx reads your sources and builds your documentation.  [#]_
+:doc:`configuration file<config>` by default, where you can configure all
+aspects of how Sphinx reads your sources and builds your documentation.  [#]_
 
 Sphinx comes with a script called :program:`sphinx-quickstart` that sets up a
-source directory and creates a default :file:`conf.py` with the most useful
-configuration values from a few questions it asks you.  Just run ::
+source directory and creates a default :doc:`configuration file<config>`
+:file:`conf.py` with the most useful configuration values from a few questions
+it asks you.  Just run ::
 
    $ sphinx-quickstart
 
@@ -206,18 +207,19 @@ directives/roles.
 Basic configuration
 -------------------
 
-Earlier we mentioned that the :file:`conf.py` file controls how Sphinx processes
-your documents.  In that file, which is executed as a Python source file, you
-assign configuration values.  For advanced users: since it is executed by
-Sphinx, you can do non-trivial tasks in it, like extending :data:`sys.path` or
-importing a module to find out the version you are documenting.
+Earlier we mentioned that the :doc:`configuration file<config>` controls how
+Sphinx processes your documents.  In that file, which is executed as a Python
+source file, you assign configuration values.  For advanced users: since it is
+executed by Sphinx, you can do non-trivial tasks in it, like extending
+:data:`sys.path` or importing a module to find out the version you are
+documenting.
 
 The config values that you probably want to change are already put into the
-:file:`conf.py` by :program:`sphinx-quickstart` and initially commented out
-(with standard Python syntax: a ``#`` comments the rest of the line).  To change
-the default value, remove the hash sign and modify the value.  To customize a
-config value that is not automatically added by :program:`sphinx-quickstart`,
-just add an additional assignment.
+:doc:`configuration file<config>` by :program:`sphinx-quickstart` and
+initially commented out (with standard Python syntax: a ``#`` comments the
+rest of the line).  To change the default value, remove the hash sign and
+modify the value.  To customize a config value that is not automatically added
+by :program:`sphinx-quickstart`, just add an additional assignment.
 
 Keep in mind that the file uses Python syntax for strings, numbers, lists and so
 on.  The file is saved in UTF-8 by default, as indicated by the encoding
@@ -235,10 +237,10 @@ source files, in documentation strings.  Sphinx supports the inclusion of
 docstrings from your modules with an :dfn:`extension` (an extension is a Python
 module that provides additional features for Sphinx projects) called "autodoc".
 
-In order to use autodoc, you need to activate it in :file:`conf.py` by putting
-the string ``'sphinx.ext.autodoc'`` into the list assigned to the
-:confval:`extensions` config value.  Then, you have a few additional directives
-at your disposal.
+In order to use autodoc, you need to activate it in the :doc:`configuration
+file<config>` by putting the string ``'sphinx.ext.autodoc'`` into the list
+assigned to the :confval:`extensions` config value.  Then, you have a few
+additional directives at your disposal.
 
 For example, to document the function ``io.open()``, reading its
 signature and docstring from the source file, you'd write this::
@@ -253,7 +255,7 @@ options for the auto directives, like ::
 
 autodoc needs to import your modules in order to extract the docstrings.
 Therefore, you must add the appropriate path to :py:data:`sys.path` in your
-:file:`conf.py`.
+:doc:`configuration file<config>`.
 
 .. warning::
 
@@ -276,9 +278,10 @@ documentation, you can do it with :mod:`sphinx.ext.intersphinx`.
 
 .. _Python documentation: https://docs.python.org/3
 
-In order to use intersphinx, you need to activate it in :file:`conf.py` by
-putting the string ``'sphinx.ext.intersphinx'`` into the :confval:`extensions`
-list and set up the :confval:`intersphinx_mapping` config value.
+In order to use intersphinx, you need to activate it in the
+:doc:`configuration file<config>` by putting the string
+``'sphinx.ext.intersphinx'`` into the :confval:`extensions` list and set up
+the :confval:`intersphinx_mapping` config value.
 
 For example, to link to ``io.open()`` in the Python library manual, you need to
 setup your :confval:`intersphinx_mapping` like::
@@ -315,9 +318,9 @@ More topics to be covered
 
 .. rubric:: Footnotes
 
-.. [#] This is the usual layout.  However, :file:`conf.py` can also live in
-       another directory, the :term:`configuration directory`.  See
-       :ref:`invocation`.
+.. [#] This is the usual layout.  However, the
+   :doc:`configuration file<config>` can also live in any other directory.
+   See :ref:`invocation` for more details.
 
 .. |more| image:: more.png
           :align: middle

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -43,7 +43,7 @@ if False:
 # mimetype, and META-INF/container.xml are created.
 # This template section also defines strings that are embedded in the html
 # output but that may be customized by (re-)setting module attributes,
-# e.g. from conf.py.
+# e.g. from the config file.
 
 MIMETYPE_TEMPLATE = 'application/epub+zip'  # no EOL!
 

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -22,7 +22,7 @@ from sphinx.builders.epub import EpubBuilder
 # mimetype, and META-INF/container.xml are created.
 # This template section also defines strings that are embedded in the html
 # output but that may be customized by (re-)setting module attributes,
-# e.g. from conf.py.
+# e.g. from the config file.
 
 NAVIGATION_DOC_TEMPLATE = u'''\
 <?xml version="1.0" encoding="UTF-8"?>

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -524,7 +524,7 @@ class StandaloneHTMLBuilder(Builder):
 
         self.info(bold('writing additional pages...'), nonl=1)
 
-        # additional pages from conf.py
+        # additional pages from the config file
         for pagename, template in self.config.html_additional_pages.items():
             self.info(' '+pagename, nonl=1)
             self.handle_page(pagename, {}, template)
@@ -1117,7 +1117,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         # no indices or search pages are supported
         self.info(bold('writing additional files...'), nonl=1)
 
-        # additional pages from conf.py
+        # additional pages from the config file
         for pagename, template in self.config.html_additional_pages.items():
             self.info(' '+pagename, nonl=1)
             self.handle_page(pagename, {}, template)

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -165,8 +165,8 @@ class LaTeXBuilder(Builder):
             # fresh document
             new_tree = new_document('<latex output>')
             new_sect = nodes.section()
-            new_sect += nodes.title(u'<Set title in conf.py>',
-                                    u'<Set title in conf.py>')
+            new_sect += nodes.title(u'<Set title in the config file>',
+                                    u'<Set title in the config file>')
             new_tree += new_sect
             for node in tree.traverse(addnodes.toctree):
                 new_sect += node

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -186,8 +186,8 @@ class TexinfoBuilder(Builder):
             # fresh document
             new_tree = new_document('<texinfo output>')
             new_sect = nodes.section()
-            new_sect += nodes.title(u'<Set title in conf.py>',
-                                    u'<Set title in conf.py>')
+            new_sect += nodes.title(u'<Set title in the config file>',
+                                    u'<Set title in the config file>')
             new_tree += new_sect
             for node in tree.traverse(addnodes.toctree):
                 new_sect += node

--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -239,7 +239,7 @@ def cut_lines(pre, post=0, what=None):
     lines of every docstring.  If *what* is a sequence of strings,
     only docstrings of a type in *what* will be processed.
 
-    Use like this (e.g. in the ``setup()`` function of :file:`conf.py`)::
+    Use like this (e.g. in the ``setup()`` function of the config file)::
 
        from sphinx.ext.autodoc import cut_lines
        app.connect('autodoc-process-docstring', cut_lines(4, what=['module']))

--- a/sphinx/ext/ifconfig.py
+++ b/sphinx/ext/ifconfig.py
@@ -14,7 +14,7 @@
 
     The argument for ``ifconfig`` is a plain Python expression, evaluated in the
     namespace of the project configuration (that is, all variables from
-    ``conf.py`` are available.)
+    the config file are available.)
 
     :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/sphinx/ext/linkcode.py
+++ b/sphinx/ext/linkcode.py
@@ -33,7 +33,7 @@ def doctree_read(app, doctree):
     resolve_target = getattr(env.config, 'linkcode_resolve', None)
     if not callable(env.config.linkcode_resolve):
         raise LinkcodeError(
-            "Function `linkcode_resolve` is not given in conf.py")
+            "Function `linkcode_resolve` is not given in the config file")
 
     domain_keys = dict(
         py=['module', 'fullname'],

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -23,12 +23,12 @@ if False:
 
 
 class Config(object):
-    """Sphinx napoleon extension settings in `conf.py`.
+    """Sphinx napoleon extension settings in the config file.
 
     Listed below are all the settings used by napoleon and their default
-    values. These settings can be changed in the Sphinx `conf.py` file. Make
+    values. These settings can be changed in the Sphinx config file. Make
     sure that both "sphinx.ext.autodoc" and "sphinx.ext.napoleon" are
-    enabled in `conf.py`::
+    enabled in the config file::
 
         # conf.py
 
@@ -332,8 +332,8 @@ def _process_docstring(app, what, name, obj, options, lines):
     of docstring lines that `_process_docstring` modifies in place to change
     what Sphinx outputs.
 
-    The following settings in conf.py control what styles of docstrings will
-    be parsed:
+    The following settings in the config file control what styles of
+    docstrings will be parsed:
 
     * ``napoleon_google_docstring`` -- parse Google style docstrings
     * ``napoleon_numpy_docstring`` -- parse NumPy style docstrings
@@ -378,8 +378,8 @@ def _skip_member(app, what, name, obj, skip, options):
     # type: (Sphinx, unicode, unicode, Any, bool, Any) -> bool
     """Determine if private and special class members are included in docs.
 
-    The following settings in conf.py determine if private and special class
-    members or init methods are included in the generated documentation:
+    The following settings in the config file determine if private and special
+    class members or init methods are included in the generated documentation:
 
     * ``napoleon_include_init_with_doc`` --
       include init methods if they have docstrings

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -53,7 +53,7 @@ class BuildDoc(Command):
            author='Bernard Montgomery',
            version=release,
            cmdclass=cmdclass,
-           # these are optional and override conf.py settings
+           # these are optional and override config file settings
            command_options={
                'build_sphinx': {
                    'project': ('setup.py', name),

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1043,7 +1043,7 @@
 \ifspx@opt@dontkeepoldnames\else
   \typeout{** (sphinx) defining (legacy) text style macros without \string\sphinx\space prefix}
   \typeout{** if clashes with packages, set latex_keep_old_macro_names=False
-    in conf.py}
+    in the config file}
   \@for\@tempa:=code,strong,bfcode,email,tablecontinued,titleref,%
                 menuselection,accelerator,crossref,termref,optional\do
 {% first, check if command with no prefix already exists


### PR DESCRIPTION
This pull request addresses #3133 and enhances the -c command line option. "-c" may now either specify a directory or point to a config file. In case of a directory, it is assumed to contain a conf.py file. The behavior of -c remains fully backwards compatible.

The commit contains the (small) functional changes in the command line parser and many changes in the documentation. Most occurrences of :file:`conf.py` have been replaced by a link to the configuration file
documentation. I've also simplified some sentences mentioning the config file whenever it seemed appropriate.

Please let me know what is needed in order to get this patch accepted.