### PR TITLE
latex: Fix #3878 by using ``\sphinxbfcode`` and not ``\sphinxstrong``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ Bugs fixed
 * #3865: use of self.env.warn in sphinx extension fails
 * #3824: production lists apply smart quotes transform since Sphinx 1.6.1
 * latex: fix ``\sphinxbfcode`` swallows initial space of argument
+* #3878: Quotes in auto-documented class attributes should be straight quotes
+  in PDF output
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1231,7 +1231,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_desc_annotation(self, node):
         # type: (nodes.Node) -> None
-        self.body.append(r'\sphinxstrong{')
+        self.body.append(r'\sphinxbfcode{')
 
     def depart_desc_annotation(self, node):
         # type: (nodes.Node) -> None


### PR DESCRIPTION
See #3878 for details. Now output looks like this. 

Actually  I was testing with French and one sees secondary problem here not related to this Pr (for this secondary problem see #3880)

![capture d ecran 2017-06-19 a 10 51 01](https://user-images.githubusercontent.com/2589111/27277587-09f20b4a-54df-11e7-8ec3-4283a74743a1.png)

