### PR TITLE
Fix #3445: (latex) make ``\\usepackage[utf8x]{inputenc}`` usable

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -102,8 +102,9 @@ ADDITIONAL_SETTINGS = {
     'pdflatex': {
         'inputenc':     '\\usepackage[utf8]{inputenc}',
         'utf8extra':   ('\\ifdefined\\DeclareUnicodeCharacter\n'
+                        ' \\ifdefined\\DeclareUnicodeCharacterAsOptional\\else\n'
                         '  \\DeclareUnicodeCharacter{00A0}{\\nobreakspace}\n'
-                        '\\fi'),
+                        '\\fi\\fi'),
     },
     'xelatex': {
         'latex_engine': 'xelatex',


### PR DESCRIPTION

### Relates
- #3444, #234 

in case of ``utf8x`` option to `inputenc`, `\DeclareUnicodeCharacter` works with decimal, not hexadecimal Unicode code points. Further, it is not needed for handling `U+00A0` as it does it automatically.