### PR TITLE
:decorator-lines: option for literalinclude

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,7 @@ Features added
 * HTML buildre uses experimental HTML5 writer if ``html_experimental_html5_builder`` is True
   and docutils 0.13 and newer is installed.
 * LaTeX macros to customize space before and after tables in PDF output (refs #3504)
+* #3348: Workaround to specify number of decorator lines.
 
 Bugs fixed
 ----------

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -259,6 +259,8 @@ class LiteralIncludeReader(object):
             else:
                 start = tags[pyobject][1]
                 end = tags[pyobject][2]
+                extra = self.options.get('decorator-lines', 0)
+                start = max(start - extra, 1)
                 lines = lines[start - 1:end - 1]
                 if 'lineno-match' in self.options:
                     self.lineno_start = start
@@ -378,6 +380,7 @@ class LiteralInclude(Directive):
         'language': directives.unchanged_required,
         'encoding': directives.encoding,
         'pyobject': directives.unchanged_required,
+        'decorator-lines': int,
         'lines': directives.unchanged_required,
         'start-after': directives.unchanged_required,
         'end-before': directives.unchanged_required,


### PR DESCRIPTION
Not a true fix, but maybe a useful hack.

Signed-off-by: Ray Lehtiniemi <rayl@mail.com>

Subject: Workaround for #3348

### Feature or Bugfix
- Feature

### Purpose
- Provide a quick workaround for the :pyobject: option to literalinclude to deal with decorators

### Detail
Just manually specify the number of lines you want the pyobject block to pull in from the source file.

### Relates
- #3348

