### PR TITLE
latex writer: move over template parts into latex.tex_t

### DIFF
--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -44,6 +44,10 @@
 \newcommand{\sphinxlogo}{<%= logo %>}
 \renewcommand{\releasename}{<%= releasename %>}
 <%= makeindex %>
+\begin{document}
+<%= shorthandoff %>
+<%= maketitle %>
+<%= tableofcontents %>
 <%= body %>
 <%= atendofbody %>
 <%= indices %>

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -47,13 +47,6 @@ if False:
 
 logger = logging.getLogger(__name__)
 
-BEGIN_DOC = r'''
-\begin{document}
-%(shorthandoff)s
-%(maketitle)s
-%(tableofcontents)s
-'''
-
 SHORTHANDOFF = r'''
 \ifdefined\shorthandoff
   \ifnum\catcode`\=\string=\active\shorthandoff{=}\fi
@@ -901,7 +894,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         self.curfilestack.append(node.get('docname', ''))
         if self.first_document == 1:
             # the first document is all the regular content ...
-            self.body.append(BEGIN_DOC % self.elements)
             self.first_document = 0
         elif self.first_document == 0:
             # ... and all others are the appendices

--- a/tests/roots/test-build-multiple-latex-docs/conf.py
+++ b/tests/roots/test-build-multiple-latex-docs/conf.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+master_doc =  'file2'
+
+latex_documents = [
+        ('file1', 'file1.tex', 'Multiple files building test: file1', 'Sphinx',
+            'article'),
+        ('file2', 'file2.tex', 'Multiple files building test: file2', 'Sphinx',
+            'report'),
+]

--- a/tests/roots/test-build-multiple-latex-docs/file1.rst
+++ b/tests/roots/test-build-multiple-latex-docs/file1.rst
@@ -1,0 +1,4 @@
+Testing multiple latex documents build
+======================================
+
+This is the first document.

--- a/tests/roots/test-build-multiple-latex-docs/file2.rst
+++ b/tests/roots/test-build-multiple-latex-docs/file2.rst
@@ -1,0 +1,4 @@
+Testing multiple latex documents build
+======================================
+
+This is the second document.

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -178,9 +178,25 @@ def test_latex_basic(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
+    assert r'\begin{document}' in result
+    assert r'\maketitle' in result
+    assert r'\sphinxtableofcontents' in result
     assert r'\title{The basic Sphinx documentation for testing}' in result
     assert r'\release{}' in result
     assert r'\renewcommand{\releasename}{}' in result
+
+
+@pytest.mark.sphinx('latex', testroot='basic', confoverrides={'language':'de'})
+def test_latex_shorthandoff(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'test.tex').text(encoding='utf8')
+    print(result)
+    print(status.getvalue())
+    print(warning.getvalue())
+    assert ('\\ifdefined\\shorthandoff\n'
+            '  \\ifnum\\catcode`\\=\\string=\\active\\shorthandoff{=}\\fi\n'
+            '  \\ifnum\\catcode`\\"=\\active\\shorthandoff{"}\\fi\n'
+            '\\fi\n' in result)
 
 
 @pytest.mark.sphinx('latex', testroot='latex-title')

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -122,6 +122,14 @@ def test_build_latex_doc(app, status, warning, engine, docclass):
     compile_latex_document(app)
 
 
+@pytest.mark.sphinx('latex', testroot='build-multiple-latex-docs')
+def test_build_multiple_latex_docs(app, status, warning):
+    app.builder.build_all()
+
+    assert (app.outdir / 'file1.tex').isfile()
+    assert (app.outdir / 'file2.tex').isfile()
+
+
 @pytest.mark.sphinx('latex')
 def test_writer(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
In order to be able to have custom templates for latex that have content at the beginning of the document, we need to have it in the template, and not in the code. 