### PR TITLE
tests: Fix invalid escape sequence

### DIFF
--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -955,7 +955,7 @@ def test_latex_table_longtable(app, status, warning):
     table = tables['longtable having caption']
     assert ('\\begin{longtable}{|l|l|}\n\\caption{caption for longtable\\strut}'
             '\\label{\\detokenize{longtable:id1}}'
-            '\\\\*[\sphinxlongtablecapskipadjust]\n\\hline' in table)
+            '\\\\*[\\sphinxlongtablecapskipadjust]\n\\hline' in table)
 
     # longtable having verbatim
     table = tables['longtable having verbatim']


### PR DESCRIPTION
This fixes this warning with Python 3.6:
```
tests/test_build_latex.py:958: DeprecationWarning: invalid escape sequence \s
  '\\\\*[\sphinxlongtablecapskipadjust]\n\\hline' in table)
```

The warning could be seen i.e. in Python 3.6 Travis output.