### PR TITLE
Fix intersphinx debug tool

### DIFF
--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -26,6 +26,7 @@
 
 from __future__ import print_function
 
+import sys
 import time
 import functools
 import posixpath
@@ -340,17 +341,26 @@ def setup(app):
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}
 
 
-if __name__ == '__main__':
-    # debug functionality to print out an inventory
-    import sys
+def debug(argv):
+    """Debug functionality to print out an inventory"""
+    if len(argv) < 2:
+        print("Print out an inventory file.\n"
+              "Error: must specify local path or URL to an inventory file.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    class MockConfig(object):
+        intersphinx_timeout = None  # type: int
+        tls_verify = False
 
     class MockApp(object):
         srcdir = ''
+        config = MockConfig()
 
         def warn(self, msg):
             print(msg, file=sys.stderr)
 
-    filename = sys.argv[1]
+    filename = argv[1]
     invdata = fetch_inventory(MockApp(), '', filename)  # type: ignore
     for key in sorted(invdata or {}):
         print(key)
@@ -358,3 +368,7 @@ if __name__ == '__main__':
             print('\t%-40s %s%s' % (entry,
                                     einfo[3] != '-' and '%-40s: ' % einfo[3] or '',
                                     einfo[2]))
+
+
+if __name__ == '__main__':
+    debug(argv=sys.argv)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
I recently discovered that intersphinx has a debugging tool that can be run by calling `python -m sphinx.ext.intersphinx`. However, this tool is currently broken for loading URLs, probably because it's not tested or documented. This pull request fixes the debugging tool and adds automated tests. If we determine that it's generally useful, we can add documentation about this debugging tool, as well -- but that can happen in a future pull request.

