### PR TITLE
Fix #4027: use rawsource in autosectionlabel extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   matrix:
     - DOCUTILS=0.12
     - DOCUTILS=0.13.1
+    - DOCUTILS=0.14
 matrix:
   exclude:
     - python: "3.4"

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ Incompatible changes
 * #3962: sphinx-apidoc now recognizes given directory as an implicit namespace
   package when ``--implicit-namespaces`` option given, not subdirectories of
   given directory.
+* #4027: sphinx.ext.autosectionlabel now expects labels to be the same as they
+  are in the raw source; no smart quotes, nothig fancy.
 
 Deprecated
 ----------

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -23,9 +23,10 @@ def register_sections_as_label(app, document):
         labelid = node['ids'][0]
         docname = app.env.docname
         if app.config.autosectionlabel_prefix_document:
-            name = nodes.fully_normalize_name(docname + ':' + node[0].astext())
+            name = nodes.fully_normalize_name(
+                docname + ':' + node[0].rawsource)
         else:
-            name = nodes.fully_normalize_name(node[0].astext())
+            name = nodes.fully_normalize_name(node[0].rawsource)
         sectname = clean_astext(node[0])
 
         if name in labels:

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -22,11 +22,11 @@ def register_sections_as_label(app, document):
     for node in document.traverse(nodes.section):
         labelid = node['ids'][0]
         docname = app.env.docname
+        ref_name = getattr(node[0], 'rawsource', node[0].astext())
         if app.config.autosectionlabel_prefix_document:
-            name = nodes.fully_normalize_name(
-                docname + ':' + node[0].rawsource)
+            name = nodes.fully_normalize_name(docname + ':' + ref_name)
         else:
-            name = nodes.fully_normalize_name(node[0].rawsource)
+            name = nodes.fully_normalize_name(ref_name)
         sectname = clean_astext(node[0])
 
         if name in labels:

--- a/tests/roots/test-ext-autosectionlabel-prefix-document/index.rst
+++ b/tests/roots/test-ext-autosectionlabel-prefix-document/index.rst
@@ -15,6 +15,9 @@ For Windows users
 For UNIX users
 --------------
 
+This one's got an apostrophe
+----------------------------
+
 
 References
 ==========
@@ -23,3 +26,4 @@ References
 * :ref:`index:Installation`
 * :ref:`index:For Windows users`
 * :ref:`index:For UNIX users`
+* :ref:`index:This one's got an apostrophe`

--- a/tests/roots/test-ext-autosectionlabel/index.rst
+++ b/tests/roots/test-ext-autosectionlabel/index.rst
@@ -15,6 +15,9 @@ For Windows users
 For UNIX users
 --------------
 
+This one's got an apostrophe
+----------------------------
+
 
 References
 ==========
@@ -23,3 +26,4 @@ References
 * :ref:`Installation`
 * :ref:`For Windows users`
 * :ref:`For UNIX users`
+* :ref:`This one's got an apostrophe`

--- a/tests/test_ext_autosectionlabel.py
+++ b/tests/test_ext_autosectionlabel.py
@@ -35,6 +35,12 @@ def test_autosectionlabel_html(app, status, warning):
             '<span class="std std-ref">For UNIX users</span></a></li>')
     assert re.search(html, content, re.S)
 
+    html = ('<li><a class="reference internal" '
+            'href="#this-one-s-got-an-apostrophe">'
+            '<span class="std std-ref">This one’s got an apostrophe'
+            '</span></a></li>')
+    assert re.search(html, content, re.S)
+
 
 # Re-use test definition from above, just change the test root directory
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel-prefix-document')

--- a/tests/test_ext_autosectionlabel.py
+++ b/tests/test_ext_autosectionlabel.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-import os
 import re
 
 import pytest

--- a/tests/test_ext_autosectionlabel.py
+++ b/tests/test_ext_autosectionlabel.py
@@ -37,19 +37,15 @@ def test_autosectionlabel_html(app, status, warning):
     assert re.search(html, content, re.S)
 
 
-@pytest.mark.skipif(
-    os.environ.get('DOCUTILS', None) not in ('0.13.1', '0.14'),
-    reason='Requires docutils >= 0.13.1',
-)
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel')
 def test_autosectionlabel_html_apostrophe(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').text()
-    html = ('<li><a class="reference internal" '
-            'href="#this-one-s-got-an-apostrophe">'
-            '<span class="std std-ref">This one’s got an apostrophe'
-            '</span></a></li>')
+    html = (u'<li><a class="reference internal" '
+            u'href="#this-one-s-got-an-apostrophe">'
+            u'<span class="std std-ref">This one’s got an apostrophe'
+            u'</span></a></li>')
     assert re.search(html, content, re.S)
 
 
@@ -60,10 +56,6 @@ def test_autosectionlabel_prefix_document_html(app, status, warning):
 
 
 # Re-use test definition from above, just change the test root directory
-@pytest.mark.skipif(
-    os.environ.get('DOCUTILS', None) not in ('0.13.1', '0.14'),
-    reason='Requires docutils >= 0.13.1',
-)
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel-prefix-document')
 def test_autosectionlabel_prefix_document_html_apostrophe(app, status, warning):
     return test_autosectionlabel_html_apostrophe(app, status, warning)

--- a/tests/test_ext_autosectionlabel.py
+++ b/tests/test_ext_autosectionlabel.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import os
 import re
 
 import pytest
@@ -35,6 +36,16 @@ def test_autosectionlabel_html(app, status, warning):
             '<span class="std std-ref">For UNIX users</span></a></li>')
     assert re.search(html, content, re.S)
 
+
+@pytest.mark.skipif(
+    os.environ.get('DOCUTILS', None) not in ('0.13.1', '0.14'),
+    reason='Requires docutils >= 0.13.1',
+)
+@pytest.mark.sphinx('html', testroot='ext-autosectionlabel')
+def test_autosectionlabel_html_apostrophe(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'index.html').text()
     html = ('<li><a class="reference internal" '
             'href="#this-one-s-got-an-apostrophe">'
             '<span class="std std-ref">This one’s got an apostrophe'
@@ -46,3 +57,13 @@ def test_autosectionlabel_html(app, status, warning):
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel-prefix-document')
 def test_autosectionlabel_prefix_document_html(app, status, warning):
     return test_autosectionlabel_html(app, status, warning)
+
+
+# Re-use test definition from above, just change the test root directory
+@pytest.mark.skipif(
+    os.environ.get('DOCUTILS', None) not in ('0.13.1', '0.14'),
+    reason='Requires docutils >= 0.13.1',
+)
+@pytest.mark.sphinx('html', testroot='ext-autosectionlabel-prefix-document')
+def test_autosectionlabel_prefix_document_html_apostrophe(app, status, warning):
+    return test_autosectionlabel_html_apostrophe(app, status, warning)


### PR DESCRIPTION
Subject: use rawsource in autosectionlabel extension

Fixes #4027

Feature or Bugfix

Feature, probably?

*Purpose*

See related issue.

Can this break anything? Any existing autosectionlabel `ref`s that use smartquotes that arent' present in the rawsource already.

*Relates*

#4027
