### PR TITLE
Make searchtools.js compatible with pre-Sphinx1.5 templates

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js_t
+++ b/sphinx/themes/basic/static/searchtools.js_t
@@ -269,6 +269,9 @@ var Search = {
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
           var suffix = DOCUMENTATION_OPTIONS.SOURCELINK_SUFFIX;
+          if (suffix === undefined) {
+            suffix = '.txt';
+          }
           $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item[5] + (item[5].slice(-suffix.length) === suffix ? '' : suffix),
                   dataType: "text",
                   complete: function(jqxhr, textstatus) {


### PR DESCRIPTION
There are still plenty of projects which use custom templates where `DOCUMENTATION_OPTIONS` does not define `SOURCELINK_SUFFIX`. For example, [scipy / numpy](https://github.com/scipy/scipy-sphinx-theme/blob/master/_theme/scipy/layout.html#L91) which are using their own theme, or packages using outdated version of sphinx-rtd-theme like [pygit2](https://github.com/libgit2/pygit2/blob/master/docs/_themes/sphinx_rtd_theme/layout.html#L129). See also many bugs on GitHub that reference our PR #2454 (scroll to the bottom of that PR).

Currently search does not work in these projects (`searchtools.js` fails with TypeError since 71dd8bfbf94417ad). Make suffix fall back to `.txt` since that is the default value of [the configuration option](http://www.sphinx-doc.org/en/stable/config.html#confval-html_sourcelink_suffix).