### PR TITLE
Small fix when type of string is bytes instead of string

### DIFF
--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -161,6 +161,8 @@ class InventoryFile(object):
         # type: (unicode, BuildEnvironment, Builder) -> None
         def escape(string):
             # type: (unicode) -> unicode
+            if type(string) == bytes:
+                string = string.decode("utf-8")
             return re.sub("\\s+", " ", string)
 
         with open(os.path.join(filename), 'wb') as f:


### PR DESCRIPTION
Subject: Small fix in the escape function (when string type is bytes and not string)

### Feature or Bugfix
- Bugfix

### Purpose
- Small fix on the `escape` conversion function

### Detail
- I was unable to compile scipy lecture notes using Python3 and I had to fix this specific function.

### Relates
