### PR TITLE
viewcode is highlighting code syntax even with conf.py's highlight_la…

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -156,7 +156,7 @@ def collect_pages(app):
         # construct a page name for the highlighted source
         pagename = '_modules/' + modname.replace('.', '/')
         # highlight the source using the builder's highlighter
-        if env.config.highlight_language in ('python3', 'default'):
+        if env.config.highlight_language in ('python3', 'default', 'none'):
             lexer = env.config.highlight_language
         else:
             lexer = 'python'


### PR DESCRIPTION
…nguage='none'

http://www.sphinx-doc.org/en/stable/markup/code.html#code-examples says:

> none (no highlighting)

Subject: little bugfix

### Feature or Bugfix

- Bugfix

### Purpose
- viewcode highlighting syntax even with highlight_language='none'

