### PR TITLE
Integrate the 'sphinx-apidoc' command in the setuptools command

### DIFF
--- a/doc/setuptools.rst
+++ b/doc/setuptools.rst
@@ -127,6 +127,28 @@ Options for setuptools integration
 
    .. versionadded:: 1.5
 
+.. confval:: apidoc
+
+   A boolean that ensures the ``sphinx-apidoc`` command is called before
+   building documentation. Default is false.
+
+   .. versionadded:: 1.6
+
+.. confval:: apidoc-dir
+
+   The target build directory for API documentation. This can be relative to
+   the ``setup.py`` or ``setup.cfg`` file, or it can be absolute. Default is
+   ``$source_dir/api``.
+
+   .. versionadded:: 1.6
+
+.. confval:: apidoc-exclude
+
+   A list of modules to ignore if building API documentation. Default is
+   ``['setup.py']``.
+
+  .. versionadded:: 1.6
+
 .. confval:: project
 
    The documented project's name. Default is ``''``.

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -366,7 +366,7 @@ Note: By default this script will not overwrite already created files.""")
     if not opts.destdir:
         parser.error('An output directory is required.')
     if opts.header is None:
-        opts.header = path.abspath(rootpath).split(path.sep)[-1]
+        opts.header = path.basename(rootpath)
     if opts.suffix.startswith('.'):
         opts.suffix = opts.suffix[1:]
     if not path.isdir(rootpath):

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -149,3 +149,21 @@ def test_build_sphinx_warning_is_error_return_nonzero_status(setup_command):
     print(out)
     print(err)
     assert proc.returncode != 0, 'expect non-zero status for setup.py'
+
+
+@pytest.mark.setup_command('--apidoc')
+def test_build_sphinx_with_apidoc_minimal(setup_command):
+    proc = setup_command.proc
+    out, err = proc.communicate()
+    print(out)
+    print(err)
+    assert proc.returncode == 0, 'expect zero status for setup.py'
+
+
+@pytest.mark.setup_command('--apidoc', '--apidoc-exclude', 'setup.py,sphinx')
+def test_build_sphinx_with_apidoc_excludes(setup_command):
+    proc = setup_command.proc
+    out, err = proc.communicate()
+    print(out)
+    print(err)
+    assert proc.returncode == 0, 'expect zero status for setup.py'


### PR DESCRIPTION
Subject: Integrate the `sphinx-apidoc` command in the setuptools command

### Feature or Bugfix

- Feature

### Purpose

- Integrate the `sphinx-apidoc` command in the setuptools command

### Detail

Allow running of the 'apidoc' command before building documentation.
This necessitates three new configuration options:

- 'apidoc'
- 'apidoc-dir'
- 'apidoc-exclude'

These are all documented. Anyone wanting more configurability should
continue running the 'sphinx-apidoc' command separately

### Relates

- #1135

