### PR TITLE
#3996 adjust setuptools doc

### DIFF
--- a/doc/setuptools.rst
+++ b/doc/setuptools.rst
@@ -32,8 +32,15 @@ For instance, from ``setup.py``::
             'build_sphinx': {
                 'project': ('setup.py', name),
                 'version': ('setup.py', version),
-                'release': ('setup.py', release)}},
+                'release': ('setup.py', release),
+                'source_dir': ('setup.py', 'doc')}},
     )
+
+.. note::
+
+    If you set Sphinx options directly in the ``setup()`` command, replace
+    hyphens in variable names with underscores. In the example above,
+    ``source-dir`` becomes ``source_dir``.
 
 Or add this section in ``setup.cfg``::
 
@@ -41,6 +48,7 @@ Or add this section in ``setup.cfg``::
     project = 'My project'
     version = 1.2
     release = 1.2.0
+    source-dir = 'doc'
 
 Once configured, call this by calling the relevant command on ``setup.py``::
 


### PR DESCRIPTION
Fixes #3996
Subject: add note: replace hyphen with underscore if build options set in setup() command

### Feature or Bugfix
- Doc

### Purpose
The setup() options containing a hypen (e.g. 'source-dir') not work when using them in 'command_options' in setup.py. See: http://www.sphinx-doc.org/en/stable/setuptools.html
These options work fine if they are provided as command line arguments or in a ``setup.cfg`` file.
I'll add a note to the docs that in case of providing the option directly in the setup command, one has to replace hyphens in variable names with underscores.

### Relates
- #3996
