### PR TITLE
apidoc takes extension options

### DIFF
--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -410,8 +410,8 @@ Note: By default this script will not overwrite already created files.""")
             module_path = rootpath,
             append_syspath = opts.append_syspath,
         )
-        enabled_exts = {'ext_'+ext: getattr(opts, 'ext_'+ext)
-                        for ext in EXTENSIONS if getattr(opts, 'ext_'+ext)}
+        enabled_exts = {'ext_' + ext: getattr(opts, 'ext_' + ext)
+                        for ext in EXTENSIONS if getattr(opts, 'ext_' + ext)}
         d.update(enabled_exts)
 
         if isinstance(opts.header, binary_type):

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -346,6 +346,12 @@ Note: By default this script will not overwrite already created files.""")
                       'defaults to --doc-version')
     parser.add_option('--version', action='store_true', dest='show_version',
                       help='Show version information and exit')
+    from sphinx.quickstart import EXTENSIONS
+    group = parser.add_option_group('Extension options')
+    for ext in EXTENSIONS:
+        group.add_option('--ext-' + ext, action='store_true',
+                         dest='ext_' + ext, default=False,
+                         help='enable %s extension' % ext)
 
     (opts, args) = parser.parse_args(argv[1:])
 
@@ -404,6 +410,10 @@ Note: By default this script will not overwrite already created files.""")
             module_path = rootpath,
             append_syspath = opts.append_syspath,
         )
+        enabled_exts = {'ext_'+ext: getattr(opts, 'ext_'+ext)
+                        for ext in EXTENSIONS if getattr(opts, 'ext_'+ext)}
+        d.update(enabled_exts)
+
         if isinstance(opts.header, binary_type):
             d['project'] = d['project'].decode('utf-8')
         if isinstance(opts.author, binary_type):

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -25,6 +25,7 @@ from fnmatch import fnmatch
 
 from sphinx.util.osutil import FileAvoidWrite, walk
 from sphinx import __display_version__
+from sphinx.quickstart import EXTENSIONS
 
 if False:
     # For type annotation
@@ -346,7 +347,6 @@ Note: By default this script will not overwrite already created files.""")
                       'defaults to --doc-version')
     parser.add_option('--version', action='store_true', dest='show_version',
                       help='Show version information and exit')
-    from sphinx.quickstart import EXTENSIONS
     group = parser.add_option_group('Extension options')
     for ext in EXTENSIONS:
         group.add_option('--ext-' + ext, action='store_true',

--- a/tests/test_apidoc.py
+++ b/tests/test_apidoc.py
@@ -158,8 +158,3 @@ def test_extension_parsed(make_app, apidoc):
     with open(outdir / 'conf.py') as f:
         rst = f.read()
         assert "sphinx.ext.mathjax" in rst
-
-    app = make_app('text', srcdir=outdir)
-    app.build()
-    print(app._status.getvalue())
-    print(app._warning.getvalue())

--- a/tests/test_apidoc.py
+++ b/tests/test_apidoc.py
@@ -145,3 +145,21 @@ def test_multibyte_parameters(make_app, apidoc):
     app.build()
     print(app._status.getvalue())
     print(app._warning.getvalue())
+
+
+@pytest.mark.apidoc(
+    coderoot=(rootdir / 'root'),
+    options=['--ext-mathjax'],
+)
+def test_extension_parsed(make_app, apidoc):
+    outdir = apidoc.outdir
+    assert (outdir / 'conf.py').isfile()
+
+    with open(outdir / 'conf.py') as f:
+        rst = f.read()
+        assert "sphinx.ext.mathjax" in rst
+
+    app = make_app('text', srcdir=outdir)
+    app.build()
+    print(app._status.getvalue())
+    print(app._warning.getvalue())


### PR DESCRIPTION
Subject: apidoc parses extensions

Feature: added parsing of extensions to apidoc, which are then forwarded to sphinx.quickstart.generate

I build my documentation similar to the way described here http://stackoverflow.com/a/22273180. As I wanted to add math formulas to the documentation I needed to pass --ext-mathjax to sphinx.quickstart so that it ends up in conf.py. I thought this might be useful to someone else as well.

Cheers,
Gerald
