### PR TITLE
Fix #4006: Fix crash on parallel build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * Missing ``texinputs_win/Makefile`` to be used in latexpdf builder on windows.
 * #4026: nature: Fix macOS Safari scrollbar color
 * #3877: Fix for C++ multiline signatures.
+* #4006: Fix crash on parallel build
 
 Testing
 --------

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -122,6 +122,7 @@ class ParallelTasks(object):
                     logger.handle(log)
                 self._result_funcs.pop(tid)(self._args.pop(tid), result)
                 self._procs[tid].join()
+                self._precvs.pop(tid)
                 self._pworking -= 1
                 break
         else:


### PR DESCRIPTION
refs: #4006.

This tries to fix `sphinx/util/parallel.py`. So careful review is needed.
@shimizukawa could you review this?