### PR TITLE
#3537 set IE doc mode to Edge if not HTML5

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -120,6 +120,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml"{% if language is not none %} lang="{{ language }}"{% endif %}>
 {%- endif %}
   <head>
+    {%- if not html5_doctype %}
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    {%- endif %}
     {%- if use_meta_charset or html5_doctype %}
     <meta charset="{{ encoding }}" />
     {%- else %}


### PR DESCRIPTION
Fixes #3537
Subject: Set IE document mode

### Feature or Bugfix
- Bugfix?

### Purpose
Sets ``<meta http-equiv="X-UA-Compatible" content="IE=Edge" />`` to make legacy Internet Explorers use highest possible browser mode.

### Detail
Doesn't add the corresponding meta tag if doc type is HTML5, because then it's not necessary, according to the Microsoft documentation.
See: https://msdn.microsoft.com/en-us/library/jj676915(v=vs.85).aspx#DCModes.
### Relates
- #3537

