### PR TITLE
Categorize "duplicate citation" warnings.

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -542,7 +542,7 @@ class StandardDomain(Domain):
             if label in self.data['citations']:
                 path = env.doc2path(self.data['citations'][label][0])
                 env.warn_node('duplicate citation %s, other instance in %s' %
-                              (label, path), node)
+                              (label, path), node, type='ref', subtype='citation')
             self.data['citations'][label] = (docname, node['ids'][0])
 
     def note_labels(self, env, docname, document):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- I wanted to suppress "duplicate citation" warnings using the ``suppress_warnings`` conf value.  This requires that the warning in question have a type and subtype, which "duplicate citation" didn't have.  

### Details
- This pull request categorizes "duplicate citation" as "ref.citation".  This category of warning is already documented, although I could not find anywhere else that uses it.

