### PR TITLE
#3722 Make memory address regex more permissive.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Features added
 Bugs fixed
 ----------
 
+* #3722: Made memory_Address_regex more permissive to help reproducible
+build efforts
 * #3821: Failed to import sphinx.util.compat with docutils-0.14rc1
 * #3829: sphinx-quickstart template is incomplete regarding use of alabaster
 * #3772: 'str object' has no attribute 'filename'

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -24,7 +24,7 @@ if False:
 # relatively import this module
 inspect = __import__('inspect')
 
-memory_address_re = re.compile(r' at 0x[0-9a-f]{8,16}(?=>)', re.IGNORECASE)
+memory_address_re = re.compile(r'( at |:)0x[0-9a-f]{8,16}(?=>)', re.IGNORECASE)
 
 
 if PY3:


### PR DESCRIPTION
Subject: Make the memory address regular expression in sphinx/util/inspect.py more permissive.  This change allows memory addresses preceded by a colon to be removed which helps projects using sphinx generate more reproducible documentation and builds.

### Feature or Bugfix
- Bugfix

### Purpose
Strip more memory addresses to help build reproducibility.  


### Relates
https://github.com/sphinx-doc/sphinx/issues/3722


