### PR TITLE
Avoiding indent after index entries in latex

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2006,6 +2006,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.body.append(r'\index{%s|see{%s}}' % (p1, p2))
                 else:
                     logger.warning('unknown index entry type %s found', type)
+                self.body.append('%\n')
             except ValueError as err:
                 logger.warning(str(err))
         raise nodes.SkipNode

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2006,9 +2006,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.body.append(r'\index{%s|see{%s}}' % (p1, p2))
                 else:
                     logger.warning('unknown index entry type %s found', type)
-                self.body.append('\\ignorespaces ')
             except ValueError as err:
                 logger.warning(str(err))
+        if not node.get('inline', True):
+            self.body.append('\\ignorespaces ')
         raise nodes.SkipNode
 
     def visit_raw(self, node):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2006,7 +2006,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.body.append(r'\index{%s|see{%s}}' % (p1, p2))
                 else:
                     logger.warning('unknown index entry type %s found', type)
-                self.body.append('%\n')
+                self.body.append('\\ignorespaces ')
             except ValueError as err:
                 logger.warning(str(err))
         raise nodes.SkipNode

--- a/tests/roots/test-latex-index/conf.py
+++ b/tests/roots/test-latex-index/conf.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'

--- a/tests/roots/test-latex-index/index.rst
+++ b/tests/roots/test-latex-index/index.rst
@@ -1,0 +1,12 @@
+test-latex-index
+================
+
+A :index:`famous` :index:`equation`:
+
+.. math::
+
+   E = m c^2
+
+.. index:: Einstein, relativity
+
+and some text.

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1020,3 +1020,12 @@ def test_latex_remote_images(app, status, warning):
     assert '\\sphinxincludegraphics{{NOT_EXIST}.PNG}' not in result
     assert ('WARNING: Could not fetch remote image: '
             'http://example.com/NOT_EXIST.PNG [404]' in warning.getvalue())
+
+
+@pytest.mark.sphinx('latex', testroot='latex-index')
+def test_latex_index(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'Python.tex').text(encoding='utf8')
+    assert 'A \\index{famous}famous \\index{equation}equation:\n' in result
+    assert '\n\\index{Einstein}\\index{relativity}\\ignorespaces \nand' in result


### PR DESCRIPTION

Subject: Remove unnecessary indent after an index entry in latex

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

When index entries are added in the middle of a paragraph but not inline, for example between a math equation and following text like here:

```
\end{equation}
\index{domain}\index{feasible set}
and we call \eqref{equation:linear:eq-lo-lo1} an 
```

then the first word (in this case *and*) is preceded in pdf by a small indent of the size of roughly one space.

### Detail

This fix solves the problem; for instance the above is typeset as

```
\end{equation}
\index{domain}%
\index{feasible set}%

and we call \eqref{equation:linear:eq-lo-lo1} an 
```

Now the *and* is aligned to the left as it should be.

### Relates
- <URL or Ticket>

