### PR TITLE
Allow override docwriter for LaTeXBuilder.

### DIFF
--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -100,9 +100,13 @@ class LaTeXBuilder(Builder):
                     '[2016/05/29 stylesheet for highlighting with pygments]\n\n')
             f.write(highlighter.get_stylesheet())
 
+    def get_docwriter(self):
+        # type: () -> LaTeXWriter
+        return LaTeXWriter(self)
+
     def write(self, *ignored):
         # type: (Any) -> None
-        docwriter = LaTeXWriter(self)
+        docwriter = self.get_docwriter()
         docsettings = OptionParser(
             defaults=self.env.settings,
             components=(docwriter,),


### PR DESCRIPTION
Subject: Allow overriding docwriter in LaTeXBuilder

### Feature or Bugfix
- Feature (trivial)

### Purpose
- I am customizing LaTeXWriter for better Chinese support by subclassing it.  I'd like to use my own writer in LaTeXBuilder, the simplest way is subclassing LaTeXBuilder and only change the writer it uses. So I added a one-line method for setting docwriter in subclass.

### Detail
- Add a get_docwriter() method in LaTeXBuilder, and let write() call it to get a docwriter, the default implementation of get_docwriter() returns a LaTeXWriter.

### Relates
- none

