### PR TITLE
Fix Docutils emits warning that language localisation and/or smart quotes are not available

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -672,16 +672,21 @@ class BuildEnvironment(object):
         self.settings['trim_footnote_reference_space'] = \
             self.config.trim_footnote_reference_space
         self.settings['gettext_compact'] = self.config.gettext_compact
-        language = (self.config.language or 'en').replace('_', '-')
-        self.settings['language_code'] = language
+        self.settings['language_code'] = 'en'
+        self.settings['smart_quotes'] = True  # We enable smartypants by default
         if self.config.html_use_smartypants is not None:
             warnings.warn("html_use_smartypants option is deprecated. Use the "
                           "smart_quotes option in docutils.conf instead.",
                           RemovedInSphinx17Warning)
-            if language in smartchars.quotes:
-                self.settings['smart_quotes'] = self.config.html_use_smartypants
-        elif language in smartchars.quotes:  # We enable smartypants by default
-            self.settings['smart_quotes'] = True
+            self.settings['smart_quotes'] = self.config.html_use_smartypants
+        language = self.config.language or 'en'
+        if self.settings['smart_quotes'] and language in smartchars.quotes:
+            # trick Docutils smartquotes transform to apply even if document
+            # language is not available for Docutils's own localisation
+            smartchars.quotes['en'] = smartchars.quotes[language]
+        else:
+            self.settings.pop('language_code')
+            self.settings.pop('smart_quotes')
 
         docutilsconf = path.join(self.srcdir, 'docutils.conf')
         # read docutils.conf from source dir, not from current dir


### PR DESCRIPTION
Closes: #3788, #3806

Trick Docutils into thinking the document is with language set to ``'en'`` else <strike>its smartquotes transform will refuse to apply, even if it knows the language, in case the language has no Docutils localisation available. </strike>

EDIT: this description is not correct (due to hastiness in pushing the PR). It is only that a Warning is emitted in case the language, for which smart quotes are available, is not also available as an available language locale for Docutils generated strings.

Refs: #3666 

In my testing with Docutils 0.13.1

- with Turkish, no smart quotes applied (they are not available at 0.13.1); no warnings

- with Estonian, smart quotes applied despite the language is not known to Docutils for localisation; no warnings

- with French and English correct smart quotes applied.

- In case of successive builds with distinct languages, no warnings from left over language in pickled environment

relates: #3808 

see also: https://sourceforge.net/p/docutils/mailman/message/35861407/
