### PR TITLE
By default, ``make latexpdf`` will try to ignore LaTeX errors

### DIFF
--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -212,7 +212,7 @@ The builder's "name" must be given to the **-b** command-line option of
       first LaTeX error, but still report the copious console output from
       LaTeX while e.g. ``LATEXOPTS="-silent --halt-on-error"`` would reduce
       console output to a minimum.
-      
+
    .. autoattribute:: name
 
    .. autoattribute:: format

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -203,15 +203,29 @@ The builder's "name" must be given to the **-b** command-line option of
          Use of ``latexmk`` on GNU/Linux or Mac OS X.
 
       Since 1.6, ``make latexpdf`` (or ``make -C "<builddir>/latex"`` after a
-      run of ``sphinx-build``) uses ``latexmk`` (on GNU/Linux and Mac OS X)
-      and it invokes it with options ``-f --interaction=nonstopmode``. This
-      tries to force compilation to PDF even if some types of LaTeX errors
-      arise. It can be overridden by appending ``LATEXOPTS="<options>"`` to
-      the command, for example
-      ``LATEXOPTS="--halt-on-error --interaction=nonstopmode"`` will halt on
-      first LaTeX error, but still report the copious console output from
-      LaTeX while e.g. ``LATEXOPTS="-silent --halt-on-error"`` would reduce
-      console output to a minimum.
+      ``sphinx-build`` run) uses ``latexmk`` (on GNU/Linux and Mac OS X).
+      It invokes it with option ``-f`` which attempts to complete targets
+      even in case of LaTeX processing errors. This can be overridden via
+      ``LATEXMKOPTS`` variable, for example:
+
+      .. code-block:: console
+
+         make latexpdf LATEXMKOPTS=""
+
+      The ``pdflatex`` calls themselves obey the ``LATEXOPTS`` variable whose
+      default is ``--interaction=nonstopmode`` (same as ``-interaction
+      nonstopmode``.) In order to stop the
+      compilation on first error one can use ``--halt-on-error``.
+
+      Example:
+
+      .. code-block:: console
+
+         make latexpdf LATEXMKOPTS="-silent" LATEXOPTS="--halt-on-error"
+
+      In case the first ``pdflatex`` run aborts with an error, this will stop
+      further ``latexmk`` processing (no ``-f`` option). The console output
+      will be kept to a bare minimum during target processing (``-silent``).
 
    .. autoattribute:: name
 

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -202,6 +202,17 @@ The builder's "name" must be given to the **-b** command-line option of
       .. versionchanged:: 1.6
          Use of ``latexmk`` on GNU/Linux or Mac OS X.
 
+      Since 1.6, ``make latexpdf`` (or ``make -C "<builddir>/latex"`` after a
+      run of ``sphinx-build``) uses ``latexmk`` (on GNU/Linux and Mac OS X)
+      and it invokes it with options ``-f --interaction=nonstopmode``. This
+      tries to force compilation to PDF even if some types of LaTeX errors
+      arise. It can be overridden by appending ``LATEXOPTS="<options>"`` to
+      the command, for example
+      ``LATEXOPTS="--halt-on-error --interaction=nonstopmode"`` will halt on
+      first LaTeX error, but still report the copious console output from
+      LaTeX while e.g. ``LATEXOPTS="-silent --halt-on-error"`` would reduce
+      console output to a minimum.
+      
    .. autoattribute:: name
 
    .. autoattribute:: format

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -15,7 +15,7 @@ ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
 # Prefix for archive names
 ARCHIVEPRREFIX =
 # Additional LaTeX options
-LATEXOPTS =
+LATEXOPTS = -f --interaction=nonstopmode
 # format: pdf or dvi
 FMT = pdf
 
@@ -58,13 +58,13 @@ PDFLATEX = $(LATEX)
 {%- endif %}
 	$(PDFLATEX) $(LATEXOPTS) '$<'
 
+all: $(ALLPDF)
+
 all-dvi: $(ALLDVI)
 
 all-ps: $(ALLPS)
 
 all-pdf: $(ALLPDF)
-
-all: $(ALLPDF)
 
 zip: all-$(FMT)
 	mkdir $(ARCHIVEPREFIX)docs-$(FMT)

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -14,8 +14,10 @@ ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
 
 # Prefix for archive names
 ARCHIVEPRREFIX =
-# Additional LaTeX options
-LATEXOPTS = -f --interaction=nonstopmode
+# Additional LaTeX options (used via latexmkrc/latexmkjarc file)
+LATEXOPTS = --interaction=nonstopmode
+# Additional latexmk options
+LATEXMKOPTS = -f
 # format: pdf or dvi
 FMT = pdf
 
@@ -40,11 +42,11 @@ PDFLATEX = $(LATEX)
 {% if latex_engine == 'platex' -%}
 %.dvi: %.tex $(ALLIMGS) FORCE_MAKE
 	for f in *.pdf; do extractbb "$$f"; done
-	$(LATEX) $(LATEXOPTS) '$<'
+	$(LATEX) $(LATEXMKOPTS) '$<'
 
 {% elif latex_engine != 'xelatex' -%}
 %.dvi: %.tex FORCE_MAKE
-	$(LATEX) $(LATEXOPTS) '$<'
+	$(LATEX) $(LATEXMKOPTS) '$<'
 
 {% endif -%}
 %.ps: %.dvi
@@ -56,7 +58,7 @@ PDFLATEX = $(LATEX)
 {%- else -%}
 %.pdf: %.tex FORCE_MAKE
 {%- endif %}
-	$(PDFLATEX) $(LATEXOPTS) '$<'
+	$(PDFLATEX) $(LATEXMKOPTS) '$<'
 
 all: $(ALLPDF)
 

--- a/sphinx/texinputs/latexmkjarc
+++ b/sphinx/texinputs/latexmkjarc
@@ -1,4 +1,4 @@
-$latex = 'platex --halt-on-error --interaction=nonstopmode -kanji=utf8 %O %S';
+$latex = 'platex -kanji=utf8 %O %S';
 $dvipdf = 'dvipdfmx %O -o %D %S';
 $makeindex = 'rm -f %D; mendex -U -f -d %B.dic -s python.ist %S || echo "mendex exited with error code $? (ignoring)" && : >> %D';
 add_cus_dep( "glo", "gls", 0, "makeglo" );

--- a/sphinx/texinputs/latexmkjarc
+++ b/sphinx/texinputs/latexmkjarc
@@ -1,4 +1,4 @@
-$latex = 'platex -kanji=utf8 %O %S';
+$latex = 'platex $LATEXOPTS -kanji=utf8 %O %S';
 $dvipdf = 'dvipdfmx %O -o %D %S';
 $makeindex = 'rm -f %D; mendex -U -f -d %B.dic -s python.ist %S || echo "mendex exited with error code $? (ignoring)" && : >> %D';
 add_cus_dep( "glo", "gls", 0, "makeglo" );

--- a/sphinx/texinputs/latexmkrc
+++ b/sphinx/texinputs/latexmkrc
@@ -1,7 +1,7 @@
-$latex = 'latex --halt-on-error --interaction=nonstopmode %O %S';
-$pdflatex = 'pdflatex --halt-on-error --interaction=nonstopmode %O %S';
-$lualatex = 'lualatex --halt-on-error --interaction=nonstopmode %O %S';
-$xelatex = 'xelatex --no-pdf --halt-on-error --interaction=nonstopmode %O %S';
+$latex = 'latex %O %S';
+$pdflatex = 'pdflatex %O %S';
+$lualatex = 'lualatex %O %S';
+$xelatex = 'xelatex --no-pdf %O %S';
 $makeindex = 'makeindex -s python.ist %O -o %D %S';
 add_cus_dep( "glo", "gls", 0, "makeglo" );
 sub makeglo {

--- a/sphinx/texinputs/latexmkrc
+++ b/sphinx/texinputs/latexmkrc
@@ -1,7 +1,7 @@
-$latex = 'latex %O %S';
-$pdflatex = 'pdflatex %O %S';
-$lualatex = 'lualatex %O %S';
-$xelatex = 'xelatex --no-pdf %O %S';
+$latex = 'latex $LATEXOPTS %O %S';
+$pdflatex = 'pdflatex $LATEXOPTS %O %S';
+$lualatex = 'lualatex $LATEXOPTS %O %S';
+$xelatex = 'xelatex --no-pdf $LATEXOPTS %O %S';
 $makeindex = 'makeindex -s python.ist %O -o %D %S';
 add_cus_dep( "glo", "gls", 0, "makeglo" );
 sub makeglo {


### PR DESCRIPTION
Let ``latexmk`` work by default with `-f` option which forces it to try to compile to PDF, even in case of LaTeX errors. The call to ``make latexpdf`` or ``make -C <builddir>/latex`` can override this if ending with ``LATEXOPTS = "<options>"``.

Also, the ``all`` target of the LaTeX Makefile put in build directory has been moved higher up so that it is default target if ``make -C <builddir>/latex``  does not specify a target (formerly ``all-dvi`` was default, but for ``xelatex`` engine this resulted in no compilation attempted).

### Feature or Bugfix

This is a potential bugfix, as the feature is part of 1.6-release and not yet released.

I checked the project mentioned at #3289 (https://developer.blender.org/project/view/53/), and realized behaviour with 1.6-release differed from 1.5.5, due to the ``--halt-on-error`` from #3082 (409605d). With this PR, the ``make latexpdf`` behaves more like in ``1.5.5``.

The idea of the ``--halt-on-error`` was to facilitate people not too much knowledgeable in LaTeX identify the first error occurring in document, because secondary errors are sometimes misleading. But the problem is that LaTeX has sometimes minor issues causing errors, and it might be important for a project to still be able to produce a PDF file, even though LaTeX complains. Hence, this PR takes the opposite view to use by default a "force" mode.

This is not related to the ``sphinx-build`` processing to ``latex`` target but only regards the ``latex --> pdf`` part. 

Also, the Blender project uses a Makefile which after having done ``sphinx-build`` does``make -C <builddir>/latex`` and this caused problem in my testing with 1.6-release and `xelatex` engine due to ``make`` then attempting to use ``all-dvi`` which was not suitable. Hence this PR moves the ``all`` target (which defaults to ``all-pdf``) to be first in Makefile put in ``<builddir>/latex``.

### Relates
- #3082

