### PR TITLE
Return non-zero exit status when make subprocess fails

### DIFF
--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 import sys
+import subprocess
 from os import path
 
 import sphinx
@@ -196,16 +197,14 @@ class Make(object):
         if self.run_generic_build('latex') > 0:
             return 1
         with cd(self.builddir_join('latex')):
-            os.system('%s all-pdf' % self.makecmd)
-        return 0
+            return subprocess.call([self.makecmd, 'all-pdf'])
 
     def build_latexpdfja(self):
         # type: () -> int
         if self.run_generic_build('latex') > 0:
             return 1
         with cd(self.builddir_join('latex')):
-            os.system('%s all-pdf-ja' % self.makecmd)
-        return 0
+            return subprocess.call([self.makecmd, 'all-pdf-ja'])
 
     def build_text(self):
         # type: () -> int
@@ -231,8 +230,7 @@ class Make(object):
         if self.run_generic_build('texinfo') > 0:
             return 1
         with cd(self.builddir_join('texinfo')):
-            os.system('%s info' % self.makecmd)
-        return 0
+            return subprocess.call([self.makecmd, 'info'])
 
     def build_gettext(self):
         # type: () -> int


### PR DESCRIPTION
As reported in https://bugs.debian.org/876048:

If latexmk is not installed, then make subprocess returns non-zero exit status, but sphinx-build (in make mode) still returns 0. This makes it difficult for build systems to detect failures.
```
$ sphinx-build -M latexpdf policy policy/_build
Running Sphinx v1.6.3
[...]
build succeeded.
latexmk -pdf -dvi- -ps-  'policy.tex'
make: latexmk: Command not found
Makefile:33: recipe for target 'policy.pdf' failed
make: *** [policy.pdf] Error 127
$ echo $?
0
```

This pull requests makes sphinx-build return the exit status from its child process.
Also it changes `os.system` to `subprocess.call` to avoid unnecessary shell calls and improve security.