### PR TITLE
Fix &nbsp is appeared in EPUB docs #3450 again

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -595,6 +595,10 @@ class HTMLTranslator(BaseTranslator):
     def depart_hlistcol(self, node):
         self.body.append('</td>')
 
+    def visit_option_group(self, node):
+        BaseTranslator.visit_option_group(self, node)
+        self.context[-2] = self.context[-2].replace('&nbsp;', '&#160;')
+
     def bulk_text_processor(self, text):
         return text
 
@@ -831,10 +835,6 @@ class SmartyPantsHTMLTranslator(HTMLTranslator):
     def depart_option(self, node):
         self.no_smarty -= 1
         HTMLTranslator.depart_option(self, node)
-
-    def visit_option_group(self, node):
-        HTMLTranslator.visit_option_group(self, node)
-        self.context[-2] = self.context[-2].replace('&nbsp;', '&#160;')
 
     def bulk_text_processor(self, text):
         if self.no_smarty <= 0:

--- a/tests/roots/test-html_entity/conf.py
+++ b/tests/roots/test-html_entity/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+html_theme = 'classic'
+exclude_patterns = ['_build']

--- a/tests/roots/test-html_entity/index.rst
+++ b/tests/roots/test-html_entity/index.rst
@@ -1,0 +1,31 @@
+.. _index:
+
+test-html_entity (#3450)
+=========================
+
+Empty cell
+----------
+
+.. list-table::
+   :header-rows: 1
+   - * un
+     *
+     * trois
+
+Return description in function signature
+----------------------------------------
+
+.. py:function:: test() -> string
+
+   rarr
+
+Field list that has long name (over 14 characters)
+--------------------------------------------------
+
+:abcdefghijklmnopqrstuvwxyz: fieldlist
+
+Option list that has long name (over 14 characters)
+---------------------------------------------------
+
+-a                 all
+-b long_long_file  use file

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1139,3 +1139,12 @@ def test_html_sourcelink_suffix(app):
     assert '<a href="_sources/images.txt"' in content_images
     assert (app.outdir / '_sources' / 'otherext.foo').exists()
     assert (app.outdir / '_sources' / 'images.txt').exists()
+
+
+@pytest.mark.sphinx('html', testroot='html_entity')
+def test_html_entity(app):
+    app.builder.build_all()
+    valid_entities = {'amp', 'lt', 'gt', 'quot', 'apos'}
+    content = (app.outdir / 'index.html').text()
+    for entity in re.findall(r'&([a-z]+);', content, re.M):
+        assert entity not in valid_entities


### PR DESCRIPTION
Subject: Fix again/epub nbsp issue again

### Feature or Bugfix
- Bugfix

### Detail
- Add test
- Fix code (move one method from SmartyPantsHTMLTranslator to HTMLTranslator)

SmartyPantsHTMLTranslator is derived from HTMLTranslator. So fixing code should be in upper class as much as possible.

### Relates
- #3450
- #3452

