### PR TITLE
fix #1733: fix span tags for ids is in table tag (for html5 validation)

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -918,7 +918,7 @@ class StandaloneHTMLBuilder(Builder):
     def dump_inventory(self):
         # type: () -> None
         def safe_name(string):
-            return re.sub("\s+", " ", string)
+            return re.sub(r"\s+", " ", string)
 
         logger.info(bold('dumping object inventory... '), nonl=True)
         with open(path.join(self.outdir, INVENTORY_FILENAME), 'wb') as f:


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
- Bugfix

### Purpose
- improve html5 validation score

### Detail
- html5 doesn't allow span tags in table tags, but docutils generates that if table has several ids.

### Relates
- #1733

