### PR TITLE
Fix grammar in exclude_patterns explanation comment

### DIFF
--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -79,7 +79,7 @@ language = {{ language | repr }}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-# This patterns also effect to html_static_path and html_extra_path
+# This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = [{{ exclude_patterns }}]
 
 # The name of the Pygments (syntax highlighting) style to use.


### PR DESCRIPTION
Subject: Fix grammar in comment explaining the `exclude_patterns` field in `conf.py`.

### Feature or Bugfix
- Bugfix

### Purpose
The comment currently explaining how to use `exclude_patterns` says:

> This patterns also effect to html_static_path and html_extra_path

This is ungrammatical; I propose a fix, based on my understanding of how the value affects other values in `conf.py`.