### PR TITLE
Allow running Sphinx without ssl

### DIFF
--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -36,30 +36,34 @@ except ImportError:
         # for requests < 2.4.0
         InsecureRequestWarning = None
 
-# try to load requests[security]
+# try to load requests[security] (but only if SSL is available)
 try:
-    pkg_resources.require(['requests[security]'])
-except (pkg_resources.DistributionNotFound,
-        pkg_resources.VersionConflict):
     import ssl
-    if not getattr(ssl, 'HAS_SNI', False):
-        # don't complain on each url processed about the SSL issue
-        requests.packages.urllib3.disable_warnings(
-            requests.packages.urllib3.exceptions.InsecurePlatformWarning)
+except ImportError:
+    pass
+else:
+    try:
+        pkg_resources.require(['requests[security]'])
+    except (pkg_resources.DistributionNotFound,
+            pkg_resources.VersionConflict):
+        if not getattr(ssl, 'HAS_SNI', False):
+            # don't complain on each url processed about the SSL issue
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecurePlatformWarning)
+            warnings.warn(
+                'Some links may return broken results due to being unable to '
+                'check the Server Name Indication (SNI) in the returned SSL cert '
+                'against the hostname in the url requested. Recommended to '
+                'install "requests[security]" as a dependency or upgrade to '
+                'a python version with SNI support (Python 3 and Python 2.7.9+).'
+            )
+    except pkg_resources.UnknownExtra:
         warnings.warn(
             'Some links may return broken results due to being unable to '
             'check the Server Name Indication (SNI) in the returned SSL cert '
             'against the hostname in the url requested. Recommended to '
-            'install "requests[security]" as a dependency or upgrade to '
-            'a python version with SNI support (Python 3 and Python 2.7.9+).'
+            'install requests-2.4.1+.'
         )
-except pkg_resources.UnknownExtra:
-    warnings.warn(
-        'Some links may return broken results due to being unable to '
-        'check the Server Name Indication (SNI) in the returned SSL cert '
-        'against the hostname in the url requested. Recommended to '
-        'install requests-2.4.1+.'
-    )
 
 useragent_header = [('User-Agent',
                      'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0')]


### PR DESCRIPTION
Subject: `intersphinx` should work even if SSL is not available

### Feature or Bugfix
- Bugfix

### Purpose
Currently, one cannot import `intersphinx` if SSL is not available, even if one only wants to use `intersphinx` locally. This is due to an `import ssl` in `sphinx/util/requests.py`. The import of `ssl` should be guarded by a `try/except ImportError`.

### Relates
- https://trac.sagemath.org/ticket/22252