### PR TITLE
epub has duplicated nav.xhtml link except first time

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Bugs fixed
 
 * #3445: setting ``'inputenc'`` key to ``\\usepackage[utf8x]{inputenc}`` leads
   to failed PDF build
+* EPUB file has duplicated ``nav.xhtml`` link in ``content.opf``
+  except first time build
 
 Testing
 --------

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -570,7 +570,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         self.ignored_files = ['.buildinfo', 'mimetype', 'content.opf',
                               'toc.ncx', 'META-INF/container.xml',
                               'Thumbs.db', 'ehthumbs.db', '.DS_Store',
-                              self.config.epub_basename + '.epub'] + \
+                              'nav.xhtml', self.config.epub_basename + '.epub'] + \
             self.config.epub_exclude_files
         if not self.use_index:
             self.ignored_files.append('genindex' + self.out_suffix)


### PR DESCRIPTION
Subject: Remove duplication to ``nav.xhtml`` link from ``content.opf``

### Feature or Bugfix
- Bugfix

### Purpose
- content.opf contained duplicated link to ``nav.xhtml``.  Current ``EpubBuilder`` implementation correct all files in ``_build/epub`` and add links to ``<manifest>`` section in ``content.opf``. At first time build, ``content.opf`` generated before ``nav.xhtml``, so it has correct links, but at next, ``EpubBuilder`` would find ``nav.xhtml`` and add its link again.


