### PR TITLE
Fixed bug that conf.py was not overwritten by template

### DIFF
--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -438,7 +438,10 @@ def generate(d, overwrite=True, silent=False, templatedir=None):
         else:
             print('File %s already exists, skipping.' % fpath)
 
-    with open(os.path.join(package_dir, 'templates', 'quickstart', 'conf.py_t')) as f:
+    conf_path = os.path.join(templatedir, 'conf.py_t') if templatedir else None
+    if not conf_path or not path.isfile(conf_path):
+        conf_path = os.path.join(package_dir, 'templates', 'quickstart', 'conf.py_t')
+    with open(conf_path) as f:
         conf_text = convert_python_source(f.read())
 
     write_file(path.join(srcdir, 'conf.py'), template.render_string(conf_text, d))


### PR DESCRIPTION
It is a fix for a bug where 'conf.py' is not overwritten with 'sphinx-quickstart'.
Rebase stable branch.
