### PR TITLE
Do not emit local citations warning

### DIFF
--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -296,12 +296,6 @@ class UnreferencedFootnotesDetector(SphinxTransform):
                                type='ref', subtype='footnote',
                                location=node)
 
-        for node in self.document.citations:
-            if node['names'][0] not in self.document.citation_refs:
-                logger.warning('Citation [%s] is not referenced.', node['names'][0],
-                               type='ref', subtype='citation',
-                               location=node)
-
 
 class FilterSystemMessages(SphinxTransform):
     """Filter system messages from a doctree."""


### PR DESCRIPTION
https://github.com/sphinx-doc/sphinx/pull/3565 allows to emit warning for unused citations, however through testing I noticed this only checked for the current file whereas citations are allowed to be global (for example refs in a bibliography.rst, and citations in docstrings)
Until these checks could be resolved globally, I propose to not emit these false positive (I would not know enough of sphinx's internals to do that)

