### PR TITLE
#4068: Update linkcheck docs to use requests

### DIFF
--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -423,14 +423,18 @@ instructions.
 .. class:: CheckExternalLinksBuilder
 
    This builder scans all documents for external links, tries to open them with
-   :mod:`urllib2`, and writes an overview which ones are broken and redirected
-   to standard output and to :file:`output.txt` in the output directory.
+   ``requests``, and writes an overview which ones are broken and redirected to
+   standard output and to :file:`output.txt` in the output directory.
 
    .. autoattribute:: name
 
    .. autoattribute:: format
 
    .. autoattribute:: supported_image_types
+
+   .. versionchanged:: 1.5
+
+      Since Sphinx-1.5, the linkcheck builder comes to use requests module.
 
 .. module:: sphinx.builders.xml
 .. class:: XMLBuilder


### PR DESCRIPTION
Update linkcheck docs to use requests instead of urllib2.

### Relates
- Closes #4068 
- #2389
- http://www.sphinx-doc.org/en/stable/_modules/sphinx/builders/linkcheck.html#CheckExternalLinksBuilder