### PR TITLE
Fix typo in 'emphasize-lines'

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -434,7 +434,7 @@ class LiteralInclude(Directive):
                                   'lineno-match' in self.options)
             retnode['classes'] += self.options.get('class', [])
             extra_args = retnode['highlight_args'] = {}
-            if 'empahsize-lines' in self.options:
+            if 'emphasize-lines' in self.options:
                 hl_lines = parselinenos(self.options['emphasize-lines'], lines)
                 if any(i >= lines for i in hl_lines):
                     logger.warning('line number spec is out of range(1-%d): %r' %


### PR DESCRIPTION
Signed-off-by: Ray Lehtiniemi <rayl@mail.com>

Subject: Fix typo in emphasize-lines option

### Feature or Bugfix
- Bugfix

### Purpose
- Fix typo that impacted this feature

### Detail
- Check for option had a spelling mistake

### Relates
- none

