### PR TITLE
Remove unneeded ``{}`` in LaTeX transition code

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1879,10 +1879,12 @@ These options influence LaTeX output. See further :doc:`latex`.
            modifying it also such as "tocloft" or "etoc".
      ``'transition'``
         Commands used to display transitions, default
-        ``'\n\n\\bigskip\\hrule{}\\bigskip\n\n'``.  Override if you want to
+        ``'\n\n\\bigskip\\hrule\\bigskip\n\n'``.  Override if you want to
         display transitions differently.
 
         .. versionadded:: 1.2
+        .. versionchanged:: 1.6
+           Remove unneeded ``{}`` after ``\\hrule``.
      ``'printindex'``
         "printindex" call, the last thing in the file, default
         ``'\\printindex'``.  Override if you want to generate the index

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -91,7 +91,7 @@ DEFAULT_SETTINGS = {
     'tableofcontents': '\\sphinxtableofcontents',
     'atendofbody':     '',
     'printindex':      '\\printindex',
-    'transition':      '\n\n\\bigskip\\hrule{}\\bigskip\n\n',
+    'transition':      '\n\n\\bigskip\\hrule\\bigskip\n\n',
     'figure_align':    'htbp',
     'tocdepth':        '',
     'secnumdepth':     '',


### PR DESCRIPTION
Subject: remove unneeded ``{}`` in LaTeX macros for transitions.

### Feature or Bugfix
- Bugfix (sort of). It is only that the ``{}`` at this location does nothing.

By the way, I realized there is no unit test checking this transition code.