### PR TITLE
Fix ext.graphviz alignment.

### DIFF
--- a/tests/roots/test-ext-graphviz/index.rst
+++ b/tests/roots/test-ext-graphviz/index.rst
@@ -25,3 +25,8 @@ Hello |graph| graphviz world
    :caption: on right
 
    foo -> bar
+
+.. digraph:: foo
+   :align: center
+
+   centered

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -16,7 +16,7 @@ import pytest
 
 @pytest.mark.sphinx('html', testroot='ext-graphviz')
 @pytest.mark.usefixtures('if_graphviz_found')
-def test_graphviz_html(app, status, warning):
+def test_graphviz_png_html(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').text()
@@ -34,6 +34,51 @@ def test_graphviz_html(app, status, warning):
             r'<span class="caption-text">on right</span>.*</p>\s*</div>')
     assert re.search(html, content, re.S)
 
+    html = (r'<div align=\"center\" class=\"align-center\">'
+            r'<img src=\".*\.png\" alt=\"digraph foo {\n'
+            r'centered\n'
+            r'}\" />\n</div>')
+    assert re.search(html, content, re.S)
+
+@pytest.mark.sphinx('html', testroot='ext-graphviz',
+                    confoverrides={'graphviz_output_format': 'svg'})
+@pytest.mark.usefixtures('if_graphviz_found')
+def test_graphviz_svg_html(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'index.html').text()
+
+    html = (r'<div class=\"figure\" .*?>\n'
+            r'<object data=\".*\.svg\".*>\n'
+            r'\s+<p class=\"warning\">digraph foo {\n'
+            r'bar -&gt; baz\n'
+            r'}</p></object>\n'
+            r'<p class=\"caption\"><span class=\"caption-text\">'
+            r'caption of graph</span>.*</p>\n</div>')
+    assert re.search(html, content, re.S)
+
+    html = (r'Hello <object.*>\n'
+            r'\s+<p class=\"warning\">graph</p></object>\n'
+            r' graphviz world')
+    assert re.search(html, content, re.S)
+
+    html = (r'<div class=\"figure align-right\" .*\>\n'
+            r'<object data=\".*\.svg\".*>\n'
+            r'\s+<p class=\"warning\">digraph bar {\n'
+            r'foo -&gt; bar\n'
+            r'}</p></object>\n'
+            r'<p class=\"caption\"><span class=\"caption-text\">'
+            r'on right</span>.*</p>\n'
+            r'</div>')
+    assert re.search(html, content, re.S)
+
+    html = (r'<div align=\"center\" class=\"align-center\">'
+            r'<object data=\".*\.svg\".*>\n'
+            r'\s+<p class=\"warning\">digraph foo {\n'
+            r'centered\n'
+            r'}</p></object>\n'
+            r'</div>')
+    assert re.search(html, content, re.S)
 
 @pytest.mark.sphinx('latex', testroot='ext-graphviz')
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -52,6 +97,11 @@ def test_graphviz_latex(app, status, warning):
     macro = ('\\\\begin{wrapfigure}{r}{0pt}\n\\\\centering\n'
              '\\\\includegraphics{graphviz-\\w+.pdf}\n'
              '\\\\caption{on right}\\\\label{.*}\\\\end{wrapfigure}')
+    assert re.search(macro, content, re.S)
+
+    macro = (r'\{\\hfill'
+             r'\\includegraphics{graphviz-.*}'
+             r'\\hspace\*{\\fill}}')
     assert re.search(macro, content, re.S)
 
 


### PR DESCRIPTION
Subject: Fix ext.graphviz Alignment.

### Feature or Bugfix
- Bugfix

### Purpose
- Fix the implementation of the `:align:` option to the graphviz directives.

### Detail
- Implement the `:align:` option for html output when `graphviz_output_format = 'svg'`.
- Implement `:align: center` for latex output.

### Relates
- Closes #4032
