### PR TITLE
Use inspect instead of checking types

### DIFF
--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -16,7 +16,7 @@ import sys
 import inspect
 import traceback
 import warnings
-from types import FunctionType, BuiltinFunctionType, MethodType, ModuleType
+from types import FunctionType, MethodType, ModuleType
 
 from six import PY2, iterkeys, iteritems, itervalues, text_type, class_types, \
     string_types, StringIO
@@ -1341,7 +1341,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
         # type: (Any, unicode, bool, Any) -> bool
-        return isinstance(member, (FunctionType, BuiltinFunctionType))
+        return inspect.isfunction(member) or inspect.isbuiltin(member)
 
     def format_args(self):
         # type: () -> unicode
@@ -1637,13 +1637,16 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
     # some non-data descriptors as methods
     priority = 10
 
-    method_types = (FunctionType, BuiltinFunctionType, MethodType)
+    @staticmethod
+    def is_function_or_method(obj):
+        return inspect.isfunction(obj) or inspect.isbuiltin(obj) or inspect.ismethod(obj)
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
         # type: (Any, unicode, bool, Any) -> bool
-        non_attr_types = cls.method_types + (type, MethodDescriptorType)
+        non_attr_types = (type, MethodDescriptorType)
         isdatadesc = isdescriptor(member) and not \
+            cls.is_function_or_method(member) and not \
             isinstance(member, non_attr_types) and not \
             type(member).__name__ == "instancemethod"
         # That last condition addresses an obscure case of C-defined
@@ -1663,7 +1666,7 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
         if isenumattribute(self.object):
             self.object = self.object.value
         if isdescriptor(self.object) and \
-                not isinstance(self.object, self.method_types):
+                not self.is_function_or_method(self.object):
             self._datadescriptor = True
         else:
             # if it's not a data descriptor


### PR DESCRIPTION
Subject: use the `inspect` module instead of `isinstance` checks

### Feature or Bugfix
- Feature

### Purpose
As alternative to #3623, autodoc should use `inspect.isfunction(...)` instead of `isinstance(..., FunctionType)`. This way, projects which have custom function types (like Cython functions) can monkey-patch `inspect` and have Sphinx working correctly.

This way, Sphinx is also more future-proof in case the implementation of `inspect.isfunction()` ever changes (for example, because of https://bugs.python.org/issue30071).

### Relates
- #3623 
- https://bugs.python.org/issue30071

Two projects needing this:
- https://github.com/sagemath/cysignals
- https://github.com/fplll/fpylll