### PR TITLE
Fix #3657: EPUB builder crashes if document startswith genindex exists

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Bugs fixed
 * #3614: Sphinx crashes with requests-2.5.0
 * #3618: autodoc crashes with tupled arguments
 * #3664: No space after the bullet in items of a latex list produced by Sphinx
+* #3657: EPUB builder crashes if document startswith genindex exists
 
 Testing
 --------

--- a/sphinx/builders/epub.py
+++ b/sphinx/builders/epub.py
@@ -500,7 +500,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         This method is overwritten for genindex pages in order to fix href link
         attributes.
         """
-        if pagename.startswith('genindex'):
+        if pagename.startswith('genindex') and 'genindexentries' in addctx:
             if not self.use_index:
                 return
             self.fix_genindex(addctx['genindexentries'])


### PR DESCRIPTION
refs: #3657 