### PR TITLE
latex: add stretch/shrink between successive singleline or multipleline cpp signatures

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -650,12 +650,18 @@
 \newlength{\py@argswidth}
 \newcommand{\py@sigparams}[2]{%
   \parbox[t]{\py@argswidth}{#1\sphinxcode{)}#2}}
-\newcommand{\pysigline}[1]{\item[{#1}]\nopagebreak}
+\newcommand{\pysigline}[1]{\item[{#1}]}
 \newcommand{\pysiglinewithargsret}[3]{%
   \settowidth{\py@argswidth}{#1\sphinxcode{(}}%
   \addtolength{\py@argswidth}{-2\py@argswidth}%
   \addtolength{\py@argswidth}{\linewidth}%
   \item[{#1\sphinxcode{(}\py@sigparams{#2}{#3}}]}
+\newcommand{\pysigstartmultiline}{%
+ \def\pysigstartmultiline{\vskip\smallskipamount\parskip\z@skip\itemsep\z@skip}%
+ \edef\pysigstopmultiline
+     {\noexpand\leavevmode\parskip\the\parskip\relax\itemsep\the\itemsep\relax}%
+ \parskip\z@skip\itemsep\z@skip
+}
 
 % Production lists
 %

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -918,10 +918,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.body.append(hyper)
         if not node.get('is_multiline'):
             self._visit_signature_line(node)
+        else:
+            self.body.append('%\n\\pysigstartmultiline\n')
 
     def depart_desc_signature(self, node):
         if not node.get('is_multiline'):
             self._depart_signature_line(node)
+        else:
+            self.body.append('%\n\\pysigstopmultiline')
 
     def visit_desc_signature_line(self, node):
         self._visit_signature_line(node)


### PR DESCRIPTION
This is resuscitated PR #3084, which was a latex follow-up to #3072.

I have rebased it on master and added a commit to try to implement https://github.com/sphinx-doc/sphinx/pull/3084#issuecomment-262049188

The used spacing  is `\smallskipamount` whose default is ``3.0pt plus 1.0pt minus 1.0pt ``.

It could be made configurable variable of latex writer.

If ok, must this be on master or can it go to 1.5-release ?