### PR TITLE
Unknown html_theme_options throw warnings instead of errors.

### DIFF
--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -133,8 +133,9 @@ class Theme(object):
 
         for option, value in iteritems(overrides):
             if option not in options:
-                raise ThemeError('unsupported theme option %r given' % option)
-            options[option] = value
+                logger.warning('unsupported theme option %r given' % option)
+            else:
+                options[option] = value
 
         return options
 

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -47,8 +47,10 @@ def test_theme_api(app, status, warning):
         theme.get_config('theme', 'foobar')
 
     # options API
-    with pytest.raises(ThemeError):
-        theme.get_options({'nonexisting': 'foo'})
+
+    options = theme.get_options({'nonexisting': 'foo'})
+    assert 'nonexisting' not in options.keys()
+
     options = theme.get_options(cfg.html_theme_options)
     assert options['testopt'] == 'foo'
     assert options['nosidebar'] == 'false'


### PR DESCRIPTION
Subject: Unknown html_theme_options throw warnings instead of errors

### Feature or Bugfix
- Bugfix

### Purpose
New behavior: a sphinx build does not stop, if for the configured theme an unknown but also unneeded html_theme_options is provided.

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
Fixed #3884

