### PR TITLE
Add appveyor for testing on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,17 @@
+# ref: https://packaging.python.org/appveyor/
+
+environment:
+  matrix:
+    - PYTHON: 36-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - python -m pip install -U pip setuptools
+  - python -m pip install -r test-reqs.txt
+
+build: off
+
+test_script:
+  - cd tests
+  - python run.py -vvv
+


### PR DESCRIPTION
### Feature or Bugfix
- Feature: testing environment on Windows

### Purpose
- test on WIndows to detect OS specific problems such as #3592

### review point
- .appveyor.yml just test with py36-x64

### test result example

- https://ci.appveyor.com/project/sphinxdoc/sphinx/build/1.0.3

### refs

- https://packaging.python.org/appveyor/
