### PR TITLE
Added autosectionlabel_prefix_document config option

### DIFF
--- a/doc/ext/autosectionlabel.rst
+++ b/doc/ext/autosectionlabel.rst
@@ -22,4 +22,18 @@ For example::
 
 
 Internally, this extension generates the labels for each section.  If same
-section names are used in whole of document, any one is used for a target.
+section names are used in whole of document, any one is used for a target by
+default. The ``autosectionlabel_prefix_document`` configuration variable can be
+used to make headings which appear multiple times but in different documents
+unique.
+
+Configuration
+-------------
+
+.. confval:: autosectionlabel_prefix_document
+
+   True to prefix each section label with the name of the document it is in,
+   followed by a colon. For example, ``index:Introduction`` for a section
+   called ``Introduction`` that appears in document ``index.rst``.  Useful for
+   avoiding ambiguity when the same section heading appears in different
+   documents.

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -20,9 +20,12 @@ def register_sections_as_label(app, document):
     labels = app.env.domaindata['std']['labels']
     anonlabels = app.env.domaindata['std']['anonlabels']
     for node in document.traverse(nodes.section):
-        name = nodes.fully_normalize_name(node[0].astext())
         labelid = node['ids'][0]
         docname = app.env.docname
+        if app.config.autosectionlabel_prefix_document:
+            name = nodes.fully_normalize_name(docname + ':' + node[0].astext())
+        else:
+            name = nodes.fully_normalize_name(node[0].astext())
         sectname = clean_astext(node[0])
 
         if name in labels:
@@ -35,4 +38,5 @@ def register_sections_as_label(app, document):
 
 
 def setup(app):
+    app.add_config_value('autosectionlabel_prefix_document', False, 'env')
     app.connect('doctree-read', register_sections_as_label)

--- a/tests/roots/test-ext-autosectionlabel-prefix-document/conf.py
+++ b/tests/roots/test-ext-autosectionlabel-prefix-document/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+extensions = ['sphinx.ext.autosectionlabel']
+master_doc = 'index'
+autosectionlabel_prefix_document = True

--- a/tests/roots/test-ext-autosectionlabel-prefix-document/index.rst
+++ b/tests/roots/test-ext-autosectionlabel-prefix-document/index.rst
@@ -1,0 +1,25 @@
+=========================================
+test-ext-autosectionlabel-prefix-document
+=========================================
+
+
+Introduce of Sphinx
+===================
+
+Installation
+============
+
+For Windows users
+-----------------
+
+For UNIX users
+--------------
+
+
+References
+==========
+
+* :ref:`index:Introduce of Sphinx`
+* :ref:`index:Installation`
+* :ref:`index:For Windows users`
+* :ref:`index:For UNIX users`

--- a/tests/test_ext_autosectionlabel.py
+++ b/tests/test_ext_autosectionlabel.py
@@ -34,3 +34,9 @@ def test_autosectionlabel_html(app, status, warning):
     html = ('<li><a class="reference internal" href="#for-unix-users">'
             '<span class="std std-ref">For UNIX users</span></a></li>')
     assert re.search(html, content, re.S)
+
+
+# Re-use test definition from above, just change the test root directory
+@pytest.mark.sphinx('html', testroot='ext-autosectionlabel-prefix-document')
+def test_autosectionlabel_prefix_document_html(app, status, warning):
+    return test_autosectionlabel_html(app, status, warning)


### PR DESCRIPTION
This PR implements a new configuration option ``autosectionlabel_prefix_document`` for the built-in ``autosectionlabel`` extension. If switched on, every label that is auto-generated by the extension will be prefixed with the document's name, followed by a slash. E.g. a section called ``Introduction`` in document ``index.rst`` will be auto-labeled ``index/Introduction``. The purpose of this is to avoid ambiguity when the same heading is used multiple times, but in different documents.

Shamelessly stolen from @tk0miya's [sphinxcontrib_section_autoref extension](https://gist.github.com/tk0miya/4036201).

Comes with documentation + tests. For this I moved the original ``autosectionlabel`` test root dir into a subdirectory, please check if this is all right with you or else let me know how you would like the tests to be structured (I haven't seen any other tests structured like this, but it makes sense to me and seems to work).

In the future maybe someone can make another option like this that uses the complete "section hierarchy" as the prefix, so even duplicate sections *within the same document* can be unambiguously referred to.