### PR TITLE
Add label for c++ domain

### DIFF
--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -540,6 +540,7 @@ defined in the documentation:
 
    Reference a C-language type.
 
+.. _cpp-domain:
 
 The C++ Domain
 --------------


### PR DESCRIPTION
Currently it's [#id2](http://www.sphinx-doc.org/en/stable/domains.html#id2) on sphinx-doc documentation

Subject: Label for C++ domain in docs is autogenerated ID

This makes it unreliable to link to elsewhere on the internet.

This fixes gives a more "permanent" label.