### PR TITLE
Add warning messages for required EPUB3 metadata

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,8 @@ Features added
   (refs: #3416)
 * Use for LuaLaTeX same default settings as for XeLaTeX (i.e. ``fontspec`` and
   ``polyglossia``). (refs: #3070, #3466)
+* #3463: Add warning messages for required EPUB3 metadata. Add default value to
+  ``epub_description`` to avoid warning like other settings.
 
 Bugs fixed
 ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1289,7 +1289,7 @@ the `Dublin Core metadata <http://dublincore.org/>`_.
 
 .. confval:: epub_description
 
-   The description of the document. The default value is ``''``.
+   The description of the document. The default value is ``'unknown'``.
 
    .. versionadded:: 1.4
 

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -65,6 +65,7 @@ class Epub3Builder(EpubBuilder):
     def handle_finish(self):
         # type: () -> None
         """Create the metainfo files and finally the epub."""
+        self.validate_config_value()
         self.get_toc()
         self.build_mimetype(self.outdir, 'mimetype')
         self.build_container(self.outdir, 'META-INF/container.xml')
@@ -72,6 +73,44 @@ class Epub3Builder(EpubBuilder):
         self.build_navigation_doc(self.outdir, 'nav.xhtml')
         self.build_toc(self.outdir, 'toc.ncx')
         self.build_epub(self.outdir, self.config.epub_basename + '.epub')
+
+    def validate_config_value(self):
+        # <package> lang attribute, dc:language
+        if not self.app.config.epub_language:
+            self.app.warn(
+                'conf value "epub_language" (or "language") '
+                'should not be empty for EPUB3')
+        # <package> unique-identifier attribute
+        if not self.app.config.epub_uid:
+            self.app.warn('conf value "epub_uid" should not be empty for EPUB3')
+        # dc:title
+        if not self.app.config.epub_title:
+            self.app.warn(
+                'conf value "epub_title" (or "html_title") '
+                'should not be empty for EPUB3')
+        # dc:creator
+        if not self.app.config.epub_author:
+            self.app.warn('conf value "epub_author" should not be empty for EPUB3')
+        # dc:contributor
+        if not self.app.config.epub_contributor:
+            self.app.warn('conf value "epub_contributor" should not be empty for EPUB3')
+        # dc:description
+        if not self.app.config.epub_description:
+            self.app.warn('conf value "epub_description" should not be empty for EPUB3')
+        # dc:publisher
+        if not self.app.config.epub_publisher:
+            self.app.warn('conf value "epub_publisher" should not be empty for EPUB3')
+        # dc:rights
+        if not self.app.config.epub_copyright:
+            self.app.warn(
+                'conf value "epub_copyright" (or "copyright")'
+                'should not be empty for EPUB3')
+        # dc:identifier
+        if not self.app.config.epub_identifier:
+            self.app.warn('conf value "epub_identifier" should not be empty for EPUB3')
+        # meta ibooks:version
+        if not self.app.config.version:
+            self.app.warn('conf value "version" should not be empty for EPUB3')
 
     def content_metadata(self):
         # type: () -> Dict
@@ -179,7 +218,7 @@ def setup(app):
     app.setup_extension('sphinx.builders.epub')
     app.add_builder(Epub3Builder)
 
-    app.add_config_value('epub_description', '', 'epub3', string_classes)
+    app.add_config_value('epub_description', 'unknown', 'epub3', string_classes)
     app.add_config_value('epub_contributor', 'unknown', 'epub3', string_classes)
     app.add_config_value('epub_writing_mode', 'horizontal', 'epub3',
                          ENUM('horizontal', 'vertical'))

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -84,7 +84,7 @@ def test_build_epub(app):
     metadata = opf.find("./idpf:metadata")
     assert metadata.find("./dc:language").text == 'en'
     assert metadata.find("./dc:title").text == 'Python  documentation'
-    assert metadata.find("./dc:description").text is None
+    assert metadata.find("./dc:description").text == 'unknown'
     assert metadata.find("./dc:creator").text == 'unknown'
     assert metadata.find("./dc:contributor").text == 'unknown'
     assert metadata.find("./dc:publisher").text == 'unknown'


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
- Feature

### Purpose
- Detect warning of EPUB validator during Sphinx build

### Detail
- Check the required properties are empty or not

### Sample conf.py

```
epub_contributor = ''
epub_description = ''
epub_uid = ''
epub_publisher = ''
epub_title = ''
epub_author = ''
epub_language = ''
epub_identifier = ''
epub_copyright = ''
epub_scheme = ''
```

### Sample warning messages

```
$ make epub                                                                                                                                                                      [fix/epub_dublincore_validation_error]
Running Sphinx v1.5.3+/00091863
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [epub]: targets for 1 source files that are out of date
updating environment: 1 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                                                                                                                            
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index                                                                                                                                                                                                             
generating indices... genindex
writing additional pages...
copying static files... done
copying extra files... done
WARNING: conf value "epub_language" (or "language")  should not be empty for EPUB3
WARNING: conf value "epub_uid" should not be empty for EPUB3
WARNING: conf value "epub_title" (or "html_title")  should not be empty for EPUB3
WARNING: conf value "epub_author" should not be empty for EPUB3
WARNING: conf value "epub_contributor" should not be empty for EPUB3
WARNING: conf value "epub_description" should not be empty for EPUB3
WARNING: conf value "epub_publisher" should not be empty for EPUB3
WARNING: conf value "epub_copyright" (or "copyright") should not be empty for EPUB3
WARNING: conf value "epub_identifier" should not be empty for EPUB3
WARNING: conf value "version" should not be empty for EPUB3
```

### Test result of EPUB validator

<img width="1031" alt="2017-02-26 10 40 14" src="https://cloud.githubusercontent.com/assets/564612/23336335/fe9575ca-fc0f-11e6-96e9-d53e8890bc45.png">
