### PR TITLE
Don't warn about .png format favicons

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -305,8 +305,6 @@ class StandaloneHTMLBuilder(Builder):
 
         favicon = self.config.html_favicon and \
             path.basename(self.config.html_favicon) or ''
-        if favicon and os.path.splitext(favicon)[1] != '.ico':
-            self.warn('html_favicon is not an .ico file')
 
         if not isinstance(self.config.html_use_opensearch, string_types):
             self.warn('html_use_opensearch config value must now be a string')


### PR DESCRIPTION
It looks like every browser can now handle .png favicons:

    https://caniuse.com/#feat=link-icon-png

(When looking at that page, note that iOS Safari and Opera Mini don't
support .ico favicons either.) So I don't think sphinx needs to warn
about this anymore...

This is especially annoying because I build with -nW, which is great
for catching lots of real errors but means that currently it's
actually impossible for me to use a .png favicon, even though it's
smaller, easier to work with, and supported by everything except
sphinx.