### PR TITLE
Improve support for C++ references with intersphinx

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4818,11 +4818,11 @@ class CPPDomain(Domain):
     object_types = {
         'class':      ObjType(l_('class'),      'class',             'type', 'typeOrConcept'),
         'function':   ObjType(l_('function'),   'function',  'func', 'type', 'typeOrConcept'),
-        'member':     ObjType(l_('member'),     'member',    'var'                          ),
+        'member':     ObjType(l_('member'),     'member',    'var'),
         'type':       ObjType(l_('type'),                            'type', 'typeOrConcept'),
         'concept':    ObjType(l_('concept'),    'concept',                   'typeOrConcept'),
         'enum':       ObjType(l_('enum'),       'enum',              'type', 'typeOrConcept'),
-        'enumerator': ObjType(l_('enumerator'), 'enumerator'                                )
+        'enumerator': ObjType(l_('enumerator'), 'enumerator')
     }
 
     directives = {

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4816,12 +4816,12 @@ class CPPDomain(Domain):
     name = 'cpp'
     label = 'C++'
     object_types = {
-        'class': ObjType(l_('class'), 'class'),
-        'function': ObjType(l_('function'), 'func'),
+        'class': ObjType(l_('class'), 'class', 'typeOrConcept'),
+        'function': ObjType(l_('function'), 'func', 'typeOrConcept'),
         'member': ObjType(l_('member'), 'member'),
-        'type': ObjType(l_('type'), 'type'),
-        'concept': ObjType(l_('concept'), 'concept'),
-        'enum': ObjType(l_('enum'), 'enum'),
+        'type': ObjType(l_('type'), 'type', 'typeOrConcept'),
+        'concept': ObjType(l_('concept'), 'concept', 'typeOrConcept'),
+        'enum': ObjType(l_('enum'), 'enum', 'typeOrConcept'),
         'enumerator': ObjType(l_('enumerator'), 'enumerator')
     }
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4816,13 +4816,13 @@ class CPPDomain(Domain):
     name = 'cpp'
     label = 'C++'
     object_types = {
-        'class':        ObjType(l_('class'),      'class',     'type',               'typeOrConcept'),
-        'function':     ObjType(l_('function'),   'func',      'function',  'type',  'typeOrConcept'),
-        'member':       ObjType(l_('member'),     'member',    'var'),
-        'type':         ObjType(l_('type'),       'type',                            'typeOrConcept'),
-        'concept':      ObjType(l_('concept'),    'concept',                         'typeOrConcept'),
-        'enum':         ObjType(l_('enum'),       'enum',      'type',               'typeOrConcept'),
-        'enumerator':   ObjType(l_('enumerator'), 'enumerator')
+        'class':      ObjType(l_('class'),      'class',             'type', 'typeOrConcept'),
+        'function':   ObjType(l_('function'),   'function',  'func', 'type', 'typeOrConcept'),
+        'member':     ObjType(l_('member'),     'member',    'var'                          ),
+        'type':       ObjType(l_('type'),                            'type', 'typeOrConcept'),
+        'concept':    ObjType(l_('concept'),    'concept',                   'typeOrConcept'),
+        'enum':       ObjType(l_('enum'),       'enum',              'type', 'typeOrConcept'),
+        'enumerator': ObjType(l_('enumerator'), 'enumerator'                                )
     }
 
     directives = {

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4816,13 +4816,13 @@ class CPPDomain(Domain):
     name = 'cpp'
     label = 'C++'
     object_types = {
-        'class': ObjType(l_('class'), 'class', 'typeOrConcept'),
-        'function': ObjType(l_('function'), 'func', 'typeOrConcept'),
-        'member': ObjType(l_('member'), 'member'),
-        'type': ObjType(l_('type'), 'type', 'typeOrConcept'),
-        'concept': ObjType(l_('concept'), 'concept', 'typeOrConcept'),
-        'enum': ObjType(l_('enum'), 'enum', 'typeOrConcept'),
-        'enumerator': ObjType(l_('enumerator'), 'enumerator')
+        'class':        ObjType(l_('class'),      'class',     'type',               'typeOrConcept'),
+        'function':     ObjType(l_('function'),   'func',      'function',  'type',  'typeOrConcept'),
+        'member':       ObjType(l_('member'),     'member',    'var'),
+        'type':         ObjType(l_('type'),       'type',                            'typeOrConcept'),
+        'concept':      ObjType(l_('concept'),    'concept',                         'typeOrConcept'),
+        'enum':         ObjType(l_('enum'),       'enum',      'type',               'typeOrConcept'),
+        'enumerator':   ObjType(l_('enumerator'), 'enumerator')
     }
 
     directives = {
@@ -4955,16 +4955,10 @@ class CPPDomain(Domain):
                 return True
             if declTyp == 'templateParam':
                 return True
-            if typ == 'var' or typ == 'member':
-                return declTyp in ['var', 'member']
-            if typ in ['enum', 'enumerator', 'function', 'class', 'concept']:
-                return declTyp == typ
-            validForType = ['enum', 'class', 'function', 'type']
-            if typ == 'typeOrConcept':
-                return declTyp == 'concept' or declTyp in validForType
-            if typ == 'type':
-                return declTyp in validForType
-            print("Type is %s" % typ)
+            objtypes = self.objtypes_for_role(typ)
+            if objtypes and declTyp in objtypes:
+                return True
+            print("Type is %s, declType is %s" % (typ, declTyp))
             assert False
         if not checkType():
             warner.warn("cpp:%s targets a %s (%s)."

--- a/tests/roots/test-ext-intersphinx-cppdomain/index.rst
+++ b/tests/roots/test-ext-intersphinx-cppdomain/index.rst
@@ -4,3 +4,5 @@ test-ext-intersphinx-cppdomain
 .. cpp:namespace:: foo
 
 :cpp:class:`Bar`
+
+.. cpp:function:: std::uint8_t FooBarBaz()

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -232,6 +232,12 @@ def test_missing_reference_cppdomain(tempdir, app, status, warning):
             ' href="https://docs.python.org/index.html#cpp_foo_bar"'
             ' title="(in foo v2.0)"><code class="xref cpp cpp-class docutils literal">'
             '<span class="pre">Bar</span></code></a>' in html)
+    assert ('<a class="reference external"'
+            ' href="https://docs.python.org/index.html#std"'
+            ' title="(in foo v2.0)">std</a>' in html)
+    assert ('<a class="reference external"'
+            ' href="https://docs.python.org/index.html#std_uint8_t"'
+            ' title="(in foo v2.0)">uint8_t</a>' in html)
 
 
 def test_missing_reference_jsdomain(tempdir, app, status, warning):

--- a/tests/test_util_inventory.py
+++ b/tests/test_util_inventory.py
@@ -34,6 +34,8 @@ module1 py:module 0 foo.html#module-module1 Long Module desc
 module2 py:module 0 foo.html#module-$ -
 module1.func py:function 1 sub/foo.html#$ -
 CFunc c:function 2 cfunc.html#CFunc -
+std cpp:type 1 index.html#std -
+std::uint8_t cpp:type 1 index.html#std_uint8_t -
 foo::Bar cpp:class 1 index.html#cpp_foo_bar -
 foo::Bar::baz cpp:function 1 index.html#cpp_foo_bar_baz -
 a term std:term -1 glossary.html#term-a-term -


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Back with Sphinx 1.4.x I was able to add objects to an intersphinx inventory file and have them get picked up when used in function declarations (such as for parameters or the return value).  Items that aren't picked up show up in the list of unresolved references if the `-n` parameter is passed during the build.  This broke somehow in Sphinx 1.5.x and is still broken in 1.6.x.  I think that the break is caused by the `add_pending_xref` command that passes `cpp:typeOrConcept` as the reftype.  Intersphinx doesn't know that this reftype is allowed to match to multiple actual types and marking the item in the inventory as cpp:typeOrConcept doesn't help either.

I was able to fix this by modeling the objtypes list on what's in the python domain and add additional reftypes where needed.  I also then updated an if/elseif tree in cpp.py to use this information instead of duplicating it's effect.

This only applies to types that are found in a function declaration, not to explicit references, those were being found correctly (as shown in some of the existing tests).  I added an additional check to the test for a return type in a function declaration and it required this change for that check to pass.  The handling for namespaces in a type declaration is a little unexpected I think, but that's how it gets handled elsewhere in the code.