### PR TITLE
LaTeX, pass dvipdfm option to geometry package for Japanese documents

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,7 @@ Bugs fixed
 * #3308: Parsed-literals don't wrap very long lines with pdf builder (ref #3340)
 * #3295: Could not import extension sphinx.builders.linkcheck
 * #3285: autosummary: asterisks are escaped twice
+* LaTeX, pass dvipdfm option to geometry package for Japanese documents
 
 
 Release 1.5.1 (released Dec 13, 2016)

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1733,6 +1733,11 @@ These options influence LaTeX output. See further :doc:`latex`.
           ``'\\usepackage[margin=1in,marginparwidth=0.5in]{geometry}'``.
 
         .. versionadded:: 1.5
+
+        .. versionchanged:: 1.5.2
+           For Japanese documents also ``dvipdfm`` option is passed to
+           ``geometry``.
+
      ``'babel'``
         "babel" package inclusion, default ``'\\usepackage{babel}'`` (the
         suitable document language string is passed as class option, and

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -122,6 +122,8 @@ ADDITIONAL_SETTINGS = {
     },
     'platex': {
         'latex_engine': 'platex',
+        'geometry': ('\\usepackage[margin=1in,marginparwidth=0.5in,dvipdfm]'
+                       '{geometry}'),
     },
 }
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -123,7 +123,7 @@ ADDITIONAL_SETTINGS = {
     'platex': {
         'latex_engine': 'platex',
         'geometry': ('\\usepackage[margin=1in,marginparwidth=0.5in,dvipdfm]'
-                       '{geometry}'),
+                     '{geometry}'),
     },
 }
 


### PR DESCRIPTION
Subject: pass correct option to geometry LaTeX package<short purpose of this pull request>

### Feature or Bugfix
- Bugfix

### Purpose
Pass the correct option to LaTeX package for Japanese documents.

### Detail
Japanese LaTeX documents build by Sphinx use `dvipdfmx` class option, but this option is not recognized by `geometry` package, which wants `dvipdfm`:

> dvipdfm works like dvips except for landscape correction. You can set this option when using dvipdfmx and xdvipdfmx to process the dvi output.

Without it, `geometry` assumes `dvips`. It behaves the same except in case of landscape orientation. For more detail see http://www.ctan.org/pkg/geometry

Memo: `hyperref` package recognizes `dvipdfmx` class option, contrarily to `geometry`.

### Relates

Use of `geometry` started at 34f1ce1 (Sphinx 1.5)

