### PR TITLE
Fix PyObject.before_content()

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -332,6 +332,7 @@ class PyObject(ObjectDescription):
         only the most recent object is tracked. This object prefix name will be
         removed with :py:meth:`after_content`.
         """
+        prefix = None
         if self.names:
             # fullname and name_prefix come from the `handle_signature` method.
             # fullname represents the full object name that is constructed using
@@ -342,8 +343,6 @@ class PyObject(ObjectDescription):
                 prefix = fullname
             elif name_prefix:
                 prefix = name_prefix.strip('.')
-            else:
-                prefix = None
         if prefix:
             self.env.ref_context['py:class'] = prefix
             if self.allow_nesting:


### PR DESCRIPTION
Fix "UnboundLocalError: local variable 'prefix' referenced before
assignment" variable in PyObject.before_content(): define prefix when
self.names is false.

Fix regression introduced by 279588931023c14c. See the Pythonx bug report: http://bugs.python.org/issue29973

Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

