### PR TITLE
i18n: This string is used as html_title, it needs to be capitalized.

### DIFF
--- a/sphinx/locale/fr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fr/LC_MESSAGES/sphinx.po
@@ -356,7 +356,7 @@ msgstr "précédent"
 #: sphinx/builders/html.py:1313
 #, python-format
 msgid "%s %s documentation"
-msgstr "documentation %s %s"
+msgstr "Documentation %s %s"
 
 #: sphinx/builders/latex.py:199 sphinx/builders/texinfo.py:217
 msgid " (in "


### PR DESCRIPTION
Subject: Just to fix capitalization in a title.

### Feature or Bugfix
- "Bugfix"

### Purpose
- On french translated documentation, the html_title is not properly capitalized, see: https://www.afpy.org/doc/python/3.6/
