### PR TITLE
Update latex style file date and version string to 1.5.1

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2016/10/29 v1.5 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2016/12/11 v1.5.1 LaTeX package (Sphinx markup)]
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.


### PR DESCRIPTION
Indeed, this helps double-checks user latex logs about used version.

I am not sure whether this fits Sphinx release policy, hence this PR.