### PR TITLE
Properties can have types documented with :type:

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -553,7 +553,10 @@ class GoogleDocstring(UnicodeMixin):
     def _parse_attribute_docstring(self):
         # type: () -> List[unicode]
         _type, _desc = self._consume_inline_attribute()
-        return self._format_field('', _type, _desc)
+        lines = self._format_field('', '', _desc)
+        if _type:
+            lines.extend(['', ':type: %s' % _type])
+        return lines
 
     def _parse_attributes_section(self, section):
         # type: (unicode) -> List[unicode]
@@ -566,8 +569,11 @@ class GoogleDocstring(UnicodeMixin):
                     lines.append(':vartype %s: %s' % (_name, _type))
             else:
                 lines.extend(['.. attribute:: ' + _name, ''])
-                fields = self._format_field('', _type, _desc)
+                fields = self._format_field('', '', _desc)
                 lines.extend(self._indent(fields, 3))
+                if _type:
+                    lines.append('')
+                    lines.extend(self._indent([':type: %s' % _type], 3))
                 lines.append('')
         if self._config.napoleon_use_ivar:
             lines.append('')

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -288,6 +288,12 @@ class DocFieldTransformer(object):
                 fieldtype, fieldarg = fieldname.astext(), ''
             typedesc, is_typefield = typemap.get(fieldtype, (None, None))
 
+            # collect the content, trying not to keep unnecessary paragraphs
+            if _is_single_paragraph(fieldbody):
+                content = fieldbody.children[0].children
+            else:
+                content = fieldbody.children
+
             # sort out unknown fields
             if typedesc is None or typedesc.has_arg != bool(fieldarg):
                 # either the field name is unknown, or the argument doesn't
@@ -297,15 +303,26 @@ class DocFieldTransformer(object):
                     new_fieldname += ' ' + fieldarg
                 fieldname[0] = nodes.Text(new_fieldname)
                 entries.append(field)
+
+                # but if this has a type then we can at least link it
+                if typedesc and is_typefield and content:
+                    target = content[0].astext()
+                    xrefs = typedesc.make_xrefs(
+                        typedesc.typerolename,
+                        self.directive.domain,
+                        target,
+                        contnode=content[0],
+                    )
+                    if _is_single_paragraph(fieldbody):
+                        fieldbody.children[0].clear()
+                        fieldbody.children[0].extend(xrefs)
+                    else:
+                        fieldbody.clear()
+                        fieldbody.extend(xrefs)
+
                 continue
 
             typename = typedesc.name
-
-            # collect the content, trying not to keep unnecessary paragraphs
-            if _is_single_paragraph(fieldbody):
-                content = fieldbody.children[0].children
-            else:
-                content = fieldbody.children
 
             # if the field specifies a type, put it in the types collection
             if is_typefield:

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -58,15 +58,21 @@ Sample namedtuple subclass
 
 .. attribute:: attr1
 
-   *Arbitrary type* -- Quick description of attr1
+   Quick description of attr1
+
+   :type: Arbitrary type
 
 .. attribute:: attr2
 
-   *Another arbitrary type* -- Quick description of attr2
+   Quick description of attr2
+
+   :type: Another arbitrary type
 
 .. attribute:: attr3
 
-   *Type* -- Adds a newline after the type
+   Adds a newline after the type
+
+   :type: Type
 """
 
         self.assertEqual(expected, actual)
@@ -323,7 +329,9 @@ Attributes:
         expected = """\
 .. attribute:: in_attr
 
-   :class:`numpy.ndarray` -- super-dooper attribute
+   super-dooper attribute
+
+   :type: :class:`numpy.ndarray`
 """
         self.assertEqual(expected, actual)
 
@@ -336,7 +344,9 @@ Attributes:
         expected = """\
 .. attribute:: in_attr
 
-   *numpy.ndarray* -- super-dooper attribute
+   super-dooper attribute
+
+   :type: numpy.ndarray
 """
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Currently the type's of properties cannot be linked in either rst or in napoleon. This adds the ability for properties (and attributes) to document their type with `:type:`.

### Detail
- This is a little hacky. Because `:type:` is already part of an existing field, this doesn't define `:type:` on its own as a domain directive. Instead, any type fields always link the given type properly. So `:type:` is identified as having no arguments, is capitalised, and the type linked.

### Relates
- #2979

