### PR TITLE
Use duck-typing for checking functions

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -60,7 +60,7 @@ if PY3:
                                        kwodefs, argspec[6])
         while hasattr(func, '__wrapped__'):
             func = func.__wrapped__
-        if not inspect.isfunction(func):
+        if not hasattr(func, '__code__'):
             raise TypeError('%r is not a Python function' % func)
         return inspect.getfullargspec(func)
 
@@ -79,7 +79,7 @@ else:  # 2.7
                 keywords = {}
             parts = len(func.args), keywords.keys()
             func = func.func
-        if not inspect.isfunction(func):
+        if not hasattr(func, '__code__'):
             raise TypeError('%r is not a Python function' % func)
         args, varargs, varkw = inspect.getargs(func.__code__)
         func_defaults = func.__defaults__
@@ -126,6 +126,17 @@ def isdescriptor(x):
     """Check if the object is some kind of descriptor."""
     for item in '__get__', '__set__', '__delete__':
         if hasattr(safe_getattr(x, item, None), '__call__'):
+            return True
+    return False
+
+
+def isfunction(x):
+    # type: (Any) -> bool
+    """Check if the object is some kind of function."""
+    if inspect.isbuiltin(x):
+        return True
+    for cls in inspect.getmro(type(x)):
+        if "__code__" in cls.__dict__:
             return True
     return False
 


### PR DESCRIPTION
Subject: Use duck-typing instead of checking types to determine if something is a function

### Feature or Bugfix
- Feature fixing a bug

### Purpose
[Cython](http://cython.org/) has a custom type "cyfunction" which can be inspected and whose argspec can be determined in the usual way. The only obstruction is that Sphinx does not consider these cyfunctions as functions, because it checks the type. This PR fixes this by using duck-typing: if something has a `__code__` attribute, it is assumed to be a function.

### Relates
- http://cython.readthedocs.io/en/latest/src/userguide/limitations.html#inspect-support
- Use case: http://cysignals.readthedocs.io/en/latest/pysignals.html#cysignals.pysignals.setsignal (built from https://github.com/sagemath/cysignals/blob/master/src/cysignals/pysignals.pyx)
- https://github.com/OpenDreamKit/OpenDreamKit/issues/87