### PR TITLE
#3987 remove alabaster-specific sidebars from sphinx-quickstart template

### DIFF
--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -114,11 +114,8 @@ html_static_path = ['{{ dot }}static']
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
     '**': [
-        'about.html',
-        'navigation.html',
         'relations.html',  # needs 'show_related': True theme option to display
         'searchbox.html',
-        'donate.html',
     ]
 }
 


### PR DESCRIPTION
Fixes #3987 

Subject: Removes alabaster-specific sidebars from sphinx-quickstart template

### Feature or Bugfix
- Bugfix

### Purpose
Removes alabaster-specific sidebars from sphinx-quickstart template.
Otherwise, changing the theme after initiating a project breaks the build.
One has to adjust ``html_sidebars`` in the config file first, to fix this.
This is a bit confusing.
With the adjusted settings, it's possible to build common themes right away. I tested with:
* ``basic``
* ``alabaster``
* ``sphinxdoc``

### Detail
#3987

