### PR TITLE
Fix #3746: PDF builds fail with latexmk version 4.48 or earlier

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,8 @@ Bugs fixed
 * #3725: Todo looks different from note in LaTeX output
 * #3479: stub-columns have no effect in LaTeX output
 * #3738: Nonsensical code in theming.py
+* #3746: PDF builds fail with latexmk 4.48 or earlier due to undefined
+  options ``-pdfxe`` and ``-pdflua``
 
 Testing
 --------

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -211,8 +211,12 @@ The builder's "name" must be given to the **-b** command-line option of
 
          make latexpdf LATEXMKOPTS="-silent"
 
-      reduces console output to a minimum. To pass options directly to the
-      ``pdflatex`` executable, use variable ``LATEXOPTS`` (for example
+      reduces console output to a minimum. Also, if ``latexmk`` version is
+      4.52b or higher (Jan 17) and ``xelatex`` is the :confval:`latex_engine`,
+      then ``LATEXMKOPTS="-xelatex"`` will speed up PDF builds.
+
+      To pass options directly to the
+      ``(pdf|xe|lua)latex`` executable, use variable ``LATEXOPTS`` (for example
       ``LATEXOPTS="--interaction=nonstopmode"``).
 
    .. autoattribute:: name

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -17,23 +17,21 @@ ARCHIVEPRREFIX =
 # Additional LaTeX options (passed via variables in latexmkrc/latexmkjarc file)
 export LATEXOPTS =
 # Additional latexmk options
+{% if latex_engine == 'xelatex' -%}
+# with latexmk version 4.52b or higher set LATEXMKOPTS to -xelatex either here
+# or on command line for faster builds.
+{% endif -%}
 LATEXMKOPTS =
-# format: pdf or dvi
+# format: pdf or dvi (used only by archive targets)
 FMT = pdf
 
 {% if latex_engine == 'platex' -%}
 # latexmkrc is read then overridden by latexmkjarc
 LATEX = latexmk -r latexmkjarc -dvi
 PDFLATEX = latexmk -r latexmkjarc -pdfdvi -dvi- -ps-
-{% elif latex_engine == 'pdflatex' -%}
+{% else -%}
 LATEX = latexmk -dvi
 PDFLATEX = latexmk -pdf -dvi- -ps-
-{% elif latex_engine == 'lualatex' -%}
-LATEX = latexmk -lualatex
-PDFLATEX = latexmk -pdflua -dvi- -ps-
-{% elif latex_engine == 'xelatex' -%}
-LATEX = latexmk -pdfxe -dvi- -ps-
-PDFLATEX = $(LATEX)
 {% endif %}
 
 %.png %.gif %.jpg %.jpeg: FORCE_MAKE

--- a/sphinx/texinputs/latexmkrc_t
+++ b/sphinx/texinputs/latexmkrc_t
@@ -1,5 +1,13 @@
+{% if latex_engine == 'pdflatex' -%}
 $latex = 'latex ' . $ENV{'LATEXOPTS'} . ' %O %S';
 $pdflatex = 'pdflatex ' . $ENV{'LATEXOPTS'} . ' %O %S';
+{% elif latex_engine == 'lualatex' -%}
+$latex = 'lualatex --output-format=dvi ' . $ENV{'LATEXOPTS'} . ' %O %S';
+$pdflatex = 'lualatex ' . $ENV{'LATEXOPTS'} . ' %O %S';
+{% elif latex_engine == 'xelatex' -%}
+$latex = 'xelatex --no-pdf ' . $ENV{'LATEXOPTS'} . ' %O %S';
+$pdflatex = 'xelatex ' . $ENV{'LATEXOPTS'} . ' %O %S';
+{% endif -%}
 $lualatex = 'lualatex ' . $ENV{'LATEXOPTS'} . ' %O %S';
 $xelatex = 'xelatex --no-pdf ' . $ENV{'LATEXOPTS'} . ' %O %S';
 $makeindex = 'makeindex -s python.ist %O -o %D %S';


### PR DESCRIPTION
This is tested to work at least with latexmk version: 4.39 (10 Nov 2013), and it should work with earlier versions too.

Fixes #3746.

Sorry for oversight of having tested only with recent latexmk. 

