### PR TITLE
Change MathJax CDN

### DIFF
--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -74,7 +74,7 @@ def setup(app):
     # more information for mathjax secure url is here:
     # http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn
     app.add_config_value('mathjax_path',
-                         'https://cdn.mathjax.org/mathjax/latest/MathJax.js?'
+                         'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?'
                          'config=TeX-AMS-MML_HTMLorMML', False)
     app.add_config_value('mathjax_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('mathjax_display', [r'\[', r'\]'], 'html')


### PR DESCRIPTION
Subject: change MathJax CDN due to MathJax CDN shutdown.

### Feature or Bugfix

- Bugfix

### Purpose

To fix #3599

### Detail

Because MathJax CDN will be shut down, change CDN URL to `https://cdnjs.cloudflare.com` according to [MathJax blog post](https://www.mathjax.org/cdn-shutting-down/)

And pinned version to `MathJax 2.7.0`

### Relates

#3599
