### PR TITLE
3824 no smart quotes for nodes

### DIFF
--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -96,7 +96,7 @@ class desc_signature(nodes.Part, nodes.Inline, nodes.TextElement):
     """
 
 
-class desc_signature_line(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_signature_line(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for a line in a multi-line object signatures.
 
     It should only be used in a ``desc_signature`` with ``is_multiline`` set.
@@ -106,7 +106,7 @@ class desc_signature_line(nodes.Part, nodes.Inline, nodes.TextElement):
 
 # nodes to use within a desc_signature or desc_signature_line
 
-class desc_addname(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_addname(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for additional name parts (module name, class name)."""
 
 
@@ -114,7 +114,7 @@ class desc_addname(nodes.Part, nodes.Inline, nodes.TextElement):
 desc_classname = desc_addname
 
 
-class desc_type(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_type(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for return types or object type names."""
 
 
@@ -125,20 +125,20 @@ class desc_returns(desc_type):
         return ' -> ' + nodes.TextElement.astext(self)
 
 
-class desc_name(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_name(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for the main object name."""
 
 
-class desc_parameterlist(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_parameterlist(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for a general parameter list."""
     child_text_separator = ', '
 
 
-class desc_parameter(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_parameter(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for a single parameter."""
 
 
-class desc_optional(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_optional(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for marking optional parts of the parameter list."""
     child_text_separator = ', '
 
@@ -147,7 +147,7 @@ class desc_optional(nodes.Part, nodes.Inline, nodes.TextElement):
         return '[' + nodes.TextElement.astext(self) + ']'
 
 
-class desc_annotation(nodes.Part, nodes.Inline, nodes.TextElement):
+class desc_annotation(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for signature annotations (not Python 3-style annotations)."""
 
 
@@ -179,7 +179,7 @@ class productionlist(nodes.Admonition, nodes.Element):
     """
 
 
-class production(nodes.Part, nodes.Inline, nodes.TextElement):
+class production(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     """Node for a single grammar production rule."""
 
 

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -49,6 +49,11 @@ class translatable(object):
         raise NotImplementedError
 
 
+class not_smartquotable(object):
+    """A node which does not support smart-quotes."""
+    support_smartquotes = False
+
+
 class toctree(nodes.General, nodes.Element, translatable):
     """Node for inserting a "TOC tree"."""
 
@@ -266,13 +271,13 @@ class download_reference(nodes.reference):
     """Node for download references, similar to pending_xref."""
 
 
-class literal_emphasis(nodes.emphasis):
+class literal_emphasis(nodes.emphasis, not_smartquotable):
     """Node that behaves like `emphasis`, but further text processors are not
     applied (e.g. smartypants for HTML output).
     """
 
 
-class literal_strong(nodes.strong):
+class literal_strong(nodes.strong, not_smartquotable):
     """Node that behaves like `strong`, but further text processors are not
     applied (e.g. smartypants for HTML output).
     """

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -19,7 +19,7 @@ from sphinx import addnodes
 from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.i18n import format_date
-from sphinx.util.nodes import apply_source_workaround
+from sphinx.util.nodes import apply_source_workaround, is_smartquotable
 
 if False:
     # For type annotation
@@ -343,6 +343,7 @@ class SphinxSmartQuotes(SmartQuotes):
         texttype = {True: 'literal',  # "literal" text is not changed:
                     False: 'plain'}
         for txtnode in txtnodes:
+            smartquotable = is_smartquotable(txtnode.parent)
             nodetype = texttype[isinstance(txtnode.parent,
                                            (nodes.literal,
                                             addnodes.literal_emphasis,
@@ -360,4 +361,4 @@ class SphinxSmartQuotes(SmartQuotes):
                                             nodes.image,
                                             nodes.raw,
                                             nodes.problematic))]
-            yield (nodetype, txtnode.astext())
+            yield (texttype[smartquotable], txtnode.astext())

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -343,22 +343,5 @@ class SphinxSmartQuotes(SmartQuotes):
         texttype = {True: 'literal',  # "literal" text is not changed:
                     False: 'plain'}
         for txtnode in txtnodes:
-            smartquotable = is_smartquotable(txtnode.parent)
-            nodetype = texttype[isinstance(txtnode.parent,
-                                           (nodes.literal,
-                                            addnodes.literal_emphasis,
-                                            addnodes.literal_strong,
-                                            addnodes.desc_addname,
-                                            addnodes.desc_annotation,
-                                            addnodes.desc_name,
-                                            addnodes.desc_optional,
-                                            addnodes.desc_parameter,
-                                            addnodes.desc_parameterlist,
-                                            addnodes.desc_signature_line,
-                                            addnodes.desc_type,
-                                            addnodes.production,
-                                            nodes.math,
-                                            nodes.image,
-                                            nodes.raw,
-                                            nodes.problematic))]
+            smartquotable = not is_smartquotable(txtnode)
             yield (texttype[smartquotable], txtnode.astext())

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -364,6 +364,22 @@ def process_only_nodes(doctree, tags):
                 node.replace_self(nodes.comment())
 
 
+SMARTQUOTABLE_NODES = (
+    addnodes.not_smartquotable,
+)
+
+
+def is_smartquotable(node):
+    # type: (nodes.Node) -> bool
+    """Check the node is smart-quotable or not."""
+    if isinstance(node, SMARTQUOTABLE_NODES):
+        return False
+    elif getattr(node, 'support_smartquotes', None) is False:
+        return False
+    else:
+        return True
+
+
 # monkey-patch Element.copy to copy the rawsource and line
 
 def _new_copy(self):

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -364,7 +364,13 @@ def process_only_nodes(doctree, tags):
                 node.replace_self(nodes.comment())
 
 
-SMARTQUOTABLE_NODES = (
+NON_SMARTQUOTABLE_PARENT_NODES = (
+    nodes.FixedTextElement,
+    nodes.literal,
+    nodes.math,
+    nodes.image,
+    nodes.raw,
+    nodes.problematic,
     addnodes.not_smartquotable,
 )
 
@@ -372,7 +378,7 @@ SMARTQUOTABLE_NODES = (
 def is_smartquotable(node):
     # type: (nodes.Node) -> bool
     """Check the node is smart-quotable or not."""
-    if isinstance(node, SMARTQUOTABLE_NODES):
+    if isinstance(node.parent, NON_SMARTQUOTABLE_PARENT_NODES):
         return False
     elif getattr(node, 'support_smartquotes', None) is False:
         return False


### PR DESCRIPTION
Refactor #3825 using `FixedTextElement`.
And I also added `addnodes.not_smartquotable` to represent the node does not support smart-quotes.