### PR TITLE
refactor latex table templates to avoid extra vertical space (refs #3405)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ Incompatible changes
   has the custom code to fit image to available width if oversized.
 * The subclasses of ``sphinx.domains.Index`` should override ``generate()``
   method.  The default implementation raises NotImplementedError
+* LaTeX positioned long tables horizontally centered, and short ones
+  flushed left (no text flow around table.) The position now defaults to center in
+  both cases, and it will obey Docutils 0.13 ``:align:`` option (refs #3415, #3377)
 
 Features removed
 ----------------
@@ -49,6 +52,7 @@ Features added
 * #3402: Allow to suppress "download file not readable" warnings using
   :confval:`suppress_warnings`.
 * #3377: latex: Add support for Docutils 0.13 ``:align:`` option for tables
+  (but does not implement text flow around table).
 
 Bugs fixed
 ----------

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -1,15 +1,20 @@
-<%- if table.align %>
+\begingroup
+<% if table.align -%>
   <%- if table.align == 'center' -%>
-    \begin{center}
-  <%- elif table.align in ('left', 'right') -%>
-    \begin{flush<%= table.align%>}
-  <%- endif -%>
-<% endif -%>
-<%- if table.caption -%>
+  \centering
+  <%- elif table.align == 'left' -%>
+  \raggedright
+  <%- else -%>
+  \raggedleft
+  <%- endif %>
+<%- else -%>
+  \centering
+<%- endif %>
+<% if table.caption -%>
 \begin{threeparttable}
 \capstart\caption{<%= ''.join(table.caption) %>}<%= labels %>
 <% endif -%>
-\noindent\begin{tabular}<%= table.get_colspec() -%>
+\begin{tabular}<%= table.get_colspec() -%>
 \hline
 <%= ''.join(table.header) %>
 <%=- ''.join(table.body) %>
@@ -17,10 +22,5 @@
 <%- if table.caption %>
 \end{threeparttable}
 <%- endif %>
-<%- if table.align %>
-  <%- if table.align == 'center' -%>
-    \end{center}
-  <%- elif table.align in ('left', 'right') -%>
-    \end{flush<%= table.align%>}
-  <% endif -%>
-<% endif -%>
+\par
+\endgroup

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -1,15 +1,20 @@
-<%- if table.align %>
+\begingroup
+<% if table.align -%>
   <%- if table.align == 'center' -%>
-    \begin{center}
-  <%- elif table.align in ('left', 'right') -%>
-    \begin{flush<%= table.align%>}
-  <%- endif -%>
-<% endif -%>
-<%- if table.caption -%>
+  \centering
+  <%- elif table.align == 'left' -%>
+  \raggedright
+  <%- else -%>
+  \raggedleft
+  <%- endif %>
+<%- else -%>
+  \centering
+<%- endif %>
+<% if table.caption -%>
 \begin{threeparttable}
 \capstart\caption{<%= ''.join(table.caption) %>}<%= labels %>
 <% endif -%>
-\noindent\begin{tabulary}{\linewidth}<%= table.get_colspec() -%>
+\begin{tabulary}{\linewidth}<%= table.get_colspec() -%>
 \hline
 <%= ''.join(table.header) %>
 <%=- ''.join(table.body) %>
@@ -17,10 +22,5 @@
 <%- if table.caption %>
 \end{threeparttable}
 <%- endif %>
-<%- if table.align %>
-  <%- if table.align == 'center' -%>
-    \end{center}
-  <%- elif table.align in ('left', 'right') -%>
-    \end{flush<%= table.align%>}
-  <% endif -%>
-<% endif -%>
+\par
+\endgroup

--- a/tests/roots/test-latex-table/tabular.rst
+++ b/tests/roots/test-latex-table/tabular.rst
@@ -30,7 +30,7 @@ table having :align: option (tabulary)
 --------------------------------------
 
 .. table::
-   :align: center
+   :align: right
 
    ======= =======
    header1 header2

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -481,7 +481,7 @@ def test_footnote(app, status, warning):
             '\ncite\n}') in result
     assert '\\caption{Table caption \\sphinxfootnotemark[4]' in result
     assert 'name \\sphinxfootnotemark[5]' in result
-    assert ('\\end{threeparttable}\n%\n'
+    assert ('\\end{threeparttable}\n\\par\n\\endgroup\n%\n'
             '\\begin{footnotetext}[4]\sphinxAtStartFootnote\n'
             'footnotes in table caption\n%\n\\end{footnotetext}%\n'
             '\\begin{footnotetext}[5]\sphinxAtStartFootnote\n'
@@ -831,7 +831,7 @@ def test_latex_table_tabulars(app, status, warning):
 
     # simple_table
     table = tables['simple table']
-    assert ('\\noindent\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
+    assert ('\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
     assert ('\\hline\n'
             '\\sphinxstylethead{\\relax \nheader1\n\\unskip}\\relax &'
             '\\sphinxstylethead{\\relax \nheader2\n\\unskip}\\relax' in table)
@@ -842,42 +842,43 @@ def test_latex_table_tabulars(app, status, warning):
 
     # table having :widths: option
     table = tables['table having :widths: option']
-    assert ('\\noindent\\begin{tabular}{|\\X{30}{100}|\\X{70}{100}|}' in table)
+    assert ('\\begin{tabular}{|\\X{30}{100}|\\X{70}{100}|}' in table)
     assert ('\\hline\n\\end{tabular}' in table)
 
     # table having :align: option (tabulary)
     table = tables['table having :align: option (tabulary)']
-    assert ('\\begin{center}\\noindent\\begin{tabulary}{\\linewidth}{|L|L|}\n' in table)
-    assert ('\\hline\n\\end{tabulary}\\end{center}' in table)
+    assert ('\\begingroup\n\\centering\n'
+            '\\begin{tabulary}{\\linewidth}{|L|L|}\n' in table)
+    assert ('\\hline\n\\end{tabulary}\n\\par\n\\endgroup' in table)
 
     # table having :align: option (tabular)
     table = tables['table having :align: option (tabular)']
-    assert ('\\begin{flushleft}'
-            '\\noindent\\begin{tabular}{|\X{30}{100}|\X{70}{100}|}\n' in table)
-    assert ('\\hline\n\\end{tabular}\\end{flushleft}' in table)
+    assert ('\\begingroup\n\\raggedright\n'
+            '\\begin{tabular}{|\X{30}{100}|\X{70}{100}|}\n' in table)
+    assert ('\\hline\n\\end{tabular}\n\\par\n\\endgroup' in table)
 
     # table with tabularcolumn
     table = tables['table with tabularcolumn']
-    assert ('\\noindent\\begin{tabulary}{\\linewidth}{|c|c|}' in table)
+    assert ('\\begin{tabulary}{\\linewidth}{|c|c|}' in table)
 
     # table having caption
     table = tables['table having caption']
     assert ('\\begin{threeparttable}\n\\capstart\\caption{caption for table}'
             '\\label{\\detokenize{tabular:id1}}' in table)
-    assert ('\\noindent\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
+    assert ('\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
     assert ('\\hline\n\\end{tabulary}\n\\end{threeparttable}' in table)
 
     # table having verbatim
     table = tables['table having verbatim']
-    assert ('\\noindent\\begin{tabular}{|*{2}{\\X{1}{2}|}}\n\\hline' in table)
+    assert ('\\begin{tabular}{|*{2}{\\X{1}{2}|}}\n\\hline' in table)
 
     # table having problematic cell
     table = tables['table having problematic cell']
-    assert ('\\noindent\\begin{tabular}{|*{2}{\\X{1}{2}|}}\n\\hline' in table)
+    assert ('\\begin{tabular}{|*{2}{\\X{1}{2}|}}\n\\hline' in table)
 
     # table having both :widths: and problematic cell
     table = tables['table having both :widths: and problematic cell']
-    assert ('\\noindent\\begin{tabular}{|\\X{30}{100}|\\X{70}{100}|}' in table)
+    assert ('\\begin{tabular}{|\\X{30}{100}|\\X{70}{100}|}' in table)
 
 
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
@@ -958,7 +959,7 @@ def test_latex_table_complex_tables(app, status, warning):
 
     # grid table
     table = tables['grid table']
-    assert ('\\noindent\\begin{tabulary}{\\linewidth}{|L|L|L|}' in table)
+    assert ('\\begin{tabulary}{\\linewidth}{|L|L|L|}' in table)
     assert ('\\hline\n'
             '\\sphinxstylethead{\\relax \nheader1\n\\unskip}\\relax &'
             '\\sphinxstylethead{\\relax \nheader2\n\\unskip}\\relax &'
@@ -975,7 +976,7 @@ def test_latex_table_complex_tables(app, status, warning):
 
     # complex spanning cell
     table = tables['complex spanning cell']
-    assert ('\\noindent\\begin{tabulary}{\\linewidth}{|L|L|L|L|L|}' in table)
+    assert ('\\begin{tabulary}{\\linewidth}{|L|L|L|L|L|}' in table)
     assert ('\\hline\n'
             '\\multirow{3}{*}{\\relax \ncell1-1\n\\unskip}\\relax &'
             '\\multirow{3}{*}{\\relax \ncell1-2\n\\unskip}\\relax &'

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -831,23 +831,24 @@ def test_latex_table_tabulars(app, status, warning):
 
     # simple_table
     table = tables['simple table']
-    assert ('\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
+    assert ('\\begingroup\n\\centering\n\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
     assert ('\\hline\n'
             '\\sphinxstylethead{\\relax \nheader1\n\\unskip}\\relax &'
             '\\sphinxstylethead{\\relax \nheader2\n\\unskip}\\relax' in table)
     assert ('\\hline\ncell1-1\n&\ncell1-2\n\\\\' in table)
     assert ('\\hline\ncell2-1\n&\ncell2-2\n\\\\' in table)
     assert ('\\hline\ncell3-1\n&\ncell3-2\n\\\\' in table)
-    assert ('\\hline\n\\end{tabulary}' in table)
+    assert ('\\hline\n\\end{tabulary}\n\\par\n\\endgroup' in table)
 
     # table having :widths: option
     table = tables['table having :widths: option']
-    assert ('\\begin{tabular}{|\\X{30}{100}|\\X{70}{100}|}' in table)
-    assert ('\\hline\n\\end{tabular}' in table)
+    assert ('\\begingroup\n\\centering\n'
+            '\\begin{tabular}{|\\X{30}{100}|\\X{70}{100}|}' in table)
+    assert ('\\hline\n\\end{tabular}\n\\par\n\\endgroup' in table)
 
     # table having :align: option (tabulary)
     table = tables['table having :align: option (tabulary)']
-    assert ('\\begingroup\n\\centering\n'
+    assert ('\\begingroup\n\\raggedleft\n'
             '\\begin{tabulary}{\\linewidth}{|L|L|}\n' in table)
     assert ('\\hline\n\\end{tabulary}\n\\par\n\\endgroup' in table)
 
@@ -863,10 +864,12 @@ def test_latex_table_tabulars(app, status, warning):
 
     # table having caption
     table = tables['table having caption']
-    assert ('\\begin{threeparttable}\n\\capstart\\caption{caption for table}'
+    assert ('\\begingroup\n\\centering\n'
+            '\\begin{threeparttable}\n\\capstart\\caption{caption for table}'
             '\\label{\\detokenize{tabular:id1}}' in table)
     assert ('\\begin{tabulary}{\\linewidth}{|L|L|}' in table)
-    assert ('\\hline\n\\end{tabulary}\n\\end{threeparttable}' in table)
+    assert ('\\hline\n\\end{tabulary}\n\\end{threeparttable}'
+            '\n\\par\n\\endgroup' in table)
 
     # table having verbatim
     table = tables['table having verbatim']


### PR DESCRIPTION
- The center, flushleft, flushright environments added at #3405 add extra vertical spaces in PDF output compared to earlier situation. This PR removes them.

- The tabular and tabulary templates are also modified in order for produced LaTeX code to have start of environments at start of new line, for better readability

- By default, the table will be horizontally centered. This is already the default behaviour of longtable. Before incorporation of ``:align:`` option, default for short tables not using longtable was flushleft and one could not change it. Now default is like longtable centered.

### Relates
-  #3405, #3377 

