### PR TITLE
Moving to standard logging/warning module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,8 +8,6 @@ Incompatible changes
   members by default. Thanks to Luc Saffre.
 * LaTeX ``\includegraphics`` command isn't overloaded: only ``\sphinxincludegraphics``
   has the custom code to fit image to available width if oversized.
-* #2367: ``Sphinx.warn()``, ``Sphinx.info()`` and other logging methods are now
-  deprecated.  Please use ``sphinx.util.logging`` (:ref:`logging-api`) instead.
 
 Features added
 --------------
@@ -27,6 +25,8 @@ Deprecated
 * ``sphinx.util.compat.Directive`` class is now deprecated. Please use instead
   ``docutils.parsers.rsr.Directive``
 * ``sphinx.util.compat.docutils_version`` is now deprecated
+* #2367: ``Sphinx.warn()``, ``Sphinx.info()`` and other logging methods are now
+  deprecated.  Please use ``sphinx.util.logging`` (:ref:`logging-api`) instead.
 
 Release 1.5.2 (in development)
 ===============================

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Incompatible changes
   members by default. Thanks to Luc Saffre.
 * LaTeX ``\includegraphics`` command isn't overloaded: only ``\sphinxincludegraphics``
   has the custom code to fit image to available width if oversized.
+* #2367: ``Sphinx.warn()``, ``Sphinx.info()`` and other logging methods are now
+  deprecated.  Please use ``sphinx.util.logging`` (:ref:`logging-api`) instead.
 
 Features added
 --------------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -54,3 +54,4 @@ APIs used for writing extensions
    domainapi
    parserapi
    nodes
+   logging

--- a/doc/extdev/logging.rst
+++ b/doc/extdev/logging.rst
@@ -1,0 +1,78 @@
+.. _logging-api:
+
+Logging API
+===========
+
+.. function:: sphinx.util.logging.getLogger(name)
+
+   Return a logger wrapped by :class:`SphinxLoggerAdapter` with the specified *name*.
+
+   Example usage::
+
+     from sphinx.util import logging  # Load instead python's logging module
+
+     logger = logging.getLogger(__name__)
+     logger.info('Hello, this is an extension!')
+
+.. class:: SphinxLoggerAdapter(logging.LoggerAdapter)
+
+   .. method:: SphinxLoggerAdapter.error(level, msg, *args, **kwargs)
+   .. method:: SphinxLoggerAdapter.critical(level, msg, *args, **kwargs)
+   .. method:: SphinxLoggerAdapter.warning(level, msg, *args, **kwargs)
+
+      Logs a message with specified level on this logger.
+      Basically, the arguments are same as python's logging module.
+
+      In addition, Sphinx logger supports following keyword arguments:
+
+      **type**, ***subtype***
+        Indicate categories of warning logs.  It is used to suppress
+        warnings by :confval:`suppress_warnings` setting.
+
+      **location**
+        Indicate where the warning is happened.  It is used to show
+        the path and line number to each log.  It allows docname,
+        tuple of docname and line number and nodes::
+
+          logger = sphinx.util.logging.getLogger(__name__)
+          logger.warning('Warning happened!', location='index')
+          logger.warning('Warning happened!', location=('chapter1/index', 10))
+          logger.warning('Warning happened!', location=some_node)
+
+      **color**
+        Indicate the color of logs.  By default, warning level logs are
+        colored as ``"darkred"``.  The others are not colored.
+
+   .. method:: SphinxLoggerAdapter.log(level, msg, *args, **kwargs)
+   .. method:: SphinxLoggerAdapter.info(level, msg, *args, **kwargs)
+   .. method:: SphinxLoggerAdapter.verbose(level, msg, *args, **kwargs)
+   .. method:: SphinxLoggerAdapter.debug(level, msg, *args, **kwargs)
+   .. method:: SphinxLoggerAdapter.debug2(level, msg, *args, **kwargs)
+
+      Logs a message with specified level on this logger.
+      Basically, the arguments are same as python's logging module.
+
+      In addition, Sphinx logger supports following keyword arguments:
+
+      **nonl**
+        If true, the logger does not fold lines at end of the log message.
+        The default is ``False``.
+
+      **color**
+        Indicate the color of logs.  By default, debug level logs are
+        colored as ``"darkgray"``, and debug2 ones are ``"lightgray"``.
+        The others are not colored.
+
+.. function:: pending_logging()
+
+   Make all logs as pending while the context::
+
+     with pending_logging():
+       logger.warning('Warning message!')  # not flushed yet
+       some_long_process()
+
+     # the warning is flushed here
+
+.. function:: pending_warnings()
+
+   Make warning logs as pending while the context.  Similar to :func:`pending_logging`.

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -319,7 +319,7 @@ class Sphinx(object):
                 if isinstance(err, IOError) and err.errno == ENOENT:
                     logger.info('not yet created')
                 else:
-                    logger.info('failed: %s' % err)
+                    logger.info('failed: %s', err)
                 self._init_env(freshenv=True)
 
     def _init_builder(self, buildername):

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -35,7 +35,7 @@ from sphinx.errors import SphinxError, ExtensionError, VersionRequirementError, 
     ConfigError
 from sphinx.domains import ObjType
 from sphinx.domains.std import GenericObject, Target, StandardDomain
-from sphinx.deprecation import RemovedInSphinx17Warning
+from sphinx.deprecation import RemovedInSphinx17Warning, RemovedInSphinx20Warning
 from sphinx.environment import BuildEnvironment
 from sphinx.io import SphinxStandaloneReader
 from sphinx.roles import XRefRole
@@ -399,6 +399,8 @@ class Sphinx(object):
             warnings.warn('colorfunc option of warn() is now deprecated.',
                           RemovedInSphinx17Warning)
 
+        warnings.warn('app.warning() is now deprecated. Use sphinx.util.logging instead.',
+                      RemovedInSphinx20Warning)
         logger.warning(message, type=type, subtype=subtype, location=location)
 
     def info(self, message='', nonl=False):
@@ -408,21 +410,29 @@ class Sphinx(object):
         If *nonl* is true, don't emit a newline at the end (which implies that
         more info output will follow soon.)
         """
+        warnings.warn('app.info() is now deprecated. Use sphinx.util.logging instead.',
+                      RemovedInSphinx20Warning)
         logger.info(message, nonl=nonl)
 
     def verbose(self, message, *args, **kwargs):
         # type: (unicode, Any, Any) -> None
         """Emit a verbose informational message."""
+        warnings.warn('app.verbose() is now deprecated. Use sphinx.util.logging instead.',
+                      RemovedInSphinx20Warning)
         logger.verbose(message, *args, **kwargs)
 
     def debug(self, message, *args, **kwargs):
         # type: (unicode, Any, Any) -> None
         """Emit a debug-level informational message."""
+        warnings.warn('app.debug() is now deprecated. Use sphinx.util.logging instead.',
+                      RemovedInSphinx20Warning)
         logger.debug(message, *args, **kwargs)
 
     def debug2(self, message, *args, **kwargs):
         # type: (unicode, Any, Any) -> None
         """Emit a lowlevel debug-level informational message."""
+        warnings.warn('app.debug2() is now deprecated. Use sphinx.util.logging instead.',
+                      RemovedInSphinx20Warning)
         logger.debug2(message, *args, **kwargs)
 
     def _display_chunk(chunk):

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -233,9 +233,9 @@ class Sphinx(object):
         if self.config.needs_extensions:
             for extname, needs_ver in self.config.needs_extensions.items():
                 if extname not in self._extensions:
-                    self.warn('needs_extensions config value specifies a '
-                              'version requirement for extension %s, but it is '
-                              'not loaded' % extname)
+                    logger.warning('needs_extensions config value specifies a '
+                                   'version requirement for extension %s, but it is '
+                                   'not loaded', extname)
                     continue
                 has_ver = self._extension_metadata[extname]['version']
                 if has_ver == 'unknown version' or needs_ver > has_ver:
@@ -246,7 +246,7 @@ class Sphinx(object):
 
         # check primary_domain if requested
         if self.config.primary_domain and self.config.primary_domain not in self.domains:
-            self.warn('primary_domain %r not found, ignored.' % self.config.primary_domain)
+            logger.warning('primary_domain %r not found, ignored.', self.config.primary_domain)
 
         # set up translation infrastructure
         self._init_i18n()

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -177,11 +177,11 @@ class Sphinx(object):
         self.tags = Tags(tags)
         self.config = Config(confdir, CONFIG_FILENAME,
                              confoverrides or {}, self.tags)
-        self.config.check_unicode(self.warn)
+        self.config.check_unicode()
         # defer checking types until i18n has been initialized
 
         # initialize some limited config variables before loading extensions
-        self.config.pre_init_values(self.warn)
+        self.config.pre_init_values()
 
         # check the Sphinx version if requested
         if self.config.needs_sphinx and self.config.needs_sphinx > sphinx.__display_version__:
@@ -227,7 +227,7 @@ class Sphinx(object):
                 )
 
         # now that we know all config values, collect them from conf.py
-        self.config.init_values(self.warn)
+        self.config.init_values()
 
         # check extension versions if requested
         if self.config.needs_extensions:
@@ -251,7 +251,7 @@ class Sphinx(object):
         # set up translation infrastructure
         self._init_i18n()
         # check all configuration values for permissible types
-        self.config.check_types(self.warn)
+        self.config.check_types()
         # set up source_parsers
         self._init_source_parsers()
         # set up the build environment
@@ -528,9 +528,9 @@ class Sphinx(object):
         if extension in self._extensions:
             return
         if extension in EXTENSION_BLACKLIST:
-            self.warn('the extension %r was already merged with Sphinx since version %s; '
-                      'this extension is ignored.' % (
-                          extension, EXTENSION_BLACKLIST[extension]))
+            logger.warning('the extension %r was already merged with Sphinx since version %s; '
+                           'this extension is ignored.',
+                           extension, EXTENSION_BLACKLIST[extension])
             return
         self._setting_up_extension.append(extension)
         try:
@@ -540,8 +540,8 @@ class Sphinx(object):
             raise ExtensionError('Could not import extension %s' % extension,
                                  err)
         if not hasattr(mod, 'setup'):
-            self.warn('extension %r has no setup() function; is it really '
-                      'a Sphinx extension module?' % extension)
+            logger.warning('extension %r has no setup() function; is it really '
+                           'a Sphinx extension module?', extension)
             ext_meta = None
         else:
             try:
@@ -561,9 +561,9 @@ class Sphinx(object):
             if not ext_meta.get('version'):
                 ext_meta['version'] = 'unknown version'
         except Exception:
-            self.warn('extension %r returned an unsupported object from '
-                      'its setup() function; it should return None or a '
-                      'metadata dictionary' % extension)
+            logger.warning('extension %r returned an unsupported object from '
+                           'its setup() function; it should return None or a '
+                           'metadata dictionary', extension)
             ext_meta = {'version': 'unknown version'}
         self._extensions[extension] = mod
         self._extension_metadata[extension] = ext_meta
@@ -668,10 +668,10 @@ class Sphinx(object):
         self.debug('[app] adding node: %r', (node, kwds))
         if not kwds.pop('override', False) and \
            hasattr(nodes.GenericNodeVisitor, 'visit_' + node.__name__):
-            self.warn('while setting up extension %s: node class %r is '
-                      'already registered, its visitors will be overridden' %
-                      (self._setting_up_extension, node.__name__),
-                      type='app', subtype='add_node')
+            logger.warning('while setting up extension %s: node class %r is '
+                           'already registered, its visitors will be overridden',
+                           self._setting_up_extension, node.__name__,
+                           type='app', subtype='add_node')
         nodes._add_node_class_names([node.__name__])
         for key, val in iteritems(kwds):
             try:
@@ -722,10 +722,10 @@ class Sphinx(object):
         self.debug('[app] adding directive: %r',
                    (name, obj, content, arguments, options))
         if name in directives._directives:
-            self.warn('while setting up extension %s: directive %r is '
-                      'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], name),
-                      type='app', subtype='add_directive')
+            logger.warning('while setting up extension %s: directive %r is '
+                           'already registered, it will be overridden',
+                           self._setting_up_extension[-1], name,
+                           type='app', subtype='add_directive')
         directives.register_directive(
             name, self._directive_helper(obj, content, arguments, **options))
 
@@ -733,10 +733,10 @@ class Sphinx(object):
         # type: (unicode, Any) -> None
         self.debug('[app] adding role: %r', (name, role))
         if name in roles._roles:
-            self.warn('while setting up extension %s: role %r is '
-                      'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], name),
-                      type='app', subtype='add_role')
+            logger.warning('while setting up extension %s: role %r is '
+                           'already registered, it will be overridden',
+                           self._setting_up_extension[-1], name,
+                           type='app', subtype='add_role')
         roles.register_local_role(name, role)
 
     def add_generic_role(self, name, nodeclass):
@@ -745,10 +745,10 @@ class Sphinx(object):
         # register_canonical_role
         self.debug('[app] adding generic role: %r', (name, nodeclass))
         if name in roles._roles:
-            self.warn('while setting up extension %s: role %r is '
-                      'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], name),
-                      type='app', subtype='add_generic_role')
+            logger.warning('while setting up extension %s: role %r is '
+                           'already registered, it will be overridden',
+                           self._setting_up_extension[-1], name,
+                           type='app', subtype='add_generic_role')
         role = roles.GenericRole(name, nodeclass)
         roles.register_local_role(name, role)
 
@@ -891,10 +891,10 @@ class Sphinx(object):
         # type: (unicode, Parser) -> None
         self.debug('[app] adding search source_parser: %r, %r', suffix, parser)
         if suffix in self._additional_source_parsers:
-            self.warn('while setting up extension %s: source_parser for %r is '
-                      'already registered, it will be overridden' %
-                      (self._setting_up_extension[-1], suffix),
-                      type='app', subtype='add_source_parser')
+            logger.warning('while setting up extension %s: source_parser for %r is '
+                           'already registered, it will be overridden',
+                           self._setting_up_extension[-1], suffix,
+                           type='app', subtype='add_source_parser')
         self._additional_source_parsers[suffix] = parser
 
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -287,7 +287,7 @@ class Builder(object):
             logger.info(bold('building [%s]' % self.name) + ': ' + summary)
 
         # while reading, collect all warnings from docutils
-        with logging.pending_logging():
+        with logging.pending_warnings():
             updated_docnames = set(self.env.update(self.config, self.srcdir,
                                                    self.doctreedir, self.app))
 
@@ -386,7 +386,7 @@ class Builder(object):
 
     def _write_serial(self, docnames):
         # type: (Sequence[unicode]) -> None
-        with logging.pending_logging():
+        with logging.pending_warnings():
             for docname in self.app.status_iterator(
                     docnames, 'writing output... ', darkgreen, len(docnames)):
                 doctree = self.env.get_and_resolve_doctree(docname, self)

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -161,8 +161,8 @@ class Builder(object):
                     if candidate:
                         break
                 else:
-                    logger.warn_node('no matching candidate for image URI %r' % node['uri'],
-                                     node)
+                    logger.warning('no matching candidate for image URI %r', node['uri'],
+                                   location=node)
                     continue
                 node['uri'] = candidate
             else:

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -40,6 +40,9 @@ if False:
     from sphinx.util.tags import Tags  # NOQA
 
 
+logger = logging.getLogger(__name__)
+
+
 class Builder(object):
     """
     Builds target formats from the reST sources.
@@ -180,7 +183,7 @@ class Builder(object):
         def cat2relpath(cat):
             return path.relpath(cat.mo_path, self.env.srcdir).replace(path.sep, SEP)
 
-        self.info(bold('building [mo]: ') + message)
+        logger.info(bold('building [mo]: ') + message)
         for catalog in self.app.status_iterator(
                 catalogs, 'writing output... ', darkgreen, len(catalogs),
                 cat2relpath):
@@ -281,7 +284,7 @@ class Builder(object):
         First updates the environment, and then calls :meth:`write`.
         """
         if summary:
-            self.info(bold('building [%s]' % self.name) + ': ' + summary)
+            logger.info(bold('building [%s]' % self.name) + ': ' + summary)
 
         # while reading, collect all warnings from docutils
         with logging.pending_logging():
@@ -289,29 +292,29 @@ class Builder(object):
                                                    self.doctreedir, self.app))
 
         doccount = len(updated_docnames)
-        self.info(bold('looking for now-outdated files... '), nonl=1)
+        logger.info(bold('looking for now-outdated files... '), nonl=1)
         for docname in self.env.check_dependents(updated_docnames):
             updated_docnames.add(docname)
         outdated = len(updated_docnames) - doccount
         if outdated:
-            self.info('%d found' % outdated)
+            logger.info('%d found' % outdated)
         else:
-            self.info('none found')
+            logger.info('none found')
 
         if updated_docnames:
             # save the environment
             from sphinx.application import ENV_PICKLE_FILENAME
-            self.info(bold('pickling environment... '), nonl=True)
+            logger.info(bold('pickling environment... '), nonl=True)
             self.env.topickle(path.join(self.doctreedir, ENV_PICKLE_FILENAME))
-            self.info('done')
+            logger.info('done')
 
             # global actions
-            self.info(bold('checking consistency... '), nonl=True)
+            logger.info(bold('checking consistency... '), nonl=True)
             self.env.check_consistency()
-            self.info('done')
+            logger.info('done')
         else:
             if method == 'update' and not docnames:
-                self.info(bold('no targets are out of date.'))
+                logger.info(bold('no targets are out of date.'))
                 return
 
         # filter "docnames" (list of outdated files) by the updated
@@ -358,7 +361,7 @@ class Builder(object):
             docnames = set(build_docnames) | set(updated_docnames)
         else:
             docnames = set(build_docnames)
-        self.app.debug('docnames to write: %s', ', '.join(sorted(docnames)))
+        logger.debug('docnames to write: %s', ', '.join(sorted(docnames)))
 
         # add all toctree-containing files that may have changed
         for docname in list(docnames):
@@ -367,9 +370,9 @@ class Builder(object):
                     docnames.add(tocdocname)
         docnames.add(self.config.master_doc)
 
-        self.info(bold('preparing documents... '), nonl=True)
+        logger.info(bold('preparing documents... '), nonl=True)
         self.prepare_writing(docnames)
-        self.info('done')
+        logger.info('done')
 
         warnings = []  # type: List[Tuple[Tuple, Dict]]
         if self.parallel_ok:
@@ -425,7 +428,7 @@ class Builder(object):
             tasks.add_task(write_process, arg, add_warnings)
 
         # make sure all threads have finished
-        self.info(bold('waiting for workers...'))
+        logger.info(bold('waiting for workers...'))
         tasks.join()
 
         for warning, kwargs in warnings:

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -18,6 +18,7 @@ import shlex
 
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.config import string_classes
+from sphinx.util import logging
 from sphinx.util.osutil import copyfile, ensuredir, make_filename
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.fileutil import copy_asset
@@ -32,6 +33,9 @@ if False:
     # For type annotation
     from typing import Any  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 # Use plistlib.dump in 3.4 and above
 try:
@@ -118,13 +122,13 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
         target_dir = self.outdir
 
         if path.isdir(source_dir):
-            self.info(bold('copying localized files... '), nonl=True)
+            logger.info(bold('copying localized files... '), nonl=True)
 
             excluded = Matcher(self.config.exclude_patterns + ['**/.*'])
             copy_asset(source_dir, target_dir, excluded,
                        context=self.globalcontext, renderer=self.templates)
 
-            self.info('done')
+            logger.info('done')
 
     def build_helpbook(self):
         # type: () -> None
@@ -165,20 +169,20 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
         if self.config.applehelp_remote_url is not None:
             info_plist['HPDBookRemoteURL'] = self.config.applehelp_remote_url
 
-        self.info(bold('writing Info.plist... '), nonl=True)
+        logger.info(bold('writing Info.plist... '), nonl=True)
         with open(path.join(contents_dir, 'Info.plist'), 'wb') as f:
             write_plist(info_plist, f)
-        self.info('done')
+        logger.info('done')
 
         # Copy the icon, if one is supplied
         if self.config.applehelp_icon:
-            self.info(bold('copying icon... '), nonl=True)
+            logger.info(bold('copying icon... '), nonl=True)
 
             try:
                 copyfile(path.join(self.srcdir, self.config.applehelp_icon),
                          path.join(resources_dir, info_plist['HPDBookIconPath']))
 
-                self.info('done')
+                logger.info('done')
             except Exception as err:
                 self.warn('cannot copy icon file %r: %s' %
                           (path.join(self.srcdir, self.config.applehelp_icon),
@@ -186,16 +190,16 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
                 del info_plist['HPDBookIconPath']
 
         # Build the access page
-        self.info(bold('building access page...'), nonl=True)
+        logger.info(bold('building access page...'), nonl=True)
         with codecs.open(path.join(language_dir, '_access.html'), 'w') as f:
             f.write(access_page_template % {
                 'toc': htmlescape(toc, quote=True),
                 'title': htmlescape(self.config.applehelp_title)
             })
-        self.info('done')
+        logger.info('done')
 
         # Generate the help index
-        self.info(bold('generating help index... '), nonl=True)
+        logger.info(bold('generating help index... '), nonl=True)
 
         args = [
             self.config.applehelp_indexer_path,
@@ -217,7 +221,7 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
             args += ['-l', self.config.applehelp_locale]
 
         if self.config.applehelp_disable_external_tools:
-            self.info('skipping')
+            logger.info('skipping')
 
             self.warn('you will need to index this help book with:\n  %s'
                       % (' '.join([pipes.quote(arg) for arg in args])))
@@ -232,13 +236,13 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
                 if p.returncode != 0:
                     raise AppleHelpIndexerFailed(output)
                 else:
-                    self.info('done')
+                    logger.info('done')
             except OSError:
                 raise AppleHelpIndexerFailed('Command not found: %s' % args[0])
 
         # If we've been asked to, sign the bundle
         if self.config.applehelp_codesign_identity:
-            self.info(bold('signing help book... '), nonl=True)
+            logger.info(bold('signing help book... '), nonl=True)
 
             args = [
                 self.config.applehelp_codesign_path,
@@ -251,7 +255,7 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
             args.append(self.bundle_path)
 
             if self.config.applehelp_disable_external_tools:
-                self.info('skipping')
+                logger.info('skipping')
 
                 self.warn('you will need to sign this help book with:\n  %s'
                           % (' '.join([pipes.quote(arg) for arg in args])))
@@ -266,7 +270,7 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
                     if p.returncode != 0:
                         raise AppleHelpCodeSigningFailed(output)
                     else:
-                        self.info('done')
+                        logger.info('done')
                 except OSError:
                     raise AppleHelpCodeSigningFailed('Command not found: %s' % args[0])
 

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -184,9 +184,8 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
 
                 logger.info('done')
             except Exception as err:
-                self.warn('cannot copy icon file %r: %s' %
-                          (path.join(self.srcdir, self.config.applehelp_icon),
-                           err))
+                logger.warning('cannot copy icon file %r: %s',
+                               path.join(self.srcdir, self.config.applehelp_icon), err)
                 del info_plist['HPDBookIconPath']
 
         # Build the access page
@@ -223,8 +222,8 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
         if self.config.applehelp_disable_external_tools:
             logger.info('skipping')
 
-            self.warn('you will need to index this help book with:\n  %s'
-                      % (' '.join([pipes.quote(arg) for arg in args])))
+            logger.warning('you will need to index this help book with:\n  %s',
+                           ' '.join([pipes.quote(arg) for arg in args]))
         else:
             try:
                 p = subprocess.Popen(args,
@@ -256,9 +255,8 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
 
             if self.config.applehelp_disable_external_tools:
                 logger.info('skipping')
-
-                self.warn('you will need to sign this help book with:\n  %s'
-                          % (' '.join([pipes.quote(arg) for arg in args])))
+                logger.warning('you will need to sign this help book with:\n  %s',
+                               ' '.join([pipes.quote(arg) for arg in args]))
             else:
                 try:
                     p = subprocess.Popen(args,

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -136,7 +136,7 @@ class ChangesBuilder(Builder):
                 try:
                     lines = f.readlines()
                 except UnicodeDecodeError:
-                    self.warn('could not read %r for changelog creation' % docname)
+                    logger.warning('could not read %r for changelog creation', docname)
                     continue
             targetfn = path.join(self.outdir, 'rst', os_path(docname)) + '.html'
             ensuredir(path.dirname(targetfn))

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -38,8 +38,7 @@ class ChangesBuilder(Builder):
     def init(self):
         # type: () -> None
         self.create_template_bridge()
-        Theme.init_themes(self.confdir, self.config.html_theme_path,
-                          warn=self.warn)
+        Theme.init_themes(self.confdir, self.config.html_theme_path)
         self.theme = Theme('default')
         self.templates.init(self, self.theme)
 

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -18,6 +18,7 @@ from sphinx import package_dir
 from sphinx.locale import _
 from sphinx.theming import Theme
 from sphinx.builders import Builder
+from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.fileutil import copy_asset_file
@@ -27,6 +28,9 @@ if False:
     # For type annotation
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 class ChangesBuilder(Builder):
@@ -59,9 +63,9 @@ class ChangesBuilder(Builder):
         apichanges = []     # type: List[Tuple[unicode, unicode, int]]
         otherchanges = {}   # type: Dict[Tuple[unicode, unicode], List[Tuple[unicode, unicode, int]]]  # NOQA
         if version not in self.env.versionchanges:
-            self.info(bold('no changes in version %s.' % version))
+            logger.info(bold('no changes in version %s.' % version))
             return
-        self.info(bold('writing summary file...'))
+        logger.info(bold('writing summary file...'))
         for type, docname, lineno, module, descname, content in \
                 self.env.versionchanges[version]:
             if isinstance(descname, tuple):
@@ -125,7 +129,7 @@ class ChangesBuilder(Builder):
                     break
             return line
 
-        self.info(bold('copying source files...'))
+        logger.info(bold('copying source files...'))
         for docname in self.env.all_docs:
             with codecs.open(self.env.doc2path(docname), 'r',  # type: ignore
                              self.env.config.source_encoding) as f:

--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -19,6 +19,7 @@ from os import path
 from docutils import nodes
 
 from sphinx import addnodes
+from sphinx.util import logging
 from sphinx.util.osutil import make_filename
 from sphinx.builders.html import StandaloneHTMLBuilder
 
@@ -31,6 +32,9 @@ if False:
     # For type annotation
     from typing import Any  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 class DevhelpBuilder(StandaloneHTMLBuilder):
@@ -60,7 +64,7 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
 
     def build_devhelp(self, outdir, outname):
         # type: (unicode, unicode) -> None
-        self.info('dumping devhelp index...')
+        logger.info('dumping devhelp index...')
 
         # Basic info
         root = etree.Element('book',

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -477,14 +477,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 img = Image.open(path.join(self.srcdir, src))
             except IOError:
                 if not self.is_vector_graphics(src):
-                    self.warn('cannot read image file %r: copying it instead' %
-                              (path.join(self.srcdir, src), ))
+                    logger.warning('cannot read image file %r: copying it instead',
+                                   path.join(self.srcdir, src))
                 try:
                     copyfile(path.join(self.srcdir, src),
                              path.join(self.outdir, self.imagedir, dest))
                 except (IOError, OSError) as err:
-                    self.warn('cannot copy image file %r: %s' %
-                              (path.join(self.srcdir, src), err))
+                    logger.warning('cannot copy image file %r: %s',
+                                   path.join(self.srcdir, src), err)
                 continue
             if self.config.epub_fix_images:
                 if img.mode in ('P',):
@@ -499,8 +499,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
             try:
                 img.save(path.join(self.outdir, self.imagedir, dest))
             except (IOError, OSError) as err:
-                self.warn('cannot write image file %r: %s' %
-                          (path.join(self.srcdir, src), err))
+                logger.warning('cannot write image file %r: %s',
+                               path.join(self.srcdir, src), err)
 
     def copy_image_files(self):
         # type: () -> None
@@ -510,7 +510,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         if self.images:
             if self.config.epub_fix_images or self.config.epub_max_image_width:
                 if not Image:
-                    self.warn('PIL not found - copying image files')
+                    logger.warning('PIL not found - copying image files')
                     super(EpubBuilder, self).copy_image_files()
                 else:
                     self.copy_image_files_pil()
@@ -551,14 +551,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def build_mimetype(self, outdir, outname):
         # type: (unicode, unicode) -> None
         """Write the metainfo file mimetype."""
-        logger.info('writing %s file...' % outname)
+        logger.info('writing %s file...', outname)
         with codecs.open(path.join(outdir, outname), 'w', 'utf-8') as f:  # type: ignore
             f.write(self.mimetype_template)
 
     def build_container(self, outdir, outname):
         # type: (unicode, unicode) -> None
         """Write the metainfo file META-INF/cointainer.xml."""
-        logger.info('writing %s file...' % outname)
+        logger.info('writing %s file...', outname)
         fn = path.join(outdir, outname)
         try:
             os.mkdir(path.dirname(fn))
@@ -593,7 +593,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """Write the metainfo file content.opf It contains bibliographic data,
         a file list and the spine (the reading order).
         """
-        logger.info('writing %s file...' % outname)
+        logger.info('writing %s file...', outname)
 
         # files
         if not outdir.endswith(os.sep):
@@ -618,8 +618,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
                     # we always have JS and potentially OpenSearch files, don't
                     # always warn about them
                     if ext not in ('.js', '.xml'):
-                        self.warn('unknown mimetype for %s, ignoring' % filename,
-                                  type='epub', subtype='unknown_project_files')
+                        logger.warning('unknown mimetype for %s, ignoring', filename,
+                                       type='epub', subtype='unknown_project_files')
                     continue
                 filename = filename.replace(os.sep, '/')
                 projectfiles.append(self.file_template % {
@@ -804,7 +804,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def build_toc(self, outdir, outname):
         # type: (unicode, unicode) -> None
         """Write the metainfo file toc.ncx."""
-        logger.info('writing %s file...' % outname)
+        logger.info('writing %s file...', outname)
 
         if self.config.epub_tocscope == 'default':
             doctree = self.env.get_and_resolve_doctree(self.config.master_doc,
@@ -828,7 +828,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         It is a zip file with the mimetype file stored uncompressed as the first
         entry.
         """
-        logger.info('writing %s file...' % outname)
+        logger.info('writing %s file...', outname)
         projectfiles = ['META-INF/container.xml', 'content.opf', 'toc.ncx']  # type: List[unicode]  # NOQA
         projectfiles.extend(self.files)
         epub = zipfile.ZipFile(path.join(outdir, outname), 'w',  # type: ignore

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -29,6 +29,7 @@ from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, copyfile, make_filename, EEXIST
 from sphinx.util.smartypants import sphinx_smarty_pants as ssp
 from sphinx.util.console import brown  # type: ignore
@@ -37,6 +38,9 @@ if False:
     # For type annotation
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 # (Fragment) templates from which the metainfo files content.opf, toc.ncx,
@@ -547,14 +551,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def build_mimetype(self, outdir, outname):
         # type: (unicode, unicode) -> None
         """Write the metainfo file mimetype."""
-        self.info('writing %s file...' % outname)
+        logger.info('writing %s file...' % outname)
         with codecs.open(path.join(outdir, outname), 'w', 'utf-8') as f:  # type: ignore
             f.write(self.mimetype_template)
 
     def build_container(self, outdir, outname):
         # type: (unicode, unicode) -> None
         """Write the metainfo file META-INF/cointainer.xml."""
-        self.info('writing %s file...' % outname)
+        logger.info('writing %s file...' % outname)
         fn = path.join(outdir, outname)
         try:
             os.mkdir(path.dirname(fn))
@@ -589,7 +593,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """Write the metainfo file content.opf It contains bibliographic data,
         a file list and the spine (the reading order).
         """
-        self.info('writing %s file...' % outname)
+        logger.info('writing %s file...' % outname)
 
         # files
         if not outdir.endswith(os.sep):
@@ -800,7 +804,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def build_toc(self, outdir, outname):
         # type: (unicode, unicode) -> None
         """Write the metainfo file toc.ncx."""
-        self.info('writing %s file...' % outname)
+        logger.info('writing %s file...' % outname)
 
         if self.config.epub_tocscope == 'default':
             doctree = self.env.get_and_resolve_doctree(self.config.master_doc,
@@ -824,7 +828,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         It is a zip file with the mimetype file stored uncompressed as the first
         entry.
         """
-        self.info('writing %s file...' % outname)
+        logger.info('writing %s file...' % outname)
         projectfiles = ['META-INF/container.xml', 'content.opf', 'toc.ncx']  # type: List[unicode]  # NOQA
         projectfiles.extend(self.files)
         epub = zipfile.ZipFile(path.join(outdir, outname), 'w',  # type: ignore

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -16,6 +16,10 @@ from datetime import datetime
 
 from sphinx.config import string_classes
 from sphinx.builders.epub import EpubBuilder
+from sphinx.util import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 # (Fragment) templates from which the metainfo files content.opf, toc.ncx,
@@ -235,7 +239,7 @@ class Epub3Builder(EpubBuilder):
 
     def build_navigation_doc(self, outdir, outname):
         """Write the metainfo file nav.xhtml."""
-        self.info('writing %s file...' % outname)
+        logger.info('writing %s file...' % outname)
 
         if self.config.epub_tocscope == 'default':
             doctree = self.env.get_and_resolve_doctree(

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -239,7 +239,7 @@ class Epub3Builder(EpubBuilder):
 
     def build_navigation_doc(self, outdir, outname):
         """Write the metainfo file nav.xhtml."""
-        logger.info('writing %s file...' % outname)
+        logger.info('writing %s file...', outname)
 
         if self.config.epub_tocscope == 'default':
             doctree = self.env.get_and_resolve_doctree(
@@ -262,16 +262,16 @@ class Epub3Builder(EpubBuilder):
 
 def validate_config_values(app):
     if app.config.epub3_description is not None:
-        app.warn('epub3_description is deprecated. Use epub_description instead.')
+        logger.warning('epub3_description is deprecated. Use epub_description instead.')
         app.config.epub_description = app.config.epub3_description
 
     if app.config.epub3_contributor is not None:
-        app.warn('epub3_contributor is deprecated. Use epub_contributor instead.')
+        logger.warning('epub3_contributor is deprecated. Use epub_contributor instead.')
         app.config.epub_contributor = app.config.epub3_contributor
 
     if app.config.epub3_page_progression_direction is not None:
-        app.warn('epub3_page_progression_direction option is deprecated'
-                 ' from 1.5. Use epub_writing_mode instead.')
+        logger.warning('epub3_page_progression_direction option is deprecated'
+                       ' from 1.5. Use epub_writing_mode instead.')
 
 
 def setup(app):

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 from six import iteritems
 
 from sphinx.builders import Builder
-from sphinx.util import split_index_msg
+from sphinx.util import split_index_msg, logging
 from sphinx.util.tags import Tags
 from sphinx.util.nodes import extract_messages, traverse_translatable_index
 from sphinx.util.osutil import safe_relpath, ensuredir, canon_path
@@ -35,6 +35,9 @@ if False:
     from docutils import nodes  # NOQA
     from sphinx.util.i18n import CatalogInfo  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 POHEADER = r"""
 # SOME DESCRIPTIVE TITLE.
@@ -216,8 +219,8 @@ class MessageCatalogBuilder(I18nBuilder):
     def _extract_from_template(self):
         # type: () -> None
         files = self._collect_templates()
-        self.info(bold('building [%s]: ' % self.name), nonl=1)
-        self.info('targets for %d template files' % len(files))
+        logger.info(bold('building [%s]: ' % self.name), nonl=1)
+        logger.info('targets for %d template files' % len(files))
 
         extract_translations = self.templates.environment.extract_translations
 

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -220,7 +220,7 @@ class MessageCatalogBuilder(I18nBuilder):
         # type: () -> None
         files = self._collect_templates()
         logger.info(bold('building [%s]: ' % self.name), nonl=1)
-        logger.info('targets for %d template files' % len(files))
+        logger.info('targets for %d template files', len(files))
 
         extract_translations = self.templates.environment.extract_translations
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -209,8 +209,8 @@ class StandaloneHTMLBuilder(Builder):
                 if tag != 'tags':
                     raise ValueError
         except ValueError:
-            self.warn('unsupported build info format in %r, building all' %
-                      path.join(self.outdir, '.buildinfo'))
+            logger.warning('unsupported build info format in %r, building all',
+                           path.join(self.outdir, '.buildinfo'))
         except Exception:
             pass
         if old_config_hash != self.config_hash or \
@@ -325,10 +325,10 @@ class StandaloneHTMLBuilder(Builder):
         favicon = self.config.html_favicon and \
             path.basename(self.config.html_favicon) or ''
         if favicon and os.path.splitext(favicon)[1] != '.ico':
-            self.warn('html_favicon is not an .ico file')
+            logger.warning('html_favicon is not an .ico file')
 
         if not isinstance(self.config.html_use_opensearch, string_types):
-            self.warn('html_use_opensearch config value must now be a string')
+            logger.warning('html_use_opensearch config value must now be a string')
 
         self.relations = self.env.collect_relations()
 
@@ -595,8 +595,8 @@ class StandaloneHTMLBuilder(Builder):
                     copyfile(path.join(self.srcdir, src),
                              path.join(self.outdir, self.imagedir, dest))
                 except Exception as err:
-                    self.warn('cannot copy image file %r: %s' %
-                              (path.join(self.srcdir, src), err))
+                    logger.warning('cannot copy image file %r: %s',
+                                   path.join(self.srcdir, src), err)
 
     def copy_download_files(self):
         # type: () -> None
@@ -614,8 +614,8 @@ class StandaloneHTMLBuilder(Builder):
                     copyfile(path.join(self.srcdir, src),
                              path.join(self.outdir, '_downloads', dest))
                 except Exception as err:
-                    self.warn('cannot copy downloadable file %r: %s' %
-                              (path.join(self.srcdir, src), err))
+                    logger.warning('cannot copy downloadable file %r: %s',
+                                   path.join(self.srcdir, src), err)
 
     def copy_static_files(self):
         # type: () -> None
@@ -655,7 +655,7 @@ class StandaloneHTMLBuilder(Builder):
         for static_path in self.config.html_static_path:
             entry = path.join(self.confdir, static_path)
             if not path.exists(entry):
-                self.warn('html_static_path entry %r does not exist' % entry)
+                logger.warning('html_static_path entry %r does not exist', entry)
                 continue
             copy_asset(entry, path.join(self.outdir, '_static'), excluded,
                        context=ctx, renderer=self.templates)
@@ -664,7 +664,7 @@ class StandaloneHTMLBuilder(Builder):
             logobase = path.basename(self.config.html_logo)
             logotarget = path.join(self.outdir, '_static', logobase)
             if not path.isfile(path.join(self.confdir, self.config.html_logo)):
-                self.warn('logo file %r does not exist' % self.config.html_logo)
+                logger.warning('logo file %r does not exist', self.config.html_logo)
             elif not path.isfile(logotarget):
                 copyfile(path.join(self.confdir, self.config.html_logo),
                          logotarget)
@@ -672,7 +672,7 @@ class StandaloneHTMLBuilder(Builder):
             iconbase = path.basename(self.config.html_favicon)
             icontarget = path.join(self.outdir, '_static', iconbase)
             if not path.isfile(path.join(self.confdir, self.config.html_favicon)):
-                self.warn('favicon file %r does not exist' % self.config.html_favicon)
+                logger.warning('favicon file %r does not exist', self.config.html_favicon)
             elif not path.isfile(icontarget):
                 copyfile(path.join(self.confdir, self.config.html_favicon),
                          icontarget)
@@ -687,7 +687,7 @@ class StandaloneHTMLBuilder(Builder):
         for extra_path in self.config.html_extra_path:
             entry = path.join(self.confdir, extra_path)
             if not path.exists(entry):
-                self.warn('html_extra_path entry %r does not exist' % entry)
+                logger.warning('html_extra_path entry %r does not exist', entry)
                 continue
 
             copy_asset(entry, self.outdir, excluded)
@@ -748,9 +748,9 @@ class StandaloneHTMLBuilder(Builder):
                 self.indexer.load(f, self.indexer_format)  # type: ignore
         except (IOError, OSError, ValueError):
             if keep:
-                self.warn('search index couldn\'t be loaded, but not all '
-                          'documents will be built: the index will be '
-                          'incomplete.')
+                logger.warning('search index couldn\'t be loaded, but not all '
+                               'documents will be built: the index will be '
+                               'incomplete.')
         # delete all entries for files that will be rebuilt
         self.indexer.prune(keep)
 
@@ -789,9 +789,9 @@ class StandaloneHTMLBuilder(Builder):
                     if has_wildcard(pattern):
                         # warn if both patterns contain wildcards
                         if has_wildcard(matched):
-                            self.warn('page %s matches two patterns in '
-                                      'html_sidebars: %r and %r' %
-                                      (pagename, matched, pattern))
+                            logger.warning('page %s matches two patterns in '
+                                           'html_sidebars: %r and %r',
+                                           pagename, matched, pattern)
                         # else the already matched pattern is more specific
                         # than the present one, because it contains no wildcard
                         continue
@@ -863,9 +863,9 @@ class StandaloneHTMLBuilder(Builder):
         try:
             output = self.templates.render(templatename, ctx)
         except UnicodeError:
-            self.warn("a Unicode error occurred when rendering the page %s. "
-                      "Please make sure all config values that contain "
-                      "non-ASCII content are Unicode strings." % pagename)
+            logger.warning("a Unicode error occurred when rendering the page %s. "
+                           "Please make sure all config values that contain "
+                           "non-ASCII content are Unicode strings.", pagename)
             return
 
         if not outfilename:
@@ -876,7 +876,7 @@ class StandaloneHTMLBuilder(Builder):
             with codecs.open(outfilename, 'w', encoding, 'xmlcharrefreplace') as f:  # type: ignore  # NOQA
                 f.write(output)
         except (IOError, OSError) as err:
-            self.warn("error writing file %s: %s" % (outfilename, err))
+            logger.warning("error writing file %s: %s", outfilename, err)
         if self.copysource and ctx.get('sourcename'):
             # copy the source file for the "show source" link
             source_name = path.join(self.outdir, '_sources',
@@ -1270,8 +1270,8 @@ class JSONHTMLBuilder(SerializingHTMLBuilder):
 def validate_config_values(app):
     # type: (Sphinx) -> None
     if app.config.html_translator_class:
-        app.warn('html_translator_class is deprecated. '
-                 'Use Sphinx.set_translator() API instead.')
+        logger.warning('html_translator_class is deprecated. '
+                       'Use Sphinx.set_translator() API instead.')
 
 
 def setup(app):

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -159,10 +159,9 @@ class StandaloneHTMLBuilder(Builder):
 
     def init_templates(self):
         # type: () -> None
-        Theme.init_themes(self.confdir, self.config.html_theme_path,
-                          warn=self.warn)
+        Theme.init_themes(self.confdir, self.config.html_theme_path)
         themename, themeoptions = self.get_theme_config()
-        self.theme = Theme(themename, warn=self.warn)
+        self.theme = Theme(themename)
         self.theme_options = themeoptions.copy()
         self.create_template_bridge()
         self.templates.init(self, self.theme)
@@ -314,8 +313,7 @@ class StandaloneHTMLBuilder(Builder):
         lufmt = self.config.html_last_updated_fmt
         if lufmt is not None:
             self.last_updated = format_date(lufmt or _('%b %d, %Y'),
-                                            language=self.config.language,
-                                            warn=self.warn)
+                                            language=self.config.language)
         else:
             self.last_updated = None
 

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -18,9 +18,13 @@ from os import path
 from docutils import nodes
 
 from sphinx import addnodes
-from sphinx.util.osutil import make_filename
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.util import logging
+from sphinx.util.osutil import make_filename
 from sphinx.util.pycompat import htmlescape
+
+
+logger = logging.getLogger(__name__)
 
 
 # Project file (*.hhp) template.  'outname' is the file basename (like
@@ -207,12 +211,12 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
         StandaloneHTMLBuilder.write_doc(self, docname, doctree)
 
     def build_hhx(self, outdir, outname):
-        self.info('dumping stopword list...')
+        logger.info('dumping stopword list...')
         with self.open_file(outdir, outname+'.stp') as f:
             for word in sorted(stopwords):
                 print(word, file=f)
 
-        self.info('writing project file...')
+        logger.info('writing project file...')
         with self.open_file(outdir, outname+'.hhp') as f:
             f.write(project_template % {
                 'outname': outname,
@@ -233,7 +237,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                         print(path.join(root, fn)[olen:].replace(os.sep, '\\'),
                               file=f)
 
-        self.info('writing TOC file...')
+        logger.info('writing TOC file...')
         with self.open_file(outdir, outname+'.hhc') as f:
             f.write(contents_header)
             # special books
@@ -273,7 +277,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                 write_toc(node)
             f.write(contents_footer)
 
-        self.info('writing index file...')
+        logger.info('writing index file...')
         index = self.env.create_index(self)
         with self.open_file(outdir, outname+'.hhk') as f:
             f.write('<UL>\n')

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -122,7 +122,7 @@ class LaTeXBuilder(Builder):
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
                 encoding='utf-8')
-            logger.info("processing " + targetname + "... ", nonl=1)
+            logger.info("processing %s...", targetname, nonl=1)
             toctrees = self.env.get_doctree(docname).traverse(addnodes.toctree)
             if toctrees:
                 if toctrees[0].get('maxdepth') > 0:
@@ -241,7 +241,7 @@ class LaTeXBuilder(Builder):
 def validate_config_values(app):
     # type: (Sphinx) -> None
     if app.config.latex_toplevel_sectioning not in (None, 'part', 'chapter', 'section'):
-        logger.warning('invalid latex_toplevel_sectioning, ignored: %s' %
+        logger.warning('invalid latex_toplevel_sectioning, ignored: %s',
                        app.config.latex_toplevel_sectioning)
         app.config.latex_toplevel_sectioning = None  # type: ignore
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -76,16 +76,16 @@ class LaTeXBuilder(Builder):
         # type: () -> None
         preliminary_document_data = [list(x) for x in self.config.latex_documents]
         if not preliminary_document_data:
-            self.warn('no "latex_documents" config value found; no documents '
-                      'will be written')
+            logger.warning('no "latex_documents" config value found; no documents '
+                           'will be written')
             return
         # assign subdirs to titles
         self.titles = []  # type: List[Tuple[unicode, unicode]]
         for entry in preliminary_document_data:
             docname = entry[0]
             if docname not in self.env.all_docs:
-                self.warn('"latex_documents" config value references unknown '
-                          'document %s' % docname)
+                logger.warning('"latex_documents" config value references unknown '
+                               'document %s', docname)
                 continue
             self.document_data.append(entry)  # type: ignore
             if docname.endswith(SEP+'index'):
@@ -241,50 +241,58 @@ class LaTeXBuilder(Builder):
 def validate_config_values(app):
     # type: (Sphinx) -> None
     if app.config.latex_toplevel_sectioning not in (None, 'part', 'chapter', 'section'):
-        app.warn('invalid latex_toplevel_sectioning, ignored: %s' %
-                 app.config.latex_toplevel_sectioning)
+        logger.warning('invalid latex_toplevel_sectioning, ignored: %s' %
+                       app.config.latex_toplevel_sectioning)
         app.config.latex_toplevel_sectioning = None  # type: ignore
 
     if app.config.latex_use_parts:
         if app.config.latex_toplevel_sectioning:
-            app.warn('latex_use_parts conflicts with latex_toplevel_sectioning, ignored.')
+            logger.warning('latex_use_parts conflicts with '
+                           'latex_toplevel_sectioning, ignored.')
         else:
-            app.warn('latex_use_parts is deprecated. Use latex_toplevel_sectioning instead.')
+            logger.warning('latex_use_parts is deprecated. '
+                           'Use latex_toplevel_sectioning instead.')
             app.config.latex_toplevel_sectioning = 'part'  # type: ignore
 
     if app.config.latex_use_modindex is not True:  # changed by user
-        app.warn('latex_use_modindex is deprecated. Use latex_domain_indices instead.')
+        logger.warning('latex_use_modindex is deprecated. '
+                       'Use latex_domain_indices instead.')
 
     if app.config.latex_preamble:
         if app.config.latex_elements.get('preamble'):
-            app.warn("latex_preamble conflicts with latex_elements['preamble'], ignored.")
+            logger.warning("latex_preamble conflicts with "
+                           "latex_elements['preamble'], ignored.")
         else:
-            app.warn("latex_preamble is deprecated. Use latex_elements['preamble'] instead.")
+            logger.warning("latex_preamble is deprecated. "
+                           "Use latex_elements['preamble'] instead.")
             app.config.latex_elements['preamble'] = app.config.latex_preamble
 
     if app.config.latex_paper_size != 'letter':
         if app.config.latex_elements.get('papersize'):
-            app.warn("latex_paper_size conflicts with latex_elements['papersize'], ignored.")
+            logger.warning("latex_paper_size conflicts with "
+                           "latex_elements['papersize'], ignored.")
         else:
-            app.warn("latex_paper_size is deprecated. "
-                     "Use latex_elements['papersize'] instead.")
+            logger.warning("latex_paper_size is deprecated. "
+                           "Use latex_elements['papersize'] instead.")
             if app.config.latex_paper_size:
                 app.config.latex_elements['papersize'] = app.config.latex_paper_size + 'paper'
 
     if app.config.latex_font_size != '10pt':
         if app.config.latex_elements.get('pointsize'):
-            app.warn("latex_font_size conflicts with latex_elements['pointsize'], ignored.")
+            logger.warning("latex_font_size conflicts with "
+                           "latex_elements['pointsize'], ignored.")
         else:
-            app.warn("latex_font_size is deprecated. Use latex_elements['pointsize'] instead.")
+            logger.warning("latex_font_size is deprecated. "
+                           "Use latex_elements['pointsize'] instead.")
             app.config.latex_elements['pointsize'] = app.config.latex_font_size
 
     if 'footer' in app.config.latex_elements:
         if 'postamble' in app.config.latex_elements:
-            app.warn("latex_elements['footer'] conflicts with "
-                     "latex_elements['postamble'], ignored.")
+            logger.warning("latex_elements['footer'] conflicts with "
+                           "latex_elements['postamble'], ignored.")
         else:
-            app.warn("latex_elements['footer'] is deprecated. "
-                     "Use latex_elements['preamble'] instead.")
+            logger.warning("latex_elements['footer'] is deprecated. "
+                           "Use latex_elements['preamble'] instead.")
             app.config.latex_elements['postamble'] = app.config.latex_elements['footer']
 
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -20,7 +20,7 @@ from docutils.utils import new_document
 from docutils.frontend import OptionParser
 
 from sphinx import package_dir, addnodes, highlighting
-from sphinx.util import texescape
+from sphinx.util import texescape, logging
 from sphinx.config import string_classes, ENUM
 from sphinx.errors import SphinxError
 from sphinx.locale import _
@@ -36,6 +36,9 @@ if False:
     # For type annotation
     from typing import Any, Iterable, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 class LaTeXBuilder(Builder):
@@ -119,7 +122,7 @@ class LaTeXBuilder(Builder):
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
                 encoding='utf-8')
-            self.info("processing " + targetname + "... ", nonl=1)
+            logger.info("processing " + targetname + "... ", nonl=1)
             toctrees = self.env.get_doctree(docname).traverse(addnodes.toctree)
             if toctrees:
                 if toctrees[0].get('maxdepth') > 0:
@@ -133,7 +136,7 @@ class LaTeXBuilder(Builder):
                 appendices=((docclass != 'howto') and self.config.latex_appendices or []))
             doctree['tocdepth'] = tocdepth
             self.post_process_images(doctree)
-            self.info("writing... ", nonl=1)
+            logger.info("writing... ", nonl=1)
             doctree.settings = docsettings
             doctree.settings.author = author
             doctree.settings.title = title
@@ -141,7 +144,7 @@ class LaTeXBuilder(Builder):
             doctree.settings.docname = docname
             doctree.settings.docclass = docclass
             docwriter.write(doctree, destination)
-            self.info("done")
+            logger.info("done")
 
     def get_contentsname(self, indexfile):
         # type: (unicode) -> unicode
@@ -157,7 +160,7 @@ class LaTeXBuilder(Builder):
     def assemble_doctree(self, indexfile, toctree_only, appendices):
         # type: (unicode, bool, List[unicode]) -> nodes.Node
         self.docnames = set([indexfile] + appendices)
-        self.info(darkgreen(indexfile) + " ", nonl=1)
+        logger.info(darkgreen(indexfile) + " ", nonl=1)
         tree = self.env.get_doctree(indexfile)
         tree['docname'] = indexfile
         if toctree_only:
@@ -178,8 +181,8 @@ class LaTeXBuilder(Builder):
             appendix = self.env.get_doctree(docname)
             appendix['docname'] = docname
             largetree.append(appendix)
-        self.info()
-        self.info("resolving references...")
+        logger.info('')
+        logger.info("resolving references...")
         self.env.resolve_references(largetree, indexfile, self)
         # resolve :ref:s to distant tex files -- we can't add a cross-reference,
         # but append the document name
@@ -202,16 +205,16 @@ class LaTeXBuilder(Builder):
         # type: () -> None
         # copy image files
         if self.images:
-            self.info(bold('copying images...'), nonl=1)
+            logger.info(bold('copying images...'), nonl=1)
             for src, dest in iteritems(self.images):
-                self.info(' '+src, nonl=1)
+                logger.info(' '+src, nonl=1)
                 copy_asset_file(path.join(self.srcdir, src),
                                 path.join(self.outdir, dest))
-            self.info()
+            logger.info('')
 
         # copy TeX support files from texinputs
         context = {'latex_engine': self.config.latex_engine}
-        self.info(bold('copying TeX support files...'))
+        logger.info(bold('copying TeX support files...'))
         staticdirname = path.join(package_dir, 'texinputs')
         for filename in os.listdir(staticdirname):
             if not filename.startswith('.'):
@@ -220,11 +223,11 @@ class LaTeXBuilder(Builder):
 
         # copy additional files
         if self.config.latex_additional_files:
-            self.info(bold('copying additional files...'), nonl=1)
+            logger.info(bold('copying additional files...'), nonl=1)
             for filename in self.config.latex_additional_files:
-                self.info(' '+filename, nonl=1)
+                logger.info(' '+filename, nonl=1)
                 copy_asset_file(path.join(self.confdir, filename), self.outdir)
-            self.info()
+            logger.info('')
 
         # the logo is handled differently
         if self.config.latex_logo:
@@ -232,7 +235,7 @@ class LaTeXBuilder(Builder):
                 raise SphinxError('logo file %r does not exist' % self.config.latex_logo)
             else:
                 copy_asset_file(path.join(self.confdir, self.config.latex_logo), self.outdir)
-        self.info('done')
+        logger.info('done')
 
 
 def validate_config_values(app):

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -233,7 +233,7 @@ class CheckExternalLinksBuilder(Builder):
         if status == 'working' and info == 'old':
             return
         if lineno:
-            logger.info('(line %4d) ' % lineno, nonl=1)
+            logger.info('(line %4d) ', lineno, nonl=1)
         if status == 'ignored':
             if info:
                 logger.info(darkgray('-ignored- ') + uri + ': ' + info)
@@ -247,8 +247,8 @@ class CheckExternalLinksBuilder(Builder):
         elif status == 'broken':
             self.write_entry('broken', docname, lineno, uri + ': ' + info)
             if self.app.quiet or self.app.warningiserror:
-                self.warn('broken link: %s (%s)' % (uri, info),
-                          '%s:%s' % (self.env.doc2path(docname), lineno))
+                logger.warning('broken link: %s (%s)', uri, info,
+                               location=(self.env.doc2path(docname), lineno))
             else:
                 logger.info(red('broken    ') + uri + red(' - ' + info))
         elif status == 'redirected':

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -45,8 +45,8 @@ class ManualPageBuilder(Builder):
     def init(self):
         # type: () -> None
         if not self.config.man_pages:
-            self.warn('no "man_pages" config value found; no manual pages '
-                      'will be written')
+            logger.warning('no "man_pages" config value found; no manual pages '
+                           'will be written')
 
     def get_outdated_docs(self):
         # type: () -> Union[unicode, List[unicode]]

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -19,6 +19,7 @@ from docutils.frontend import OptionParser
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
+from sphinx.util import logging
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import make_filename
 from sphinx.util.console import bold, darkgreen  # type: ignore
@@ -28,6 +29,9 @@ if False:
     # For type annotation
     from typing import Any, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 class ManualPageBuilder(Builder):
@@ -62,7 +66,7 @@ class ManualPageBuilder(Builder):
             components=(docwriter,),
             read_config_files=True).get_default_values()
 
-        self.info(bold('writing... '), nonl=True)
+        logger.info(bold('writing... '), nonl=True)
 
         for info in self.config.man_pages:
             docname, name, description, authors, section = info
@@ -73,7 +77,7 @@ class ManualPageBuilder(Builder):
                     authors = []
 
             targetname = '%s.%s' % (name, section)
-            self.info(darkgreen(targetname) + ' { ', nonl=True)
+            logger.info(darkgreen(targetname) + ' { ', nonl=True)
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
                 encoding='utf-8')
@@ -82,7 +86,7 @@ class ManualPageBuilder(Builder):
             docnames = set()  # type: Set[unicode]
             largetree = inline_all_toctrees(self, docnames, docname, tree,
                                             darkgreen, [docname])
-            self.info('} ', nonl=True)
+            logger.info('} ', nonl=True)
             self.env.resolve_references(largetree, docname, self)
             # remove pending_xref nodes
             for pendingnode in largetree.traverse(addnodes.pending_xref):
@@ -95,7 +99,7 @@ class ManualPageBuilder(Builder):
             largetree.settings.section = section
 
             docwriter.write(largetree, destination)
-        self.info()
+        logger.info('')
 
     def finish(self):
         # type: () -> None

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -21,7 +21,7 @@ from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.util import force_decode
+from sphinx.util import force_decode, logging
 from sphinx.util.osutil import make_filename
 from sphinx.util.pycompat import htmlescape
 
@@ -29,6 +29,9 @@ if False:
     # For type annotation
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 _idpattern = re.compile(
@@ -138,7 +141,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
 
     def build_qhp(self, outdir, outname):
         # type: (unicode, unicode) -> None
-        self.info('writing project file...')
+        logger.info('writing project file...')
 
         # sections
         tocdoc = self.env.get_and_resolve_doctree(self.config.master_doc, self,
@@ -216,7 +219,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
             nspace, 'doc', self.get_target_uri(self.config.master_doc))
         startpage = 'qthelp://' + posixpath.join(nspace, 'doc', 'index.html')
 
-        self.info('writing collection project file...')
+        logger.info('writing collection project file...')
         with codecs.open(path.join(outdir, outname+'.qhcp'), 'w', 'utf-8') as f:  # type: ignore  # NOQA
             f.write(collection_template % {  # type: ignore
                 'outname': htmlescape(outname),

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -124,16 +124,16 @@ class TexinfoBuilder(Builder):
         # type: () -> None
         preliminary_document_data = [list(x) for x in self.config.texinfo_documents]
         if not preliminary_document_data:
-            self.warn('no "texinfo_documents" config value found; no documents '
-                      'will be written')
+            logger.warning('no "texinfo_documents" config value found; no documents '
+                           'will be written')
             return
         # assign subdirs to titles
         self.titles = []  # type: List[Tuple[unicode, unicode]]
         for entry in preliminary_document_data:
             docname = entry[0]
             if docname not in self.env.all_docs:
-                self.warn('"texinfo_documents" config value references unknown '
-                          'document %s' % docname)
+                logger.warning('"texinfo_documents" config value references unknown '
+                               'document %s', docname)
                 continue
             self.document_data.append(entry)  # type: ignore
             if docname.endswith(SEP+'index'):
@@ -240,7 +240,7 @@ class TexinfoBuilder(Builder):
             with open(fn, 'w') as mkfile:
                 mkfile.write(TEXINFO_MAKEFILE)
         except (IOError, OSError) as err:
-            self.warn("error writing file %s: %s" % (fn, err))
+            logger.warning("error writing file %s: %s", fn, err)
         logger.info(' done')
 
 

--- a/sphinx/builders/text.py
+++ b/sphinx/builders/text.py
@@ -15,8 +15,11 @@ from os import path
 from docutils.io import StringOutput
 
 from sphinx.builders import Builder
+from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.writers.text import TextWriter
+
+logger = logging.getLogger(__name__)
 
 
 class TextBuilder(Builder):
@@ -65,7 +68,7 @@ class TextBuilder(Builder):
             with codecs.open(outfilename, 'w', 'utf-8') as f:
                 f.write(self.writer.output)
         except (IOError, OSError) as err:
-            self.warn("error writing file %s: %s" % (outfilename, err))
+            logger.warning("error writing file %s: %s", outfilename, err)
 
     def finish(self):
         pass

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -16,8 +16,11 @@ from docutils import nodes
 from docutils.io import StringOutput
 
 from sphinx.builders import Builder
+from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.writers.xml import XMLWriter, PseudoXMLWriter
+
+logger = logging.getLogger(__name__)
 
 
 class XMLBuilder(Builder):
@@ -80,7 +83,7 @@ class XMLBuilder(Builder):
             with codecs.open(outfilename, 'w', 'utf-8') as f:
                 f.write(self.writer.output)
         except (IOError, OSError) as err:
-            self.warn("error writing file %s: %s" % (outfilename, err))
+            logger.warning("error writing file %s: %s", outfilename, err)
 
     def finish(self):
         pass

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -219,7 +219,7 @@ class Config(object):
             if isinstance(value, binary_type) and nonascii_re.search(value):  # type: ignore
                 logger.warning('the config value %r is set to a string with non-ASCII '
                                'characters; this can lead to Unicode errors occurring. '
-                               'Please use Unicode strings, e.g. %r.' % (name, u'Content'))
+                               'Please use Unicode strings, e.g. %r.', name, u'Content')
 
     def convert_overrides(self, name, value):
         # type: (unicode, Any) -> Any
@@ -258,7 +258,7 @@ class Config(object):
                 elif name in self._raw_config:
                     self.__dict__[name] = self._raw_config[name]
             except ValueError as exc:
-                logger.warning("%s" % exc)
+                logger.warning("%s", exc)
 
     def init_values(self):
         # type: () -> None
@@ -270,14 +270,14 @@ class Config(object):
                     config.setdefault(realvalname, {})[key] = value  # type: ignore
                     continue
                 elif valname not in self.values:
-                    logger.warning('unknown config value %r in override, ignoring' % valname)
+                    logger.warning('unknown config value %r in override, ignoring', valname)
                     continue
                 if isinstance(value, string_types):
                     config[valname] = self.convert_overrides(valname, value)
                 else:
                     config[valname] = value
             except ValueError as exc:
-                logger.warning("%s" % exc)
+                logger.warning("%s", exc)
         for name in config:
             if name in self.values:
                 self.__dict__[name] = config[name]

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -16,6 +16,7 @@ from six import PY2, PY3, iteritems, string_types, binary_type, text_type, integ
 
 from sphinx.errors import ConfigError
 from sphinx.locale import l_
+from sphinx.util import logging
 from sphinx.util.i18n import format_date
 from sphinx.util.osutil import cd
 from sphinx.util.pycompat import execfile_, NoneType
@@ -24,6 +25,8 @@ if False:
     # For type annotation
     from typing import Any, Callable, Tuple  # NOQA
     from sphinx.util.tags import Tags  # NOQA
+
+logger = logging.getLogger(__name__)
 
 nonascii_re = re.compile(br'[\x80-\xff]')
 copyright_year_re = re.compile(r'^((\d{4}-)?)(\d{4})(?=[ ,])')
@@ -166,8 +169,8 @@ class Config(object):
                     config[k] = copyright_year_re.sub('\g<1>%s' % format_date('%Y'),  # type: ignore  # NOQA
                                                       config[k])
 
-    def check_types(self, warn):
-        # type: (Callable) -> None
+    def check_types(self):
+        # type: () -> None
         # check all values for deviation from the default value's type, since
         # that can result in TypeErrors all over the place
         # NB. since config values might use l_() we have to wait with calling
@@ -186,7 +189,7 @@ class Config(object):
             current = self[name]
             if isinstance(permitted, ENUM):
                 if not permitted.match(current):
-                    warn(CONFIG_ENUM_WARNING.format(
+                    logger.warning(CONFIG_ENUM_WARNING.format(
                         name=name, current=current, candidates=permitted.candidates))
             else:
                 if type(current) is type(default):
@@ -201,22 +204,22 @@ class Config(object):
                     continue  # at least we share a non-trivial base class
 
                 if permitted:
-                    warn(CONFIG_PERMITTED_TYPE_WARNING.format(
+                    logger.warning(CONFIG_PERMITTED_TYPE_WARNING.format(
                         name=name, current=type(current),
                         permitted=str([cls.__name__ for cls in permitted])))
                 else:
-                    warn(CONFIG_TYPE_WARNING.format(
+                    logger.warning(CONFIG_TYPE_WARNING.format(
                         name=name, current=type(current), default=type(default)))
 
-    def check_unicode(self, warn):
-        # type: (Callable) -> None
+    def check_unicode(self):
+        # type: () -> None
         # check all string values for non-ASCII characters in bytestrings,
         # since that can result in UnicodeErrors all over the place
         for name, value in iteritems(self._raw_config):
             if isinstance(value, binary_type) and nonascii_re.search(value):  # type: ignore
-                warn('the config value %r is set to a string with non-ASCII '
-                     'characters; this can lead to Unicode errors occurring. '
-                     'Please use Unicode strings, e.g. %r.' % (name, u'Content'))
+                logger.warning('the config value %r is set to a string with non-ASCII '
+                               'characters; this can lead to Unicode errors occurring. '
+                               'Please use Unicode strings, e.g. %r.' % (name, u'Content'))
 
     def convert_overrides(self, name, value):
         # type: (unicode, Any) -> Any
@@ -244,8 +247,8 @@ class Config(object):
             else:
                 return value
 
-    def pre_init_values(self, warn):
-        # type: (Callable) -> None
+    def pre_init_values(self):
+        # type: () -> None
         """Initialize some limited config variables before loading extensions"""
         variables = ['needs_sphinx', 'suppress_warnings', 'html_translator_class']
         for name in variables:
@@ -255,10 +258,10 @@ class Config(object):
                 elif name in self._raw_config:
                     self.__dict__[name] = self._raw_config[name]
             except ValueError as exc:
-                warn(exc)
+                logger.warning("%s" % exc)
 
-    def init_values(self, warn):
-        # type: (Callable) -> None
+    def init_values(self):
+        # type: () -> None
         config = self._raw_config
         for valname, value in iteritems(self.overrides):
             try:
@@ -267,14 +270,14 @@ class Config(object):
                     config.setdefault(realvalname, {})[key] = value  # type: ignore
                     continue
                 elif valname not in self.values:
-                    warn('unknown config value %r in override, ignoring' % valname)
+                    logger.warning('unknown config value %r in override, ignoring' % valname)
                     continue
                 if isinstance(value, string_types):
                     config[valname] = self.convert_overrides(valname, value)
                 else:
                     config[valname] = value
             except ValueError as exc:
-                warn(exc)
+                logger.warning("%s" % exc)
         for name in config:
             if name in self.values:
                 self.__dict__[name] = config[name]

--- a/sphinx/deprecation.py
+++ b/sphinx/deprecation.py
@@ -18,4 +18,8 @@ class RemovedInSphinx17Warning(PendingDeprecationWarning):
     pass
 
 
+class RemovedInSphinx20Warning(PendingDeprecationWarning):
+    pass
+
+
 RemovedInNextVersionWarning = RemovedInSphinx16Warning

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -22,6 +22,7 @@ from sphinx.roles import XRefRole
 from sphinx.locale import l_, _
 from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
+from sphinx.util import logging
 from sphinx.util.nodes import make_refnode
 from sphinx.util.pycompat import UnicodeMixin
 from sphinx.util.docfields import Field, GroupedField
@@ -33,6 +34,8 @@ if False:
     from sphinx.builders import Builder  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
+
+logger = logging.getLogger(__name__)
 
 """
     Important note on ids
@@ -3060,7 +3063,7 @@ class Symbol(object):
                     msg = "Duplicate declaration, also defined in '%s'.\n"
                     msg += "Declaration is '%s'."
                     msg = msg % (ourChild.docname, name)
-                    env.warn(otherChild.docname, msg)
+                    logger.warning(msg, location=otherChild.docname)
                 else:
                     # Both have declarations, and in the same docname.
                     # This can apparently happen, it should be safe to
@@ -4872,7 +4875,7 @@ class CPPDomain(Domain):
                     msg = "Duplicate declaration, also defined in '%s'.\n"
                     msg += "Name of declaration is '%s'."
                     msg = msg % (ourNames[name], name)
-                    self.env.warn(docname, msg)
+                    logger.warning(msg, docname)
                 else:
                     ourNames[name] = docname
 
@@ -4882,7 +4885,7 @@ class CPPDomain(Domain):
         class Warner(object):
             def warn(self, msg):
                 if emitWarnings:
-                    env.warn_node(msg, node)
+                    logger.warn_node(msg, node)
         warner = Warner()
         parser = DefinitionParser(target, warner, env.config)
         try:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4885,7 +4885,7 @@ class CPPDomain(Domain):
         class Warner(object):
             def warn(self, msg):
                 if emitWarnings:
-                    logger.warn_node(msg, node)
+                    logger.warning(msg, location=node)
         warner = Warner()
         parser = DefinitionParser(target, warner, env.config)
         try:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -787,10 +787,9 @@ class PythonDomain(Domain):
         if not matches:
             return None
         elif len(matches) > 1:
-            logger.warn_node(
-                'more than one target found for cross-reference '
-                '%r: %s' % (target, ', '.join(match[0] for match in matches)),
-                node)
+            logger.warning('more than one target found for cross-reference %r: %s',
+                           target, ', '.join(match[0] for match in matches),
+                           location=node)
         name, obj = matches[0]
 
         if obj[1] == 'module':

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -21,6 +21,7 @@ from sphinx.roles import XRefRole
 from sphinx.locale import l_, _
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
+from sphinx.util import logging
 from sphinx.util.nodes import make_refnode
 from sphinx.util.docfields import Field, GroupedField, TypedField
 
@@ -30,6 +31,8 @@ if False:
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 # REs for Python signatures
@@ -784,7 +787,7 @@ class PythonDomain(Domain):
         if not matches:
             return None
         elif len(matches) > 1:
-            env.warn_node(
+            logger.warn_node(
                 'more than one target found for cross-reference '
                 '%r: %s' % (target, ', '.join(match[0] for match in matches)),
                 node)

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -23,7 +23,7 @@ from sphinx.roles import XRefRole
 from sphinx.locale import l_, _
 from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
-from sphinx.util import ws_re
+from sphinx.util import ws_re, logging
 from sphinx.util.nodes import clean_astext, make_refnode
 
 if False:
@@ -40,6 +40,8 @@ if False:
 
     RoleFunction = Callable[[unicode, unicode, unicode, int, Inliner, Dict, List[unicode]],
                             Tuple[List[nodes.Node], List[nodes.Node]]]
+
+logger = logging.getLogger(__name__)
 
 
 # RE for option descriptions
@@ -163,12 +165,10 @@ class Cmdoption(ObjectDescription):
             potential_option = potential_option.strip()
             m = option_desc_re.match(potential_option)  # type: ignore
             if not m:
-                self.env.warn(
-                    self.env.docname,
-                    'Malformed option description %r, should '
-                    'look like "opt", "-opt args", "--opt args", '
-                    '"/opt args" or "+opt args"' % potential_option,
-                    self.lineno)
+                logger.warning('Malformed option description %r, should '
+                               'look like "opt", "-opt args", "--opt args", '
+                               '"/opt args" or "+opt args"', potential_option,
+                               location=(self.env.docname, self.lineno))
                 continue
             optname, args = m.groups()
             if count:
@@ -573,8 +573,8 @@ class StandardDomain(Domain):
             label = node[0].astext()
             if label in self.data['citations']:
                 path = env.doc2path(self.data['citations'][label][0])
-                env.warn_node('duplicate citation %s, other instance in %s' %
-                              (label, path), node)
+                logger.warn_node('duplicate citation %s, other instance in %s' %
+                                 (label, path), node)
             self.data['citations'][label] = (docname, node['ids'][0])
 
     def note_labels(self, env, docname, document):
@@ -596,8 +596,8 @@ class StandardDomain(Domain):
                 # link and object descriptions
                 continue
             if name in labels:
-                env.warn_node('duplicate label %s, ' % name + 'other instance '
-                              'in ' + env.doc2path(labels[name][0]), node)
+                logger.warn_node('duplicate label %s, ' % name + 'other instance '
+                                 'in ' + env.doc2path(labels[name][0]), node)
             anonlabels[name] = docname, labelid
             if node.tagname == 'section':
                 sectname = clean_astext(node[0])  # node[0] == title node
@@ -688,7 +688,7 @@ class StandardDomain(Domain):
             return None
 
         if env.config.numfig is False:
-            env.warn_node('numfig is disabled. :numref: is ignored.', node)
+            logger.warn_node('numfig is disabled. :numref: is ignored.', node)
             return contnode
 
         target_node = env.get_doctree(docname).ids.get(labelid)
@@ -701,7 +701,7 @@ class StandardDomain(Domain):
             if fignumber is None:
                 return contnode
         except ValueError:
-            env.warn_node("no number is assigned for %s: %s" % (figtype, labelid), node)
+            logger.warn_node("no number is assigned for %s: %s" % (figtype, labelid), node)
             return contnode
 
         try:
@@ -711,7 +711,7 @@ class StandardDomain(Domain):
                 title = env.config.numfig_format.get(figtype, '')
 
             if figname is None and '%{name}' in title:
-                env.warn_node('the link has no caption: %s' % title, node)
+                logger.warn_node('the link has no caption: %s' % title, node)
                 return contnode
             else:
                 fignum = '.'.join(map(str, fignumber))
@@ -725,10 +725,10 @@ class StandardDomain(Domain):
                     # old style format (cf. "Fig.%s")
                     newtitle = title % fignum
         except KeyError as exc:
-            env.warn_node('invalid numfig_format: %s (%r)' % (title, exc), node)
+            logger.warn_node('invalid numfig_format: %s (%r)' % (title, exc), node)
             return contnode
         except TypeError:
-            env.warn_node('invalid numfig_format: %s' % title, node)
+            logger.warn_node('invalid numfig_format: %s' % title, node)
             return contnode
 
         return self.build_reference_node(fromdocname, builder,

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -573,8 +573,8 @@ class StandardDomain(Domain):
             label = node[0].astext()
             if label in self.data['citations']:
                 path = env.doc2path(self.data['citations'][label][0])
-                logger.warn_node('duplicate citation %s, other instance in %s' %
-                                 (label, path), node)
+                logger.warning('duplicate citation %s, other instance in %s', label, path,
+                               location=node)
             self.data['citations'][label] = (docname, node['ids'][0])
 
     def note_labels(self, env, docname, document):
@@ -596,8 +596,9 @@ class StandardDomain(Domain):
                 # link and object descriptions
                 continue
             if name in labels:
-                logger.warn_node('duplicate label %s, ' % name + 'other instance '
-                                 'in ' + env.doc2path(labels[name][0]), node)
+                logger.warning('duplicate label %s, ' % name + 'other instance '
+                               'in ' + env.doc2path(labels[name][0]),
+                               location=node)
             anonlabels[name] = docname, labelid
             if node.tagname == 'section':
                 sectname = clean_astext(node[0])  # node[0] == title node
@@ -688,7 +689,7 @@ class StandardDomain(Domain):
             return None
 
         if env.config.numfig is False:
-            logger.warn_node('numfig is disabled. :numref: is ignored.', node)
+            logger.warning('numfig is disabled. :numref: is ignored.', location=node)
             return contnode
 
         target_node = env.get_doctree(docname).ids.get(labelid)
@@ -701,7 +702,8 @@ class StandardDomain(Domain):
             if fignumber is None:
                 return contnode
         except ValueError:
-            logger.warn_node("no number is assigned for %s: %s" % (figtype, labelid), node)
+            logger.warning("no number is assigned for %s: %s", figtype, labelid,
+                           location=node)
             return contnode
 
         try:
@@ -711,7 +713,7 @@ class StandardDomain(Domain):
                 title = env.config.numfig_format.get(figtype, '')
 
             if figname is None and '%{name}' in title:
-                logger.warn_node('the link has no caption: %s' % title, node)
+                logger.warning('the link has no caption: %s', title, location=node)
                 return contnode
             else:
                 fignum = '.'.join(map(str, fignumber))
@@ -725,10 +727,10 @@ class StandardDomain(Domain):
                     # old style format (cf. "Fig.%s")
                     newtitle = title % fignum
         except KeyError as exc:
-            logger.warn_node('invalid numfig_format: %s (%r)' % (title, exc), node)
+            logger.warning('invalid numfig_format: %s (%r)', title, exc, location=node)
             return contnode
         except TypeError:
-            logger.warn_node('invalid numfig_format: %s' % title, node)
+            logger.warning('invalid numfig_format: %s', title, location=node)
             return contnode
 
         return self.build_reference_node(fromdocname, builder,

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -902,8 +902,8 @@ class BuildEnvironment(object):
             rel_filename, filename = self.relfn2path(targetname, docname)
             self.dependencies[docname].add(rel_filename)
             if not os.access(filename, os.R_OK):
-                logger.warn_node('download file not readable: %s' % filename,
-                                 node)
+                logger.warning('download file not readable: %s', filename,
+                               location=node)
                 continue
             uniquename = self.dlfiles.add_file(docname, filename)
             node['filename'] = uniquename
@@ -921,8 +921,8 @@ class BuildEnvironment(object):
                     if mimetype not in candidates:
                         globbed.setdefault(mimetype, []).append(new_imgpath)
                 except (OSError, IOError) as err:
-                    logger.warn_node('image file %s not readable: %s' %
-                                     (filename, err), node)
+                    logger.warning('image file %s not readable: %s', filename, err,
+                                   location=node)
             for key, files in iteritems(globbed):
                 candidates[key] = sorted(files, key=len)[0]  # select by similarity
 
@@ -934,13 +934,13 @@ class BuildEnvironment(object):
             node['candidates'] = candidates = {}
             imguri = node['uri']
             if imguri.startswith('data:'):
-                logger.warn_node('image data URI found. some builders might not support', node,
-                                 type='image', subtype='data_uri')
+                logger.warning('image data URI found. some builders might not support',
+                               location=node, type='image', subtype='data_uri')
                 candidates['?'] = imguri
                 continue
             elif imguri.find('://') != -1:
-                logger.warn_node('nonlocal image URI found: %s' % imguri, node,
-                                 type='image', subtype='nonlocal_uri')
+                logger.warning('nonlocal image URI found: %s', imguri,
+                               location=node, type='image', subtype='nonlocal_uri')
                 candidates['?'] = imguri
                 continue
             rel_imgpath, full_imgpath = self.relfn2path(imguri, docname)
@@ -969,8 +969,8 @@ class BuildEnvironment(object):
             for imgpath in itervalues(candidates):
                 self.dependencies[docname].add(imgpath)
                 if not os.access(path.join(self.srcdir, imgpath), os.R_OK):
-                    logger.warn_node('image file not readable: %s' % imgpath,
-                                     node)
+                    logger.warning('image file not readable: %s', imgpath,
+                                   location=node)
                     continue
                 self.images.add_file(docname, imgpath)
 
@@ -1183,7 +1183,8 @@ class BuildEnvironment(object):
                   (node['refdomain'], typ)
         else:
             msg = '%r reference target not found: %%(target)s' % typ
-        logger.warn_node(msg % {'target': target}, node, type='ref', subtype=typ)
+        logger.warning(msg % {'target': target},
+                       location=node, type='ref', subtype=typ)
 
     def _resolve_doc_reference(self, builder, refdoc, node, contnode):
         # type: (Builder, unicode, nodes.Node, nodes.Node) -> nodes.Node
@@ -1234,9 +1235,9 @@ class BuildEnvironment(object):
             return None
         if len(results) > 1:
             nice_results = ' or '.join(':%s:' % r[0] for r in results)
-            logger.warn_node('more than one target found for \'any\' cross-'
-                             'reference %r: could be %s' % (target, nice_results),
-                             node)
+            logger.warning('more than one target found for \'any\' cross-'
+                           'reference %r: could be %s', target, nice_results,
+                           location=node)
         res_role, newnode = results[0]
         # Override "any" class with the actual role type to get the styling
         # approximately correct.

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -33,7 +33,7 @@ from docutils.frontend import OptionParser
 
 from sphinx import addnodes
 from sphinx.io import SphinxStandaloneReader, SphinxDummyWriter, SphinxFileInput
-from sphinx.util import get_matching_docs, docname_join, FilenameUniqDict
+from sphinx.util import get_matching_docs, docname_join, FilenameUniqDict, logging
 from sphinx.util.nodes import clean_astext, WarningStream, is_translatable, \
     process_only_nodes
 from sphinx.util.osutil import SEP, getcwd, fs_encoding, ensuredir
@@ -59,6 +59,8 @@ if False:
     from sphinx.config import Config  # NOQA
     from sphinx.domains import Domain  # NOQA
     from sphinx.environment.managers import EnvironmentManager  # NOQA
+
+logger = logging.getLogger(__name__)
 
 default_settings = {
     'embed_stylesheet': False,
@@ -553,7 +555,7 @@ class BuildEnvironment(object):
         # this cache also needs to be updated every time
         self._nitpick_ignore = set(self.config.nitpick_ignore)
 
-        app.info(bold('updating environment: '), nonl=True)
+        logger.info(bold('updating environment: '), nonl=True)
 
         added, changed, removed = self.get_outdated_files(config_changed)
 
@@ -569,7 +571,7 @@ class BuildEnvironment(object):
 
         msg += '%s added, %s changed, %s removed' % (len(added), len(changed),
                                                      len(removed))
-        app.info(msg)
+        logger.info(msg)
 
         self.app = app
 
@@ -664,7 +666,7 @@ class BuildEnvironment(object):
             tasks.add_task(read_process, chunk, merge)
 
         # make sure all threads have finished
-        app.info(bold('waiting for workers...'))
+        logger.info(bold('waiting for workers...'))
         tasks.join()
 
         for warning, kwargs in warnings:

--- a/sphinx/environment/managers/indexentries.py
+++ b/sphinx/environment/managers/indexentries.py
@@ -55,7 +55,7 @@ class IndexEntries(EnvironmentManager):
                 for entry in node['entries']:
                     split_index_msg(entry[0], entry[1])
             except ValueError as exc:
-                logger.warn_node(str(exc), node)
+                logger.warning(str(exc), location=node)
                 node.parent.remove(node)
             else:
                 for entry in node['entries']:

--- a/sphinx/environment/managers/indexentries.py
+++ b/sphinx/environment/managers/indexentries.py
@@ -16,7 +16,7 @@ from itertools import groupby
 
 from six import text_type
 from sphinx import addnodes
-from sphinx.util import iteritems, split_index_msg, split_into
+from sphinx.util import iteritems, split_index_msg, split_into, logging
 from sphinx.locale import _
 from sphinx.environment.managers import EnvironmentManager
 
@@ -26,6 +26,8 @@ if False:
     from docutils import nodes  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 class IndexEntries(EnvironmentManager):
@@ -53,7 +55,7 @@ class IndexEntries(EnvironmentManager):
                 for entry in node['entries']:
                     split_index_msg(entry[0], entry[1])
             except ValueError as exc:
-                self.env.warn_node(exc, node)
+                logger.warn_node(str(exc), node)
                 node.parent.remove(node)
             else:
                 for entry in node['entries']:
@@ -119,9 +121,9 @@ class IndexEntries(EnvironmentManager):
                         add_entry(first, _('see also %s') % second, None,
                                   link=False, key=index_key)
                     else:
-                        self.env.warn(fn, 'unknown index entry type %r' % type)
+                        logger.warning('unknown index entry type %r', type, location=fn)
                 except ValueError as err:
-                    self.env.warn(fn, str(err))
+                    logger.warning(str(err), location=fn)
 
         # sort the index entries; put all symbols at the front, even those
         # following the letters in ASCII, this is where the chr(127) comes from

--- a/sphinx/environment/managers/toctree.py
+++ b/sphinx/environment/managers/toctree.py
@@ -317,15 +317,13 @@ class Toctree(EnvironmentManager):
                                     refnode.children = [nodes.Text(title)]
                     if not toc.children:
                         # empty toc means: no titles will show up in the toctree
-                        logger.warn_node(
-                            'toctree contains reference to document %r that '
-                            'doesn\'t have a title: no link will be generated'
-                            % ref, toctreenode)
+                        logger.warning('toctree contains reference to document %r that '
+                                       'doesn\'t have a title: no link will be generated',
+                                       ref, location=toctreenode)
                 except KeyError:
                     # this is raised if the included file does not exist
-                    logger.warn_node(
-                        'toctree contains reference to nonexisting document %r'
-                        % ref, toctreenode)
+                    logger.warning('toctree contains reference to nonexisting document %r',
+                                   ref, location=toctreenode)
                 else:
                     # if titles_only is given, only keep the main title and
                     # sub-toctrees

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -10,7 +10,10 @@
 """
 
 from docutils import nodes
+from sphinx.util import logging
 from sphinx.util.nodes import clean_astext
+
+logger = logging.getLogger(__name__)
 
 
 def register_sections_as_label(app, document):
@@ -23,8 +26,8 @@ def register_sections_as_label(app, document):
         sectname = clean_astext(node[0])
 
         if name in labels:
-            app.env.warn_node('duplicate label %s, ' % name + 'other instance '
-                              'in ' + app.env.doc2path(labels[name][0]), node)
+            logger.warn_node('duplicate label %s, ' % name + 'other instance '
+                             'in ' + app.env.doc2path(labels[name][0]), node)
 
         anonlabels[name] = docname, labelid
         labels[name] = docname, labelid, sectname

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -26,8 +26,9 @@ def register_sections_as_label(app, document):
         sectname = clean_astext(node[0])
 
         if name in labels:
-            logger.warn_node('duplicate label %s, ' % name + 'other instance '
-                             'in ' + app.env.doc2path(labels[name][0]), node)
+            logger.warning('duplicate label %s, ' % name + 'other instance '
+                           'in ' + app.env.doc2path(labels[name][0]),
+                           location=node)
 
         anonlabels[name] = docname, labelid
         labels[name] = docname, labelid, sectname

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -69,7 +69,7 @@ from docutils import nodes
 
 import sphinx
 from sphinx import addnodes
-from sphinx.util import import_object, rst
+from sphinx.util import import_object, rst, logging
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.ext.autodoc import Options
 
@@ -80,6 +80,8 @@ if False:
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.ext.autodoc import Documenter  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 # -- autosummary_toc node ------------------------------------------------------
@@ -305,8 +307,7 @@ class Autosummary(Directive):
                 # be cached anyway)
                 documenter.analyzer.find_attr_docs()
             except PycodeError as err:
-                documenter.env.app.debug(
-                    '[autodoc] module analyzer failed: %s', err)
+                logger.debug('[autodoc] module analyzer failed: %s', err)
                 # no source file -- e.g. for builtin and C modules
                 documenter.analyzer = None
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -608,13 +608,13 @@ def process_generate_options(app):
 
     suffix = get_rst_suffix(app)
     if suffix is None:
-        app.warn('autosummary generats .rst files internally. '
-                 'But your source_suffix does not contain .rst. Skipped.')
+        logging.warning('autosummary generats .rst files internally. '
+                        'But your source_suffix does not contain .rst. Skipped.')
         return
 
     generate_autosummary_docs(genfiles, builder=app.builder,
-                              warn=app.warn, info=app.info, suffix=suffix,
-                              base_path=app.srcdir)
+                              warn=logger.warning, info=logger.info,
+                              suffix=suffix, base_path=app.srcdir)
 
 
 def setup(app):

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -20,12 +20,15 @@ from six.moves import cPickle as pickle
 
 import sphinx
 from sphinx.builders import Builder
+from sphinx.util import logging
 from sphinx.util.inspect import safe_getattr
 
 if False:
     # For type annotation
     from typing import Any, Callable, IO, Pattern, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 # utility
@@ -35,14 +38,14 @@ def write_header(f, text, char='-'):
     f.write(char * len(text) + '\n')
 
 
-def compile_regex_list(name, exps, warnfunc):
-    # type: (unicode, unicode, Callable) -> List[Pattern]
+def compile_regex_list(name, exps):
+    # type: (unicode, unicode) -> List[Pattern]
     lst = []
     for exp in exps:
         try:
             lst.append(re.compile(exp))
         except Exception:
-            warnfunc('invalid regex %r in %s' % (exp, name))
+            logger.warning('invalid regex %r in %s', exp, name)
     return lst
 
 
@@ -62,21 +65,18 @@ class CoverageBuilder(Builder):
             try:
                 self.c_regexes.append((name, re.compile(exp)))
             except Exception:
-                self.warn('invalid regex %r in coverage_c_regexes' % exp)
+                logger.warning('invalid regex %r in coverage_c_regexes', exp)
 
         self.c_ignorexps = {}  # type: Dict[unicode, List[Pattern]]
         for (name, exps) in iteritems(self.config.coverage_ignore_c_items):
-            self.c_ignorexps[name] = compile_regex_list(
-                'coverage_ignore_c_items', exps, self.warn)
-        self.mod_ignorexps = compile_regex_list(
-            'coverage_ignore_modules', self.config.coverage_ignore_modules,
-            self.warn)
-        self.cls_ignorexps = compile_regex_list(
-            'coverage_ignore_classes', self.config.coverage_ignore_classes,
-            self.warn)
-        self.fun_ignorexps = compile_regex_list(
-            'coverage_ignore_functions', self.config.coverage_ignore_functions,
-            self.warn)
+            self.c_ignorexps[name] = compile_regex_list('coverage_ignore_c_items',
+                                                        exps)
+        self.mod_ignorexps = compile_regex_list('coverage_ignore_modules',
+                                                self.config.coverage_ignore_modules)
+        self.cls_ignorexps = compile_regex_list('coverage_ignore_classes',
+                                                self.config.coverage_ignore_classes)
+        self.fun_ignorexps = compile_regex_list('coverage_ignore_functions',
+                                                self.config.coverage_ignore_functions)
 
     def get_outdated_docs(self):
         # type: () -> unicode
@@ -147,8 +147,7 @@ class CoverageBuilder(Builder):
             try:
                 mod = __import__(mod_name, fromlist=['foo'])
             except ImportError as err:
-                self.warn('module %s could not be imported: %s' %
-                          (mod_name, err))
+                logger.warning('module %s could not be imported: %s', mod_name, err)
                 self.py_undoc[mod_name] = {'error': err}
                 continue
 

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -25,7 +25,7 @@ from docutils.parsers.rst import Directive, directives
 
 import sphinx
 from sphinx.builders import Builder
-from sphinx.util import force_decode
+from sphinx.util import force_decode, logging
 from sphinx.util.nodes import set_source_info
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.osutil import fs_encoding
@@ -34,6 +34,8 @@ if False:
     # For type annotation
     from typing import Any, Callable, IO, Iterable, Sequence, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+logger = logging.getLogger(__name__)
 
 blankline_re = re.compile(r'^\s*<BLANKLINE>', re.MULTILINE)
 doctestopt_re = re.compile(r'#\s*doctest:.+$', re.MULTILINE)
@@ -262,7 +264,7 @@ Results of doctest builder run on %s
 
     def _out(self, text):
         # type: (unicode) -> None
-        self.info(text, nonl=True)
+        logger.info(text, nonl=True)
         self.outfile.write(text)
 
     def _warn_out(self, text):
@@ -270,7 +272,7 @@ Results of doctest builder run on %s
         if self.app.quiet or self.app.warningiserror:
             self.warn(text)
         else:
-            self.info(text, nonl=True)
+            logger.info(text, nonl=True)
         if isinstance(text, binary_type):
             text = force_decode(text, None)
         self.outfile.write(text)
@@ -311,7 +313,7 @@ Doctest summary
         if build_docnames is None:
             build_docnames = sorted(self.env.all_docs)
 
-        self.info(bold('running tests...'))
+        logger.info(bold('running tests...'))
         for docname in build_docnames:
             # no need to resolve the doctree
             doctree = self.env.get_doctree(docname)

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -270,7 +270,7 @@ Results of doctest builder run on %s
     def _warn_out(self, text):
         # type: (unicode) -> None
         if self.app.quiet or self.app.warningiserror:
-            self.warn(text)
+            logger.warning(text)
         else:
             logger.info(text, nonl=True)
         if isinstance(text, binary_type):
@@ -347,9 +347,9 @@ Doctest summary
         for node in doctree.traverse(condition):
             source = 'test' in node and node['test'] or node.astext()
             if not source:
-                self.warn('no code/output in %s block at %s:%s' %
-                          (node.get('testnodetype', 'doctest'),
-                           self.env.doc2path(docname), node.line))
+                logger.warning('no code/output in %s block at %s:%s',
+                               node.get('testnodetype', 'doctest'),
+                               self.env.doc2path(docname), node.line)
             code = TestCode(source, type=node.get('testnodetype', 'doctest'),
                             lineno=node.line, options=node.get('options'))
             node_groups = node.get('groups', ['default'])
@@ -442,9 +442,8 @@ Doctest summary
                         doctest_encode(code[0].code, self.env.config.source_encoding), {},  # type: ignore  # NOQA
                         group.name, filename_str, code[0].lineno)
                 except Exception:
-                    self.warn('ignoring invalid doctest code: %r' %
-                              code[0].code,
-                              '%s:%s' % (filename, code[0].lineno))
+                    logger.warning('ignoring invalid doctest code: %r', code[0].code,
+                                   location=(filename, code[0].lineno))
                     continue
                 if not test.examples:
                     continue

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -26,6 +26,7 @@ from docutils.statemachine import ViewList
 import sphinx
 from sphinx.errors import SphinxError
 from sphinx.locale import _
+from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
@@ -33,6 +34,8 @@ if False:
     # For type annotation
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 mapname_re = re.compile(r'<map id="(.*?)"')
@@ -204,8 +207,8 @@ def render_dot(self, code, options, format, prefix='graphviz'):
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory
             raise
-        self.builder.warn('dot command %r cannot be run (needed for graphviz '
-                          'output), check the graphviz_dot setting' % graphviz_dot)
+        logger.warning('dot command %r cannot be run (needed for graphviz '
+                       'output), check the graphviz_dot setting', graphviz_dot)
         if not hasattr(self.builder, '_graphviz_warned_dot'):
             self.builder._graphviz_warned_dot = {}
         self.builder._graphviz_warned_dot[graphviz_dot] = True
@@ -236,7 +239,7 @@ def warn_for_deprecated_option(self, node):
         return
 
     if 'inline' in node:
-        self.builder.warn(':inline: option for graphviz is deprecated since version 1.4.0.')
+        logger.warning(':inline: option for graphviz is deprecated since version 1.4.0.')
         self.builder._graphviz_warned_inline = True
 
 
@@ -250,7 +253,7 @@ def render_dot_html(self, node, code, options, prefix='graphviz',
                                 "'svg', but is %r" % format)
         fname, outfn = render_dot(self, code, options, format, prefix)
     except GraphvizError as exc:
-        self.builder.warn('dot code %r: ' % code + str(exc))
+        logger.warning('dot code %r: ' % code + str(exc))
         raise nodes.SkipNode
 
     if fname is None:
@@ -296,7 +299,7 @@ def render_dot_latex(self, node, code, options, prefix='graphviz'):
     try:
         fname, outfn = render_dot(self, code, options, 'pdf', prefix)
     except GraphvizError as exc:
-        self.builder.warn('dot code %r: ' % code + str(exc))
+        logger.warning('dot code %r: ' % code + str(exc))
         raise nodes.SkipNode
 
     is_inline = self.is_inline(node)
@@ -333,7 +336,7 @@ def render_dot_texinfo(self, node, code, options, prefix='graphviz'):
     try:
         fname, outfn = render_dot(self, code, options, 'png', prefix)
     except GraphvizError as exc:
-        self.builder.warn('dot code %r: ' % code + str(exc))
+        logger.warning('dot code %r: ' % code + str(exc))
         raise nodes.SkipNode
     if fname is not None:
         self.body.append('@image{%s,,,[graphviz],png}\n' % fname[:-4])

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -25,6 +25,7 @@ from docutils import nodes
 import sphinx
 from sphinx.locale import _
 from sphinx.errors import SphinxError, ExtensionError
+from sphinx.util import logging
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.osutil import ensuredir, ENOENT, cd
 from sphinx.util.pycompat import sys_encoding
@@ -35,6 +36,8 @@ if False:
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.ext.mathbase import math as math_node, displaymath  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 class MathExtError(SphinxError):
@@ -142,9 +145,9 @@ def render_math(self, math):
         except OSError as err:
             if err.errno != ENOENT:   # No such file or directory
                 raise
-            self.builder.warn('LaTeX command %r cannot be run (needed for math '
-                              'display), check the imgmath_latex setting' %
-                              self.builder.config.imgmath_latex)
+            logger.warning('LaTeX command %r cannot be run (needed for math '
+                           'display), check the imgmath_latex setting',
+                           self.builder.config.imgmath_latex)
             self.builder._imgmath_warned_latex = True
             return None, None
 
@@ -183,10 +186,10 @@ def render_math(self, math):
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory
             raise
-        self.builder.warn('%s command %r cannot be run (needed for math '
-                          'display), check the imgmath_%s setting' %
-                          (image_translator, image_translator_executable,
-                           image_translator))
+        logger.warning('%s command %r cannot be run (needed for math '
+                       'display), check the imgmath_%s setting',
+                       image_translator, image_translator_executable,
+                       image_translator)
         self.builder._imgmath_warned_image_translator = True
         return None, None
 
@@ -234,7 +237,7 @@ def html_visit_math(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        self.builder.warn('display latex %r: ' % node['latex'] + msg)
+        logger.warning('display latex %r: ' % node['latex'] + msg)
         raise nodes.SkipNode
     if fname is None:
         # something failed -- use text-only as a bad substitute
@@ -262,7 +265,7 @@ def html_visit_displaymath(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        self.builder.warn('inline latex %r: ' % node['latex'] + msg)
+        logger.warning('inline latex %r: ' % node['latex'] + msg)
         raise nodes.SkipNode
     self.body.append(self.starttag(node, 'div', CLASS='math'))
     self.body.append('<p>')

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -237,7 +237,7 @@ def html_visit_math(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        logger.warning('display latex %r: ' % node['latex'] + msg)
+        logger.warning('display latex %r: %s', node['latex'], msg)
         raise nodes.SkipNode
     if fname is None:
         # something failed -- use text-only as a bad substitute
@@ -265,7 +265,7 @@ def html_visit_displaymath(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        logger.warning('inline latex %r: ' % node['latex'] + msg)
+        logger.warning('inline latex %r: %s', node['latex'], msg)
         raise nodes.SkipNode
     self.body.append(self.starttag(node, 'div', CLASS='math'))
     self.body.append('<p>')

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -42,7 +42,7 @@ from docutils.utils import relative_path
 import sphinx
 from sphinx.locale import _
 from sphinx.builders.html import INVENTORY_FILENAME
-from sphinx.util import requests
+from sphinx.util import requests, logging
 
 if False:
     # For type annotation
@@ -56,6 +56,7 @@ if False:
 
     Inventory = Dict[unicode, Dict[unicode, Tuple[unicode, unicode, unicode, unicode]]]
 
+logger = logging.getLogger(__name__)
 
 UTF8StreamReader = codecs.lookup('utf-8')[2]
 
@@ -235,7 +236,7 @@ def fetch_inventory(app, uri, inv):
         if hasattr(f, 'url'):
             newinv = f.url  # type: ignore
             if inv != newinv:
-                app.info('intersphinx inventory has moved: %s -> %s' % (inv, newinv))
+                logger.info('intersphinx inventory has moved: %s -> %s' % (inv, newinv))
 
                 if uri in (inv, path.dirname(inv), path.dirname(inv) + '/'):
                     uri = path.dirname(newinv)
@@ -294,7 +295,7 @@ def load_mappings(app):
             if '://' not in inv or uri not in cache \
                     or cache[uri][1] < cache_time:
                 safe_inv_url = _get_safe_url(inv)  # type: ignore
-                app.info(
+                logger.info(
                     'loading intersphinx inventory from %s...' % safe_inv_url)
                 invdata = fetch_inventory(app, uri, inv)
                 if invdata:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -229,14 +229,14 @@ def fetch_inventory(app, uri, inv):
         else:
             f = open(path.join(app.srcdir, inv), 'rb')
     except Exception as err:
-        app.warn('intersphinx inventory %r not fetchable due to '
-                 '%s: %s' % (inv, err.__class__, err))
+        logger.warning('intersphinx inventory %r not fetchable due to %s: %s',
+                       inv, err.__class__, err)
         return
     try:
         if hasattr(f, 'url'):
             newinv = f.url  # type: ignore
             if inv != newinv:
-                logger.info('intersphinx inventory has moved: %s -> %s' % (inv, newinv))
+                logger.info('intersphinx inventory has moved: %s -> %s', inv, newinv)
 
                 if uri in (inv, path.dirname(inv), path.dirname(inv) + '/'):
                     uri = path.dirname(newinv)
@@ -247,8 +247,8 @@ def fetch_inventory(app, uri, inv):
             except ValueError:
                 raise ValueError('unknown or unsupported inventory version')
     except Exception as err:
-        app.warn('intersphinx inventory %r not readable due to '
-                 '%s: %s' % (inv, err.__class__.__name__, err))
+        logger.warning('intersphinx inventory %r not readable due to %s: %s',
+                       inv, err.__class__.__name__, err)
     else:
         return invdata
 
@@ -274,7 +274,7 @@ def load_mappings(app):
             # new format
             name, (uri, inv) = key, value
             if not isinstance(name, string_types):
-                app.warn('intersphinx identifier %r is not string. Ignored' % name)
+                logger.warning('intersphinx identifier %r is not string. Ignored', name)
                 continue
         else:
             # old format, no name
@@ -295,8 +295,7 @@ def load_mappings(app):
             if '://' not in inv or uri not in cache \
                     or cache[uri][1] < cache_time:
                 safe_inv_url = _get_safe_url(inv)  # type: ignore
-                logger.info(
-                    'loading intersphinx inventory from %s...' % safe_inv_url)
+                logger.info('loading intersphinx inventory from %s...', safe_inv_url)
                 invdata = fetch_inventory(app, uri, inv)
                 if invdata:
                     cache[uri] = (name, now, invdata)

--- a/sphinx/ext/pngmath.py
+++ b/sphinx/ext/pngmath.py
@@ -209,7 +209,7 @@ def html_visit_math(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        logger.warning('display latex %r: ' % node['latex'] + msg)
+        logger.warning('display latex %r: %s', node['latex'], msg)
         raise nodes.SkipNode
     if fname is None:
         # something failed -- use text-only as a bad substitute
@@ -237,7 +237,7 @@ def html_visit_displaymath(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        logger.warning('inline latex %r: ' % node['latex'] + msg)
+        logger.warning('inline latex %r: %s', node['latex'], msg)
         raise nodes.SkipNode
     self.body.append(self.starttag(node, 'div', CLASS='math'))
     self.body.append('<p>')

--- a/sphinx/ext/pngmath.py
+++ b/sphinx/ext/pngmath.py
@@ -25,6 +25,7 @@ from docutils import nodes
 
 import sphinx
 from sphinx.errors import SphinxError, ExtensionError
+from sphinx.util import logging
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.osutil import ensuredir, ENOENT, cd
 from sphinx.util.pycompat import sys_encoding
@@ -35,6 +36,8 @@ if False:
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.ext.mathbase import math as math_node, displaymath  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 class MathExtError(SphinxError):
@@ -133,9 +136,9 @@ def render_math(self, math):
         except OSError as err:
             if err.errno != ENOENT:   # No such file or directory
                 raise
-            self.builder.warn('LaTeX command %r cannot be run (needed for math '
-                              'display), check the pngmath_latex setting' %
-                              self.builder.config.pngmath_latex)
+            logger.warning('LaTeX command %r cannot be run (needed for math '
+                           'display), check the pngmath_latex setting',
+                           self.builder.config.pngmath_latex)
             self.builder._mathpng_warned_latex = True
             return None, None
 
@@ -158,9 +161,9 @@ def render_math(self, math):
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory
             raise
-        self.builder.warn('dvipng command %r cannot be run (needed for math '
-                          'display), check the pngmath_dvipng setting' %
-                          self.builder.config.pngmath_dvipng)
+        logger.warning('dvipng command %r cannot be run (needed for math '
+                       'display), check the pngmath_dvipng setting',
+                       self.builder.config.pngmath_dvipng)
         self.builder._mathpng_warned_dvipng = True
         return None, None
     stdout, stderr = p.communicate()
@@ -206,7 +209,7 @@ def html_visit_math(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        self.builder.warn('display latex %r: ' % node['latex'] + msg)
+        logger.warning('display latex %r: ' % node['latex'] + msg)
         raise nodes.SkipNode
     if fname is None:
         # something failed -- use text-only as a bad substitute
@@ -234,7 +237,7 @@ def html_visit_displaymath(self, node):
         sm = nodes.system_message(msg, type='WARNING', level=2,
                                   backrefs=[], source=node['latex'])
         sm.walkabout(self)
-        self.builder.warn('inline latex %r: ' % node['latex'] + msg)
+        logger.warning('inline latex %r: ' % node['latex'] + msg)
         raise nodes.SkipNode
     self.body.append(self.starttag(node, 'div', CLASS='math'))
     self.body.append('<p>')
@@ -252,7 +255,8 @@ def html_visit_displaymath(self, node):
 
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
-    app.warn('sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.')
+    logger.warning('sphinx.ext.pngmath has been deprecated. '
+                   'Please use sphinx.ext.imgmath instead.')
     try:
         mathbase_setup(app, (html_visit_math, None), (html_visit_displaymath, None))
     except ExtensionError:

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -18,6 +18,7 @@ from docutils.parsers.rst import directives
 import sphinx
 from sphinx.locale import _
 from sphinx.environment import NoUri
+from sphinx.util import logging
 from sphinx.util.nodes import set_source_info
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
@@ -27,6 +28,8 @@ if False:
     from typing import Any, Iterable  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 class todo_node(nodes.Admonition, nodes.Element):
@@ -97,7 +100,7 @@ def process_todos(app, doctree):
         })
 
         if env.config.todo_emit_warnings:
-            env.warn_node("TODO entry found: %s" % node[1].astext(), node)
+            logger.warn_node("TODO entry found: %s" % node[1].astext(), node)
 
 
 class TodoList(Directive):

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -100,7 +100,8 @@ def process_todos(app, doctree):
         })
 
         if env.config.todo_emit_warnings:
-            logger.warn_node("TODO entry found: %s" % node[1].astext(), node)
+            logger.warning("TODO entry found: %s", node[1].astext(),
+                           location=node)
 
 
 class TodoList(Directive):

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -39,7 +39,7 @@ def _get_full_modname(app, modname, attribute):
     except AttributeError:
         # sphinx.ext.viewcode can't follow class instance attribute
         # then AttributeError logging output only verbose mode.
-        logger.verbose('Didn\'t find %s in %s' % (attribute, modname))
+        logger.verbose('Didn\'t find %s in %s', attribute, modname)
         return None
     except Exception as e:
         # sphinx.ext.viewcode follow python domain directives.

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -19,7 +19,7 @@ import sphinx
 from sphinx import addnodes
 from sphinx.locale import _
 from sphinx.pycode import ModuleAnalyzer
-from sphinx.util import get_full_modname
+from sphinx.util import get_full_modname, logging
 from sphinx.util.nodes import make_refnode
 from sphinx.util.console import blue  # type: ignore
 
@@ -29,6 +29,8 @@ if False:
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 
+logger = logging.getLogger(__name__)
+
 
 def _get_full_modname(app, modname, attribute):
     # type: (Sphinx, str, unicode) -> unicode
@@ -37,16 +39,16 @@ def _get_full_modname(app, modname, attribute):
     except AttributeError:
         # sphinx.ext.viewcode can't follow class instance attribute
         # then AttributeError logging output only verbose mode.
-        app.verbose('Didn\'t find %s in %s' % (attribute, modname))
+        logger.verbose('Didn\'t find %s in %s' % (attribute, modname))
         return None
     except Exception as e:
         # sphinx.ext.viewcode follow python domain directives.
         # because of that, if there are no real modules exists that specified
         # by py:function or other directives, viewcode emits a lot of warnings.
         # It should be displayed only verbose mode.
-        app.verbose(traceback.format_exc().rstrip())
-        app.verbose('viewcode can\'t import %s, failed with error "%s"' %
-                    (modname, e))
+        logger.verbose(traceback.format_exc().rstrip())
+        logger.verbose('viewcode can\'t import %s, failed with error "%s"' %
+                       (modname, e))
         return None
 
 

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -47,8 +47,7 @@ def _get_full_modname(app, modname, attribute):
         # by py:function or other directives, viewcode emits a lot of warnings.
         # It should be displayed only verbose mode.
         logger.verbose(traceback.format_exc().rstrip())
-        logger.verbose('viewcode can\'t import %s, failed with error "%s"' %
-                       (modname, e))
+        logger.verbose('viewcode can\'t import %s, failed with error "%s"', modname, e)
         return None
 
 

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -24,6 +24,7 @@ from sphinx.transforms.i18n import (
     PreserveTranslatableMessages, Locale, RemoveTranslatableInline,
 )
 from sphinx.util import import_object, split_docinfo
+from sphinx.util.docutils import LoggingReporter
 
 if False:
     # For type annotation
@@ -72,6 +73,14 @@ class SphinxBaseReader(standalone.Reader):
     def get_transforms(self):
         # type: () -> List[Transform]
         return standalone.Reader.get_transforms(self) + self.transforms
+
+    def new_document(self):
+        document = standalone.Reader.new_document(self)
+        reporter = document.reporter
+        document.reporter = LoggingReporter(reporter.source, reporter.report_level,
+                                            reporter.halt_level, reporter.debug_flag,
+                                            reporter.error_handler)
+        return document
 
 
 class SphinxStandaloneReader(SphinxBaseReader):

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -26,6 +26,9 @@ except ImportError:
 
 from sphinx import package_dir
 from sphinx.errors import ThemeError
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
 
 if False:
     # For type annotation
@@ -43,8 +46,8 @@ class Theme(object):
     themepath = []  # type: List[unicode]
 
     @classmethod
-    def init_themes(cls, confdir, theme_path, warn=None):
-        # type: (unicode, unicode, Callable) -> None
+    def init_themes(cls, confdir, theme_path):
+        # type: (unicode, unicode) -> None
         """Search all theme paths for available themes."""
         cls.themepath = list(theme_path)
         cls.themepath.append(path.join(package_dir, 'themes'))
@@ -62,9 +65,8 @@ class Theme(object):
                         tname = theme[:-4]
                         tinfo = zfile
                     except Exception:
-                        if warn:
-                            warn('file %r on theme path is not a valid '
-                                 'zipfile or contains no theme' % theme)
+                        logger.warning('file %r on theme path is not a valid '
+                                       'zipfile or contains no theme', theme)
                         continue
                 else:
                     if not path.isfile(path.join(themedir, theme, THEMECONF)):
@@ -105,8 +107,8 @@ class Theme(object):
         cls.themes[name] = (path.join(themedir, name), None)
         return
 
-    def __init__(self, name, warn=None):
-        # type: (unicode, Callable) -> None
+    def __init__(self, name):
+        # type: (unicode) -> None
         if name not in self.themes:
             self.load_extra_theme(name)
             if name not in self.themes:
@@ -162,7 +164,7 @@ class Theme(object):
             raise ThemeError('no theme named %r found, inherited by %r' %
                              (inherit, name))
         else:
-            self.base = Theme(inherit, warn=warn)
+            self.base = Theme(inherit)
 
     def get_confstr(self, section, name, default=NODEFAULT):
         # type: (unicode, unicode, Any) -> Any

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -181,7 +181,7 @@ class AutoIndexUpgrader(Transform):
             if 'entries' in node and any(len(entry) == 4 for entry in node['entries']):
                 msg = ('4 column based index found. '
                        'It might be a bug of extensions you use: %r' % node['entries'])
-                logger.warn_node(msg, node)
+                logger.warning(msg, location=node)
                 for i, entry in enumerate(node['entries']):
                     if len(entry) == 4:
                         node['entries'][i] = entry + (None,)

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -177,12 +177,11 @@ class AutoIndexUpgrader(Transform):
 
     def apply(self):
         # type: () -> None
-        env = self.document.settings.env
         for node in self.document.traverse(addnodes.index):
             if 'entries' in node and any(len(entry) == 4 for entry in node['entries']):
                 msg = ('4 column based index found. '
                        'It might be a bug of extensions you use: %r' % node['entries'])
-                env.warn_node(msg, node)
+                logger.warn_node(msg, node)
                 for i, entry in enumerate(node['entries']):
                     if len(entry) == 4:
                         node['entries'][i] = entry + (None,)

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -34,7 +34,6 @@ class DefaultSubstitutions(Transform):
 
     def apply(self):
         # type: () -> None
-        env = self.document.settings.env
         config = self.document.settings.env.config
         # only handle those not otherwise defined in the document
         to_handle = default_substitutions - set(self.document.substitution_defs)
@@ -45,7 +44,7 @@ class DefaultSubstitutions(Transform):
                 if refname == 'today' and not text:
                     # special handling: can also specify a strftime format
                     text = format_date(config.today_fmt or _('%b %d, %Y'),
-                                       language=config.language, warn=env.warn)
+                                       language=config.language)
                 ref.replace_self(nodes.Text(text, text))
 
 

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -15,8 +15,12 @@ from docutils.transforms.parts import ContentsFilter
 
 from sphinx import addnodes
 from sphinx.locale import _
+from sphinx.util import logging
 from sphinx.util.i18n import format_date
 from sphinx.util.nodes import apply_source_workaround
+
+
+logger = logging.getLogger(__name__)
 
 default_substitutions = set([
     'version',
@@ -215,7 +219,7 @@ class FilterSystemMessages(Transform):
         filterlevel = env.config.keep_warnings and 2 or 5
         for node in self.document.traverse(nodes.system_message):
             if node['level'] < filterlevel:
-                env.app.debug('%s [filtered system message]', node.astext())
+                logger.debug('%s [filtered system message]', node.astext())
                 node.parent.remove(node)
 
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -274,8 +274,8 @@ class Locale(Transform):
             old_foot_refs = node.traverse(is_autonumber_footnote_ref)
             new_foot_refs = patch.traverse(is_autonumber_footnote_ref)
             if len(old_foot_refs) != len(new_foot_refs):
-                logger.warn_node('inconsistent footnote references in '
-                                 'translated message', node)
+                logger.warning('inconsistent footnote references in translated message',
+                               location=node)
             old_foot_namerefs = {}  # type: Dict[unicode, List[nodes.footnote_reference]]
             for r in old_foot_refs:
                 old_foot_namerefs.setdefault(r.get('refname'), []).append(r)
@@ -309,7 +309,8 @@ class Locale(Transform):
             old_refs = node.traverse(is_refnamed_ref)
             new_refs = patch.traverse(is_refnamed_ref)
             if len(old_refs) != len(new_refs):
-                logger.warn_node('inconsistent references in translated message', node)
+                logger.warning('inconsistent references in translated message',
+                               location=node)
             old_ref_names = [r['refname'] for r in old_refs]
             new_ref_names = [r['refname'] for r in new_refs]
             orphans = list(set(old_ref_names) - set(new_ref_names))
@@ -337,7 +338,8 @@ class Locale(Transform):
             new_refs = patch.traverse(is_refnamed_footnote_ref)
             refname_ids_map = {}
             if len(old_refs) != len(new_refs):
-                logger.warn_node('inconsistent references in translated message', node)
+                logger.warning('inconsistent references in translated message',
+                               location=node)
             for old in old_refs:
                 refname_ids_map[old["refname"]] = old["ids"]
             for new in new_refs:
@@ -352,7 +354,8 @@ class Locale(Transform):
             new_refs = patch.traverse(addnodes.pending_xref)
             xref_reftarget_map = {}
             if len(old_refs) != len(new_refs):
-                logger.warn_node('inconsistent term references in translated message', node)
+                logger.warning('inconsistent term references in translated message',
+                               location=node)
 
             def get_ref_key(node):
                 # type: (nodes.Node) -> Tuple[unicode, unicode, unicode]

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -17,7 +17,7 @@ from docutils.utils import relative_path
 from docutils.transforms import Transform
 
 from sphinx import addnodes
-from sphinx.util import split_index_msg
+from sphinx.util import split_index_msg, logging
 from sphinx.util.i18n import find_catalog
 from sphinx.util.nodes import (
     LITERAL_TYPE_NODES, IMAGE_TYPE_NODES,
@@ -32,6 +32,8 @@ if False:
     from typing import Any, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 def publish_msgstr(app, source, source_path, source_line, config, settings):
@@ -272,8 +274,8 @@ class Locale(Transform):
             old_foot_refs = node.traverse(is_autonumber_footnote_ref)
             new_foot_refs = patch.traverse(is_autonumber_footnote_ref)
             if len(old_foot_refs) != len(new_foot_refs):
-                env.warn_node('inconsistent footnote references in '
-                              'translated message', node)
+                logger.warn_node('inconsistent footnote references in '
+                                 'translated message', node)
             old_foot_namerefs = {}  # type: Dict[unicode, List[nodes.footnote_reference]]
             for r in old_foot_refs:
                 old_foot_namerefs.setdefault(r.get('refname'), []).append(r)
@@ -307,8 +309,7 @@ class Locale(Transform):
             old_refs = node.traverse(is_refnamed_ref)
             new_refs = patch.traverse(is_refnamed_ref)
             if len(old_refs) != len(new_refs):
-                env.warn_node('inconsistent references in '
-                              'translated message', node)
+                logger.warn_node('inconsistent references in translated message', node)
             old_ref_names = [r['refname'] for r in old_refs]
             new_ref_names = [r['refname'] for r in new_refs]
             orphans = list(set(old_ref_names) - set(new_ref_names))
@@ -336,8 +337,7 @@ class Locale(Transform):
             new_refs = patch.traverse(is_refnamed_footnote_ref)
             refname_ids_map = {}
             if len(old_refs) != len(new_refs):
-                env.warn_node('inconsistent references in '
-                              'translated message', node)
+                logger.warn_node('inconsistent references in translated message', node)
             for old in old_refs:
                 refname_ids_map[old["refname"]] = old["ids"]
             for new in new_refs:
@@ -352,8 +352,7 @@ class Locale(Transform):
             new_refs = patch.traverse(addnodes.pending_xref)
             xref_reftarget_map = {}
             if len(old_refs) != len(new_refs):
-                env.warn_node('inconsistent term references in '
-                              'translated message', node)
+                logger.warn_node('inconsistent term references in translated message', node)
 
             def get_ref_key(node):
                 # type: (nodes.Node) -> Tuple[unicode, unicode, unicode]

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -28,6 +28,7 @@ from six.moves.urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, 
 from docutils.utils import relative_path
 
 from sphinx.errors import PycodeError, SphinxParallelError, ExtensionError
+from sphinx.util import logging
 from sphinx.util.console import strip_colors
 from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.osutil import fs_encoding
@@ -45,6 +46,9 @@ from sphinx.util.matching import patfilter  # noqa
 if False:
     # For type annotation
     from typing import Any, Callable, Iterable, Pattern, Sequence, Tuple  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 # Generally useful regular expressions.
 ws_re = re.compile(r'\s+')                      # type: Pattern
@@ -532,3 +536,12 @@ def split_docinfo(text):
         return '', result[0]
     else:
         return result[1:]
+
+
+def display_chunk(chunk):
+    # type: (Union[List, Tuple, unicode]) -> unicode
+    if isinstance(chunk, (list, tuple)):
+        if len(chunk) == 1:
+            return text_type(chunk[0])
+        return '%s .. %s' % (chunk[0], chunk[-1])
+    return text_type(chunk)

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -124,25 +124,13 @@ class sphinx_domains(object):
 
 
 class WarningStream(object):
-    level_mapping = {
-        'DEBUG': logger.debug,
-        'INFO': logger.info,
-        'WARNING': logger.warning,
-        'ERROR': logger.error,
-        'SEVERE': logger.critical,
-    }
-
     def write(self, text):
         matched = report_re.search(text)
         if not matched:
             logger.warning(text.rstrip("\r\n"))
         else:
             location, type, level, message = matched.groups()
-            if type in self.level_mapping:
-                logger_method = self.level_mapping.get(type)
-                logger_method(message, location=location)
-            else:
-                logger.warning(text.rstrip("\r\n"))
+            logger.log(type, message, location=location)
 
 
 class LoggingReporter(Reporter):

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -22,8 +22,11 @@ from babel.messages.pofile import read_po
 from babel.messages.mofile import write_mo
 
 from sphinx.errors import SphinxError
+from sphinx.util import logging
 from sphinx.util.osutil import SEP, walk
 from sphinx.deprecation import RemovedInSphinx16Warning
+
+logger = logging.getLogger(__name__)
 
 if False:
     # For type annotation
@@ -171,8 +174,8 @@ date_format_mappings = {
 }
 
 
-def babel_format_date(date, format, locale, warn=None, formatter=babel.dates.format_date):
-    # type: (datetime, unicode, unicode, Callable, Callable) -> unicode
+def babel_format_date(date, format, locale, formatter=babel.dates.format_date):
+    # type: (datetime, unicode, unicode, Callable) -> unicode
     if locale is None:
         locale = 'en'
 
@@ -187,15 +190,13 @@ def babel_format_date(date, format, locale, warn=None, formatter=babel.dates.for
         # fallback to English
         return formatter(date, format, locale='en')
     except AttributeError:
-        if warn:
-            warn('Invalid date format. Quote the string by single quote '
-                 'if you want to output it directly: %s' % format)
-
+        logger.warning('Invalid date format. Quote the string by single quote '
+                       'if you want to output it directly: %s', format)
         return format
 
 
-def format_date(format, date=None, language=None, warn=None):
-    # type: (str, datetime, unicode, Callable) -> unicode
+def format_date(format, date=None, language=None):
+    # type: (str, datetime, unicode) -> unicode
     if format is None:
         format = 'medium'
 
@@ -213,7 +214,7 @@ def format_date(format, date=None, language=None, warn=None):
         warnings.warn('LDML format support will be dropped at Sphinx-1.6',
                       RemovedInSphinx16Warning)
 
-        return babel_format_date(date, format, locale=language, warn=warn,
+        return babel_format_date(date, format, locale=language,
                                  formatter=babel.dates.format_datetime)
     else:
         # consider the format as ustrftime's and try to convert it to babel's

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from collections import defaultdict
 
 from six import PY2, StringIO
+from docutils import nodes
 from docutils.utils import get_source_line
 
 from sphinx.errors import SphinxWarning
@@ -91,23 +92,6 @@ class SphinxWarningLogRecord(logging.LogRecord):
 
 class SphinxLoggerAdapter(logging.LoggerAdapter):
     """LoggerAdapter allowing ``type`` and ``subtype`` keywords."""
-
-    def warn_node(self, message, node, **kwargs):
-        # type: (unicode, nodes.Node, Any) -> None
-        """Emit a warning for specific node.
-
-        :param message: a message of warning
-        :param node: a node related with the warning
-        """
-        (source, line) = get_source_line(node)
-        if source and line:
-            kwargs['location'] = "%s:%s" % (source, line)
-        elif source:
-            kwargs['location'] = "%s:" % source
-        elif line:
-            kwargs['location'] = "<unknown>:%s" % line
-
-        self.warning(message, **kwargs)
 
     def log(self, level, msg, *args, **kwargs):
         # type: (Union[int, str], unicode, Any, Any) -> None
@@ -372,6 +356,16 @@ class WarningLogRecordTranslator(logging.Filter):
                 record.location = '%s:%s' % (self.app.env.doc2path(docname), lineno)
             elif docname:
                 record.location = '%s' % self.app.env.doc2path(docname)
+            else:
+                record.location = None
+        elif isinstance(location, nodes.Node):
+            (source, line) = get_source_line(location)
+            if source and line:
+                record.location = "%s:%s" % (source, line)
+            elif source:
+                record.location = "%s:" % source
+            elif line:
+                record.location = "<unknown>:%s" % line
             else:
                 record.location = None
         elif location and ':' not in location:

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -8,6 +8,114 @@
     :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
+
+import logging
+import logging.handlers
+from six import string_types
+from contextlib import contextmanager
+from docutils.utils import get_source_line
+
+from sphinx.errors import SphinxWarning
+from sphinx.util.console import darkred  # type: ignore
+
+
+def getLogger(name):
+    """Get logger wrapped by SphinxLoggerAdapter."""
+    return SphinxLoggerAdapter(logging.getLogger(name), {})
+
+
+class SphinxLogRecord(logging.LogRecord):
+    """Log record class supporting location"""
+    def getMessage(self):
+        message = super(SphinxLogRecord, self).getMessage()
+        if isinstance(message, string_types):
+            location = getattr(self, 'location', None)
+            if location:
+                message = '%s: WARNING: %s' % (location, message)
+            elif 'WARNING:' not in message:
+                message = 'WARNING: %s' % message
+
+            return darkred(message)
+        else:
+            return message
+
+
+class SphinxLoggerAdapter(logging.LoggerAdapter):
+    """LoggerAdapter allowing ``type`` and ``subtype`` keywords."""
+
+    def warn(self, message, location=None, **kwargs):
+        """Emit a warning.
+
+        :param message: a message of warning
+        :param location: a tuple of (docname, lineno) or a string describing the location
+        """
+        if location:
+            kwargs['location'] = location
+
+        self.warning(message, **kwargs)
+
+    def warn_node(self, message, node, **kwargs):
+        """Emit a warning for specific node.
+
+        :param message: a message of warning
+        :param node: a node related with the warning
+        """
+        kwargs['location'] = "%s:%s" % get_source_line(node)
+        self.warning(message, **kwargs)
+
+    def process(self, msg, kwargs):
+        extra = kwargs.setdefault('extra', {})
+        if 'type' in kwargs:
+            extra['type'] = kwargs.pop('type')
+        if 'subtype' in kwargs:
+            extra['subtype'] = kwargs.pop('subtype')
+        if 'location' in kwargs:
+            extra['location'] = kwargs.pop('location')
+
+        return msg, kwargs
+
+
+class MemoryHandler(logging.handlers.BufferingHandler):
+    """Handler buffering all logs."""
+
+    def __init__(self):
+        super(MemoryHandler, self).__init__(-1)
+
+    def shouldFlush(self, record):
+        return False  # never flush
+
+    def flushTo(self, logger):
+        self.acquire()
+        try:
+            for record in self.buffer:
+                logger.handle(record)
+            self.buffer = []  # type: ignore
+        finally:
+            self.release()
+
+
+@contextmanager
+def pending_logging():
+    """contextmanager to pend logging temporary."""
+    logger = logging.getLogger()
+    memhandler = MemoryHandler()
+
+    try:
+        handlers = []
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+            handlers.append(handler)
+
+        logger.addHandler(memhandler)
+        yield
+    finally:
+        logger.removeHandler(memhandler)
+
+        for handler in handlers:
+            logger.addHandler(handler)
+
+        memhandler.flushTo(logger)
 
 
 def is_suppressed_warning(type, subtype, suppress_warnings):
@@ -27,3 +135,78 @@ def is_suppressed_warning(type, subtype, suppress_warnings):
                 return True
 
     return False
+
+
+class WarningSuppressor(logging.Filter):
+    """Filter logs by `suppress_warnings`."""
+
+    def __init__(self, app):
+        self.app = app
+        super(WarningSuppressor, self).__init__()
+
+    def filter(self, record):
+        type = getattr(record, 'type', None)
+        subtype = getattr(record, 'subtype', None)
+
+        if is_suppressed_warning(type, subtype, self.app.config.suppress_warnings):
+            return False
+        else:
+            self.app._warncount += 1
+            return True
+
+
+class WarningIsErrorFilter(logging.Filter):
+    """Raise exception if warning emitted."""
+
+    def __init__(self, app):
+        self.app = app
+        super(WarningIsErrorFilter, self).__init__()
+
+    def filter(self, record):
+        if self.app.warningiserror:
+            raise SphinxWarning(record.msg % record.args)
+        else:
+            return True
+
+
+class LogRecordTranslator(logging.Filter):
+    """Converts a log record to one Sphinx expects
+
+    * Make a instance of SphinxLogRecord
+    * docname to path if location given
+    """
+    def __init__(self, app):
+        self.app = app
+        super(LogRecordTranslator, self).__init__()
+
+    def filter(self, record):
+        if isinstance(record, logging.LogRecord):
+            record.__class__ = SphinxLogRecord  # force subclassing to handle location
+
+        location = getattr(record, 'location', None)
+        if isinstance(location, tuple):
+            docname, lineno = location
+            if docname and lineno:
+                record.location = '%s:%s' % (self.app.env.doc2path(docname), lineno)
+            elif docname:
+                record.location = '%s' % (self.app.env.doc2path(docname))
+            else:
+                record.location = None
+
+        return True
+
+
+def setup(app, status, warning):
+    """Setup root logger for Sphinx"""
+    logger = logging.getLogger()
+
+    # clear all handlers
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+
+    warning_handler = logging.StreamHandler(warning)
+    warning_handler.addFilter(WarningSuppressor(app))
+    warning_handler.addFilter(WarningIsErrorFilter(app))
+    warning_handler.addFilter(LogRecordTranslator(app))
+    warning_handler.setLevel(logging.WARNING)
+    logger.addHandler(warning_handler)

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -50,7 +50,14 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
         :param message: a message of warning
         :param node: a node related with the warning
         """
-        kwargs['location'] = "%s:%s" % get_source_line(node)
+        (source, line) = get_source_line(node)
+        if source and line:
+            kwargs['location'] = "%s:%s" % (source, line)
+        elif source:
+            kwargs['location'] = "%s:" % source
+        elif line:
+            kwargs['location'] = "<unknown>:%s" % line
+
         self.warning(message, **kwargs)
 
     def process(self, msg, kwargs):
@@ -178,9 +185,11 @@ class LogRecordTranslator(logging.Filter):
             if docname and lineno:
                 record.location = '%s:%s' % (self.app.env.doc2path(docname), lineno)
             elif docname:
-                record.location = '%s' % (self.app.env.doc2path(docname))
+                record.location = '%s' % self.app.env.doc2path(docname)
             else:
                 record.location = None
+        elif location and ':' not in location:
+            record.location = '%s' % self.app.env.doc2path(location)
 
         return True
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -31,6 +31,18 @@ if False:
 VERBOSE = 15
 DEBUG2 = 5
 
+LEVEL_NAMES = defaultdict(lambda: logging.WARNING)  # type: Dict[str, int]
+LEVEL_NAMES.update({
+    'CRITICAL': logging.CRITICAL,
+    'SEVERE': logging.CRITICAL,
+    'ERROR': logging.ERROR,
+    'WARNING': logging.WARNING,
+    'INFO': logging.INFO,
+    'VERBOSE': VERBOSE,
+    'DEBUG': logging.DEBUG,
+    'DEBUG2': DEBUG2,
+})
+
 VERBOSITY_MAP = defaultdict(lambda: 0)  # type: Dict[int, int]
 VERBOSITY_MAP.update({
     0: logging.INFO,
@@ -96,6 +108,14 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
             kwargs['location'] = "<unknown>:%s" % line
 
         self.warning(message, **kwargs)
+
+    def log(self, level, msg, *args, **kwargs):
+        # type: (Union[int, str], unicode, Any, Any) -> None
+        if isinstance(level, int):
+            super(SphinxLoggerAdapter, self).log(level, msg, *args, **kwargs)
+        else:
+            levelno = LEVEL_NAMES.get(level)
+            super(SphinxLoggerAdapter, self).log(levelno, msg, *args, **kwargs)
 
     def verbose(self, msg, *args, **kwargs):
         # type: (unicode, Any, Any) -> None

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -44,17 +44,6 @@ class SphinxLogRecord(logging.LogRecord):
 class SphinxLoggerAdapter(logging.LoggerAdapter):
     """LoggerAdapter allowing ``type`` and ``subtype`` keywords."""
 
-    def warn(self, message, location=None, **kwargs):
-        """Emit a warning.
-
-        :param message: a message of warning
-        :param location: a tuple of (docname, lineno) or a string describing the location
-        """
-        if location:
-            kwargs['location'] = location
-
-        self.warning(message, **kwargs)
-
     def warn_node(self, message, node, **kwargs):
         """Emit a warning for specific node.
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -23,7 +23,7 @@ from sphinx.util.console import colorize
 
 if False:
     # For type annotation
-    from typing import Any, Generator, IO, Tuple  # NOQA
+    from typing import Any, Generator, IO, Tuple, Union  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
@@ -422,12 +422,12 @@ def setup(app, status, warning):
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
 
-    info_handler = NewLineStreamHandler(SafeEncodingWriter(status))
+    info_handler = NewLineStreamHandler(SafeEncodingWriter(status))  # type: ignore
     info_handler.addFilter(InfoFilter())
     info_handler.setLevel(VERBOSITY_MAP.get(app.verbosity))
     info_handler.setFormatter(ColorizeFormatter())
 
-    warning_handler = WarningStreamHandler(SafeEncodingWriter(warning))
+    warning_handler = WarningStreamHandler(SafeEncodingWriter(warning))  # type: ignore
     warning_handler.addFilter(WarningSuppressor(app))
     warning_handler.addFilter(WarningIsErrorFilter(app))
     warning_handler.addFilter(WarningLogRecordTranslator(app))

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -18,12 +18,15 @@ from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.locale import pairindextypes
+from sphinx.util import logging
 
 if False:
     # For type annotation
     from typing import Any, Callable, Iterable, Tuple, Union  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.utils.tags import Tags  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 class WarningStream(object):
@@ -304,15 +307,14 @@ def inline_all_toctrees(builder, docnameset, docname, tree, colorfunc, traversed
             if includefile not in traversed:
                 try:
                     traversed.append(includefile)
-                    builder.info(colorfunc(includefile) + " ", nonl=1)
+                    logger.info(colorfunc(includefile) + " ", nonl=1)
                     subtree = inline_all_toctrees(builder, docnameset, includefile,
                                                   builder.env.get_doctree(includefile),
                                                   colorfunc, traversed)
                     docnameset.add(includefile)
                 except Exception:
-                    builder.warn('toctree contains ref to nonexisting '
-                                 'file %r' % includefile,
-                                 builder.env.doc2path(docname))
+                    logger.warning('toctree contains ref to nonexisting file %r',
+                                   includefile, location=docname)
                 else:
                     sof = addnodes.start_of_file(docname=includefile)
                     sof.children = subtree.children
@@ -350,8 +352,8 @@ def set_role_source_info(inliner, lineno, node):
     node.source, node.line = inliner.reporter.get_source_and_line(lineno)
 
 
-def process_only_nodes(doctree, tags, warn_node=None):
-    # type: (nodes.Node, Tags, Callable) -> None
+def process_only_nodes(doctree, tags):
+    # type: (nodes.Node, Tags) -> None
     # A comment on the comment() nodes being inserted: replacing by [] would
     # result in a "Losing ids" exception if there is a target node before
     # the only node, so we make sure docutils can transfer the id to
@@ -360,10 +362,8 @@ def process_only_nodes(doctree, tags, warn_node=None):
         try:
             ret = tags.eval_condition(node['expr'])
         except Exception as err:
-            if warn_node is None:
-                raise err
-            warn_node('exception while evaluating only '
-                      'directive expression: %s' % err, node)
+            logger.warn_node('exception while evaluating only '
+                             'directive expression: %s' % err, node)
             node.replace_self(node.children or nodes.comment())
         else:
             if ret:

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -362,8 +362,8 @@ def process_only_nodes(doctree, tags):
         try:
             ret = tags.eval_condition(node['expr'])
         except Exception as err:
-            logger.warn_node('exception while evaluating only '
-                             'directive expression: %s' % err, node)
+            logger.warning('exception while evaluating only directive expression: %s', err,
+                           location=node)
             node.replace_self(node.children or nodes.comment())
         else:
             if ret:

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -22,8 +22,11 @@ from docutils.writers.html4css1 import Writer, HTMLTranslator as BaseTranslator
 from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx16Warning
 from sphinx.locale import admonitionlabels, _
+from sphinx.util import logging
 from sphinx.util.images import get_image_size
 from sphinx.util.smartypants import sphinx_smarty_pants
+
+logger = logging.getLogger(__name__)
 
 # A good overview of the purpose behind these classes can be found here:
 # http://www.arnebrodowski.de/blog/write-your-own-restructuredtext-writer.html
@@ -289,7 +292,7 @@ class HTMLTranslator(BaseTranslator):
                 prefix = self.builder.config.numfig_format.get(figtype)
                 if prefix is None:
                     msg = 'numfig_format is not defined for %s' % figtype
-                    self.builder.warn(msg)
+                    logger.warning(msg)
                 else:
                     numbers = self.builder.fignumbers[key][figure_id]
                     self.body.append(prefix % '.'.join(map(str, numbers)) + ' ')
@@ -299,7 +302,7 @@ class HTMLTranslator(BaseTranslator):
         if figtype:
             if len(node['ids']) == 0:
                 msg = 'Any IDs not assigned for %s node' % node.tagname
-                self.builder.env.warn_node(msg, node)
+                logger.warn_node(msg, node)
             else:
                 append_fignumber(figtype, node['ids'][0])
 
@@ -522,8 +525,8 @@ class HTMLTranslator(BaseTranslator):
             if not ('width' in node and 'height' in node):
                 size = get_image_size(os.path.join(self.builder.srcdir, olduri))
                 if size is None:
-                    self.builder.env.warn_node('Could not obtain image size. '
-                                               ':scale: option is ignored.', node)
+                    logger.warn_node('Could not obtain image size. '
+                                     ':scale: option is ignored.', node)
                 else:
                     if 'width' not in node:
                         node['width'] = str(size[0])
@@ -755,10 +758,10 @@ class HTMLTranslator(BaseTranslator):
         self.body.append(self.starttag(node, 'tr', '', CLASS='field'))
 
     def visit_math(self, node, math_env=''):
-        self.builder.warn('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/ext/math.html',
-                          (self.builder.current_docname, node.line))
+        logger.warning('using "math" markup without a Sphinx math extension '
+                       'active, please use one of the math extensions '
+                       'described at http://sphinx-doc.org/ext/math.html',
+                       location=(self.builder.current_docname, node.line))
         raise nodes.SkipNode
 
     def unknown_visit(self, node):

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -302,7 +302,7 @@ class HTMLTranslator(BaseTranslator):
         if figtype:
             if len(node['ids']) == 0:
                 msg = 'Any IDs not assigned for %s node' % node.tagname
-                logger.warn_node(msg, node)
+                logger.warning(msg, location=node)
             else:
                 append_fignumber(figtype, node['ids'][0])
 
@@ -525,8 +525,8 @@ class HTMLTranslator(BaseTranslator):
             if not ('width' in node and 'height' in node):
                 size = get_image_size(os.path.join(self.builder.srcdir, olduri))
                 if size is None:
-                    logger.warn_node('Could not obtain image size. '
-                                     ':scale: option is ignored.', node)
+                    logger.warning('Could not obtain image size. :scale: option is ignored.',
+                                   location=node)
                 else:
                     if 'width' not in node:
                         node['width'] = str(size[0])

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -364,11 +364,10 @@ class HTMLTranslator(BaseTranslator):
         else:
             opts = {}
 
-        def warner(msg, **kwargs):
-            self.builder.warn(msg, (self.builder.current_docname, node.line), **kwargs)
         highlighted = self.highlighter.highlight_block(
-            node.rawsource, lang, opts=opts, warn=warner, linenos=linenos,
-            **highlight_args)
+            node.rawsource, lang, opts=opts, linenos=linenos,
+            location=(self.builder.current_docname, node.line), **highlight_args
+        )
         starttag = self.starttag(node, 'div', suffix='',
                                  CLASS='highlight-%s' % lang)
         self.body.append(starttag + highlighted + '</div>\n')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2155,12 +2155,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
             else:
                 opts = {}
 
-            def warner(msg, **kwargs):
-                # type: (unicode) -> None
-                self.builder.warn(msg, (self.curfilestack[-1], node.line), **kwargs)
-            hlcode = self.highlighter.highlight_block(code, lang, opts=opts,
-                                                      warn=warner, linenos=linenos,
-                                                      **highlight_args)
+            hlcode = self.highlighter.highlight_block(
+                code, lang, opts=opts, linenos=linenos,
+                location=(self.curfilestack[-1], node.line), **highlight_args
+            )
             # workaround for Unicode issue
             hlcode = hlcode.replace(u'€', u'@texteuro[]')
             if self.in_footnote:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -26,7 +26,7 @@ from sphinx import highlighting
 from sphinx.errors import SphinxError
 from sphinx.deprecation import RemovedInSphinx16Warning
 from sphinx.locale import admonitionlabels, _
-from sphinx.util import split_into
+from sphinx.util import split_into, logging
 from sphinx.util.i18n import format_date
 from sphinx.util.nodes import clean_astext, traverse_parent
 from sphinx.util.template import LaTeXRenderer
@@ -38,6 +38,7 @@ if False:
     from typing import Any, Callable, Iterator, Pattern, Tuple, Union  # NOQA
     from sphinx.builder import Builder  # NOQA
 
+logger = logging.getLogger(__name__)
 
 BEGIN_DOC = r'''
 \begin{document}
@@ -438,8 +439,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if builder.config.language and not self.babel.is_supported_language():
             # emit warning if specified language is invalid
             # (only emitting, nothing changed to processing)
-            self.builder.warn('no Babel option known for language %r' %
-                              builder.config.language)
+            logger.warning('no Babel option known for language %r',
+                           builder.config.language)
 
         # simply use babel.get_language() always, as get_language() returns
         # 'english' even if language is invalid or empty
@@ -490,7 +491,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             tocdepth = document['tocdepth'] + self.top_sectionlevel - 2
             maxdepth = len(self.sectionnames) - self.top_sectionlevel
             if tocdepth > maxdepth:
-                self.builder.warn('too large :maxdepth:, ignored.')
+                logger.warning('too large :maxdepth:, ignored.')
                 tocdepth = maxdepth
 
             self.elements['tocdepth'] = '\\setcounter{tocdepth}{%d}' % tocdepth
@@ -566,7 +567,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         for key in self.builder.config.latex_elements:
             if key not in self.elements:
                 msg = _("Unknown configure key: latex_elements[%r] is ignored.")
-                self.builder.warn(msg % key)
+                logger.warning(msg % key)
 
     def restrict_footnote(self, node):
         # type: (nodes.Node) -> None
@@ -891,8 +892,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             if self.this_is_the_title:
                 if len(node.children) != 1 and not isinstance(node.children[0],
                                                               nodes.Text):
-                    self.builder.warn('document title is not a single Text node',
-                                      (self.curfilestack[-1], node.line))
+                    logger.warning('document title is not a single Text node',
+                                   location=(self.curfilestack[-1], node.line))
                 if not self.elements['title']:
                     # text needs to be escaped since it is inserted into
                     # the output literally
@@ -930,10 +931,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
             # Redirect body output until title is finished.
             self.pushbody([])
         else:
-            self.builder.warn(
-                'encountered title node not in section, topic, table, '
-                'admonition or sidebar',
-                (self.curfilestack[-1], node.line or ''))
+            logger.warning('encountered title node not in section, topic, table, '
+                           'admonition or sidebar',
+                           location=(self.curfilestack[-1], node.line or ''))
             self.body.append('\\sphinxstyleothertitle{')
             self.context.append('}\n')
         self.in_title = 1
@@ -1573,7 +1573,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         try:
             return rstdim_to_latexdim(width_str)
         except ValueError:
-            self.builder.warn('dimension unit %s is invalid. Ignored.' % width_str)
+            logger.warning('dimension unit %s is invalid. Ignored.', width_str)
 
     def is_inline(self, node):
         # type: (nodes.Node) -> bool
@@ -1886,10 +1886,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     p1, p2 = [self.encode(x) for x in split_into(2, 'seealso', string)]
                     self.body.append(r'\index{%s|see{%s}}' % (p1, p2))
                 else:
-                    self.builder.warn(
-                        'unknown index entry type %s found' % type)
+                    logger.warning('unknown index entry type %s found', type)
             except ValueError as err:
-                self.builder.warn(str(err))
+                logger.warning(str(err))
         raise nodes.SkipNode
 
     def visit_raw(self, node):
@@ -1953,8 +1952,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 else:
                     self.context.append('}}}')
         else:
-            self.builder.warn('unusable reference target found: %s' % uri,
-                              (self.curfilestack[-1], node.line))
+            logger.warning('unusable reference target found: %s', uri,
+                           location=(self.curfilestack[-1], node.line))
             self.context.append('')
 
     def depart_reference(self, node):
@@ -2459,10 +2458,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_math(self, node):
         # type: (nodes.Node) -> None
-        self.builder.warn('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/ext/math.html',
-                          (self.curfilestack[-1], node.line))
+        logger.warning('using "math" markup without a Sphinx math extension '
+                       'active, please use one of the math extensions '
+                       'described at http://sphinx-doc.org/ext/math.html',
+                       location=(self.curfilestack[-1], node.line))
         raise nodes.SkipNode
 
     visit_math_block = visit_math

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -21,8 +21,11 @@ from docutils.writers.manpage import (
 from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx16Warning
 from sphinx.locale import admonitionlabels, _
+from sphinx.util import logging
 import sphinx.util.docutils
 from sphinx.util.i18n import format_date
+
+logger = logging.getLogger(__name__)
 
 
 class ManualPageWriter(Writer):
@@ -437,9 +440,9 @@ class ManualPageTranslator(BaseTranslator):
         pass
 
     def visit_math(self, node):
-        self.builder.warn('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/ext/math.html')
+        logger.warning('using "math" markup without a Sphinx math extension '
+                       'active, please use one of the math extensions '
+                       'described at http://sphinx-doc.org/ext/math.html')
         raise nodes.SkipNode
 
     visit_math_block = visit_math

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -23,6 +23,7 @@ from sphinx import addnodes, __display_version__
 from sphinx.errors import ExtensionError
 from sphinx.deprecation import RemovedInSphinx16Warning
 from sphinx.locale import admonitionlabels, _
+from sphinx.util import logging
 from sphinx.util.i18n import format_date
 from sphinx.writers.latex import collected_footnote
 
@@ -30,6 +31,8 @@ if False:
     # For type annotation
     from typing import Any, Callable, Iterator, Pattern, Tuple, Union  # NOQA
     from sphinx.builders.texinfo import TexinfoBuilder  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 COPYING = """\
@@ -651,9 +654,9 @@ class TexinfoTranslator(nodes.NodeVisitor):
         if isinstance(parent, (nodes.Admonition, nodes.sidebar, nodes.topic)):
             raise nodes.SkipNode
         elif not isinstance(parent, nodes.section):
-            self.builder.warn(
-                'encountered title node not in section, topic, table, '
-                'admonition or sidebar', (self.curfilestack[-1], node.line))
+            logger.warning('encountered title node not in section, topic, table, '
+                           'admonition or sidebar',
+                           location=(self.curfilestack[-1], node.line))
             self.visit_rubric(node)
         else:
             try:
@@ -1331,8 +1334,8 @@ class TexinfoTranslator(nodes.NodeVisitor):
                 node.parent.get('literal_block'))):
             self.body.append('\n@caption{')
         else:
-            self.builder.warn('caption not inside a figure.',
-                              (self.curfilestack[-1], node.line))
+            logger.warning('caption not inside a figure.',
+                           location=(self.curfilestack[-1], node.line))
 
     def depart_caption(self, node):
         # type: (nodes.Node) -> None
@@ -1434,13 +1437,13 @@ class TexinfoTranslator(nodes.NodeVisitor):
 
     def unimplemented_visit(self, node):
         # type: (nodes.Node) -> None
-        self.builder.warn("unimplemented node type: %r" % node,
-                          (self.curfilestack[-1], node.line))
+        logger.warning("unimplemented node type: %r", node,
+                       location=(self.curfilestack[-1], node.line))
 
     def unknown_visit(self, node):
         # type: (nodes.Node) -> None
-        self.builder.warn("unknown node type: %r" % node,
-                          (self.curfilestack[-1], node.line))
+        logger.warning("unknown node type: %r", node,
+                       location=(self.curfilestack[-1], node.line))
 
     def unknown_departure(self, node):
         # type: (nodes.Node) -> None
@@ -1756,9 +1759,9 @@ class TexinfoTranslator(nodes.NodeVisitor):
 
     def visit_math(self, node):
         # type: (nodes.Node) -> None
-        self.builder.warn('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/ext/math.html')
+        logger.warning('using "math" markup without a Sphinx math extension '
+                       'active, please use one of the math extensions '
+                       'described at http://sphinx-doc.org/ext/math.html')
         raise nodes.SkipNode
 
     visit_math_block = visit_math

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -22,11 +22,14 @@ from docutils.utils import column_width
 from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx16Warning
 from sphinx.locale import admonitionlabels, _
+from sphinx.util import logging
 
 if False:
     # For type annotation
     from typing import Any, Callable, Tuple, Union  # NOQA
     from sphinx.builders.text import TextBuilder  # NOQA
+
+logger = logging.getLogger(__name__)
 
 
 class TextWrapper(textwrap.TextWrapper):
@@ -1174,10 +1177,10 @@ class TextTranslator(nodes.NodeVisitor):
 
     def visit_math(self, node):
         # type: (nodes.Node) -> None
-        self.builder.warn('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/ext/math.html',
-                          (self.builder.current_docname, node.line))
+        logger.warning('using "math" markup without a Sphinx math extension '
+                       'active, please use one of the math extensions '
+                       'described at http://sphinx-doc.org/ext/math.html',
+                       location=(self.builder.current_docname, node.line))
         raise nodes.SkipNode
 
     visit_math_block = visit_math

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import codecs
 
 from docutils import nodes
 
@@ -66,22 +65,6 @@ def test_output(app, status, warning):
     app.warn("Bad news!")
     assert strip_escseq(warning.getvalue()) == "WARNING: Bad news!\n"
     assert app._warncount == old_count + 1
-
-
-@with_app()
-def test_output_with_unencodable_char(app, status, warning):
-
-    class StreamWriter(codecs.StreamWriter):
-        def write(self, object):
-            self.stream.write(object.encode('cp1252').decode('cp1252'))
-
-    app._status = StreamWriter(status)
-
-    # info with UnicodeEncodeError
-    status.truncate(0)
-    status.seek(0)
-    app.info(u"unicode \u206d...")
-    assert status.getvalue() == "unicode ?...\n"
 
 
 @with_app()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -48,26 +48,6 @@ def test_emit_with_nonascii_name_node(app, status, warning):
 
 
 @with_app()
-def test_output(app, status, warning):
-    # info with newline
-    status.truncate(0)  # __init__ writes to status
-    status.seek(0)
-    app.info("Nothing here...")
-    assert status.getvalue() == "Nothing here...\n"
-    # info without newline
-    status.truncate(0)
-    status.seek(0)
-    app.info("Nothing here...", True)
-    assert status.getvalue() == "Nothing here..."
-
-    # warning
-    old_count = app._warncount
-    app.warn("Bad news!")
-    assert strip_escseq(warning.getvalue()) == "WARNING: Bad news!\n"
-    assert app._warncount == old_count + 1
-
-
-@with_app()
 def test_extensions(app, status, warning):
     app.setup_extension('shutil')
     assert strip_escseq(warning.getvalue()).startswith("WARNING: extension 'shutil'")

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -40,10 +40,10 @@ with "\\?": b?'here: >>>(\\\\|/)xbb<<<'
 """
 
 HTML_WARNINGS = ENV_WARNINGS + """\
-%(root)s/index.rst:\\d+: WARNING: no matching candidate for image URI u'foo.\\*'
-%(root)s/index.rst:\\d+: WARNING: Could not lex literal_block as "c". Highlighting skipped.
 %(root)s/index.rst:\\d+: WARNING: unknown option: &option
 %(root)s/index.rst:\\d+: WARNING: citation not found: missing
+%(root)s/index.rst:\\d+: WARNING: no matching candidate for image URI u'foo.\\*'
+%(root)s/index.rst:\\d+: WARNING: Could not lex literal_block as "c". Highlighting skipped.
 """
 
 if PY3:

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -9,9 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+import mock
 from pygments.lexer import RegexLexer
 from pygments.token import Text, Name
-from pygments.filters import ErrorToken
 from pygments.formatters.html import HtmlFormatter
 
 from sphinx.highlighting import PygmentsBridge
@@ -89,7 +89,8 @@ def test_trim_doctest_flags():
         PygmentsBridge.html_formatter = HtmlFormatter
 
 
-def test_default_highlight():
+@mock.patch('sphinx.highlighting.logger')
+def test_default_highlight(logger):
     bridge = PygmentsBridge('html')
 
     # default: highlights as python3
@@ -107,8 +108,7 @@ def test_default_highlight():
                    '<span class="s2">&quot;Hello sphinx world&quot;</span>\n</pre></div>\n')
 
     # python3: raises error if highlighting failed
-    try:
-        ret = bridge.highlight_block('reST ``like`` text', 'python3')
-        assert False, "highlight_block() does not raise any exceptions"
-    except ErrorToken:
-        pass  # raise parsing error
+    ret = bridge.highlight_block('reST ``like`` text', 'python3')
+    logger.warning.assert_called_with('Could not lex literal_block as "%s". '
+                                      'Highlighting skipped.', 'python3',
+                                      type='misc', subtype='highlighting_failure', location=None)

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -111,4 +111,5 @@ def test_default_highlight(logger):
     ret = bridge.highlight_block('reST ``like`` text', 'python3')
     logger.warning.assert_called_with('Could not lex literal_block as "%s". '
                                       'Highlighting skipped.', 'python3',
-                                      type='misc', subtype='highlighting_failure', location=None)
+                                      type='misc', subtype='highlighting_failure',
+                                      location=None)

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -23,7 +23,7 @@ from six import string_types
 
 from util import tempdir, rootdir, path, gen_with_app, with_app, SkipTest, \
     assert_re_search, assert_not_re_search, assert_in, assert_not_in, \
-    assert_startswith, assert_node, repr_as, etree_parse
+    assert_startswith, assert_node, repr_as, etree_parse, strip_escseq
 
 
 root = tempdir / 'test-intl'
@@ -931,4 +931,4 @@ def test_image_glob_intl_using_figure_language_filename(app, status, warning):
 
 
 def getwarning(warnings):
-    return repr_as(warnings.getvalue().replace(os.sep, '/'), '<warnings>')
+    return repr_as(strip_escseq(warnings.getvalue().replace(os.sep, '/')), '<warnings>')

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -225,12 +225,12 @@ def test_warn_node(app, status, warning):
 
 
 @with_app()
-def test_pending_logging(app, status, warning):
+def test_pending_warnings(app, status, warning):
     logging.setup(app, status, warning)
     logger = logging.getLogger(__name__)
 
     logger.warning('message1')
-    with logging.pending_logging():
+    with logging.pending_warnings():
         # not logged yet (bufferred) in here
         logger.warning('message2')
         logger.warning('message3')

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -21,6 +21,7 @@ from util import with_app, raises, strip_escseq
 
 @with_app()
 def test_info_and_warning(app, status, warning):
+    app.verbosity = 3
     logging.setup(app, status, warning)
     logger = logging.getLogger(__name__)
 
@@ -41,6 +42,69 @@ def test_info_and_warning(app, status, warning):
     assert 'message3' in warning.getvalue()
     assert 'message4' in warning.getvalue()
     assert 'message5' in warning.getvalue()
+
+
+@with_app()
+def test_verbosity_filter(app, status, warning):
+    # verbosity = 0: INFO
+    app.verbosity = 0
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.info('message1')
+    logger.verbose('message2')
+    logger.debug('message3')
+    logger.debug2('message4')
+
+    assert 'message1' in status.getvalue()
+    assert 'message2' not in status.getvalue()
+    assert 'message3' not in status.getvalue()
+    assert 'message4' not in status.getvalue()
+
+    # verbosity = 1: VERBOSE
+    app.verbosity = 1
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.info('message1')
+    logger.verbose('message2')
+    logger.debug('message3')
+    logger.debug2('message4')
+
+    assert 'message1' in status.getvalue()
+    assert 'message2' in status.getvalue()
+    assert 'message3' not in status.getvalue()
+    assert 'message4' not in status.getvalue()
+
+    # verbosity = 2: DEBUG
+    app.verbosity = 2
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.info('message1')
+    logger.verbose('message2')
+    logger.debug('message3')
+    logger.debug2('message4')
+
+    assert 'message1' in status.getvalue()
+    assert 'message2' in status.getvalue()
+    assert 'message3' in status.getvalue()
+    assert 'message4' not in status.getvalue()
+
+    # verbosity = 3: DEBUG2
+    app.verbosity = 3
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.info('message1')
+    logger.verbose('message2')
+    logger.debug('message3')
+    logger.debug2('message4')
+
+    assert 'message1' in status.getvalue()
+    assert 'message2' in status.getvalue()
+    assert 'message3' in status.getvalue()
+    assert 'message4' in status.getvalue()
 
 
 @with_app()

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -14,6 +14,7 @@ from docutils import nodes
 
 from sphinx.errors import SphinxWarning
 from sphinx.util import logging
+from sphinx.util.console import colorize
 from sphinx.util.logging import is_suppressed_warning
 
 from util import with_app, raises, strip_escseq
@@ -238,3 +239,33 @@ def test_pending_logging(app, status, warning):
 
     # actually logged as ordered
     assert 'WARNING: message2\nWARNING: message3' in strip_escseq(warning.getvalue())
+
+
+@with_app()
+def test_colored_logs(app, status, warning):
+    app.verbosity = 3
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    # default colors
+    logger.debug2('message1')
+    logger.debug('message2')
+    logger.verbose('message3')
+    logger.info('message4')
+    logger.warning('message5')
+    logger.critical('message6')
+    logger.error('message7')
+
+    assert colorize('lightgray', 'message1') in status.getvalue()
+    assert colorize('darkgray', 'message2') in status.getvalue()
+    assert 'message3\n' in status.getvalue()  # not colored
+    assert 'message4\n' in status.getvalue()  # not colored
+    assert colorize('darkred', 'WARNING: message5') in warning.getvalue()
+    assert 'WARNING: message6\n' in warning.getvalue()  # not colored
+    assert 'WARNING: message7\n' in warning.getvalue()  # not colored
+
+    # color specification
+    logger.debug('message8', color='white')
+    logger.info('message9', color='red')
+    assert colorize('white', 'message8') in status.getvalue()
+    assert colorize('red', 'message9') in status.getvalue()

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -199,30 +199,24 @@ def test_warning_location(app, status, warning):
     assert 'index.txt:10: WARNING: message2' in warning.getvalue()
 
     logger.warning('message3', location=None)
-    assert '\x1b[31mWARNING: message3' in warning.getvalue()  # \x1b[31m = darkred
-
-
-@with_app()
-def test_warn_node(app, status, warning):
-    logging.setup(app, status, warning)
-    logger = logging.getLogger(__name__)
+    assert colorize('darkred', 'WARNING: message3') in warning.getvalue()
 
     node = nodes.Node()
     node.source, node.line = ('index.txt', 10)
-    logger.warn_node('message1', node)
-    assert 'index.txt:10: WARNING: message1' in warning.getvalue()
+    logger.warning('message4', location=node)
+    assert 'index.txt:10: WARNING: message4' in warning.getvalue()
 
     node.source, node.line = ('index.txt', None)
-    logger.warn_node('message2', node)
-    assert 'index.txt:: WARNING: message2' in warning.getvalue()
+    logger.warning('message5', location=node)
+    assert 'index.txt:: WARNING: message5' in warning.getvalue()
 
     node.source, node.line = (None, 10)
-    logger.warn_node('message3', node)
-    assert '<unknown>:10: WARNING: message3' in warning.getvalue()
+    logger.warning('message6', location=node)
+    assert '<unknown>:10: WARNING: message6' in warning.getvalue()
 
     node.source, node.line = (None, None)
-    logger.warn_node('message4', node)
-    assert '\x1b[31mWARNING: message4' in warning.getvalue()  # \x1b[31m = darkred
+    logger.warning('message7', location=node)
+    assert colorize('darkred', 'WARNING: message7') in warning.getvalue()
 
 
 @with_app()

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -296,9 +296,10 @@ def test_output_with_unencodable_char(app, status, warning):
             self.stream.write(object.encode('cp1252').decode('cp1252'))
 
     logging.setup(app, StreamWriter(status), warning)
+    logger = logging.getLogger(__name__)
 
     # info with UnicodeEncodeError
     status.truncate(0)
     status.seek(0)
-    app.info(u"unicode \u206d...")
+    logger.info(u"unicode \u206d...")
     assert status.getvalue() == "unicode ?...\n"

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -19,6 +19,42 @@ from sphinx.util.logging import is_suppressed_warning
 from util import with_app, raises, strip_escseq
 
 
+@with_app()
+def test_info_and_warning(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.debug('message1')
+    logger.info('message2')
+    logger.warning('message3')
+    logger.critical('message4')
+    logger.error('message5')
+
+    assert 'message1' in status.getvalue()
+    assert 'message2' in status.getvalue()
+    assert 'message3' not in status.getvalue()
+    assert 'message4' not in status.getvalue()
+    assert 'message5' not in status.getvalue()
+
+    assert 'message1' not in warning.getvalue()
+    assert 'message2' not in warning.getvalue()
+    assert 'message3' in warning.getvalue()
+    assert 'message4' in warning.getvalue()
+    assert 'message5' in warning.getvalue()
+
+
+@with_app()
+def test_nonl_info_log(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.info('message1', nonl=True)
+    logger.info('message2')
+    logger.info('message3')
+
+    assert 'message1message2\nmessage3' in status.getvalue()
+
+
 def test_is_suppressed_warning():
     suppress_warnings = ["ref", "files.*", "rest.duplicated_labels"]
 
@@ -36,6 +72,8 @@ def test_is_suppressed_warning():
 def test_suppress_warnings(app, status, warning):
     logging.setup(app, status, warning)
     logger = logging.getLogger(__name__)
+
+    app._warncount = 0  # force reset
 
     app.config.suppress_warnings = []
     warning.truncate(0)

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -10,7 +10,13 @@
 """
 from __future__ import print_function
 
+from docutils import nodes
+
+from sphinx.errors import SphinxWarning
+from sphinx.util import logging
 from sphinx.util.logging import is_suppressed_warning
+
+from util import with_app, raises, strip_escseq
 
 
 def test_is_suppressed_warning():
@@ -24,3 +30,109 @@ def test_is_suppressed_warning():
     assert is_suppressed_warning("files", "stylesheet", suppress_warnings) is True
     assert is_suppressed_warning("rest", "syntax", suppress_warnings) is False
     assert is_suppressed_warning("rest", "duplicated_labels", suppress_warnings) is True
+
+
+@with_app()
+def test_suppress_warnings(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    app.config.suppress_warnings = []
+    warning.truncate(0)
+    logger.warning('message1', type='test', subtype='logging')
+    logger.warning('message2', type='test', subtype='crash')
+    logger.warning('message3', type='actual', subtype='logging')
+    assert 'message1' in warning.getvalue()
+    assert 'message2' in warning.getvalue()
+    assert 'message3' in warning.getvalue()
+    assert app._warncount == 3
+
+    app.config.suppress_warnings = ['test']
+    warning.truncate(0)
+    logger.warning('message1', type='test', subtype='logging')
+    logger.warning('message2', type='test', subtype='crash')
+    logger.warning('message3', type='actual', subtype='logging')
+    assert 'message1' not in warning.getvalue()
+    assert 'message2' not in warning.getvalue()
+    assert 'message3' in warning.getvalue()
+    assert app._warncount == 4
+
+    app.config.suppress_warnings = ['test.logging']
+    warning.truncate(0)
+    logger.warning('message1', type='test', subtype='logging')
+    logger.warning('message2', type='test', subtype='crash')
+    logger.warning('message3', type='actual', subtype='logging')
+    assert 'message1' not in warning.getvalue()
+    assert 'message2' in warning.getvalue()
+    assert 'message3' in warning.getvalue()
+    assert app._warncount == 6
+
+
+@with_app()
+def test_warningiserror(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    # if False, warning is not error
+    app.warningiserror = False
+    logger.warning('message')
+
+    # if True, warning raises SphinxWarning exception
+    app.warningiserror = True
+    raises(SphinxWarning, logger.warning, 'message')
+
+
+@with_app()
+def test_warning_location(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.warning('message1', location='index')
+    assert 'index.txt: WARNING: message1' in warning.getvalue()
+
+    logger.warning('message2', location=('index', 10))
+    assert 'index.txt:10: WARNING: message2' in warning.getvalue()
+
+    logger.warning('message3', location=None)
+    assert '\x1b[31mWARNING: message3' in warning.getvalue()  # \x1b[31m = darkred
+
+
+@with_app()
+def test_warn_node(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    node = nodes.Node()
+    node.source, node.line = ('index.txt', 10)
+    logger.warn_node('message1', node)
+    assert 'index.txt:10: WARNING: message1' in warning.getvalue()
+
+    node.source, node.line = ('index.txt', None)
+    logger.warn_node('message2', node)
+    assert 'index.txt:: WARNING: message2' in warning.getvalue()
+
+    node.source, node.line = (None, 10)
+    logger.warn_node('message3', node)
+    assert '<unknown>:10: WARNING: message3' in warning.getvalue()
+
+    node.source, node.line = (None, None)
+    logger.warn_node('message4', node)
+    assert '\x1b[31mWARNING: message4' in warning.getvalue()  # \x1b[31m = darkred
+
+
+@with_app()
+def test_pending_logging(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.warning('message1')
+    with logging.pending_logging():
+        # not logged yet (bufferred) in here
+        logger.warning('message2')
+        logger.warning('message3')
+        assert 'WARNING: message1' in warning.getvalue()
+        assert 'WARNING: message2' not in warning.getvalue()
+        assert 'WARNING: message3' not in warning.getvalue()
+
+    # actually logged as ordered
+    assert 'WARNING: message2\nWARNING: message3' in strip_escseq(warning.getvalue())


### PR DESCRIPTION
Note: This is still experimental.
refs: #2367.

TODO:

- [x] Replace `app.info()`
- [x] Support parallel build
- [x] Add testcode to verify new logging structure (or test manually?)
- [x] Replace all `self.warn()` by `logger.warning()`
- [x] Write docs for logging API
- [x] Emit warning on using old logging methods