### PR TITLE
setup.cfg: Ignore .venv

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ universal = 1
 [flake8]
 max-line-length = 95
 ignore = E116,E241,E251
-exclude = .git,.tox,tests/*,build/*,sphinx/search/*,sphinx/pycode/pgen2/*,doc/ext/example*.py
+exclude = .git,.tox,.venv,tests/*,build/*,sphinx/search/*,sphinx/pycode/pgen2/*,doc/ext/example*.py
 
 [build_sphinx]
 warning-is-error = 1


### PR DESCRIPTION
Subject: Add a 'pep8' target and ignore '.venv' directories

### Feature or Bugfix
- Refactor

### Purpose
- Make pep8 easier to run and more useful

### Detail
- N/A

### Relates
- N/A

