### PR TITLE
Escape TeX special chars in title, release, author

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -382,9 +382,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.elements.update({
             'wrapperclass': self.format_docclass(document.settings.docclass),
             # if empty, the title is set to the first section title
-            'title':        document.settings.title,
-            'release':      builder.config.release,
-            'author':       document.settings.author,
+            'title':        self.encode(document.settings.title),
+            'release':      self.encode(builder.config.release),
+            'author':       self.encode(document.settings.author),
             'releasename':  _('Release'),
             'indexname':    _('Index'),
         })

--- a/tests/roots/test-basic/conf.py
+++ b/tests/roots/test-basic/conf.py
@@ -3,5 +3,5 @@
 master_doc = 'index'
 
 latex_documents = [
-    (master_doc, 'test.tex', 'The basic Sphinx documentation for testing', 'Sphinx', 'report')
+    (master_doc, 'test.tex', 'The basic Le_Sphinx documentation for testing', 'Sphinx', 'report')
 ]

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -157,7 +157,7 @@ def test_latex_title(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\title{The basic Sphinx documentation for testing}' in result
+    assert '\\title{The basic Le\\_Sphinx documentation for testing}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-title')


### PR DESCRIPTION
Subject: Escape TeX special chars in title, release, author

### Feature or Bugfix
- Bugfix

### Purpose
- Whenever special characters (underscores) were in the title, release or author configuration, the generated LaTeX file contained errors.

### Detail
- Add `encode` to title, release, author in the LaTeX writer.
- Test file updated accordingly

By the way, is there a way to only play one test instead of doing `make test`? What is the value of `$(TEST)` in the Makefile?