### PR TITLE
Fix #4115: Typo in doc

### DIFF
--- a/doc/man/sphinx-autogen.rst
+++ b/doc/man/sphinx-autogen.rst
@@ -15,7 +15,7 @@ that, using the :rst:dir:`autodoc` extension, document items included in
 
 *sourcefile* is the path to one or more reStructuredText documents containing
 :rst:dir:`autosummary` entries with the ``:toctree::`` option set. *sourcefile*
-can be an :py:module:`fnmatch`-style pattern.
+can be an :py:mod:`fnmatch`-style pattern.
 
 Options
 -------


### PR DESCRIPTION
Subject: Fix typo in doc

It's `py:mod`, not `py:module`.

### Feature or Bugfix
- Bugfix

### Purpose
- N/A

### Detail
- #4115 

### Relates
- N/A

