### PR TITLE
corrected output directory for .pot files

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -94,14 +94,14 @@ This section describe a easy way to translate with sphinx-intl.
 
       $ make gettext
 
-   As a result, many pot files are generated under ``_build/locale``
+   As a result, many pot files are generated under ``_build/gettext``
    directory.
 
 #. Setup/Update your `locale_dir`:
 
    .. code-block:: console
 
-      $ sphinx-intl update -p _build/locale -l de -l ja
+      $ sphinx-intl update -p _build/gettext -l de -l ja
 
    Done. You got these directories that contain po files:
 


### PR DESCRIPTION
Sphinx's `make gettext` always creates the .pot files in $BUILD_DIR/gettext, regardless of the paths configured in `locale_dirs`; those only affect sphinx-intl's operation

Subject: adjust documentation for sphinx and sphinx-intl operation

### Feature or Bugfix
- Bugfix

### Purpose

- Corrected output directory for .pot files. Sphinx's `make gettext` always creates the .pot files in $BUILD_DIR/gettext, regardless of the paths configured in `locale_dirs`; those only affect sphinx-intl's operation.

### Relates


