### PR TITLE
Don't use forced mode by default for latexmk runs

### DIFF
--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -202,30 +202,18 @@ The builder's "name" must be given to the **-b** command-line option of
       .. versionchanged:: 1.6
          Use of ``latexmk`` on GNU/Linux or Mac OS X.
 
-      Since 1.6, ``make latexpdf`` (or ``make -C "<builddir>/latex"`` after a
-      ``sphinx-build`` run) uses ``latexmk`` (on GNU/Linux and Mac OS X).
-      It invokes it with option ``-f`` which attempts to complete targets
-      even in case of LaTeX processing errors. This can be overridden via
-      ``LATEXMKOPTS`` variable, for example:
+      Since 1.6, and on GNU/Linux and Mac OS X, ``make latexpdf`` (or
+      ``make -C "<builddir>/latex"`` after a ``sphinx-build`` run) uses
+      ``latexmk``. One can pass to ``latexmk`` options via the ``LATEXMKOPTS``
+      Makefile variable. For example:
 
       .. code-block:: console
 
-         make latexpdf LATEXMKOPTS=""
+         make latexpdf LATEXMKOPTS="-silent"
 
-      The ``pdflatex`` calls themselves obey the ``LATEXOPTS`` variable whose
-      default is ``--interaction=nonstopmode`` (same as ``-interaction
-      nonstopmode``.) In order to stop the
-      compilation on first error one can use ``--halt-on-error``.
-
-      Example:
-
-      .. code-block:: console
-
-         make latexpdf LATEXMKOPTS="-silent" LATEXOPTS="--halt-on-error"
-
-      In case the first ``pdflatex`` run aborts with an error, this will stop
-      further ``latexmk`` processing (no ``-f`` option). The console output
-      will be kept to a bare minimum during target processing (``-silent``).
+      reduces console output to a minimum. To pass options directly to the
+      ``pdflatex`` executable, use variable ``LATEXOPTS`` (for example
+      ``LATEXOPTS="--interaction=nonstopmode"``).
 
    .. autoattribute:: name
 

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -15,9 +15,9 @@ ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
 # Prefix for archive names
 ARCHIVEPRREFIX =
 # Additional LaTeX options (passed via variables in latexmkrc/latexmkjarc file)
-export LATEXOPTS = --interaction=nonstopmode
+export LATEXOPTS =
 # Additional latexmk options
-LATEXMKOPTS = -f
+LATEXMKOPTS =
 # format: pdf or dvi
 FMT = pdf
 


### PR DESCRIPTION
At #3695 which was merged into 1.6b3 I use `-f` option for the `latexmk` run, as called from `make latexpdf` or simply `make` in `<builddir>/latex`.

Also, by default the `pdflatex` is called with ``--interaction=nonstopmode`` (the implementation is fixed at #3719).

On further testing with projects having latex runtime errors (due to missing graphics files), I am now of the opinion that this is not good. First, it was a change from 1.5.x behaviours. Second, perhaps I had not so much experience with how 1.5.x behaved in case of latex runtime error, and I was under wrong impression.

Already, many projects have `LATEXOPTS = --interaction=nonstopmode` in their custom Makefiles, and this will be obeyed with no change. Further in case a pdflatex run has an error and was run with this setting, the 1.5.x Make recipe would abort after first pdflatex run.

If we use latexmk with `-f` option as is in 1.6b3, it will go on for more runs. This is in a way good to get at least some pdf with in some cases a table of contents or an index, but the latex console output is so voluminous it makes harder for user to see the first error. And if `-f` option is used with normal interaction mode which is `errorstopmode`, the user might be disconcerted after typing `X` to abort TeX, that Latexmk continues trying up to 5 more runs. 

I thus propose to revert the current defaults for LATEXMKOPTS and LATEXOPTS in the Makefile template, and leave them empty, thus recovering the behaviour of Sphinx runs as was the case with 1.5.x and earlier.

I leave the `export` in the Makefile, else Perl will complain of an uninitialized variable in `latexmkrc` except is user defined `LATEXOPTS` in the environment or in the `make` command line.

### Relates
- #3695, #3719  (this PR extends it)

