### PR TITLE
Latex table newlines

### DIFF
--- a/sphinx/templates/latex/longtable.tex_t
+++ b/sphinx/templates/latex/longtable.tex_t
@@ -3,19 +3,21 @@
 \caption{<%= ''.join(table.caption) %>}<%= labels %>\\
 <% endif -%>
 \hline
-<%= ''.join(table.header) -%>
+<%= ''.join(table.header) %>
 \endfirsthead
 
 \multicolumn{<%= table.colcount %>}{c}%
 {{\tablecontinued{\tablename\ \thetable{} -- <%= _('continued from previous page') %>}}} \\
 \hline
-<%= ''.join(table.header) -%>
+<%= ''.join(table.header) %>
 \endhead
 
-\hline \multicolumn{<%= table.colcount %>}{|r|}{{\tablecontinued{<%= _('Continued on next page') %>}}} \\ \hline
+\hline
+\multicolumn{<%= table.colcount %>}{|r|}{{\tablecontinued{<%= _('Continued on next page') %>}}} \\
+\hline
 \endfoot
 
 \endlastfoot
 
-<%= ''.join(table.body) -%>
+<%= ''.join(table.body) %>
 \end{longtable}

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -1,12 +1,12 @@
 <%- if table.caption -%>
 \begin{threeparttable}
 \capstart\caption{<%= ''.join(table.caption) %>}<%= labels %>
-<%- endif %>
+<% endif -%>
 \noindent\begin{tabular}<%= table.get_colspec() -%>
 \hline
-<%= ''.join(table.header) -%>
-<%= ''.join(table.body) -%>
+<%= ''.join(table.header) %>
+<%=- ''.join(table.body) %>
 \end{tabular}
-<%- if table.caption -%>
+<%- if table.caption %>
 \end{threeparttable}
-<%- endif -%>
+<%- endif %>

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -1,12 +1,12 @@
 <%- if table.caption -%>
 \begin{threeparttable}
 \capstart\caption{<%= ''.join(table.caption) %>}<%= labels %>
-<%- endif %>
+<% endif -%>
 \noindent\begin{tabulary}{\linewidth}<%= table.get_colspec() -%>
 \hline
-<%= ''.join(table.header) -%>
-<%= ''.join(table.body) -%>
+<%= ''.join(table.header) %>
+<%=- ''.join(table.body) %>
 \end{tabulary}
-<%- if table.caption -%>
+<%- if table.caption %>
 \end{threeparttable}
-<%- endif -%>
+<%- endif %>

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1216,7 +1216,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                                        dict(table=self.table, labels=labels))
         self.body.append("\n\n")
         self.body.append(table)
-        self.body.append("\n\n")
+        self.body.append("\n")
 
         self.unrestrict_footnote(node)
         self.table = None

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -481,7 +481,7 @@ def test_footnote(app, status, warning):
             '\ncite\n}') in result
     assert '\\caption{Table caption \\sphinxfootnotemark[4]' in result
     assert 'name \\sphinxfootnotemark[5]' in result
-    assert ('\\end{threeparttable}\n\n%\n'
+    assert ('\\end{threeparttable}\n%\n'
             '\\begin{footnotetext}[4]\sphinxAtStartFootnote\n'
             'footnotes in table caption\n%\n\\end{footnotetext}%\n'
             '\\begin{footnotetext}[5]\sphinxAtStartFootnote\n'
@@ -514,7 +514,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
             'in caption of normal table}\\label{\\detokenize{index:id28}}') in result
     assert ('\\caption{footnote \\sphinxfootnotemark[8] '
             'in caption \sphinxfootnotemark[9] of longtable}') in result
-    assert ('\end{longtable}\n\n%\n\\begin{footnotetext}[8]'
+    assert ('\end{longtable}\n%\n\\begin{footnotetext}[8]'
             '\sphinxAtStartFootnote\n'
             'Foot note in longtable\n%\n\\end{footnotetext}' in result)
     assert ('This is a reference to the code-block in the footnote:\n'
@@ -837,7 +837,7 @@ def test_latex_table(app, status, warning):
     assert ('\\hline\ncell1-1\n&\ncell1-2\n\\\\' in table)
     assert ('\\hline\ncell2-1\n&\ncell2-2\n\\\\' in table)
     assert ('\\hline\ncell3-1\n&\ncell3-2\n\\\\' in table)
-    assert ('\\hline\\end{tabulary}' in table)
+    assert ('\\hline\n\\end{tabulary}' in table)
 
     # table having :widths: option
     table = tables['table having :widths: option']
@@ -848,7 +848,7 @@ def test_latex_table(app, status, warning):
     assert ('\\hline\ncell1-1\n&\ncell1-2\n\\\\' in table)
     assert ('\\hline\ncell2-1\n&\ncell2-2\n\\\\' in table)
     assert ('\\hline\ncell3-1\n&\ncell3-2\n\\\\' in table)
-    assert ('\\hline\\end{tabular}' in table)
+    assert ('\\hline\n\\end{tabular}' in table)
 
     # table with tabularcolumn
     table = tables['table with tabularcolumn']
@@ -865,7 +865,7 @@ def test_latex_table(app, status, warning):
     assert ('\\hline\ncell1-1\n&\ncell1-2\n\\\\' in table)
     assert ('\\hline\ncell2-1\n&\ncell2-2\n\\\\' in table)
     assert ('\\hline\ncell3-1\n&\ncell3-2\n\\\\' in table)
-    assert ('\\hline\\end{tabulary}' in table)
+    assert ('\\hline\n\\end{tabulary}' in table)
     assert ('\\end{threeparttable}' in table)
 
     # table having verbatim
@@ -886,20 +886,20 @@ def test_latex_table(app, status, warning):
     assert ('\\hline\n'
             '\\sphinxstylethead{\\relax \nheader1\n\\unskip}\\relax &'
             '\\sphinxstylethead{\\relax \nheader2\n\\unskip}\\relax \\\\\n'
-            '\\hline\\endfirsthead' in table)
+            '\\hline\n\\endfirsthead' in table)
     assert ('\\multicolumn{2}{c}%\n'
             '{{\\tablecontinued{\\tablename\\ \\thetable{} -- '
             'continued from previous page}}} \\\\\n\\hline\n'
             '\\sphinxstylethead{\\relax \nheader1\n\\unskip}\\relax &'
             '\\sphinxstylethead{\\relax \nheader2\n\\unskip}\\relax \\\\\n'
-            '\\hline\\endhead' in table)
-    assert ('\\hline \\multicolumn{2}{|r|}'
-            '{{\\tablecontinued{Continued on next page}}} \\\\ \\hline\n'
-            '\\endfoot\n\n\\endlastfoot' in table)
+            '\\hline\n\\endhead' in table)
+    assert ('\\hline\n\\multicolumn{2}{|r|}'
+            '{{\\tablecontinued{Continued on next page}}} \\\\\n'
+            '\\hline\n\\endfoot\n\n\\endlastfoot' in table)
     assert ('\ncell1-1\n&\ncell1-2\n\\\\' in table)
     assert ('\\hline\ncell2-1\n&\ncell2-2\n\\\\' in table)
     assert ('\\hline\ncell3-1\n&\ncell3-2\n\\\\' in table)
-    assert ('\\hline\\end{longtable}' in table)
+    assert ('\\hline\n\\end{longtable}' in table)
 
     # longtable having :widths: option
     table = tables['longtable having :widths: option']


### PR DESCRIPTION
Subject: streamlines the way table mark-up in produced latex file uses newlines

1. In theory `tabular` in LaTeX can be inline object but I believe from Docutils point of view tables are paragraph like objects, hence for uniformty all kinds of table mark-up (tabular, tabulary, threeparttable wrapper, longtable) are ended the same.

2. it seems `table.body` sometimes starts with a `\n` and I don't know where this comes from. Hence the longtable.tex_t template which contains
   ```
   \endlastfoot

   <%= ''.join(table.body) %>
   ```
   produces two blank lines on output. (I have tested with ``'a'+''.join(table.body)``). Tested with
   ```
   .. table::
      :class: longtable

      ======= =======
      header1 header2
      ======= =======
      cell1-1 cell1-2
      cell2-1 cell2-2
      cell3-1 cell3-2
      ======= =======
   ```

3. I propose (not done here so far) that ``\\noindent\\begin{tabular}...`` should have a new line between ``\\noindent`` and ``\\begin`` in order for ``\begin`` in output tex file to be at start of line for better readability (if anyone is actually reading the tex files produced by Sphinx ;-) ).
