### PR TITLE
Fix #3315: Bibliography crashes on latex build with docclass 'memoir'

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1090,8 +1090,14 @@
 
 % make commands known to non-Sphinx document classes
 \providecommand*{\sphinxtableofcontents}{\tableofcontents}
-\providecommand*{\sphinxthebibliography}{\thebibliography}
-\providecommand*{\sphinxtheindex}{\theindex}
+\spx@ifundefined{sphinxthebibliography}
+ {\newenvironment
+  {sphinxthebibliography}{\begin{thebibliography}}{\end{thebibliography}}%
+ }
+ {}% else clause of ifundefined
+\spx@ifundefined{sphinxtheindex}
+ {\newenvironment{sphinxtheindex}{\begin{theindex}}{\end{theindex}}}%
+ {}% else clause of ifundefined
 
 % remove LaTeX's cap on nesting depth if 'maxlistdepth' key used.
 % This is a hack, which works with the standard classes: it assumes \@toodeep


### PR DESCRIPTION
Subject: fix #3315 (bugfix for merge into 1.5.2 release)
