### PR TITLE
Fix #3496: latex longtable's last column...

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1135,8 +1135,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('\n\\hline\n')
             self.body.extend(self.tableheaders)
             self.body.append('\\endhead\n\n')
-            self.body.append(r'\hline \multicolumn{%s}{r}{\makebox[0pt][r]'
-                             r'{\tablecontinued{%s}}}\\'
+            self.body.append(r'\hline \multicolumn{%s}{|r|}{\makebox[0pt][r]'
+                             r'{\tablecontinued{%s}}}\\\hline'
                              % (self.table.colcount,
                                 _('Continued on next page')))
             self.body.append('\n\\endfoot\n\n')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1129,12 +1129,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.extend(self.tableheaders)
             self.body.append('\\endfirsthead\n\n')
             self.body.append('\\multicolumn{%s}{c}%%\n' % self.table.colcount)
-            self.body.append(r'{{\tablecontinued{\tablename\ \thetable{} -- %s}}} \\'
+            self.body.append(r'{\makebox[0pt]{\tablecontinued{\tablename\ '
+                             r'\thetable{} -- %s}}}\\'
                              % _('continued from previous page'))
             self.body.append('\n\\hline\n')
             self.body.extend(self.tableheaders)
             self.body.append('\\endhead\n\n')
-            self.body.append(r'\hline \multicolumn{%s}{|r|}{{\tablecontinued{%s}}} \\ \hline'
+            self.body.append(r'\hline \multicolumn{%s}{r}{\makebox[0pt][r]'
+                             r'{\tablecontinued{%s}}}\\'
                              % (self.table.colcount,
                                 _('Continued on next page')))
             self.body.append('\n\\endfoot\n\n')


### PR DESCRIPTION
... may be much wider than its contents

### Feature or Bugfix
- Bugfix

### Purpose

Fix #3496 

### Detail

The source of the problem is that longtable takes into account the width of the header and footer of the table. If it is wider than the table natural width, the last column (and it only!) ends up stretched to match.

Currently this PR has a breaking change: the footer has lost its frame. The reason is that "Continued on next page" does not fit in the frame if the columns are narrow. On the other hand long tables with such narrow columns may be rare, so I have no objection reverting this breaking change if it is deemed better (one needs to use again ``|r|`` and ``\\\hline``  not simply ``\\``). The #3496 would still be fixed but one may get result as last image next shows.

Snapshots:

![capture d ecran 2017-03-02 a 19 04 35](https://cloud.githubusercontent.com/assets/2589111/23520872/ee8b1610-ff7c-11e6-977e-6691639fbb75.png)

![capture d ecran 2017-03-02 a 19 05 02](https://cloud.githubusercontent.com/assets/2589111/23520880/f3dff716-ff7c-11e6-9ffa-36d063bbcc90.png)

If with frame: (as is currently case)

![capture d ecran 2017-03-02 a 19 06 18](https://cloud.githubusercontent.com/assets/2589111/23520881/f779aec6-ff7c-11e6-9a9f-cf393f03230d.png)

Note: as tables have been much refactored on master, if this is merged then one needs to merge manually stable in master and fix conflicts during this (it may be that git is clever enough to understand the changes will apply to ``sphinx/templates/latex/longtable.tex_t``...) (and one should update tests also after the merge; the present commit needed no test update on stable but I think it will on master as tests have been extended for tables)