### PR TITLE
Make it easier to override variables in Makefiles generated by quickstart

### DIFF
--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -2,9 +2,9 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
+SPHINXOPTS   ?=
+SPHINXBUILD  ?= sphinx-build
+PAPER        ?=
 BUILDDIR      = {{ rbuilddir }}
 
 # Internal variables.


### PR DESCRIPTION
This way one can use e.g. `SPHINXBUILD=/usr/bin/sphinx-build make html` to override the default sphinx-build path.

References (but not fixes) #3965.