### PR TITLE
[Napoleon] Fixed the regular expression for xref 

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -33,7 +33,7 @@ _google_section_regex = re.compile(r'^(\s|\w)+:\s*$')
 _google_typed_arg_regex = re.compile(r'\s*(.+?)\s*\(\s*(.*[^\s]+)\s*\)')
 _numpy_section_regex = re.compile(r'^[=\-`:\'"~^_*+#<>]{2,}\s*$')
 _single_colon_regex = re.compile(r'(?<!:):(?!:)')
-_xref_regex = re.compile(r'(:\w+:\S+:`.+?`|:\S+:`.+?`|`.+?`)')
+_xref_regex = re.compile(r'(:(?:[a-zA-Z0-9]+[\-_+:.])*[a-zA-Z0-9]+:`.+?`)')
 _bullet_list_regex = re.compile(r'^(\*|\+|\-)(\s+\S|\s*$)')
 _enumerated_list_regex = re.compile(
     r'^(?P<paren>\()?'


### PR DESCRIPTION
I changed it to only match roles that are valid according to the [docultils specification](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#interpreted-text):

> A role name is a single word consisting of alphanumerics plus isolated internal hyphens, underscores, plus signs, colons, and periods; no whitespace or other characters are allowed.

The previous one caused errors when having multiple successive xrefs without whitespace between them. Here is a slightly modified version of the example from the docs that uses links for typing classes:

```python
def function_with_pep484_type_annotations(param1: Dict[int, str], param2: str) -> Optional[bool]:
    r"""Example function with PEP 484 type annotations.

    Args:
        param1 (:class:`~typing.Dict`\[:class:`int`, :class:`str`\]): The first parameter.
        param2 (:class:`str`): The second parameter.
        
    Returns:
        :class:`~typing.Optional`\[:class:`bool`]: The return value. True for success, False otherwise.
    """
```
The lacking whitespace between two pairs of colons breaks the splitting with the old regular expression and the fields are not recognized properly. With the new one it works.