### PR TITLE
Add support for docutils 0.14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,15 +6,15 @@ environment:
 
   matrix:
     - PYTHON: 27
-      DOCUTILS: 0.12
+      DOCUTILS: 0.13.1
       TEST_IGNORE: --ignore py35
     - PYTHON: 27
-      DOCUTILS: 0.13.1
+      DOCUTILS: 0.14
       TEST_IGNORE: --ignore py35
     - PYTHON: 36
-      DOCUTILS: 0.13.1
+      DOCUTILS: 0.14
     - PYTHON: 36-x64
-      DOCUTILS: 0.13.1
+      DOCUTILS: 0.14
 
 install:
   - C:\Python%PYTHON%\python.exe -m pip install -U pip setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,20 @@ env:
     - PYTHONWARNINGS=all
     - SKIP_LATEX_BUILD=1
   matrix:
-    - DOCUTILS=0.12
     - DOCUTILS=0.13.1
+    - DOCUTILS=0.14
 matrix:
   exclude:
     - python: "3.4"
-      env: DOCUTILS=0.12
+      env: DOCUTILS=0.13.1
     - python: "3.5"
-      env: DOCUTILS=0.12
+      env: DOCUTILS=0.13.1
     - python: "3.6"
-      env: DOCUTILS=0.12
+      env: DOCUTILS=0.13.1
     - python: nightly
-      env: DOCUTILS=0.12
+      env: DOCUTILS=0.13.1
     - python: "pypy-5.4.1"
-      env: DOCUTILS=0.12
+      env: DOCUTILS=0.13.1
 addons:
   apt:
     packages:

--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,8 @@ Bugs fixed
 Testing
 --------
 
+* Add support for docutils 0.14
+
 Release 1.6.4 (in development)
 ==============================
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=flake8,py27,py34,py35,py36,pypy,du13,du12,du11
+envlist=flake8,py27,py34,py35,py36,pypy,du14,du13,du12,du11
 
 [testenv]
 passenv = https_proxy http_proxy no_proxy
@@ -35,6 +35,11 @@ deps=
 [testenv:du13]
 deps=
     docutils==0.13.1
+    {[testenv]deps}
+
+[testenv:du14]
+deps=
+    docutils==0.14
     {[testenv]deps}
 
 [testenv:flake8]


### PR DESCRIPTION
Subject: Add docutils 0.14 to test matrix

### Feature or Bugfix
- Testing

### Purpose
- Add docutils 0.14 to CI test matrix as docutils 0.14 is just out.

### Relates
- http://docutils.sourceforge.net/RELEASE-NOTES.html#release-0-14-2017-08-03
- https://github.com/sphinx-doc/sphinx/pull/3217#discussion_r91833953
  - the latest two versions are to be used for CI tests on Travis CI (except tox.ini)