### PR TITLE
fix #2762: change html template for xhtml validation error (for epub)

### DIFF
--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -47,6 +47,11 @@ THEME_WRITING_MODES = {
 
 DOCTYPE = '''<!DOCTYPE html>'''
 
+HTML_TAG = (
+    u'<html xmlns="http://www.w3.org/1999/xhtml" '
+    u'xmlns:epub="http://www.idpf.org/2007/ops">'
+)
+
 
 class Epub3Builder(_epub_base.EpubBuilder):
     """
@@ -60,6 +65,8 @@ class Epub3Builder(_epub_base.EpubBuilder):
 
     template_dir = path.join(package_dir, 'templates', 'epub3')
     doctype = DOCTYPE
+    html_tag = HTML_TAG
+    use_meta_charset = True
 
     # Finish by building the epub file
     def handle_finish(self):
@@ -134,6 +141,8 @@ class Epub3Builder(_epub_base.EpubBuilder):
 
         writing_mode = self.config.epub_writing_mode
         self.globalcontext['theme_writing_mode'] = THEME_WRITING_MODES.get(writing_mode)
+        self.globalcontext['html_tag'] = self.html_tag
+        self.globalcontext['use_meta_charset'] = self.use_meta_charset
 
     def build_navlist(self, navnodes):
         # type: (List[nodes.Node]) -> List[NavPoint]

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -110,9 +110,17 @@
     {%- endfor %}
 {%- endmacro %}
 
+{%- if html_tag %}
+{{ html_tag }}
+{%- else %}
 <html xmlns="http://www.w3.org/1999/xhtml"{% if language is not none %} lang="{{ language }}"{% endif %}>
+{%- endif %}
   <head>
+    {%- if use_meta_charset %}
+    <meta charset="{{ encoding }}" />
+    {%- else %}
     <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
+    {%- endif %}
     {{ metatags }}
     {%- block htmltitle %}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>


### PR DESCRIPTION
Subject: fix xhtml validation error for epub output

### Feature or Bugfix
- Bugfix

### Purpose
- Fix xhtml validation (https://validator.w3.org/nu/)

### Detail
- Change ``<meta http-equiv>`` to ``<meta charset>`` (http-equiv is invalid for xhtml)
- Add epub namespace to html tag.
- These changes are worked only on epub builder.

### Relates
- #2762