### PR TITLE
Python rtypes should match classes, not all objects

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -189,7 +189,7 @@ class PyObject(ObjectDescription):
         Field('returnvalue', label=l_('Returns'), has_arg=False,
               names=('returns', 'return')),
         PyField('returntype', label=l_('Return type'), has_arg=False,
-                names=('rtype',), bodyrolename='obj'),
+                names=('rtype',), bodyrolename='class'),
     ]
 
     allow_nesting = False

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -36,3 +36,5 @@ module
    :type  x: int
    :param y: param y
    :type  y: tuple(str, float)
+   :rtype:   list
+

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -113,7 +113,8 @@ def test_domain_py_xrefs(app, status, warning):
     assert_refnode(refnodes[8], False, False, 'tuple', 'class')
     assert_refnode(refnodes[9], False, False, 'str', 'class')
     assert_refnode(refnodes[10], False, False, 'float', 'class')
-    assert len(refnodes) == 11
+    assert_refnode(refnodes[11], False, False, 'list', 'class')
+    assert len(refnodes) == 12
 
 
 @pytest.mark.sphinx('dummy', testroot='domain-py')


### PR DESCRIPTION
Subject: `rtype` should be matching against classes, not all objects

### Feature or Bugfix
- Bugfix

### Purpose/Details

Sphinx gets confused when there are multiple references available for a type.

```python
class Foo(object):
    def list(self):
        """ asdasd """

def bar(x):
    """
    :rtype: list
    """
    return [x]
```

### Relates
- #3927 
- #2549

