### PR TITLE
Fix #3356 and #3394 latex text layout for Japanese document

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,9 @@ Bugs fixed
 * #3364: sphinx-quickstart prompts overflow on Console with 80 chars width
 * since 1.5, PDF's TOC and bookmarks lack an entry for general Index
   (refs: #3383)
+* #3356: Page layout for Japanese ``'manual'`` docclass has a shorter text area
+* #3394: When ``'pointsize'`` is not ``10pt``, Japanese ``'manual'`` document
+  gets wrong PDF page dimensions
 
 Testing
 --------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1733,11 +1733,15 @@ These options influence LaTeX output. See further :doc:`latex`.
      ``'geometry'``
         "geometry" package inclusion, the default definition is:
 
-          ``'\\usepackage{geometry}'`` (with ``[dvipdfm]`` for Japanese documents)
+          ``'\\usepackage{geometry}'``
 
-        and :file:`sphinx.sty` executes a ``\PassOptionsToPackages`` with
-        ``hmargin=1in,vmargin=1in,marginparwidth=0.5in``. See :doc:`latex`
-        for the corresponding ``'sphinxsetup'`` options.
+        with an additional ``[dvipdfm]`` for Japanese documents.
+        The Sphinx LaTeX style file executes:
+
+          ``\PassOptionsToPackage{hmargin=1in,vmargin=1in,marginpar=0.5in}{geometry}``
+
+        which can be customized via corresponding ``'sphinxsetup'`` options.
+        See :doc:`latex`.
 
         .. versionadded:: 1.5
 
@@ -1745,24 +1749,20 @@ These options influence LaTeX output. See further :doc:`latex`.
            ``dvipdfm`` option if :confval:`latex_engine` is ``'platex'``.
 
         .. versionadded:: 1.5.3
-           The ``'sphinxsetup'`` margin keys. See :doc:`latex`.
+           The ``'sphinxsetup'`` keys for ``hmargin, ...``.
 
         .. versionchanged:: 1.5.3
-           The key is executed after the  ``\sphinxsetup`` which follows
+           The execution has been moved to after the  ``\sphinxsetup`` which follows
            immediately the loading of :file:`sphinx.sty`. This is in order
            to handle the paper layout options in a special way for Japanese
            documents: the text width will be set to an integer multiple of the
            *zenkaku* width, and the text height to an integer multiple
            of the baseline.
 
-           Further, as the ``jsbook`` Japanese standard document class handles
-           pointsize other than ``10pt`` in a special manner, Sphinx uses then
-           as first document class option ``truedimen``: this will be received
-           by ``geometry`` package and help it interpret correctly further
-           class options such as ``letterpaper`` or ``a4paper``.
-
-           For ``jreport`` (Japanese ``'howto'`` documents), the situation is
-           otherwise, and the ``truedimen`` must not be used for ``geometry``.
+           For Japanese ``'manual'`` documents, Sphinx passes additionally to
+           ``geometry`` the ``truedimen`` option for compatibility with the way
+           the ``jsbook`` class handles dimensions when the pointsize is not
+           ``10pt``.
 
      ``'babel'``
         "babel" package inclusion, default ``'\\usepackage{babel}'`` (the

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1733,13 +1733,36 @@ These options influence LaTeX output. See further :doc:`latex`.
      ``'geometry'``
         "geometry" package inclusion, the default definition is:
 
-          ``'\\usepackage[margin=1in,marginparwidth=0.5in]{geometry}'``.
+          ``'\\usepackage{geometry}'`` (with ``[dvipdfm]`` for Japanese documents)
+
+        and :file:`sphinx.sty` executes a ``\PassOptionsToPackages`` with
+        ``hmargin=1in,vmargin=1in,marginparwidth=0.5in``. See :doc:`latex`
+        for the corresponding ``'sphinxsetup'`` options.
 
         .. versionadded:: 1.5
 
         .. versionchanged:: 1.5.2
-           For Japanese documents also ``dvipdfm`` option is passed to
-           ``geometry``.
+           ``dvipdfm`` option if :confval:`latex_engine` is ``'platex'``.
+
+        .. versionadded:: 1.5.3
+           The ``'sphinxsetup'`` margin keys. See :doc:`latex`.
+
+        .. versionchanged:: 1.5.3
+           The key is executed after the  ``\sphinxsetup`` which follows
+           immediately the loading of :file:`sphinx.sty`. This is in order
+           to handle the paper layout options in a special way for Japanese
+           documents: the text width will be set to an integer multiple of the
+           *zenkaku* width, and the text height to an integer multiple
+           of the baseline.
+
+           Further, as the ``jsbook`` Japanese standard document class handles
+           pointsize other than ``10pt`` in a special manner, Sphinx uses then
+           as first document class option ``truedimen``: this will be received
+           by ``geometry`` package and help it interpret correctly further
+           class options such as ``letterpaper`` or ``a4paper``.
+
+           For ``jreport`` (Japanese ``'howto'`` documents), the situation is
+           otherwise, and the ``truedimen`` must not be used for ``geometry``.
 
      ``'babel'``
         "babel" package inclusion, default ``'\\usepackage{babel}'`` (the

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1740,8 +1740,8 @@ These options influence LaTeX output. See further :doc:`latex`.
 
           ``\PassOptionsToPackage{hmargin=1in,vmargin=1in,marginpar=0.5in}{geometry}``
 
-        which can be customized via corresponding ``'sphinxsetup'`` options.
-        See :doc:`latex`.
+        which can be customized via corresponding :ref:`'sphinxsetup' options
+        <latexsphinxsetup>`.
 
         .. versionadded:: 1.5
 
@@ -1749,20 +1749,17 @@ These options influence LaTeX output. See further :doc:`latex`.
            ``dvipdfm`` option if :confval:`latex_engine` is ``'platex'``.
 
         .. versionadded:: 1.5.3
-           The ``'sphinxsetup'`` keys for ``hmargin, ...``.
+           The :ref:`'sphinxsetup' keys for the margins
+           <latexsphinxsetuphmargin>`.
 
         .. versionchanged:: 1.5.3
-           The execution has been moved to after the  ``\sphinxsetup`` which follows
-           immediately the loading of :file:`sphinx.sty`. This is in order
-           to handle the paper layout options in a special way for Japanese
-           documents: the text width will be set to an integer multiple of the
-           *zenkaku* width, and the text height to an integer multiple
-           of the baseline.
-
-           For Japanese ``'manual'`` documents, Sphinx passes additionally to
-           ``geometry`` the ``truedimen`` option for compatibility with the way
-           the ``jsbook`` class handles dimensions when the pointsize is not
-           ``10pt``.
+           The location in the LaTeX file has been moved to after
+           ``\usepackage{sphinx}`` and ``\sphinxsetup{..}``, hence also after
+           insertion of ``'fontpkg'`` key. This is in order to handle the paper
+           layout options in a special way for Japanese documents: the text
+           width will be set to an integer multiple of the *zenkaku* width, and
+           the text height to an integer multiple of the baseline. See the
+           :ref:`hmargin <latexsphinxsetuphmargin>` documentation for more.
 
      ``'babel'``
         "babel" package inclusion, default ``'\\usepackage{babel}'`` (the

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -14,13 +14,19 @@ The *latex* target does not benefit from pre-prepared themes like the
 .. raw:: latex
 
    \begingroup
-   \sphinxsetup{verbatimwithframe=false,%
-                VerbatimColor={named}{OldLace}, TitleColor={named}{DarkGoldenrod},%
-                hintBorderColor={named}{LightCoral}, attentionBgColor={named}{LightPink},%
-                attentionborder=3pt,  attentionBorderColor={named}{Crimson},%
-                noteBorderColor={named}{Olive}, noteborder=2pt,%
-                cautionBorderColor={named}{Cyan}, cautionBgColor={named}{LightCyan},%
-                cautionborder=3pt}
+   \sphinxsetup{%
+         verbatimwithframe=false,
+         VerbatimColor={named}{OldLace},
+         TitleColor={named}{DarkGoldenrod},
+         hintBorderColor={named}{LightCoral},
+         attentionborder=3pt,
+         attentionBorderColor={named}{Crimson},
+         attentionBgColor={named}{FloralWhite},
+         noteborder=2pt,
+         noteBorderColor={named}{Olive},
+         cautionborder=3pt,
+         cautionBorderColor={named}{Cyan},
+         cautionBgColor={named}{LightCyan}}
    \relax
 
 
@@ -109,13 +115,19 @@ If non-empty, it will be passed as argument to the ``\sphinxsetup`` command::
      dynamically the option values: this is actually what we did for the
      duration of this chapter for the PDF output, which is styled using::
 
+       \sphinxsetup{%
          verbatimwithframe=false,
-         VerbatimColor={named}{OldLace}, TitleColor={named}{DarkGoldenrod},
-         hintBorderColor={named}{LightCoral}, attentionBgColor={named}{LightPink},
-         attentionborder=3pt,  attentionBorderColor={named}{Crimson},
-         noteBorderColor={named}{Olive}, noteborder=2pt,
-         cautionBorderColor={named}{Cyan}, cautionBgColor={named}{LightCyan},
-         cautionborder=3pt
+         VerbatimColor={named}{OldLace},
+         TitleColor={named}{DarkGoldenrod},
+         hintBorderColor={named}{LightCoral},
+         attentionborder=3pt,
+         attentionBorderColor={named}{Crimson},
+         attentionBgColor={named}{FloralWhite},
+         noteborder=2pt,
+         noteBorderColor={named}{Olive},
+         cautionborder=3pt,
+         cautionBorderColor={named}{Cyan},
+         cautionBgColor={named}{LightCyan}}
 
      and with the ``svgnames`` option having been passed to "xcolor" package::
 
@@ -155,15 +167,15 @@ Here are the currently available options together with their default values.
 
        For a ``'manual'`` type document, which by default uses the ``jsbook``
        LaTeX document class, the dimension units must be so-called "true"
-       units:
+       units::
 
-         'sphinxsetup': 'hmargin=1.5truein, vmargin=1.5truein, marginpar=2zw'
+         'sphinxsetup': 'hmargin=1.5truein, vmargin=1.5truein, marginpar=5zw',
 
-       This is due to ``jsbook`` LaTeX class way of handling the pointsize
-       when it is not ``10pt``.
+       This is due to the LaTeX class ``jsbook``'s way of handling the
+       pointsize when it is not ``10pt``.
 
        To the contrary, the ``jreport`` class, which is used for ``'howto'``
-       document must be configured with "normal" units.
+       documents, must be configured with "normal" units.
 
     .. versionadded:: 1.5.3
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -163,19 +163,24 @@ Here are the currently available options together with their default values.
     package to set the text width to an exact multiple of the *zenkaku* width
     of the base document font.
 
-    .. attention::
+    .. hint::
 
-       For a ``'manual'`` type document, which by default uses the ``jsbook``
-       LaTeX document class, the dimension units must be so-called "true"
-       units::
+       For a ``'manual'`` type document with :confval:`language` set to
+       ``'ja'``, which by default uses the ``jsbook`` LaTeX document class, the
+       dimension units, when the pointsize isn't ``10pt``, must be so-called TeX
+       "true" units::
 
          'sphinxsetup': 'hmargin=1.5truein, vmargin=1.5truein, marginpar=5zw',
 
-       This is due to the LaTeX class ``jsbook``'s way of handling the
-       pointsize when it is not ``10pt``.
+       This is due to the way the LaTeX class ``jsbook``'s handles the
+       pointsize.
 
-       To the contrary, the ``jreport`` class, which is used for ``'howto'``
-       documents, must be configured with "normal" units.
+       Or, one uses regular units but with ``nomag`` as document class option.
+       This can be achieved for example via::
+
+         'pointsize': 'nomag,12pt',
+
+       in the :confval:`latex_elements` configuration variable.
 
     .. versionadded:: 1.5.3
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -137,6 +137,55 @@ Here are the currently available options together with their default values.
    LaTeX requires for keys with Boolean values to use **lowercase** ``true`` or
    ``false``.
 
+``hmargin``
+    The dimensions of the horizontal margins. Legacy Sphinx default value is
+    ``1in`` (which stands for ``{1in,1in}``.) It is passed over as ``hmargin``
+    option to ``geometry`` package.
+
+    Here is an example for non-Japanese documents of use of this key::
+
+      'sphinxsetup': 'hmargin={2in,1.5in}, vmargin={1.5in,2in}, marginpar=1in',
+
+    Japanese documents currently accept only the form with only one dimension.
+    This option is handled then in a special manner in order for ``geometry``
+    package to set the text width to an exact multiple of the *zenkaku* width
+    of the base document font.
+
+    .. attention::
+
+       For a ``'manual'`` type document, which by default uses the ``jsbook``
+       LaTeX document class, the dimension units must be so-called "true"
+       units:
+
+         'sphinxsetup': 'hmargin=1.5truein, vmargin=1.5truein, marginpar=2zw'
+
+       This is due to ``jsbook`` LaTeX class way of handling the pointsize
+       when it is not ``10pt``.
+
+       To the contrary, the ``jreport`` class, which is used for ``'howto'``
+       document must be configured with "normal" units.
+
+    .. versionadded:: 1.5.3
+
+``vmargin``
+    The dimension of the vertical margins. Legacy Sphinx default value is
+    ``1in`` (or ``{1in,1in}``.) Passed over as ``vmargin`` option to
+    ``geometry``.
+
+    Japanese documents will arrange for the text height to be an integer
+    multiple of the baselineskip, taking the closest match suitable for the
+    asked-for vertical margin. It can then be only one dimension. See notice
+    above.
+
+    .. versionadded:: 1.5.3
+
+``marginpar``
+    The ``\marginparwidth`` LaTeX dimension, defaults to ``0.5in``. For Japanese
+    documents, the value is modified to be the closest integer multiple of the
+    *zenkaku* width.
+
+    .. versionadded:: 1.5.3
+
 ``verbatimwithframe``
     default ``true``. Boolean to specify if :rst:dir:`code-block`\ s and literal
     includes are framed. Setting it to ``false`` does not deactivate use of

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -81,6 +81,8 @@ configured, for example::
 
     latex_additional_files = ["mystyle.sty"]
 
+.. _latexsphinxsetup:
+
 The Sphinx LaTeX style package options
 --------------------------------------
 
@@ -149,6 +151,8 @@ Here are the currently available options together with their default values.
    LaTeX requires for keys with Boolean values to use **lowercase** ``true`` or
    ``false``.
 
+.. _latexsphinxsetuphmargin:
+
 ``hmargin``
     The dimensions of the horizontal margins. Legacy Sphinx default value is
     ``1in`` (which stands for ``{1in,1in}``.) It is passed over as ``hmargin``
@@ -172,7 +176,7 @@ Here are the currently available options together with their default values.
 
          'sphinxsetup': 'hmargin=1.5truein, vmargin=1.5truein, marginpar=5zw',
 
-       This is due to the way the LaTeX class ``jsbook``'s handles the
+       This is due to the way the LaTeX class ``jsbook`` handles the
        pointsize.
 
        Or, one uses regular units but with ``nomag`` as document class option.

--- a/sphinx/templates/latex/content.tex_t
+++ b/sphinx/templates/latex/content.tex_t
@@ -14,7 +14,6 @@
    \let\sphinxpxdimen\pdfpxdimen\else\newdimen\sphinxpxdimen
 \fi \sphinxpxdimen=<%= pxunit %>\relax
 <%= passoptionstopackages %>
-<%= geometry %>
 <%= inputenc %>
 <%= utf8extra %>
 <%= cmappkg %>
@@ -26,6 +25,7 @@
 <%= longtable %>
 \usepackage<%= sphinxpkgoptions %>{sphinx}
 <%= sphinxsetup %>
+<%= geometry %>
 \usepackage{multirow}
 \usepackage{eqparbox}
 <%= usepackages %>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1089,7 +1089,9 @@
  \ifx\@jsc@uplatextrue\undefined\else
  % the way we found in order for the papersize special written by
  % geometry in the dvi file to be correct in case of jsbook class
-   \PassOptionsToPackage{truedimen}{geometry}%
+   \ifnum\mag=\@m\else
+     \PassOptionsToPackage{truedimen}{geometry}%
+   \fi
  \fi
  \PassOptionsToPackage{%
     hmarginratio={1:1},%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1086,6 +1086,11 @@
  \newcommand*\sphinxtextlinesja[1]{%
     \numexpr\@ne+\dimexpr\paperheight-\topskip-\dimexpr#1+#1\relax\relax/
                  \baselineskip\relax}%
+ \ifx\@jsc@uplatextrue\undefined\else
+ % the way we found in order for the papersize special written by
+ % geometry in the dvi file to be correct in case of jsbook class
+   \PassOptionsToPackage{truedimen}{geometry}%
+ \fi
  \PassOptionsToPackage{%
     hmarginratio={1:1},%
     textwidth=\unexpanded{\sphinxtextwidthja{\spx@opt@hmargin}},%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/01/16 v1.5.2 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/02/03 v1.5.3 LaTeX package (Sphinx markup)]
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.
@@ -60,6 +60,18 @@
 % Handle options via "kvoptions" (later loaded by hyperref anyhow)
 \RequirePackage{kvoptions}
 \SetupKeyvalOptions{prefix=spx@opt@} % use \spx@opt@ prefix
+
+% Sphinx legacy text layout: 1in margins on all four sides
+\ifx\@jsc@uplatextrue\undefined
+\DeclareStringOption[1in]{hmargin}
+\DeclareStringOption[1in]{vmargin}
+\DeclareStringOption[.5in]{marginpar}
+\else
+% Japanese standard document classes handle \mag in a special way
+\DeclareStringOption[\inv@mag in]{hmargin}
+\DeclareStringOption[\inv@mag in]{vmargin}
+\DeclareStringOption[.5\dimexpr\inv@mag in\relax]{marginpar}
+\fi
 
 \DeclareBoolOption{dontkeepoldnames} % \ifspx@opt@dontkeepoldnames = \iffalse
 \DeclareStringOption[0]{maxlistdepth}% \newcommand*\spx@opt@maxlistdepth{0}
@@ -1052,13 +1064,44 @@
   {\endlist}
 \fi
 
-% adjust the margins for footer,
-% this works with the jsclasses only (Japanese standard document classes)
-% FIXME: rather, pass options to "geometry".
+\ifx\kanjiskip\undefined
+  \PassOptionsToPackage{%
+     hmargin={\unexpanded{\spx@opt@hmargin}},%
+     vmargin={\unexpanded{\spx@opt@vmargin}},%
+     marginpar=\unexpanded{\spx@opt@marginpar}}
+  {geometry}
+\else
+ % set text width for Japanese documents to be integer multiple of 1zw
+ % and text height to be integer multiple of \baselineskip
+ % the execution is delayed to \sphinxsetup then geometry.sty
+ \normalsize\normalfont
+ \newcommand*\sphinxtextwidthja[1]{%
+    \if@twocolumn\tw@\fi
+    \dimexpr
+       \numexpr\dimexpr\paperwidth-\dimexpr#1+#1\relax\relax/
+               \dimexpr\if@twocolumn\tw@\else\@ne\fi zw\relax
+    zw\relax}%
+ \newcommand*\sphinxmarginparwidthja[1]{%
+    \dimexpr\numexpr\dimexpr#1\relax/\dimexpr1zw\relax zw\relax}%
+ \newcommand*\sphinxtextlinesja[1]{%
+    \numexpr\@ne+\dimexpr\paperheight-\topskip-\dimexpr#1+#1\relax\relax/
+                 \baselineskip\relax}%
+ \PassOptionsToPackage{%
+    hmarginratio={1:1},%
+    textwidth=\unexpanded{\sphinxtextwidthja{\spx@opt@hmargin}},%
+    vmarginratio={1:1},%
+    lines=\unexpanded{\sphinxtextlinesja{\spx@opt@vmargin}},%
+    marginpar=\unexpanded{\sphinxmarginparwidthja{\spx@opt@marginpar}},%
+    footskip=2\baselineskip,%
+  }{geometry}%
+\fi
+
+% fix fncychap's bug which uses prematurely the \textwidth value
+\@ifpackagewith{fncychap}{Bjornstrup}
+               {\AtBeginDocument{\mylen\textwidth\advance\mylen-2\myhi}}%
+
 \ifx\@jsc@uplatextrue\undefined\else
   \PassOptionsToPackage{setpagesize=false}{hyperref}
-  \setlength\footskip{2\baselineskip}
-  \addtolength{\textheight}{-2\baselineskip}
 \fi
 
 % fix the double index and bibliography on the table of contents

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/02/03 v1.5.3 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/02/06 v1.5.3 LaTeX package (Sphinx markup)]
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.
@@ -1078,18 +1078,18 @@
  \newcommand*\sphinxtextwidthja[1]{%
     \if@twocolumn\tw@\fi
     \dimexpr
-       \numexpr\dimexpr\paperwidth-\dimexpr#1+#1\relax\relax/
+       \numexpr\dimexpr\paperwidth-\tw@\dimexpr#1\relax\relax/
                \dimexpr\if@twocolumn\tw@\else\@ne\fi zw\relax
     zw\relax}%
  \newcommand*\sphinxmarginparwidthja[1]{%
     \dimexpr\numexpr\dimexpr#1\relax/\dimexpr1zw\relax zw\relax}%
  \newcommand*\sphinxtextlinesja[1]{%
-    \numexpr\@ne+\dimexpr\paperheight-\topskip-\dimexpr#1+#1\relax\relax/
+    \numexpr\@ne+\dimexpr\paperheight-\topskip-\tw@\dimexpr#1\relax\relax/
                  \baselineskip\relax}%
  \ifx\@jsc@uplatextrue\undefined\else
  % the way we found in order for the papersize special written by
  % geometry in the dvi file to be correct in case of jsbook class
-   \ifnum\mag=\@m\else
+   \ifnum\mag=\@m\else % do nothing special if nomag class option or 10pt
      \PassOptionsToPackage{truedimen}{geometry}%
    \fi
  \fi
@@ -1105,7 +1105,8 @@
 
 % fix fncychap's bug which uses prematurely the \textwidth value
 \@ifpackagewith{fncychap}{Bjornstrup}
-               {\AtBeginDocument{\mylen\textwidth\advance\mylen-2\myhi}}%
+ {\AtBeginDocument{\mylen\textwidth\advance\mylen-2\myhi}}%
+ {}% <-- "false" clause of \@ifpackagewith
 
 \ifx\@jsc@uplatextrue\undefined\else
   \PassOptionsToPackage{setpagesize=false}{hyperref}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -436,11 +436,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
                 # pTeX (Japanese TeX) for support
                 if builder.config.language == 'ja':
-                    # if document uses Japanese standard document classes, then
-                    # geometry package needs truedimen as initial *class* option
-                    if docclass[:2] == 'js':
-                        self.elements['papersize'] = ('truedimen,' +
-                                                      self.elements['papersize'])
                     # use dvipdfmx as default class option in Japanese
                     self.elements['classoptions'] = ',dvipdfmx'
                     # disable babel which has not publishing quality in Japanese

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -57,8 +57,7 @@ DEFAULT_SETTINGS = {
     'sphinxpkgoptions':     '',
     'sphinxsetup':     '',
     'passoptionstopackages': '',
-    'geometry':       ('\\usepackage[margin=1in,marginparwidth=0.5in]'
-                       '{geometry}'),
+    'geometry':        '\\usepackage{geometry}',
     'inputenc':        '',
     'utf8extra':       '',
     'cmappkg':         '\\usepackage{cmap}',
@@ -122,8 +121,7 @@ ADDITIONAL_SETTINGS = {
     },
     'platex': {
         'latex_engine': 'platex',
-        'geometry': ('\\usepackage[margin=1in,marginparwidth=0.5in,dvipdfm]'
-                     '{geometry}'),
+        'geometry':     '\\usepackage[dvipdfm]{geometry}',
     },
 }
 
@@ -438,6 +436,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
                 # pTeX (Japanese TeX) for support
                 if builder.config.language == 'ja':
+                    # if document uses Japanese standard document classes, then
+                    # geometry package needs truedimen as initial *class* option
+                    if docclass[:2] == 'js':
+                        self.elements['papersize'] = ('truedimen,' +
+                                                      self.elements['papersize'])
                     # use dvipdfmx as default class option in Japanese
                     self.elements['classoptions'] = ',dvipdfmx'
                     # disable babel which has not publishing quality in Japanese

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -423,7 +423,7 @@ def test_babel_with_language_ja(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\documentclass[truedimen,letterpaper,10pt,dvipdfmx]{sphinxmanual}' in result
+    assert '\\documentclass[letterpaper,10pt,dvipdfmx]{sphinxmanual}' in result
     assert '\\usepackage{babel}' not in result
     assert '\\usepackage{times}' in result
     assert '\\usepackage[Sonny]{fncychap}' not in result

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -423,7 +423,7 @@ def test_babel_with_language_ja(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\documentclass[letterpaper,10pt,dvipdfmx]{sphinxmanual}' in result
+    assert '\\documentclass[truedimen,letterpaper,10pt,dvipdfmx]{sphinxmanual}' in result
     assert '\\usepackage{babel}' not in result
     assert '\\usepackage{times}' in result
     assert '\\usepackage[Sonny]{fncychap}' not in result


### PR DESCRIPTION
This commit moves the location of ``geometry`` package to after
``sphinx`` package is loaded; it adds new keys for ``'sphinxsetup'``
allowing to easily configure the page margins, by-passing the legacy 1in
for all margins applied by Sphinx. For Japanese documents, the specified
margins are slightly modified in order for text width to be an integer
multiple of the zw dimension unit, and for text height to have an
integer number of baselines. It is always possible to use directly
``'geometry'`` key to ``latex_elements`` for complete control, if
desired.

Subject: <short purpose of this pull request>

### Feature and Bugfix
- Feature: allows configuration of text margins from conf.py
- Bugfix: #3356

This PR will slightly alter page layout, the most important change being that the text height for ``manual``  docclass gains 2 baselines. (only for Japanese documents...)

### Purpose
- straighten out some issues with Japanese text layout and pick this opportunity to make text layout generally speaking more easily customizable.
- the Japanese ``howto`` and ``manual`` docclass are now handled a bit more similarly.
- the non-Japanese documents gain the ability to specify from conf.py separate margins for left, right, top, bottom, using ``geometry`` package syntax (the interface for Japanese documents is more restricted as left and right must be equal and top and bottom too.)

### Relates
- #3356 
- the ``parskip`` package should not be loaded from inside sphinx.sty, but made into a template key, whose loading can be cancelled from conf.py, but this is for another occasion.
- the ``parskip`` package does not look really adapted to Japanese typesetting as it introduces vertical shifts of one half baseline. But anyhow Sphinx uses  ``raggedbottom`` config. But again, this PR does nothing with ``parskip``.
- <strike>this PR does also nothing regarding the matter of dvi specials</strike> (see https://github.com/sphinx-doc/sphinx/issues/3356#issuecomment-277379079) final version does after all

