### PR TITLE
Don't override the smart_quotes setting if it was already set

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -675,12 +675,13 @@ class BuildEnvironment(object):
 
         language = self.config.language or 'en'
         self.settings['language_code'] = language
-        self.settings['smart_quotes'] = True
-        for tag in normalize_language_tag(language):
-            if tag in smartchars.quotes:
-                break
-        else:
-            self.settings['smart_quotes'] = False
+        if 'smart_quotes' not in self.settings:
+            self.settings['smart_quotes'] = True
+            for tag in normalize_language_tag(language):
+                if tag in smartchars.quotes:
+                    break
+            else:
+                self.settings['smart_quotes'] = False
 
         docutilsconf = path.join(self.srcdir, 'docutils.conf')
         # read docutils.conf from source dir, not from current dir


### PR DESCRIPTION
This is needed to fix: https://github.com/sphinx-contrib/spelling/issues/1

The spelling plugin needs to disable `smart_quotes`, because otherwise it can't recognize contractions. Right now the place it has a settings object runs before this code. Adding this check ensures that if `smart_quotes` was already set, it won't be turned back on.