### PR TITLE
test_markup: Make verify functions test both HTML and LaTeX outputs

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -97,9 +97,9 @@ def verify_re_latex(app, parse):
 def verify_re(verify_re_html, verify_re_latex):
     def verify_re_(rst, html_expected, latex_expected):
         if html_expected:
-            return verify_re_html(rst, html_expected)
+            verify_re_html(rst, html_expected)
         if latex_expected:
-            return verify_re_latex(rst, latex_expected)
+            verify_re_latex(rst, latex_expected)
     return verify_re_
 
 
@@ -107,9 +107,9 @@ def verify_re(verify_re_html, verify_re_latex):
 def verify(verify_re_html, verify_re_latex):
     def verify_(rst, html_expected, latex_expected):
         if html_expected:
-            return verify_re_html(rst, re.escape(html_expected) + '$')
+            verify_re_html(rst, re.escape(html_expected) + '$')
         if latex_expected:
-            return verify_re_latex(rst, re.escape(latex_expected) + '$')
+            verify_re_latex(rst, re.escape(latex_expected) + '$')
     return verify_
 
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -179,7 +179,7 @@ def get_verifier(verify, verify_re):
         'verify',
         '"John"',
         '<p>&#8220;John&#8221;</p>',
-        "``John''",
+        r'\sphinxquotedblleft{}John\sphinxquotedblright{}',
     ),
     (
         # ... but not in literal text


### PR DESCRIPTION
Previously they would return after performing the HTML check, without running the LaTeX one.

(This is something I noticed while working on a different pull request.)