### PR TITLE
Tweak latexpdf Makefile for win

### DIFF
--- a/sphinx/texinputs_win/Makefile_t
+++ b/sphinx/texinputs_win/Makefile_t
@@ -27,14 +27,14 @@ all-dvi: $(ALLDVI)
 all-ps: $(ALLPS)
 
 all-pdf-ja:
-	for f in *.pdf *.png *.gif *.jpg *.jpeg; do extractbb $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	-for f in *.idx; do mendex -U -f -d "`basename $$f .idx`.dic" -s python.ist $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.dvi; do dvipdfmx $$f; done
+	for %%f in (*.pdf *.png *.gif *.jpg *.jpeg) do extractbb %%f)
+	for %%f in (*.tex) do (platex -kanji=utf8 $(LATEXOPTS) %%f)
+	for %%f in (*.tex) do (platex -kanji=utf8 $(LATEXOPTS) %%f)
+	for %%f in (*.tex) do (platex -kanji=utf8 $(LATEXOPTS) %%f)
+	-for %%f in (*.idx) do (mendex -U -f -d "%%~nf.dic" -s python.ist %%f)
+	for %%f in (*.tex) do (platex -kanji=utf8 $(LATEXOPTS) %%f)
+	for %%f in (*.tex) do (platex -kanji=utf8 $(LATEXOPTS) %%f)
+	for %%f in (*.dvi) do (dvipdfmx %%f)
 
 zip: all-$(FMT)
 	mkdir $(ARCHIVEPREFIX)docs-$(FMT)
@@ -79,7 +79,7 @@ xz: tar
 	dvips '$<'
 
 clean:
-	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI)
+	del *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ps *.tar *.tar.gz *.tar.bz2 *.tar.xz $(ALLPDF) $(ALLDVI) 2> NUL
 
 .PHONY: all all-pdf all-dvi all-ps clean zip tar gz bz2 xz
 .PHONY: all-pdf-ja


### PR DESCRIPTION
Bugfix

Current sphinx doesn't work fine with using mingw-make because it emmit "for in syntax is wrong".
If you are using GoW (Gnu on WIndows)'s make command, it works well because it supports unix `for` syntax in Makefile.

### Purpose
- This change makes `make latexpdf` works well with using cmd.exe native `for` command without GoW.

### note
- This also works fine on Windows PowerShell.
- If this change is applied, I don't know what happen with using GoW make

### log after applied this PR
```
(v) C:\Users\taka\sphinx-try\doc>make latexpdf
Running Sphinx v1.6.3
loading translations [ja]... done
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [latex]: all documents
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
processing p.tex...index
resolving references...
writing... done
copying TeX support files...
done
build succeeded.
for %%f in (*.pdf *.png *.gif *.jpg *.jpeg) do extractbb %%f)

extractbb:warning: Can't find file (p.pdf)), or it is forbidden to read ...skipping

for %%f in (*.tex) do (platex -kanji=utf8  %%f)
This is e-pTeX, Version 3.14159265-p3.7.1-161114-2.6 (utf8.sjis) (TeX Live 2017/W32TeX) (preloaded format=platex)
 restricted \write18 enabled.
entering extended mode
(./p.tex(guessed encoding: UTF-8 = utf8)
pLaTeX2e <2017/05/05> (based on LaTeX2e <2017-04-15>)
Babel <3.10> and hyphenation patterns for 84 language(s) loaded.(./sphinxmanual.cls
Document Class: sphinxmanual 2017/03/26 v1.6 Document class (Sphinx manual)
----------(snip)---------
Writing index file p.idx
(./p.aux(guessed encoding: UTF-8 = utf8)) (c:/Develop/texlive/2017/texmf-dist/tex/latex/base/ts1cmr.fd)
(I search kanjifont definition file: . . )
*geometry* detected driver: dvipdfm
(c:/Develop/texlive/2017/texmf-dist/tex/latex/hyperref/nameref.sty
(c:/Develop/texlive/2017/texmf-dist/tex/generic/oberdiek/gettitlestring.sty))
(./p.out) (./p.out)
(c:/Develop/texlive/2017/texmf-dist/tex/latex/psnfss/t1phv.fd)
----------(snip)---------
for %%f in (*.idx) do (mendex -U -f -d "%%~nf.dic" -s python.ist %%f)
This is mendex version 2.6f [14-Aug-2009] (utf8.uptex) (TeX Live 2017/W32TeX).
Warning: Couldn't find dictionary file p.dic.
Scanning input file p.idx....done (0 entries accepted, 0 rejected).
0 entries accepted, 0 rejected.
Nothing written in output file.
make: [all-pdf-ja] エラー 255 (無視されました)
----------(snip)---------
```