### PR TITLE
fix epub validation error at content.opf

### DIFF
--- a/sphinx/templates/epub2/content.opf_t
+++ b/sphinx/templates/epub2/content.opf_t
@@ -25,13 +25,13 @@
     {%- if spine.linear %}
     <itemref idref="{{ spine.idref }}" />
     {%- else %}
-    <itemref idref="{{ spine.idref }}" linear="no" />'''
+    <itemref idref="{{ spine.idref }}" linear="no" />
     {%- endif %}
     {%- endfor %}
   </spine>
   <guide>
     {%- for guide in guides %}
-    <reference type="{{ guide.type }}" title="{{ guide.title }}" href="{{ guide.uri }}" />'''
+    <reference type="{{ guide.type }}" title="{{ guide.title }}" href="{{ guide.uri }}" />
     {%- endfor %}
   </guide>
 </package>

--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -34,13 +34,13 @@
     {%- if spine.linear %}
     <itemref idref="{{ spine.idref }}" />
     {%- else %}
-    <itemref idref="{{ spine.idref }}" linear="no" />'''
+    <itemref idref="{{ spine.idref }}" linear="no" />
     {%- endif %}
     {%- endfor %}
   </spine>
   <guide>
     {%- for guide in guides %}
-    <reference type="{{ guide.type }}" title="{{ guide.title }}" href="{{ guide.uri }}" />'''
+    <reference type="{{ guide.type }}" title="{{ guide.title }}" href="{{ guide.uri }}" />
     {%- endfor %}
   </guide>
 </package>


### PR DESCRIPTION
Subject: fix epub validation error at content.opf

### Feature or Bugfix
- Bugfix

### Detail

<itemref> and <guide> tags contains trailing unnecessary characters. Epub validator reports them as errors:

```
<itemref idref="epub-62" linear="no" />'''
```

<img width="1202" alt="2017-02-25 2 00 55" src="https://cloud.githubusercontent.com/assets/564612/23312936/e6a04466-fafe-11e6-9a0e-634883bd3095.png">
