### PR TITLE
Supress error when warnfunc is None

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -38,6 +38,8 @@ class WarningStream(object):
 
     def write(self, text):
         # type: (str) -> None
+        if self.warnfunc is None:
+            return
         text = text.strip()
         if text:
             self.warnfunc(self._re.sub(r'\1:', text), None, '')


### PR DESCRIPTION
This resolves issue we have building translations.
There is a warning which is causing an error because `warnfunc` is None.

This fixes/works around #3803