### PR TITLE
Allow empty toctree in singlehtml builder

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -968,7 +968,8 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         if 'includehidden' not in kwds:
             kwds['includehidden'] = False
         toctree = self.env.get_toctree_for(docname, self, collapse, **kwds)
-        self.fix_refuris(toctree)
+        if toctree is not None:
+            self.fix_refuris(toctree)
         return self.render_partial(toctree)['fragment']
 
     def assemble_doctree(self):

--- a/tests/roots/test-toctree-empty/conf.py
+++ b/tests/roots/test-toctree-empty/conf.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+html_theme = 'classic'
+exclude_patterns = ['_build']

--- a/tests/roots/test-toctree-empty/index.rst
+++ b/tests/roots/test-toctree-empty/index.rst
@@ -1,0 +1,4 @@
+test-toctree-empty
+==================
+
+.. toctree::

--- a/tests/test_toctree.py
+++ b/tests/test_toctree.py
@@ -26,3 +26,13 @@ def test_relations(app, status, warning):
     assert app.builder.relations['qux/qux_1'] == ['qux/index', 'qux/index', 'qux/qux_2']
     assert app.builder.relations['qux/qux_2'] == ['qux/index', 'qux/qux_1', None]
     assert 'quux' not in app.builder.relations
+
+
+@pytest.mark.sphinx('singlehtml', testroot='toctree-empty')
+def test_singlehtml_toctree(app, status, warning):
+    docname = 'index'
+    app.builder.build_all()
+    try:
+        app.builder._get_local_toctree('index')
+    except AttributeError:
+        pytest.fail('Unexpected AttributeError in app.builder.fix_refuris')


### PR DESCRIPTION
We noticed this issue with the 0.2.x release of snide/sphinx_rtd_theme. Because
we are calling toctree unconditionally, we notice a bug in the singlehtml
builder when the docs have an empty/nonexistant toctree. In this case,
`fix_refuris` as being passed `None`, which failed to traverse, throwing an
exception.

This conditionally fixes the refuris instead.