### PR TITLE
Refactor epub builder

### DIFF
--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -12,8 +12,8 @@
 
 import os
 import re
-import zipfile
 from os import path
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 from datetime import datetime
 from collections import namedtuple
 
@@ -703,16 +703,13 @@ class EpubBuilder(StandaloneHTMLBuilder):
         entry.
         """
         logger.info('writing %s file...', outname)
-        projectfiles = ['META-INF/container.xml', 'content.opf', 'toc.ncx']  # type: List[unicode]  # NOQA
-        projectfiles.extend(self.files)
-        epub = zipfile.ZipFile(path.join(outdir, outname), 'w',  # type: ignore
-                               zipfile.ZIP_DEFLATED)
-        epub.write(path.join(outdir, 'mimetype'), 'mimetype',  # type: ignore
-                   zipfile.ZIP_STORED)
-        for file in projectfiles:
-            fp = path.join(outdir, file)
-            epub.write(fp, file, zipfile.ZIP_DEFLATED)  # type: ignore
-        epub.close()
+        epub_filename = path.join(outdir, outname)
+        with ZipFile(epub_filename, 'w', ZIP_DEFLATED) as epub:  # type: ignore
+            epub.write(path.join(outdir, 'mimetype'), 'mimetype', ZIP_STORED)  # type: ignore
+            for filename in [u'META-INF/container.xml', u'content.opf', u'toc.ncx']:
+                epub.write(path.join(outdir, filename), filename, ZIP_DEFLATED)  # type: ignore
+            for filename in self.files:
+                epub.write(path.join(outdir, filename), filename, ZIP_DEFLATED)  # type: ignore
 
 
 def setup(app):

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -148,6 +148,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         self.link_suffix = '.xhtml'
         self.playorder = 0
         self.tocid = 0
+        self.id_cache = {}  # type: Dict[unicode, unicode]
         self.use_index = self.get_builder_config('use_index', 'epub')
 
     def get_theme_config(self):
@@ -155,14 +156,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
         return self.config.epub_theme, self.config.epub_theme_options
 
     # generic support functions
-    def make_id(self, name, id_cache={}):
-        # type: (unicode, Dict[unicode, unicode]) -> unicode
+    def make_id(self, name):
+        # type: (unicode) -> unicode
         # id_cache is intentionally mutable
         """Return a unique id for name."""
-        id = id_cache.get(name)
+        id = self.id_cache.get(name)
         if not id:
             id = 'epub-%d' % self.env.new_serialno('epub')
-            id_cache[name] = id
+            self.id_cache[name] = id
         return id
 
     def esc(self, name):

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -516,7 +516,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         if not self.use_index:
             self.ignored_files.append('genindex' + self.out_suffix)
         for root, dirs, files in os.walk(outdir):
-            for fn in files:
+            for fn in sorted(files):
                 filename = path.join(root, fn)[olen:]
                 if filename in self.ignored_files:
                     continue

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -536,14 +536,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
 
         # spine
         spinefiles = set()
-        for item in self.refnodes:
-            if '#' in item['refuri']:
+        for refnode in self.refnodes:
+            if '#' in refnode['refuri']:
                 continue
-            if item['refuri'] in self.ignored_files:
+            if refnode['refuri'] in self.ignored_files:
                 continue
-            spine = Spine(self.esc(self.make_id(item['refuri'])), True)
+            spine = Spine(self.esc(self.make_id(refnode['refuri'])), True)
             metadata['spines'].append(spine)
-            spinefiles.add(item['refuri'])
+            spinefiles.add(refnode['refuri'])
         for info in self.domain_indices:
             spine = Spine(self.esc(self.make_id(info[0] + self.out_suffix)), True)
             metadata['spines'].append(spine)
@@ -565,8 +565,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
             image = image.replace(os.sep, '/')
             metadata['cover'] = self.esc(self.make_id(image))
             if html_tmpl:
-                spine.insert(0, self.spine_template % {
-                    'idref': self.esc(self.make_id(self.coverpage_name))})
+                spine = Spine(self.esc(self.make_id(self.coverpage_name)), True)
+                metadata['spines'].insert(0, spine)
                 if self.coverpage_name not in self.files:
                     ext = path.splitext(self.coverpage_name)[-1]
                     self.files.append(self.coverpage_name)
@@ -608,7 +608,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                         metadata)
 
     def new_navpoint(self, node, level, incr=True):
-        # type: (nodes.Node, int, bool) -> unicode
+        # type: (nodes.Node, int, bool) -> NavPoint
         """Create a new entry in the toc from the node at given level."""
         # XXX Modifies the node
         if incr:
@@ -618,7 +618,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                         node['text'], node['refuri'], [])
 
     def build_navpoints(self, nodes):
-        # type: (nodes.Node) -> unicode
+        # type: (nodes.Node) -> List[NavPoint]
         """Create the toc navigation structure.
 
         Subelements of a node are nested inside the navpoint.  For nested nodes
@@ -663,7 +663,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         return navstack[0].children
 
     def toc_metadata(self, level, navpoints):
-        # type: (int, List[unicode]) -> Dict[unicode, Any]
+        # type: (int, List[NavPoint]) -> Dict[unicode, Any]
         """Create a dictionary with all metadata for the toc.ncx file
         properly escaped.
         """

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -14,6 +14,7 @@ import codecs
 from os import path
 from datetime import datetime
 
+from sphinx import package_dir
 from sphinx.config import string_classes
 from sphinx.builders.epub import EpubBuilder
 from sphinx.util import logging
@@ -110,6 +111,8 @@ class Epub3Builder(EpubBuilder):
     an epub file.
     """
     name = 'epub'
+
+    template_dir = path.join(package_dir, 'templates', 'epub3')
 
     navigation_doc_template = NAVIGATION_DOC_TEMPLATE
     navlist_template = NAVLIST_TEMPLATE

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -60,42 +60,6 @@ NAVLIST_TEMPLATE_END_BLOCK = u'''%(indent)s        </ol>
 %(indent)s      </li>'''
 NAVLIST_INDENT = '  '
 
-PACKAGE_DOC_TEMPLATE = u'''\
-<?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="%(lang)s"
- unique-identifier="%(uid)s"
- prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/">
-  <metadata xmlns:opf="http://www.idpf.org/2007/opf"
-        xmlns:dc="http://purl.org/dc/elements/1.1/">
-    <dc:language>%(lang)s</dc:language>
-    <dc:title>%(title)s</dc:title>
-    <dc:description>%(description)s</dc:description>
-    <dc:creator>%(author)s</dc:creator>
-    <dc:contributor>%(contributor)s</dc:contributor>
-    <dc:publisher>%(publisher)s</dc:publisher>
-    <dc:rights>%(copyright)s</dc:rights>
-    <dc:identifier id="%(uid)s">%(id)s</dc:identifier>
-    <dc:date>%(date)s</dc:date>
-    <meta property="dcterms:modified">%(date)s</meta>
-    <meta property="ibooks:version">%(version)s</meta>
-    <meta property="ibooks:specified-fonts">true</meta>
-    <meta property="ibooks:binding">true</meta>
-    <meta property="ibooks:scroll-axis">%(ibook_scroll_axis)s</meta>
-  </metadata>
-  <manifest>
-    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-    <item id="nav" href="nav.xhtml"\
- media-type="application/xhtml+xml" properties="nav"/>
-%(files)s
-  </manifest>
-  <spine toc="ncx" page-progression-direction="%(page_progression_direction)s">
-%(spine)s
-  </spine>
-  <guide>
-%(guide)s
-  </guide>
-</package>
-'''
 
 DOCTYPE = u'''<!DOCTYPE html>'''
 
@@ -120,7 +84,6 @@ class Epub3Builder(EpubBuilder):
     navlist_template_begin_block = NAVLIST_TEMPLATE_BEGIN_BLOCK
     navlist_template_end_block = NAVLIST_TEMPLATE_END_BLOCK
     navlist_indent = NAVLIST_INDENT
-    content_template = PACKAGE_DOC_TEMPLATE
     doctype = DOCTYPE
 
     # Finish by building the epub file
@@ -135,13 +98,12 @@ class Epub3Builder(EpubBuilder):
         self.build_toc(self.outdir, 'toc.ncx')
         self.build_epub(self.outdir, self.config.epub_basename + '.epub')
 
-    def content_metadata(self, files, spine, guide):
-        # type: (List[unicode], List[unicode], List[unicode]) -> Dict
+    def content_metadata(self):
+        # type: () -> Dict
         """Create a dictionary with all metadata for the content.opf
         file properly escaped.
         """
-        metadata = super(Epub3Builder, self).content_metadata(
-            files, spine, guide)
+        metadata = super(Epub3Builder, self).content_metadata()
         metadata['description'] = self.esc(self.config.epub_description)
         metadata['contributor'] = self.esc(self.config.epub_contributor)
         metadata['page_progression_direction'] = self._page_progression_direction()

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -149,7 +149,6 @@ class Epub3Builder(EpubBuilder):
         # type: (nodes.Node, int, bool) -> unicode
         """Create a new entry in the toc from the node at given level."""
         # XXX Modifies the node
-        self.tocid += 1
         node['indent'] = self.navlist_indent * level
         if has_child:
             return self.navlist_template_has_child % node

--- a/sphinx/templates/epub2/container.xml
+++ b/sphinx/templates/epub2/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>

--- a/sphinx/templates/epub2/content.opf_t
+++ b/sphinx/templates/epub2/content.opf_t
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0"
+      unique-identifier="%(uid)s">
+  <metadata xmlns:opf="http://www.idpf.org/2007/opf"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:language>{{ lang }}</dc:language>
+    <dc:title>{{ title }}</dc:title>
+    <dc:creator opf:role="aut">{{ author }}</dc:creator>
+    <dc:publisher>{{ publisher }}</dc:publisher>
+    <dc:rights>{{ copyright }}</dc:rights>
+    <dc:identifier id="{{ uid }}" opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
+    <dc:date>{{ date }}</dc:date>
+    {%- if cover %}
+    <meta name="cover" content="{{ cover }}"/>
+    {%- endif %}
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    {%- for item in manifest_items %}
+    <item id="{{ item.id }}" href="{{ item.href }}" media-type="{{ item.media_type }}" />
+    {%- endfor %}
+  </manifest>
+  <spine toc="ncx">
+    {%- for spine in spines %}
+    {%- if spine.linear %}
+    <itemref idref="{{ spine.idref }}" />
+    {%- else %}
+    <itemref idref="{{ spine.idref }}" linear="no" />'''
+    {%- endif %}
+    {%- endfor %}
+  </spine>
+  <guide>
+    {%- for guide in guides %}
+    <reference type="{{ guide.type }}" title="{{ guide.title }}" href="{{ guide.uri }}" />'''
+    {%- endfor %}
+  </guide>
+</package>

--- a/sphinx/templates/epub2/mimetype
+++ b/sphinx/templates/epub2/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/sphinx/templates/epub2/toc.ncx_t
+++ b/sphinx/templates/epub2/toc.ncx_t
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ncx version="2005-1" xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <head>
+    <meta name="dtb:uid" content="{{ uid }}"/>
+    <meta name="dtb:depth" content="{{ level }}"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle>
+    <text>{{ title }}</text>
+  </docTitle>
+  <navMap>
+{{ navpoints }}
+  </navMap>
+</ncx>

--- a/sphinx/templates/epub3/container.xml
+++ b/sphinx/templates/epub3/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>

--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="{{ lang }}"
+ unique-identifier="{{ uid }}"
+ prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/">
+  <metadata xmlns:opf="http://www.idpf.org/2007/opf"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:language>{{ lang }}</dc:language>
+    <dc:title>{{ title }}</dc:title>
+    <dc:description>{{ description }}</dc:description>
+    <dc:creator>{{ author }}</dc:creator>
+    <dc:contributor>{{ contributor }}</dc:contributor>
+    <dc:publisher>{{ publisher }}</dc:publisher>
+    <dc:rights>{{ copyright }}</dc:rights>
+    <dc:identifier id="{{ uid }}">{{ id }}</dc:identifier>
+    <dc:date>{{ date }}</dc:date>
+    <meta property="dcterms:modified">{{ date }}</meta>
+    <meta property="ibooks:version">{{ version }}</meta>
+    <meta property="ibooks:specified-fonts">true</meta>
+    <meta property="ibooks:binding">true</meta>
+    <meta property="ibooks:scroll-axis">{{ ibook_scroll_axis }}</meta>
+    {%- if cover %}
+    <meta name="cover" content="{{ cover }}"/>
+    {%- endif %}
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    {%- for item in manifest_items %}
+    <item id="{{ item.id }}" href="{{ item.href }}" media-type="{{ item.media_type }}" />
+    {%- endfor %}
+  </manifest>
+  <spine toc="ncx" page-progression-direction="{{ page_progression_direction }}">
+    {%- for spine in spines %}
+    {%- if spine.linear %}
+    <itemref idref="{{ spine.idref }}" />
+    {%- else %}
+    <itemref idref="{{ spine.idref }}" linear="no" />'''
+    {%- endif %}
+    {%- endfor %}
+  </spine>
+  <guide>
+    {%- for guide in guides %}
+    <reference type="{{ guide.type }}" title="{{ guide.title }}" href="{{ guide.uri }}" />'''
+    {%- endfor %}
+  </guide>
+</package>

--- a/sphinx/templates/epub3/mimetype
+++ b/sphinx/templates/epub3/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/sphinx/templates/epub3/nav.xhtml_t
+++ b/sphinx/templates/epub3/nav.xhtml_t
@@ -1,0 +1,26 @@
+{%- macro toctree(navlist) -%}
+<ol>
+{%- for nav in navlist %}
+  <li>
+    <a href="{{ nav.refuri }}">{{ nav.text }}</a>
+    {%- if nav.children %}
+{{ toctree(nav.children)|indent(4, true) }}
+    {%- endif %}
+  </li>
+{%- endfor %}
+</ol>
+{%- endmacro -%}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops" lang="{{ lang }}" xml:lang="{{ lang }}">
+  <head>
+    <title>{{ toc_locale }}</title>
+  </head>
+  <body>
+    <nav epub:type="toc">
+      <h1>{{ toc_locale }}</h1>
+{{ toctree(navlist)|indent(6, true) }}
+    </nav>
+  </body>
+</html>

--- a/sphinx/templates/epub3/toc.ncx_t
+++ b/sphinx/templates/epub3/toc.ncx_t
@@ -1,0 +1,24 @@
+{%- macro navPoints(navlist) %}
+{%- for nav in navlist %}
+<navPoint id="{{ nav.navpoint }}" playOrder="{{ nav.playorder }}">
+  <navLabel>
+    <text>{{ nav.text }}</text>
+  </navLabel>
+  <content src="{{ nav.refuri }}" />{{ navPoints(nav.children)|indent(2, true) }}
+</navPoint>
+{%- endfor %}
+{%- endmacro -%}
+<?xml version="1.0"?>
+<ncx version="2005-1" xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <head>
+    <meta name="dtb:uid" content="{{ uid }}"/>
+    <meta name="dtb:depth" content="{{ level }}"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle>
+    <text>{{ title }}</text>
+  </docTitle>
+  <navMap>{{ navPoints(navpoints)|indent(4, true) }}
+  </navMap>
+</ncx>

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -9,7 +9,44 @@
     :license: BSD, see LICENSE for details.
 """
 
+from xml.etree import ElementTree
+
 import pytest
+
+
+class EPUBElementTree(object):
+    """Test helper for content.opf and tox.ncx"""
+    namespaces = {
+        'idpf': 'http://www.idpf.org/2007/opf',
+        'dc': 'http://purl.org/dc/elements/1.1/',
+        'ibooks': 'http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/',
+        'ncx': 'http://www.daisy.org/z3986/2005/ncx/',
+    }
+
+    def __init__(self, tree):
+        self.tree = tree
+
+    @classmethod
+    def fromstring(cls, string):
+        return cls(ElementTree.fromstring(string))
+
+    def find(self, match):
+        ret = self.tree.find(match, namespaces=self.namespaces)
+        if ret is not None:
+            return self.__class__(ret)
+        else:
+            return ret
+
+    def findall(self, match):
+        ret = self.tree.findall(match, namespaces=self.namespaces)
+        return [self.__class__(e) for e in ret]
+
+    def __getattr__(self, name):
+        return getattr(self.tree, name)
+
+    def __iter__(self):
+        for child in self.tree:
+            yield self.__class__(child)
 
 
 @pytest.mark.sphinx('epub', testroot='basic')
@@ -17,3 +54,88 @@ def test_build_epub(app):
     app.build()
     assert (app.outdir / 'mimetype').text() == 'application/epub+zip'
     assert (app.outdir / 'META-INF' / 'container.xml').exists()
+
+    # toc.ncx
+    toc = EPUBElementTree.fromstring((app.outdir / 'toc.ncx').text())
+    assert toc.find("./ncx:docTitle/ncx:text").text == 'Python  documentation'
+
+    # toc.ncx / head
+    meta = list(toc.find("./ncx:head"))
+    assert meta[0].attrib == {'name': 'dtb:uid', 'content': 'unknown'}
+    assert meta[1].attrib == {'name': 'dtb:depth', 'content': '1'}
+    assert meta[2].attrib == {'name': 'dtb:totalPageCount', 'content': '0'}
+    assert meta[3].attrib == {'name': 'dtb:maxPageNumber', 'content': '0'}
+
+    # toc.ncx / navMap
+    navpoints = toc.findall("./ncx:navMap/ncx:navPoint")
+    assert len(navpoints) == 1
+    assert navpoints[0].attrib == {'id': 'navPoint2', 'playOrder': '1'}
+    assert navpoints[0].find("./ncx:content").attrib == {'src': 'index.xhtml'}
+
+    navlabel = navpoints[0].find("./ncx:navLabel/ncx:text")
+    assert navlabel.text == 'The basic Sphinx documentation for testing'
+
+    # content.opf
+    opf = EPUBElementTree.fromstring((app.outdir / 'content.opf').text())
+
+    # content.opf / metadata
+    metadata = opf.find("./idpf:metadata")
+    assert metadata.find("./dc:language").text == 'en'
+    assert metadata.find("./dc:title").text == 'Python  documentation'
+    assert metadata.find("./dc:description").text is None
+    assert metadata.find("./dc:creator").text == 'unknown'
+    assert metadata.find("./dc:contributor").text == 'unknown'
+    assert metadata.find("./dc:publisher").text == 'unknown'
+    assert metadata.find("./dc:rights").text is None
+    assert metadata.find("./idpf:meta[@property='ibooks:version']").text is None
+    assert metadata.find("./idpf:meta[@property='ibooks:specified-fonts']").text == 'true'
+    assert metadata.find("./idpf:meta[@property='ibooks:binding']").text == 'true'
+    assert metadata.find("./idpf:meta[@property='ibooks:scroll-axis']").text == 'vertical'
+
+    # content.opf / manifest
+    manifest = opf.find("./idpf:manifest")
+    items = list(manifest)
+    assert items[0].attrib == {'id': 'ncx',
+                               'href': 'toc.ncx',
+                               'media-type': 'application/x-dtbncx+xml'}
+    assert items[1].attrib == {'id': 'nav',
+                               'href': 'nav.xhtml',
+                               'media-type': 'application/xhtml+xml',
+                               'properties': 'nav'}
+    assert items[2].attrib == {'id': 'epub-0',
+                               'href': 'genindex.xhtml',
+                               'media-type': 'application/xhtml+xml'}
+    assert items[3].attrib == {'id': 'epub-1',
+                               'href': 'index.xhtml',
+                               'media-type': 'application/xhtml+xml'}
+
+    for i, item in enumerate(items[2:]):
+        # items are named as epub-NN
+        assert item.get('id') == 'epub-%d' % i
+
+    # content.opf / spine
+    spine = opf.find("./idpf:spine")
+    itemrefs = list(spine)
+    assert spine.get('toc') == 'ncx'
+    assert spine.get('page-progression-direction') == 'ltr'
+    assert itemrefs[0].get('idref') == 'epub-1'
+    assert itemrefs[1].get('idref') == 'epub-0'
+
+    # content.opf / guide
+    reference = opf.find("./idpf:guide/idpf:reference")
+    assert reference.get('type') == 'toc'
+    assert reference.get('title') == 'Table of Contents'
+    assert reference.get('href') == 'index.xhtml'
+
+
+@pytest.mark.sphinx('epub', testroot='footnotes',
+                    confoverrides={'epub_cover': ('_images/rimg.png', None)})
+def test_epub_cover(app):
+    app.build()
+
+    # content.opf / metadata
+    opf = EPUBElementTree.fromstring((app.outdir / 'content.opf').text())
+    cover_image = opf.find("./idpf:manifest/idpf:item[@href='%s']" % app.config.epub_cover[0])
+    cover = opf.find("./idpf:metadata/idpf:meta[@name='cover']")
+    assert cover
+    assert cover.get('content') == cover_image.get('id')

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -210,3 +210,38 @@ def test_nested_toc(app):
     grandchild = tocchildren[1].findall("./xhtml:ol/xhtml:li")
     assert len(grandchild) == 1
     assert navinfo(grandchild[0]) == ('foo.xhtml#foo-1-1', 'foo.1-1')
+
+
+@pytest.mark.sphinx('epub', testroot='basic')
+def test_epub_writing_mode(app):
+    # horizontal (default)
+    app.build()
+
+    # horizontal / page-progression-direction
+    opf = EPUBElementTree.fromstring((app.outdir / 'content.opf').text())
+    assert opf.find("./idpf:spine").get('page-progression-direction') == 'ltr'
+
+    # horizontal / ibooks:scroll-axis
+    metadata = opf.find("./idpf:metadata")
+    assert metadata.find("./idpf:meta[@property='ibooks:scroll-axis']").text == 'vertical'
+
+    # horizontal / writing-mode (CSS)
+    css = (app.outdir / '_static' / 'epub.css').text()
+    assert 'writing-mode: horizontal-tb;' in css
+
+    # vertical
+    app.config.epub_writing_mode = 'vertical'
+    (app.outdir / 'index.xhtml').unlink()  # forcely rebuild
+    app.build()
+
+    # vertical / page-progression-direction
+    opf = EPUBElementTree.fromstring((app.outdir / 'content.opf').text())
+    assert opf.find("./idpf:spine").get('page-progression-direction') == 'rtl'
+
+    # vertical / ibooks:scroll-axis
+    metadata = opf.find("./idpf:metadata")
+    assert metadata.find("./idpf:meta[@property='ibooks:scroll-axis']").text == 'horizontal'
+
+    # vertical / writing-mode (CSS)
+    css = (app.outdir / '_static' / 'epub.css').text()
+    assert 'writing-mode: vertical-rl;' in css

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+    test_build_html
+    ~~~~~~~~~~~~~~~
+
+    Test the HTML builder and check output against XPath.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+
+@pytest.mark.sphinx('epub', testroot='basic')
+def test_build_epub(app):
+    app.build()
+    assert (app.outdir / 'mimetype').text() == 'application/epub+zip'
+    assert (app.outdir / 'META-INF' / 'container.xml').exists()


### PR DESCRIPTION
Before deprecate epub2 builder (refs: #3221), I refactored the builder and added test cases.
As a result, that makes easier to deprecate it.