### PR TITLE
Mention style-checks and type-checks in the devguide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -127,6 +127,11 @@ These are the basic steps needed to start developing on Sphinx.
        cd doc
        make clean html latexpdf
 
+   * Run code style checks and type checks (type checks require mypy)::
+
+      make style-check
+      make type-check
+
    * Run the unit tests under different Python environments using
      :program:`tox`::
 


### PR DESCRIPTION
It would be nice to mention the style-checks and type-checks such that new developers do not get failed CI tests due to these. Many other ways to test changes are already mentioned in the devguide / CONTRIBUTING file so it seems like an omission not to mention the code style tests