### PR TITLE
Update tutorial.rst

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -153,9 +153,9 @@ very general sense) in any :dfn:`domain`.  A domain is a collection of object
 types that belong together, complete with markup to create and reference
 descriptions of these objects.
 
-The most prominent domain is the Python domain.  To e.g. document the Python
-built-in function ``enumerate()``, you would add this to one of your source
-files::
+The most prominent domain is the Python domain. For example, to document
+Python's built-in function ``enumerate()``, you would add this to one of your
+source files::
 
    .. py:function:: enumerate(sequence[, start=0])
 


### PR DESCRIPTION
Subject: Fixed grammatical syntax errors and cleared up phrasing in `doc/tutorial.rst`

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- The document's use of "To e.g." may not be parseable by all humans.

### Detail
- I've switched to the more standard form of "For example, to"
- I've also done some optimization, as genitives parse much quicker than article chaining.

### Relates
- https://github.com/sphinx-doc/sphinx/blob/master/doc/tutorial.rst

