### PR TITLE
epub: Sort manifest entries by filename

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -513,6 +513,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         if not self.use_index:
             self.ignored_files.append('genindex' + self.out_suffix)
         for root, dirs, files in os.walk(outdir):
+            dirs.sort()
             for fn in sorted(files):
                 filename = path.join(root, fn)[olen:]
                 if filename in self.ignored_files:


### PR DESCRIPTION
is a fixup on commit 0b7c73a98133236883f1c80afbd6acf530928e70

is required because the os.walk loop is run per directory
and the ordering of directories is indeterministic
