### PR TITLE
Load non-minified JS files from sphinx.package_dir

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -414,7 +414,7 @@ class IndexBuilder(object):
     def get_js_stemmer_rawcode(self):
         if self.lang.js_stemmer_rawcode:
             return path.join(
-                path.dirname(path.abspath(__file__)),
+                sphinx.package_dir, 'search',
                 'non-minified-js',
                 self.lang.js_stemmer_rawcode
             )


### PR DESCRIPTION
This makes the code consistent with other parts of Sphinx (i.e. [autosummary extension](https://github.com/sphinx-doc/sphinx/blob/stable/sphinx/ext/autosummary/generate.py#L102) or [quickstart](https://github.com/sphinx-doc/sphinx/blob/stable/sphinx/quickstart.py#L438)), and allows downstream packagers to move all static files to `/usr/share` (we [do that](https://packages.debian.org/sid/all/sphinx-common/filelist) in Debian).