### PR TITLE
Make websupport dependency optional

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 
 * #3661: sphinx-build crashes on parallel build
 * #3669: gettext builder fails with "ValueError: substring not found"
+* #3660: Sphinx always depends on sphinxcontrib-websupport and its dependencies
 
 Testing
 --------

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ requires = [
     'alabaster>=0.7,<0.8',
     'imagesize',
     'requests>=2.0.0',
-    'sphinxcontrib-websupport',
     'typing',
     'setuptools',
 ]
@@ -59,6 +58,9 @@ extras_require = {
     # Environment Marker works for wheel 0.24 or later
     ':sys_platform=="win32"': [
         'colorama>=0.3.5',
+    ],
+    'websupport': [
+        'sphinxcontrib-websupport',
     ],
     'test': [
         'pytest',

--- a/sphinx/websupport/__init__.py
+++ b/sphinx/websupport/__init__.py
@@ -12,11 +12,16 @@
 import warnings
 
 from sphinx.deprecation import RemovedInSphinx20Warning
-from sphinxcontrib.websupport import WebSupport  # NOQA
-from sphinxcontrib.websupport import errors  # NOQA
-from sphinxcontrib.websupport.search import BaseSearch, SEARCH_ADAPTERS  # NOQA
-from sphinxcontrib.websupport.storage import StorageBackend  # NOQA
 
-warnings.warn('sphinx.websupport module is now provided as sphinxcontrib.webuspport. '
-              'sphinx.websupport will be removed in Sphinx-2.0.  Please use it instaed',
-              RemovedInSphinx20Warning)
+try:
+    from sphinxcontrib.websupport import WebSupport  # NOQA
+    from sphinxcontrib.websupport import errors  # NOQA
+    from sphinxcontrib.websupport.search import BaseSearch, SEARCH_ADAPTERS  # NOQA
+    from sphinxcontrib.websupport.storage import StorageBackend  # NOQA
+
+    warnings.warn('sphinx.websupport module is now provided as sphinxcontrib-webuspport. '
+                  'sphinx.websupport will be removed in Sphinx-2.0.  Please use it instaed',
+                  RemovedInSphinx20Warning)
+except ImportError:
+    warnings.warn('Since Sphinx-1.6, sphinx.websupport module is now separated to '
+                  'sphinxcontrib-webuspport package. Please add it into your dependency list.')


### PR DESCRIPTION
Since 1.3, Sphinx uses `extra_require` to depend on websupport packages.
So I also use it to add `sphinxcontrib-websupport` into our dependency list.
It adds no new dependencies if user does not use websupport feature (it is only used by web-applications!)

refs: #3660 