### PR TITLE
3799 support ngettext

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -332,9 +332,9 @@ class Sphinx(object):
             status = (self.statuscode == 0 and
                       __('succeeded') or __('finished with problems'))
             if self._warncount:
-                logger.info(bold(__('build %s, %s warning%s.') %
-                                 (status, self._warncount,
-                                  self._warncount != 1 and 's' or '')))
+                logger.info(bold(__('build %s, %s warning.',
+                            'build %s, %s warnings.', self._warncount) %
+                                 (status, self._warncount)))
             else:
                 logger.info(bold(__('build %s.') % status))
         except Exception as err:

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -227,29 +227,35 @@ pairindextypes = {
 translators = {}  # type: Dict[unicode, Any]
 
 if PY3:
-    def _(message):
+    def _(message, *args):
         # type: (unicode) -> unicode
         try:
-            return translators['sphinx'].gettext(message)
+            if len(args) <= 1:
+                return translators['sphinx'].gettext(message)
+            else:  # support pluralization
+                return translators['sphinx'].ngettext(message, args[0], args[1])
         except KeyError:
             return message
 else:
-    def _(message):
+    def _(message, *args):
         # type: (unicode) -> unicode
         try:
-            return translators['sphinx'].ugettext(message)
+            if len(args) <= 1:
+                return translators['sphinx'].ugettext(message)
+            else:  # support pluralization
+                return translators['sphinx'].ungettext(message, args[0], args[1])
         except KeyError:
             return message
 
 
-def __(message):
+def __(message, *args):
     # type: (unicode) -> unicode
     """A dummy wrapper to i18n'ize exceptions and command line messages.
 
     In future, the messages are translated using LC_MESSAGES or any other
     locale settings.
     """
-    return message
+    return message if len(args) <= 1 else args[0]
 
 
 def init(locale_dirs, language, catalog='sphinx'):

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -228,7 +228,7 @@ translators = {}  # type: Dict[unicode, Any]
 
 if PY3:
     def _(message, *args):
-        # type: (unicode) -> unicode
+        # type: (unicode, *Any) -> unicode
         try:
             if len(args) <= 1:
                 return translators['sphinx'].gettext(message)
@@ -238,7 +238,7 @@ if PY3:
             return message
 else:
     def _(message, *args):
-        # type: (unicode) -> unicode
+        # type: (unicode, *Any) -> unicode
         try:
             if len(args) <= 1:
                 return translators['sphinx'].ugettext(message)
@@ -249,7 +249,7 @@ else:
 
 
 def __(message, *args):
-    # type: (unicode) -> unicode
+    # type: (unicode, *Any) -> unicode
     """A dummy wrapper to i18n'ize exceptions and command line messages.
 
     In future, the messages are translated using LC_MESSAGES or any other


### PR DESCRIPTION
Fixes #3799.
Adds ngettext support to allow pluralization in internal localization calls

### Feature or Bugfix
Although it fixes a reported issue #3799, it's rather a maintenance task

### Purpose
Adds ngettext support to allow pluralization in internal localization calls.

### Detail
I extended the locale package and the capabilities of the `_` localization function to support pluralization.
Now, one can call `_('% warning', '% warnings', amount_warnings)' and gettext will figure out the correct plural form. This is relevant because not every language has exactly one plural.
See https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Plural-forms.html.
- See #3799

