### PR TITLE
Fix #3633: misdetect unreferenced citations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Incompatible changes
 --------------------
 
 * #3345: Replace the custom smartypants code with docutils' smart_quotes
+* Add line numbers to citation data in std domain
 
 Deprecated
 ----------
@@ -15,12 +16,16 @@ Deprecated
 Features added
 --------------
 
+* Add a new event `env-check-consistency` to check consistency to extensions
+* Add `Domain.check_consistency()` to check consistency
+
 Bugs fixed
 ----------
 
 * #3661: sphinx-build crashes on parallel build
 * #3669: gettext builder fails with "ValueError: substring not found"
 * #3660: Sphinx always depends on sphinxcontrib-websupport and its dependencies
+* #3633: misdetect unreferenced citations
 
 Testing
 --------

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -597,6 +597,8 @@ handlers to the events.  Example:
 
    .. versionadded:: 1.6
 
+      As a **experimental** event
+
 .. event:: html-collect-pages (app)
 
    Emitted when the HTML builder is starting to write non-document pages.  You

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -590,6 +590,13 @@ handlers to the events.  Example:
    .. versionchanged:: 1.3
       The handlers' return value is now used.
 
+.. event:: env-check-consistency (env)
+
+   Emmited when Consistency checks phase.  You can check consistency of
+   metadata for whole of documents.
+
+   .. versionadded:: 1.6
+
 .. event:: html-collect-pages (app)
 
    Emitted when the HTML builder is starting to write non-document pages.  You

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -242,7 +242,7 @@ class Domain(object):
 
     def check_consistency(self):
         # type: () -> None
-        """Do consistency checks."""
+        """Do consistency checks (**experimental**)."""
         pass
 
     def process_field_xref(self, pnode):

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -240,6 +240,11 @@ class Domain(object):
         """Process a document after it is read by the environment."""
         pass
 
+    def check_consistency(self):
+        # type: () -> None
+        """Do consistency checks."""
+        pass
+
     def process_field_xref(self, pnode):
         # type: (nodes.Node) -> None
         """Process a pending xref created in a doc field.

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -78,7 +78,7 @@ default_settings = {
 # or changed to properly invalidate pickle files.
 #
 # NOTE: increase base version by 2 to have distinct numbers for Py2 and 3
-ENV_VERSION = 51 + (sys.version_info[0] - 2)
+ENV_VERSION = 52 + (sys.version_info[0] - 2)
 
 
 dummy_reporter = Reporter('', 4, 4)
@@ -1014,3 +1014,8 @@ class BuildEnvironment(object):
                     continue
                 logger.warning('document isn\'t included in any toctree',
                                location=docname)
+
+        # call check-consistency for all extensions
+        for domain in self.domains.values():
+            domain.check_consistency()
+        self.app.emit('env-check-consistency', self)

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -31,6 +31,7 @@ core_events = {
     'env-get-updated': 'env',
     'env-purge-doc': 'env, docname',
     'env-before-read-docs': 'env, docnames',
+    'env-check-consistency': 'env',
     'source-read': 'docname, source text',
     'doctree-read': 'the doctree before being pickled',
     'env-merge-info': 'env, read docnames, other env instance',

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -296,12 +296,6 @@ class UnreferencedFootnotesDetector(SphinxTransform):
                                type='ref', subtype='footnote',
                                location=node)
 
-        for node in self.document.citations:
-            if node['names'][0] not in self.document.citation_refs:
-                logger.warning('Citation [%s] is not referenced.', node['names'][0],
-                               type='ref', subtype='citation',
-                               location=node)
-
 
 class FilterSystemMessages(SphinxTransform):
     """Filter system messages from a doctree."""

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -25,6 +25,7 @@ def test_process_doc_handle_figure_caption():
         nametypes={'testname': True},
         nameids={'testname': 'testid'},
         ids={'testid': figure_node},
+        citation_refs={},
     )
     document.traverse.return_value = []
 
@@ -47,6 +48,7 @@ def test_process_doc_handle_table_title():
         nametypes={'testname': True},
         nameids={'testname': 'testid'},
         ids={'testid': table_node},
+        citation_refs={},
     )
     document.traverse.return_value = []
 


### PR DESCRIPTION
refs: #3633

I wonder if I should merge this into 1.6 or not. This certainly fix the problem of #3633, but it also brings new interface to sphinx-events and domains. I think this is both bug-fix and new feature.

In addition, I feel we should consider carefully to add new interface to sphinx-core. I think the idea of `env-check-consistency` is not so bad. But there are no reason to add `env-updated` event instead (I only need to hook before saving environment object. either is fine to me).

Note: the original issue #3558 mentioned only to footnotes, not citations. At this moment, nobody want to warn about unreferenced citations. So I'm okay to remove this feature from 1.6 release.

@shimizukawa What do you think?