### PR TITLE
Add html_sidebars for alabaster by default

### DIFF
--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -107,6 +107,21 @@ html_theme = 'alabaster'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['{{ dot }}static']
 
+# Custom sidebar templates, must be a dictionary that maps document names
+# to template names.
+#
+# This is required for the alabaster theme and you should remove this if you
+# switch your theme and don't want to customize this.
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',
+        'searchbox.html',
+        'donate.html',
+    ]
+}
+
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
Subject: Add html_sidebars for alabaster by default

### Feature or Bugfix
- Bugfix

### Purpose
It's required for alabaster to render correctly, see:
http://alabaster.readthedocs.io/en/latest/installation.html

### Detail
- Without this the sidebar renders quite weird with the default alabaster theme.