### PR TITLE
Fix Python domain nesting

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -151,6 +151,9 @@ class PyTypedField(PyXrefMixin, TypedField):
 class PyObject(ObjectDescription):
     """
     Description of a general Python object.
+
+    :cvar allow_nesting: Class is an object that allows for nested namespaces
+    :vartype allow_nesting: bool
     """
     option_spec = {
         'noindex': directives.flag,
@@ -176,6 +179,8 @@ class PyObject(ObjectDescription):
         PyField('returntype', label=l_('Return type'), has_arg=False,
                 names=('rtype',), bodyrolename='obj'),
     ]
+
+    allow_nesting = False
 
     def get_signature_prefix(self, sig):
         # type: (unicode) -> unicode
@@ -302,6 +307,56 @@ class PyObject(ObjectDescription):
             self.indexnode['entries'].append(('single', indextext,
                                               fullname, '', None))
 
+    def before_content(self):
+        """Handle object nesting before content
+
+        If this class is a nestable object, such as a class object, build up a
+        representation of the nesting heirarchy so that de-nesting multiple
+        levels works correctly.
+
+        If this class isn't a nestable object, just set the current class name
+        using the object prefix, if any. This class name will be removed with
+        :py:meth:`after_content`, and is not added to the list of nested
+        classes.
+        """
+        # type: () -> None
+        prefix = None
+        if self.names:
+            (cls_name, cls_name_prefix) = self.names.pop()
+            prefix = cls_name_prefix.strip('.') if cls_name_prefix else None
+            if self.allow_nesting:
+                prefix = cls_name
+        if prefix:
+            self.env.ref_context['py:class'] = prefix
+            if self.allow_nesting:
+                try:
+                    self.env.ref_context['py:classes'].append(prefix)
+                except (AttributeError, KeyError):
+                    self.env.ref_context['py:classes'] = [prefix]
+
+    def after_content(self):
+        """Handle object de-nesting after content
+
+        If this class is a nestable object, removing the last nested class prefix
+        ends further nesting in the object.
+
+        If this class is not a nestable object, the list of classes should not
+        be altered as we didn't affect the nesting levels in
+        :py:meth:`before_content`.
+        """
+        # type: () -> None
+        if self.allow_nesting:
+            try:
+                self.env.ref_context['py:classes'].pop()
+            except (KeyError, IndexError):
+                self.env.ref_context['py:classes'] = []
+        try:
+            cls_name = self.env.ref_context.get('py:classes', [])[-1]
+        except IndexError:
+            cls_name = None
+        finally:
+            self.env.ref_context['py:class'] = cls_name
+
 
 class PyModulelevel(PyObject):
     """
@@ -331,6 +386,8 @@ class PyClasslike(PyObject):
     Description of a class-like object (classes, interfaces, exceptions).
     """
 
+    allow_nesting = True
+
     def get_signature_prefix(self, sig):
         # type: (unicode) -> unicode
         return self.objtype + ' '
@@ -345,28 +402,6 @@ class PyClasslike(PyObject):
             return name_cls[0]
         else:
             return ''
-
-    def before_content(self):
-        # type: () -> None
-        PyObject.before_content(self)
-        if self.names:
-            (cls_name, cls_name_prefix) = self.names.pop()
-            try:
-                self.env.ref_context['py:classes'].append(cls_name)
-            except (AttributeError, KeyError):
-                self.env.ref_context['py:classes'] = [cls_name]
-            finally:
-                self.env.ref_context['py:class'] = cls_name
-
-    def after_content(self):
-        # type: () -> None
-        try:
-            self.env.ref_context['py:classes'].pop()
-            cls_name = self.env.ref_context['py:classes'][-1]
-            self.env.ref_context['py:class'] = cls_name
-        except (KeyError, IndexError):
-            self.env.ref_context['py:classes'] = []
-            self.env.ref_context['py:class'] = None
 
 
 class PyClassmember(PyObject):
@@ -442,14 +477,6 @@ class PyClassmember(PyObject):
                 return _('%s (%s attribute)') % (attrname, clsname)
         else:
             return ''
-
-    def before_content(self):
-        # type: () -> None
-        PyObject.before_content(self)
-        lastname = self.names and self.names[-1][1]
-        if lastname and not self.env.ref_context.get('py:class'):
-            lastname = lastname.strip('.')
-            self.env.ref_context['py:class'] = lastname
 
 
 class PyDecoratorMixin(object):

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -308,6 +308,7 @@ class PyObject(ObjectDescription):
                                               fullname, '', None))
 
     def before_content(self):
+        # type: () -> None
         """Handle object nesting before content
 
         If this class is a nestable object, such as a class object, build up a
@@ -319,7 +320,6 @@ class PyObject(ObjectDescription):
         :py:meth:`after_content`, and is not added to the list of nested
         classes.
         """
-        # type: () -> None
         prefix = None
         if self.names:
             (cls_name, cls_name_prefix) = self.names.pop()
@@ -335,6 +335,7 @@ class PyObject(ObjectDescription):
                     self.env.ref_context['py:classes'] = [prefix]
 
     def after_content(self):
+        # type: () -> None
         """Handle object de-nesting after content
 
         If this class is a nestable object, removing the last nested class prefix
@@ -344,7 +345,6 @@ class PyObject(ObjectDescription):
         be altered as we didn't affect the nesting levels in
         :py:meth:`before_content`.
         """
-        # type: () -> None
         if self.allow_nesting:
             try:
                 self.env.ref_context['py:classes'].pop()

--- a/tests/roots/test-domain-js/conf.py
+++ b/tests/roots/test-domain-js/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+html_theme = 'classic'
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-js/index.rst
+++ b/tests/roots/test-domain-js/index.rst
@@ -1,0 +1,6 @@
+test-domain-js
+==============
+
+.. toctree::
+
+    roles

--- a/tests/roots/test-domain-js/roles.rst
+++ b/tests/roots/test-domain-js/roles.rst
@@ -5,20 +5,44 @@ roles
 
 .. js:function:: top_level
 
+* :js:class:`TopLevel`
+* :js:func:`top_level`
+
+
 .. js:class:: NestedParentA
+
+    * Link to :js:func:`child_1`
 
     .. js:function:: child_1()
 
+        * Link to :js:func:`NestedChildA.subchild_2`
+        * Link to :js:func:`child_2`
+        * Link to :any:`any_child`
+
     .. js:function:: any_child()
+
+        * Link to :js:class:`NestedChildA`
 
     .. js:class:: NestedChildA
 
         .. js:function:: subchild_1()
 
+            * Link to :js:func:`subchild_2`
+
         .. js:function:: subchild_2()
+
+            Link to :js:func:`NestedParentA.child_1`
 
     .. js:function:: child_2()
 
+        Link to :js:func:`NestedChildA.subchild_1`
+
 .. js:class:: NestedParentB
 
+    * Link to :js:func:`child_1`
+
     .. js:function:: child_1()
+
+        * Link to :js:class:`NestedParentB`
+
+* :js:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-js/roles.rst
+++ b/tests/roots/test-domain-js/roles.rst
@@ -1,0 +1,45 @@
+.. js:class:: TopLevel
+
+.. js:function:: top_level
+
+* :js:class:`TopLevel`
+* :js:func:`top_level`
+
+
+.. js:class:: NestedParentA
+
+    * Link to :js:func:`child_1`
+
+    .. js:function:: child_1()
+
+        * Link to :js:func:`NestedChildA.subchild_2`
+        * Link to :js:func:`child_2`
+        * Link to :any:`any_child`
+
+    .. js:function:: any_child()
+
+        * Link to :js:class:`NestedChildA`
+
+    .. js:class:: NestedChildA
+
+        .. js:function:: subchild_1()
+
+            * Link to :js:func:`subchild_2`
+
+        .. js:function:: subchild_2()
+
+            Link to :js:func:`NestedParentA.child_1`
+
+    .. js:function:: child_2()
+
+        Link to :js:func:`NestedChildA.subchild_1`
+
+.. js:class:: NestedParentB
+
+    * Link to :js:func:`child_1`
+
+    .. js:function:: child_1()
+
+        * Link to :js:class:`NestedParentB`
+
+* :js:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-js/roles.rst
+++ b/tests/roots/test-domain-js/roles.rst
@@ -1,45 +1,24 @@
+roles
+=====
+
 .. js:class:: TopLevel
 
 .. js:function:: top_level
 
-* :js:class:`TopLevel`
-* :js:func:`top_level`
-
-
 .. js:class:: NestedParentA
-
-    * Link to :js:func:`child_1`
 
     .. js:function:: child_1()
 
-        * Link to :js:func:`NestedChildA.subchild_2`
-        * Link to :js:func:`child_2`
-        * Link to :any:`any_child`
-
     .. js:function:: any_child()
-
-        * Link to :js:class:`NestedChildA`
 
     .. js:class:: NestedChildA
 
         .. js:function:: subchild_1()
 
-            * Link to :js:func:`subchild_2`
-
         .. js:function:: subchild_2()
-
-            Link to :js:func:`NestedParentA.child_1`
 
     .. js:function:: child_2()
 
-        Link to :js:func:`NestedChildA.subchild_1`
-
 .. js:class:: NestedParentB
 
-    * Link to :js:func:`child_1`
-
     .. js:function:: child_1()
-
-        * Link to :js:class:`NestedParentB`
-
-* :js:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-py/conf.py
+++ b/tests/roots/test-domain-py/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+html_theme = 'classic'
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-py/index.rst
+++ b/tests/roots/test-domain-py/index.rst
@@ -4,3 +4,4 @@ test-domain-py
 .. toctree::
 
     roles
+    module

--- a/tests/roots/test-domain-py/index.rst
+++ b/tests/roots/test-domain-py/index.rst
@@ -1,0 +1,6 @@
+test-domain-py
+==============
+
+.. toctree::
+
+    roles

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -1,13 +1,22 @@
 module
-------
+======
 
 .. py:module:: module_a.submodule
 
+* Link to :py:cls:`ModTopLevel`
+
 .. py:class:: ModTopLevel
+
+    * Link to :py:meth:`mod_child_1`
+    * Link to :py:meth:`ModTopLevel.mod_child_1`
 
 .. py:method:: ModTopLevel.mod_child_1
 
+    * Link to :py:meth:`mod_child_2`
+
 .. py:method:: ModTopLevel.mod_child_2
+
+    * Link to :py:meth:`module_a.submodule.ModTopLevel.mod_child_1`
 
 .. py:currentmodule:: None
 
@@ -15,4 +24,8 @@ module
 
 .. py:module:: module_b.submodule
 
+* Link to :py:cls:`ModTopLevel`
+
 .. py:class:: ModTopLevel
+
+    * Link to :py:cls:`ModNoModule`

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -3,7 +3,7 @@ module
 
 .. py:module:: module_a.submodule
 
-* Link to :py:cls:`ModTopLevel`
+* Link to :py:class:`ModTopLevel`
 
 .. py:class:: ModTopLevel
 
@@ -24,8 +24,8 @@ module
 
 .. py:module:: module_b.submodule
 
-* Link to :py:cls:`ModTopLevel`
+* Link to :py:class:`ModTopLevel`
 
 .. py:class:: ModTopLevel
 
-    * Link to :py:cls:`ModNoModule`
+    * Link to :py:class:`ModNoModule`

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -1,0 +1,18 @@
+module
+------
+
+.. py:module:: module_a.submodule
+
+.. py:class:: ModTopLevel
+
+.. py:method:: ModTopLevel.mod_child_1
+
+.. py:method:: ModTopLevel.mod_child_2
+
+.. py:currentmodule:: None
+
+.. py:class:: ModNoModule
+
+.. py:module:: module_b.submodule
+
+.. py:class:: ModTopLevel

--- a/tests/roots/test-domain-py/roles.rst
+++ b/tests/roots/test-domain-py/roles.rst
@@ -1,24 +1,48 @@
 roles
------
+=====
 
 .. py:class:: TopLevel
 
 .. py:method:: top_level
 
+* :py:class:`TopLevel`
+* :py:meth:`top_level`
+
+
 .. py:class:: NestedParentA
+
+    * Link to :py:meth:`child_1`
 
     .. py:method:: child_1()
 
+        * Link to :py:meth:`NestedChildA.subchild_2`
+        * Link to :py:meth:`child_2`
+        * Link to :any:`any_child`
+
     .. py:method:: any_child()
+
+        * Link to :py:class:`NestedChildA`
 
     .. py:class:: NestedChildA
 
         .. py:method:: subchild_1()
 
+            * Link to :py:meth:`subchild_2`
+
         .. py:method:: subchild_2()
+
+            Link to :py:meth:`NestedParentA.child_1`
 
     .. py:method:: child_2()
 
+        Link to :py:meth:`NestedChildA.subchild_1`
+
 .. py:class:: NestedParentB
 
+    * Link to :py:meth:`child_1`
+
     .. py:method:: child_1()
+
+        * Link to :py:class:`NestedParentB`
+
+* :py:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-py/roles.rst
+++ b/tests/roots/test-domain-py/roles.rst
@@ -1,0 +1,48 @@
+roles
+-----
+
+.. py:class:: TopLevel
+
+.. py:method:: top_level
+
+* :py:class:`TopLevel`
+* :py:meth:`top_level`
+
+
+.. py:class:: NestedParentA
+
+    * Link to :py:meth:`child_1`
+
+    .. py:method:: child_1()
+
+        * Link to :py:meth:`NestedChildA.subchild_2`
+        * Link to :py:meth:`child_2`
+        * Link to :any:`any_child`
+
+    .. py:method:: any_child()
+
+        * Link to :py:class:`NestedChildA`
+
+    .. py:class:: NestedChildA
+
+        .. py:method:: subchild_1()
+
+            * Link to :py:meth:`subchild_2`
+
+        .. py:method:: subchild_2()
+
+            Link to :py:meth:`NestedParentA.child_1`
+
+    .. py:method:: child_2()
+
+        Link to :py:meth:`NestedChildA.subchild_1`
+
+.. py:class:: NestedParentB
+
+    * Link to :py:meth:`child_1`
+
+    .. py:method:: child_1()
+
+        * Link to :py:class:`NestedParentB`
+
+* :py:class:`NestedParentA.NestedChildA`

--- a/tests/roots/test-domain-py/roles.rst
+++ b/tests/roots/test-domain-py/roles.rst
@@ -5,44 +5,20 @@ roles
 
 .. py:method:: top_level
 
-* :py:class:`TopLevel`
-* :py:meth:`top_level`
-
-
 .. py:class:: NestedParentA
-
-    * Link to :py:meth:`child_1`
 
     .. py:method:: child_1()
 
-        * Link to :py:meth:`NestedChildA.subchild_2`
-        * Link to :py:meth:`child_2`
-        * Link to :any:`any_child`
-
     .. py:method:: any_child()
-
-        * Link to :py:class:`NestedChildA`
 
     .. py:class:: NestedChildA
 
         .. py:method:: subchild_1()
 
-            * Link to :py:meth:`subchild_2`
-
         .. py:method:: subchild_2()
-
-            Link to :py:meth:`NestedParentA.child_1`
 
     .. py:method:: child_2()
 
-        Link to :py:meth:`NestedChildA.subchild_1`
-
 .. py:class:: NestedParentB
 
-    * Link to :py:meth:`child_1`
-
     .. py:method:: child_1()
-
-        * Link to :py:class:`NestedParentB`
-
-* :py:class:`NestedParentA.NestedChildA`

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+    test_domain_js
+    ~~~~~~~~~~~~~~
+
+    Tests the JavaScript Domain
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+
+@pytest.mark.sphinx(testroot='domain-js')
+def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
+    from sphinx.domains.javascript import JavaScriptDomain
+
+    calls = {}
+
+    def wrapped_find_obj(fn):
+        def wrapped(*args):
+            ret = fn(*args)
+            # args = [domain, env, env object, role text, role type, order]
+            calls[args[2:-1]] = ret
+            return ret
+        return wrapped
+
+    JavaScriptDomain.find_obj = wrapped_find_obj(JavaScriptDomain.find_obj)
+
+    app.builder.build_all()
+
+    calls_expected = {
+        (None, u'TopLevel', u'class'): (u'TopLevel', (u'roles', u'class')),
+        (None, u'top_level', u'func'): (u'top_level', (u'roles', u'function')),
+        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
+        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
+        (None, u'subchild_2', u'func'): (u'subchild_2', (u'roles', u'function')),
+        (None, u'NestedParentA.child_1', u'func'): (None, None),
+        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
+        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
+        (None, u'NestedParentB', u'class'): (u'NestedParentB', (u'roles', u'class')),
+        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
+        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
+        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function'))
+    }
+
+    assert calls_expected == calls
+
+    with pytest.raises(KeyError):
+        assert (calls[('NestedParentA.NestedChildA', 'subchild_2',
+                       'func')] \
+                == ('NestedParentA.NestedChildA.subchild_2',
+                    ('roles', 'function')))
+    with pytest.raises(KeyError):
+        assert (calls[('NestedParentA.NestedChildA',
+                       'NestedParentA.child_1', 'func')] \
+                == ('NestedParentA.child_1', ('roles', 'function')))
+    with pytest.raises(KeyError):
+        assert (calls[('NestedParentA', 'NestedChildA.subchild_2',
+                       'func')] \
+                == ('NestedParentA.NestedChildA.subchild_2',
+                    ('roles', 'function')))

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -10,6 +10,32 @@
 """
 
 import pytest
+import mock
+
+
+@pytest.mark.sphinx(testroot='domain-js')
+def test_domain_js_xrefs(app, status, warning):
+    """Domain objects have correct prefixes when looking up xrefs"""
+    find_obj = app.env.domains['js'].find_obj
+    app.env.domains['js'].find_obj = mock.Mock(wraps=find_obj)
+    app.builder.build_all()
+
+    def assert_called(prefix, obj_name, obj_type, searchmode=0):
+        app.env.domains['js'].find_obj.assert_any_call(
+            app.env, prefix, obj_name, obj_type, searchmode)
+
+    assert_called(None, u'TopLevel', u'class')
+    assert_called(None, u'top_level', u'func')
+    assert_called(None, u'child_1', u'func')
+    assert_called(None, u'NestedChildA.subchild_2', u'func')
+    assert_called(None, u'child_2', u'func')
+    assert_called(None, u'any_child', None, 1)
+    assert_called(None, u'NestedChildA', u'class')
+    assert_called(None, u'subchild_2', u'func')
+    assert_called(None, u'NestedParentA.child_1', u'func')
+    assert_called(None, u'NestedChildA.subchild_1', u'func')
+    assert_called(None, u'NestedParentB', u'class')
+    assert_called(None, u'NestedParentA.NestedChildA', u'class')
 
 
 @pytest.mark.sphinx(testroot='domain-js')
@@ -39,21 +65,10 @@ def test_domain_js_find_obj(app, status, warning):
 
     app.builder.build_all()
 
-    xrefs = {
-        (None, u'NONEXISTANT', u'class'): (None, None),
-        (None, u'TopLevel', u'class'): (u'TopLevel', (u'roles', u'class')),
-        (None, u'top_level', u'func'): (u'top_level', (u'roles', u'function')),
-        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
-        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
-        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function')),
-        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
-        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
-        (None, u'subchild_2', u'func'): (u'subchild_2', (u'roles', u'function')),
-        (None, u'NestedParentA.child_1', u'func'): (None, None),
-        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
-        (None, u'NestedParentB', u'class'): (u'NestedParentB', (u'roles', u'class')),
-        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
-    }
-
-    for (search, found) in xrefs.items():
-        assert find_obj(*search) == found
+    assert find_obj(None, u'NONEXISTANT', u'class') == (None, None)
+    assert find_obj(None, u'TopLevel', u'class') == (
+        u'TopLevel', (u'roles', u'class'))
+    assert find_obj(None, u'NestedParentA.NestedChildA', u'class') == (
+        None, None)
+    assert find_obj(None, u'subchild_2', u'func') == (
+        u'subchild_2', (u'roles', u'function'))

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -33,31 +33,16 @@ def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
     calls_expected = {
         (None, u'TopLevel', u'class'): (u'TopLevel', (u'roles', u'class')),
         (None, u'top_level', u'func'): (u'top_level', (u'roles', u'function')),
-        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
-        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
+        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
+        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
+        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function')),
+        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
+        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
         (None, u'subchild_2', u'func'): (u'subchild_2', (u'roles', u'function')),
         (None, u'NestedParentA.child_1', u'func'): (None, None),
-        (None, u'NestedChildA.subchild_2', u'func'): (None, None),
-        (None, u'NestedChildA', u'class'): (u'NestedChildA', (u'roles', u'class')),
+        (None, u'NestedChildA.subchild_1', u'func'): (None, None),
         (None, u'NestedParentB', u'class'): (u'NestedParentB', (u'roles', u'class')),
-        (None, u'any_child', None): (u'any_child', (u'roles', u'function')),
-        (None, u'child_1', u'func'): (u'child_1', (u'roles', u'function')),
-        (None, u'child_2', u'func'): (u'child_2', (u'roles', u'function'))
+        (None, u'NestedParentA.NestedChildA', u'class'): (None, None),
     }
 
     assert calls_expected == calls
-
-    with pytest.raises(KeyError):
-        assert (calls[('NestedParentA.NestedChildA', 'subchild_2',
-                       'func')] \
-                == ('NestedParentA.NestedChildA.subchild_2',
-                    ('roles', 'function')))
-    with pytest.raises(KeyError):
-        assert (calls[('NestedParentA.NestedChildA',
-                       'NestedParentA.child_1', 'func')] \
-                == ('NestedParentA.child_1', ('roles', 'function')))
-    with pytest.raises(KeyError):
-        assert (calls[('NestedParentA', 'NestedChildA.subchild_2',
-                       'func')] \
-                == ('NestedParentA.NestedChildA.subchild_2',
-                    ('roles', 'function')))

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -66,39 +66,31 @@ def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
     app.builder.build_all()
 
     calls_expected = {
-        (None, u'NestedChildA.subchild_1', u'meth'): [],
-        (u'NestedParentA', u'NestedChildA.subchild_2', u'meth'): [
-            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
-        ],
-        (u'NestedParentA.NestedChildA', u'subchild_2', u'meth'): [
-            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
-        ],
-        (None, u'TopLevel', u'class'): [(u'TopLevel', (u'roles', u'class'))],
-        (u'NestedParentA.NestedChildA', u'NestedParentA.child_1', u'meth'): [
-            (u'NestedParentA.child_1', (u'roles', u'method'))
-        ],
-        (None, u'NestedParentA.NestedChildA', u'class'): [
-            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
-        ],
-        (None, u'top_level', u'meth'): [(u'top_level', (u'roles', u'method'))],
-        (u'NestedParentA', u'child_2', u'meth'): [
-            (u'child_2', (u'roles', u'method'))
-        ],
-        (u'NestedParentA', u'NestedChildA', u'class'): [
-            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
-        ],
-        (u'NestedParentA', u'any_child', None): [
-            (u'NestedParentA.any_child', (u'roles', u'method'))
-        ],
+        (None, u'TopLevel', u'class'): [
+            (u'TopLevel', (u'roles', u'class'))],
+        (None, u'top_level', u'meth'): [
+            (u'top_level', (u'roles', u'method'))],
         (u'NestedParentA', u'child_1', u'meth'): [
-            (u'NestedParentA.child_1', (u'roles', u'method'))
-        ],
-        (u'NestedParentB', u'NestedParentB', u'class'): [
-            (u'NestedParentB', (u'roles', u'class'))
-        ],
+            (u'NestedParentA.child_1', (u'roles', u'method'))],
+        (u'NestedParentA', u'NestedChildA.subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))],
+        (u'NestedParentA', u'child_2', u'meth'): [
+            (u'child_2', (u'roles', u'method'))],
+        (u'NestedParentA', u'any_child', None): [
+            (u'NestedParentA.any_child', (u'roles', u'method'))],
+        (u'NestedParentA', u'NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))],
+        (u'NestedParentA.NestedChildA', u'subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))],
+        (u'NestedParentA.NestedChildA', u'NestedParentA.child_1', u'meth'): [
+            (u'NestedParentA.child_1', (u'roles', u'method'))],
+        (None, u'NestedChildA.subchild_1', u'meth'): [],
         (u'NestedParentB', u'child_1', u'meth'): [
-            (u'NestedParentB.child_1', (u'roles', u'method'))
-        ]
+            (u'NestedParentB.child_1', (u'roles', u'method'))],
+        (u'NestedParentB', u'NestedParentB', u'class'): [
+            (u'NestedParentB', (u'roles', u'class'))],
+        (None, u'NestedParentA.NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))],
     }
 
     assert calls_expected == calls

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -69,24 +69,20 @@ def test_domain_py_xrefs(app, status, warning):
     assert_called(None, u'NestedParentA.NestedChildA', u'subchild_2', u'meth')
     assert_called(None, u'NestedParentA.NestedChildA', u'NestedParentA.child_1',
                   u'meth')
-    assert_called(None, None, u'NestedChildA.subchild_1', u'meth')
+    assert_called(None, u'NestedParentA', u'NestedChildA.subchild_1', u'meth')
     assert_called(None, u'NestedParentB', u'child_1', u'meth')
     assert_called(None, u'NestedParentB', u'NestedParentB', u'class')
     assert_called(None, None, u'NestedParentA.NestedChildA', u'class')
 
+    assert_called('module_a.submodule', None, 'ModTopLevel', 'class')
     assert_called('module_a.submodule', 'ModTopLevel', 'mod_child_1', 'meth')
     assert_called('module_a.submodule', 'ModTopLevel',
                   'ModTopLevel.mod_child_1', 'meth')
     assert_called('module_a.submodule', 'ModTopLevel', 'mod_child_2', 'meth')
     assert_called('module_a.submodule', 'ModTopLevel',
                   'module_a.submodule.ModTopLevel.mod_child_1', 'meth')
-
-    with pytest.raises(AssertionError):
-        assert_called('module_a.submodule', None, 'ModTopLevel', 'class')
-    with pytest.raises(AssertionError):
-        assert_called('module_b.submodule', None, 'ModTopLevel', 'class')
-    with pytest.raises(AssertionError):
-        assert_called('module_b.submodule', 'ModTopLevel', 'ModNoModule', 'class')
+    assert_called('module_b.submodule', None, 'ModTopLevel', 'class')
+    assert_called('module_b.submodule', 'ModTopLevel', 'ModNoModule', 'class')
 
 
 @pytest.mark.sphinx(testroot='domain-py')
@@ -115,7 +111,7 @@ def test_domain_py_objects(app, status, warning):
     assert objects['NestedParentA.NestedChildA'] == ('roles', 'class')
     assert objects['NestedParentA.NestedChildA.subchild_1'] == ('roles', 'method')
     assert objects['NestedParentA.NestedChildA.subchild_2'] == ('roles', 'method')
-    assert objects['child_2'] == ('roles', 'method')
+    assert objects['NestedParentA.child_2'] == ('roles', 'method')
     assert objects['NestedParentB'] == ('roles', 'class')
     assert objects['NestedParentB.child_1'] == ('roles', 'method')
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -100,6 +100,7 @@ def test_domain_py_objects(app, status, warning):
     assert objects['module_a.submodule.ModTopLevel'] == ('module', 'class')
     assert objects['module_a.submodule.ModTopLevel.mod_child_1'] == ('module', 'method')
     assert objects['module_a.submodule.ModTopLevel.mod_child_2'] == ('module', 'method')
+    assert 'ModTopLevel.ModNoModule' not in objects
     assert objects['ModNoModule'] == ('module', 'class')
     assert objects['module_b.submodule.ModTopLevel'] == ('module', 'class')
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -10,6 +10,7 @@
 """
 
 from six import text_type
+import pytest
 
 from sphinx import addnodes
 from sphinx.domains.python import py_sig_re, _pseudo_parse_arglist
@@ -44,3 +45,60 @@ def test_function_signatures():
 
     rv = parse('func(a=[][, b=None])')
     assert text_type(rv) == u'a=[], [b=None]'
+
+
+@pytest.mark.sphinx(testroot='domain-py')
+def test_build_domain_py_xrefs_resolve_correctly(app, status, warning):
+    from sphinx.domains.python import PythonDomain
+
+    calls = {}
+
+    def wrapped_find_obj(fn):
+        def wrapped(*args):
+            ret = fn(*args)
+            # args = [domain, env, ??, env object, role text, role type, order]
+            calls[args[3:-1]] = ret
+            return ret
+        return wrapped
+
+    PythonDomain.find_obj = wrapped_find_obj(PythonDomain.find_obj)
+
+    app.builder.build_all()
+
+    calls_expected = {
+        (None, u'NestedChildA.subchild_1', u'meth'): [],
+        (u'NestedParentA', u'NestedChildA.subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
+        ],
+        (u'NestedParentA.NestedChildA', u'subchild_2', u'meth'): [
+            (u'NestedParentA.NestedChildA.subchild_2', (u'roles', u'method'))
+        ],
+        (None, u'TopLevel', u'class'): [(u'TopLevel', (u'roles', u'class'))],
+        (u'NestedParentA.NestedChildA', u'NestedParentA.child_1', u'meth'): [
+            (u'NestedParentA.child_1', (u'roles', u'method'))
+        ],
+        (None, u'NestedParentA.NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
+        ],
+        (None, u'top_level', u'meth'): [(u'top_level', (u'roles', u'method'))],
+        (u'NestedParentA', u'child_2', u'meth'): [
+            (u'child_2', (u'roles', u'method'))
+        ],
+        (u'NestedParentA', u'NestedChildA', u'class'): [
+            (u'NestedParentA.NestedChildA', (u'roles', u'class'))
+        ],
+        (u'NestedParentA', u'any_child', None): [
+            (u'NestedParentA.any_child', (u'roles', u'method'))
+        ],
+        (u'NestedParentA', u'child_1', u'meth'): [
+            (u'NestedParentA.child_1', (u'roles', u'method'))
+        ],
+        (u'NestedParentB', u'NestedParentB', u'class'): [
+            (u'NestedParentB', (u'roles', u'class'))
+        ],
+        (u'NestedParentB', u'child_1', u'meth'): [
+            (u'NestedParentB.child_1', (u'roles', u'method'))
+        ]
+    }
+
+    assert calls_expected == calls


### PR DESCRIPTION
This fixes a problem with the Python domain object nesting. Because only one
object name was stored in `ref_context`, and reset to `None` in
`after_content`, nesting broke if you put anything after a nested class:

```rst
.. py:class:: Parent

    .. py:method:: foo()

        This wouldn't resolve: :py:meth:`bar`

    .. py:class:: Child

        In the `after_content` method, the object is reset to `None`, so
        anything after this in the same nesting is considered to be top level
        instead.

    .. py:method:: bar()

        This is top level, as the domain thinks the surrounding object is
        `None`
```

This depends on #3460 and will require a rebase after that is merged.