### PR TITLE
Fix #3190: Update util.split_docinfo so that it parses multi-line field bodies.

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -545,7 +545,7 @@ def encode_uri(uri):
 
 
 def split_docinfo(text):
-    docinfo_re = re.compile('\A((?:\s*:\w+:.*?\n)+)', re.M)
+    docinfo_re = re.compile('\A((?:\s*:\w+:.*?\n(?:[ \t]+.*?\n)*)+)', re.M)
     result = docinfo_re.split(text, 1)
     if len(result) == 1:
         return '', result[0]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -41,3 +41,8 @@ def test_splitdocinfo():
     docinfo, content = split_docinfo(source)
     assert docinfo == ':author: Georg Brandl\n:title: Manual of Sphinx\n'
     assert content == '\nHello world.\n'
+
+    source = ":multiline: one\n\ttwo\n\tthree\n\nHello world.\n"
+    docinfo, content = split_docinfo(source)
+    assert docinfo == ":multiline: one\n\ttwo\n\tthree\n"
+    assert content == '\nHello world.\n'


### PR DESCRIPTION
This pull request fixes issue #3190.

Field Lists, which are used to define docinfo, allow multi-line field bodies, but util.split_docinfo didn't consider it. This PR updates the regex in that function so that it splits such multi-line field bodies at the correct point.