### PR TITLE
Fix #3392: "releasename" in latex_elements is not working

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #3364: sphinx-quickstart prompts overflow on Console with 80 chars width
 * since 1.5, PDF's TOC and bookmarks lack an entry for general Index
   (refs: #3383)
+* #3392: ``'releasename'`` in :confval:`latex_elements` is not working
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -85,7 +85,7 @@ DEFAULT_SETTINGS = {
     'release':         '',
     'author':          '',
     'logo':            '',
-    'releasename':     'Release',
+    'releasename':     '',
     'makeindex':       '\\makeindex',
     'shorthandoff':    '',
     'maketitle':       '\\maketitle',
@@ -387,9 +387,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
             'title':        document.settings.title,    # treat as a raw LaTeX code
             'release':      self.encode(builder.config.release),
             'author':       document.settings.author,   # treat as a raw LaTeX code
-            'releasename':  _('Release'),
             'indexname':    _('Index'),
         })
+        if not self.elements['releasename']:
+            self.elements.update({
+                'releasename':  _('Release'),
+            })
         if not builder.config.latex_keep_old_macro_names:
             self.elements['sphinxpkgoptions'] = 'dontkeepoldnames'
         if document.settings.docclass == 'howto':


### PR DESCRIPTION
Bugfix: ``'releasename'`` user setting was overridden by latex writer by  translation of default string ``'Release'``.

### Relates
- #3392 
- #1136, #1782, #1966

