### PR TITLE
Reporting fix for autodoc + doctest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Other contributors, listed alphabetically, are:
 * Joel Wurtz -- cellspanning support in LaTeX
 * Hong Xu -- svg support in imgmath extension and various bug fixes
 * Stephen Finucane -- setup command improvements and documentation
+* Zac Hatfield-Dodds -- doctest reporting improvements
 
 Many thanks for all contributions!
 

--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 ----------
 
 * #3924: docname lost after dynamically parsing RST in extension
+* Report true location of failing doctests in docstrings when using autodoc.
 
 Testing
 --------

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -401,7 +401,8 @@ Doctest summary
                                self.env.doc2path(docname), node.line)
             code = TestCode(source, type=node.get('testnodetype', 'doctest'),
                             lineno=node.line, options=node.get('options'))
-            node_groups = node.get('groups', ['default'])
+            fallback = path.basename(node.source or 'default').rpartition(':')[-1]
+            node_groups = node.get('groups', [fallback])
             if '*' in node_groups:
                 add_to_all_groups.append(code)
                 continue

--- a/tests/test_ext_doctest.py
+++ b/tests/test_ext_doctest.py
@@ -21,9 +21,9 @@ def test_build(app, status, warning):
     app.builder.build_all()
     if app.statuscode != 0:
         assert False, 'failures in doctests:' + status.getvalue()
-    # in doctest.txt, there are two named groups and the default group,
-    # so the cleanup function must be called three times
-    assert cleanup_called == 3, 'testcleanup did not get executed enough times'
+    # in doctest.txt, there are two named groups, the default group, and
+    # non-grouped calls, so the cleanup function must be called four times
+    assert cleanup_called == 4, 'testcleanup did not get executed enough times'
 
 
 def test_compare_version():


### PR DESCRIPTION
The `ext.doctest` builder is lovely, because - with `ext.autodoc` - you can check all the code examples in your documentation at once.  Unfortunately, this combination of extensions has a small problem.  When a doctest from a docstring included by autodoc fails, the file given is wherever it was included rather than the actual source file, and the line number is relative to the start of the docstring.

It is then pointlessly difficult to track down the actual code that is failing.

This pull therefore changes the "group" notation for doctests sourced from docstrings, to clarify what needs to be fixed.  Before:

    File "data.rst", line 19, in default

And after: 

    File "data.rst", line 19, in docstring of hypothesis.strategies.deferred

I was prompted by HypothesisWorks/hypothesis-python#711, and spent a fair while attempting to trace back to true paths and file-relative line numbers, but ultimately gave up as the information is discarded in an earlier pass and there's no obvious way to pass it along.  This pull still makes manual fixes much easier, and an automatic patcher possible.