### PR TITLE
Streamline obsolete color set-up in LaTeX style file

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -402,33 +402,15 @@
 
 %% COLOR (general)
 %
-% FIXME: the reasons might be obsolete (better color drivers now?)
-% use pdfoutput for pTeX and dvipdfmx
-% when pTeX (\kanjiskip is defined), set pdfoutput to evade \include{pdfcolor}
-\ifx\kanjiskip\undefined\else
-  \newcount\pdfoutput\pdfoutput=0
-\fi
-
-% for PDF output, use colors and maximal compression
-\newif\ifsphinxpdfoutput % used in \maketitle
-\ifx\pdfoutput\undefined\else
- \ifnum\pdfoutput=\z@
-  \let\py@NormalColor\relax
-  \let\py@TitleColor\relax
- \else
-  \sphinxpdfoutputtrue
-  \input{pdfcolor}
-  \def\py@NormalColor{\color[rgb]{0.0,0.0,0.0}}
-  \def\py@TitleColor{\color{TitleColor}}
-  \pdfcompresslevel=9
- \fi
-\fi
-
-% XeLaTeX can do colors, too
-\ifx\XeTeXrevision\undefined\else
-  \def\py@NormalColor{\color[rgb]{0.0,0.0,0.0}}
-  \def\py@TitleColor{\color{TitleColor}}
-\fi
+% FIXME: \normalcolor should probably be used in place of \py@NormalColor
+% elsewhere, and \py@NormalColor shoudl never be defined. \normalcolor
+% switches to the colour from last \color call in preamble.
+\def\py@NormalColor{\color{black}}
+% FIXME: it is probably better to use \color{TitleColor}, as TitleColor
+% can be customized from 'sphinxsetup', and drop usage of \py@TitleColor
+\def\py@TitleColor{\color{TitleColor}}
+% FIXME: this line should be dropped, as "9" is default anyhow.
+\ifdefined\pdfcompresslevel\pdfcompresslevel = 9 \fi
 
 
 %% PAGE STYLING

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -403,7 +403,7 @@
 %% COLOR (general)
 %
 % FIXME: \normalcolor should probably be used in place of \py@NormalColor
-% elsewhere, and \py@NormalColor shoudl never be defined. \normalcolor
+% elsewhere, and \py@NormalColor should never be defined. \normalcolor
 % switches to the colour from last \color call in preamble.
 \def\py@NormalColor{\color{black}}
 % FIXME: it is probably better to use \color{TitleColor}, as TitleColor

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -31,7 +31,8 @@
 %
 \renewcommand{\maketitle}{%
   \noindent\rule{\textwidth}{1pt}\newline\null\par
-  \ifsphinxpdfoutput
+  % FIXME: use \hypersetup{pdfauthor={\@author}, pdftitle={\@title}}
+  \ifdefined\pdfinfo
     \begingroup
     % These \defs are required to deal with multi-line authors; it
     % changes \\ to ', ' (comma-space), making it pass muster for

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -30,7 +30,7 @@
 % ``Bjarne'' style a bit better.
 %
 \renewcommand{\maketitle}{%
-  \noindent\rule{\textwidth}{1pt}\newline\null\par
+  \noindent\rule{\textwidth}{1pt}\par
   % FIXME: use \hypersetup{pdfauthor={\@author}, pdftitle={\@title}}
   \ifdefined\pdfinfo
     \begingroup

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -30,7 +30,7 @@
 % ``Bjarne'' style a bit better.
 %
 \renewcommand{\maketitle}{%
-  \noindent\rule{\textwidth}{1pt}\ifsphinxpdfoutput\newline\null\fi\par
+  \noindent\rule{\textwidth}{1pt}\newline\null\par
   \ifsphinxpdfoutput
     \begingroup
     % These \defs are required to deal with multi-line authors; it

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -40,7 +40,7 @@
   \begin{titlepage}%
     \let\footnotesize\small
     \let\footnoterule\relax
-    \noindent\rule{\textwidth}{1pt}\ifsphinxpdfoutput\newline\null\fi\par
+    \noindent\rule{\textwidth}{1pt}\newline\null\par
     \ifsphinxpdfoutput
       \begingroup
       % These \defs are required to deal with multi-line authors; it

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -40,7 +40,7 @@
   \begin{titlepage}%
     \let\footnotesize\small
     \let\footnoterule\relax
-    \noindent\rule{\textwidth}{1pt}\newline\null\par
+    \noindent\rule{\textwidth}{1pt}\par
     % FIXME: use \hypersetup{pdfauthor={\@author}, pdftitle={\@title}}
     \ifdefined\pdfinfo
       \begingroup

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -41,7 +41,8 @@
     \let\footnotesize\small
     \let\footnoterule\relax
     \noindent\rule{\textwidth}{1pt}\newline\null\par
-    \ifsphinxpdfoutput
+    % FIXME: use \hypersetup{pdfauthor={\@author}, pdftitle={\@title}}
+    \ifdefined\pdfinfo
       \begingroup
       % These \defs are required to deal with multi-line authors; it
       % changes \\ to ', ' (comma-space), making it pass muster for

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -563,9 +563,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
                                                 language=builder.config.language)
         if builder.config.latex_logo:
             # no need for \\noindent here, used in flushright
-            self.elements['logo'] = ('{\\parskip0pt \\nointerlineskip\n'
-                                     '\\sphinxincludegraphics{%s}\\par}' %
-                                     path.basename(builder.config.latex_logo))
+            self.elements['logo'] = '\\sphinxincludegraphics{%s}\\par' % \
+                                    path.basename(builder.config.latex_logo)
 
         if builder.config.language \
            and 'fncychap' not in builder.config.latex_elements:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -563,8 +563,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
                                                 language=builder.config.language)
         if builder.config.latex_logo:
             # no need for \\noindent here, used in flushright
-            self.elements['logo'] = '\\sphinxincludegraphics{%s}\\par' % \
-                                    path.basename(builder.config.latex_logo)
+            self.elements['logo'] = ('{\\parskip0pt \\nointerlineskip\n'
+                                     '\\sphinxincludegraphics{%s}\\par}' %
+                                     path.basename(builder.config.latex_logo))
 
         if builder.config.language \
            and 'fncychap' not in builder.config.latex_elements:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -86,7 +86,7 @@ DEFAULT_SETTINGS = {
     'date':            '',
     'release':         '',
     'author':          '',
-    'logo':            '',
+    'logo':            '\\vbox{}',
     'releasename':     '',
     'makeindex':       '\\makeindex',
     'shorthandoff':    '',


### PR DESCRIPTION
Streamline obsolete color set-up in LaTeX style file

The file ``pdfcolor.tex`` included in tex distributions is for Plain pdfTeX, not for LaTeX use. Loading it complicates task of supporting multiple TeX engines. If needed all corresponding colour names are better available from ``color`` or ``xcolor`` ``dvipsnames`` option. It is better to leave responsability of using this option to Sphinx user, if needed. The TeX macros defined by ``pdfcolor.tex`` were never documented to Sphinx user, and they can not be used from reST apart from ``.. raw:: latex`` directive, they are for Plain TeX without use of ``color`` package. Thus, this commit drops loading this file and the complicated conditionals around it (`\ifsphinxpdfoutput`), also used in the class files Sphinx provides. <strike>(as this commit is based on master branch which is currently broken (at dbffb05) I did not test really `platex` engine, but I will update.)</strike> (now rebased)

On the occasion of this change to the class files, I have also reverted commit 7db8141 which maintained a title page layout for `xelatex` which was probably accidental and due to wrong spaces in TeX file. This will affect `platex` too and adds a line between top rule and logo, like for `pdflatex` engine. This was mentioned at https://github.com/sphinx-doc/sphinx/pull/2736#issuecomment-230140016

### Feature or Bugfix
- Bugfix (in my opinion) but it is also breaking change (added blank line on title page for Japanase and xelatex, making it identical to pdflatex or lualatex)

### Relates
This fixes issue #2693.

### Question
Arguably the blank line after top rule on title page and above logo was an accidental feature. This commit inserts it deliberately for all engines, not only pdflatex and lualatex. Perhaps it would be better to suppress it for all engines, making the xelatex and platex behaviour the default ?