### PR TITLE
nature: Fix macOS Safari scrollbar color

### DIFF
--- a/sphinx/themes/nature/static/nature.css_t
+++ b/sphinx/themes/nature/static/nature.css_t
@@ -16,7 +16,7 @@
 body {
     font-family: Arial, sans-serif;
     font-size: 100%;
-    background-color: #111;
+    background-color: #fff;
     color: #555;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Subject: nature: Fix macOS Safari scrollbar color

### Feature or Bugfix
- Bugfix

### Purpose
See subject.

### Detail
macOS scrollbars overlap the contents, and the color is either black or white, depending on the color of the body. Therefore having a black body causes the scrollbar to appear white, and since the theme itself is light, the scrollbar is barely visible. Fix this by setting body to have a white background-color, matching the visible color coming from div.body.

Before:

![Before](https://user-images.githubusercontent.com/816232/29745811-4c1e8156-8abd-11e7-86ae-9941e568aed5.png)

After:

![After](https://user-images.githubusercontent.com/816232/29745825-69ad128c-8abd-11e7-94a2-e7d654141921.png)

(Look in the top right corner)

### Relates
N/A
