### PR TITLE
 [Napoleon] implement missing Sphinx admonitions

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -140,9 +140,15 @@ class GoogleDocstring(UnicodeMixin):
             self._sections = {
                 'args': self._parse_parameters_section,
                 'arguments': self._parse_parameters_section,
+                'attention': self._parse_attention_section,
                 'attributes': self._parse_attributes_section,
+                'caution': self._parse_caution_section,
+                'danger': self._parse_danger_section,
+                'error': self._parse_error_section,
                 'example': self._parse_examples_section,
                 'examples': self._parse_examples_section,
+                'hint': self._parse_hint_section,
+                'important': self._parse_important_section,
                 'keyword args': self._parse_keyword_arguments_section,
                 'keyword arguments': self._parse_keyword_arguments_section,
                 'methods': self._parse_methods_section,
@@ -155,6 +161,7 @@ class GoogleDocstring(UnicodeMixin):
                 'raises': self._parse_raises_section,
                 'references': self._parse_references_section,
                 'see also': self._parse_see_also_section,
+                'tip': self._parse_tip_section,
                 'todo': self._parse_todo_section,
                 'warning': self._parse_warning_section,
                 'warnings': self._parse_warning_section,
@@ -550,6 +557,15 @@ class GoogleDocstring(UnicodeMixin):
                     lines = self._consume_to_next_section()
             self._parsed_lines.extend(lines)
 
+    def _parse_admonition_section(self, section, admonition):
+        # type: (unicode, unicode) -> List[unicode]
+        lines = self._consume_to_next_section()
+        return self._format_admonition(admonition, lines)
+
+    def _parse_attention_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'attention')
+
     def _parse_attribute_docstring(self):
         # type: () -> List[unicode]
         _type, _desc = self._consume_inline_attribute()
@@ -573,10 +589,30 @@ class GoogleDocstring(UnicodeMixin):
             lines.append('')
         return lines
 
+    def _parse_caution_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'caution')
+
     def _parse_examples_section(self, section):
         # type: (unicode) -> List[unicode]
         use_admonition = self._config.napoleon_use_admonition_for_examples
         return self._parse_generic_section(section, use_admonition)
+
+    def _parse_danger_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'danger')
+
+    def _parse_error_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'error')
+
+    def _parse_hint_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'hint')
+
+    def _parse_important_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'important')
 
     def _parse_usage_section(self, section):
         # type: (unicode) -> List[unicode]
@@ -623,8 +659,7 @@ class GoogleDocstring(UnicodeMixin):
 
     def _parse_note_section(self, section):
         # type: (unicode) -> List[unicode]
-        lines = self._consume_to_next_section()
-        return self._format_admonition('note', lines)
+        return self._parse_admonition_section(section, 'note')
 
     def _parse_notes_section(self, section):
         # type: (unicode) -> List[unicode]
@@ -718,18 +753,19 @@ class GoogleDocstring(UnicodeMixin):
 
     def _parse_see_also_section(self, section):
         # type: (unicode) -> List[unicode]
-        lines = self._consume_to_next_section()
-        return self._format_admonition('seealso', lines)
+        return self._parse_admonition_section(section, 'seealso')
+
+    def _parse_tip_section(self, section):
+        # type: (unicode) -> List[unicode]
+        return self._parse_admonition_section(section, 'tip')
 
     def _parse_todo_section(self, section):
         # type: (unicode) -> List[unicode]
-        lines = self._consume_to_next_section()
-        return self._format_admonition('todo', lines)
+        return self._parse_admonition_section(section, 'todo')
 
     def _parse_warning_section(self, section):
         # type: (unicode) -> List[unicode]
-        lines = self._consume_to_next_section()
-        return self._format_admonition('warning', lines)
+        return self._parse_admonition_section(section, 'warning')
 
     def _parse_warns_section(self, section):
         # type: (unicode) -> List[unicode]

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -266,6 +266,42 @@ class GoogleDocstringTest(BaseDocstringTest):
         """
     )]
 
+    def test_sphinx_admonitions(self):
+        admonition_map = {
+            'Attention': 'attention',
+            'Caution': 'caution',
+            'Danger': 'danger',
+            'Error': 'error',
+            'Hint': 'hint',
+            'Important': 'important',
+            'Note': 'note',
+            'Tip': 'tip',
+            'Todo': 'todo',
+            'Warning': 'warning',
+            'Warnings': 'warning',
+        }
+        config = Config()
+        for section, admonition in admonition_map.items():
+            # Multiline
+            actual = str(GoogleDocstring(("{}:\n"
+                      "    this is the first line\n"
+                      "\n"
+                      "    and this is the second line\n"
+                      ).format(section), config))
+            expect = (".. {}::\n"
+                      "\n"
+                      "   this is the first line\n"
+                      "   \n"
+                      "   and this is the second line\n"
+                      ).format(admonition)
+            self.assertEqual(expect, actual)
+            # Single line
+            actual = str(GoogleDocstring(("{}:\n"
+                      "    this is a single line\n"
+                      ).format(section), config))
+            expect = ".. {}:: this is a single line\n".format(admonition)
+            self.assertEqual(expect, actual)
+
     def test_docstrings(self):
         config = Config(
             napoleon_use_param=False,
@@ -1070,6 +1106,51 @@ class NumpyDocstringTest(BaseDocstringTest):
                  description of yielded value
         """
     )]
+
+    def test_sphinx_admonitions(self):
+
+        admonition_map = {
+            'Attention': 'attention',
+            'Caution': 'caution',
+            'Danger': 'danger',
+            'Error': 'error',
+            'Hint': 'hint',
+            'Important': 'important',
+            'Note': 'note',
+            'Tip': 'tip',
+            'Todo': 'todo',
+            'Warning': 'warning',
+            'Warnings': 'warning',
+        }
+
+        config = Config()
+        for section, admonition in admonition_map.items():
+
+            # Multiline
+            actual = str(NumpyDocstring(("{}\n"
+                      "{}\n"
+                      "    this is the first line\n"
+                      "\n"
+                      "    and this is the second line\n"
+                      ).format(section, '-'*len(section)),
+                      config))
+            expect = (".. {}::\n"
+                      "\n"
+                      "   this is the first line\n"
+                      "   \n"
+                      "   and this is the second line\n"
+                      ).format(admonition)
+            self.assertEqual(expect, actual)
+
+            # Single line
+            actual = str(NumpyDocstring(("{}\n"
+                      "{}\n"
+                      "    this is a single line\n"
+                      ).format(section, '-'*len(section)),
+                      config))
+            expect = (".. {}:: this is a single line\n"
+                      .format(admonition))
+            self.assertEqual(expect, actual)
 
     def test_docstrings(self):
         config = Config(


### PR DESCRIPTION
Subject: **[Napoleon] implement missing Sphinx admonitions**

### Feature or Bugfix
- Feature

### Purpose
Sphinx is able to a defined set of admonitions (*attention, caution, danger, error, hint, important, note, tip, warning*), but napoleon only supports a subset of them as section titles. This PR intends to fill the gap.

### Details

- Map napoleon docstring section names to Sphinx admonitions:

    Section | Admonition | Already implemented | Added by this PR
    --- | --- | --- | ---
    Attention | attention | | :heavy_check_mark:
    Caution | caution | | :heavy_check_mark:
    Danger | danger | |:heavy_check_mark:
    Error | error | | :heavy_check_mark:
    Hint | hint | | :heavy_check_mark:
    Important | important | | :heavy_check_mark:
    Note | note | :heavy_check_mark: |
    See Also | seealso | :heavy_check_mark: |
    Tip | tip | | :heavy_check_mark:
    Todo | todo | :heavy_check_mark: |
    Warning | warning | :heavy_check_mark: |
    Warnings | warning | :heavy_check_mark: |

- Add tests for GoogleDocstring

  * Check multiple lines
    ```
    Section:      ---------->        .. admonition::
        foo  
        bar                             foo 
                                        bar
    ```

  * Check single line
    ```
    Section:      ---------->        .. admonition:: foo
        foo 
    ```

- Add tests for NumpyDocstring

  * Check multiple lines
    ```
    Section      ---------->        .. admonition::
    -------
    foo                                foo
    bar                                bar
    ```


  * Check single line
    ```
    Section      ---------->        .. admonition:: foo
    -------
    foo
    ```


