### PR TITLE
#1236 add note: omit underscore in internal ref

### DIFF
--- a/doc/markup/inline.rst
+++ b/doc/markup/inline.rst
@@ -145,9 +145,14 @@ Cross-referencing arbitrary locations
      The same works for tables that are given an explicit caption using the
      :dudir:`table` directive.
 
-   * Labels that aren't placed before a section title can still be referenced
-     to, but you must give the link an explicit title, using this syntax:
+   * Labels that aren't placed before a section title can still be referenced,
+     but you must give the link an explicit title, using this syntax:
      ``:ref:`Link title <label-name>```.
+
+   .. note::
+
+      Reference labels must start with an underscore. When referencing a
+      label, the underscore must be omitted (see examples above).
 
    Using :rst:role:`ref` is advised over standard reStructuredText links to
    sections (like ```Section title`_``) because it works across files, when


### PR DESCRIPTION
Subject: Add note: omit underscore in internal ref (see #1236)

### Feature or Bugfix
- Docs

### Purpose
- Adds note, as requested by #1236

### Detail
I am actually not sure if this is necessary. If users don't ignore the Sphinx warnings, the system will point them to their mistake, anyway. You can either merge this or close the PR and ticket.

### Relates
- #1236

