### PR TITLE
Fix #3788: Docutils emits warnings for unsupported languages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
 * #3796: env.resolve_references() crashes when non-document node given
 * #3803: Sphinx crashes with invalid PO files
 * #3791: PDF "continued on next page" for long tables isn't internationalized
+* #3788: smartquotes emits warnings for unsupported languages
 
 Testing
 --------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -22,7 +22,9 @@ from collections import deque
 from six import iteritems
 from six.moves import cStringIO
 
+import docutils
 from docutils import nodes
+from docutils.languages import get_language as docutils_get_language
 from docutils.parsers.rst import directives, roles
 
 import sphinx
@@ -104,6 +106,14 @@ CONFIG_FILENAME = 'conf.py'
 ENV_PICKLE_FILENAME = 'environment.pickle'
 
 logger = logging.getLogger(__name__)
+
+
+# monkey patch docutils get_language
+def patched_docutils_get_language(language_code, reporter=None):  # NOQA
+    return docutils_get_language(language_code)
+
+
+docutils.languages.get_language = patched_docutils_get_language
 
 
 class Sphinx(object):

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -25,7 +25,7 @@ from six.moves import cPickle as pickle
 
 from docutils.io import NullOutput
 from docutils.core import Publisher
-from docutils.utils import Reporter, get_source_line
+from docutils.utils import Reporter, get_source_line, normalize_language_tag
 from docutils.utils.smartquotes import smartchars
 from docutils.parsers.rst import roles
 from docutils.parsers.rst.languages import en as english
@@ -672,18 +672,22 @@ class BuildEnvironment(object):
         self.settings['trim_footnote_reference_space'] = \
             self.config.trim_footnote_reference_space
         self.settings['gettext_compact'] = self.config.gettext_compact
-        language = (self.config.language or 'en').replace('_', '-')
+
+        language = self.config.language or 'en'
         self.settings['language_code'] = language
+        self.settings['smart_quotes'] = True
         if self.config.html_use_smartypants is not None:
             warnings.warn("html_use_smartypants option is deprecated. Smart "
                           "quotes are on by default; if you want to disable "
                           "or customize them, use the smart_quotes option in "
                           "docutils.conf.",
                           RemovedInSphinx17Warning)
-            if language in smartchars.quotes:
-                self.settings['smart_quotes'] = self.config.html_use_smartypants
-        elif language in smartchars.quotes:  # We enable smartypants by default
-            self.settings['smart_quotes'] = True
+            self.settings['smart_quotes'] = self.config.html_use_smartypants
+        for tag in normalize_language_tag(language):
+            if tag in smartchars.quotes:
+                    break
+        else:
+            self.settings['smart_quotes'] = False
 
         docutilsconf = path.join(self.srcdir, 'docutils.conf')
         # read docutils.conf from source dir, not from current dir


### PR DESCRIPTION
This monkey-patches docutils.languages.get_language() to suppress Docutils emitted warning when the document settings use a language_code for which Docutils has no ready-made localisation. 

It appears that in the past the language_code was always ``'en'`` but now it is needed for functioning of the smartquotes transform.

The list of languages for which Docutils has smart quotes is not the same for which it provides localisation (which Sphinx does not use).

There is probably much better way to do the replacement of ``get_language``. Feel free to improve.

I prefer this to my other proposal #3811.

### Relates:

#3788, #3806, #3808.
