### PR TITLE
add deprecation helper to LaTeX style file (and fixes #3428)

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,22 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/02/06 v1.5.3 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/02/17 v1.5.3 LaTeX package (Sphinx markup)]
+
+%% for deprecation warnings
+\newcommand\sphinxdeprecationwarning[4]{% #1 the deprecated macro or name,
+% #2 = version when deprecated, #3 = version when removed, #4 = message
+  \edef\spx@tempa{\detokenize{#1}}%
+  \spx@ifundefined{sphinx_depr_\spx@tempa}{%
+     \global\expandafter\let\csname sphinx_depr_\spx@tempa\endcsname\spx@tempa
+     \expandafter\AtEndDocument\expandafter{\expandafter\let\expandafter
+         \sphinxdeprecatedmacro\csname sphinx_depr_\spx@tempa\endcsname
+         \PackageWarningNoLine{sphinx}{^^J**** SPHINX DEPRECATION WARNING:^^J
+         \sphinxdeprecatedmacro\space will be (or has been)
+         deprecated at Sphinx #2^^J and will be removed at Sphinx #3.^^J
+         #4^^J****}}%
+  }{% warning already emitted (at end of latex log), don't repeat
+  }}
 
 % we delay handling of options to after having loaded packages, because
 % of the need to use \definecolor.
@@ -1181,22 +1196,34 @@
        \firstchoice@false\else\firstchoice@true\fi
    \spx@originalcaption }
 
-% by default, also define macros with the no-prefix names
 \ifspx@opt@dontkeepoldnames\else
+  \let\spx@alreadydefinedlist\@empty
   \typeout{** (sphinx) defining (legacy) text style macros without \string\sphinx\space prefix}
   \typeout{** if clashes with packages, set latex_keep_old_macro_names=False
     in conf.py}
   \@for\@tempa:=code,strong,bfcode,email,tablecontinued,titleref,%
                 menuselection,accelerator,crossref,termref,optional\do
-{% first, check if command with no prefix already exists
-  \expandafter\newcommand\csname\@tempa\endcsname{}%
+ {% first, check if command with no prefix already exists
+  \spx@ifundefined{\@tempa}{%
   % give it the meaning defined so far with \sphinx prefix
   \expandafter\let\csname\@tempa\expandafter\endcsname
                   \csname sphinx\@tempa\endcsname
   % redefine the \sphinx prefixed macro to expand to non-prefixed one
   \expandafter\def\csname sphinx\@tempa\expandafter\endcsname
                   \expandafter{\csname\@tempa\endcsname}%
-}%
+  }{\edef\spx@alreadydefinedlist{\spx@alreadydefinedlist{\@tempa}}}%
+ }%
+  \ifx\spx@alreadydefinedlist\@empty\else
+    \expandafter\@tfor\expandafter\@tempa\expandafter:\expandafter=\spx@alreadydefinedlist\do
+    {% emit warning now
+     \PackageWarning{sphinx}{not redefining already existing \@backslashchar\@tempa\space!^^J%
+        Anyhow, Sphinx mark-up uses only \string\sphinx\@tempa.}%
+     % and also at end of log for better visibility
+     \expandafter\sphinxdeprecationwarning\expandafter{\csname\@tempa\endcsname}{1.6}{1.7}
+       {\sphinxdeprecatedmacro\space already existed at Sphinx loading time! Not redefined!^^J
+         Sphinx mark-up uses only \string\sphinx\expandafter\@gobble\sphinxdeprecatedmacro.}%
+    }%
+  \fi
 \fi
 
 % additional customizable styling


### PR DESCRIPTION
Fix #3428 on stable for 1.5.3.

With this commit, XeLaTeX build (or LuaLaTeX, if using fontspec) with fontspec 2.6 will not fail due to `\newcommand` complaining that `\strong` already exists but rather will emit a warning like this:

```console
Package sphinx Warning: 
**** SPHINX DEPRECATION WARNING:
 \strong  will be (or has been) deprecated at Sphinx 1.6
 and will be removed at Sphinx 1.7.
 \strong  already existed at Sphinx loading time! Not redefined!
 Sphinx mark-up uses only \sphinxstrong .
****.

[1] (./FOO.aux) )
Output written on FOO.pdf (5 pages).
```

### Feature or Bugfix
- This can be considered a Bugfix because the method with `\newcommand` is too
strong as it stops compilation with an Error in case the macro pre-existed.
- It is also slight refactoring of sphinx.sty to facilitate deprecation in future. For example notice environment will be handled like this at 1.6: 
```latex
\newenvironment{notice}
  {\sphinxdeprecationwarning {notice}{1.6}{1.7}{%
  This document was probably built with a Sphinx extension using ``notice''^^J
  environment. At Sphinx 1.7, ``notice'' environment will be removed. Please^^J
  report to extension author to use ``sphinxadmonition'' instead.^^J%
  ****}\begin{sphinxadmonition}}{\end{sphinxadmonition}}
```
producing something like this at end of log (only once even if ``notice`` is used multiple times):
```console
Package sphinx Warning: 
**** SPHINX DEPRECATION WARNING:
 notice is deprecated at Sphinx 1.6 and will be removed at Sphinx 1.7.
 This document was probably built with a Sphinx extension using ``notice''
 environment. At Sphinx 1.7, ``notice'' environment will be removed. Please
 report to extension author to use ``sphinxadmonition'' instead.
****
```

### Purpose
- Avoid stopping latexpdf as anyhow already since Sphinx 1.4.5 the old macro
names are only maintained for backwards compatibility. Thus, even if
``latex_keep_old_macro_names=True``, in case a macro with old name pre-exists
Sphinx, just ignore it.

### Relates
- #3429

