### PR TITLE
Fix #3289: LaTeX builder: Emit warnings if the document contains aligned figures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Incompatible changes
 
 * LaTeX package ``threeparttable`` is not used and not loaded by Sphinx
   anymore (refs #3686, #3532, #3377)
+* #3289: LaTeX builder: Emit warnings if the document contains aligned figures
+  because it might not be layouted well by wrapfig-macro's limitation.
 
 Deprecated
 ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -239,6 +239,7 @@ General configuration
    * misc.highlighting_failure
    * toc.secnum
    * epub.unknown_project_files
+   * latex.wrapfig
 
    You can choose from these types.
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1787,6 +1787,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('\\begin{wrapfigure}{%s}{%s}\n\\centering' %
                              (node['align'] == 'right' and 'r' or 'l', length or '0pt'))
             self.context.append(ids + '\\end{wrapfigure}\n')
+
+            # emit a warning about wrapfig (refs: #3289)
+            logger.warning(_('A figure having :align: option has detected. '
+                             'LaTeX might not layout it well. Please check generated PDF.'),
+                           location=node, type='latex', subtype='wrapfig')
         elif self.in_minipage:
             if ('align' not in node.attributes or
                     node.attributes['align'] == 'center'):


### PR DESCRIPTION
refs: #3289. Regarding a problem of wrapfig, it seems there are no good solution. To prevent to collapse the layout silently, this emits warnings on aligned figures has detected.

Now I'm put this as PR for 1.6-release branch. But I will change the target branch after reviewing for some reasons:

* I need to review before merging.
* 1.6 will be released soon. (this is not a blocker)
* Introducing warnings is a incompatible changes for `-W` (warn is error option) users