### PR TITLE
LaTeX writer: leave ``"`` character inside parsed-literal as is

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -355,7 +355,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.this_is_the_title = 1
         self.literal_whitespace = 0
         self.no_contractions = 0
-        self.is_parsed_literal = 0
+        self.in_parsed_literal = 0
         self.compact_list = 0
         self.first_param = 0
         self.remember_multirow = {}
@@ -1928,7 +1928,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_literal_block(self, node):
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight
-            self.is_parsed_literal +=1
+            self.in_parsed_literal += 1
             self.body.append('\\begin{alltt}\n')
         else:
             ids = ''
@@ -1990,7 +1990,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def depart_literal_block(self, node):
         self.body.append('\n\\end{alltt}\n')
-        self.is_parsed_literal -=1
+        self.in_parsed_literal -= 1
     visit_doctest_block = visit_literal_block
     depart_doctest_block = depart_literal_block
 
@@ -2193,7 +2193,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_Text(self, node):
         text = self.encode(node.astext())
-        if not self.no_contractions and not self.is_parsed_literal:
+        if not self.no_contractions and not self.in_parsed_literal:
             text = educate_quotes_latex(text)
         self.body.append(text)
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -355,6 +355,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.this_is_the_title = 1
         self.literal_whitespace = 0
         self.no_contractions = 0
+        self.is_parsed_literal = 0
         self.compact_list = 0
         self.first_param = 0
         self.remember_multirow = {}
@@ -1927,6 +1928,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_literal_block(self, node):
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight
+            self.is_parsed_literal +=1
             self.body.append('\\begin{alltt}\n')
         else:
             ids = ''
@@ -1988,6 +1990,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def depart_literal_block(self, node):
         self.body.append('\n\\end{alltt}\n')
+        self.is_parsed_literal -=1
     visit_doctest_block = visit_literal_block
     depart_doctest_block = depart_literal_block
 
@@ -2190,7 +2193,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_Text(self, node):
         text = self.encode(node.astext())
-        if not self.no_contractions:
+        if not self.no_contractions and not self.is_parsed_literal:
             text = educate_quotes_latex(text)
         self.body.append(text)
 


### PR DESCRIPTION
Subject: do not apply smartypants for LaTeX output inside parsed literal contents

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail

Consider this:

    .. parsed-literal::

       Here is an **important example** of *html tag*:
       |hrefexample|

    .. |hrefexample| replace::  <a href:"http://www.mydomain.com">Look here!</a>

The LaTeX writer currently replaces the double quote character ``"`` by either ```` `` ```` or `''`, as these are the recognized input forms in LaTeX for quotes. However inside parsed-literal this replacement appears to be a bug, because anyhow the whole things is rendered in an ``alltt`` environment, i.e. verbatim. The example above renders in  PDF as

![capture d ecran 2017-01-14 a 18 42 32](https://cloud.githubusercontent.com/assets/2589111/21956914/101cd76c-da8b-11e6-84f4-269194ecd6fc.png)

With this patch it will render in PDF as

![capture d ecran 2017-01-14 a 18 41 50](https://cloud.githubusercontent.com/assets/2589111/21956911/06b2d60e-da8b-11e6-933c-0f0069cd197e.png)
