### PR TITLE
Fix #3308: Parsed-literals don't wrap very long lines with pdf builder

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -143,13 +143,20 @@ Here are the currently available options together with their default values.
        LaTeX requires ``true`` or ``false`` to be specified in *lowercase*.
 
 ``verbatimwrapslines``
-    default ``true``. Tells whether long lines in :rst:dir:`code-block`\ s
-    should be wrapped.
+    default ``true``. Tells whether long lines in :rst:dir:`code-block`\ 's
+    contents should wrap.
 
     .. (comment) It is theoretically possible to customize this even
        more and decide at which characters a line-break can occur and whether
        before or after, but this is accessible currently only by re-defining some
        macros with complicated LaTeX syntax from :file:`sphinx.sty`.
+
+``parsedliteralwraps``
+    default ``true``. Tells whether long lines in :dudir:`parsed-literal`\ 's
+    contents should wrap.
+
+    .. versionadded:: 1.5.2
+       set this option value to ``false`` to recover former behaviour.
 
 ``inlineliteralwraps``
     default ``true``. Allows linebreaks inside inline literals: but extra
@@ -160,7 +167,7 @@ Here are the currently available options together with their default values.
     (or shrinked) in order to accomodate the linebreak.
 
     .. versionadded:: 1.5
-       set this option to ``false`` to recover former behaviour.
+       set this option value to ``false`` to recover former behaviour.
 
 ``verbatimvisiblespace``
     default ``\textcolor{red}{\textvisiblespace}``. When a long code line is

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{footnotehyper-sphinx}%
- [2016/10/27 v0.9f hyperref aware footnote.sty for sphinx (JFB)]
+ [2017/01/14 v1.5.2 hyperref aware footnote.sty for sphinx (JFB)]
 %%
 %% Package: footnotehyper-sphinx
 %% Version: based on footnotehyper.sty v0.9f (2016/10/03)
@@ -15,6 +15,7 @@
 %% 4. \sphinxfootnotemark, and use of \spx@opt@BeforeFootnote from sphinx.sty.
 %% Note: with \footnotemark[N]/\footnotetext[N] syntax, hyperref
 %% does not insert an hyperlink. This is _not_ improved here.
+%% 5. use of \sphinxunactivateextrasandspace for parsed literals
 %%
 \DeclareOption*{\PackageWarning{footnotehyper}{Option `\CurrentOption' is unknown}}%
 \ProcessOptions\relax
@@ -92,7 +93,7 @@
 %% \spx@opt@BeforeFootnote is defined in sphinx.sty
 \def\FNH@fixed@footnote {\spx@opt@BeforeFootnote\ifx\@currenvir\fn@footnote
     \expandafter\FNH@footnoteenv\else\expandafter\fn@latex@@footnote\fi }%
-\def\FNH@footnoteenv {\@ifnextchar[\FNH@xfootnoteenv%]
+\def\FNH@footnoteenv {\sphinxunactivateextrasandspace\@ifnextchar[\FNH@xfootnoteenv%]
     {\stepcounter\@mpfn
      \protected@xdef\@thefnmark{\thempfn}\@footnotemark
      \def\FNH@endfntext@next{\FNH@endfntext@link}\fn@startfntext}}%

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{footnotehyper-sphinx}%
- [2017/01/14 v1.5.2 hyperref aware footnote.sty for sphinx (JFB)]
+ [2017/01/16 v1.5.2 hyperref aware footnote.sty for sphinx (JFB)]
 %%
 %% Package: footnotehyper-sphinx
 %% Version: based on footnotehyper.sty v0.9f (2016/10/03)
@@ -93,7 +93,8 @@
 %% \spx@opt@BeforeFootnote is defined in sphinx.sty
 \def\FNH@fixed@footnote {\spx@opt@BeforeFootnote\ifx\@currenvir\fn@footnote
     \expandafter\FNH@footnoteenv\else\expandafter\fn@latex@@footnote\fi }%
-\def\FNH@footnoteenv {\sphinxunactivateextrasandspace\@ifnextchar[\FNH@xfootnoteenv%]
+\def\FNH@footnoteenv {\catcode13=5\sphinxunactivateextrasandspace
+    \@ifnextchar[\FNH@xfootnoteenv%]
     {\stepcounter\@mpfn
      \protected@xdef\@thefnmark{\thempfn}\@footnotemark
      \def\FNH@endfntext@next{\FNH@endfntext@link}\fn@startfntext}}%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/01/09 v1.5.2 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/01/14 v1.5.2 LaTeX package (Sphinx markup)]
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.
@@ -91,6 +91,8 @@
 \DeclareBoolOption[true]{verbatimwithframe}
 \DeclareBoolOption[true]{verbatimwrapslines}
 \DeclareBoolOption[true]{inlineliteralwraps}
+% parsed literal
+\DeclareBoolOption[true]{parsedliteralwraps}
 % \textvisiblespace for compatibility with fontspec+XeTeX/LuaTeX
 \DeclareStringOption[\textcolor{red}{\textvisiblespace}]{verbatimvisiblespace}
 \DeclareStringOption % must use braces to hide the brackets
@@ -534,6 +536,66 @@
    \def\sphinxVerbatimEnvironment{\gdef\FV@EnvironName{sphinxVerbatimintable}}%
    \begin{sphinxVerbatim}}
   {\end{sphinxVerbatim}}
+
+% Parsed literal: allow long lines to wrap like they do in code-blocks
+
+% this should be kept in sync with definitions in sphinx.util.texescape
+\newcommand*\sphinxbreaksattexescapedchars{%
+  \def\do##1##2% put potential break point before character
+     {\def##1{\discretionary{}{\sphinxafterbreak\char`##2}{\char`##2}}}%
+  \do\{\{\do\textless\<\do\#\#\do\%\%\do\$\$% {, <, #, %, $
+  \def\do##1##2% put potential break point after character
+     {\def##1{\discretionary{\char`##2}{\sphinxafterbreak}{\char`##2}}}%
+  \do\_\_\do\}\}\do\textasciicircum\^\do\&\&% _, }, ^, &,
+  \do\textgreater\>\do\textasciitilde\~% >, ~
+}
+\newcommand*\sphinxbreaksviaactiveinparsedliteral{%
+  \sphinxbreaksviaactive % by default handles . , ; ? ! /
+  \do\-% we need also the hyphen character
+  \lccode`\~`\~ %
+  % update \dospecials as it is used by \url
+  % but deactivation will already have been done hence commented out
+  %  \expandafter\def\expandafter\dospecials\expandafter{\dospecials
+  %   \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-}%
+}
+\newcommand*\sphinxbreaksatspaceinparsedliteral{%
+  \lccode`~32 \lowercase{\def~}{\leavevmode
+       \nobreak\hskip\z@ plus\fontdimen3\font minus\fontdimen4\font
+       \discretionary{\copy\sphinxvisiblespacebox}{\sphinxafterbreak}
+                     {\kern\fontdimen2\font}%
+       }\lccode`\~`\~
+}
+% now the hack for \url to work (hyperref is required dependency):
+% the aim it to deactivate - . , ; ? ! / in \url's argument
+\def\spx@hack@hyper@normalise {%
+  \expandafter\spx@hack@hyper@normalise@aux\hyper@normalise
+              \spx@hack@hyper@normalise@aux\hyper@n@rmalise\relax\spx@undefined
+}%
+\long\def\spx@hack@hyper@normalise@aux#1\hyper@n@rmalise#2#3\spx@undefined{%
+  \ifx\spx@hack@hyper@normalise@aux#2%
+      \def\hyper@normalise
+       {#1\let\do\@makeother
+        \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-%
+        \hyper@n@rmalise}%
+  \else
+      \PackageWarning{sphinx}{Could not patch \string\url\space command.%
+      ^^J    Not using active characters in alltt environment}%
+      \let\do\@makeother
+      \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-%
+  \fi
+}%
+% now for the modified alltt environment
+\newenvironment{sphinxalltt}
+{\begin{alltt}%
+ \ifspx@opt@parsedliteralwraps
+   \sbox\sphinxcontinuationbox {\spx@opt@verbatimcontinued}%
+   \sbox\sphinxvisiblespacebox {\spx@opt@verbatimvisiblespace}%
+   \sphinxbreaksattexescapedchars
+   \sphinxbreaksviaactiveinparsedliteral
+   \sphinxbreaksatspaceinparsedliteral
+   \spx@hack@hyper@normalise
+ \fi }
+{\end{alltt}}% \end{alltt} (<-- only to fix Emacs/AUCTeX fontification issue)
 
 % Topic boxes
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/01/14 v1.5.2 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/01/16 v1.5.2 LaTeX package (Sphinx markup)]
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.
@@ -399,6 +399,7 @@
 \def\sphinx@verbatim@nolig@list {\do \`}%
 % Some characters . , ; ? ! / are not pygmentized.
 % This macro makes them "active" and they will insert potential linebreaks
+% In math mode, the characters are de-activated.
 \newcommand*\sphinxbreaksbeforeactivelist {}% none
 \newcommand*\sphinxbreaksafteractivelist  {\do\.\do\,\do\;\do\?\do\!\do\/}
 \newcommand*\sphinxbreaksviaactive {%
@@ -412,6 +413,15 @@
    \sphinxbreaksafteractivelist
    \lccode`\~`\~
 }
+
+% If the linebreak is at a space, the latter will be displayed as visible
+% space at end of first line, and a continuation symbol starts next line.
+% Stretch/shrink are however usually zero for typewriter font.
+\def\spx@verbatim@space {%
+     \nobreak\hskip\z@ plus\fontdimen3\font minus\fontdimen4\font
+     \discretionary{\copy\sphinxvisiblespacebox}{\sphinxafterbreak}
+                   {\kern\fontdimen2\font}%
+}%
 
 % needed to create wrapper environments of fancyvrb's Verbatim
 \newcommand*{\sphinxVerbatimEnvironment}{\gdef\FV@EnvironName{sphinxVerbatim}}
@@ -468,14 +478,7 @@
                 \doublehyphendemerits\z@\finalhyphendemerits\z@
                 \strut ##1\strut}%
           }%
-  % If the linebreak is at a space, the latter will be displayed as visible
-  % space at end of first line, and a continuation symbol starts next line.
-  % Stretch/shrink are however usually zero for typewriter font.
-  \def\FV@Space {%
-       \nobreak\hskip\z@ plus\fontdimen3\font minus\fontdimen4\font
-       \discretionary{\copy\sphinxvisiblespacebox}{\sphinxafterbreak}
-                     {\kern\fontdimen2\font}%
-       }%
+  \let\FV@Space\spx@verbatim@space
   % Allow breaks at special characters using \PYG... macros.
   \sphinxbreaksatspecials
   % Breaks at punctuation characters . , ; ? ! and / (needs catcode activation)
@@ -559,11 +562,7 @@
   %   \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-}%
 }
 \newcommand*\sphinxbreaksatspaceinparsedliteral{%
-  \lccode`~32 \lowercase{\def~}{\ifmmode\@xobeysp\else\leavevmode
-       \nobreak\hskip\z@ plus\fontdimen3\font minus\fontdimen4\font
-       \discretionary{\copy\sphinxvisiblespacebox}{\sphinxafterbreak}
-                     {\kern\fontdimen2\font}\fi
-       }\lccode`\~`\~
+  \lccode`~32 \lowercase{\let~}\spx@verbatim@space\lccode`\~`\~
 }
 % now the hack for \url to work (hyperref is required dependency):
 % the aim it to deactivate - . , ; ? ! / in \url's argument
@@ -573,7 +572,7 @@
 }%
 \long\def\spx@hack@hyper@normalise@aux#1\hyper@n@rmalise#2#3\spx@undefined{%
   \ifx\spx@hack@hyper@normalise@aux#2%
-      \def\hyper@normalise{#1\sphinxunactivateextras\hyper@n@rmalise}%
+      \def\hyper@normalise{#1\sphinxunactivateextrasandspace\hyper@n@rmalise}%
   \else
       \PackageWarning{sphinx}{Could not patch \string\url\space command.%
       ^^J    Not using extra active characters in alltt environment}%
@@ -582,7 +581,7 @@
 }%
 \newcommand*{\sphinxunactivateextras}{\let\do\@makeother
       \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-}%
-\newcommand*{\sphinxunactivateextrasandspace}{\catcode13=5\catcode32=10\relax
+\newcommand*{\sphinxunactivateextrasandspace}{\catcode32=10\relax
       \sphinxunactivateextras}%
 % now for the modified alltt environment
 \newenvironment{sphinxalltt}
@@ -595,8 +594,11 @@
    \sphinxbreaksviaactiveinparsedliteral
    \sphinxbreaksatspaceinparsedliteral
    \spx@hack@hyper@normalise
-   \everymath\expandafter{\the\everymath\catcode`\^=7\catcode`\_=8 }%
-   \everydisplay\expandafter{\the\everydisplay\catcode`\^=7\catcode`\_=8 }%
+% alltt takes care of the ' as derivative ("prime") in math mode
+   \everymath\expandafter{\the\everymath\sphinxunactivateextrasandspace
+             \catcode`\<=12\catcode`\>=12\catcode`\^=7\catcode`\_=8 }%
+   \everydisplay\expandafter{\the\everydisplay\sphinxunactivateextrasandspace
+             \catcode`\<=12\catcode`\>=12\catcode`\^=7\catcode`\_=8 }%
  \fi }
 {\end{alltt}}
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -559,10 +559,10 @@
   %   \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-}%
 }
 \newcommand*\sphinxbreaksatspaceinparsedliteral{%
-  \lccode`~32 \lowercase{\def~}{\leavevmode
+  \lccode`~32 \lowercase{\def~}{\ifmmode\@xobeysp\else\leavevmode
        \nobreak\hskip\z@ plus\fontdimen3\font minus\fontdimen4\font
        \discretionary{\copy\sphinxvisiblespacebox}{\sphinxafterbreak}
-                     {\kern\fontdimen2\font}%
+                     {\kern\fontdimen2\font}\fi
        }\lccode`\~`\~
 }
 % now the hack for \url to work (hyperref is required dependency):
@@ -573,20 +573,21 @@
 }%
 \long\def\spx@hack@hyper@normalise@aux#1\hyper@n@rmalise#2#3\spx@undefined{%
   \ifx\spx@hack@hyper@normalise@aux#2%
-      \def\hyper@normalise
-       {#1\let\do\@makeother
-        \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-%
-        \hyper@n@rmalise}%
+      \def\hyper@normalise{#1\sphinxunactivateextras\hyper@n@rmalise}%
   \else
       \PackageWarning{sphinx}{Could not patch \string\url\space command.%
-      ^^J    Not using active characters in alltt environment}%
-      \let\do\@makeother
-      \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-%
+      ^^J    Not using extra active characters in alltt environment}%
+      \sphinxunactivateextras
   \fi
 }%
+\newcommand*{\sphinxunactivateextras}{\let\do\@makeother
+      \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-}%
+\newcommand*{\sphinxunactivateextrasandspace}{\catcode13=5\catcode32=10\relax
+      \sphinxunactivateextras}%
 % now for the modified alltt environment
 \newenvironment{sphinxalltt}
-{\begin{alltt}%
+{% at start of next line to work around Emacs/AUCTeX issue with this file
+\begin{alltt}%
  \ifspx@opt@parsedliteralwraps
    \sbox\sphinxcontinuationbox {\spx@opt@verbatimcontinued}%
    \sbox\sphinxvisiblespacebox {\spx@opt@verbatimvisiblespace}%
@@ -594,8 +595,10 @@
    \sphinxbreaksviaactiveinparsedliteral
    \sphinxbreaksatspaceinparsedliteral
    \spx@hack@hyper@normalise
+   \everymath\expandafter{\the\everymath\catcode`\^=7\catcode`\_=8 }%
+   \everydisplay\expandafter{\the\everydisplay\catcode`\^=7\catcode`\_=8 }%
  \fi }
-{\end{alltt}}% \end{alltt} (<-- only to fix Emacs/AUCTeX fontification issue)
+{\end{alltt}}
 
 % Topic boxes
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1030,14 +1030,20 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('%%\n\\begin{footnotetext}[%s]'
                              '\\sphinxAtStartFootnote\n' % node['number'])
         else:
-            self.body.append('%%\n\\begin{footnote}[%s]'
-                             '\\sphinxAtStartFootnote\n' % node['number'])
+            if self.in_parsed_literal:
+                self.body.append('\\begin{footnote}[%s]' % node['number'])
+            else:
+                self.body.append('%%\n\\begin{footnote}[%s]' % node['number'])
+            self.body.append('\\sphinxAtStartFootnote\n')
 
     def depart_collected_footnote(self, node):
         if 'footnotetext' in node:
             self.body.append('%\n\\end{footnotetext}')
         else:
-            self.body.append('%\n\\end{footnote}')
+            if self.in_parsed_literal:
+                self.body.append('\\end{footnote}')
+            else:
+                self.body.append('%\n\\end{footnote}')
         self.in_footnote -= 1
 
     def visit_label(self, node):
@@ -1434,6 +1440,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         attrs = node.attributes
         pre = []                        # in reverse order
         post = []
+        if self.in_parsed_literal:
+            pre = ['\\begingroup\\sphinxunactivateextrasandspace\\relax ']
+            post = ['\\endgroup ']
         include_graphics_options = []
         is_inline = self.is_inline(node)
         if 'width' in attrs:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1929,7 +1929,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight
             self.in_parsed_literal += 1
-            self.body.append('\\begin{alltt}\n')
+            self.body.append('\\begin{sphinxalltt}\n')
         else:
             ids = ''
             for id in self.pop_hyperlink_ids('code-block'):
@@ -1989,7 +1989,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             raise nodes.SkipNode
 
     def depart_literal_block(self, node):
-        self.body.append('\n\\end{alltt}\n')
+        self.body.append('\n\\end{sphinxalltt}\n')
         self.in_parsed_literal -= 1
     visit_doctest_block = visit_literal_block
     depart_doctest_block = depart_literal_block


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- allow long lines in the contents of parsed-literal directives to wrap in a similar way as they do in code-blocks

### Detail
- does nothing about absence of syntax highlighting
- does not change font size like code-blocks do
- I hope to have fully circumvented potential issues with URI's which are rendered via `\url`, 
- did only basic testing beyond that. Maybe other constructs endind in parsed-literal rendering may need, like `\url`, some special TeX attention (potential problems due to TeX active characters)

### Relates
- #3306 (if this ticket is addressed in future by a fusion of parsed-literal and code-block  for PDF build, perhaps the present PR will become obsoleted, because it only tries to replicated for parsed-literal what is done in code-blocks -- the latter having their contents Pygmentized, contrarily to the former which only have some sort of TeX escaping in place.)


