### PR TITLE
copy static files beyond symlinked directories under _static directory

### DIFF
--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -77,7 +77,7 @@ def copy_asset(source, destination, excluded=lambda path: False, context=None, r
         copy_asset_file(source, destination, context, renderer)
         return
 
-    for root, dirs, files in walk(source):
+    for root, dirs, files in walk(source, followlinks=True):
         reldir = relative_path(source, root)
         for dir in dirs[:]:
             if excluded(posixpath.join(reldir, dir)):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- copy static files beyond symlinked directories under _static directory

### Detail
- If you have `foo/` directory somewhere and it is symlinked from `_static/foo`, `foo` directory has never copied into `build/html/_static` directory.
- This behavior has been changed since #2744 (release-1.5)


