### PR TITLE
Allow sphinx.js in a user locale dir to override sphinx.js from Sphinx

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -143,13 +143,14 @@ class StandaloneHTMLBuilder(Builder):
 
     def _get_translations_js(self):
         # type: () -> unicode
-        candidates = [path.join(package_dir, 'locale', self.config.language,
+        candidates = [path.join(dir, self.config.language,
+                                'LC_MESSAGES', 'sphinx.js')
+                      for dir in self.config.locale_dirs] + \
+                     [path.join(package_dir, 'locale', self.config.language,
                                 'LC_MESSAGES', 'sphinx.js'),
                       path.join(sys.prefix, 'share/sphinx/locale',
-                                self.config.language, 'sphinx.js')] + \
-                     [path.join(dir, self.config.language,
-                                'LC_MESSAGES', 'sphinx.js')
-                      for dir in self.config.locale_dirs]
+                                self.config.language, 'sphinx.js')]
+
         for jsfile in candidates:
             if path.isfile(jsfile):
                 return jsfile


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Allow sphinx.js in a user locale dir to override sphinx.js from Sphinx

This is done by simply changing the search order.