### PR TITLE
Set 'document' attribute of new node in DocFieldTransformer

### DIFF
--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -299,6 +299,7 @@ class DocFieldTransformer(object):
 
             translatable_content = nodes.inline(fieldbody.rawsource,
                                                 translatable=True)
+            translatable_content.document = fieldbody.parent.document
             translatable_content.source = fieldbody.parent.source
             translatable_content.line = fieldbody.parent.line
             translatable_content += content


### PR DESCRIPTION
All nodes of sphinx should have the `document` attribute defined, but the inline node created as `translatable_content` in DocFieldTransformer does not. The attribute is useful for debugging purposes in general, and in this particular case allow custom "Doc fields" to access `env.domaindata`.