### PR TITLE
Docs: Add seealso message to config page leading to api docs

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -50,8 +50,8 @@ Important points to note:
   Note that the current builder tag is not available in ``conf.py``, as it is
   created *after* the builder is initialized.
 
-.. seealso:: Aditional configurations, such as adding stylesheets, javascripts,
-   builders, ect... can be made through the :doc:`/extdev/appapi`.
+.. seealso:: Additional configurations, such as adding stylesheets,
+   javascripts, builders, etc. can be made through the :doc:`/extdev/appapi`.
 
 
 General configuration

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -50,6 +50,9 @@ Important points to note:
   Note that the current builder tag is not available in ``conf.py``, as it is
   created *after* the builder is initialized.
 
+.. seealso:: Aditional configurations, such as adding stylesheets, javascripts,
+   builders, ect... can be made through the :doc:`/extdev/appapi`.
+
 
 General configuration
 ---------------------


### PR DESCRIPTION
While hanging around IRC in both #sphinx-doc and #readthedocs
I have found that a lot of people do not know about these options
even though a lot of them are pretty common. For example,
adding a simple theme override, most people will edit layout.html
instead of Sphinx.add_stylesheet.
