### PR TITLE
Fix #3851 and fix #3706 about box drawing characters for PDF output

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1485,7 +1485,7 @@
   \ifx\spx@bd@height   \@undefined\def\spx@bd@height{\baselineskip}\fi
   \ifx\spx@bd@width    \@undefined\setbox0\hbox{0}\def\spx@bd@width{\wd0 }\fi
   \ifx\spx@bd@thickness\@undefined\def\spx@bd@thickness{.6\p@}\fi
-  \ifx\spx@bd@raise    \@undefined\def\spx@bd@lower{\dp\strutbox}\fi
+  \ifx\spx@bd@lower    \@undefined\def\spx@bd@lower{\dp\strutbox}\fi
   \lower\spx@bd@lower#1{#2}%
   \endgroup
 }%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1478,6 +1478,41 @@
 % figure legend comes after caption and may contain arbitrary body elements
 \newenvironment{sphinxlegend}{\par\small}{\par}
 
+% Declare Unicode characters used by linux tree command to pdflatex utf8/utf8x
+\def\spx@bd#1#2{%
+  \leavevmode
+  \begingroup
+  \ifx\spx@bd@height   \@undefined\def\spx@bd@height{\baselineskip}\fi
+  \ifx\spx@bd@width    \@undefined\setbox0\hbox{0}\def\spx@bd@width{\wd0 }\fi
+  \ifx\spx@bd@thickness\@undefined\def\spx@bd@thickness{.6\p@}\fi
+  \ifx\spx@bd@raise    \@undefined\def\spx@bd@lower{\dp\strutbox}\fi
+  \lower\spx@bd@lower#1{#2}%
+  \endgroup
+}%
+\@namedef{sphinx@u2500}% BOX DRAWINGS LIGHT HORIZONTAL
+  {\spx@bd{\vbox to\spx@bd@height}
+          {\vss\hrule\@height\spx@bd@thickness
+                     \@width\spx@bd@width\vss}}%
+\@namedef{sphinx@u2502}% BOX DRAWINGS LIGHT VERTICAL
+  {\spx@bd{\hb@xt@\spx@bd@width}
+          {\hss\vrule\@height\spx@bd@height
+                     \@width \spx@bd@thickness\hss}}%
+\@namedef{sphinx@u2514}% BOX DRAWINGS LIGHT UP AND RIGHT
+  {\spx@bd{\hb@xt@\spx@bd@width}
+          {\hss\raise.5\spx@bd@height
+           \hb@xt@\z@{\hss\vrule\@height.5\spx@bd@height
+                                \@width \spx@bd@thickness\hss}%
+           \vbox to\spx@bd@height{\vss\hrule\@height\spx@bd@thickness
+                                            \@width.5\spx@bd@width\vss}}}%
+\@namedef{sphinx@u251C}% BOX DRAWINGS LIGHT VERTICAL AND RIGHT
+  {\spx@bd{\hb@xt@\spx@bd@width}
+          {\hss
+           \hb@xt@\z@{\hss\vrule\@height\spx@bd@height
+                                \@width \spx@bd@thickness\hss}%
+           \vbox to\spx@bd@height{\vss\hrule\@height\spx@bd@thickness
+                                            \@width.5\spx@bd@width\vss}}}%
+\protected\def\sphinxunichar#1{\@nameuse{sphinx@u#1}}%
+
 % Tell TeX about pathological hyphenation cases:
 \hyphenation{Base-HTTP-Re-quest-Hand-ler}
 \endinput

--- a/sphinx/util/texescape.py
+++ b/sphinx/util/texescape.py
@@ -40,12 +40,9 @@ tex_replacements = [
     # used to separate -- in options
     ('﻿', r'{}'),
     # map some special Unicode characters to similar ASCII ones
-    ('─', r'-'),
     ('⎽', r'\_'),
-    ('╲', r'\textbackslash{}'),
     ('–', r'\textendash{}'),
     ('|', r'\textbar{}'),
-    ('│', r'\textbar{}'),
     ('ℯ', r'e'),
     ('ⅈ', r'i'),
     ('⁰', r'\(\sp{\text{0}}\)'),

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -105,9 +105,22 @@ ADDITIONAL_SETTINGS = {
     'pdflatex': {
         'inputenc':     '\\usepackage[utf8]{inputenc}',
         'utf8extra':   ('\\ifdefined\\DeclareUnicodeCharacter\n'
-                        ' \\ifdefined\\DeclareUnicodeCharacterAsOptional\\else\n'
+                        ' \\ifdefined\\DeclareUnicodeCharacterAsOptional\n'
+                        '  \\DeclareUnicodeCharacter{"00A0}{\\nobreakspace}\n'
+                        '  \\DeclareUnicodeCharacter{"2500}{\\sphinxunichar{2500}}\n'
+                        '  \\DeclareUnicodeCharacter{"2502}{\\sphinxunichar{2502}}\n'
+                        '  \\DeclareUnicodeCharacter{"2514}{\\sphinxunichar{2514}}\n'
+                        '  \\DeclareUnicodeCharacter{"251C}{\\sphinxunichar{251C}}\n'
+                        '  \\DeclareUnicodeCharacter{"2572}{\\textbackslash}\n'
+                        ' \\else\n'
                         '  \\DeclareUnicodeCharacter{00A0}{\\nobreakspace}\n'
-                        '\\fi\\fi'),
+                        '  \\DeclareUnicodeCharacter{2500}{\\sphinxunichar{2500}}\n'
+                        '  \\DeclareUnicodeCharacter{2502}{\\sphinxunichar{2502}}\n'
+                        '  \\DeclareUnicodeCharacter{2514}{\\sphinxunichar{2514}}\n'
+                        '  \\DeclareUnicodeCharacter{251C}{\\sphinxunichar{251C}}\n'
+                        '  \\DeclareUnicodeCharacter{2572}{\\textbackslash}\n'
+                        ' \\fi\n'
+                        '\\fi'),
     },
     'xelatex': {
         'latex_engine': 'xelatex',


### PR DESCRIPTION
Do not tex-escape them, but provide suitable definitions for pdflatex
only (and platex). Define the 4 box drawing characters needed by unix
tree command with charset utf8. Also define the U+2572 as it was
previously escaped for all engines.

No definitions for xelatex/lualatex as it is then only a matter of using
a font providing them (a priori, only the mono font needs definition, as
the characters will be used in literal blocks).

- Bugfix

### Detail

The 3 Unicode box drawing characters previously handled by texescape have been removed: so xelatex and lualatex will be able to use native characters with fonts providing them.

For pdflatex/platex, they are defined by macros. 2 additional box drawing characters are defined so that the 4 needed for unix `tree` command with charset utf8 are provided.

│, ├, ─, and └  are simulated using horizontal and vertical rules. Advantage is that there is no whitespace left between lines, because they take the full width. Disadvantage is that copying pasting from PDF does not get them, because they are not font glyphs. LaTeX package `pmboxdraw`has this approach for the U+25xx range (only for characters involving only horizontal and vertical moves). And the `ucs (utf8x)` package does it for postcript output only via postscript commands. The `pmboxdraw` has thousands of lines, but only 4 characters are needed for unix `tree` which is most common appearance of these characters.

If need arises, one can provide some more definitions using TeX "hrule/vrule". 


╲ is mapped to `\textbackslash` as was the case when it was "tex-escaped".


Output with pdflatex:

![capture d ecran 2017-06-18 a 19 31 00](https://user-images.githubusercontent.com/2589111/27262827-06fa8d3e-545f-11e7-8a86-855bc9605492.png)


It works for Japanese too, but there is some whitespace between text lines, probably an issue with `\baselineskip` or `\lineskip` TeX parameters (investigation delayed). Output with Japanese (manual type document)

![capture d ecran 2017-06-18 a 19 59 28](https://user-images.githubusercontent.com/2589111/27262907-b5caffdc-5460-11e7-96d3-eec4924eb433.png)

source for test:

```rst
Illustrate a tree with unix `tree` cmd::

  $ tree
  .
  └── f11
      ├── f111
      ├── f112
      │   └── README
      └── f113
  $
```

### Relates
- #3851, #3706

