### PR TITLE
Protect isenumclass predicate against non-class arguments

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -104,7 +104,7 @@ def isenumclass(x):
     """Check if the object is subclass of enum."""
     if enum is None:
         return False
-    return issubclass(x, enum.Enum)
+    return inspect.isclass(x) and issubclass(x, enum.Enum)
 
 
 def isenumattribute(x):


### PR DESCRIPTION

Subject: Protect isenumclass predicate against non-class arguments

### Feature or Bugfix
- Bugfix

### Purpose

Not being a class is a reasonable way a thing might not be an enum class,
but without an explicit check, isenumclass raises an exception in this case.

### Detail

fixes: #3731

### Relates
- <URL or Ticket>

