### PR TITLE
Make ``'extraclassoptions'`` key of ``latex_elements`` public

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1714,6 +1714,14 @@ These options influence LaTeX output. See further :doc:`latex`.
 
    * Keys that don't need to be overridden unless in special cases are:
 
+     ``'extraclassoptions'``
+        The default is the empty string. Example: ``'extraclassoptions':
+        'openany'`` will allow chapters (for documents of the ``'manual'``
+        type) to start on any page.
+
+        .. versionadded:: 1.2
+        .. versionchanged:: 1.6
+           Added this documentation.
      ``'maxlistdepth'``
         LaTeX allows by default at most 6 levels for nesting list and
         quote-like environments, with at most 4 enumerated lists, and 4 bullet

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -179,12 +179,8 @@ Here are the currently available options together with their default values.
        This is due to the way the LaTeX class ``jsbook`` handles the
        pointsize.
 
-       Or, one uses regular units but with ``nomag`` as document class option.
-       This can be achieved for example via::
-
-         'pointsize': 'nomag,12pt',
-
-       in the :confval:`latex_elements` configuration variable.
+       Or, one uses regular units but with ``nomag`` as extra document class
+       option (cf. ``'extraclassoptions'`` key of :confval:`latex_elements`.)
 
     .. versionadded:: 1.5.3
 


### PR DESCRIPTION
Subject: config setting ``latex_elements`` has a key ``'extraclassoptions'`` which was left undocumented and without any specific internal use. It was introduced at 4f08d04 (Sphinx 1.2).

Making it public gives an official way to pass more options to document class. For example ``'openany'`` value fixes #2344.

