### PR TITLE
Prevent a TypeError bug for get_full_modname()

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -281,7 +281,11 @@ def get_module_source(modname):
 
 
 def get_full_modname(modname, attribute):
-    # type: (str, unicode) -> unicode
+    # type: (str, unicode) -> Union[unicode, NoneType]
+    if modname is None:
+        # Prevents a TypeError: if the last getattr() call will return None
+        # then it's better to return it directly
+        return None
     __import__(modname)
     module = sys.modules[modname]
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -281,7 +281,7 @@ def get_module_source(modname):
 
 
 def get_full_modname(modname, attribute):
-    # type: (str, unicode) -> Union[unicode, NoneType]
+    # type: (str, unicode) -> unicode
     if modname is None:
         # Prevents a TypeError: if the last getattr() call will return None
         # then it's better to return it directly


### PR DESCRIPTION
Subject: prevent a TypeError bug for `get_full_modname()` in `sphinx.util`.

### Bugfix
It prevents this bug:
```python
viewcode can't import None, failed with error "__import__() argument 1 must be str, not None"
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/sphinx/ext/viewcode.py", line 28, in _get_full_modname
    return get_full_modname(modname, attribute)
  File "/usr/local/lib/python3.5/dist-packages/sphinx/util/__init__.py", line 263, in get_full_modname
    __import__(modname)
TypeError: __import__() argument 1 must be str, not None
```

### Purpose
- Just a small trick, instead of waiting to the end to return `None`, return it directly if the rest of the function will fail if `modname = None` instead of a string.