### PR TITLE
Fix intersphinx debug tool

### DIFF
--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -26,6 +26,7 @@
 
 from __future__ import print_function
 
+import sys
 import time
 import zlib
 import codecs
@@ -373,17 +374,26 @@ def setup(app):
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}
 
 
-if __name__ == '__main__':
-    # debug functionality to print out an inventory
-    import sys
+def debug(argv):
+    """Debug functionality to print out an inventory"""
+    if len(argv) < 2:
+        print("Print out an inventory file.\n"
+              "Error: must specify local path or URL to an inventory file.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    class MockConfig(object):
+        intersphinx_timeout = None  # type: int
+        tls_verify = False
 
     class MockApp(object):
         srcdir = ''
+        config = MockConfig()
 
         def warn(self, msg):
             print(msg, file=sys.stderr)
 
-    filename = sys.argv[1]
+    filename = argv[1]
     invdata = fetch_inventory(MockApp(), '', filename)
     for key in sorted(invdata or {}):
         print(key)
@@ -391,3 +401,7 @@ if __name__ == '__main__':
             print('\t%-40s %s%s' % (entry,
                                     einfo[3] != '-' and '%-40s: ' % einfo[3] or '',
                                     einfo[2]))
+
+
+if __name__ == '__main__':
+    debug(argv=sys.argv)

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -16,12 +16,16 @@ import zlib
 from six import BytesIO
 from docutils import nodes
 import mock
+import pytest
+import requests
+from io import BytesIO
 
 from sphinx import addnodes
 from sphinx.ext.intersphinx import setup as intersphinx_setup
 from sphinx.ext.intersphinx import read_inventory, \
     load_mappings, missing_reference, _strip_basic_auth, \
-    _get_safe_url, fetch_inventory, INVENTORY_FILENAME
+    _get_safe_url, fetch_inventory, INVENTORY_FILENAME, \
+    debug
 
 
 inventory_v1 = '''\
@@ -282,3 +286,53 @@ def test_getsafeurl_unauthed():
     expected = 'https://domain.com/project/objects.inv'
     actual = _get_safe_url(url)
     assert expected == actual
+
+
+def test_debug_noargs(capsys):
+    """debug interface, without arguments"""
+    with pytest.raises(SystemExit):
+        debug(['sphinx/ext/intersphinx.py'])
+
+    expected = (
+        "Print out an inventory file.\n"
+        "Error: must specify local path or URL to an inventory file."
+    )
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ""
+    assert stderr == expected + "\n"
+
+
+def test_debug_file(capsys, tempdir):
+    """debug interface, with file argument"""
+    inv_file = tempdir / 'inventory'
+    inv_file.write_bytes(inventory_v2)
+
+    debug(['sphinx/ext/intersphinx.py', str(inv_file)])
+
+    stdout, stderr = capsys.readouterr()
+    assert stdout.startswith("c:function\n")
+    assert stderr == ""
+
+
+@mock.patch('requests.get')
+def test_debug_url(fake_get, capsys):
+    """debug interface, with url argument"""
+    raw = BytesIO(inventory_v2)
+    real_read = raw.read
+
+    def fake_read(*args, **kwargs):
+        return real_read()
+
+    raw.read = fake_read
+    url = 'http://hostname/' + INVENTORY_FILENAME
+    resp = requests.Response()
+    resp.status_code = 200
+    resp.url = url
+    resp.raw = raw
+    fake_get.return_value = resp
+
+    debug(['sphinx/ext/intersphinx.py', url])
+
+    stdout, stderr = capsys.readouterr()
+    assert stdout.startswith("c:function\n")
+    assert stderr == ""


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
I recently discovered that intersphinx has a debugging tool that can be run by calling `python -m sphinx.ext.intersphinx`. However, this tool is currently broken for loading URLs, probably because it's not tested or documented. This pull request fixes the debugging tool and adds automated tests. If we determine that it's generally useful, we can add documentation about this debugging tool, as well -- but that can happen in a future pull request.

This is the same change as #3576, but applied to the `stable` branch instead of the `master` branch.