### PR TITLE
fix HTML5 validation check (role attribute of body tag is unnecessary)

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -151,7 +151,7 @@
 {%- endblock %}
 {%- block extrahead %} {% endblock %}
   </head>
-  <body role="document">
+  <body>
 {%- block header %}{% endblock %}
 
 {%- block relbar1 %}{{ relbar() }}{% endblock %}


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
- Bugfix

### Purpose
- Fix HTML5 validator issue

### Detail
- "Warning: The document role is unnecessary for element body." is appears with the following tool
- https://html5.validator.nu/

### Relates
- #1733

