### PR TITLE
Drop usage of `threeparttable` (LaTeX)

### DIFF
--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -11,6 +11,7 @@
   \centering
 <%- endif %>
 <% if table.caption -%>
+\sphinxcapstartof{table}
 \sphinxcaptionof{table}{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
 <% endif -%>

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -12,7 +12,7 @@
 <%- endif %>
 <% if table.caption -%>
 \sphinxcapstartof{table}
-\sphinxcaptionof{table}{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
 <% endif -%>
 \begin{tabular}[t]<%= table.get_colspec() -%>

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -11,8 +11,8 @@
   \centering
 <%- endif %>
 <% if table.caption -%>
-\begin{threeparttable}
-\capstart\caption{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxcaptionof{table}{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxaftercaption
 <% endif -%>
 \begin{tabular}[t]<%= table.get_colspec() -%>
 \hline
@@ -22,8 +22,5 @@
 <%- endif -%>
 <%=- ''.join(table.body) %>
 \end{tabular}
-<%- if table.caption %>
-\end{threeparttable}
-<%- endif %>
 \par
 \sphinxattableend\end{savenotes}

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -11,6 +11,7 @@
   \centering
 <%- endif %>
 <% if table.caption -%>
+\sphinxcapstartof{table}
 \sphinxcaptionof{table}{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
 <% endif -%>

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -11,8 +11,8 @@
   \centering
 <%- endif %>
 <% if table.caption -%>
-\begin{threeparttable}
-\capstart\caption{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxcaptionof{table}{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxaftercaption
 <% endif -%>
 \begin{tabulary}{\linewidth}[t]<%= table.get_colspec() -%>
 \hline
@@ -22,8 +22,5 @@
 <%- endif -%>
 <%=- ''.join(table.body) %>
 \end{tabulary}
-<%- if table.caption %>
-\end{threeparttable}
-<%- endif %>
 \par
 \sphinxattableend\end{savenotes}

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -12,7 +12,7 @@
 <%- endif %>
 <% if table.caption -%>
 \sphinxcapstartof{table}
-\sphinxcaptionof{table}{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
 <% endif -%>
 \begin{tabulary}{\linewidth}[t]<%= table.get_colspec() -%>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -617,6 +617,7 @@
 %
 \newenvironment{sphinxfigure-in-table}[1][\linewidth]{%
   \def\@captype{figure}%
+  \sphinxsetvskipsforfigintablecaption
   \begin{minipage}{#1}%
 }{\end{minipage}}
 % store original \caption macro for use with figures in longtable and tabulary
@@ -625,7 +626,9 @@
   {\ifx\equation$%$% this is trick to identify tabulary first pass
        \firstchoice@false\else\firstchoice@true\fi
    \spx@originalcaption }
-
+\newcommand*\sphinxsetvskipsforfigintablecaption
+  {\abovecaptionskip\smallskipamount
+   \belowcaptionskip\smallskipamount}
 
 %% FOOTNOTES
 %

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -105,29 +105,30 @@
 \let\sphinxattableend\sphinxatlongtableend
 % longtable's wraps captions to a maximal width of \LTcapwidth
 % so we do the same for all tables
+\newcommand*\sphinxcapstartof[1]{%
+   \vskip\parskip
+   \vbox{}% force baselineskip for good positioning by capstart of hyperanchor
+   \def\@captype{#1}%
+   \capstart
+% move back vertically to compensate space inserted by next paragraph
+   \vskip-\baselineskip\vskip-\parskip
+}%
 \newcommand\sphinxcaptionof[3][\LTcapwidth]{%
    \noindent\hb@xt@\linewidth{\hss
       \vtop{\@tempdima\dimexpr#1\relax
 % don't exceed linewidth for the caption width
             \ifdim\@tempdima>\linewidth\hsize\linewidth\else\hsize\@tempdima\fi
-            \def\@captype{#2}%
-            \capstart % must be after setting \@captype
 % longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
             \abovecaptionskip\z@skip
             \belowcaptionskip\z@skip
-% hyperref anchor (and a \write) cause the \vtop to have zero height. Hence if
-% the caption is first thing in a list item, the item label (which gets
-% inserted indirectly by the \noindent) will have its baseline same as top of
-% box which is \ht\strutbox above the caption text baseline. This avoids a
-% wide caption overwriting the item label.
             \caption[{#3}]%
                {\strut\ignorespaces#3\ifhmode\unskip\@finalstrut\strutbox\fi}%
            }\hss}%
    \par\prevdepth\dp\strutbox
 }%
 \newcommand\sphinxaftercaption
-{% the default definition serves with a caption above a table, to make sure its
- % last baseline is \sphinxbelowcaptionspace above table top rule
+{% this default definition serves with a caption *above* a table, to make sure
+ % its last baseline is \sphinxbelowcaptionspace above table top
  \nobreak
    \vskip\dimexpr\sphinxbelowcaptionspace\relax
    \vskip-\baselineskip\vskip-\parskip

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -105,10 +105,12 @@
 \let\sphinxattableend\sphinxatlongtableend
 % longtable's wraps captions to a maximal width of \LTcapwidth
 % so we do the same for all tables
-\newcommand\sphinxcaptionof[2]{%
+\newcommand\sphinxcaptionof[3][\LTcapwidth]{%
    \noindent\hb@xt@\linewidth{\hss
-      \vtop{\hsize\LTcapwidth
-            \def\@captype{#1}%
+      \vtop{\@tempdima\dimexpr#1\relax
+% don't exceed linewidth for the caption width
+            \ifdim\@tempdima>\linewidth\hsize\linewidth\else\hsize\@tempdima\fi
+            \def\@captype{#2}%
             \capstart % must be after setting \@captype
 % longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
             \abovecaptionskip\z@skip
@@ -118,8 +120,8 @@
 % inserted indirectly by the \noindent) will have its baseline same as top of
 % box which is \ht\strutbox above the caption text baseline. This avoids a
 % wide caption overwriting the item label.
-            \caption[{#2}]%
-               {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
+            \caption[{#3}]%
+               {\strut\ignorespaces#3\ifhmode\unskip\@finalstrut\strutbox\fi}%
            }\hss}%
    \par\prevdepth\dp\strutbox
 }%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -106,16 +106,21 @@
 % longtable's wraps captions to a maximal width of \LTcapwidth
 % so we do the same for all tables
 \newcommand\sphinxcaptionof[2]{%
-   \noindent\makebox[\linewidth]{%
+   \noindent\hb@xt@\linewidth{\hss
       \vtop{\hsize\LTcapwidth
             \def\@captype{#1}%
             \capstart % must be after setting \@captype
 % longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
             \abovecaptionskip\z@skip
             \belowcaptionskip\z@skip
+% hyperref anchor (and a \write) cause the \vtop to have zero height. Hence if
+% the caption is first thing in a list item, the item label (which gets
+% inserted indirectly by the \noindent) will have its baseline same as top of
+% box which is \ht\strutbox above the caption text baseline. This avoids a
+% wide caption overwriting the item label.
             \caption[{#2}]%
                {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
-           }}%
+           }\hss}%
    \par\prevdepth\dp\strutbox
 }%
 \newcommand\sphinxaftercaption

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -113,7 +113,7 @@
 % move back vertically to compensate space inserted by next paragraph
    \vskip-\baselineskip\vskip-\parskip
 }%
-\newcommand\sphinxcaptionof[3][\LTcapwidth]{%
+\newcommand\sphinxcaption[2][\LTcapwidth]{%
    \noindent\hb@xt@\linewidth{\hss
       \vtop{\@tempdima\dimexpr#1\relax
 % don't exceed linewidth for the caption width
@@ -121,8 +121,8 @@
 % longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
             \abovecaptionskip\z@skip
             \belowcaptionskip\z@skip
-            \caption[{#3}]%
-               {\strut\ignorespaces#3\ifhmode\unskip\@finalstrut\strutbox\fi}%
+            \caption[{#2}]%
+               {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
            }\hss}%
    \par\prevdepth\dp\strutbox
 }%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/04/25 v1.6 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2017/04/30 v1.6 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -57,40 +57,55 @@
       #1\dimexpr\linewidth-\arrayrulewidth\relax-\tw@\tabcolsep-\arrayrulewidth\relax}}
 % using here T (for Tabulary) feels less of a problem than the X could be
 \newcolumntype{T}{J}%
+% For tables allowing pagebreaks
 \RequirePackage{longtable}
-% For table captions.
-\RequirePackage{threeparttable}
-% fixing the LaTeX mess of vertical spaces with threeparttable and longtable
-% The user interface:
+% User interface to set-up whitespace before and after tables:
 \newcommand*\sphinxtablepre {0pt}%
 \newcommand*\sphinxtablepost{\medskipamount}%
+\newcommand*\sphinxbelowcaptionspace{.5\sphinxbaselineskip}%
 % as one can not use \baselineskip from inside longtable (it is zero there)
 % we need \sphinxbaselineskip, which defaults to \baselineskip
-\newcommand*\sphinxbelowcaptionspace{.5\sphinxbaselineskip}%
 \def\sphinxbaselineskip{\baselineskip}%
-% Helper macros, not a priori for user customization
+% These commands are inserted by the table templates
 \def\sphinxatlongtablestart
    {\par
     \vskip\parskip
     \vskip\dimexpr\sphinxtablepre\relax % adjust vertical position
     \vbox{}% get correct baseline from above
     \LTpre\z@skip\LTpost\z@skip % set to zero longtable's own skips
-    \edef\sphinxbaselineskip{\dimexpr\the\dimexpr\baselineskip\relax\relax}}%
+    \edef\sphinxbaselineskip{\dimexpr\the\dimexpr\baselineskip\relax\relax}%
+   }%
 \def\sphinxatlongtableend{\prevdepth\z@\vskip\sphinxtablepost\relax}%
-% the longtable template inserts a \strut at caption's end
 \def\sphinxlongtablecapskipadjust
-   {\dimexpr-\dp\strutbox-\sphinxbaselineskip
-            +\sphinxbelowcaptionspace\relax}%
-% tabular(y) with or without threeparttable
+   {\dimexpr-\dp\strutbox-\sphinxbaselineskip+\sphinxbelowcaptionspace\relax}%
+% Now for tables not using longtable
 \def\sphinxattablestart
    {\par
     \vskip\dimexpr\sphinxtablepre\relax
-    \belowcaptionskip\sphinx@TPTbelowcaptionskip}%
+   }%
 \let\sphinxattableend\sphinxatlongtableend
-% the tabular(y) templates use [t] vertical placement parameter
-\def\sphinx@TPTbelowcaptionskip
-   {\dimexpr-1.2\baselineskip % .2\baselineskip hardcoded in threeparttable
-            +\sphinxbelowcaptionspace\relax }%
+% longtable's wraps captions to a maximal width of \LTcapwidth
+% so we do the same for all tables
+\newcommand\sphinxcaptionof[2]{%
+   \noindent\makebox[\linewidth]{%
+      \vtop{\hsize\LTcapwidth
+            \def\@captype{#1}%
+            \capstart % must be after setting \@captype
+% longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
+            \abovecaptionskip\z@skip
+            \belowcaptionskip\z@skip
+            \caption[{#2}]%
+               {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
+           }}%
+   \par\prevdepth\dp\strutbox
+}%
+\newcommand\sphinxaftercaption
+{% the default definition serves with a caption above a table, to make sure its
+ % last baseline is \sphinxbelowcaptionspace above table top rule
+ \nobreak
+   \vskip\dimexpr\sphinxbelowcaptionspace\relax
+   \vskip-\baselineskip\vskip-\parskip
+}%
 % varwidth is crucial for our handling of general contents in merged cells
 \RequirePackage{varwidth}
 % but addition of a compatibility patch with hyperref is needed

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -492,7 +492,7 @@ def test_footnote(app, status, warning):
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
             '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
             '\ncite\n}') in result
-    assert '\\sphinxcaptionof{table}{Table caption \\sphinxfootnotemark[4]' in result
+    assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
             'footnote in table caption\n%\n\\end{footnotetext}\\ignorespaces %\n'
             '\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'
@@ -517,7 +517,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}.}' in result)
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
-    assert ('\\sphinxcaptionof{table}{The table title with a reference'
+    assert ('\\sphinxcaption{The table title with a reference'
             ' to {[}AuthorYear{]}}' in result)
     assert '\\paragraph{The rubric title with a reference to {[}AuthorYear{]}}' in result
     assert ('\\chapter{The section with a reference to \\sphinxfootnotemark[4]}\n'
@@ -528,7 +528,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
             '\\sphinxfootnotemark[6].}\\label{\\detokenize{index:id27}}\\end{figure}\n'
             '%\n\\begin{footnotetext}[6]\\sphinxAtStartFootnote\n'
             'Footnote in caption\n%\n\\end{footnotetext}')in result
-    assert ('\\sphinxcaptionof{table}{footnote \\sphinxfootnotemark[7] in '
+    assert ('\\sphinxcaption{footnote \\sphinxfootnotemark[7] in '
             'caption of normal table}\\label{\\detokenize{index:id28}}') in result
     assert ('\\caption{footnote \\sphinxfootnotemark[8] '
             'in caption \\sphinxfootnotemark[9] of longtable\\strut}') in result
@@ -896,7 +896,7 @@ def test_latex_table_tabulars(app, status, warning):
     table = tables['table having caption']
     assert ('\\begin{savenotes}\\sphinxattablestart\n\\centering\n'
             '\\sphinxcapstartof{table}\n'
-            '\\sphinxcaptionof{table}{caption for table}'
+            '\\sphinxcaption{caption for table}'
             '\\label{\\detokenize{tabular:id1}}\n'
             '\\sphinxaftercaption' in table)
     assert ('\\begin{tabulary}{\\linewidth}[t]{|T|T|}' in table)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -895,6 +895,7 @@ def test_latex_table_tabulars(app, status, warning):
     # table having caption
     table = tables['table having caption']
     assert ('\\begin{savenotes}\\sphinxattablestart\n\\centering\n'
+            '\\sphinxcapstartof{table}\n'
             '\\sphinxcaptionof{table}{caption for table}'
             '\\label{\\detokenize{tabular:id1}}\n'
             '\\sphinxaftercaption' in table)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -31,7 +31,7 @@ from test_build_html import ENV_WARNINGS
 LATEX_ENGINES = ['pdflatex', 'lualatex', 'xelatex']
 DOCCLASSES = ['howto', 'manual']
 STYLEFILES = ['article.cls', 'fancyhdr.sty', 'titlesec.sty', 'amsmath.sty',
-              'framed.sty', 'color.sty', 'fancyvrb.sty', 'threeparttable.sty',
+              'framed.sty', 'color.sty', 'fancyvrb.sty',
               'fncychap.sty', 'geometry.sty', 'kvoptions.sty', 'hyperref.sty']
 
 LATEX_WARNINGS = ENV_WARNINGS + """\
@@ -492,7 +492,7 @@ def test_footnote(app, status, warning):
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
             '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
             '\ncite\n}') in result
-    assert '\\caption{Table caption \\sphinxfootnotemark[4]' in result
+    assert '\\sphinxcaptionof{table}{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
             'footnote in table caption\n%\n\\end{footnotetext}\\ignorespaces %\n'
             '\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'
@@ -501,7 +501,7 @@ def test_footnote(app, status, warning):
     assert ('Information about VIDIOC\\_CROPCAP %\n'
             '\\begin{footnote}[6]\\sphinxAtStartFootnote\n'
             'footnote in table not in header\n%\n\\end{footnote}\n\\\\\n\\hline\n'
-            '\\end{tabulary}\n\\end{threeparttable}\n'
+            '\\end{tabulary}\n'
             '\\par\n\\sphinxattableend\\end{savenotes}\n') in result
 
 
@@ -517,7 +517,8 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}.}' in result)
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
-    assert '\\caption{The table title with a reference to {[}AuthorYear{]}}' in result
+    assert ('\\sphinxcaptionof{table}{The table title with a reference'
+            ' to {[}AuthorYear{]}}' in result)
     assert '\\paragraph{The rubric title with a reference to {[}AuthorYear{]}}' in result
     assert ('\\chapter{The section with a reference to \\sphinxfootnotemark[4]}\n'
             '\\label{\\detokenize{index:the-section-with-a-reference-to}}'
@@ -527,8 +528,8 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
             '\\sphinxfootnotemark[6].}\\label{\\detokenize{index:id27}}\\end{figure}\n'
             '%\n\\begin{footnotetext}[6]\\sphinxAtStartFootnote\n'
             'Footnote in caption\n%\n\\end{footnotetext}')in result
-    assert ('\\caption{footnote \\sphinxfootnotemark[7] '
-            'in caption of normal table}\\label{\\detokenize{index:id28}}') in result
+    assert ('\\sphinxcaptionof{table}{footnote \\sphinxfootnotemark[7] in '
+            'caption of normal table}\\label{\\detokenize{index:id28}}') in result
     assert ('\\caption{footnote \\sphinxfootnotemark[8] '
             'in caption \\sphinxfootnotemark[9] of longtable\\strut}') in result
     assert ('\\endlastfoot\n%\n\\begin{footnotetext}[8]\\sphinxAtStartFootnote\n'
@@ -894,10 +895,11 @@ def test_latex_table_tabulars(app, status, warning):
     # table having caption
     table = tables['table having caption']
     assert ('\\begin{savenotes}\\sphinxattablestart\n\\centering\n'
-            '\\begin{threeparttable}\n\\capstart\\caption{caption for table}'
-            '\\label{\\detokenize{tabular:id1}}' in table)
+            '\\sphinxcaptionof{table}{caption for table}'
+            '\\label{\\detokenize{tabular:id1}}\n'
+            '\\sphinxaftercaption' in table)
     assert ('\\begin{tabulary}{\\linewidth}[t]{|T|T|}' in table)
-    assert ('\\hline\n\\end{tabulary}\n\\end{threeparttable}'
+    assert ('\\hline\n\\end{tabulary}'
             '\n\\par\n\\sphinxattableend\\end{savenotes}' in table)
 
     # table having verbatim


### PR DESCRIPTION
Subject: LaTeX tables with captions are currently rendered either with `longtable` or `threeparttable` (with tabular or tabulary). The `threeparttable` is thought out to allow table notes, but Sphinx never made usage of this. Besides it produces a caption of the same width of the table itself, but there is no reliable way in LaTeX2e to wrap text around a box of unknown dimensions in a fully automatized way, thus currently, the table is always (like longtable) set in its own paragraph. The user can use `:align:` docutils option to decide if located left, center or right.

Problem is that threeparttable is loaded for almost no benefits. And captions wrapped to the table width look weird compared to captions of longtable which are wrapped at a fixed maximal width of `4in` (it can be customized by length `\LTcapwidth`).

This PR drops usage of `threeparttable`, achieves exact same vertical spacing as for longtable and wraps the table caption also to `\LTcapwidth` space. (by default `4in`).

This fixes issue #3532, with code-blocks or figures in tables having their own captions. It was very difficult to fix this without dropping threeparttable, also because via the table templates the user can position the caption before or after the table, but threeparttable does not expect that `\caption` will be used for anything else than the table caption and redefines it at the start of environment.

I don't know how to best "deprecate" `threeparttable`: there can not be transition, either we use it or we don't. The user can add its usage in the table templates and then add the loading of the package via the `'preamble'` key. A priori the only difference in output for existing documents is that the table caption is not wrapped to the table width but to `\LTcapwidth`.

Not using threeparttable means all tables are now handled the same, whether by longtable or not for the caption width.

### Feature or Bugfix
It fixes bug #3532. Also, using threeparttable appears to me to have been a Sphinx bug from the start, because its most salient features such as table notes were never made used of, and tables were always rendered in their own paragraphs, so wrapping the caption to the table width did not make much sense.

Thus for me it is bug fix. But it is a change for people if they somehow hacked at the LaTeX level the threeparttable to achieve some effect. And it changes the wrapping of table captions when not using longtable. For a long time it was very difficult for Sphinx user to customize tables, table templates make it much easier now but exist for a short time. Thus people using templates in their way can still do it, perhaps only by adding loading of `threeparttable` and adding their own macros to fix issues such as #3491 as was done in #3504.

Notice also that this PR fixes some complicated issue with `\belowcaptionskip` and `\abovecaptionskip` due to `threeparttable` definitions which did not take into account that multiple `\caption` commands could be used in the environment.

- #3532, #3504 (care has been put into controlling vertical space like in #3504, it is now actually simpler, and much easier for user to put table caption below the table if desired).

