### PR TITLE
Add latex key to configure literal blocks caption position in PDF output

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -189,14 +189,25 @@ The available styling options
     default ``true``. Tells whether long lines in :rst:dir:`code-block`\ 's
     contents should wrap.
 
+``literalblockcappos``
+    default ``t`` for "top". Decides the caption position. Alternative is
+    ``b`` ("bottom").
+
+    .. versionadded:: 1.7
+
 ``verbatimhintsturnover``
-    default ``false``. If ``true``, code-blocks display "continued on next
+    default ``true``. If ``true``, code-blocks display "continued on next
     page", "continued from previous page" hints in case of pagebreaks.
 
     .. versionadded:: 1.6.3
-       the default will change to ``true`` at 1.7 and horizontal positioning
-       of continuation hints (currently right aligned only) will be
-       customizable.
+    .. versionchanged:: 1.7
+       the default changed from ``false`` to ``true``.
+
+``verbatimcontinuedalign``, ``verbatimcontinuesalign``
+    default ``c``. Horizontal position relative to the framed contents:
+    either ``l`` (left aligned), ``r`` (right aligned) or ``c`` (centered).
+
+    .. versionadded:: 1.7
 
 ``parsedliteralwraps``
     default ``true``. Tells whether long lines in :dudir:`parsed-literal`\ 's
@@ -356,10 +367,9 @@ Macros
      with LaTeX packages.
 - more text styling: ``\sphinxstyle<bar>`` with ``<bar>`` one of
   ``indexentry``, ``indexextra``, ``indexpageref``, ``topictitle``,
-  ``sidebartitle``, ``othertitle``, ``sidebarsubtitle``,
-  ``theadfamily``, ``emphasis``, ``literalemphasis``, ``strong``,
-  ``literalstrong``, ``abbreviation``, ``literalintitle``, ``codecontinued``,
-  ``codecontinues``.
+  ``sidebartitle``, ``othertitle``, ``sidebarsubtitle``, ``theadfamily``,
+  ``emphasis``, ``literalemphasis``, ``strong``, ``literalstrong``,
+  ``abbreviation``, ``literalintitle``, ``codecontinued``, ``codecontinues``
 
   .. versionadded:: 1.5
      these macros were formerly hard-coded as non customizable ``\texttt``,

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -708,12 +708,9 @@
 % #2 = for material below frame, such as a caption or "continues on next page"
 % #3 = actual contents, which will be typeset with a background color
 \long\def\spx@CustomFBox#1#2#3{%
-  \leavevmode
   \begingroup
   \setbox\@tempboxa\hbox{{#3}}% inner braces to avoid color leaks
-  \hbox
-   {\lower\dimexpr\fboxrule+\dp\@tempboxa\hbox{%
-      \vbox{#1% above frame
+  \vbox{#1% above frame
             % draw frame border _latest_ to avoid pdf viewer issue
             \kern\fboxrule
             \hbox{\kern\fboxrule
@@ -726,10 +723,8 @@
             \hrule\@height\fboxrule
             \kern\dimexpr\ht\@tempboxa+\dp\@tempboxa\relax
             \hrule\@height\fboxrule
-            #2% below frame
-          }%
-    }%
-   }%
+        #2% below frame
+       }%
   \endgroup
 }%
 \def\spx@fcolorbox@put@c#1{% hide width from framed.sty measuring

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -656,10 +656,6 @@
 \let\OriginalVerbatim   \Verbatim
 \let\endOriginalVerbatim\endVerbatim
 
-% if the available space on page is less than \literalblockneedspace, insert pagebreak
-\newcommand{\sphinxliteralblockneedspace}{5\baselineskip}
-\newcommand{\sphinxliteralblockwithoutcaptionneedspace}{1.5\baselineskip}
-
 % for captions of literal blocks
 % also define `\theH...` macros for hyperref
 \newcounter{literalblock}
@@ -678,38 +674,6 @@
 % only if a \listof{literalblock}{foo} command is encountered, which is
 % analogous to \listoffigures, but for the code listings (foo = chosen title.)
 \newcommand*{\ext@literalblock}{lol}
-
-% The title (caption) is specified from outside as macro \sphinxVerbatimTitle.
-% \sphinxVerbatimTitle is reset to empty after each use of Verbatim.
-\newcommand*\sphinxVerbatimTitle {}
-% This box to typeset the caption before framed.sty multiple passes for framing.
-\newbox\spx@Verbatim@TitleBox
-% This is a workaround to a "feature" of French lists, which shows when non-
-% paragraph material immediately follows a list. A priori usable generally
-% as it does only \par for normal situations.
-\newcommand*\sphinxvspacefixafterfrenchlists{%
-   \ifvmode\ifdim\lastskip<\z@ \vskip\parskip\fi\else\par\fi
-}
-% Holder macro for labels of literal blocks. Set-up by LaTeX writer.
-\newcommand*\sphinxLiteralBlockLabel {}
-\newcommand*\sphinxSetupCaptionForVerbatim [1]
-{%
-    \sphinxvspacefixafterfrenchlists
-    \needspace{\sphinxliteralblockneedspace}%
-% insert a \label via \sphinxLiteralBlockLabel
-% reset to normal the color for the literal block caption
-% the caption inserts \abovecaptionskip whitespace above itself (usually 10pt)
-% there is also \belowcaptionskip but it is usually zero, hence the \smallskip
-    \def\sphinxVerbatimTitle
-       {\py@NormalColor
-        \captionof{literalblock}{\sphinxLiteralBlockLabel #1}\smallskip }%
-}
-\newcommand*\sphinxSetupCodeBlockInFootnote {%
-  \fvset{fontsize=\footnotesize}\let\caption\sphinxfigcaption
-  \sphinxverbatimwithminipagetrue % reduces vertical spaces
-  % we counteract float.sty's \caption which does \@normalsize
-  \let\normalsize\footnotesize\let\@parboxrestore\relax
-  \abovecaptionskip \smallskipamount \belowcaptionskip \z@skip}
 
 \newif\ifspx@inframed % flag set if we are already in a framed environment
 % if forced use of minipage encapsulation is needed (e.g. table cells)
@@ -841,6 +805,38 @@
                    {\kern\fontdimen2\font}%
 }%
 
+% if the available space on page is less than \literalblockneedspace, insert pagebreak
+\newcommand{\sphinxliteralblockneedspace}{5\baselineskip}
+\newcommand{\sphinxliteralblockwithoutcaptionneedspace}{1.5\baselineskip}
+% The title (caption) is specified from outside as macro \sphinxVerbatimTitle.
+% \sphinxVerbatimTitle is reset to empty after each use of Verbatim.
+\newcommand*\sphinxVerbatimTitle {}
+% This box to typeset the caption before framed.sty multiple passes for framing.
+\newbox\sphinxVerbatim@TitleBox
+% This is a workaround to a "feature" of French lists, when literal block
+% follows immediately; usable generally (does only \par then), a priori...
+\newcommand*\sphinxvspacefixafterfrenchlists{%
+   \ifvmode\ifdim\lastskip<\z@ \vskip\parskip\fi\else\par\fi
+}
+% Holder macro for labels of literal blocks. Set-up by LaTeX writer.
+\newcommand*\sphinxLiteralBlockLabel {}
+\newcommand*\sphinxSetupCaptionForVerbatim [1]
+{%
+    \sphinxvspacefixafterfrenchlists
+    \needspace{\sphinxliteralblockneedspace}%
+% insert a \label via \sphinxLiteralBlockLabel
+% reset to normal the color for the literal block caption
+    \def\sphinxVerbatimTitle
+       {\py@NormalColor\sphinxcaption{\sphinxLiteralBlockLabel #1}}%
+}
+\newcommand*\sphinxSetupCodeBlockInFootnote {%
+  \fvset{fontsize=\footnotesize}\let\caption\sphinxfigcaption
+  \sphinxverbatimwithminipagetrue % reduces vertical spaces
+  % we counteract \caption issueing \@normalsize
+  % this all happens in a group
+  \let\normalsize\footnotesize\let\@parboxrestore\relax
+  \abovecaptionskip \smallskipamount \belowcaptionskip \z@skip
+}
 % needed to create wrapper environments of fancyvrb's Verbatim
 \newcommand*{\sphinxVerbatimEnvironment}{\gdef\FV@EnvironName{sphinxVerbatim}}
 % Sphinx <1.5 optional argument was in fact mandatory. It is now really

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -684,10 +684,17 @@
 \newcommand*\sphinxVerbatimTitle {}
 % This box to typeset the caption before framed.sty multiple passes for framing.
 \newbox\spx@Verbatim@TitleBox
+% This is a workaround to a "feature" of French lists, which shows when non-
+% paragraph material immediately follows a list. A priori usable generally
+% as it does only \par for normal situations.
+\newcommand*\sphinxvspacefixafterfrenchlists{%
+   \ifvmode\ifdim\lastskip<\z@ \vskip\parskip\fi\else\par\fi
+}
 % Holder macro for labels of literal blocks. Set-up by LaTeX writer.
 \newcommand*\sphinxLiteralBlockLabel {}
 \newcommand*\sphinxSetupCaptionForVerbatim [1]
 {%
+    \sphinxvspacefixafterfrenchlists
     \needspace{\sphinxliteralblockneedspace}%
 % insert a \label via \sphinxLiteralBlockLabel
 % reset to normal the color for the literal block caption
@@ -839,13 +846,10 @@
 % Sphinx <1.5 optional argument was in fact mandatory. It is now really
 % optional and handled by original Verbatim.
 \newenvironment{sphinxVerbatim}{%
-  % quit horizontal mode if we are still in a paragraph
-  \par
-  % list starts new par, but we don't want it to be set apart vertically
-  \parskip\z@skip
   % first, let's check if there is a caption
   \ifx\sphinxVerbatimTitle\empty
-      \addvspace\z@% counteract possible previous negative skip (French lists!)
+      \sphinxvspacefixafterfrenchlists
+      \parskip\z@skip
       \smallskip
       % there was no caption. Check if nevertheless a label was set.
       \ifx\sphinxLiteralBlockLabel\empty\else
@@ -856,6 +860,7 @@
       \fi
       \let\spx@Verbatim@Title\@empty
   \else
+     \parskip\z@skip
   % non-empty \sphinxVerbatimTitle has label inside it (in case there is one)
      \setbox\spx@Verbatim@TitleBox
             \hbox{\begin{minipage}{\linewidth}%
@@ -1110,10 +1115,9 @@
   {\parskip\z@skip\noindent}%
   }
   {%
-  \par
   % counteract previous possible negative skip (French lists!):
   % (we can't cancel that any earlier \vskip introduced a potential pagebreak)
-  \ifdim\lastskip<\z@\vskip-\lastskip\fi
+  \sphinxvspacefixafterfrenchlists
   \nobreak\vbox{\noindent\kern\@totalleftmargin
       {\color{spx@notice@bordercolor}%
        \rule[\dimexpr.4\baselineskip-\spx@notice@border\relax]

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -114,19 +114,25 @@
 % move back vertically to compensate space inserted by next paragraph
    \vskip-\baselineskip\vskip-\parskip
 }%
+% use \LTcapwidth (default is 4in) to wrap caption (if line width is bigger)
 \newcommand\sphinxcaption[2][\LTcapwidth]{%
    \noindent\hb@xt@\linewidth{\hss
       \vtop{\@tempdima\dimexpr#1\relax
 % don't exceed linewidth for the caption width
             \ifdim\@tempdima>\linewidth\hsize\linewidth\else\hsize\@tempdima\fi
-% longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
-            \abovecaptionskip\z@skip
-            \belowcaptionskip\z@skip
+% longtable ignores \abovecaptionskip/\belowcaptionskip, so add hooks here
+% to uniformize control of caption distance to tables
+            \abovecaptionskip\sphinxabovecaptionskip
+            \belowcaptionskip\sphinxbelowcaptionskip
             \caption[{#2}]%
                {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
            }\hss}%
    \par\prevdepth\dp\strutbox
 }%
+\def\spx@abovecaptionskip{\abovecaptionskip}
+\newcommand*\sphinxabovecaptionskip{\z@skip}
+\newcommand*\sphinxbelowcaptionskip{\z@skip}
+
 \newcommand\sphinxaftercaption
 {% this default definition serves with a caption *above* a table, to make sure
  % its last baseline is \sphinxbelowcaptionspace above table top
@@ -256,8 +262,11 @@
 % verbatim
 \DeclareBoolOption[true]{verbatimwithframe}
 \DeclareBoolOption[true]{verbatimwrapslines}
-\DeclareBoolOption[false]{verbatimhintsturnover}
+\DeclareBoolOption[true]{verbatimhintsturnover}
 \DeclareBoolOption[true]{inlineliteralwraps}
+\DeclareStringOption[t]{literalblockcappos}
+\DeclareStringOption[r]{verbatimcontinuedalign}
+\DeclareStringOption[r]{verbatimcontinuesalign}
 % parsed literal
 \DeclareBoolOption[true]{parsedliteralwraps}
 % \textvisiblespace for compatibility with fontspec+XeTeX/LuaTeX
@@ -678,22 +687,27 @@
 \newif\ifspx@inframed % flag set if we are already in a framed environment
 % if forced use of minipage encapsulation is needed (e.g. table cells)
 \newif\ifsphinxverbatimwithminipage   \sphinxverbatimwithminipagefalse
-\long\def\spx@colorbox #1#2#3{%
-% let the framing obey the current indentation (adapted from framed.sty's code).
+
+% Framing macro for use with framed.sty's \FrameCommand
+%  - it obeys current indentation,
+%  - frame is \fboxsep separated from the contents,
+%  - the contents use the full available text width,
+%  - #1 = color of frame, #2 = color of background,
+%  - #3 = above frame, #4 = below frame, #5 = within frame,
+%  - #3 and #4 must be already typeset boxes; they must issue \normalcolor
+%    or similar, else, they are under scope of color #1
+\long\def\spx@fcolorbox #1#2#3#4#5{%
   \hskip\@totalleftmargin
   \hskip-\fboxsep\hskip-\fboxrule
-  \spx@fcolorbox{VerbatimBorderColor}{VerbatimColor}{#1}{#2}{#3}%
+  % use of \color@b@x here is compatible with both xcolor.sty and color.sty
+  \color@b@x {\color{#1}\spx@CustomFBox{#3}{#4}}{\color{#2}}{#5}%
   \hskip-\fboxsep\hskip-\fboxrule
   \hskip-\linewidth \hskip-\@totalleftmargin \hskip\columnwidth
-}
-% use of \color@b@x here is compatible with both xcolor.sty and color.sty
-\long\def\spx@fcolorbox #1#2#3#4%
-  {\color@b@x {\color{#1}\spx@VerbatimFBox{#3}{#4}}{\color{#2}}}%
-% Frame drawing macro
-% #1 = used by default for title above frame, may contain "continued" hint
-% #2 = for material underneath frame, used for "continues on next page" hint
-% #3 = actual contents with background color
-\long\def\spx@VerbatimFBox#1#2#3{%
+}%
+% #1 = for material above frame, such as a caption or a "continued" hint
+% #2 = for material below frame, such as a caption or "continues on next page"
+% #3 = actual contents, which will be typeset with a background color
+\long\def\spx@CustomFBox#1#2#3{%
   \leavevmode
   \begingroup
   \setbox\@tempboxa\hbox{{#3}}% inner braces to avoid color leaks
@@ -717,37 +731,40 @@
     }%
    }%
   \endgroup
-}
-
-% Customize framed.sty \MakeFramed to glue caption to literal block
-% and add optional hint "continued on next page"
-\def\spx@Verbatim@FrameCommand
-   {\spx@colorbox\spx@Verbatim@Title{}}%
-% Macros for a frame with page breaks:
-\def\spx@Verbatim@FirstFrameCommand
-   {\spx@colorbox\spx@Verbatim@Title\spx@Verbatim@Continues}%
-\def\spx@Verbatim@MidFrameCommand
-   {\spx@colorbox\spx@Verbatim@Continued\spx@Verbatim@Continues}%
-\def\spx@Verbatim@LastFrameCommand
-   {\spx@colorbox\spx@Verbatim@Continued{}}%
-
-\def\spx@Verbatim@Title{% hide width from framed.sty measuring
-  \moveright\dimexpr\fboxrule+.5\wd\@tempboxa
-  \hb@xt@\z@{\hss\unhcopy\spx@Verbatim@TitleBox\hss}%
 }%
-\def\spx@Verbatim@Continued{%
-  \moveright\dimexpr\fboxrule+\wd\@tempboxa-\fboxsep
-  \hb@xt@\z@{\hss
-             {\normalcolor\sphinxstylecodecontinued\literalblockcontinuedname}}%
+\def\spx@fcolorbox@put@c#1{% hide width from framed.sty measuring
+    \moveright\dimexpr\fboxrule+.5\wd\@tempboxa\hb@xt@\z@{\hss#1\hss}%
 }%
-\def\spx@Verbatim@Continues{%
-  \moveright\dimexpr\fboxrule+\wd\@tempboxa-\fboxsep
-  \hb@xt@\z@{\hss
-             {\normalcolor\sphinxstylecodecontinues\literalblockcontinuesname}}%
+\def\spx@fcolorbox@put@r#1{% right align with contents, width hidden
+    \moveright\dimexpr\fboxrule+\wd\@tempboxa-\fboxsep\hb@xt@\z@{\hss#1}%
 }%
+\def\spx@fcolorbox@put@l#1{% left align with contents, width hidden
+    \moveright\dimexpr\fboxrule+\fboxsep\hb@xt@\z@{#1\hss}%
+}%
+%
+\def\sphinxVerbatim@Continued
+   {\csname spx@fcolorbox@put@\spx@opt@verbatimcontinuedalign\endcsname
+    {\normalcolor\sphinxstylecodecontinued\literalblockcontinuedname}}%
+\def\sphinxVerbatim@Continues
+   {\csname spx@fcolorbox@put@\spx@opt@verbatimcontinuesalign\endcsname
+    {\normalcolor\sphinxstylecodecontinues\literalblockcontinuesname}}%
+\def\sphinxVerbatim@Title
+   {\spx@fcolorbox@put@c{\unhcopy\sphinxVerbatim@TitleBox}}%
+\let\sphinxVerbatim@Before\@empty
+\let\sphinxVerbatim@After\@empty
 % Defaults are redefined in document preamble according to language
 \newcommand*\literalblockcontinuedname{continued from previous page}%
 \newcommand*\literalblockcontinuesname{continues on next page}%
+%
+\def\spx@verbatimfcolorbox{\spx@fcolorbox{VerbatimBorderColor}{VerbatimColor}}%
+\def\sphinxVerbatim@FrameCommand
+   {\spx@verbatimfcolorbox\sphinxVerbatim@Before\sphinxVerbatim@After}%
+\def\sphinxVerbatim@FirstFrameCommand
+   {\spx@verbatimfcolorbox\sphinxVerbatim@Before\sphinxVerbatim@Continues}%
+\def\sphinxVerbatim@MidFrameCommand
+   {\spx@verbatimfcolorbox\sphinxVerbatim@Continued\sphinxVerbatim@Continues}%
+\def\sphinxVerbatim@LastFrameCommand
+   {\spx@verbatimfcolorbox\sphinxVerbatim@Continued\sphinxVerbatim@After}%
 
 % For linebreaks inside Verbatim environment from package fancyvrb.
 \newbox\sphinxcontinuationbox
@@ -832,21 +849,19 @@
 \newcommand*\sphinxSetupCodeBlockInFootnote {%
   \fvset{fontsize=\footnotesize}\let\caption\sphinxfigcaption
   \sphinxverbatimwithminipagetrue % reduces vertical spaces
-  % we counteract \caption issueing \@normalsize
-  % this all happens in a group
+  % we counteract (this is in a group) the \@normalsize from \caption
   \let\normalsize\footnotesize\let\@parboxrestore\relax
-  \abovecaptionskip \smallskipamount \belowcaptionskip \z@skip
+  \def\spx@abovecaptionskip{\sphinxverbatimsmallskipamount}%
 }
 % needed to create wrapper environments of fancyvrb's Verbatim
 \newcommand*{\sphinxVerbatimEnvironment}{\gdef\FV@EnvironName{sphinxVerbatim}}
-% Sphinx <1.5 optional argument was in fact mandatory. It is now really
-% optional and handled by original Verbatim.
+\newcommand*{\sphinxverbatimsmallskipamount}{\smallskipamount}
 \newenvironment{sphinxVerbatim}{%
   % first, let's check if there is a caption
   \ifx\sphinxVerbatimTitle\empty
       \sphinxvspacefixafterfrenchlists
       \parskip\z@skip
-      \smallskip
+      \vskip\sphinxverbatimsmallskipamount
       % there was no caption. Check if nevertheless a label was set.
       \ifx\sphinxLiteralBlockLabel\empty\else
       % we require some space to be sure hyperlink target from \phantomsection
@@ -854,25 +869,37 @@
           \needspace{\sphinxliteralblockwithoutcaptionneedspace}%
           \phantomsection\sphinxLiteralBlockLabel
       \fi
-      \let\spx@Verbatim@Title\@empty
   \else
      \parskip\z@skip
-  % non-empty \sphinxVerbatimTitle has label inside it (in case there is one)
-     \setbox\spx@Verbatim@TitleBox
+     \if t\spx@opt@literalblockcappos
+       \vskip\spx@abovecaptionskip
+       \def\sphinxVerbatim@Before
+           {\sphinxVerbatim@Title\nointerlineskip
+            \kern\dimexpr-\dp\strutbox+\sphinxbelowcaptionspace\relax}%
+     \else
+       \vskip\sphinxverbatimsmallskipamount
+       \def\sphinxVerbatim@After
+          {\nointerlineskip\kern\dp\strutbox\sphinxVerbatim@Title}%
+     \fi
+     \def\@captype{literalblock}%
+     \capstart
+     % \sphinxVerbatimTitle must reset color
+     \setbox\sphinxVerbatim@TitleBox
             \hbox{\begin{minipage}{\linewidth}%
                     \sphinxVerbatimTitle
                   \end{minipage}}%
   \fi
+  \global\let\sphinxLiteralBlockLabel\empty
+  \global\let\sphinxVerbatimTitle\empty
   \fboxsep\sphinxverbatimsep \fboxrule\sphinxverbatimborder
-  % setting borderwidth to zero is simplest for no-frame effect with same pagebreaks
   \ifspx@opt@verbatimwithframe\else\fboxrule\z@\fi
-  \let\FrameCommand     \spx@Verbatim@FrameCommand
-  \let\FirstFrameCommand\spx@Verbatim@FirstFrameCommand
-  \let\MidFrameCommand  \spx@Verbatim@MidFrameCommand
-  \let\LastFrameCommand \spx@Verbatim@LastFrameCommand
+  \let\FrameCommand     \sphinxVerbatim@FrameCommand
+  \let\FirstFrameCommand\sphinxVerbatim@FirstFrameCommand
+  \let\MidFrameCommand  \sphinxVerbatim@MidFrameCommand
+  \let\LastFrameCommand \sphinxVerbatim@LastFrameCommand
   \ifspx@opt@verbatimhintsturnover\else
-      \let\spx@Verbatim@Continued\@empty
-      \let\spx@Verbatim@Continues\@empty
+      \let\sphinxVerbatim@Continued\@empty
+      \let\sphinxVerbatim@Continues\@empty
   \fi
   \ifspx@opt@verbatimwrapslines
   % fancyvrb's Verbatim puts each input line in (unbreakable) horizontal boxes.
@@ -903,13 +930,21 @@
   \def\@toodeep {\advance\@listdepth\@ne}%
   % The list environment is needed to control perfectly the vertical space.
   % Note: \OuterFrameSep used by framed.sty is later set to \topsep hence 0pt.
-  % - if caption: vertical space above caption = (\abovecaptionskip + D) with
-  %   D = \baselineskip-\FrameHeightAdjust, and then \smallskip above frame.
-  % - if no caption: (\smallskip + D) above frame. By default D=6pt.
-  % Use trivlist rather than list to avoid possible "too deeply nested" error.
+  % - if caption: distance from last text baseline to caption baseline is
+  %   A+(B-F)+\ht\strutbox, A = \abovecaptionskip (default 10pt), B =
+  %   \baselineskip, F is the framed.sty \FrameHeightAdjust macro, default 6pt.
+  %   Formula valid for F < 10pt.
+  % - distance of baseline of caption to top of frame is like for tables:
+  %   \sphinxbelowcaptionspace (=0.5\baselineskip)
+  % - if no caption: distance of last text baseline to code frame is S+(B-F),
+  %   with S = \sphinxverbatimtopskip (=\smallskip)
+  % - and distance from bottom of frame to next text baseline is
+  %   \baselineskip+\parskip.
+  % The \trivlist is used to avoid possible "too deeply nested" error.
   \itemsep   \z@skip
   \topsep    \z@skip
-  \partopsep \z@skip% trivlist will set \parsep to \parskip = zero (see above)
+  \partopsep \z@skip
+  % trivlist will set \parsep to \parskip = zero
   % \leftmargin will be set to zero by trivlist
   \rightmargin\z@
   \parindent  \z@% becomes \itemindent. Default zero, but perhaps overwritten.
@@ -945,10 +980,12 @@
   {% don't use a frame if in a table cell
    \spx@opt@verbatimwithframefalse
    \sphinxverbatimwithminipagetrue
-   % counteract longtable redefinition of caption
+   % the literal block caption uses \sphinxcaption which is wrapper of \caption,
+   % but \caption must be modified because longtable redefines it to work only
+   % for the own table caption, and tabulary has multiple passes
    \let\caption\sphinxfigcaption
-   % reduce above caption space if in a table cell
-   \abovecaptionskip\smallskipamount
+   % reduce above caption skip
+   \def\spx@abovecaptionskip{\sphinxverbatimsmallskipamount}%
    \def\sphinxVerbatimEnvironment{\gdef\FV@EnvironName{sphinxVerbatimintable}}%
    \begin{sphinxVerbatim}}
   {\end{sphinxVerbatim}}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2284,8 +2284,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
             else:
                 hlcode += '\\end{sphinxVerbatim}'
             self.body.append('\n' + hlcode + '\n')
-            if ids:
-                self.body.append('\\let\\sphinxLiteralBlockLabel\\empty\n')
             raise nodes.SkipNode
 
     def depart_literal_block(self, node):
@@ -2488,8 +2486,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         if node.get('literal_block'):
             self.in_container_literal_block -= 1
-            self.body.append('\\let\\sphinxVerbatimTitle\\empty\n')
-            self.body.append('\\let\\sphinxLiteralBlockLabel\\empty\n')
 
     def visit_decoration(self, node):
         # type: (nodes.Node) -> None

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -542,8 +542,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     assert ('&\nThis is one more footnote with some code in it %\n'
             '\\begin{footnote}[10]\\sphinxAtStartFootnote\n'
             'Third footnote in longtable\n') in result
-    assert ('\\end{sphinxVerbatim}\n\\let\\sphinxVerbatimTitle\\empty\n'
-            '\\let\\sphinxLiteralBlockLabel\\empty\n%\n\\end{footnote}.\n') in result
+    assert ('\\end{sphinxVerbatim}\n%\n\\end{footnote}.\n') in result
     assert '\\begin{sphinxVerbatim}[commandchars=\\\\\\{\\}]' in result
 
 


### PR DESCRIPTION
With ``literalblockcappos=b`` added to ``'sphinxsetup'``, the captions of literal blocks are typeset after the literal block in PDF output. Default is ``t`` which says to typeset them above.

Also added ``verbatimcontinuedalign`` and ``verbatimcontinuesalign`` with possible values ``l, c, r`` for alignment of continuation hints with respect to literal block contents (relates #3792). This gives for example:

![capture d ecran 2017-06-17 a 10 15 04](https://user-images.githubusercontent.com/2589111/27251575-03ba42e2-534a-11e7-87bd-a1db2a578673.png)

The ``verbatimhintsturnover`` default is now ``true`` so that at 1.7 continuation hints (internationalized) will be the default.

### Details

* In case the caption is printed after the literal block, nevertheless the internal links will be set up to point to start of literal block.

* The caption width is now wrapped to the same maximal width as for table captions: the `\LTcapwidth` parameter whose default is `4in`.

* I have considered horizontal alignment of the caption itself. This can be done indeed for literal blocks, but I dropped it because it is not easy to do the similar thing for tables:

  - for longtable, one can patch macros for alignment with respect to the table sides, but not easily alignment with respect to the line width,
  - for tabular, tabulary, one can extend caption macro to get alignment with respect to the line width, but not with respect to the table sides (as we dropped threeparttable which could be used for that but has many induced problems) except if the table width is known in advance.

  Hence I dropped horizontal alignment for caption of literal blocks.

* In future, if a global config setting is added for caption placement, this PR does it already for literal blocks, so this will facilitate implementation. For tables, it is already not too complicated thanks to the templates. For figures, some refactoring is needed first.

* The `\sphinxcaption` which is used for tables (except longtable) and with this PR for literal blocks too has been made more flexible: earlier it hard-coded reset of `\abovecaptionskip/\belowcaptionskip` to `0pt` for uniform treatement of tables, now the two are reset to values given by some user modifiable macros.

* If caption is on top the distance from baseline of caption text to frame of literal block is now same value as for table captions (`\sphinxbelowcaptionspace` whose default is `6pt = 0.5\baselineskip = \parskip`). This is slightly increase from previous setting, in order to get uniformity with table caption placement.

* More generally, the vertical spacing for literal blocks is now customizable via renewcommand of latex macros (see next).

### Memo on vertical spacing

Here are the default values for vertical spacing (in English documents):

- tables: 
   
   * if the table has no caption, there is `\baselineskip (12pt) + \parskip (6pt) + \sphinxtablepre (0pt) = 18pt` from baseline of text to top of table,
   * if the table has a caption, this is again `18pt` to top of caption (i.e. `\ht\strutbox = 8.4pt` above caption text baseline),
   * underneath table there is `12pt+6pt+\sphinxtablepost(=\medskipamount=6pt) = 24pt` from table bottom frame to next text baseline.

- literal blocks:

   * if with no caption, there is `\sphinxverbatimsmallskipamount (=\smallskipamount=3pt) + \baselineskip (12pt) - \FrameHeightAdjust (default 6pt) = 9pt` from baseline of previous text to top of block frame,
   * if with caption (on top), there is `\abovecaptionskip (10pt) + same (12 pt - 6pt) = 16pt` from baseline of previous text to top of caption,
   * after the literal-block there is `\baselineskip+\parskip=18pt` from bottom frame to next text baseline.

These values were already the ones theoretically for literal blocks before this PR, but for a reason I have not fully understood, in case with caption I measured a bit smaller on stable branch, perhaps `15pt`, not the `16pt`. Perhaps some stretch-shrink which is now not rendered due to refactoring of latex macros.

Compared to tables, literal blocks are less separated from ambient text, and in cse of caption there is much less difference between "before" and "after" spaces.

Note: all this is now customizable easily except the spacing after literal block, there is no hook to customize it, contrarily to tables. This can be added later if a need arises.

(regarding literal block top vertical spacing, it was reduced in #2460)

### Relates

#3792, #2460, #3504

and #1723

