### PR TITLE
Don't ignore first argument passed to sphinx.apidoc.main

### DIFF
--- a/sphinx-apidoc.py
+++ b/sphinx-apidoc.py
@@ -12,4 +12,4 @@ import sys
 
 if __name__ == '__main__':
     from sphinx.apidoc import main
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/sphinx-autogen.py
+++ b/sphinx-autogen.py
@@ -12,4 +12,4 @@ import sys
 
 if __name__ == '__main__':
     from sphinx.ext.autosummary.generate import main
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/sphinx-build.py
+++ b/sphinx-build.py
@@ -12,4 +12,4 @@ import sys
 
 if __name__ == '__main__':
     from sphinx import main
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/sphinx-quickstart.py
+++ b/sphinx-quickstart.py
@@ -12,4 +12,4 @@ import sys
 
 if __name__ == '__main__':
     from sphinx.quickstart import main
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -63,7 +63,7 @@ if __version__.endswith('+'):
         pass
 
 
-def main(argv=sys.argv):
+def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     if sys.argv[1:2] == ['-M']:
         return make_main(argv)
@@ -71,7 +71,7 @@ def main(argv=sys.argv):
         return build_main(argv)
 
 
-def build_main(argv=sys.argv):
+def build_main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     """Sphinx build "main" command-line entry."""
     if (sys.version_info[:3] < (2, 7, 0) or
@@ -113,7 +113,7 @@ def build_main(argv=sys.argv):
     return cmdline.main(argv)  # type: ignore
 
 
-def make_main(argv=sys.argv):
+def make_main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     """Sphinx build "make mode" entry."""
     from sphinx import make_mode
@@ -121,4 +121,4 @@ def make_main(argv=sys.argv):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -117,7 +117,7 @@ def make_main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     """Sphinx build "make mode" entry."""
     from sphinx import make_mode
-    return make_mode.run_make_mode(argv[2:])  # type: ignore
+    return make_mode.run_make_mode(argv[1:])  # type: ignore
 
 
 if __name__ == '__main__':

--- a/sphinx/__main__.py
+++ b/sphinx/__main__.py
@@ -11,4 +11,4 @@
 import sys
 from sphinx import main
 
-sys.exit(main(sys.argv))
+sys.exit(main(sys.argv[1:]))

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -282,7 +282,7 @@ def is_excluded(root, excludes):
     return False
 
 
-def main(argv=sys.argv):
+def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     """Parse and check the command line arguments."""
     parser = optparse.OptionParser(
@@ -356,7 +356,7 @@ Note: By default this script will not overwrite already created files.""")
                          dest='ext_' + ext, default=False,
                          help='enable %s extension' % ext)
 
-    (opts, args) = parser.parse_args(argv[1:])
+    (opts, args) = parser.parse_args(argv)
 
     if opts.show_version:
         print('Sphinx (sphinx-apidoc) %s' % __display_version__)

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -114,7 +114,7 @@ def handle_exception(app, opts, exception, stderr=sys.stderr):
                   file=stderr)
 
 
-def main(argv=sys.argv[1:]):  # typing: ignore
+def main(argv=sys.argv[1:]):  # type: ignore
     # type: (List[unicode]) -> int
     parser = optparse.OptionParser(USAGE, epilog=EPILOG, formatter=MyFormatter())
     parser.add_option('--version', action='store_true', dest='version',

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -114,7 +114,7 @@ def handle_exception(app, opts, exception, stderr=sys.stderr):
                   file=stderr)
 
 
-def main(argv=sys.argv[1:]):
+def main(argv=sys.argv[1:]):  # typing: ignore
     # type: (List[unicode]) -> int
     parser = optparse.OptionParser(USAGE, epilog=EPILOG, formatter=MyFormatter())
     parser.add_option('--version', action='store_true', dest='version',

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -181,7 +181,7 @@ def main(argv):
 
     # parse options
     try:
-        opts, args = parser.parse_args(list(argv[1:]))
+        opts, args = parser.parse_args(argv)
     except SystemExit as err:
         return err.code
 

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -114,7 +114,7 @@ def handle_exception(app, opts, exception, stderr=sys.stderr):
                   file=stderr)
 
 
-def main(argv):
+def main(argv=sys.argv[1:]):
     # type: (List[unicode]) -> int
     parser = optparse.OptionParser(USAGE, epilog=EPILOG, formatter=MyFormatter())
     parser.add_option('--version', action='store_true', dest='version',

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -59,7 +59,7 @@ if False:
     from sphinx.environment import BuildEnvironment  # NOQA
 
 
-def main(argv=sys.argv):
+def main(argv=sys.argv[1:]):
     # type: (List[str]) -> None
     usage = """%prog [OPTIONS] SOURCEFILE ..."""
     p = optparse.OptionParser(usage.strip())
@@ -75,7 +75,7 @@ def main(argv=sys.argv):
     p.add_option("-i", "--imported-members", action="store_true",
                  dest="imported_members", default=False,
                  help="Document imported members (default: %default)")
-    options, args = p.parse_args(argv[1:])
+    options, args = p.parse_args(argv)
 
     if len(args) < 1:
         p.error('no input files given')

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -383,4 +383,4 @@ if __name__ == '__main__':
     import logging  # type: ignore
     logging.basicConfig()
 
-    debug(argv=sys.argv)  # type: ignore
+    debug(argv=sys.argv[1:])  # type: ignore

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -302,8 +302,7 @@ class Make(object):
         if doctreedir is None:
             doctreedir = self.builddir_join('doctrees')
 
-        args = [sys.argv[0],
-                '-b', builder,
+        args = ['-b', builder,
                 '-d', doctreedir,
                 self.srcdir,
                 self.builddir_join(builder)]

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -570,7 +570,7 @@ class MyFormatter(optparse.IndentedHelpFormatter):
         return "\n".join(result)
 
 
-def main(argv=sys.argv):
+def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     if not color_terminal():
         nocolor()
@@ -642,7 +642,7 @@ def main(argv=sys.argv):
 
     # parse options
     try:
-        opts, args = parser.parse_args(argv[1:])
+        opts, args = parser.parse_args(argv)
     except SystemExit as err:
         return err.code
 

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -712,4 +712,4 @@ def main(argv=sys.argv[1:]):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_apidoc.py
+++ b/tests/test_apidoc.py
@@ -25,7 +25,7 @@ def apidoc(tempdir, apidoc_params):
     _, kwargs = apidoc_params
     coderoot = kwargs.get('coderoot', (rootdir / 'root'))
     outdir = tempdir / 'out'
-    args = ['sphinx-apidoc', '-o', outdir, '-F', coderoot] + kwargs.get('options', [])
+    args = ['-o', outdir, '-F', coderoot] + kwargs.get('options', [])
     apidoc_main(args)
     return namedtuple('apidoc', 'coderoot,outdir')(coderoot, outdir)
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -298,8 +298,7 @@ def test_default_filename(tempdir):
 
 
 def test_extensions(tempdir):
-    qs.main(['sphinx-quickstart', '-q',
-             '-p', 'project_name', '-a', 'author',
+    qs.main(['-q', '-p', 'project_name', '-a', 'author',
              '--extensions', 'foo,bar,baz', tempdir])
 
     conffile = tempdir / 'conf.py'

--- a/utils/check_sources.py
+++ b/utils/check_sources.py
@@ -256,4 +256,4 @@ def main(argv):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))

--- a/utils/check_sources.py
+++ b/utils/check_sources.py
@@ -179,13 +179,13 @@ def check_xhtml(fn, lines):
                 yield lno + 1, "used " + bad_tag
 
 
-def main(argv):
+def main(argv=sys.argv[1:]):
     parser = OptionParser(usage='Usage: %prog [-v] [-i ignorepath]* [path]')
     parser.add_option('-v', '--verbose', dest='verbose', default=False,
                       action='store_true')
     parser.add_option('-i', '--ignore-path', dest='ignored_paths',
                       default=[], action='append')
-    options, args = parser.parse_args(argv[1:])
+    options, args = parser.parse_args(argv)
 
     if len(args) == 0:
         path = '.'


### PR DESCRIPTION
### Feature or Bugfix

Bugfix? Depends on whether you consider it a bug or a feature 😉 

### Purpose

We use Sphinx to generate our documentation. Our API changes fairly often, so in order to make sure our API docs stay up-to-date, we always re-run `sphinx-apidoc` with each build. Unfortunately, Read the Docs skips our Makefile and directly calls:
```
$ sphinx-build -b html . _build/html
```
To get around this, we run `sphinx-apidoc` from our `conf.py`. Our call looks something like:
```python
import sphinx.apidoc.main as sphinx_apidoc

sphinx_apidoc(['--force', '--no-toc', '--output-dir=.', '../spack'])
```
At first I was really confused why this gave different results than:
```
$ sphinx-apidoc --force --not-toc --output-dir=. ../spack
```
but after reading the source code, I quickly discovered that `main` ignores the first argument it is passed. This makes perfect sense when running `sphinx-apidoc` from the command line, as the first argument will be the name of the script. But it is much less intuitive when being called directly from `main`. This PR fixes that.

### Detail

By default, `main` will still process `sys.argv[1:]`, but if passed a list of arguments, it will now process all of them. I'm not sure if this bug (feature?) is documented already. My only concern is that this change isn't really backwards compatible. If you wanted it to be, I could theoretically check if the first argument is `sphinx-apidoc` and skip it if so.

### Relates

First reported here:
https://github.com/LLNL/spack/pull/3982/files#r113266150

