### PR TITLE
Add tests for xrefs on Python and JavaScript domains

### DIFF
--- a/tests/roots/test-domain-js/conf.py
+++ b/tests/roots/test-domain-js/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+html_theme = 'classic'
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-js/index.rst
+++ b/tests/roots/test-domain-js/index.rst
@@ -1,0 +1,6 @@
+test-domain-js
+==============
+
+.. toctree::
+
+    roles

--- a/tests/roots/test-domain-js/roles.rst
+++ b/tests/roots/test-domain-js/roles.rst
@@ -5,20 +5,44 @@ roles
 
 .. js:function:: top_level
 
+* :js:class:`TopLevel`
+* :js:func:`top_level`
+
+
 .. js:class:: NestedParentA
+
+    * Link to :js:func:`child_1`
 
     .. js:function:: child_1()
 
+        * Link to :js:func:`NestedChildA.subchild_2`
+        * Link to :js:func:`child_2`
+        * Link to :any:`any_child`
+
     .. js:function:: any_child()
+
+        * Link to :js:class:`NestedChildA`
 
     .. js:class:: NestedChildA
 
         .. js:function:: subchild_1()
 
+            * Link to :js:func:`subchild_2`
+
         .. js:function:: subchild_2()
+
+            Link to :js:func:`NestedParentA.child_1`
 
     .. js:function:: child_2()
 
+        Link to :js:func:`NestedChildA.subchild_1`
+
 .. js:class:: NestedParentB
 
+    * Link to :js:func:`child_1`
+
     .. js:function:: child_1()
+
+        * Link to :js:class:`NestedParentB`
+
+* :js:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-js/roles.rst
+++ b/tests/roots/test-domain-js/roles.rst
@@ -1,0 +1,45 @@
+.. js:class:: TopLevel
+
+.. js:function:: top_level
+
+* :js:class:`TopLevel`
+* :js:func:`top_level`
+
+
+.. js:class:: NestedParentA
+
+    * Link to :js:func:`child_1`
+
+    .. js:function:: child_1()
+
+        * Link to :js:func:`NestedChildA.subchild_2`
+        * Link to :js:func:`child_2`
+        * Link to :any:`any_child`
+
+    .. js:function:: any_child()
+
+        * Link to :js:class:`NestedChildA`
+
+    .. js:class:: NestedChildA
+
+        .. js:function:: subchild_1()
+
+            * Link to :js:func:`subchild_2`
+
+        .. js:function:: subchild_2()
+
+            Link to :js:func:`NestedParentA.child_1`
+
+    .. js:function:: child_2()
+
+        Link to :js:func:`NestedChildA.subchild_1`
+
+.. js:class:: NestedParentB
+
+    * Link to :js:func:`child_1`
+
+    .. js:function:: child_1()
+
+        * Link to :js:class:`NestedParentB`
+
+* :js:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-js/roles.rst
+++ b/tests/roots/test-domain-js/roles.rst
@@ -1,45 +1,24 @@
+roles
+=====
+
 .. js:class:: TopLevel
 
 .. js:function:: top_level
 
-* :js:class:`TopLevel`
-* :js:func:`top_level`
-
-
 .. js:class:: NestedParentA
-
-    * Link to :js:func:`child_1`
 
     .. js:function:: child_1()
 
-        * Link to :js:func:`NestedChildA.subchild_2`
-        * Link to :js:func:`child_2`
-        * Link to :any:`any_child`
-
     .. js:function:: any_child()
-
-        * Link to :js:class:`NestedChildA`
 
     .. js:class:: NestedChildA
 
         .. js:function:: subchild_1()
 
-            * Link to :js:func:`subchild_2`
-
         .. js:function:: subchild_2()
-
-            Link to :js:func:`NestedParentA.child_1`
 
     .. js:function:: child_2()
 
-        Link to :js:func:`NestedChildA.subchild_1`
-
 .. js:class:: NestedParentB
 
-    * Link to :js:func:`child_1`
-
     .. js:function:: child_1()
-
-        * Link to :js:class:`NestedParentB`
-
-* :js:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-py/conf.py
+++ b/tests/roots/test-domain-py/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+html_theme = 'classic'
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-py/index.rst
+++ b/tests/roots/test-domain-py/index.rst
@@ -4,3 +4,4 @@ test-domain-py
 .. toctree::
 
     roles
+    module

--- a/tests/roots/test-domain-py/index.rst
+++ b/tests/roots/test-domain-py/index.rst
@@ -1,0 +1,6 @@
+test-domain-py
+==============
+
+.. toctree::
+
+    roles

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -1,13 +1,22 @@
 module
-------
+======
 
 .. py:module:: module_a.submodule
 
+* Link to :py:cls:`ModTopLevel`
+
 .. py:class:: ModTopLevel
+
+    * Link to :py:meth:`mod_child_1`
+    * Link to :py:meth:`ModTopLevel.mod_child_1`
 
 .. py:method:: ModTopLevel.mod_child_1
 
+    * Link to :py:meth:`mod_child_2`
+
 .. py:method:: ModTopLevel.mod_child_2
+
+    * Link to :py:meth:`module_a.submodule.ModTopLevel.mod_child_1`
 
 .. py:currentmodule:: None
 
@@ -15,4 +24,8 @@ module
 
 .. py:module:: module_b.submodule
 
+* Link to :py:cls:`ModTopLevel`
+
 .. py:class:: ModTopLevel
+
+    * Link to :py:cls:`ModNoModule`

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -1,0 +1,18 @@
+module
+------
+
+.. py:module:: module_a.submodule
+
+.. py:class:: ModTopLevel
+
+.. py:method:: ModTopLevel.mod_child_1
+
+.. py:method:: ModTopLevel.mod_child_2
+
+.. py:currentmodule:: None
+
+.. py:class:: ModNoModule
+
+.. py:module:: module_b.submodule
+
+.. py:class:: ModTopLevel

--- a/tests/roots/test-domain-py/roles.rst
+++ b/tests/roots/test-domain-py/roles.rst
@@ -1,24 +1,48 @@
 roles
------
+=====
 
 .. py:class:: TopLevel
 
 .. py:method:: top_level
 
+* :py:class:`TopLevel`
+* :py:meth:`top_level`
+
+
 .. py:class:: NestedParentA
+
+    * Link to :py:meth:`child_1`
 
     .. py:method:: child_1()
 
+        * Link to :py:meth:`NestedChildA.subchild_2`
+        * Link to :py:meth:`child_2`
+        * Link to :any:`any_child`
+
     .. py:method:: any_child()
+
+        * Link to :py:class:`NestedChildA`
 
     .. py:class:: NestedChildA
 
         .. py:method:: subchild_1()
 
+            * Link to :py:meth:`subchild_2`
+
         .. py:method:: subchild_2()
+
+            Link to :py:meth:`NestedParentA.child_1`
 
     .. py:method:: child_2()
 
+        Link to :py:meth:`NestedChildA.subchild_1`
+
 .. py:class:: NestedParentB
 
+    * Link to :py:meth:`child_1`
+
     .. py:method:: child_1()
+
+        * Link to :py:class:`NestedParentB`
+
+* :py:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-py/roles.rst
+++ b/tests/roots/test-domain-py/roles.rst
@@ -1,0 +1,48 @@
+roles
+-----
+
+.. py:class:: TopLevel
+
+.. py:method:: top_level
+
+* :py:class:`TopLevel`
+* :py:meth:`top_level`
+
+
+.. py:class:: NestedParentA
+
+    * Link to :py:meth:`child_1`
+
+    .. py:method:: child_1()
+
+        * Link to :py:meth:`NestedChildA.subchild_2`
+        * Link to :py:meth:`child_2`
+        * Link to :any:`any_child`
+
+    .. py:method:: any_child()
+
+        * Link to :py:class:`NestedChildA`
+
+    .. py:class:: NestedChildA
+
+        .. py:method:: subchild_1()
+
+            * Link to :py:meth:`subchild_2`
+
+        .. py:method:: subchild_2()
+
+            Link to :py:meth:`NestedParentA.child_1`
+
+    .. py:method:: child_2()
+
+        Link to :py:meth:`NestedChildA.subchild_1`
+
+.. py:class:: NestedParentB
+
+    * Link to :py:meth:`child_1`
+
+    .. py:method:: child_1()
+
+        * Link to :py:class:`NestedParentB`
+
+* :py:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-py/roles.rst
+++ b/tests/roots/test-domain-py/roles.rst
@@ -5,44 +5,20 @@ roles
 
 .. py:method:: top_level
 
-* :py:class:`TopLevel`
-* :py:meth:`top_level`
-
-
 .. py:class:: NestedParentA
-
-    * Link to :py:meth:`child_1`
 
     .. py:method:: child_1()
 
-        * Link to :py:meth:`NestedChildA.subchild_2`
-        * Link to :py:meth:`child_2`
-        * Link to :any:`any_child`
-
     .. py:method:: any_child()
-
-        * Link to :py:class:`NestedChildA`
 
     .. py:class:: NestedChildA
 
         .. py:method:: subchild_1()
 
-            * Link to :py:meth:`subchild_2`
-
         .. py:method:: subchild_2()
-
-            Link to :py:meth:`NestedParentA.child_1`
 
     .. py:method:: child_2()
 
-        Link to :py:meth:`NestedChildA.subchild_1`
-
 .. py:class:: NestedParentB
 
-    * Link to :py:meth:`child_1`
-
     .. py:method:: child_1()
-
-        * Link to :py:class:`NestedParentB`
-
-* :py:class:`NestedParentA.NestedChildA`

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+    test_domain_js
+    ~~~~~~~~~~~~~~
+
+    Tests the JavaScript Domain
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+
+@pytest.mark.sphinx(testroot='domain-js')
+def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
+    from sphinx.domains.javascript import JavaScriptDomain
+
+    calls = {}
+
+    def wrapped_find_obj(fn):
+        def wrapped(*args):
+            ret = fn(*args)
+            # args = [domain, env, env object, role text, role type, order]
+            calls[args[2:-1]] = ret
+            return ret
+        return wrapped
+
+    JavaScriptDomain.find_obj = wrapped_find_obj(JavaScriptDomain.find_obj)
+
+    app.builder.build_all()
+
+    calls_expected = {
+        (None, u'TopLevel', u'class'): (u'TopLevel', (u'roles', u'class')),
+        (None, u'top_level', u'func'): (u'top_level', (u'roles', u'function')),
+        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
+        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
+        (None, u'subchild_2', u'func'): (u'subchild_2', (u'roles', u'function')),
+        (None, u'NestedParentA.child_1', u'func'): (None, None),
+        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
+        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
+        (None, u'NestedParentB', u'class'): (u'NestedParentB', (u'roles', u'class')),
+        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
+        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
+        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function'))
+    }
+
+    assert calls_expected == calls
+
+    with pytest.raises(KeyError):
+        assert (calls[('NestedParentA.NestedChildA', 'subchild_2',
+                       'func')] \
+                == ('NestedParentA.NestedChildA.subchild_2',
+                    ('roles', 'function')))
+    with pytest.raises(KeyError):
+        assert (calls[('NestedParentA.NestedChildA',
+                       'NestedParentA.child_1', 'func')] \
+                == ('NestedParentA.child_1', ('roles', 'function')))
+    with pytest.raises(KeyError):
+        assert (calls[('NestedParentA', 'NestedChildA.subchild_2',
+                       'func')] \
+                == ('NestedParentA.NestedChildA.subchild_2',
+                    ('roles', 'function')))

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -10,6 +10,32 @@
 """
 
 import pytest
+import mock
+
+
+@pytest.mark.sphinx(testroot='domain-js')
+def test_domain_js_xrefs(app, status, warning):
+    """Domain objects have correct prefixes when looking up xrefs"""
+    find_obj = app.env.domains['js'].find_obj
+    app.env.domains['js'].find_obj = mock.Mock(wraps=find_obj)
+    app.builder.build_all()
+
+    def assert_called(prefix, obj_name, obj_type, searchmode=0):
+        app.env.domains['js'].find_obj.assert_any_call(
+            app.env, prefix, obj_name, obj_type, searchmode)
+
+    assert_called(None, u'TopLevel', u'class')
+    assert_called(None, u'top_level', u'func')
+    assert_called(None, u'child_1', u'func')
+    assert_called(None, u'NestedChildA.subchild_2', u'func')
+    assert_called(None, u'child_2', u'func')
+    assert_called(None, u'any_child', None, 1)
+    assert_called(None, u'NestedChildA', u'class')
+    assert_called(None, u'subchild_2', u'func')
+    assert_called(None, u'NestedParentA.child_1', u'func')
+    assert_called(None, u'NestedChildA.subchild_1', u'func')
+    assert_called(None, u'NestedParentB', u'class')
+    assert_called(None, u'NestedParentA.NestedChildA', u'class')
 
 
 @pytest.mark.sphinx(testroot='domain-js')
@@ -39,21 +65,10 @@ def test_domain_js_find_obj(app, status, warning):
 
     app.builder.build_all()
 
-    xrefs = {
-        (None, u'NONEXISTANT', u'class'): (None, None),
-        (None, u'TopLevel', u'class'): (u'TopLevel', (u'roles', u'class')),
-        (None, u'top_level', u'func'): (u'top_level', (u'roles', u'function')),
-        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
-        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
-        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function')),
-        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
-        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
-        (None, u'subchild_2', u'func'): (u'subchild_2', (u'roles', u'function')),
-        (None, u'NestedParentA.child_1', u'func'): (None, None),
-        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
-        (None, u'NestedParentB', u'class'): (u'NestedParentB', (u'roles', u'class')),
-        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
-    }
-
-    for (search, found) in xrefs.items():
-        assert find_obj(*search) == found
+    assert find_obj(None, u'NONEXISTANT', u'class') == (None, None)
+    assert find_obj(None, u'TopLevel', u'class') == (
+        u'TopLevel', (u'roles', u'class'))
+    assert find_obj(None, u'NestedParentA.NestedChildA', u'class') == (
+        None, None)
+    assert find_obj(None, u'subchild_2', u'func') == (
+        u'subchild_2', (u'roles', u'function'))

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -33,31 +33,16 @@ def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
     calls_expected = {
         (None, u'TopLevel', u'class'): (u'TopLevel', (u'roles', u'class')),
         (None, u'top_level', u'func'): (u'top_level', (u'roles', u'function')),
-        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
-        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
+        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
+        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
+        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function')),
+        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
+        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
         (None, u'subchild_2', u'func'): (u'subchild_2', (u'roles', u'function')),
         (None, u'NestedParentA.child_1', u'func'): (None, None),
-        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
-        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
+        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
         (None, u'NestedParentB', u'class'): (u'NestedParentB', (u'roles', u'class')),
-        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
-        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
-        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function'))
+        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
     }
 
     assert calls_expected == calls
-
-    with pytest.raises(KeyError):
-        assert (calls[('NestedParentA.NestedChildA', 'subchild_2',
-                       'func')] \
-                == ('NestedParentA.NestedChildA.subchild_2',
-                    ('roles', 'function')))
-    with pytest.raises(KeyError):
-        assert (calls[('NestedParentA.NestedChildA',
-                       'NestedParentA.child_1', 'func')] \
-                == ('NestedParentA.child_1', ('roles', 'function')))
-    with pytest.raises(KeyError):
-        assert (calls[('NestedParentA', 'NestedChildA.subchild_2',
-                       'func')] \
-                == ('NestedParentA.NestedChildA.subchild_2',
-                    ('roles', 'function')))

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -66,39 +66,31 @@ def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
     app.builder.build_all()
 
     calls_expected = {
-        (None, u'NestedChildA.subchild_1', u'meth'): [],
-        (u'NestedParentA', u'NestedChildA.subchild_2', u'meth'): [
-            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
-        ],
-        (u'NestedParentA.NestedChildA', u'subchild_2', u'meth'): [
-            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
-        ],
-        (None, u'TopLevel', u'class'): [(u'TopLevel', (u'roles', u'class'))],
-        (u'NestedParentA.NestedChildA', u'NestedParentA.child_1', u'meth'): [
-            (u'NestedParentA.child_1', (u'roles', u'method'))
-        ],
-        (None, u'NestedParentA.NestedChildA', u'class'): [
-            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
-        ],
-        (None, u'top_level', u'meth'): [(u'top_level', (u'roles', u'method'))],
-        (u'NestedParentA', u'child_2', u'meth'): [
-            (u'child_2', (u'roles', u'method'))
-        ],
-        (u'NestedParentA', u'NestedChildA', u'class'): [
-            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
-        ],
-        (u'NestedParentA', u'any_child', None): [
-            (u'NestedParentA.any_child', (u'roles', u'method'))
-        ],
+        (None, u'TopLevel', u'class'): [
+            (u'TopLevel', (u'roles', u'class'))],
+        (None, u'top_level', u'meth'): [
+            (u'top_level', (u'roles', u'method'))],
         (u'NestedParentA', u'child_1', u'meth'): [
-            (u'NestedParentA.child_1', (u'roles', u'method'))
-        ],
-        (u'NestedParentB', u'NestedParentB', u'class'): [
-            (u'NestedParentB', (u'roles', u'class'))
-        ],
+            (u'NestedParentA.child_1', (u'roles', u'method'))],
+        (u'NestedParentA', u'NestedChildA.subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))],
+        (u'NestedParentA', u'child_2', u'meth'): [
+            (u'child_2', (u'roles', u'method'))],
+        (u'NestedParentA', u'any_child', None): [
+            (u'NestedParentA.any_child', (u'roles', u'method'))],
+        (u'NestedParentA', u'NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))],
+        (u'NestedParentA.NestedChildA', u'subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))],
+        (u'NestedParentA.NestedChildA', u'NestedParentA.child_1', u'meth'): [
+            (u'NestedParentA.child_1', (u'roles', u'method'))],
+        (None, u'NestedChildA.subchild_1', u'meth'): [],
         (u'NestedParentB', u'child_1', u'meth'): [
-            (u'NestedParentB.child_1', (u'roles', u'method'))
-        ]
+            (u'NestedParentB.child_1', (u'roles', u'method'))],
+        (u'NestedParentB', u'NestedParentB', u'class'): [
+            (u'NestedParentB', (u'roles', u'class'))],
+        (None, u'NestedParentA.NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))],
     }
 
     assert calls_expected == calls

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -10,6 +10,7 @@
 """
 
 from six import text_type
+import pytest
 
 from sphinx import addnodes
 from sphinx.domains.python import py_sig_re, _pseudo_parse_arglist
@@ -44,3 +45,60 @@ def test_function_signatures():
 
     rv = parse('func(a=[][, b=None])')
     assert text_type(rv) == u'a=[], [b=None]'
+
+
+@pytest.mark.sphinx(testroot='domain-py')
+def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
+    from sphinx.domains.python import PythonDomain
+
+    calls = {}
+
+    def wrapped_find_obj(fn):
+        def wrapped(*args):
+            ret = fn(*args)
+            # args = [domain, env, ??, env object, role text, role type, order]
+            calls[args[3:-1]] = ret
+            return ret
+        return wrapped
+
+    PythonDomain.find_obj = wrapped_find_obj(PythonDomain.find_obj)
+
+    app.builder.build_all()
+
+    calls_expected = {
+        (None, u'NestedChildA.subchild_1', u'meth'): [],
+        (u'NestedParentA', u'NestedChildA.subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
+        ],
+        (u'NestedParentA.NestedChildA', u'subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
+        ],
+        (None, u'TopLevel', u'class'): [(u'TopLevel', (u'roles', u'class'))],
+        (u'NestedParentA.NestedChildA', u'NestedParentA.child_1', u'meth'): [
+            (u'NestedParentA.child_1', (u'roles', u'method'))
+        ],
+        (None, u'NestedParentA.NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
+        ],
+        (None, u'top_level', u'meth'): [(u'top_level', (u'roles', u'method'))],
+        (u'NestedParentA', u'child_2', u'meth'): [
+            (u'child_2', (u'roles', u'method'))
+        ],
+        (u'NestedParentA', u'NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
+        ],
+        (u'NestedParentA', u'any_child', None): [
+            (u'NestedParentA.any_child', (u'roles', u'method'))
+        ],
+        (u'NestedParentA', u'child_1', u'meth'): [
+            (u'NestedParentA.child_1', (u'roles', u'method'))
+        ],
+        (u'NestedParentB', u'NestedParentB', u'class'): [
+            (u'NestedParentB', (u'roles', u'class'))
+        ],
+        (u'NestedParentB', u'child_1', u'meth'): [
+            (u'NestedParentB.child_1', (u'roles', u'method'))
+        ]
+    }
+
+    assert calls_expected == calls


### PR DESCRIPTION
These are just the passing test cases for the domains currently. I am going to
patch up issues with nesting on both domains to start, so these are the test
cases I'll be testing against. I'll see about addressing the other core
domains, or at very least the cpp domain, with similar tests if this looks
okay.

So far, these tests only test against methods/functions for the basic nesting
structure. More complete tests will test additional domain roles.

Refs #662