### PR TITLE
Protect TeX double quotes ligatures in inline literals (refs #3507)

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -438,6 +438,14 @@ Let us now list some macros from the package file
      the new macros are wrappers of the formerly hard-coded ``\texttt``,
      ``\emph``, ... The default definitions can be found in
      :file:`sphinx.sty`.
+- macros for directional double quotes: pairs of straight double quote ``"``
+  in reST source are converted into LaTeX mark-up
+  ``\sphinxquotedblleft{}`` and ``\sphinxquotedblright{}`` which default to
+  `````\ ````` and ``''`` (i.e. the TeX mark-up for directional double
+  quotes via font ligaturing mechanism.)
+
+  .. versionadded:: 1.5.4
+     Formerly, produced TeX was directly with `````\ ````` and ``''``.
 - paragraph level environments: for each admonition type ``<foo>``, the
   used environment is named ``sphinx<foo>``. They may be ``\renewenvironment``
   'd individually, and must then be defined with one argument (it is the heading

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1243,6 +1243,10 @@
 \protected\def\sphinxstyleabbreviation   {\textsc}
 \protected\def\sphinxstyleliteralintitle {\sphinxcode}
 
+% LaTeX writer uses macros to hide double quotes from \sphinxcode's \@noligs
+\protected\def\sphinxquotedblleft{``}
+\protected\def\sphinxquotedblright{''}
+
 % stylesheet for highlighting with pygments
 \RequirePackage{sphinxhighlight}
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2209,7 +2209,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_Text(self, node):
         text = self.encode(node.astext())
         if not self.no_contractions and not self.in_parsed_literal:
-            text = educate_quotes_latex(text)
+            text = educate_quotes_latex(text,
+                                        dquotes=("\\sphinxquotedblleft{}",
+                                                 "\\sphinxquotedblright{}"))
         self.body.append(text)
 
     def depart_Text(self, node):


### PR DESCRIPTION
Subject: fix #3507

### Feature or Bugfix
- Bugfix


### Purpose
- Make sure inline literals in LaTeX allow TeX ligatures for ```` `` ```` and `''`. This is done by modifying LaTeX's writer call to smartypants ``educate_quotes_latex`` to insert macros rather than explicit TeX input ```` `` ```` and `''`. 
- This needs review because my knowledge of Docutils is not enough to verify when exactly is ``visit_Text()`` executed. It does not seem to interfere with literal blocks and their Pygmentization.

Memo : Sphinx has a dissymmetry between inline literals and literal blocks in handling of `"`. In the former the `"` may have been transformed into a pair of directional quotes, with the TeX input form ```` `` ```` and `''` (up to this PR.) The latter pygmentizes `"` with no directionality, one needs to have directional quotes in the reST source to start with.

Side remark: spacing before and after the ``productionlist`` environment does not appear to be ideal.

### Test file

```

“entry”

.. productionlist::
   entry: "entry" `block`

.. productionlist::
   entry: “entry” `block`

::

   "entry" ``entry'' “entry”

```

### Relates
- #3507, #2627.

