### PR TITLE
Simplify LaTeX mark-up for table column widths (ref #3379)

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/01/16 v1.6 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/02/01 v1.6 LaTeX package (Sphinx markup)]
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.
@@ -24,6 +24,9 @@
 ******** ERROR !! PLEASE UPDATE titlesec.sty !!********^^J%
 ******** THIS VERSION SWALLOWS SECTION NUMBERS.********}}}}{}
 \RequirePackage{tabulary}
+% use of \X to minimize possibility of conflict with one-character column types
+\newcolumntype{\X}[2]{p{\dimexpr
+      (\linewidth-\arrayrulewidth)*#1/#2-\tw@\tabcolsep-\arrayrulewidth\relax}}
 \RequirePackage{makeidx}
 % For framing code-blocks and warning type notices, and shadowing topics
 \RequirePackage{framed}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1194,9 +1194,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
         elif self.table.has_verbatim:
             self.body.append('\n\\noindent\\begin{tabular}')
             endmacro = '\\end{tabular}\n\n'
-        elif self.table.has_problematic and not self.table.colspec:
-            # if the user has given us tabularcolumns, accept them and use
-            # tabulary nevertheless
+        elif self.table.colspec:
+            self.body.append('\n\\noindent\\begin{tabulary}{\\linewidth}')
+            endmacro = '\\end{tabulary}\n\n'
+        elif self.table.has_problematic or self.table.colwidths:
             self.body.append('\n\\noindent\\begin{tabular}')
             endmacro = '\\end{tabular}\n\n'
         else:
@@ -1209,15 +1210,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
             colspec = ['\\X{%d}{%d}' % (width, total)
                        for width in self.table.colwidths]
             self.body.append('{|%s|}\n' % '|'.join(colspec))
+        elif self.table.has_problematic:
+            colspec = ('*{%d}{\\X{1}{%d}|}' %
+                       (self.table.colcount, self.table.colcount))
+            self.body.append('{|' + colspec + '}\n')
+        elif self.table.longtable:
+            self.body.append('{|' + ('l|' * self.table.colcount) + '}\n')
         else:
-            if self.table.has_problematic:
-                colspec = ('*{%d}{\\X{1}{%d}|}' %
-                           (self.table.colcount, self.table.colcount))
-                self.body.append('{|' + colspec + '}\n')
-            elif self.table.longtable:
-                self.body.append('{|' + ('l|' * self.table.colcount) + '}\n')
-            else:
-                self.body.append('{|' + ('L|' * self.table.colcount) + '}\n')
+            self.body.append('{|' + ('L|' * self.table.colcount) + '}\n')
         if self.table.longtable and self.table.caption is not None:
             self.body.append(u'\\caption{')
             for caption in self.table.caption:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1206,14 +1206,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append(self.table.colspec)
         elif self.table.colwidths:
             total = sum(self.table.colwidths)
-            colspec = ['p{\\dimexpr(\\linewidth-\\arrayrulewidth)*%d/%d'
-                       '-2\\tabcolsep-\\arrayrulewidth\\relax}' % (width, total)
+            colspec = ['\\X{%d}{%d}' % (width, total)
                        for width in self.table.colwidths]
             self.body.append('{|%s|}\n' % '|'.join(colspec))
         else:
             if self.table.has_problematic:
-                colspec = ('*{%d}{p{\\dimexpr(\\linewidth-\\arrayrulewidth)/%d'
-                           '-2\\tabcolsep-\\arrayrulewidth\\relax}|}' %
+                colspec = ('*{%d}{\\X{1}{%d}|}' %
                            (self.table.colcount, self.table.colcount))
                 self.body.append('{|' + colspec + '}\n')
             elif self.table.longtable:


### PR DESCRIPTION
The ``\X`` token is used as column-specifier: this does not define or redefine ``\X`` as a LaTeX macro. Using a letter could have led to conflict with user custom column types or table packages. This column specifier takes two arguments which must be positive integers, as produced by LaTeX writer for ``:widths:`` option or for equal widths columns. As it always uses ``\linewidth`` the latter was not abstracted into a third argument.

There is no new functionality, but it shortens the produced ``.tex`` files.
