### PR TITLE
Napoleon now links property and attribute types

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -392,14 +392,14 @@ class GoogleDocstring(UnicodeMixin):
                 if '`' in _type:
                     field = '**%s** (%s)%s' % (_name, _type, separator)  # type: unicode
                 else:
-                    field = '**%s** (*%s*)%s' % (_name, _type, separator)
+                    field = '**%s** (:class:`%s`)%s' % (_name, _type, separator)
             else:
                 field = '**%s**%s' % (_name, separator)
         elif _type:
             if '`' in _type:
                 field = '%s%s' % (_type, separator)
             else:
-                field = '*%s*%s' % (_type, separator)
+                field = ':class:`%s`%s' % (_type, separator)
         else:
             field = ''
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Currently Napoleon does not link types when separated out from a property or attribute field. This adds the linking.

### Relates
#2979

