### PR TITLE
Deprecate use of notice environment in LaTeX source.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,9 @@ Deprecated
 * ``sphinx.util.compat.docutils_version`` is now deprecated
 * #2367: ``Sphinx.warn()``, ``Sphinx.info()`` and other logging methods are now
   deprecated.  Please use ``sphinx.util.logging`` (:ref:`logging-api`) instead.
+* #3318: ``notice`` is now deprecated as LaTeX environment name and will be
+  removed at Sphinx 1.7. Extension authors please use ``sphinxadmonition``
+  instead (as Sphinx does since 1.5.)
 
 Release 1.5.2 (in development)
 ===============================

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -786,10 +786,7 @@
                      \csname\@backslashchar color@#2\endcsname }
 
 % the main dispatch for all types of notices
-\newenvironment{sphinxadmonition}{\begin{notice}}{\end{notice}}
-% use of ``notice'' is for backwards compatibility and will be removed in
-% future release; sphinxadmonition environment will be defined directly.
-\newenvironment{notice}[2]{% #1=type, #2=heading
+\newenvironment{sphinxadmonition}[2]{% #1=type, #2=heading
   % can't use #1 directly in definition of end part
   \def\spx@noticetype {#1}%
   % set parameters of heavybox/lightbox
@@ -800,6 +797,16 @@
   \begin{sphinx#1}{#2}}
   % in end part, need to go around a LaTeX's "feature"
  {\edef\spx@temp{\noexpand\end{sphinx\spx@noticetype}}\spx@temp}
+% use of ``notice'' is for backwards compatibility and will be removed in
+% Sphinx 1.7.
+\newenvironment{notice}
+  {\AtEndDocument{\typeout
+{**** DEPRECATION WARNING:^^J
+This document was probably built with a Sphinx extension using ``notice''^^J
+environment. At Sphinx 1.7, ``notice'' environment will be removed. Please^^J
+report to extension author to use ``sphinxadmonition'' instead.^^J%
+****}}%
+   \begin{sphinxadmonition}}{\end{sphinxadmonition}}
 
 % Allow the release number to be specified independently of the
 % \date{}.  This allows the date to reflect the document's date and


### PR DESCRIPTION
Subject: let make latexpdf issue a warning if document uses notice environment.

### Purpose
- if some extension uses original Sphinx `notice` environment, let it be reported to extension author that this is deprecated, replaced by `sphinxadmonition` since Sphinx 1.5 and will be removed at Sphinx 1.7.

Perhaps this should be done at Python level, but the problem is that user is perfectly entitled to add her own use of a custom ``notice`` environment via `raw:: latex`  directive for example. Hence parsing the LaTeX file is not the way, it can only come out of actual pdflatex run.