### PR TITLE
tests: compile by LaTeX only with py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ install:
 script:
   - flake8
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make style-check type-check test-async; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != '3.6' ]]; then make test; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.6' ]]; then SKIP_LATEX_BUILD=1 make test; fi

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -87,6 +87,14 @@ def compile_latex_document(app):
                     app.config.latex_engine, p.returncode)
 
 
+def skip_if_requested(testfunc):
+    if 'SKIP_LATEX_BUILD' in os.environ:
+        msg = 'Skip LaTeX builds because SKIP_LATEX_BUILD is set'
+        return skip_if(True, msg)(testfunc)
+    else:
+        return testfunc
+
+
 def skip_if_stylefiles_notfound(testfunc):
     if kpsetest(*STYLEFILES) is False:
         msg = 'not running latex, the required styles do not seem to be installed'
@@ -95,6 +103,7 @@ def skip_if_stylefiles_notfound(testfunc):
         return testfunc
 
 
+@skip_if_requested
 @skip_if_stylefiles_notfound
 @pytest.mark.parametrize(
     "engine,docclass",


### PR DESCRIPTION
To make our test faster, this brings to compile docs using LaTeX only with py36.
I believe version of python does not related with the outputs of .tex sources. So I believe this keeps quality of codes.

What do you think?

Note: I also skip the variation of docutils versions. Because our LaTeX writer does not depends on the LaTeX writer of docutils (only uses `docutils.writers.latex2e.Babel` class).