### PR TITLE
Add latex support for docutils table stub columns (issue #3479)

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -332,6 +332,7 @@ class Table(object):
         self.caption = None                     # type: List[unicode]
         self.caption_footnotetexts = []         # type: List[unicode]
         self.header_footnotetexts = []          # type: List[unicode]
+        self.stubs = []                         # type: List[int]
 
         # current position
         self.col = 0
@@ -1334,6 +1335,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.table.colcount += 1
         if 'colwidth' in node:
             self.table.colwidths.append(node['colwidth'])
+        if 'stub' in node:
+            self.table.stubs.append(self.table.colcount - 1)
 
     def depart_colspec(self, node):
         # type: (nodes.Node) -> None
@@ -1444,7 +1447,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.needs_linetrimming = 1
         if len(node.traverse(nodes.paragraph)) >= 2:
             self.table.has_oldproblematic = True
-        if isinstance(node.parent.parent, nodes.thead):
+        if isinstance(node.parent.parent, nodes.thead) or (cell.col in self.table.stubs):
             if len(node) == 1 and isinstance(node[0], nodes.paragraph) and node.astext() == '':
                 pass
             else:

--- a/tests/roots/test-latex-table/longtable.rst
+++ b/tests/roots/test-latex-table/longtable.rst
@@ -130,3 +130,22 @@ longtable having problematic cell
      - cell2-2
    * - cell3-1
      - cell3-2
+
+longtable having both stub columns and problematic cell
+-------------------------------------------------------
+
+.. list-table::
+   :class: longtable
+   :header-rows: 1
+   :stub-columns: 2
+
+   * - header1
+     - header2
+     - header3
+   * - + instub1-1a
+       + instub1-1b
+     - instub1-2
+     - notinstub1-3
+   * - cell2-1
+     - cell2-2
+     - cell2-3

--- a/tests/roots/test-latex-table/tabular.rst
+++ b/tests/roots/test-latex-table/tabular.rst
@@ -133,3 +133,21 @@ table having problematic cell
      - cell2-2
    * - cell3-1
      - cell3-2
+
+table having both stub columns and problematic cell
+---------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 2
+
+   * - header1
+     - header2
+     - header3
+   * - + instub1-1a
+       + instub1-1b
+     - instub1-2
+     - notinstub1-3
+   * - cell2-1
+     - cell2-2
+     - cell2-3

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -916,6 +916,13 @@ def test_latex_table_tabulars(app, status, warning):
     table = tables['table having both :widths: and problematic cell']
     assert ('\\begin{tabular}[t]{|\\X{30}{100}|\\X{70}{100}|}' in table)
 
+    # table having both stub columns and problematic cell
+    table = tables['table having both stub columns and problematic cell']
+    assert ('&\\sphinxstylethead{\\sphinxstyletheadfamily \n'
+            'instub1-2\n\\unskip}\\relax &\nnotinstub1-3\n\\\\\n'
+            '\\hline\\sphinxstylethead{\\sphinxstyletheadfamily \n'
+            'cell2-1\n\\unskip}\\relax &' in table)
+
 
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
                     reason='docutils-0.13 or above is required')
@@ -981,6 +988,13 @@ def test_latex_table_longtable(app, status, warning):
     # longtable having both :widths: and problematic cell
     table = tables['longtable having both :widths: and problematic cell']
     assert ('\\begin{longtable}{|\\X{30}{100}|\\X{70}{100}|}' in table)
+
+    # longtable having both stub columns and problematic cell
+    table = tables['longtable having both stub columns and problematic cell']
+    assert ('&\\sphinxstylethead{\\sphinxstyletheadfamily \n'
+            'instub1-2\n\\unskip}\\relax &\nnotinstub1-3\n\\\\\n'
+            '\\hline\\sphinxstylethead{\\sphinxstyletheadfamily \n'
+            'cell2-1\n\\unskip}\\relax &' in table)
 
 
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),


### PR DESCRIPTION
This is a start: I copied over from docutils html base.

Although it may look like bug fix I do not do the PR on stable branch because tables had a lot of refactoring between stable and upcoming 1.6. But if PR is ok as is, then perhaps I can do it on stable too, because it is very small diff.

Test needs to be added.

I have tested it minimally with this

```rst

.. list-table:: Table with a header row and header column
    :header-rows: 1
    :stub-columns: 1

    * -
      - Col 1
      - Col 2
    * - Row 1
      - Cell 1,1
      - Cell 2,1
    * - Row 2
      - Cell 2,1
      - Cell 2,2

.. list-table:: Table with a header row and two header columns
    :header-rows: 1
    :stub-columns: 2

    * -
      - Col 1
      - Col 2
    * - Row 1
      - Cell 1,1
      - Cell 2,1
    * - Row 2
      - Cell 2,1
      - Cell 2,2

```

No attempt to check what happens if such cells are merged... 

### Relates
- #3479 

@tk0miya can you give a look if docutils nodes are handled properly in my PR ?
