### PR TITLE
fix #3639: use html5 writer for epub by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Incompatible changes
   (refs #3550)
 * ``Builder.env`` is not filled at instantiation
 * #3594: LaTeX: single raw directive has been considered as block level element
+* #3639: If ``html5_experimental_writer`` is available, epub builder use it by default.
 
 Features removed
 ----------------

--- a/CHANGES
+++ b/CHANGES
@@ -42,7 +42,7 @@ Incompatible changes
   (refs #3550)
 * ``Builder.env`` is not filled at instantiation
 * #3594: LaTeX: single raw directive has been considered as block level element
-* #3639: If ``html5_experimental_writer`` is available, epub builder use it by default.
+* #3639: If ``html_experimental_html5_writer`` is available, epub builder use it by default.
 
 Features removed
 ----------------

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -132,6 +132,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
     html_scaled_image_link = False
     # don't generate search index or include search page
     search = False
+    # use html5 translator by default
+    default_html5_translator = True
 
     coverpage_name = COVERPAGE_NAME
     toctree_template = TOCTREE_TEMPLATE

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -109,6 +109,8 @@ class StandaloneHTMLBuilder(Builder):
     search = True  # for things like HTML help and Apple help: suppress search
     use_index = False
     download_support = True  # enable download role
+    # use html5 translator by default
+    default_html5_translator = False
 
     # This is a class attribute because it is mutated by Sphinx.add_javascript.
     script_files = ['_static/jquery.js', '_static/underscore.js',
@@ -199,7 +201,11 @@ class StandaloneHTMLBuilder(Builder):
     def init_translator_class(self):
         # type: () -> None
         if self.translator_class is None:
-            if self.config.html_experimental_html5_writer and html5_ready:
+            use_html5_writer = self.config.html_experimental_html5_writer
+            if use_html5_writer is None:
+                use_html5_writer = self.default_html5_translator and html5_ready
+
+            if use_html5_writer and html5_ready:
                 if self.config.html_use_smartypants:
                     self.translator_class = SmartyPantsHTML5Translator
                 else:
@@ -1322,7 +1328,7 @@ def setup(app):
     app.add_config_value('html_search_options', {}, 'html')
     app.add_config_value('html_search_scorer', '', None)
     app.add_config_value('html_scaled_image_link', True, 'html')
-    app.add_config_value('html_experimental_html5_writer', False, 'html')
+    app.add_config_value('html_experimental_html5_writer', None, 'html')
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
Subject: use html5 writer for epub by default

### Feature or Bugfix
- Feature

### Purpose
- Reduce epub-check errors/warnings.

### Relates
- #3639

