### PR TITLE
Move sphinxcontrib-websupport to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ requires = [
     'imagesize',
     'requests>=2.0.0',
     'setuptools',
-    'sphinxcontrib-websupport',
 ]
 
 extras_require = {
@@ -64,6 +63,7 @@ extras_require = {
         'typing'
     ],
     'websupport': [
+        'sphinxcontrib-websupport',
         'sqlalchemy>=0.9',
         'whoosh>=2.0',
     ],


### PR DESCRIPTION
It is an optional dependency, and used by a very small set of packages.

With Sphinx 1.6, this was split into a separate module, and modules using it had time to add `sphinxcontrib-websupport` to their requirements. With Sphinx 1.7, there is no more reason to have it as a required dependency.