### PR TITLE
sort file lists

### DIFF
--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -246,7 +246,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
             olen = len(outdir)
             for root, dirs, files in os.walk(outdir):
                 staticdir = root.startswith(path.join(outdir, '_static'))
-                for fn in files:
+                for fn in sorted(files):
                     if (staticdir and not fn.endswith('.js')) or \
                        fn.endswith('.html'):
                         print(path.join(root, fn)[olen:].replace(os.sep, '\\'),

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -188,7 +188,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         for root, dirs, files in os.walk(outdir):
             resourcedir = root.startswith(staticdir) or \
                 root.startswith(imagesdir)
-            for fn in files:
+            for fn in sorted(files):
                 if (resourcedir and not fn.endswith('.js')) or \
                    fn.endswith('.html'):
                     filename = path.join(root, fn)[olen:]


### PR DESCRIPTION
similar to commit 0b7c73a98

filesystems return file lists in random order,
but we want to generate reproducible output.

See https://reproducible-builds.org/ for why this matters.


Note: this change makes the pgadmin3 package's pgadmin3.hhp file build reproducibly on openSUSE Linux