### PR TITLE
Add "--color" option to sphinx-build (fixes issue #3248).

### DIFF
--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -164,12 +164,12 @@ def main(argv):
                      help='no output on stdout, just warnings on stderr')
     group.add_option('-Q', action='store_true', dest='really_quiet',
                      help='no output at all, not even warnings')
-    group.add_option('--color', type='choice', action='store', default='auto',
-                     choices=['yes', 'no', 'auto'],
-                     help='color terminal output (yes/no/auto)')
-    group.add_option('-N', action='store_true', dest='nocolor',
-                     help='do not emit colored output (deprecated, '
-                          'please use "--color=no")')
+    group.add_option('--color', dest='color',
+                     action='store_const', const='yes', default='auto',
+                     help='Do emit colored output (default: auto-detect)')
+    group.add_option('-N', '--no-color', dest='color',
+                     action='store_const', const='no',
+                     help='Do not emit colored output (default: auot-detect)')
     group.add_option('-w', metavar='FILE', dest='warnfile',
                      help='write warnings (and errors) to given file')
     group.add_option('-W', action='store_true', dest='warningiserror',
@@ -239,8 +239,6 @@ def main(argv):
         print('Error: Cannot combine -a option and filenames.', file=sys.stderr)
         return 1
 
-    if opts.nocolor:
-        opts.color = 'no'
     if opts.color == 'no' or (opts.color == 'auto' and not color_terminal()):
         nocolor()
 

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -116,9 +116,6 @@ def handle_exception(app, opts, exception, stderr=sys.stderr):
 
 def main(argv):
     # type: (List[unicode]) -> int
-    if not color_terminal():
-        nocolor()
-
     parser = optparse.OptionParser(USAGE, epilog=EPILOG, formatter=MyFormatter())
     parser.add_option('--version', action='store_true', dest='version',
                       help='show version information and exit')
@@ -167,8 +164,12 @@ def main(argv):
                      help='no output on stdout, just warnings on stderr')
     group.add_option('-Q', action='store_true', dest='really_quiet',
                      help='no output at all, not even warnings')
+    group.add_option('--color', type='choice', action='store', default='auto',
+                     choices=['yes', 'no', 'auto'],
+                     help='color terminal output (yes/no/auto)')
     group.add_option('-N', action='store_true', dest='nocolor',
-                     help='do not emit colored output')
+                     help='do not emit colored output (deprecated, '
+                          'please use "--color=no")')
     group.add_option('-w', metavar='FILE', dest='warnfile',
                      help='write warnings (and errors) to given file')
     group.add_option('-W', action='store_true', dest='warningiserror',
@@ -239,6 +240,8 @@ def main(argv):
         return 1
 
     if opts.nocolor:
+        opts.color = 'no'
+    if opts.color == 'no' or (opts.color == 'auto' and not color_terminal()):
         nocolor()
 
     doctreedir = abspath(opts.doctreedir or path.join(outdir, '.doctrees'))


### PR DESCRIPTION
Subject: Add "--color" option to sphinx-build to force colored output.

### Feature or Bugfix
- Feature

### Purpose
- If sphinx-build is run in docker environments (e.g. in a GitLab pipeline), there is no colored output. So far, `sphinx-build` only offered a way to force *no* color, but not to *force* color. 

### Detail

### Relates
- issue #3248

