### PR TITLE
Hide debug print from autodoc extension

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -716,7 +716,6 @@ class Documenter(object):
                     # keep documented attributes
                     keep = True
                 isattr = True
-                print(membername, keep)
             elif want_all and membername.startswith('_'):
                 # ignore members whose name starts with _ by default
                 keep = self.options.private_members and \


### PR DESCRIPTION
In 1.6.4 I see additional strings on screen, looking like unhidden debug output.  Here is the session, please notice strings like "S True" and so on:
```
$ sphinx-build -W -b html docs build/sphinx/html
Running Sphinx v1.6.4
making output directory...
loading pickled environment... not yet created
loading intersphinx inventory from https://docs.scipy.org/doc/numpy/objects.inv...
loading intersphinx inventory from https://docs.scipy.org/doc/scipy/reference/objects.inv...
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 144 source files that are out of date
updating environment: 144 added, 0 changed, 0 removed
S True
_instances None
n True
MutableMatrix True
SparseMatrix True
O True
reading sources... [100%] tutorial/solvers
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] tutorial/solvers
generating indices... genindex py-modindex
highlighting module code... [100%] diofant.simplify.radsimp
writing additional pages... search
copying images... [100%] modules/vector/coordsys_rot.svg
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.
```

Here is the CI build of the project with this problem:
https://travis-ci.org/diofant/diofant/jobs/280133518

For 1.6.3 - I have not seen such messages, see e.g. latest merge:
https://travis-ci.org/diofant/diofant/jobs/27973245
