### PR TITLE
Add default quickstart support for Chinese LaTex support.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Other contributors, listed alphabetically, are:
 * Michael Wilson -- Intersphinx HTTP basic auth support
 * Joel Wurtz -- cellspanning support in LaTeX
 * Hong Xu -- svg support in imgmath extension and various bug fixes
+* Delin Chang -- Chinese LaTeX default configuration in quickstart
 
 Many thanks for all contributions!
 

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -141,7 +141,13 @@ latex_documents = [
     (master_doc, '{{ project_fn }}.tex', u'{{ project_doc_texescaped_str }}',
      u'{{ author_texescaped_str }}', 'manual'),
 ]
-
+{% if language.split('_')[0] == 'zh' %}
+# Render Chinese LaTex defaults to xelatex+ctex as it works in most cases
+# Leave it configurable here for user customization
+if language.split('_')[0] == 'zh':
+    latex_engine = 'xelatex'
+    latex_elements = {'usepackages':'\\usepackage{ctex}','polyglossia':''}
+{% endif %}
 
 # -- Options for manual page output ---------------------------------------
 

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -141,7 +141,7 @@ latex_documents = [
     (master_doc, '{{ project_fn }}.tex', u'{{ project_doc_texescaped_str }}',
      u'{{ author_texescaped_str }}', 'manual'),
 ]
-{% if language.split('_')[0] == 'zh' %}
+{% if language|default('').split('_')[0] == 'zh' %}
 # Render Chinese LaTex defaults to xelatex+ctex as it works in most cases
 # Leave it configurable here for user customization
 if language.split('_')[0] == 'zh':


### PR DESCRIPTION
Most common use of Chinese LaTeX is xelatex+ctex with encoding UTF-8, and there are many other possible configurations for different tasks.
For example, another option is to use pdflatex+ctex with encoding GBK.
Generally no one uses basic "latex" command to generate chinese pdfs as it is outdated, unmaintained and too complicated to configure.