### PR TITLE
Cleanup the C++/Intersphinx test to avoid std namespace

### DIFF
--- a/tests/roots/test-ext-intersphinx-cppdomain/index.rst
+++ b/tests/roots/test-ext-intersphinx-cppdomain/index.rst
@@ -5,4 +5,4 @@ test-ext-intersphinx-cppdomain
 
 :cpp:class:`Bar`
 
-.. cpp:function:: std::uint8_t FooBarBaz()
+.. cpp:function:: foons::bartype FooBarBaz()

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -232,6 +232,13 @@ def test_missing_reference_cppdomain(tempdir, app, status, warning):
             ' href="https://docs.python.org/index.html#cpp_foo_bar"'
             ' title="(in foo v2.0)"><code class="xref cpp cpp-class docutils literal">'
             '<span class="pre">Bar</span></code></a>' in html)
+    assert ('<a class="reference external"'
+            ' href="https://docs.python.org/index.html#foons"'
+            ' title="(in foo v2.0)">foons</a>' in html)
+    assert ('<a class="reference external"'
+            ' href="https://docs.python.org/index.html#foons_bartype"'
+            ' title="(in foo v2.0)">bartype</a>' in html)
+
 
 
 def test_missing_reference_jsdomain(tempdir, app, status, warning):

--- a/tests/test_util_inventory.py
+++ b/tests/test_util_inventory.py
@@ -38,6 +38,8 @@ std cpp:type 1 index.html#std -
 std::uint8_t cpp:type 1 index.html#std_uint8_t -
 foo::Bar cpp:class 1 index.html#cpp_foo_bar -
 foo::Bar::baz cpp:function 1 index.html#cpp_foo_bar_baz -
+foons cpp:type 1 index.html#foons -
+foons::bartype cpp:type 1 index.html#foons_bartype -
 a term std:term -1 glossary.html#term-a-term -
 ls.-l std:cmdoption 1 index.html#cmdoption-ls-l -
 docname std:doc -1 docname.html -


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
This is some cleanup for a request in issue #4082, provides the same functionality but in a randomly named namespace and type so that the `std::` namespace is not in use.  Re-adds a variation on the asserts that were removed in a previous commit.