### PR TITLE
#3205: sphinx.util.requests crashes with old pyOpenSSL (< 0.14)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 * #3212: HTML Builders crashes with docutils-0.13
 * #3207: more latex problems with references inside parsed-literal directive
   (``\DUrole``)
+* #3205: sphinx.util.requests crashes with old pyOpenSSL (< 0.14)
 
 
 Release 1.5 (released Dec 5, 2016)

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -22,7 +22,8 @@ from requests.packages.urllib3.exceptions import SSLError, InsecureRequestWarnin
 # try to load requests[security]
 try:
     pkg_resources.require(['requests[security]'])
-except pkg_resources.DistributionNotFound:
+except (pkg_resources.DistributionNotFound,
+        pkg_resources.VersionConflict):
     import ssl
     if not getattr(ssl, 'HAS_SNI', False):
         # don't complain on each url processed about the SSL issue


### PR DESCRIPTION
refs: #3205 
This also includes #3217 . so this should be merged after the PR.