### PR TITLE
C++: Do not assert False if type and declType mismatch

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4963,8 +4963,8 @@ class CPPDomain(Domain):
             if declTyp == 'templateParam':
                 return True
             objtypes = self.objtypes_for_role(typ)
-            if objtypes and declTyp in objtypes:
-                return True
+            if objtypes:
+                return declTyp in objtypes
             print("Type is %s, declType is %s" % (typ, declTyp))
             assert False
         if not checkType():


### PR DESCRIPTION
Revert to Sphinx 1.6.3 behavior where a warning was raised instead. This fixes build of some projects, like Breathe (before michaeljones/breathe#353) or pybind11 (see #4099).

The regression was introduced in 60574eae3bb435e9e8263b0a534f72ddf68dee43. Before this commit, `checkType()` returned False in case of mismatches, after it always *asserts* False. Cc @Andne @jakobandersen.