### PR TITLE
Silence ``latexpdf`` verbose output

### DIFF
--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -8,7 +8,7 @@ ALLPS  = $(addsuffix .ps,$(ALLDOCS))
 # Prefix for archive names
 ARCHIVEPRREFIX =
 # Additional LaTeX options
-LATEXOPTS = -interaction batchmode
+LATEXOPTS = -halt-on-error -interaction batchmode
 # format: pdf or dvi
 FMT = pdf
 

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -8,7 +8,7 @@ ALLPS  = $(addsuffix .ps,$(ALLDOCS))
 # Prefix for archive names
 ARCHIVEPRREFIX =
 # Additional LaTeX options
-LATEXOPTS =
+LATEXOPTS = -interaction batchmode
 # format: pdf or dvi
 FMT = pdf
 


### PR DESCRIPTION
Subject: reduce the humongous latex console output

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- the default latex console output takes dozens if not hundreds of lines; ``make latexpdf`` does it five times by default. This add tremendous clutter to console interface.
- the standard latex (also in my brief testing Japanese latex) has a command line option ``-interaction`` with four values ``errorstopmode``, ``scrollmode``, ``nonstopmode`` and ``batchmode``. Only the latter reduces significantly console output. The ``foo.log`` file remains the same.

### Detail
I did not know how to customize ``sphinx-build`` interface, hence I just modify an option to the ``Makefile`` produced in ``<build>/latex`` and which is activated from top repertory by ``make latexpdf``. One can type ``make latexpdf LATEXOPTS=""`` to recover former behaviour. Unfortunately ``batchmode`` does not give an indication of progress,  beyond the useless banner (I never understood why ``batchmode`` was not completely silent, and why ``nonstopmode`` still is so verbose.) But ``nonstopmode`` is still too verbose.

Caveat: I don't have access to a Windows Box hence could not test this on a MikTeX install. I don't know if its binaries for pdflatex, xelatex, lualatex, also recognize the command line option ``-interaction <mode>``, but I expect them to do.

On a very very big document, the user may be a bit worried if no output comes during a second or too. But for example on building the Sphinx own doc, the wait is a fraction of a second, one has no time to worry.

### Relates

See also PR #3082 which proposes to use ``latexmk`` to reduce number of latex run.

