### PR TITLE
Add Chinese latex default support (refs: #3244 #3251)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Other contributors, listed alphabetically, are:
 * Michael Wilson -- Intersphinx HTTP basic auth support
 * Joel Wurtz -- cellspanning support in LaTeX
 * Hong Xu -- svg support in imgmath extension and various bug fixes
+* Delin Chang -- Chinese support in LaTeX generation
 
 Many thanks for all contributions!
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -290,7 +290,7 @@ def default_latex_docclass(config):
 def default_latex_elements(config):
     """ Better default latex_elements settings for specific languages. """
     if config.language.split('_')[0] == 'zh':
-        return {'usepackages':'\\usepackage{ctex}'}
+        return {'usepackages': '\\usepackage{ctex}'}
     else:
         return {}
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -272,6 +272,8 @@ def default_latex_engine(config):
     """ Better default latex_engine settings for specific languages. """
     if config.language == 'ja':
         return 'platex'
+    elif config.language.split('_')[0] == 'zh':
+        return 'xelatex'
     else:
         return 'pdflatex'
 
@@ -281,6 +283,14 @@ def default_latex_docclass(config):
     if config.language == 'ja':
         return {'manual': 'jsbook',
                 'howto': 'jreport'}
+    else:
+        return {}
+
+
+def default_latex_elements(config):
+    """ Better default latex_elements settings for specific languages. """
+    if config.language.split('_')[0] == 'zh':
+        return {'usepackages':'\\usepackage{ctex}'}
     else:
         return {}
 
@@ -309,7 +319,7 @@ def setup(app):
     # so that you can give them easily on the command line
     app.add_config_value('latex_paper_size', 'letter', None)
     app.add_config_value('latex_font_size', '10pt', None)
-    app.add_config_value('latex_elements', {}, None)
+    app.add_config_value('latex_elements', default_latex_elements, None)
     app.add_config_value('latex_additional_files', [], None)
 
     app.add_config_value('latex_docclass', default_latex_docclass, None)

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -270,10 +270,13 @@ def validate_config_values(app):
 
 def default_latex_engine(config):
     """ Better default latex_engine settings for specific languages. """
-    if config.language == 'ja':
-        return 'platex'
-    elif config.language.split('_')[0] == 'zh':
-        return 'xelatex'
+    if config.language:
+        if config.language == 'ja':
+            return 'platex'
+        elif config.language.split('_')[0] == 'zh':
+            return 'xelatex'
+        else:
+            return 'pdflatex'
     else:
         return 'pdflatex'
 
@@ -289,8 +292,11 @@ def default_latex_docclass(config):
 
 def default_latex_elements(config):
     """ Better default latex_elements settings for specific languages. """
-    if config.language.split('_')[0] == 'zh':
-        return {'usepackages': '\\usepackage{ctex}'}
+    if config.language:
+        if config.language.split('_')[0] == 'zh':
+            return {'usepackages': '\\usepackage{ctex}'}
+        else:
+            return {}
     else:
         return {}
 

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -134,7 +134,7 @@ latex_elements = {
     # 'figure_align': 'htbp',
 
     # Chinese language default package ctex
-    {% if language[:3]|lower == 'zh_' %}
+    {%if language!=None and language|length>2 and language[:3]|lower=='zh_' %}
     'usepackages': '\\usepackage{ctex}',
     {% endif %}
 }

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -132,6 +132,11 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
+
+    # Chinese language default package ctex
+    {% if language[:3]|lower == 'zh_' %}
+    'usepackages': '\\usepackage{ctex}',
+    {% endif %}
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -446,6 +446,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.elements['multilingual'] = '%s\n\\setmainlanguage{%s}' % \
                 (self.elements['polyglossia'], self.babel.get_language())
 
+        # detect Chinese language, disable babel/polyglossia
+        # give warnings when no common chinese package found in configuration
+        if builder.config.language.split('_')[0] == 'zh':
+            self.elements['babel'] = ''
+            self.elements['polyglossia'] = ''
+            if not 'ctex' in self.elements['usepackages'].lower():
+                self.builder.warn('ctex package for language %s support not found\nConsider adding ctex to latex_elements in conf.py\n'
+                                  'e.g. latex_elements = {\'usepackages\':\'\\\\usepackage{ctex}\'}')
+
         if getattr(builder, 'usepackages', None):
             def declare_package(packagename, options=None):
                 if options:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -448,14 +448,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
         # detect Chinese language, disable babel/polyglossia
         # give warnings when no common chinese package found in configuration
-        if builder.config.language.split('_')[0] == 'zh':
-            self.elements['babel'] = ''
-            self.elements['polyglossia'] = ''
-            if 'ctex' not in self.elements['usepackages'].lower():
-                self.builder.warn('ctex package for language %s support not found\n'
-                                  'Consider adding ctex to latex_elements in conf.py\n'
-                                  'e.g. latex_elements = '
-                                  '{\'usepackages\':\'\\\\usepackage{ctex}\'}')
+        if builder.config.language:
+            if builder.config.language.split('_')[0] == 'zh':
+                self.elements['babel'] = ''
+                self.elements['polyglossia'] = ''
+                if 'ctex' not in self.elements['usepackages'].lower():
+                    self.builder.warn('ctex package for language %s support not found\n'
+                                      'Consider adding ctex to latex_elements in conf.py\n'
+                                      'e.g. latex_elements = '
+                                      '{\'usepackages\':\'\\\\usepackage{ctex}\'}')
 
         if getattr(builder, 'usepackages', None):
             def declare_package(packagename, options=None):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -452,8 +452,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.elements['babel'] = ''
             self.elements['polyglossia'] = ''
             if not 'ctex' in self.elements['usepackages'].lower():
-                self.builder.warn('ctex package for language %s support not found\nConsider adding ctex to latex_elements in conf.py\n'
-                                  'e.g. latex_elements = {\'usepackages\':\'\\\\usepackage{ctex}\'}')
+                self.builder.warn('ctex package for language %s support not found\n'
+                                  'Consider adding ctex to latex_elements in conf.py\n'
+                                  'e.g. latex_elements = '
+                                  '{\'usepackages\':\'\\\\usepackage{ctex}\'}')
 
         if getattr(builder, 'usepackages', None):
             def declare_package(packagename, options=None):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -451,7 +451,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if builder.config.language.split('_')[0] == 'zh':
             self.elements['babel'] = ''
             self.elements['polyglossia'] = ''
-            if not 'ctex' in self.elements['usepackages'].lower():
+            if 'ctex' not in self.elements['usepackages'].lower():
                 self.builder.warn('ctex package for language %s support not found\n'
                                   'Consider adding ctex to latex_elements in conf.py\n'
                                   'e.g. latex_elements = '


### PR DESCRIPTION
Subject: Add Chinese latex default support

### Bugfix

### Purpose
- Add Chinese default latex support

### Detail
Problem Solved: Could not generate Chinese latex documents correctly by default
- Default xelatex+ctex in latex builder for Chinese when there is no user defined latex engine/latex_elements
- Detect ctex package for Chinese in latex writer and give warnings when not found. Did not force to ctex package and leave it configurable in conf.py for users
- Clear babel/polyglossia settings for Chinese in latex writer, as they are not suitable for Chinese language
- Default ctex package setting in conf.py generated by quickstart, otherwise default empty latex_elements in conf.py would override default settings in latex builder

### Relates
- #3244 initial commit
- #3251 @tk0miya refactored latex builder

