### PR TITLE
Remove unused default_sidebars class member

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -119,9 +119,6 @@ class StandaloneHTMLBuilder(Builder):
     imgpath = None          # type: unicode
     domain_indices = []     # type: List[Tuple[unicode, Type[Index], List[Tuple[unicode, List[List[Union[unicode, int]]]]], bool]]  # NOQA
 
-    default_sidebars = ['localtoc.html', 'relations.html',
-                        'sourcelink.html', 'searchbox.html']
-
     # cached publisher object for snippets
     _publisher = None
 


### PR DESCRIPTION
It was a leftover from commit 03b9d79b347737f73d05b0d3e47782e3183840c7.
