### PR TITLE
Hide builtin extensions on traceback

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -211,9 +211,10 @@ def save_traceback(app):
             modfile = getattr(extmod, '__file__', 'unknown')
             if isinstance(modfile, bytes):
                 modfile = modfile.decode(fs_encoding, 'replace')
-            os.write(fd, ('#   %s (%s) from %s\n' % (
-                extname, app._extension_metadata[extname]['version'],
-                modfile)).encode('utf-8'))
+            version = app._extension_metadata[extname]['version']
+            if version != 'builtin':
+                os.write(fd, ('#   %s (%s) from %s\n' %
+                              (extname, version, modfile)).encode('utf-8'))
     os.write(fd, exc_format.encode('utf-8'))
     os.close(fd)
     return path


### PR DESCRIPTION
Since 1.5, we split sphinx-core to builtin extensions.
This causes traceback unreadable...
```
# Sphinx version: 1.5.1
# Python version: 3.5.2 (CPython)
# Docutils version: 0.13.1 release
# Jinja2 version: 2.8
# Loaded extensions:
#   sphinx.directives (builtin) from /usr/lib/python3.5/site-packages/sphinx/directives/__init__.py
#   sphinx.roles (builtin) from /usr/lib/python3.5/site-packages/sphinx/roles.py
#   sphinx.builders.linkcheck (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/linkcheck.py
#   sphinx.builders.epub (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/epub.py
#   sphinx.builders.websupport (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/websupport.py
#   sphinx.domains.javascript (builtin) from /usr/lib/python3.5/site-packages/sphinx/domains/javascript.py
#   sphinx.builders.html (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/html.py
#   sphinx.builders.texinfo (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/texinfo.py
#   alabaster (0.7.9) from /usr/lib/python3.5/site-packages/alabaster/__init__.py
#   sphinx.builders.changes (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/changes.py
#   sphinx.domains.c (builtin) from /usr/lib/python3.5/site-packages/sphinx/domains/c.py
#   kernel_include (1.0) from /run/media/adithya/Media/Adithya-Backup/Resources/linux-4.9/linux-4.9/Documentation/sphinx/kernel_include.py
#   sphinx.builders.applehelp (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/applehelp.py
#   rstFlatTable (1.0) from /run/media/adithya/Media/Adithya-Backup/Resources/linux-4.9/linux-4.9/Documentation/sphinx/rstFlatTable.py
#   sphinx.builders.dummy (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/dummy.py
#   sphinx.domains.cpp (builtin) from /usr/lib/python3.5/site-packages/sphinx/domains/cpp.py
#   cdomain (1.0) from /run/media/adithya/Media/Adithya-Backup/Resources/linux-4.9/linux-4.9/Documentation/sphinx/cdomain.py
#   sphinx.builders.latex (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/latex.py
#   sphinx.ext.imgmath (1.5.1) from /usr/lib/python3.5/site-packages/sphinx/ext/imgmath.py
#   sphinx.directives.other (builtin) from /usr/lib/python3.5/site-packages/sphinx/directives/other.py
#   sphinx.builders.epub3 (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/epub3.py
#   sphinx.builders.text (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/text.py
#   sphinx.builders.manpage (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/manpage.py
#   sphinx.builders.gettext (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/gettext.py
#   sphinx.domains.rst (builtin) from /usr/lib/python3.5/site-packages/sphinx/domains/rst.py
#   sphinx.directives.code (builtin) from /usr/lib/python3.5/site-packages/sphinx/directives/code.py
#   kernel-doc (1.0) from [/run/media/adithya/Media/Adithya-Backup/Resources/linux-4.9/linux-4.9/Documentation/sphinx/kernel-doc.py](url)
#   sphinx.domains.std (builtin) from /usr/lib/python3.5/site-packages/sphinx/domains/std.py
#   sphinx.builders.qthelp (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/qthelp.py
#   sphinx.directives.patches (builtin) from /usr/lib/python3.5/site-packages/sphinx/directives/patches.py
#   sphinx.domains.python (builtin) from /usr/lib/python3.5/site-packages/sphinx/domains/python.py
#   sphinx.builders.htmlhelp (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/htmlhelp.py
#   sphinx.builders.xml (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/xml.py
#   sphinx.builders.devhelp (builtin) from /usr/lib/python3.5/site-packages/sphinx/builders/devhelp.py
Traceback (most recent call last):
```

To make traceback simple, erase builtin extensions from list on traceback.