### PR TITLE
Update regex to fix character class range

### DIFF
--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -233,7 +233,7 @@ class SearchChinese(SearchLanguage):
     language_name = 'Chinese'
     js_stemmer_code = js_porter_stemmer
     stopwords = english_stopwords
-    latin1_letters = re.compile(r'(?u)\w+[\u0000-\u00ff]')
+    latin1_letters = re.compile(u'(?u)\\w+[\u0000-\u00ff]')
 
     def init(self, options):
         # type: (Dict) -> None

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -250,7 +250,7 @@ class SearchChinese(SearchLanguage):
         if JIEBA:
             chinese = list(jieba.cut_for_search(input))
 
-        latin1 = self.latin1_letters.findall(input)  # type: ignore
+        latin1 = self.latin1_letters.findall(input)
         return chinese + latin1
 
     def word_filter(self, stemmed_word):


### PR DESCRIPTION
Subject: Update regex to fix character class range

### Feature or Bugfix
- Bugfix

### Purpose

The use of a raw string literal here means that \uXXXX will not be
treated as a unicode character, but rather as the string "\\uXXXX".
I've adjusted this here to use the \x notation, but I'm not sure this
is what is intended. It might be better to instead make it a `u''`
string.

### Relates

https://lgtm.com/projects/g/sphinx-doc/sphinx/snapshot/517eb456089ac72465ed088944a4a6a7a60b12bf/files/sphinx/search/zh.py#V236

