### PR TITLE
Feature: Implement anonymous namespaces in the c++ domain

### DIFF
--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -833,6 +833,9 @@ directive.
 
    Using ``NULL``, ``0``, or ``nullptr`` as the scope will change to global scope.
 
+   A special name of the form ``anonymous{compilation unit}`` can be used to
+   represent C++ anonymous ``namespace``s.
+
    A namespace declaration can also be templated, e.g.,::
 
       .. cpp:class:: template<typename T> \

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -301,6 +301,9 @@ _operator_re = re.compile(r'''(?x)
     |   (<<|>>)=? | && | \|\|
     |   [!<>=/*%+|&^~-]=?
 ''')
+# for anonymous namespaces. We document the former, but the latter is what
+# doxygen uses.
+_anonname_re = re.compile(r'(?:anonymous|anonymous_namespace)\{([^{}]+)\}')
 # see http://en.cppreference.com/w/cpp/keyword
 _keywords = [
     'alignas', 'alignof', 'and', 'and_eq', 'asm', 'auto', 'bitand', 'bitor',
@@ -719,6 +722,24 @@ class ASTIdentifier(ASTBase):
             signode += nodes.Text(self.identifier)
         else:
             raise Exception('Unknown description mode: %s' % mode)
+
+class ASTAnonymousIdentifier(ASTIdentifier):
+    """ For anonymous C++ namespaces """
+    def __init__(self, compilation_unit):
+        self.compilation_unit = compilation_unit
+
+    @property
+    def identifier(self):
+        raise ValueError
+
+    def __unicode__(self):
+        return "anonymous (in {})".format(self.compilation_unit)
+
+    def get_id_v1(self):
+        raise NoOldIdError()
+
+    def get_id_v2(self):
+        return '12_GLOBAL__N_1'
 
 
 class ASTTemplateKeyParamPackIdDefault(ASTBase):
@@ -3589,18 +3610,22 @@ class DefinitionParser(object):
                 op = self._parse_operator()
                 names.append(op)
             else:
-                if not self.match(_identifier_re):
+                if self.match(_anonname_re):
+                    identifier = ASTAnonymousIdentifier(self.last_match.group(1))
+                    names.append(ASTNestedNameElement(identifier, None))
+                elif self.match(_identifier_re):
+                    identifier = self.matched_text
+                    # make sure there isn't a keyword
+                    if identifier in _keywords:
+                        self.fail("Expected identifier in nested name, "
+                                  "got keyword: %s" % identifier)
+                    templateArgs = self._parse_template_argument_list()
+                    identifier = ASTIdentifier(identifier)  # type: ignore
+                    names.append(ASTNestedNameElement(identifier, templateArgs))
+                else:
                     if memberPointer and len(names) > 0:
                         break
                     self.fail("Expected identifier in nested name.")
-                identifier = self.matched_text
-                # make sure there isn't a keyword
-                if identifier in _keywords:
-                    self.fail("Expected identifier in nested name, "
-                              "got keyword: %s" % identifier)
-                templateArgs = self._parse_template_argument_list()
-                identifier = ASTIdentifier(identifier)  # type: ignore
-                names.append(ASTNestedNameElement(identifier, templateArgs))
 
             self.skip_ws()
             if not self.skip_string('::'):

--- a/tests/roots/test-domain-cpp/index.rst
+++ b/tests/roots/test-domain-cpp/index.rst
@@ -37,6 +37,19 @@ directives
    A scoped enum with non-default visibility, and with a specified underlying type.
 
 
+.. cpp:var:: int some_namespace::anonymous{my_file.cpp}::some_var
+
+   A variable in an anonymous namespace, such as:
+
+   .. code::
+
+      namespace some_namespace {
+          namespace {
+              int some_var;
+          }
+      }
+
+
 .. cpp:function:: void paren_1(int, float)
 .. cpp:function:: void paren_2(int, float)
 .. cpp:function:: void paren_3(int, float)


### PR DESCRIPTION
This fixes michaeljones/breathe#326, since the actual problem is lack of core
sphinx support.

C++ has a feature of anonymous namespaces, which sort of behave like the `static` keyword. 
Note that the following code is valid C++ - none of the variable names are multiply-defined:

```c++
static int my_var;

// sort of the same as:
namespace {
   int my_var;
}

// also allowed
namespace foo {
   int my_var;
   namespace {
       int my_var;
   }
}
```

While in C++, there is no way to specify an anonymous namespace explicitly with `::`, we need some way to do so in sphinx to document them.

This introduces the syntax `anonymous{myfile.cpp}::my_var` and `foo::anonymous{my_file.cpp}::my_var`. This is similar to what `doxygen` uses to refer to these - they use `anonymous_namespace{filename}`. To make michaeljones/breathe work out of the boc, this chooses to allow either.

---

It's important to have the filename in the namespace description. If there are two files, then `anonymous{one.cpp}::var` and `anonymous{two.cpp}::var` are different things.

Right now, this doesn't actually affect the id - but nor does `static`. This at least gives scope for fixing it in future.