### PR TITLE
Enable appveyor on stable branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,4 +24,4 @@ build: off
 
 test_script:
   - cd tests
-  - C:\Python%PYTHON%\python.exe run.py --ignore py35 --color=no %TEST%
+  - C:\Python%PYTHON%\python.exe run.py --ignore py35 %TEST%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,27 @@
+environment:
+  global:
+    TEST: -v --durations 25
+    PYTHONFAULTHANDLER: x
+    PYTHONWARNINGS: all
+
+  matrix:
+    - PYTHON: 27
+      DOCUTILS: 0.12
+    - PYTHON: 27
+      DOCUTILS: 0.13.1
+    - PYTHON: 36
+      DOCUTILS: 0.13.1
+    - PYTHON: 36-x64
+      DOCUTILS: 0.13.1
+
+install:
+  - C:\Python%PYTHON%\python.exe -m pip install -U pip setuptools
+  - C:\Python%PYTHON%\python.exe -m pip install docutils==%DOCUTILS%
+  - C:\Python%PYTHON%\python.exe -m pip install -r test-reqs.txt
+
+# No automatic build, just run python tests
+build: off
+
+test_script:
+  - cd tests
+  - C:\Python%PYTHON%\python.exe run.py --ignore py35 --color=no %TEST%


### PR DESCRIPTION
This is somewhat related to the discussion in #3592, I've gotten appveyor working properly, though currently it's failing due to failing tests.  I also have some changes to make the build pass by adding xfail to the failing tests, but I'm not sure if that's desirable or not.  It would allow appveyor to be active without breaking other development work at least, so if people want I can push that changeset as well.