### PR TITLE
#3194: Refer the $MAKE environment variable to determine ``make`` command

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Features added
 --------------
 
 * #3241: emit latex warning if buggy titlesec (ref #3210)
+* #3194: Refer the $MAKE environment variable to determine ``make`` command
 
 Bugs fixed
 ----------

--- a/doc/invocation.rst
+++ b/doc/invocation.rst
@@ -384,6 +384,15 @@ You can also give one or more filenames on the command line after the source and
 build directories.  Sphinx will then try to build only these output files (and
 their dependencies).
 
+Environment variables
+---------------------
+
+The :program:`sphinx-build` refers following environment variables:
+
+.. desribe:: MAKE
+
+   A path to make command.  A command name is also allowed.
+   :program:`sphinx-build` uses it to invoke sub-build process on make-mode.
 
 Makefile options
 ----------------

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -62,6 +62,7 @@ class Make(object):
         self.srcdir = srcdir
         self.builddir = builddir
         self.opts = opts
+        self.makecmd = os.environ.get('MAKE', 'make')  # refer $MAKE to determine make command
 
     def builddir_join(self, *comps):
         return path.join(self.builddir, *comps)
@@ -162,13 +163,13 @@ class Make(object):
         if self.run_generic_build('latex') > 0:
             return 1
         with cd(self.builddir_join('latex')):
-            os.system('make all-pdf')
+            os.system('%s all-pdf' % self.makecmd)
 
     def build_latexpdfja(self):
         if self.run_generic_build('latex') > 0:
             return 1
         with cd(self.builddir_join('latex')):
-            os.system('make all-pdf-ja')
+            os.system('%s all-pdf-ja' % self.makecmd)
 
     def build_text(self):
         if self.run_generic_build('text') > 0:
@@ -189,7 +190,7 @@ class Make(object):
         if self.run_generic_build('texinfo') > 0:
             return 1
         with cd(self.builddir_join('texinfo')):
-            os.system('make info')
+            os.system('%s info' % self.makecmd)
 
     def build_gettext(self):
         dtdir = self.builddir_join('gettext', '.doctrees')


### PR DESCRIPTION
refs: #3194 
I agree this is feature improvement, but some users on BSD-like OS are hard to build document.
So I think this is important specific-bug fix.