### PR TITLE
Rebasing as asked. viewcode extension not taking highlight_code='none' in account. Original pull request: #3700

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -156,7 +156,7 @@ def collect_pages(app):
         # construct a page name for the highlighted source
         pagename = '_modules/' + modname.replace('.', '/')
         # highlight the source using the builder's highlighter
-        if env.config.highlight_language in ('python3', 'default'):
+        if env.config.highlight_language in ('python3', 'default', 'none'):
             lexer = env.config.highlight_language
         else:
             lexer = 'python'


### PR DESCRIPTION
Subject: rebasing as asked

### Feature or Bugfix
- Bugfix (please see #3700)

### Purpose
- Resubmitting as asked

### Detail
- viewcode extension was highlighting code even when `conf.py` was set to `highlight_code='none'`

### Relates
- #3700

