### PR TITLE
Categorize "duplicate citation" warnings (on master branch).

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -571,7 +571,7 @@ class StandardDomain(Domain):
             if label in self.data['citations']:
                 path = env.doc2path(self.data['citations'][label][0])
                 logger.warning('duplicate citation %s, other instance in %s', label, path,
-                               location=node)
+                               location=node, type='ref', subtype='citation')
             self.data['citations'][label] = (docname, node['ids'][0])
 
     def note_labels(self, env, docname, document):


### PR DESCRIPTION
This is the same as #3607, but targeted to `master` instead of `stable`.

