### PR TITLE
Callback on domains to annotate xrefs created from docfields.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
   are same without creation date. Thanks to Yoshiki Shibukawa.
 * #3487: intersphinx: failed to refer options
 * #3496: latex longtable's last column may be much wider than its contents
+* #2665, #2607: Link names in C++ docfields, and make it possible for other domains.
 
 Testing
 --------

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -218,6 +218,12 @@ class Domain(object):
         """Process a document after it is read by the environment."""
         pass
 
+    def process_field_xref(self, pnode):
+        """Process a pending xref created in a doc field.
+        For example, attach information about the current scope.
+        """
+        pass
+
     def resolve_xref(self, env, fromdocname, builder,
                      typ, target, node, contnode):
         """Resolve the pending_xref *node* with the given *typ* and *target*.

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4470,6 +4470,12 @@ class CPPDomain(Domain):
         # print(self.data['root_symbol'].dump(0))
         pass
 
+    def process_field_xref(self, pnode):
+        symbol = self.env.ref_context['cpp:parent_symbol']
+        key = symbol.get_lookup_key()
+        assert key
+        pnode['cpp:parent_key'] = key
+
     def merge_domaindata(self, docnames, otherdata):
         self.data['root_symbol'].merge_with(otherdata['root_symbol'],
                                             docnames, self.env)

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -85,9 +85,9 @@ def _pseudo_parse_arglist(signode, arglist):
 # This override allows our inline type specifiers to behave like :class: link
 # when it comes to handling "." and "~" prefixes.
 class PyXrefMixin(object):
-    def make_xref(self, rolename, domain, target, innernode=nodes.emphasis,
+    def make_xref(self, env, rolename, domain, target, innernode=nodes.emphasis,
                   contnode=None):
-        result = super(PyXrefMixin, self).make_xref(rolename, domain, target,
+        result = super(PyXrefMixin, self).make_xref(env, rolename, domain, target,
                                                     innernode, contnode)
         result['refspecific'] = True
         if target.startswith(('.', '~')):
@@ -101,7 +101,7 @@ class PyXrefMixin(object):
                 break
         return result
 
-    def make_xrefs(self, rolename, domain, target, innernode=nodes.emphasis,
+    def make_xrefs(self, env, rolename, domain, target, innernode=nodes.emphasis,
                    contnode=None):
         delims = '(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+)'
         delims_re = re.compile(delims)
@@ -117,7 +117,7 @@ class PyXrefMixin(object):
             if delims_re.match(sub_target):
                 results.append(contnode or innernode(sub_target, sub_target))
             else:
-                results.append(self.make_xref(rolename, domain, sub_target,
+                results.append(self.make_xref(env, rolename, domain, sub_target,
                                               innernode, contnode))
 
         return results

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -85,10 +85,10 @@ def _pseudo_parse_arglist(signode, arglist):
 # This override allows our inline type specifiers to behave like :class: link
 # when it comes to handling "." and "~" prefixes.
 class PyXrefMixin(object):
-    def make_xref(self, env, rolename, domain, target, innernode=nodes.emphasis,
-                  contnode=None):
-        result = super(PyXrefMixin, self).make_xref(env, rolename, domain, target,
-                                                    innernode, contnode)
+    def make_xref(self, rolename, domain, target, innernode=nodes.emphasis,
+                  contnode=None, env=None):
+        result = super(PyXrefMixin, self).make_xref(rolename, domain, target,
+                                                    innernode, contnode, env)
         result['refspecific'] = True
         if target.startswith(('.', '~')):
             prefix, result['reftarget'] = target[0], target[1:]
@@ -101,8 +101,8 @@ class PyXrefMixin(object):
                 break
         return result
 
-    def make_xrefs(self, env, rolename, domain, target, innernode=nodes.emphasis,
-                   contnode=None):
+    def make_xrefs(self, rolename, domain, target, innernode=nodes.emphasis,
+                   contnode=None, env=None):
         delims = '(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+)'
         delims_re = re.compile(delims)
         sub_targets = re.split(delims, target)
@@ -117,8 +117,8 @@ class PyXrefMixin(object):
             if delims_re.match(sub_target):
                 results.append(contnode or innernode(sub_target, sub_target))
             else:
-                results.append(self.make_xref(env, rolename, domain, sub_target,
-                                              innernode, contnode))
+                results.append(self.make_xref(rolename, domain, sub_target,
+                                              innernode, contnode, env))
 
         return results
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix: #2607, #2665.

### Purpose
Some docfields creates pending_xrefs, which needs to have extra information in some domains (e.g., Python and C++) in order to do name lookup in the right scope.
This PR adds an overrideable method to the domain base class, which is called from `docfields.Field.make_xref` with newly created pending_xref nodes. Is there a better way to do this?
The original problem is fixed in the C++ domain (not sure how to do it in Python).

### Detail
This is the updated example from #2665:

```rst
.. cpp:class:: NS::MyException : public std::exception

    Type of an exception.

.. cpp:namespace:: NS

.. cpp:function:: void my_function()

    :exception NS\:\:MyException:   This works.
    :exception MyException:         This now works. <================

    * Referencing :cpp:class:`NS::MyException` works.
    * Referencing :cpp:class:`MyException` also works.

.. py:class:: PyClass

    .. py:exception:: Ex

    .. py:method:: f()

        :raises PyClass.Ex: This works.
        :raises Ex: This happens to also work now, probably not for the right reason? <================

        * Referencing :py:class:`PyClass.Ex` works.
        * Referencing :py:class:`Ex` doesn't work (a bug #3065)

.. py:method:: g()

    :raises PyClass.Ex: This works.
    :raises Ex: This shouldn't work, but does (a new bug?) <================
```

Something strange is going on with scoping in the Python domain, maybe from fixing #3065?