### PR TITLE
hashlib.sha1() must take bytes, not unicode on Python 3

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -70,7 +70,7 @@ class ImageDownloader(BaseImageConverter):
         if '?' in basename:
             basename = basename.split('?')[0]
         if basename == '':
-            basename = sha1(node['uri']).hexdigest()
+            basename = sha1(node['uri'].encode("utf-8")).hexdigest()
         dirname = node['uri'].replace('://', '/').translate({ord("?"): u"/",
                                                              ord("&"): u"/"})
         ensuredir(os.path.join(self.imagedir, dirname))


### PR DESCRIPTION
Subject: hashlib.sha1() must take bytes, not unicode on Python 3

### Feature or Bugfix
- Bugfix

### Purpose
- On Python 3, hashlib.sha1() *must* take bytes, and will error out if given unicode

### Detail
- Zulip documentation build broke due to this bug in Sphinx, when building the docs in using
  a Python 3 environment.

### Relates
- https://readthedocs.org/projects/zulip/builds/5869718/