### PR TITLE
fix style check warnings

### DIFF
--- a/doc/ext/example_google.py
+++ b/doc/ext/example_google.py
@@ -83,7 +83,7 @@ def module_level_function(param1, param2=None, *args, **kwargs):
     of each parameter is required. The type and description of each parameter
     is optional, but should be included if not obvious.
 
-    If \*args or \*\*kwargs are accepted,
+    If ``*args`` or ``**kwargs`` are accepted,
     they should be listed as ``*args`` and ``**kwargs``.
 
     The format for a parameter is::

--- a/doc/ext/example_numpy.py
+++ b/doc/ext/example_numpy.py
@@ -106,7 +106,7 @@ def module_level_function(param1, param2=None, *args, **kwargs):
     The name of each parameter is required. The type and description of each
     parameter is optional, but should be included if not obvious.
 
-    If \*args or \*\*kwargs are accepted,
+    If ``*args`` or ``**kwargs`` are accepted,
     they should be listed as ``*args`` and ``**kwargs``.
 
     The format for a parameter is::

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -491,7 +491,7 @@ def test_footnote(app, status, warning):
             'VIDIOC\\_CROPCAP\n&\n') in result
     assert ('Information about VIDIOC\\_CROPCAP %\n'
             '\\begin{footnote}[6]\\sphinxAtStartFootnote\n'
-            'footnote in table not in header\n%\n\\end{footnote}\n\\\\\n\hline\n'
+            'footnote in table not in header\n%\n\\end{footnote}\n\\\\\n\\hline\n'
             '\\end{tabulary}\n\\end{threeparttable}\n\\par\n\\end{savenotes}\n') in result
 
 

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -284,7 +284,7 @@ Construct a new XBlock.
 This class should only be used by runtimes.
 
 Arguments:
-    runtime (:class:`~typing.Dict`\[:class:`int`,:class:`str`\]): Use it to
+    runtime (:class:`~typing.Dict`\\[:class:`int`,:class:`str`\\]): Use it to
         access the environment. It is available in XBlock code
         as ``self.runtime``.
 
@@ -304,7 +304,7 @@ This class should only be used by runtimes.
 :param runtime: Use it to
                 access the environment. It is available in XBlock code
                 as ``self.runtime``.
-:type runtime: :class:`~typing.Dict`\[:class:`int`,:class:`str`\]
+:type runtime: :class:`~typing.Dict`\\[:class:`int`,:class:`str`\\]
 :param field_data: Interface used by the XBlock
                    fields to access their data from wherever it is persisted.
 :type field_data: :class:`FieldData`


### PR DESCRIPTION
Subject: fix style check warnings on master branch

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail

```
doc/ext/example_google.py:127: DeprecationWarning: invalid escape sequence \*
  """
doc/ext/example_numpy.py:160: DeprecationWarning: invalid escape sequence \*
  """
tests/test_build_latex.py:494: DeprecationWarning: invalid escape sequence \h
  'footnote in table not in header\n%\n\\end{footnote}\n\\\\\n\hline\n'
tests/test_ext_napoleon_docstring.py:296: DeprecationWarning: invalid escape sequence \[
  """
tests/test_ext_napoleon_docstring.py:313: DeprecationWarning: invalid escape sequence \[
  """
```

