### PR TITLE
Fix #3702: abstract LaTeX styling of figure legends into sphinxlegend

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -438,7 +438,14 @@ Let us now list some macros from the package file
      the new macros are wrappers of the formerly hard-coded ``\texttt``,
      ``\emph``, ... The default definitions can be found in
      :file:`sphinx.sty`.
-- paragraph level environments: for each admonition type ``<foo>``, the
+- a :dudir:`figure` may have an optional legend with arbitrary body
+  elements: they are rendered in a ``sphinxlegend`` environment. The default
+  definition issues ``\small``, and ends with ``\par``.
+
+  .. versionadded:: 1.5.6
+     formerly, the ``\small`` was hardcoded in LaTeX writer and the ending
+     ``\par`` was lacking.
+- for each admonition type ``<foo>``, the
   used environment is named ``sphinx<foo>``. They may be ``\renewenvironment``
   'd individually, and must then be defined with one argument (it is the heading
   of the notice, for example ``Warning:`` for :dudir:`warning` directive, if

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1383,6 +1383,8 @@
 \protected\def\sphinxstyleliteralstrong  {\sphinxbfcode}
 \protected\def\sphinxstyleabbreviation   {\textsc}
 \protected\def\sphinxstyleliteralintitle {\sphinxcode}
+% figure legend comes after caption and may contain arbitrary body elements
+\newenvironment{sphinxlegend}{\par\small}{\par}
 
 % LaTeX writer uses macros to hide double quotes from \sphinxcode's \@noligs
 \protected\def\sphinxquotedblleft{``}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1599,10 +1599,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.unrestrict_footnote(node)
 
     def visit_legend(self, node):
-        self.body.append('{\\small ')
+        self.body.append('\n\\begin{sphinxlegend}')
 
     def depart_legend(self, node):
-        self.body.append('}')
+        self.body.append('\\end{sphinxlegend}\n')
 
     def visit_admonition(self, node):
         self.body.append('\n\\begin{sphinxadmonition}{note}')


### PR DESCRIPTION
Subject: replace hardcoded `{\small ... }` by a `sphinxlegend` environment which the user can modify.

### Feature or Bugfix
- Bugfix because the LaTeX writer code was missing an ending `\par`. So the typeface was smaller but the the interlinespacing for the last paragraph of the legend was not adjusted. In case of multiple paragraphs this meant diverging linespacing of the last one compared to earlier ones.

### Relates
- #3702 

