### PR TITLE
deprecate config setting ``latex_keep_old_macro_names`` at 1.6

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1605,22 +1605,23 @@ These options influence LaTeX output. See further :doc:`latex`.
 
 .. confval:: latex_keep_old_macro_names
 
-   If ``True`` (default) the ``\strong``, ``\code``, ``\bfcode``, ``\email``,
+   If ``True`` the ``\strong``, ``\code``, ``\bfcode``, ``\email``,
    ``\tablecontinued``, ``\titleref``, ``\menuselection``, ``\accelerator``,
    ``\crossref``, ``\termref``, and ``\optional`` text styling macros are
    pre-defined by Sphinx and may be user-customized by some
    ``\renewcommand``'s inserted either via ``'preamble'`` key or :dudir:`raw
    <raw-data-pass-through>` directive. If ``False``, only ``\sphinxstrong``,
-   etc... macros are defined (and may be redefined by user). Setting to
-   ``False`` may help solve macro name conflicts caused by user-added latex
-   packages.
+   etc... macros are defined (and may be redefined by user).
+
+   The default is ``False`` as it solves macro name conflicts caused by
+   user-added latex packages. For example ``fontspec v2.6`` defines its own
+   ``\strong`` macro.
 
    .. versionadded:: 1.4.5
-
    .. versionchanged:: 1.6
-
-      For ``'xelatex'`` engine, the default is ``False`` because LaTeX package
-      ``fontspec v2.6`` defines its own ``\strong`` macro.
+      Default was changed from ``True`` to ``False``.
+   .. deprecated:: 1.6
+      This setting will be removed at Sphinx 1.7.
 
 .. confval:: latex_elements
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1617,6 +1617,10 @@ These options influence LaTeX output. See further :doc:`latex`.
 
    .. versionadded:: 1.4.5
 
+   .. versionchanged:: 1.6
+
+      For ``'xelatex'`` engine, the default is ``False`` because LaTeX package
+      ``fontspec v2.6`` defines its own ``\strong`` macro.
 
 .. confval:: latex_elements
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -258,6 +258,11 @@ def validate_config_values(app):
                           RemovedInSphinx17Warning)
             app.config.latex_elements['postamble'] = app.config.latex_elements['footer']
 
+    if app.config.latex_keep_old_macro_names:
+        warnings.warn("latex_keep_old_macro_names is deprecated. "
+                      "LaTeX markup since Sphinx 1.4.5 uses only prefixed macro names.",
+                      RemovedInSphinx17Warning)
+
 
 def default_latex_engine(config):
     # type: (Config) -> unicode
@@ -291,7 +296,7 @@ def setup(app):
                          None)
     app.add_config_value('latex_logo', None, None, string_classes)
     app.add_config_value('latex_appendices', [], None)
-    app.add_config_value('latex_keep_old_macro_names', True, None)
+    app.add_config_value('latex_keep_old_macro_names', False, None)
     app.add_config_value('latex_toplevel_sectioning', None, None, [str])
     app.add_config_value('latex_domain_indices', True, None, [list])
     app.add_config_value('latex_show_urls', 'no', None)

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1199,7 +1199,7 @@
 \ifspx@opt@dontkeepoldnames\else
   \let\spx@alreadydefinedlist\@empty
   \typeout{** (sphinx) defining (legacy) text style macros without \string\sphinx\space prefix}
-  \typeout{** if clashes with packages, set latex_keep_old_macro_names=False
+  \typeout{** if clashes with packages, do not set latex_keep_old_macro_names=True
     in conf.py}
   \@for\@tempa:=code,strong,bfcode,email,tablecontinued,titleref,%
                 menuselection,accelerator,crossref,termref,optional\do
@@ -1224,6 +1224,7 @@
          Sphinx mark-up uses only \string\sphinx\expandafter\@gobble\sphinxdeprecatedmacro.}%
     }%
   \fi
+  \sphinxdeprecationwarning{latex_keep_old_macro_names=True}{1.6}{1.7}{}%
 \fi
 
 % additional customizable styling

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -58,7 +58,7 @@ DEFAULT_SETTINGS = {
     'classoptions':    '',
     'extraclassoptions': '',
     'maxlistdepth':    '',
-    'sphinxpkgoptions':     '',
+    'sphinxpkgoptions':     'dontkeepoldnames',
     'sphinxsetup':     '',
     'passoptionstopackages': '',
     'geometry':        '\\usepackage{geometry}',
@@ -539,8 +539,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.elements.update({
                 'releasename':  _('Release'),
             })
-        if not builder.config.latex_keep_old_macro_names:
-            self.elements['sphinxpkgoptions'] = 'dontkeepoldnames'
+        if builder.config.latex_keep_old_macro_names:
+            self.elements['sphinxpkgoptions'] = ''
         if document.settings.docclass == 'howto':
             docclass = builder.config.latex_docclass.get('howto', 'article')
         else:


### PR DESCRIPTION
Closes #3428.

I feel this is breaking change hence on master.

The Boolean ``latex_keep_old_macro_names`` is not reset, hence this might confuse extension testing its value, but I wasn't sure how to overwrite its value. In config file the user may have `latex_keep_old_macro_names = True` for accidental or deliberate reason. If it is deliberate it should be obeyed, perhaps the user doesn't have the problematic fontspec or is using xelatex but not fontspec ... it might be accidental due to un-commenting out default value (I don't recall if sphinx-quickstart produced it.)
