### PR TITLE
Fix #3807 by using old Makefile in LaTeX build repertory for windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,7 +35,7 @@ Bugs fixed
 * #3803: Sphinx crashes with invalid PO files
 * #3791: PDF "continued on next page" for long tables isn't internationalized
 * #3788: smartquotes emits warnings for unsupported languages
-* #3807: docs do not say Latexmk is dependency on Windows for ``make latexpdf``
+* #3807: latex Makefile for ``make latexpdf`` is only for unixen
 * #3781: double hyphens in option directive are compiled as endashes
 * #3817: latex builder raises AttributeError
 
@@ -54,7 +54,7 @@ Dependencies
 * (updated) latex output is tested with Ubuntu trusty's texlive packages (Feb.
   2014) and earlier tex installations may not be fully compliant, particularly
   regarding Unicode engines xelatex and lualatex
-* (added) latexmk is required for ``make latexpdf``
+* (added) latexmk is required for ``make latexpdf`` on GNU/Linux and Mac OS X
   (refs: #3082)
 
 Incompatible changes

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -200,11 +200,12 @@ The builder's "name" must be given to the **-b** command-line option of
          Formerly, testing had been done for some years on Ubuntu precise
          (based on TeXLive 2009).
       .. versionchanged:: 1.6
-         Use of ``latexmk`` for ``make latexpdf``
+         Use of ``latexmk`` for ``make latexpdf`` on GNU/Linux and Mac OS X
 
       Since 1.6, ``make latexpdf`` (or
       ``make -C "<builddir>/latex"`` after a ``sphinx-build`` run) uses
-      ``latexmk``. One can pass to ``latexmk`` options via the ``LATEXMKOPTS``
+      ``latexmk`` (not on Windows).
+      One can pass to ``latexmk`` options via the ``LATEXMKOPTS``
       Makefile variable. For example:
 
       .. code-block:: console

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -218,6 +218,12 @@ class LaTeXBuilder(Builder):
                 copy_asset_file(path.join(staticdirname, filename),
                                 self.outdir, context=context)
 
+        # use pre-1.6.x Makefile for make latexpdf on Windows
+        if os.name == 'nt':
+            staticdirname = path.join(package_dir, 'texinputs_win')
+            copy_asset_file(path.join(staticdirname, 'Makefile_t'),
+                            self.outdir, context=context)
+
         # copy additional files
         if self.config.latex_additional_files:
             logger.info(bold('copying additional files...'), nonl=1)

--- a/sphinx/texinputs_win/Makefile_t
+++ b/sphinx/texinputs_win/Makefile_t
@@ -1,0 +1,86 @@
+# Makefile for Sphinx LaTeX output
+
+ALLDOCS = $(basename $(wildcard *.tex))
+ALLPDF = $(addsuffix .pdf,$(ALLDOCS))
+ALLDVI = $(addsuffix .dvi,$(ALLDOCS))
+ALLPS  = $(addsuffix .ps,$(ALLDOCS))
+
+# Prefix for archive names
+ARCHIVEPREFIX =
+# Additional LaTeX options
+LATEXOPTS =
+# format: pdf or dvi
+FMT = pdf
+
+LATEX = latex
+PDFLATEX = {{ latex_engine }}
+MAKEINDEX = makeindex
+
+{% if latex_engine == 'platex' %}
+all: all-pdf-ja
+all-pdf: all-pdf-ja
+{% else %}
+all: $(ALLPDF)
+all-pdf: $(ALLPDF)
+{% endif -%}
+all-dvi: $(ALLDVI)
+all-ps: $(ALLPS)
+
+all-pdf-ja:
+	for f in *.pdf *.png *.gif *.jpg *.jpeg; do extractbb $$f; done
+	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	-for f in *.idx; do mendex -U -f -d "`basename $$f .idx`.dic" -s python.ist $$f; done
+	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.dvi; do dvipdfmx $$f; done
+
+zip: all-$(FMT)
+	mkdir $(ARCHIVEPREFIX)docs-$(FMT)
+	cp $(ALLPDF) $(ARCHIVEPREFIX)docs-$(FMT)
+	zip -q -r -9 $(ARCHIVEPREFIX)docs-$(FMT).zip $(ARCHIVEPREFIX)docs-$(FMT)
+	rm -r $(ARCHIVEPREFIX)docs-$(FMT)
+
+tar: all-$(FMT)
+	mkdir $(ARCHIVEPREFIX)docs-$(FMT)
+	cp $(ALLPDF) $(ARCHIVEPREFIX)docs-$(FMT)
+	tar cf $(ARCHIVEPREFIX)docs-$(FMT).tar $(ARCHIVEPREFIX)docs-$(FMT)
+	rm -r $(ARCHIVEPREFIX)docs-$(FMT)
+
+gz: tar
+	gzip -9 < $(ARCHIVEPREFIX)docs-$(FMT).tar > $(ARCHIVEPREFIX)docs-$(FMT).tar.gz
+
+bz2: tar
+	bzip2 -9 -k $(ARCHIVEPREFIX)docs-$(FMT).tar
+
+xz: tar
+	xz -9 -k $(ARCHIVEPREFIX)docs-$(FMT).tar
+
+# The number of LaTeX runs is quite conservative, but I don't expect it
+# to get run often, so the little extra time won't hurt.
+%.dvi: %.tex
+	$(LATEX) $(LATEXOPTS) '$<'
+	$(LATEX) $(LATEXOPTS) '$<'
+	$(LATEX) $(LATEXOPTS) '$<'
+	-$(MAKEINDEX) -s python.ist '$(basename $<).idx'
+	$(LATEX) $(LATEXOPTS) '$<'
+	$(LATEX) $(LATEXOPTS) '$<'
+
+%.pdf: %.tex
+	$(PDFLATEX) $(LATEXOPTS) '$<'
+	$(PDFLATEX) $(LATEXOPTS) '$<'
+	$(PDFLATEX) $(LATEXOPTS) '$<'
+	-$(MAKEINDEX) -s python.ist '$(basename $<).idx'
+	$(PDFLATEX) $(LATEXOPTS) '$<'
+	$(PDFLATEX) $(LATEXOPTS) '$<'
+
+%.ps: %.dvi
+	dvips '$<'
+
+clean:
+	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI)
+
+.PHONY: all all-pdf all-dvi all-ps clean zip tar gz bz2 xz
+.PHONY: all-pdf-ja
+


### PR DESCRIPTION
use old Makefile for latex build repertory; the new one from 1.6.1 is not compatible with Windows syntax, even with Latexmk installed, at least for Japanese documents.

refs: #3807, #3082