### PR TITLE
Implement enhanced Windows make.bat (#3741)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ doc/_build/
 tests/.coverage
 tests/build/
 utils/regression_test.js
+
+# Ignore any residual winmake testing directory
+tests/winmake/testdir
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Other contributors, listed alphabetically, are:
 * Jeppe Pihl -- literalinclude improvements
 * Rob Ruana -- napoleon extension
 * Stefan Seefeld -- toctree improvements
+* Brian Skinn -- Enhanced make.bat
 * Gregory Szorc -- performance improvements
 * Taku Shimizu -- epub3 builder
 * Antonio Valentino -- qthelp builder

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* #3741: Add support to Windows make.bat for multiple make targets in one
+  invocation, with pass-through of sphinx-build command line options
+
 Bugs fixed
 ----------
 

--- a/doc/invocation.rst
+++ b/doc/invocation.rst
@@ -398,9 +398,9 @@ Makefile options
 ----------------
 
 The :file:`Makefile` and :file:`make.bat` files created by
-:program:`sphinx-quickstart` usually run :program:`sphinx-build` only with the
-:option:`-b` and :option:`-d` options.  However, they support the following
-variables to customize behavior:
+:program:`sphinx-quickstart` by default run :program:`sphinx-build` only
+with the :option:`-b` and :option:`-d` options.  However, they support
+the following environment variables to customize behavior:
 
 .. describe:: PAPER
 
@@ -418,6 +418,25 @@ variables to customize behavior:
 .. describe:: SPHINXOPTS
 
    Additional options for :program:`sphinx-build`.
+
+On Linux, ``make`` supports the typical chaining of make targets::
+
+    ~/git/foo/doc$ make clean html
+
+On Windows, ``make.bat`` has been upgraded to support similar behavior
+(previously it could only process a single build target)::
+
+    C:\git\foo\doc> make clean html
+
+Additionally, the above :program:`sphinx-build` options (except ``-b``)
+can be supplied as arguments to ``make.bat``::
+
+    C:\git\foo\doc> make html latex text -E
+
+In the above example, the documentation would be built with the ``-E`` option
+on all three of the ``html``, ``latex`` and ``text`` targets.
+
+.. versionchanged:: 1.6.3
 
 .. _when-deprecation-warnings-are-displayed:
 

--- a/doc/invocation.rst
+++ b/doc/invocation.rst
@@ -434,7 +434,11 @@ can be supplied as arguments to ``make.bat``::
     C:\git\foo\doc> make html latex text -E
 
 In the above example, the documentation would be built with the ``-E`` option
-on all three of the ``html``, ``latex`` and ``text`` targets.
+on all three of the ``html``, ``latex`` and ``text`` targets. Note that
+the options to pass through to :program:`sphinx-build` MUST be provided
+*after* all of the build targets::
+
+    C:\git\foo\doc> make target1 target2 ... <options>
 
 .. versionchanged:: 1.6.3
 

--- a/sphinx/templates/quickstart/make.bat.new_t
+++ b/sphinx/templates/quickstart/make.bat.new_t
@@ -11,74 +11,48 @@ if "%1"=="" goto make_main
 
 setlocal
 
-set TARGETS=
-set OPTIONS=
+rem Initialize the storage variables
+set TARGETS=,
+set OPTIONS=%*
 
-:arg_loop
+rem Skip argument parsing if no arguments passed
 if "%1"=="" goto arg_continue
 
-set WORK=%1
-set TAKESARG=0
-set KEYVALUE=0
+:arg_loop
 
-REM Have to have these outside the main IF block, else they don't store correctly
-if "%WORK:~,1%"=="-" (
-   if "%WORK:~-1%"=="b" (
-      echo ERROR: Do not use '-b' option to specify make targets. Exiting...
-      endlocal
-      goto end_error
-      )
-   rem This list needs to be updated if new options are implemented
-   rem  that take values
-   if "%WORK:~-1%"=="d" set TAKESARG=1
-   if "%WORK:~-1%"=="j" set TAKESARG=1
-   if "%WORK:~-1%"=="c" set TAKESARG=1
-   if "%WORK:~-1%"=="D" set TAKESARG=2
-   if "%WORK:~-1%"=="t" set TAKESARG=1
-   if "%WORK:~-1%"=="A" set TAKESARG=2
-   if "%WORK:~-1%"=="w" set TAKESARG=1
-   )
+rem Drop from loop if OPTIONS is empty
+if "%OPTIONS%"=="" ( goto arg_continue )
 
-REM Handle options versus targets
-if "%WORK:~,1%"=="-" (
-   REM It's an option
-   if "%TAKESARG%"=="1" (
-      REM Option takes an argument; needs extra shift
-      set OPTIONS=%OPTIONS% %1 %2
-      shift /1
-      goto arg_shift
-      )
+rem Drop from loop if first character of remaining OPTIONS is a hyphen
+if "%OPTIONS:~,1%"=="-" ( goto arg_continue )
 
-   if "%TAKESARG%"=="2" (
-      REM Option takes a key-value argument pair; needs two extra shifts
-      set OPTIONS=%OPTIONS% %1 %2=%3
-      shift /1
-      shift /1
-      goto arg_shift
-      )
+rem Shift next character from OPTIONS to TARGETS.
+rem  If it's a space, shift it as a comma, but only if the 
+rem  last character of TARGETS isn't a comma
+if "%OPTIONS:~,1%"==" " (
+    if not "%TARGETS:~-1%"=="," set TARGETS=%TARGETS%,
+    ) else (
+    set TARGETS=%TARGETS%%OPTIONS:~,1%
+    )
 
-   REM Option doesn't take an argument; no extra shift
-   set OPTIONS=%OPTIONS% %1
-   goto arg_shift
-   )
+rem Either way, strip the character from OPTIONS
+set OPTIONS=%OPTIONS:~1%
 
-REM Is a target, not an option; just store (comma-delimited) and shift
-set TARGETS=%TARGETS%,%1
-goto arg_shift
-
-:arg_shift
-REM Shift once
-shift /1
+rem Return to top of loop
 goto arg_loop
 
+
 :arg_continue
-REM Strip leading comma from the targets, if any present
-if not "%TARGETS%"==""  set TARGETS=%TARGETS:~1%
+rem Strip leading and trailing commas from the targets list
+rem Space is left at start of string for the zero-target invocation case
+rem  (avoids NULL variable)
+if "%TARGETS:~,1%"=="," set TARGETS= %TARGETS:~1%
+if "%TARGETS:~-1%"=="," set TARGETS=%TARGETS:~,-1%
 
 REM Check if single target; if not, loop and rerun make.bat once per target
 echo %TARGETS% | findstr "," 1>nul 2>nul
 set MULTITARGET=%ERRORLEVEL%
-if "%MULTITARGET%"=="0" (
+if %MULTITARGET% EQU 0 (
    REM Multiple targets; loop over targets and re-execute
    for %%G in (%TARGETS%) DO (
       echo.

--- a/sphinx/templates/quickstart/make.bat.new_t
+++ b/sphinx/templates/quickstart/make.bat.new_t
@@ -16,18 +16,22 @@ set TARGETS=,
 set OPTIONS=%*
 
 rem Skip argument parsing if no arguments passed
-if "%1"=="" goto arg_continue
+if "%1"=="" ( goto arg_continue )
+
+rem Skip argument parsing if arguments start with a hyphen
+if "%OPTIONS:~,1%"=="-" ( goto arg_continue )
 
 :arg_loop
 
 rem Drop from loop if OPTIONS is empty
 if "%OPTIONS%"=="" ( goto arg_continue )
 
-rem Drop from loop if first character of remaining OPTIONS is a hyphen
-if "%OPTIONS:~,1%"=="-" ( goto arg_continue )
+rem Drop from loop if first two characters of remaining OPTIONS
+rem  are a space followed by a hyphen
+if "%OPTIONS:~,2%"==" -" ( goto arg_continue )
 
 rem Shift next character from OPTIONS to TARGETS.
-rem  If it's a space, shift it as a comma, but only if the 
+rem  If it's a space, shift it as a comma, but only if the
 rem  last character of TARGETS isn't a comma
 if "%OPTIONS:~,1%"==" " (
     if not "%TARGETS:~-1%"=="," set TARGETS=%TARGETS%,

--- a/sphinx/templates/quickstart/make.bat.new_t
+++ b/sphinx/templates/quickstart/make.bat.new_t
@@ -4,6 +4,107 @@ pushd %~dp0
 
 REM Command file for Sphinx documentation
 
+REM Parsing of multiple commandline options and targets
+
+REM If no arguments passed at all, skip entirely
+if "%1"=="" goto make_main
+
+setlocal
+
+set TARGETS=
+set OPTIONS=
+
+:arg_loop
+if "%1"=="" goto arg_continue
+
+set WORK=%1
+set TAKESARG=0
+set KEYVALUE=0
+
+REM Have to have these outside the main IF block, else they don't store correctly
+if "%WORK:~,1%"=="-" (
+   if "%WORK:~-1%"=="b" (
+      echo ERROR: Do not use '-b' option to specify make targets. Exiting...
+      endlocal
+      goto end_error
+      )
+   rem This list needs to be updated if new options are implemented
+   rem  that take values
+   if "%WORK:~-1%"=="d" set TAKESARG=1
+   if "%WORK:~-1%"=="j" set TAKESARG=1
+   if "%WORK:~-1%"=="c" set TAKESARG=1
+   if "%WORK:~-1%"=="D" set TAKESARG=2
+   if "%WORK:~-1%"=="t" set TAKESARG=1
+   if "%WORK:~-1%"=="A" set TAKESARG=2
+   if "%WORK:~-1%"=="w" set TAKESARG=1
+   )
+
+REM Handle options versus targets
+if "%WORK:~,1%"=="-" (
+   REM It's an option
+   if "%TAKESARG%"=="1" (
+      REM Option takes an argument; needs extra shift
+      set OPTIONS=%OPTIONS% %1 %2
+      shift /1
+      goto arg_shift
+      )
+
+   if "%TAKESARG%"=="2" (
+      REM Option takes a key-value argument pair; needs two extra shifts
+      set OPTIONS=%OPTIONS% %1 %2=%3
+      shift /1
+      shift /1
+      goto arg_shift
+      )
+
+   REM Option doesn't take an argument; no extra shift
+   set OPTIONS=%OPTIONS% %1
+   goto arg_shift
+   )
+
+REM Is a target, not an option; just store (comma-delimited) and shift
+set TARGETS=%TARGETS%,%1
+goto arg_shift
+
+:arg_shift
+REM Shift once
+shift /1
+goto arg_loop
+
+:arg_continue
+REM Strip leading comma from the targets, if any present
+if not "%TARGETS%"==""  set TARGETS=%TARGETS:~1%
+
+REM Check if single target; if not, loop and rerun make.bat once per target
+echo %TARGETS% | findstr "," 1>nul 2>nul
+set MULTITARGET=%ERRORLEVEL%
+if "%MULTITARGET%"=="0" (
+   REM Multiple targets; loop over targets and re-execute
+   for %%G in (%TARGETS%) DO (
+      echo.
+      echo Making target '%%G' with options '%OPTIONS%':
+      echo.
+      call make %%G %OPTIONS%
+      REM Exit if error
+      if %ERRORLEVEL% GTR 0 (
+         echo.
+         echo Make error detected. Exiting...
+         echo.
+         endlocal
+         goto end
+         )
+      )
+   REM Done once looping finished
+   endlocal
+   goto end
+   )
+
+REM Executed with single target, so fall through to main make.bat commands
+endlocal & set MAKETARGET=%TARGETS% & set MAKEOPTIONS=%OPTIONS%
+
+:make_main
+
+
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=python -msphinx
 )
@@ -11,7 +112,7 @@ set SOURCEDIR={{ rsrcdir }}
 set BUILDDIR={{ rbuilddir }}
 set SPHINXPROJ={{ project_fn }}
 
-if "%1" == "" goto help
+if "%MAKETARGET%" == "" goto help
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -26,12 +127,17 @@ if errorlevel 9009 (
 	exit /b 1
 )
 
-%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+%SPHINXBUILD% -M %MAKETARGET% %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %MAKEOPTIONS%
 goto end
 
 :help
-%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %MAKEOPTIONS%
 
 :end
 popd
+exit /b
+
+:end_error
+popd
+exit /b 1
 

--- a/tests/winmake/test_winmake.bat
+++ b/tests/winmake/test_winmake.bat
@@ -106,6 +106,14 @@ if %SILENT% EQU 0 (
     )
 set ELVAL=0
 
+rem === make ===
+rem  (there's a space after this equals sign)
+set PARAMS=
+set RETURN=RET_NULL
+goto run_test
+:RET_NULL
+set TEST_NULL=%RESULT%
+
 rem === make -h ===
 set PARAMS=-h
 set RETURN=RET_H
@@ -262,6 +270,7 @@ if %SILENT% EQU 0 (
     echo.
     echo          Arguments                        Expect    Result
     echo  --------------------------------------  --------  --------
+    echo   [none]                                    OK      %TEST_NULL%
     echo   -h                                        OK      %TEST_H%
     echo   clean                                     OK      %TEST_CLEAN%
     echo   html                                      OK      %TEST_HTML%

--- a/tests/winmake/test_winmake.bat
+++ b/tests/winmake/test_winmake.bat
@@ -1,0 +1,328 @@
+@echo off
+
+setlocal
+
+rem Set defaults
+set KEEP=0
+set VERBOSE=0
+set SILENT=0
+set TESTDIR=testdir
+set ANYFAILED=0
+
+set HDR1======
+set HDR2=-----
+
+rem Parse arguments
+:arg_loop
+if "%1"=="" goto end_arg_loop
+
+if "%1"=="-k" (
+    set KEEP=1
+    shift /1
+    goto arg_loop
+    )
+
+if "%1"=="-v" (
+    set VERBOSE=1
+    shift /1
+    goto arg_loop
+    )
+
+if "%1"=="-s" (
+    set SILENT=1
+    shift /1
+    goto arg_loop
+    )
+
+if "%1"=="-h" (
+    echo.
+    echo Test runner for Windows make.bat. If all tests succeed,
+    echo exits with ERRORLEVEL==0. Otherwise, exits ERRORLEVEL==1.
+    echo.
+    echo These tests only check for a successful [ERRORLEVEL==0]
+    echo or unsuccessful [ERRORLEVEL==1] execution of make.bat.
+    echo They do NOT check for whether the build operations
+    echo actually completed correctly.
+    echo.
+    echo It is recommended to run these tests in a freshly
+    echo created and activated virtualenv, with Sphinx installed
+    echo inside by calling `pip install -e .` from the project root.
+    echo.
+    echo.
+    echo Options
+    echo =======
+    echo.
+    echo -h   - Show this help
+    echo -k   - Keep test directory after running tests
+    echo -s   - Run tests with all output and status information suppressed
+    echo -v   - Show output from executed commands
+    echo.
+    goto end_help
+    )
+
+
+:end_arg_loop
+
+rem Can't have both silent and verbose
+if %SILENT% EQU 1 (
+    if %VERBOSE% EQU 1 (
+        echo Cannot specify both '-s' and '-v'!
+        echo Exiting ...
+        set ANYFAILED=1
+        goto end_help
+        )
+    )
+
+
+rem Quickstart Sphinx into new directory
+if %SILENT% EQU 0 (
+    echo %HDR1% Creating new Sphinx doc sandbox ...
+    echo.
+    )
+
+if exist %TESTDIR%\nul rmdir /s /q %TESTDIR%
+
+if "%VERBOSE%"=="1" (
+    python ..\..\sphinx-quickstart.py -p test -a test -v 0.0 -r 0.0 -q %TESTDIR%
+    ) else (
+    python ..\..\sphinx-quickstart.py -p test -a test -v 0.0 -r 0.0 -q %TESTDIR% 1>nul 2>nul
+    )
+
+if %ERRORLEVEL% GTR 0 (
+    if %SILENT% EQU 0 (
+        echo.
+        echo %HDR1% Error quick-starting Sphinx.
+        echo %HDR1% Exiting...
+        echo.
+        )
+    goto end
+    )
+
+
+rem Run the EXPECT-SUCCESS tests
+if %SILENT% EQU 0 (
+    echo %HDR1% Running make operations expected to succeed:
+    echo.
+    )
+set ELVAL=0
+
+rem === make -h ===
+set PARAMS=-h
+set RETURN=RET_H
+goto run_test
+:RET_H
+set TEST_H=%RESULT%
+
+rem === make clean ===
+set PARAMS=clean
+set RETURN=RET_CLEAN
+goto run_test
+:RET_CLEAN
+set TEST_CLEAN=%RESULT%
+
+rem === make html ===
+set PARAMS=html
+set RETURN=RET_HTML
+goto run_test
+:RET_HTML
+set TEST_HTML=%RESULT%
+
+rem === make latex (no regen of env) ===
+set PARAMS=latex
+set RETURN=RET_LATEX
+goto run_test
+:RET_LATEX
+set TEST_LATEX=%RESULT%
+
+rem === make clean html ===
+set PARAMS=clean html
+set RETURN=RET_CLEAN_HTML
+goto run_test
+:RET_CLEAN_HTML
+set TEST_CLEAN_HTML=%RESULT%
+
+rem === make html -a ===
+set PARAMS=html -a
+set RETURN=RET_HTML_A
+goto run_test
+:RET_HTML_A
+set TEST_HTML_A=%RESULT%
+
+rem === make html -E ===
+set PARAMS=html -E
+set RETURN=RET_HTML_E
+goto run_test
+:RET_HTML_E
+set TEST_HTML_E=%RESULT%
+
+rem === make html -Ec . ===
+set PARAMS=html -Ec .
+set RETURN=RET_HTML_E_C_dot
+goto run_test
+:RET_HTML_E_C_dot
+set TEST_HTML_E_C_dot=%RESULT%
+
+rem === make html -qWE ===
+set PARAMS=html -qWE
+set RETURN=RET_HTML_QWE
+goto run_test
+:RET_HTML_QWE
+set TEST_HTML_QWE=%RESULT%
+
+rem === make clean html -Ec . ===
+set PARAMS=clean html -Ec .
+set RETURN=RET_CLEAN_HTML_E_C_dot
+goto run_test
+:RET_CLEAN_HTML_E_C_dot
+set TEST_CLEAN_HTML_E_C_dot=%RESULT%
+
+rem === make clean html epub ===
+set PARAMS=clean html epub
+set RETURN=RET_CLEAN_HTML_EPUB
+goto run_test
+:RET_CLEAN_HTML_EPUB
+set TEST_CLEAN_HTML_EPUB=%RESULT%
+
+rem === make clean html epub -E ===
+set PARAMS=clean html epub -E
+set RETURN=RET_CLEAN_HTML_EPUB_E
+goto run_test
+:RET_CLEAN_HTML_EPUB_E
+set TEST_CLEAN_HTML_EPUB_E=%RESULT%
+
+rem === make clean html -D rst_epilog="**THIS**" ===
+set PARAMS=clean html -D rst_epilog="**THIS**"
+set RETURN=RET_CLEAN_HTML_D_RST
+goto run_test
+:RET_CLEAN_HTML_D_RST
+set TEST_CLEAN_HTML_D_RST=%RESULT%
+
+
+rem Run the EXPECT-FAIL tests
+if %SILENT% EQU 0 (
+    echo.
+    echo %HDR1% Running make operations expected to fail:
+    echo.
+    )
+set ELVAL=1
+
+rem === make -b html ===
+set PARAMS=-b html
+set RETURN=RET_B_HTML
+goto run_test
+:RET_B_HTML
+set TEST_B_HTML=%RESULT%
+
+rem === make clean html -c .. ===
+set PARAMS=clean html -c ..
+set RETURN=RET_CLEAN_HTML_C_dd
+goto run_test
+:RET_CLEAN_HTML_C_dd
+set TEST_CLEAN_HTML_C_dd=%RESULT%
+
+rem === make foo ===
+set PARAMS=foo
+set RETURN=RET_FOO
+goto run_test
+:RET_FOO
+set TEST_FOO=%RESULT%
+
+rem === make html -qW.E ===
+set PARAMS=html -qW.E
+set RETURN=RET_HTML_QWdotE
+goto run_test
+:RET_HTML_QWdotE
+set TEST_HTML_QWdotE=%RESULT%
+
+
+
+rem Report Results
+if %SILENT% EQU 0 (
+    echo.
+    echo.
+    echo ============================================================
+    echo                         TEST RESULTS
+    echo ============================================================
+    echo.
+    echo          Arguments                        Expect    Result
+    echo  --------------------------------------  --------  --------
+    echo   -h                                        OK      %TEST_H%
+    echo   clean                                     OK      %TEST_CLEAN%
+    echo   html                                      OK      %TEST_HTML%
+    echo   latex                                     OK      %TEST_LATEX%
+    echo   clean html                                OK      %TEST_CLEAN_HTML%
+    echo   html -a                                   OK      %TEST_HTML_A%
+    echo   html -E                                   OK      %TEST_HTML_E%
+    echo   html -Ec .                                OK      %TEST_HTML_E_C_dot%
+    echo   html -qWE                                 OK      %TEST_HTML_QWE%
+    echo   clean html -Ec .                          OK      %TEST_CLEAN_HTML_E_C_dot%
+    echo   clean html epub                           OK      %TEST_CLEAN_HTML_EPUB%
+    echo   clean html epub -E                        OK      %TEST_CLEAN_HTML_EPUB_E%
+    echo   clean html -D rst_epilog="**THIS**"       OK      %TEST_CLEAN_HTML_D_RST%
+    echo.
+    echo   -b html                                  ERROR    %TEST_B_HTML%
+    echo   clean html -c ..                         ERROR    %TEST_CLEAN_HTML_C_dd%
+    echo   foo                                      ERROR    %TEST_FOO%
+    echo   html -qW.E                               ERROR    %TEST_HTML_QWdotE%
+    echo.
+    echo ============================================================
+    echo.
+    echo.
+    )
+
+goto end
+
+
+:run_test
+rem Run the test, with output suppressed by default
+if "%VERBOSE%"=="1" echo. & echo.
+
+if %SILENT% EQU 0 (echo %HDR2% Testing 'make %PARAMS%' ...)
+
+if "%VERBOSE%"=="0" (
+    call %TESTDIR%\make %PARAMS% 1>nul 2>nul
+    ) else (
+    call %TESTDIR%\make %PARAMS%
+    )
+
+rem Equality comparison to the indicated expected test result
+if %ERRORLEVEL% EQU %ELVAL% (
+    set RESULT=-pass-
+    ) else (
+    set RESULT=*FAIL*
+    set ANYFAILED=1
+    )
+
+rem "Callback" to the particular test
+goto %RETURN%
+
+
+
+
+
+:end
+
+rem Remove test folder if it exists and KEEP is 0
+if "%KEEP%"=="0" (
+    if %SILENT% EQU 0 (
+        echo %HDR1% Removing Sphinx doc sandbox ...
+        echo.
+        )
+    if exist %TESTDIR%\nul rmdir /s /q %TESTDIR%
+    if %SILENT% EQU 0 (
+        echo %HDR1% Done.
+        echo.
+        )
+    ) else (
+    if %SILENT% EQU 0 (
+        echo %HDR1% Sphinx doc sandbox left in place.
+        echo.
+        )
+    )
+
+:end_help
+
+endlocal & set ANYFAILED=%ANYFAILED%
+
+exit /B %ANYFAILED%
+

--- a/tests/winmake/test_winmake.bat
+++ b/tests/winmake/test_winmake.bat
@@ -42,7 +42,7 @@ if "%1"=="-h" (
     echo These tests only check for a successful [ERRORLEVEL==0]
     echo or unsuccessful [ERRORLEVEL==1] execution of make.bat.
     echo They do NOT check for whether the build operations
-    echo actually completed correctly.
+    echo generated the documentation content properly.
     echo.
     echo It is recommended to run these tests in a freshly
     echo created and activated virtualenv, with Sphinx installed
@@ -197,6 +197,14 @@ goto run_test
 :RET_CLEAN_HTML_D_RST
 set TEST_CLEAN_HTML_D_RST=%RESULT%
 
+rem === make clean   html    epub ===
+rem (testing extra spaces in invocation)
+set PARAMS=clean   html    epub
+set RETURN=RET_CLEAN___HTML____EPUB
+goto run_test
+:RET_CLEAN___HTML____EPUB
+set TEST_CLEAN___HTML____EPUB=%RESULT%
+
 
 rem Run the EXPECT-FAIL tests
 if %SILENT% EQU 0 (
@@ -234,6 +242,14 @@ goto run_test
 :RET_HTML_QWdotE
 set TEST_HTML_QWdotE=%RESULT%
 
+rem === make clean html -E epub ===
+rem (expect fail due to target falling after option)
+set PARAMS=clean html -E epub
+set RETURN=RET_CLEAN_HTML_E_EPUB
+goto run_test
+:RET_CLEAN_HTML_E_EPUB
+set TEST_CLEAN_HTML_E_EPUB=%RESULT%
+
 
 
 rem Report Results
@@ -259,11 +275,13 @@ if %SILENT% EQU 0 (
     echo   clean html epub                           OK      %TEST_CLEAN_HTML_EPUB%
     echo   clean html epub -E                        OK      %TEST_CLEAN_HTML_EPUB_E%
     echo   clean html -D rst_epilog="**THIS**"       OK      %TEST_CLEAN_HTML_D_RST%
+    echo   clean   html    epub                      OK      %TEST_CLEAN___HTML____EPUB%
     echo.
     echo   -b html                                  ERROR    %TEST_B_HTML%
     echo   clean html -c ..                         ERROR    %TEST_CLEAN_HTML_C_dd%
     echo   foo                                      ERROR    %TEST_FOO%
     echo   html -qW.E                               ERROR    %TEST_HTML_QWdotE%
+    echo   clean html -E epub                       ERROR    %TEST_CLEAN_HTML_E_EPUB%
     echo.
     echo ============================================================
     echo.


### PR DESCRIPTION
### Feature or Bugfix
Feature

### Purpose
 - As-is, the windows `make.bat` is only able to process a single build target on each invocation. This PR incorporates modifications to the Jinja template for the new `make.bat` (the one that calls `sphinx-build` with the `-M` option) that enable (1) passing multiple build targets on a single invocation and (2) passing `sphinx-build` options to `make.bat`, which are then appended to the `sphinx-build` call to each build target.
 - The functionality of this PR is only relevant to Sphinx users on Windows. The revised `make.bat` works for this author on Windows 7 Professional, 64-bit. It is anticipated to work on Win8 and Win10, and the functionality should be independent of the active Python version. This PR should have no effect whatsoever on the internal functionality of the Sphinx project itself - it deals entirely with the surrounding `make.bat` invocation tool for `sphinx-build`.

### Detail
 - Implements the functionality proposed in #3741 

### Relates
 - Per [this comment](https://github.com/sphinx-doc/sphinx/issues/3741#issuecomment-301229140) on #3741, this PR was issued against `stable` since it does not represent a breaking change.

