### PR TITLE
#3751 document -M command line option

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -89,6 +89,26 @@ Options
    See :ref:`builders` for a list of all builders shipped with Sphinx.
    Extensions can add their own builders.
 
+.. _make_mode:
+
+.. option:: -M buildername
+
+   Alternative to :option:`-b`. Uses the Sphinx :program:`make_mode` module,
+   which provides the same build functionality as a default :ref:`Makefile or
+   Make.bat <makefile_options>`. In addition to all Sphinx
+   :ref:`builders <builders>`, the following build pipelines are available:
+
+   **latexpdf**
+     Build LaTeX files and run them through :program:`pdflatex`.
+
+   **latexpdfja**
+     Build LaTeX files and run them through :program:`platex/dvipdfmx`.
+
+   **info**
+     Build Texinfo files and run them through :program:`makeinfo`.
+
+   .. versionadded:: 1.2.1
+
 .. option:: -a
 
    If given, always write all output files. The default is to only write output
@@ -234,6 +254,8 @@ The :program:`sphinx-build` refers following environment variables:
 
    A path to make command.  A command name is also allowed.
    :program:`sphinx-build` uses it to invoke sub-build process on make-mode.
+
+.. _makefile_options:
 
 .. rubric:: Makefile Options
 

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -103,9 +103,13 @@ Options
 
    **latexpdfja**
      Build LaTeX files and run them through :program:`platex/dvipdfmx`.
+     We recommend using ``latexpdf`` instead.
 
    **info**
      Build Texinfo files and run them through :program:`makeinfo`.
+
+   .. important::
+     Sphinx only recognizes the ``-M`` option if it is placed first.
 
    .. versionadded:: 1.2.1
 

--- a/doc/man/sphinx-quickstart.rst
+++ b/doc/man/sphinx-quickstart.rst
@@ -120,7 +120,8 @@ Options
 
 .. option:: --use-make-mode, --no-use-make-mode
 
-   Makefile/make.bat uses (or not use) make-mode. Default is use.
+   :file:`Makefile/make.bat` uses (or doesn't use) :ref:`make-mode <make_mode>`.
+   Default is `use`, which generates a more concise :file:`Makefile/make.bat`.
 
    .. versionchanged:: 1.5
       make-mode is default.

--- a/doc/man/sphinx-quickstart.rst
+++ b/doc/man/sphinx-quickstart.rst
@@ -121,7 +121,7 @@ Options
 .. option:: --use-make-mode, --no-use-make-mode
 
    :file:`Makefile/make.bat` uses (or doesn't use) :ref:`make-mode <make_mode>`.
-   Default is `use`, which generates a more concise :file:`Makefile/make.bat`.
+   Default is ``use``, which generates a more concise :file:`Makefile/make.bat`.
 
    .. versionchanged:: 1.5
       make-mode is default.


### PR DESCRIPTION
Documents sphinx-build `-M` command line option

### Feature or Bugfix
- Doc

### Purpose
Documents sphinx-build `-M` command line option:
Build using the Sphinx `make_mode` module.

### Detail
Only updates the docs. At https://github.com/sphinx-doc/sphinx/issues/3196#issuecomment-266278023 are some suggestions to improve the command line (help) interface. I might create another PR for this eventually.

### Relates
#3751

