### PR TITLE
Fix #3962: sphinx-apidoc does not recognize implicit namespace packages correctly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Incompatible changes
 * #3668: The arguments has changed of main functions for each command
 * #3893: Unknown html_theme_options throw warnings instead of errors
 * #3927: Python parameter/variable types should match classes, not all objects
+* #3962: sphinx-apidoc now recognizes given directory as an implicit namespace
+  package when ``--implicit-namespaces`` option given, not subdirectories of
+  given directory.
 
 Deprecated
 ----------
@@ -60,6 +63,7 @@ Bugs fixed
 ----------
 
 * #3882: Update the order of files for HTMLHelp and QTHelp
+* #3962: sphinx-apidoc does not recognize implicit namespace packages correctly
 
 Testing
 --------

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -205,17 +205,18 @@ def recurse_tree(rootpath, excludes, opts):
     Look for every file in the directory tree and create the corresponding
     ReST files.
     """
+    followlinks = getattr(opts, 'followlinks', False)
+    includeprivate = getattr(opts, 'includeprivate', False)
+    implicit_namespaces = getattr(opts, 'implicit_namespaces', False)
+
     # check if the base directory is a package and get its name
-    if INITPY in os.listdir(rootpath):
+    if INITPY in os.listdir(rootpath) or implicit_namespaces:
         root_package = rootpath.split(path.sep)[-1]
     else:
         # otherwise, the base is a directory with packages
         root_package = None
 
     toplevels = []
-    followlinks = getattr(opts, 'followlinks', False)
-    includeprivate = getattr(opts, 'includeprivate', False)
-    implicit_namespaces = getattr(opts, 'implicit_namespaces', False)
     for root, subs, files in walk(rootpath, followlinks=followlinks):
         # document only Python module files (that aren't excluded)
         py_files = sorted(f for f in files

--- a/tests/test_apidoc.py
+++ b/tests/test_apidoc.py
@@ -60,7 +60,7 @@ def test_simple(make_app, apidoc):
 
 
 @pytest.mark.apidoc(
-    coderoot='test-apidoc-pep420',
+    coderoot='test-apidoc-pep420/a',
     options=["--implicit-namespaces"],
 )
 def test_pep_0420_enabled(make_app, apidoc):
@@ -97,7 +97,7 @@ def test_pep_0420_enabled(make_app, apidoc):
         assert "a.b.x namespace\n" in txt
 
 
-@pytest.mark.apidoc(coderoot='test-apidoc-pep420')
+@pytest.mark.apidoc(coderoot='test-apidoc-pep420/a')
 def test_pep_0420_disabled(make_app, apidoc):
     outdir = apidoc.outdir
     assert (outdir / 'conf.py').isfile()


### PR DESCRIPTION
refs: #3962 (again)