### PR TITLE
The great toxification (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ TAGS
 .tags
 .tox
 .venv
+.coverage
 .DS_Store
 sphinx/pycode/Grammar*pickle
 distribute-*

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,13 @@ deps=
 deps=flake8
 commands=flake8
 
+[testenv:pylint]
+deps=
+    pylint
+    {[testenv]deps}
+commands=
+    pylint --rcfile utils/pylintrc sphinx
+
 [testenv:py27]
 deps=
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -77,4 +77,4 @@ commands=
 
 [testenv:docs]
 commands=
-    python setup.py build_sphinx
+    python setup.py build_sphinx {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ passenv = https_proxy http_proxy no_proxy
 deps=
     six
     pytest
+    pytest-cov
     html5lib
     mock
     enum34
@@ -14,7 +15,7 @@ setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
     PYTHONDONTWRITEBYTECODE = true
 commands=
-    {envpython} -Wall tests/run.py --ignore tests/py35 {posargs}
+    {envpython} -Wall tests/run.py --ignore tests/py35 --cov=sphinx {posargs}
     sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:pypy]
@@ -63,7 +64,7 @@ deps=
     typed_ast
     {[testenv]deps}
 commands=
-    {envpython} -Wall tests/run.py {posargs}
+    {envpython} -Wall tests/run.py --cov=sphinx {posargs}
     sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps=
     typing
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
-    PYTHONDONTWRITEBYTECODE = true
 commands=
     {envpython} -Wall tests/run.py --ignore tests/py35 --cov=sphinx \
         --durations 25 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
     PYTHONDONTWRITEBYTECODE = true
 commands=
-    {envpython} -Wall tests/run.py --ignore tests/py35 --cov=sphinx {posargs}
+    {envpython} -Wall tests/run.py --ignore tests/py35 --cov=sphinx \
+        --durations 25 {posargs}
     sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:pypy]
@@ -64,7 +65,7 @@ deps=
     typed_ast
     {[testenv]deps}
 commands=
-    {envpython} -Wall tests/run.py --cov=sphinx {posargs}
+    {envpython} -Wall tests/run.py --cov=sphinx --durations 25 {posargs}
     sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ commands=
     sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:mypy]
+basepython=python3
 deps=
     mypy
 commands=


### PR DESCRIPTION
Subject: Make tox a little more friendly

Make `tox` a little more friendly by enabling extras like coverage, test profiling etc. by default, and closing gaps with the current Makefile targets such as PyLint and building docs in particular formats.

### Feature or Bugfix
- Feature

### Purpose
To paraphrase the Zen of Python (import this):

> tox is one honking great idea -- let's use more of it!

Start modernizing the test infrastructure that's using make and other hand-crafted tools by replacing them with tox-based derivatives.

**This is part one.**

### Detail
This is a multi-step process, with the end goal of completely removing the Makefile and running everything through `tox`. The first fours steps of these can be done in parallel, but combined they block the final two.

1. Make `tox` a little more friendly by enabling extras like coverage, test profiling etc. by default, and closing gaps with the current Makefile targets such as PyLint and building docs in particular formats (**this change**)
2. Replace/remove custom tooling found in `utils` in favor of modern alternatives like `flake8`
3. Centralize as much configuration as possible inside `setup.cfg` and `tox.ini`, to avoid polluting the top level directory.
4. Clean up requirements (`test-reqs.txt`, `setup.py`) to ensure virtualenv and non-virtualenv builds are identical

The remaining two steps are blocked by the above:

5. Switch CIs to use `tox` instead of the Makefile, and update `CONTRIBUTING.rst` to refer to tox. Deprecate the Makefile
6. (Bonus) Integrate [codecov.io](https://codecov.io) to make use of the coverage stats we now have

### Relates
- N/A