### PR TITLE
Add Circle CI as our CI platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: sphinxdoc/docker-ci
+    working_directory: /sphinx
+    steps:
+      - checkout
+      - run: make test PYTHON=/python3.4/bin/python

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - TEST='-v --durations 25'
     - PYTHONFAULTHANDLER=x
     - PYTHONWARNINGS=all
+    - SKIP_LATEX_BUILD=1
   matrix:
     - DOCUTILS=0.12
     - DOCUTILS=0.13.1
@@ -34,16 +35,8 @@ matrix:
 addons:
   apt:
     packages:
-    - graphviz
-    - texlive-latex-recommended
-    - texlive-latex-extra
-    - texlive-fonts-recommended
-    - texlive-fonts-extra
-    - texlive-luatex
-    - texlive-xetex
-    - lmodern
-    - latex-xcolor
-    - imagemagick
+      - graphviz
+      - imagemagick
 install:
   - pip install -U pip setuptools
   - pip install docutils==$DOCUTILS
@@ -52,4 +45,4 @@ install:
 script:
   - flake8
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make style-check type-check test-async; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != '3.6' ]]; then SKIP_LATEX_BUILD=1 make test; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.6' ]]; then make test; fi


### PR DESCRIPTION
Now we use Travis CI for continuous integration. It brings peace of minds to us :-)
But it take much time at present. In #3655, we skipped the LaTeX compilations on except for py36. Certainly it made our test faster. 
But it still slow. For example, a recent build takes about 10.5 minutes.
https://travis-ci.org/sphinx-doc/sphinx/builds/230535108

In this PR, I use Circle CI (https://circleci.com/) for testing of LaTeX compilations. And I also dropped the testcases for them from Travis CI. That allows us not to install texlive to Travis CI. Now an installation of TeXLive packages on Travis CI takes about 90+ seconds. With combination of Travis CI and Circle CI, we can do matrix tests and LaTeX compilation tests quickly!
https://travis-ci.org/sphinx-doc/sphinx/jobs/230535110

Note: We can make much faster to install TeXLive on Circle CI because Circle CI supports Docker.