### PR TITLE
Fix #3506: consistently pass node to depart_admonition in HTML writer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -89,6 +89,7 @@ Bugs fixed
 * #1574: Paragraphs in table cell doesn't work in Latex output
 * #3288: Table with merged headers not wrapping text
 * #3491: Inconsistent vertical space around table and longtable in PDF
+* #3506: Depart functions for all admonitions in HTML writer now properly pass ``node`` to ``depart_admonition``.
 
 Deprecated
 ----------

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -736,7 +736,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_attention(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_caution(self, node):
         # type: (nodes.Node) -> None
@@ -744,7 +744,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_caution(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_danger(self, node):
         # type: (nodes.Node) -> None
@@ -752,7 +752,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_danger(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_error(self, node):
         # type: (nodes.Node) -> None
@@ -760,7 +760,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_error(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_hint(self, node):
         # type: (nodes.Node) -> None
@@ -768,7 +768,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_hint(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_important(self, node):
         # type: (nodes.Node) -> None
@@ -776,7 +776,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_important(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_tip(self, node):
         # type: (nodes.Node) -> None
@@ -784,7 +784,7 @@ class HTMLTranslator(BaseTranslator):
 
     def depart_tip(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     # these are only handled specially in the SmartyPantsHTMLTranslator
     def visit_literal_emphasis(self, node):

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -679,7 +679,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_attention(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_caution(self, node):
         # type: (nodes.Node) -> None
@@ -687,7 +687,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_caution(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_danger(self, node):
         # type: (nodes.Node) -> None
@@ -695,7 +695,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_danger(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_error(self, node):
         # type: (nodes.Node) -> None
@@ -703,7 +703,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_error(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_hint(self, node):
         # type: (nodes.Node) -> None
@@ -711,7 +711,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_hint(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_important(self, node):
         # type: (nodes.Node) -> None
@@ -719,7 +719,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_important(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     def visit_tip(self, node):
         # type: (nodes.Node) -> None
@@ -727,7 +727,7 @@ class HTML5Translator(BaseTranslator):
 
     def depart_tip(self, node):
         # type: (nodes.Node) -> None
-        self.depart_admonition()
+        self.depart_admonition(node)
 
     # these are only handled specially in the SmartyPantsHTML5Translator
     def visit_literal_emphasis(self, node):

--- a/tests/roots/test-build-html-translator/conf.py
+++ b/tests/roots/test-build-html-translator/conf.py
@@ -23,7 +23,7 @@ class ConfHTMLTranslator(HTMLTranslator):
     def depart_admonition(self, node=None):
         if node is not None:
             self.depart_with_node += 1
-        super(self.__class__, self).depart_admonition(node)
+        HTMLTranslator.depart_admonition(self, node)
 
 
 # class ConfDirHTMLTranslator(HTMLTranslator):

--- a/tests/roots/test-build-html-translator/conf.py
+++ b/tests/roots/test-build-html-translator/conf.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+## set this by test
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+from sphinx.writers.html import HTMLTranslator
+# from sphinx.writers.latex import LaTeXTranslator
+# from sphinx.writers.manpage import ManualPageTranslator
+# from sphinx.writers.texinfo import TexinfoTranslator
+# from sphinx.writers.text import TextTranslator
+# from sphinx.writers.websupport import WebSupportTranslator
+# from docutils.writers.docutils_xml import XMLTranslator
+
+
+project = 'test'
+master_doc = 'index'
+
+
+class ConfHTMLTranslator(HTMLTranslator):
+    depart_with_node = 0
+
+    def depart_admonition(self, node=None):
+        if node is not None:
+            self.depart_with_node += 1
+        super().depart_admonition(node)
+
+
+# class ConfDirHTMLTranslator(HTMLTranslator):
+#     pass
+
+
+# class ConfSingleHTMLTranslator(HTMLTranslator):
+#     pass
+
+
+# class ConfPickleTranslator(HTMLTranslator):
+#     pass
+
+
+# class ConfJsonTranslator(HTMLTranslator):
+#     pass
+
+
+# class ConfLaTeXTranslator(LaTeXTranslator):
+#     pass
+
+
+# class ConfManualPageTranslator(ManualPageTranslator):
+#     pass
+
+
+# class ConfTexinfoTranslator(TexinfoTranslator):
+#     pass
+
+
+# class ConfTextTranslator(TextTranslator):
+#     pass
+
+
+# class ConfWebSupportTranslator(WebSupportTranslator):
+#     pass
+
+
+# class ConfXMLTranslator(XMLTranslator):
+#     pass
+
+
+# class ConfPseudoXMLTranslator(XMLTranslator):
+#     pass
+
+
+def setup(app):
+    app.set_translator('html', ConfHTMLTranslator)
+    # app.set_translator('dirhtml', ConfDirHTMLTranslator)
+    # app.set_translator('singlehtml', ConfSingleHTMLTranslator)
+    # app.set_translator('pickle', ConfPickleTranslator)
+    # app.set_translator('json', ConfJsonTranslator)
+    # app.set_translator('latex', ConfLaTeXTranslator)
+    # app.set_translator('man', ConfManualPageTranslator)
+    # app.set_translator('texinfo', ConfTexinfoTranslator)
+    # app.set_translator('text', ConfTextTranslator)
+    # app.set_translator('websupport', ConfWebSupportTranslator)
+    # app.set_translator('xml', ConfXMLTranslator)
+    # app.set_translator('pseudoxml', ConfPseudoXMLTranslator)

--- a/tests/roots/test-build-html-translator/conf.py
+++ b/tests/roots/test-build-html-translator/conf.py
@@ -23,7 +23,7 @@ class ConfHTMLTranslator(HTMLTranslator):
     def depart_admonition(self, node=None):
         if node is not None:
             self.depart_with_node += 1
-        super().depart_admonition(node)
+        super(self.__class__, self).depart_admonition(node)
 
 
 # class ConfDirHTMLTranslator(HTMLTranslator):

--- a/tests/roots/test-build-html-translator/conf.py
+++ b/tests/roots/test-build-html-translator/conf.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-## set this by test
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 
 from sphinx.writers.html import HTMLTranslator
-# from sphinx.writers.latex import LaTeXTranslator
-# from sphinx.writers.manpage import ManualPageTranslator
-# from sphinx.writers.texinfo import TexinfoTranslator
-# from sphinx.writers.text import TextTranslator
-# from sphinx.writers.websupport import WebSupportTranslator
-# from docutils.writers.docutils_xml import XMLTranslator
-
 
 project = 'test'
 master_doc = 'index'
@@ -26,60 +15,5 @@ class ConfHTMLTranslator(HTMLTranslator):
         HTMLTranslator.depart_admonition(self, node)
 
 
-# class ConfDirHTMLTranslator(HTMLTranslator):
-#     pass
-
-
-# class ConfSingleHTMLTranslator(HTMLTranslator):
-#     pass
-
-
-# class ConfPickleTranslator(HTMLTranslator):
-#     pass
-
-
-# class ConfJsonTranslator(HTMLTranslator):
-#     pass
-
-
-# class ConfLaTeXTranslator(LaTeXTranslator):
-#     pass
-
-
-# class ConfManualPageTranslator(ManualPageTranslator):
-#     pass
-
-
-# class ConfTexinfoTranslator(TexinfoTranslator):
-#     pass
-
-
-# class ConfTextTranslator(TextTranslator):
-#     pass
-
-
-# class ConfWebSupportTranslator(WebSupportTranslator):
-#     pass
-
-
-# class ConfXMLTranslator(XMLTranslator):
-#     pass
-
-
-# class ConfPseudoXMLTranslator(XMLTranslator):
-#     pass
-
-
 def setup(app):
     app.set_translator('html', ConfHTMLTranslator)
-    # app.set_translator('dirhtml', ConfDirHTMLTranslator)
-    # app.set_translator('singlehtml', ConfSingleHTMLTranslator)
-    # app.set_translator('pickle', ConfPickleTranslator)
-    # app.set_translator('json', ConfJsonTranslator)
-    # app.set_translator('latex', ConfLaTeXTranslator)
-    # app.set_translator('man', ConfManualPageTranslator)
-    # app.set_translator('texinfo', ConfTexinfoTranslator)
-    # app.set_translator('text', ConfTextTranslator)
-    # app.set_translator('websupport', ConfWebSupportTranslator)
-    # app.set_translator('xml', ConfXMLTranslator)
-    # app.set_translator('pseudoxml', ConfPseudoXMLTranslator)

--- a/tests/roots/test-build-html-translator/index.rst
+++ b/tests/roots/test-build-html-translator/index.rst
@@ -1,0 +1,24 @@
+=======================
+Test HTML admonitions
+=======================
+
+.. seealso:: test
+
+.. note:: test
+
+.. warning:: test
+
+.. attention:: test
+
+.. caution:: test
+
+.. danger:: test
+
+.. error:: test
+
+.. hint:: test
+
+.. important:: test
+
+.. tip:: test
+

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -442,8 +442,7 @@ def test_html_output(app, cached_etree_parse, fname, expect):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
 
-@pytest.mark.sphinx('html', testroot='build-html-translator', tags=['testtag'], confoverrides={
-    'html_context.hckey_co': 'hcval_co'})
+@pytest.mark.sphinx('html', testroot='build-html-translator')
 def test_html_translator(app):
     app.build()
     assert app.builder.docwriter.visitor.depart_with_node == 10

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -17,7 +17,6 @@ from six import PY3
 
 from sphinx import __display_version__
 from sphinx.util.inventory import InventoryFile
-
 from util import remove_unicode_literals, strip_escseq
 import xml.etree.cElementTree as ElementTree
 from html5lib import getTreeBuilder, HTMLParser
@@ -443,6 +442,11 @@ def test_html_output(app, cached_etree_parse, fname, expect):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
 
+@pytest.mark.sphinx('html', testroot='build-html-translator', tags=['testtag'], confoverrides={
+    'html_context.hckey_co': 'hcval_co'})
+def test_html_translator(app):
+    app.build()
+    assert app.builder.docwriter.visitor.depart_with_node == 10
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [


### PR DESCRIPTION
### Bugfix
Updates the HTML writer to consistently pass the ``node`` argument to ``depart_admonition``. 

### Detail
I've contributed a test that detects this condition, but I had trouble figuring out where to put it. The semantics of the existing tests that dealt with admonitions, translators, or HTML building all felt a little off. 

I took a wild guess that exercising the HTML translator should be a subtask within exercising the HTML builder. Accordingly, I added the test function itself to ``test_build_html.py``, and used ``roots/test-api-set-translator`` as a template for ``roots/test-build-html-translator``.

The other possibility I entertained was creating a new test file for the purpose of all/any translators, so I just commented out unused lines for now. If the way I have it organized is fine, I'll cut out the commented lines. Otherwise, let me know where you'd prefer this and similar tests.

### Relates
- #3506 
