### PR TITLE
Suppress extra method signatures when automethod is used within autoclass with :members:

### DIFF
--- a/tests/root/autodoc.txt
+++ b/tests/root/autodoc.txt
@@ -6,14 +6,17 @@ Just testing a few autodoc possibilities...
 .. automodule:: util
 
 .. automodule:: test_autodoc
-   :members:
 
 .. autofunction:: function
 
 .. autoclass:: Class
-   :inherited-members:
+   :members:
 
    Additional content.
+
+   .. automethod:: extradocmeth()
+
+      Here is some extra documentation to add.
 
 .. autoclass:: Outer
    :members: Inner

--- a/tests/root/conf.py
+++ b/tests/root/conf.py
@@ -78,6 +78,8 @@ autodoc_mock_imports = [
     'missing_package3.missing_module3',
 ]
 
+autodoc_member_order = 'bysource'
+
 # modify tags from conf.py
 tags.add('confpytag')
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -683,6 +683,7 @@ def test_generate():
                    ('attribute', 'test_autodoc.Class.inst_attr_inline'),
                    ('attribute', 'test_autodoc.Class.inst_attr_string'),
                    ('method', 'test_autodoc.Class.moore'),
+                   ('method', 'test_autodoc.Class.extradocmeth'),
                    ])
     options.members = ALL
     assert_processes(should, 'class', 'Class')
@@ -756,6 +757,7 @@ def test_generate():
                   '   .. py:attribute:: Class.descr',
                   '   .. py:method:: Class.meth()',
                   '   .. py:method:: Class.undocmeth()',
+                  '   .. py:method:: Class.extradocmeth()',
                   '   .. py:attribute:: Class.attr',
                   '   .. py:attribute:: Class.prop',
                   '   .. py:attribute:: Class.docattr',
@@ -949,6 +951,9 @@ class Class(Base):
 
     def excludemeth(self):
         """Method that should be excluded."""
+
+    def extradocmeth(self):
+        """A method that will have some extra documentation added."""
 
     # should not be documented
     skipattr = 'foo'

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -165,6 +165,12 @@ def test_static_output(app):
     check_extra_entries(app.builder.outdir)
 
 
+def check_node_texts(texts):
+    def check(nodes):
+        assert [n.text for n in nodes] == texts
+    return check
+
+
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'images.html': [
         (".//img[@src='_images/img.png']", ''),
@@ -210,6 +216,14 @@ def test_static_output(app):
     ],
     'autodoc.html': [
         (".//dt[@id='test_autodoc.Class']", ''),
+        (".//dt[@id='test_autodoc.Class']/../"
+         "dd/dl[@class='method']/dt/code[@class='descname']",
+         check_node_texts([
+             'meth', 'skipmeth', 'excludemeth', 'extradocmeth'])),
+        (".//dt[@id='test_autodoc.Class.extradocmeth']/../dd/p",
+         check_node_texts([
+             'A method that will have some extra documentation added.',
+             'Here is some extra documentation to add.'])),
         (".//dt[@id='test_autodoc.function']/em", r'\*\*kwds'),
         (".//dd/p", r'Return spam\.'),
     ],


### PR DESCRIPTION
Subject: To fix #1881 

### Feature or Bugfix
- Bugfix

### Purpose
- To fix #1881

### Detail
- This pull request only adds a test that illustrates the bug at present. I need some guidance to actually fix the bug
- There seem to be 2 options to fix this:
  1) In `ClassDocumenter.add_content`, parse `more_content` and add any automethod or autoattribute directives to `self.options.exclude_members` if `self.options.members` is `ALL`. This is easy to do, but will put the method at the top of the resulting documentation which breaks source order.
  2) In `ClassDocumenter.add_content`, parse `more_content` and extract the automethod and autoattribute directives into a dictionary so that `MethodDocumenter` and `AttributeDocumenter` can make use of them. Then they can be deleted from `more_content`. This is more tricky and actually requires parsing `more_content` completely
- I can fairly easily update this pull request to do 1), but I don't know enough about how to parse RST to do 2)

### Relates
- #1881 

