### PR TITLE
New conf.py directives autodoc_exclude_members + autodoc_special_members

### DIFF
--- a/doc/ext/autodoc.rst
+++ b/doc/ext/autodoc.rst
@@ -351,6 +351,26 @@ There are also new config values that you can set:
 
    .. versionadded:: 1.7
 
+.. confval:: autodoc_special_members
+
+   This value is a default list of any members names to be specifically
+   included, for example::
+
+       autodoc_special_members = ['__init__', '__next__']
+
+   This overrides the inclusion of ``special-members`` within the
+   ``autodoc_default_flags`` configuration, which would include ALL special
+   members.
+
+   This is overridden by any ``:special-members:`` directive in the autodoc
+   directive, for example::
+
+        .. automodule:: noodle
+           :members:
+           :special-members: __init__, __next__, __eq__
+
+   .. versionadded:: 1.7
+
 .. confval:: autodoc_default_flags
 
    This value is a list of autodoc directive flags that should be automatically

--- a/doc/ext/autodoc.rst
+++ b/doc/ext/autodoc.rst
@@ -334,6 +334,23 @@ There are also new config values that you can set:
    .. versionchanged:: 1.0
       Support for ``'bysource'``.
 
+.. confval:: autodoc_exclude_members
+
+   This value is a default list of any members names to be specifically
+   excluded, for example::
+
+       autodoc_exclude_members = ['__dict__', '__weakref__']
+
+   This is overridden by any ``:exclude-members:`` directive in the autodoc
+   directive, for example::
+
+        .. automodule:: noodle
+           :members:
+           :special-members:
+           :exclude-members: __dict__, __weakref__, __hash__
+
+   .. versionadded:: 1.7
+
 .. confval:: autodoc_default_flags
 
    This value is a list of autodoc directive flags that should be automatically

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -752,9 +752,11 @@ class Documenter(object):
         members_check_module, members = self.get_object_members(want_all)
 
         # remove members given by exclude-members
-        if self.options.exclude_members:
+        exclude = self.options.exclude_members or \
+            self.env.config.autodoc_exclude_members
+        if exclude:
             members = [(membername, member) for (membername, member) in members
-                       if membername not in self.options.exclude_members]
+                       if membername not in exclude]
 
         # document non-skipped members
         memberdocumenters = []  # type: List[Tuple[Documenter, bool]]
@@ -1618,6 +1620,7 @@ def setup(app):
 
     app.add_config_value('autoclass_content', 'class', True)
     app.add_config_value('autodoc_member_order', 'alphabetic', True)
+    app.add_config_value('autodoc_exclude_members', [], True)
     app.add_config_value('autodoc_default_flags', [], True)
     app.add_config_value('autodoc_docstring_signature', True, True)
     app.add_config_value('autodoc_mock_imports', [], True)

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1557,7 +1557,7 @@ class AutoDirective(Directive):
             if flag not in doc_class.option_spec:
                 continue
             if flag in self.options:
-                logger.debug('[autodoc] ignoring %s from autodoc_default_flags, using %r value',
+                logger.debug('[autodoc] ignoring %s in autodoc_default_flags, using %r value',
                              flag, self.options[flag])
                 # If autodoc_special_members was set, or the RST file has directive set, e.g.:
                 #   :special-members: __init__, __eq__

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1552,6 +1552,14 @@ class AutoDirective(Directive):
             if flag in self.env.config.autodoc_default_flags and \
                not negated:
                 self.options[flag] = None
+
+        if self.env.config.autodoc_special_members:
+            # Using autodoc_special_members (which takes a list of methods)
+            # overrides including special-members in autodoc_default_flags
+            # (which applies the default value of None meaning ALL methods).
+            # This will be parsed again, so turn it into a comma-sep string:
+            self.options['special-members'] = ','.join(self.env.config.autodoc_special_members)
+
         # process the options with the selected documenter's option_spec
         try:
             self.genopt = Options(assemble_option_dict(
@@ -1562,6 +1570,7 @@ class AutoDirective(Directive):
                                       'has an invalid value: %s' % (self.name, err),
                                       line=self.lineno)
             return [msg]
+
         # generate the output
         documenter = doc_class(self, self.arguments[0])
         documenter.generate(more_content=self.content)
@@ -1621,6 +1630,7 @@ def setup(app):
     app.add_config_value('autoclass_content', 'class', True)
     app.add_config_value('autodoc_member_order', 'alphabetic', True)
     app.add_config_value('autodoc_exclude_members', [], True)
+    app.add_config_value('autodoc_special_members', [], True)
     app.add_config_value('autodoc_default_flags', [], True)
     app.add_config_value('autodoc_docstring_signature', True, True)
     app.add_config_value('autodoc_mock_imports', [], True)

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -752,8 +752,8 @@ class Documenter(object):
         members_check_module, members = self.get_object_members(want_all)
 
         # remove members given by exclude-members
-        exclude = self.options.exclude_members or \
-            self.env.config.autodoc_exclude_members
+        exclude = (self.options.exclude_members or
+                   self.env.config.autodoc_exclude_members)
         if exclude:
             members = [(membername, member) for (membername, member) in members
                        if membername not in exclude]


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Adds ``conf.py`` setting ``autodoc_exclude_members`` (*update*) and ``autodoc_special_members``

### Relates
- #4057 and #4075 for trying to use ``:exclude-members:`` with apidoc and autodoc. 
