### PR TITLE
Sort before highlighting module code

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -146,7 +146,7 @@ def collect_pages(app):
 #    app.builder.info(' (%d module code pages)' %
 #                     len(env._viewcode_modules), nonl=1)
 
-    for modname, entry in status_iterator(iteritems(env._viewcode_modules),  # type: ignore
+    for modname, entry in status_iterator(sorted(iteritems(env._viewcode_modules)),  # type: ignore
                                           'highlighting module code... ', "blue",
                                           len(env._viewcode_modules),  # type: ignore
                                           app.verbosity, lambda x: x[0]):

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -146,10 +146,11 @@ def collect_pages(app):
 #    app.builder.info(' (%d module code pages)' %
 #                     len(env._viewcode_modules), nonl=1)
 
-    for modname, entry in status_iterator(sorted(iteritems(env._viewcode_modules)),  # type: ignore
-                                          'highlighting module code... ', "blue",
-                                          len(env._viewcode_modules),  # type: ignore
-                                          app.verbosity, lambda x: x[0]):
+    for modname, entry in status_iterator(
+            sorted(iteritems(env._viewcode_modules)),  # type: ignore
+            'highlighting module code... ', "blue",
+            len(env._viewcode_modules),  # type: ignore
+            app.verbosity, lambda x: x[0]):
         if not entry:
             continue
         code, tags, used, refname = entry


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
With this change the output will be in a predictable order on older versions of Python (where the dictionary is not sorted by default).

This is helpful for debugging and interpreting the progress from the terminal.

### Details
Example of unsorted output using Sphinx under Python 2.7 (under TravisCI where the full logging is captured):

https://travis-ci.org/peterjc/biopython/jobs/274609984

```
...
generating indices... genindex py-modindex
highlighting module code... [  0%] Bio.HMM.Utilities
highlighting module code... [  0%] Bio.SeqFeature
highlighting module code... [  1%] BioSQL.BioSeq
highlighting module code... [  1%] Bio.GA.Crossover.General
highlighting module code... [  1%] Bio.GA.Selection.RouletteWheel
highlighting module code... [  2%] Bio.Geo
...
```

### Relates
I did not open an issue on this.
