### PR TITLE
Turn any environment unpickling error into IOError

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -110,7 +110,12 @@ class BuildEnvironment(object):
     @staticmethod
     def load(f, app=None):
         # type: (IO, Sphinx) -> BuildEnvironment
-        env = pickle.load(f)
+        try:
+            env = pickle.load(f)
+        except Exception as exc:
+            # This can happen for example when the pickle is from a
+            # different version of Sphinx.
+            raise IOError(exc)
         if env.version != ENV_VERSION:
             raise IOError('build environment version not current')
         if app:


### PR DESCRIPTION
Subject: allow graceful upgrading Sphinx-1.5 -> Sphinx-1.6

### Feature or Bugfix
- Bugfix

### Purpose
The scenario is:
1. build some docs with Sphinx-1.5
2. upgrade to Sphinx-1.6
3. rebuild the same docs

This gives:
```
Traceback (most recent call last):
[...]
  File "/usr/local/src/sage-config/local/lib/python2.7/site-packages/sphinx/environment/__init__.py", line 112, in load
    env = pickle.load(f)
AttributeError: 'module' object has no attribute 'WarningStream'
```

A simple solution is: wrap the `pickle.load(f)` call in `try`/`except` and change any exception to `IOError`. That `IOError` is then caught higher up, which allows the documentation to build with a message like
```
loading pickled environment... failed: 'module' object has no attribute 'WarningStream'
```

More generally, this pickle is not crucial to building the documentation. Therefore, it should not be a hard error if this pickle is somehow corrupted.