### PR TITLE
Use Ubuntu/trusty for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+dist: trusty
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - $HOME/.cache/pip
 python:
-  - "pypy"
+  - "pypy-5.4.1"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -27,7 +27,7 @@ matrix:
       env: DOCUTILS=0.12
     - python: nightly
       env: DOCUTILS=0.12
-    - python: pypy
+    - python: "pypy-5.4.1"
       env: DOCUTILS=0.12
 addons:
   apt:


### PR DESCRIPTION
In 2017 Apr, Ubuntu/precise will reach its EOL.
Hence, the testing environment for master branch should be moved to next LTS; Ubuntu/trusty.
Fortunately, travis released trusty container as a beta feature.
https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

This also allows to test LaTeX builder on TeXLive 2013 (refs: #3070)