### PR TITLE
same default settings for lualatex as for xelatex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     - texlive-latex-extra
     - texlive-fonts-recommended
     - texlive-fonts-extra
+    - texlive-luatex
     - texlive-xetex
     - lmodern
 install:

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,9 @@ Incompatible changes
   relative (refs #3412)
 * ``literalinclude`` directive does not allow the combination of ``:diff:``
   option and other options (refs: #3416)
+* Default config for LuaLaTeX engine uses ``fontspec`` hence needs TeXLive 2013
+  or more recent TeX installation for compatibility. This also means that the
+  fonts used by default have changed to the defaults as chosen by ``fontspec``.
 
 Features removed
 ----------------
@@ -62,6 +65,8 @@ Features added
   headers) (refs: #3422)
 * Emit warning if over dedent has detected on ``literalinclude`` directive
   (refs: #3416)
+* Use for LuaLaTeX same default settings as for XeLaTeX (i.e. ``fontspec`` and
+  ``polyglossia``).
 
 Bugs fixed
 ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1696,6 +1696,8 @@ These options influence LaTeX output. See further :doc:`latex`.
         .. versionchanged:: 1.5
            For :confval:`latex_engine` set to ``'xelatex'``, the default
            is ``'\\usepackage{polyglossia}\n\\setmainlanguage{<language>}'``.
+        .. versionchanged:: 1.6
+           ``'lualatex'`` uses same default setting as ``'xelatex'``
      ``'fontpkg'``
         Font package inclusion, default ``'\\usepackage{times}'`` (which uses
         Times and Helvetica).  You can set this to ``''`` to use the Computer
@@ -1706,6 +1708,8 @@ These options influence LaTeX output. See further :doc:`latex`.
            script.
         .. versionchanged:: 1.5
            Defaults to ``''`` when :confval:`latex_engine` is ``'xelatex'``.
+        .. versionchanged:: 1.6
+           Defaults to ``''`` also with ``'lualatex'``.
      ``'fncychap'``
         Inclusion of the "fncychap" package (which makes fancy chapter titles),
         default ``'\\usepackage[Bjarne]{fncychap}'`` for English documentation
@@ -1771,6 +1775,8 @@ These options influence LaTeX output. See further :doc:`latex`.
         .. versionchanged:: 1.5
            Defaults to ``'\\usepackage{fontspec}'`` when
            :confval:`latex_engine` is ``'xelatex'``.
+        .. versionchanged:: 1.6
+           ``'lualatex'`` also uses ``fontspec`` per default.
      ``'geometry'``
         "geometry" package inclusion, the default definition is:
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -120,6 +120,10 @@ ADDITIONAL_SETTINGS = {
     },
     'lualatex': {
         'latex_engine': 'lualatex',
+        'polyglossia':  '\\usepackage{polyglossia}',
+        'babel':        '',
+        'fontenc':      '\\usepackage{fontspec}',
+        'fontpkg':      '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'
                         '{\\leavevmode\\nobreak\\ }'),
     },
@@ -577,7 +581,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # set up multilingual module...
         # 'babel' key is public and user setting must be obeyed
         if self.elements['babel']:
-            # this branch is not taken for xelatex with writer default settings
+            # this branch is not taken for xelatex/lualatex if default settings
             self.elements['multilingual'] = self.elements['babel']
             if builder.config.language:
                 self.elements['shorthandoff'] = self.babel.get_shorthandoff()

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -14,6 +14,7 @@ import os
 import re
 from itertools import product
 from subprocess import Popen, PIPE
+from shutil import copyfile
 
 from six import PY3
 import pytest
@@ -67,6 +68,9 @@ def compile_latex_document(app):
     with cd(app.outdir):
         try:
             ensuredir(app.config.latex_engine)
+            # keep a copy of latex file for this engine in case test fails
+            copyfile('SphinxTests.tex',
+                     app.config.latex_engine + '/SphinxTests.tex')
             p = Popen([app.config.latex_engine,
                        '--interaction=nonstopmode',
                        '-output-directory=%s' % app.config.latex_engine,


### PR DESCRIPTION
use same default setting for lualatex as xelatex

at my locale, this fails on final TeXLive 2012 because fontspec did not yet recognize lualatex, but it passes on final TeXLive 2013. I am not sure if it will pass on initial TeXLive 2013 ...

### Relates
- #3070

