### PR TITLE
More robust hyperlink macros in LaTeX output (refs #3317, #3340, #3533)

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -287,7 +287,7 @@
    \fi
    % fix a space-gobbling issue due to LaTeX's original \do@noligs
    \let\do@noligs\sphinx@do@noligs
-   \@noligs\endlinechar\m@ne\everyeof{\noexpand}%
+   \@noligs\endlinechar\m@ne
    \expandafter\scantokens
   \fi {\texttt{#1}}}}
 \def\sphinx@do@noligs #1{\catcode`#1\active\begingroup\lccode`\~`#1\relax
@@ -592,22 +592,6 @@
 \newcommand*\sphinxbreaksatspaceinparsedliteral{%
   \lccode`~32 \lowercase{\let~}\spx@verbatim@space\lccode`\~`\~
 }
-% now the hack for \url to work (hyperref is assumed in use):
-% the aim it to deactivate - . , ; ? ! / in \url's argument.
-% also the space token, but not end of lines which we assume don't arise there.
-\def\spx@hack@hyper@normalise {%
-  \expandafter\spx@hack@hyper@normalise@aux\hyper@normalise
-              \spx@hack@hyper@normalise@aux\hyper@n@rmalise\relax\spx@undefined
-}%
-\long\def\spx@hack@hyper@normalise@aux#1\hyper@n@rmalise#2#3\spx@undefined{%
-  \ifx\spx@hack@hyper@normalise@aux#2%
-      \def\hyper@normalise{#1\sphinxunactivateextrasandspace\hyper@n@rmalise}%
-  \else
-      \PackageWarning{sphinx}{Could not patch \string\url\space command.%
-      ^^J    Not using extra active characters in alltt environment}%
-      \sphinxunactivateextras
-  \fi
-}%
 \newcommand*{\sphinxunactivateextras}{\let\do\@makeother
       \sphinxbreaksbeforeactivelist\sphinxbreaksafteractivelist\do\-}%
 % the \catcode13=5\relax (deactivate end of input lines) is left to callers
@@ -623,16 +607,32 @@
    \sphinxbreaksattexescapedchars
    \sphinxbreaksviaactiveinparsedliteral
    \sphinxbreaksatspaceinparsedliteral
-   \spx@hack@hyper@normalise
 % alltt takes care of the ' as derivative ("prime") in math mode
    \everymath\expandafter{\the\everymath\sphinxunactivateextrasandspace
              \catcode`\<=12\catcode`\>=12\catcode`\^=7\catcode`\_=8 }%
 % not sure if displayed math (align,...) can end up in parsed-literal, anyway
    \everydisplay\expandafter{\the\everydisplay
-             \catcode13=5\sphinxunactivateextrasandspace
+             \catcode13=5 \sphinxunactivateextrasandspace
              \catcode`\<=12\catcode`\>=12\catcode`\^=7\catcode`\_=8 }%
  \fi }
 {\end{alltt}}
+
+% Protect \href's first argument in contexts such as sphinxalltt (or
+% \sphinxcode). Sphinx uses \#, \%, \& ... always inside \sphinxhref.
+\protected\def\sphinxhref#1#2{{%
+    \sphinxunactivateextrasandspace % never do \scantokens with active space!
+    \endlinechar\m@ne\everyeof{{#2}}% keep catcode regime for #2
+    \scantokens{\href{#1}}% normalise it for #1 during \href expansion
+}}
+% Same for \url. And also \nolinkurl for coherence.
+\protected\def\sphinxurl#1{{%
+    \sphinxunactivateextrasandspace
+    \endlinechar\m@ne\scantokens{\url{#1}}%
+}}
+\protected\def\sphinxnolinkurl#1{{%
+    \sphinxunactivateextrasandspace
+    \endlinechar\m@ne\scantokens{\nolinkurl{#1}}%
+}}
 
 % Topic boxes
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1755,12 +1755,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
         elif uri.startswith(URI_SCHEMES):
             if len(node) == 1 and uri == node[0]:
                 if node.get('nolinkurl'):
-                    self.body.append('\\nolinkurl{%s}' % self.encode_uri(uri))
+                    self.body.append('\\sphinxnolinkurl{%s}' % self.encode_uri(uri))
                 else:
-                    self.body.append('\\url{%s}' % self.encode_uri(uri))
+                    self.body.append('\\sphinxurl{%s}' % self.encode_uri(uri))
                 raise nodes.SkipNode
             else:
-                self.body.append('\\href{%s}{' % self.encode_uri(uri))
+                self.body.append('\\sphinxhref{%s}{' % self.encode_uri(uri))
                 self.context.append('}')
         elif uri.startswith('#'):
             # references to labels in the same document

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -551,20 +551,20 @@ def test_latex_show_urls_is_inline(app, status, warning):
             'First\n%\n\\end{footnote}') in result
     assert ('Second footnote: %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'Second\n%\n\\end{footnote}') in result
-    assert '\\href{http://sphinx-doc.org/}{Sphinx} (http://sphinx-doc.org/)' in result
+    assert '\\sphinxhref{http://sphinx-doc.org/}{Sphinx} (http://sphinx-doc.org/)' in result
     assert ('Third footnote: %\n\\begin{footnote}[3]\\sphinxAtStartFootnote\n'
             'Third\n%\n\\end{footnote}') in result
-    assert ('\\href{http://sphinx-doc.org/~test/}{URL including tilde} '
+    assert ('\\sphinxhref{http://sphinx-doc.org/~test/}{URL including tilde} '
             '(http://sphinx-doc.org/\\textasciitilde{}test/)') in result
-    assert ('\\item[{\\href{http://sphinx-doc.org/}{URL in term} '
+    assert ('\\item[{\\sphinxhref{http://sphinx-doc.org/}{URL in term} '
             '(http://sphinx-doc.org/)}] \\leavevmode\nDescription' in result)
     assert ('\\item[{Footnote in term \\sphinxfootnotemark[5]}] '
             '\\leavevmode%\n\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'
             'Footnote in term\n%\n\\end{footnotetext}\nDescription') in result
-    assert ('\\item[{\\href{http://sphinx-doc.org/}{Term in deflist} '
+    assert ('\\item[{\\sphinxhref{http://sphinx-doc.org/}{Term in deflist} '
             '(http://sphinx-doc.org/)}] \\leavevmode\nDescription') in result
-    assert '\\url{https://github.com/sphinx-doc/sphinx}\n' in result
-    assert ('\\href{mailto:sphinx-dev@googlegroups.com}'
+    assert '\\sphinxurl{https://github.com/sphinx-doc/sphinx}\n' in result
+    assert ('\\sphinxhref{mailto:sphinx-dev@googlegroups.com}'
             '{sphinx-dev@googlegroups.com}') in result
 
 
@@ -594,29 +594,29 @@ def test_latex_show_urls_is_footnote(app, status, warning):
             'First\n%\n\\end{footnote}') in result
     assert ('Second footnote: %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'Second\n%\n\\end{footnote}') in result
-    assert ('\\href{http://sphinx-doc.org/}{Sphinx}'
+    assert ('\\sphinxhref{http://sphinx-doc.org/}{Sphinx}'
             '%\n\\begin{footnote}[4]\\sphinxAtStartFootnote\n'
-            '\\nolinkurl{http://sphinx-doc.org/}\n%\n\\end{footnote}') in result
+            '\\sphinxnolinkurl{http://sphinx-doc.org/}\n%\n\\end{footnote}') in result
     assert ('Third footnote: %\n\\begin{footnote}[6]\\sphinxAtStartFootnote\n'
             'Third\n%\n\\end{footnote}') in result
-    assert ('\\href{http://sphinx-doc.org/~test/}{URL including tilde}'
+    assert ('\\sphinxhref{http://sphinx-doc.org/~test/}{URL including tilde}'
             '%\n\\begin{footnote}[5]\\sphinxAtStartFootnote\n'
-            '\\nolinkurl{http://sphinx-doc.org/~test/}\n%\n\\end{footnote}') in result
-    assert ('\\item[{\\href{http://sphinx-doc.org/}'
+            '\\sphinxnolinkurl{http://sphinx-doc.org/~test/}\n%\n\\end{footnote}') in result
+    assert ('\\item[{\\sphinxhref{http://sphinx-doc.org/}'
             '{URL in term}\\sphinxfootnotemark[8]}] '
             '\\leavevmode%\n\\begin{footnotetext}[8]\\sphinxAtStartFootnote\n'
-            '\\nolinkurl{http://sphinx-doc.org/}\n%\n'
+            '\\sphinxnolinkurl{http://sphinx-doc.org/}\n%\n'
             '\\end{footnotetext}\nDescription') in result
     assert ('\\item[{Footnote in term \\sphinxfootnotemark[10]}] '
             '\\leavevmode%\n\\begin{footnotetext}[10]\\sphinxAtStartFootnote\n'
             'Footnote in term\n%\n\\end{footnotetext}\nDescription') in result
-    assert ('\\item[{\\href{http://sphinx-doc.org/}{Term in deflist}'
+    assert ('\\item[{\\sphinxhref{http://sphinx-doc.org/}{Term in deflist}'
             '\\sphinxfootnotemark[9]}] '
             '\\leavevmode%\n\\begin{footnotetext}[9]\\sphinxAtStartFootnote\n'
-            '\\nolinkurl{http://sphinx-doc.org/}\n%\n'
+            '\\sphinxnolinkurl{http://sphinx-doc.org/}\n%\n'
             '\\end{footnotetext}\nDescription') in result
-    assert ('\\url{https://github.com/sphinx-doc/sphinx}\n' in result)
-    assert ('\\href{mailto:sphinx-dev@googlegroups.com}'
+    assert ('\\sphinxurl{https://github.com/sphinx-doc/sphinx}\n' in result)
+    assert ('\\sphinxhref{mailto:sphinx-dev@googlegroups.com}'
             '{sphinx-dev@googlegroups.com}\n') in result
 
 
@@ -646,19 +646,19 @@ def test_latex_show_urls_is_no(app, status, warning):
             'First\n%\n\\end{footnote}') in result
     assert ('Second footnote: %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'Second\n%\n\\end{footnote}') in result
-    assert '\\href{http://sphinx-doc.org/}{Sphinx}' in result
+    assert '\\sphinxhref{http://sphinx-doc.org/}{Sphinx}' in result
     assert ('Third footnote: %\n\\begin{footnote}[3]\\sphinxAtStartFootnote\n'
             'Third\n%\n\\end{footnote}') in result
-    assert '\\href{http://sphinx-doc.org/~test/}{URL including tilde}' in result
-    assert ('\\item[{\\href{http://sphinx-doc.org/}{URL in term}}] '
+    assert '\\sphinxhref{http://sphinx-doc.org/~test/}{URL including tilde}' in result
+    assert ('\\item[{\\sphinxhref{http://sphinx-doc.org/}{URL in term}}] '
             '\\leavevmode\nDescription') in result
     assert ('\\item[{Footnote in term \\sphinxfootnotemark[5]}] '
             '\\leavevmode%\n\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'
             'Footnote in term\n%\n\\end{footnotetext}\nDescription') in result
-    assert ('\\item[{\\href{http://sphinx-doc.org/}{Term in deflist}}] '
+    assert ('\\item[{\\sphinxhref{http://sphinx-doc.org/}{Term in deflist}}] '
             '\\leavevmode\nDescription') in result
-    assert ('\\url{https://github.com/sphinx-doc/sphinx}\n' in result)
-    assert ('\\href{mailto:sphinx-dev@googlegroups.com}'
+    assert ('\\sphinxurl{https://github.com/sphinx-doc/sphinx}\n' in result)
+    assert ('\\sphinxhref{mailto:sphinx-dev@googlegroups.com}'
             '{sphinx-dev@googlegroups.com}\n') in result
 
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -217,7 +217,7 @@ def get_verifier(verify, verify_re):
         'verify_re',
         u'`test <http://example.com/~me/>`_',
         None,
-        r'\\href{http://example.com/~me/}{test}.*',
+        r'\\sphinxhref{http://example.com/~me/}{test}.*',
     ),
 ])
 def test_inline(get_verifier, type, rst, html_expected, latex_expected):


### PR DESCRIPTION
Subject: address issues with ``\url`` and ``\href`` LaTeX macros when originating from contents of a parsed-literal block, or in case some extension treats them as code.

The method which is a part of #3340 included a fix for hyperlinks inside parsed literals, but this fix requires the LaTeX macros to be at top level, the fix fails if they end up as arguments of other macros, such as text styling macros. Which may happen in particular due to extensions.

The same arises when hyperlinks are wrapped inside a `\sphinxcode`, for similar reasons. (#3533)

### Feature or Bugfix
As it fixes again #3317 in a more robust way, and also #3533 (the latter is not a pure Sphinx issue but may be raised by extensions) this is:
- Bugfix

### Detail
The `\detokenize` which was used to fix at #3206 related issue #3200 involving `\hyperref` macro can not be used here, because `\href` will have macros like `\#` in its first argument. Rather than patching `\href`, Sphinx uses `\sphinxhref` mark-up with a suitable definition as wrapper of non-modified `\href`. Same with `\sphinxurl` and `\sphinxnolinkurl` (for the later case, line wrapping inside parsed-literal will now be fully under control of original `\url` macro; with #3340, it was in control of the general method of allowing line wrapping inside parsed-literal, this is slightly different, but more coherent too, as URLs will wrap the same inside and outside a parsed-literal).

The commit also removes an unneeded macro call from the definition of `\sphinxcode`.

### Relates
- #3533, #3340, #3317, #3308, #3207.

