### PR TITLE
Fix links to external option docs with intersphinx.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 * #3756: epub: Entity 'mdash' not defined
 * #3758: Sphinx crashed if logs are emitted in conf.py
 * #3755: incorrectly warns about dedent with literalinclude
+* #2822: External option references did not work in most situations when using
+  intersphinx
 
 Testing
 --------

--- a/tests/test_util_inventory.py
+++ b/tests/test_util_inventory.py
@@ -38,6 +38,7 @@ foo::Bar cpp:class 1 index.html#cpp_foo_bar -
 foo::Bar::baz cpp:function 1 index.html#cpp_foo_bar_baz -
 a term std:term -1 glossary.html#term-a-term -
 ls.-l std:cmdoption 1 index.html#cmdoption-ls-l -
+foo-bar.--field std:cmdoption 1 index.html#cmdoption-foo-bar-field -
 docname std:doc -1 docname.html -
 foo js:module 1 index.html#foo -
 foo.bar js:class 1 index.html#foo.bar -


### PR DESCRIPTION
**Subject:** Fix links to external option docs with intersphinx.

### Feature or Bugfix
- Bugfix

### Purpose

- To fix creating references to options defined in external documentation when using intersphinx.

### Detail

When using intersphinx doc sets, the `:option:` directive is unable to locate external option definitions without explicitly specifying an additional target in the form of `<progname>.<option>`. This is because the directive is attempting to use state not available over intersphinx to locate the appropriate directive. It's even worse if attempting to define a `.. program::` entry in the documentation trying to link to an external option.

To fix this, the intersphinx code for locating definitions now attempts to convert option references into the right format. It does this by rebuilding the string to normalize the program name and the option, taking care to retain the intersphinx doc set name and the current program if one isn't specified in the option. This allows external options to be correctly resolved over intersphinx without custom syntax or workarounds, behaving like other standard references.

### Relates
- #2822