### PR TITLE
Fix: since 1.5, PDF's TOC and bookmarks lack an entry for general Index

### DIFF
--- a/sphinx/texinputs/python.ist
+++ b/sphinx/texinputs/python.ist
@@ -2,10 +2,12 @@ line_max 100
 headings_flag 1
 heading_prefix "  \\bigletter "
 
-preamble "\\begin{theindex}
+preamble "\\begin{sphinxtheindex}
 \\def\\bigletter#1{{\\Large\\sffamily#1}\\nopagebreak\\vspace{1mm}}
 
 "
+
+postamble "\n\n\\end{sphinxtheindex}\n"
 
 symhead_positive "{Symbols}"
 numhead_positive "{Numbers}"


### PR DESCRIPTION
Subject: fix a bug introduced at 1.5 (143daf21): the general index does not show anymore in PDF table of contents or boomarks.

### Feature or Bugfix
- Bugfix

### Purpose
- now that environment is called `sphinxtheindex` and not `theindex`, the `.ind` file produced by `makeindex` should use new name `sphinxtheindex`. This is configured in `python.ist` file.

### Detail
- I have tested ok also with Japanese, which uses `mendex`.

### Relates
- #3031, #3315, #3316.

### Apologies
- ... for introducing the bug in the first place and never realizing the disappearance of Index from Table of contents !
