### PR TITLE
LaTeX: Make sure sphinxVerbatim environment is not cut into pieces

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2183,10 +2183,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
                                         '\\begin{sphinxVerbatim}')
             # get consistent trailer
             hlcode = hlcode.rstrip()[:-14]  # strip \end{Verbatim}
-            self.body.append('\n' + hlcode + '\\end{sphinxVerbatim')
             if self.table and not self.in_footnote:
-                self.body.append('intable')
-            self.body.append('}\n')
+                hlcode += '\\end{sphinxVerbatimintable}'
+            else:
+                hlcode += '\\end{sphinxVerbatim}'
+            self.body.append('\n' + hlcode + '\n')
             if ids:
                 self.body.append('\\let\\sphinxLiteralBlockLabel\\empty\n')
             raise nodes.SkipNode


### PR DESCRIPTION
#3022 breaks the LaTeX output of [nbsphinx](https://github.com/spatialaudio/nbsphinx) because I was assuming that the whole verbatim environment is contained in a single list element of `self.body`.

See https://github.com/spatialaudio/nbsphinx/issues/78.

This PR makes sure that only a single call to `self.body.append()` is used. The content (after concatenation) should be unchanged.