### PR TITLE
Exclude asterisk from escaping in autosummary signature

### DIFF
--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -11,7 +11,7 @@
 
 import re
 
-symbols_re = re.compile('([!-/:-@\[-`{-~])')
+symbols_re = re.compile('([!-\)\+-/:-@\[-`{-~])')
 
 
 def escape(text):


### PR DESCRIPTION
Fixes #3285 

Modifies the regex used to escape function signatures so that asterisks (i.e. `**kwargs`, `*args`) don't display a stray leading backslash.