### PR TITLE
#1685 remove non-existing attributes from custom directive doc

### DIFF
--- a/doc/extdev/markupapi.rst
+++ b/doc/extdev/markupapi.rst
@@ -70,14 +70,6 @@ using :meth:`.Sphinx.add_directive` or :meth:`.Sphinx.add_directive_to_domain`.
       The absolute line number on which the directive appeared.  This is not
       always a useful value; use :attr:`srcline` instead.
 
-   .. attribute:: src
-
-      The source file of the directive.
-
-   .. attribute:: srcline
-
-      The line number in the source file on which the directive appeared.
-
    .. attribute:: content_offset
 
       Internal offset of the directive content.  Used when calling


### PR DESCRIPTION
Subject: Remove non-existing attributes from custom directive doc

### Feature or Bugfix
- Doc

### Purpose
- Remove non-existing attributes from custom directive docs

### Detail
See docutils code:
https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/rst/__init__.py#l320
This was already fixed in the docutils doc:
https://sourceforge.net/p/docutils/code/7930/

### Relates
#1685

