### PR TITLE
Fix #3781: instruct SmartQuotes of nodes to skip

### DIFF
--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -21,7 +21,6 @@ from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.i18n import format_date
 from sphinx.util.nodes import apply_source_workaround
-from sphinx import addnodes
 
 if False:
     # For type annotation
@@ -340,7 +339,7 @@ class SphinxSmartQuotes(DocutilsSmartQuotes):  # NOQA
         # A generator that yields ``(texttype, nodetext)`` tuples for a list
         # of "Text" nodes (interface to ``smartquotes.educate_tokens()``).
 
-        texttype = {True: 'literal', # "literal" text is not changed:
+        texttype = {True: 'literal',  # "literal" text is not changed:
                     False: 'plain'}
         for txtnode in txtnodes:
             nodetype = texttype[isinstance(txtnode.parent,

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -9,16 +9,19 @@
     :license: BSD, see LICENSE for details.
 """
 
+import docutils
 from docutils import nodes
 from docutils.transforms import Transform, Transformer
 from docutils.transforms.parts import ContentsFilter
 from docutils.utils import new_document
+from docutils.transforms.universal import SmartQuotes as DocutilsSmartQuotes
 
 from sphinx import addnodes
 from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.i18n import format_date
 from sphinx.util.nodes import apply_source_workaround
+from sphinx import addnodes
 
 if False:
     # For type annotation
@@ -327,3 +330,33 @@ class SphinxContentsFilter(ContentsFilter):
     def visit_image(self, node):
         # type: (nodes.Node) -> None
         raise nodes.SkipNode
+
+
+class SphinxSmartQuotes(DocutilsSmartQuotes):  # NOQA
+    """
+    Customized SmartQuotes to avoid transform for some extra node types.
+    """
+    def get_tokens(self, txtnodes):
+        # A generator that yields ``(texttype, nodetext)`` tuples for a list
+        # of "Text" nodes (interface to ``smartquotes.educate_tokens()``).
+
+        texttype = {True: 'literal', # "literal" text is not changed:
+                    False: 'plain'}
+        for txtnode in txtnodes:
+            nodetype = texttype[isinstance(txtnode.parent,
+                                           (nodes.literal,
+                                            nodes.literal_block,
+                                            addnodes.literal_emphasis,
+                                            addnodes.literal_strong,
+                                            addnodes.desc_signature,
+                                            addnodes.productionlist,
+                                            addnodes.desc_optional,
+                                            addnodes.desc_name,
+                                            nodes.math,
+                                            nodes.image,
+                                            nodes.raw,
+                                            nodes.problematic))]
+            yield (nodetype, txtnode.astext())
+
+
+docutils.transforms.universal.SmartQuotes = SphinxSmartQuotes


### PR DESCRIPTION
Relates #3666, #3781, #3787

Ideally, we should modify the Docutils Parser object instance as it has this in docutils.parsers.rst:

```
    def get_transforms(self):
        return Component.get_transforms(self) + [universal.SmartQuotes]
```

I tried to override this class method so that it uses the ``SphinxSmartQuotes`` but I don't know how to do that. (I did it at my locale by hacking absolute path location into this method)

So again I do some bad monkey-patch, to replace Docutils original SmartQuotes from docutils.transforms.universal by the SphinxSmartQuotes with extended list of nodes not to treat via smart quotes

(because I don't know without monkey patch how to get the Docutils rst parser to use the ``SphinxSmartQuotes`` with this extended list)

The list of added nodes is approximative, I deduced it from where ``no_smarty+=1`` was used in Sphinx 1.5.6 HTML writer, before #3666 was merged.

Please improve !

Also I am not good with type annotations.
