### PR TITLE
3824 no smart quotes to productionlist

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #3821: Failed to import sphinx.util.compat with docutils-0.14rc1
+* #3824: production lists are applied smart quotes transformation
 
 Testing
 --------

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -341,7 +341,7 @@ class SphinxSmartQuotes(SmartQuotes):
                        addnodes.literal_emphasis,
                        addnodes.literal_strong,
                        addnodes.desc_signature,
-                       addnodes.productionlist,
+                       addnodes.production,
                        addnodes.desc_optional,
                        addnodes.desc_name,
                        nodes.math,

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -336,6 +336,19 @@ class SphinxSmartQuotes(SmartQuotes):
 
     refs: sphinx.parsers.RSTParser
     """
+    NO_SMARTY_NODES = (nodes.literal,
+                       nodes.literal_block,
+                       addnodes.literal_emphasis,
+                       addnodes.literal_strong,
+                       addnodes.desc_signature,
+                       addnodes.productionlist,
+                       addnodes.desc_optional,
+                       addnodes.desc_name,
+                       nodes.math,
+                       nodes.image,
+                       nodes.raw,
+                       nodes.problematic)
+
     def get_tokens(self, txtnodes):
         # A generator that yields ``(texttype, nodetext)`` tuples for a list
         # of "Text" nodes (interface to ``smartquotes.educate_tokens()``).
@@ -343,17 +356,5 @@ class SphinxSmartQuotes(SmartQuotes):
         texttype = {True: 'literal',  # "literal" text is not changed:
                     False: 'plain'}
         for txtnode in txtnodes:
-            nodetype = texttype[isinstance(txtnode.parent,
-                                           (nodes.literal,
-                                            nodes.literal_block,
-                                            addnodes.literal_emphasis,
-                                            addnodes.literal_strong,
-                                            addnodes.desc_signature,
-                                            addnodes.productionlist,
-                                            addnodes.desc_optional,
-                                            addnodes.desc_name,
-                                            nodes.math,
-                                            nodes.image,
-                                            nodes.raw,
-                                            nodes.problematic))]
+            nodetype = texttype[isinstance(txtnode.parent, self.NO_SMARTY_NODES)]
             yield (nodetype, txtnode.astext())


### PR DESCRIPTION
refs: #3824

I replaced `productionlist` by `production`. because `productionlist` nodes is not TextElement.