### PR TITLE
Clarify error message when any role has more than one target.

### DIFF
--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -134,7 +134,8 @@ class ReferencesResolver(SphinxTransform):
         if not results:
             return None
         if len(results) > 1:
-            nice_results = ' or '.join(':%s:' % r[0] for r in results)
+            nice_results = ' or '.join(':%s:`%s`' % (name, role["reftitle"])
+                                       for name, role in results)
             logger.warning(__('more than one target found for \'any\' cross-'
                               'reference %r: could be %s'), target, nice_results,
                            location=node)


### PR DESCRIPTION
Subject: Clarify error message when any role has more than one target, by including the full names of the candidate targets.

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
(see subject)

### Detail
Instead of

    WARNING: more than one target found for 'any' cross-reference 'Foo': could be :py:class: or :py:function:

clarify the ambiguous candidate targets:

    WARNING: more than one target found for 'any' cross-reference 'Foo': could be :py:class:`qualified.name.Foo` or :py:function:`other.name.Foo`

### Relates
N/A

