### PR TITLE
#2307 add `::` to show markup sample, not evaluate it

### DIFF
--- a/doc/markup/code.rst
+++ b/doc/markup/code.rst
@@ -96,7 +96,7 @@ switch on line numbers for the individual block::
       Some more Ruby code.
 
 The first line number can be selected with the ``lineno-start`` option.  If
-present, ``linenos`` is automatically activated as well.
+present, ``linenos`` is automatically activated as well::
 
    .. code-block:: ruby
       :lineno-start: 10


### PR DESCRIPTION
Subject: Fix markup glitch in documentation
Low hanging fruit ;-)

### Feature or Bugfix
- Bugfix

### Purpose
- Fixes markup glitch in documentation

### Detail
- See: #2307

### Relates
- #2307

