### PR TITLE
Fix rendering of double hyphens in long-form arguments to the 'option' directive.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Other contributors, listed alphabetically, are:
 * Jeppe Pihl -- literalinclude improvements
 * Rob Ruana -- napoleon extension
 * Stefan Seefeld -- toctree improvements
+* Brian Skinn -- bugfix option directive rendering
 * Gregory Szorc -- performance improvements
 * Taku Shimizu -- epub3 builder
 * Antonio Valentino -- qthelp builder

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Features added
 Bugs fixed
 ----------
 
+* #3781: Arguments to ``.. option::`` directive now render as literal,
+  bypassing smartypants, resulting in two hyphens instead of one
+  endash in output for long-style options (e.g., "--help")
 * #3754: HTML builder crashes if HTML theme appends own stylesheets
 * #3756: epub: Entity 'mdash' not defined
 * #3758: Sphinx crashed if logs are emitted in conf.py

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -124,6 +124,12 @@ class desc_name(nodes.Part, nodes.Inline, nodes.TextElement):
     """Node for the main object name."""
 
 
+class desc_name_literal(nodes.Part, nodes.literal, nodes.Inline,
+                        nodes.TextElement):
+    """Node for the main object name, but further text processors are not
+    applied (e.g. smartypants for HTML output)."""
+
+
 class desc_parameterlist(nodes.Part, nodes.Inline, nodes.TextElement):
     """Node for a general parameter list."""
     child_text_separator = ', '

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -166,7 +166,8 @@ class Cmdoption(ObjectDescription):
             optname, args = m.groups()
             if count:
                 signode += addnodes.desc_addname(', ', ', ')
-            signode += addnodes.desc_name(optname, optname)
+            signode += addnodes.literal_strong(optname, optname)
+##            signode += addnodes.desc_name(optname, optname)
             signode += addnodes.desc_addname(args, args)
             if not count:
                 firstname = optname

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -166,8 +166,7 @@ class Cmdoption(ObjectDescription):
             optname, args = m.groups()
             if count:
                 signode += addnodes.desc_addname(', ', ', ')
-            signode += addnodes.literal_strong(optname, optname)
-##            signode += addnodes.desc_name(optname, optname)
+            signode += addnodes.desc_name_literal(optname, optname)
             signode += addnodes.desc_addname(args, args)
             if not count:
                 firstname = optname

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -167,6 +167,14 @@ class HTMLTranslator(BaseTranslator):
         # type: (nodes.Node) -> None
         self.body.append('</code>')
 
+    def visit_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.visit_desc_name(node)
+
+    def depart_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.depart_desc_name(node)
+
     def visit_desc_parameterlist(self, node):
         # type: (nodes.Node) -> None
         self.body.append('<span class="sig-paren">(</span>')

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -137,6 +137,14 @@ class HTML5Translator(BaseTranslator):
         # type: (nodes.Node) -> None
         self.body.append('</code>')
 
+    def visit_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.visit_desc_name(node)
+
+    def depart_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.depart_desc_name(node)
+
     def visit_desc_parameterlist(self, node):
         # type: (nodes.Node) -> None
         self.body.append('<span class="sig-paren">(</span>')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1187,6 +1187,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.literal_whitespace -= 1
         self.no_contractions -= 1
 
+    def visit_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.visit_desc_name(node)
+
+    def depart_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.depart_desc_name(node)
+
     def visit_desc_parameterlist(self, node):
         # type: (nodes.Node) -> None
         # close name, open parameterlist

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -195,6 +195,14 @@ class ManualPageTranslator(BaseTranslator):
         # type: (nodes.Node) -> None
         pass
 
+    def visit_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.visit_desc_name(node)
+
+    def depart_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.depart_desc_name(node)
+
     def visit_desc_parameterlist(self, node):
         # type: (nodes.Node) -> None
         self.body.append('(')

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1602,6 +1602,14 @@ class TexinfoTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         pass
 
+    def visit_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.visit_desc_name(node)
+
+    def depart_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.depart_desc_name(node)
+
     def visit_desc_addname(self, node):
         # type: (nodes.Node) -> None
         pass

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -371,6 +371,14 @@ class TextTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         pass
 
+    def visit_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.visit_desc_name(node)
+
+    def depart_desc_name_literal(self, node):
+        # type: (nodes.Node) -> None
+        self.depart_desc_name(node)
+
     def visit_desc_addname(self, node):
         # type: (nodes.Node) -> None
         pass

--- a/tests/roots/test-directive-option/conf.py
+++ b/tests/roots/test-directive-option/conf.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'

--- a/tests/roots/test-directive-option/index.rst
+++ b/tests/roots/test-directive-option/index.rst
@@ -1,0 +1,11 @@
+test-directives-option
+======================
+
+Double hyphen rendering in option argument
+------------------------------------------
+
+.. option:: -h, --help
+
+    Print the help screen
+
+

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1204,6 +1204,15 @@ def test_html_raw_directive(app, status, warning):
     assert '<p>LaTeX: abc  ghi</p>' in result
 
 
+@pytest.mark.sphinx('html', testroot='directive-option')
+def test_html_option_directive(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'index.html').text(encoding='utf8')
+
+    # Assert that the '--help' option argument is rendered with two hyphens
+    assert '--help' in result
+
+
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
         (".//link[@href='_static/persistent.css']"


### PR DESCRIPTION
Subject: Merge bugfix for double hyphen rendering in `option` directive

### Feature or Bugfix
- Bugfix

### Purpose
- Fix bug in rendering behavior of `.. option::` when long-form arguments (e.g., `--help`) are passed to it and `smartypants` is enabled. Instead of the desired double-hyphen in the rendered output, a single endash results.
- Unit test added for the desired behavior; test fails on `stable`, passes after these changes

### Detail
-  In current versions, the arguments to `.. option::` are rendered using `docutils.nodes.desc_name`, the output of which is passed through `smartypants`, if it is enabled. `smartypants` converts the double-hyphen of any long-form argument (e.g., `--help`) to an endash, as would be expected. This leads to undesired conversion of the double-hyphen to a single endash in the rendered docs. While any experienced *nix and/or Python user would probably know that long-form arguments typically require the leading double-hyphen, this rendering error changes the semantics of the output in a breaking way.
- This bugfix creates a new `docutils.Node` subclass identical to the existing `desc_name`, but that also inherits from `nodes.literal`. This causes `smartypants` to skip processing of the arguments to `option`, avoiding the undesired endash conversion.

### Relates
- Issue #3781
- See commit messages for 371ffa3 and ef02089 for more information

