### PR TITLE
Stop enforcing that favicon's must be .ico

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -305,8 +305,6 @@ class StandaloneHTMLBuilder(Builder):
 
         favicon = self.config.html_favicon and \
             path.basename(self.config.html_favicon) or ''
-        if favicon and os.path.splitext(favicon)[1] != '.ico':
-            self.warn('html_favicon is not an .ico file')
 
         if not isinstance(self.config.html_use_opensearch, string_types):
             self.warn('html_use_opensearch config value must now be a string')


### PR DESCRIPTION
Support for at least .png and .gif is now essentially universal, and
other formats (.jpg, .svg, etc.) are relatively widespread.

This was only a warning, but it's common to run sphinx with warnings
turned into errors, so it caused problems.

[Redo of #3715, now targeted at stable instead of master]