### PR TITLE
The great toxification (part 3)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,0 @@
-[mypy]
-python_version = 2.7
-ignore_missing_imports = True
-follow_imports = skip
-incremental = True
-check_untyped_defs = True
-warn_unused_ignores = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ exclude = .git,.tox,.venv,tests/*,build/*,sphinx/search/*,sphinx/pycode/pgen2/*,
 
 [mypy]
 python_version = 2.7
+show_column_numbers = True
+show_error_context = True
 ignore_missing_imports = True
 follow_imports = skip
 incremental = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,5 +28,13 @@ max-line-length = 95
 ignore = E116,E241,E251
 exclude = .git,.tox,.venv,tests/*,build/*,sphinx/search/*,sphinx/pycode/pgen2/*,doc/ext/example*.py
 
+[mypy]
+python_version = 2.7
+ignore_missing_imports = True
+follow_imports = skip
+incremental = True
+check_untyped_defs = True
+warn_unused_ignores = True
+
 [build_sphinx]
 warning-is-error = 1


### PR DESCRIPTION
Subject: Centralize configuration

Centralize as much configuration as possible inside `setup.cfg` and `tox.ini`, to avoid polluting the top level directory

### Feature or Bugfix
- Feature

### Purpose
To paraphrase the Zen of Python (import this):

> tox is one honking great idea -- let's use more of it!

Start modernizing the test infrastructure that's using make and other hand-crafted tools by replacing them with tox-based derivatives.

**This is part twp.**

### Detail
This is a multi-step process, with the end goal of completely removing the Makefile and running everything through `tox`. The first fours steps of these can be done in parallel, but combined they block the final two.

1. Make `tox` a little more friendly by enabling extras like coverage, test profiling etc. by default, and closing gaps with the current Makefile targets such as PyLint and building docs in particular formats
2. Replace/remove custom tooling found in `utils` in favor of modern alternatives like `flake8`
3. Centralize as much configuration as possible inside `setup.cfg` and `tox.ini`, to avoid polluting the top level directory (**this change**)
4. Clean up requirements (`test-reqs.txt`, `setup.py`) to ensure virtualenv and non-virtualenv builds are identical

The remaining two steps are blocked by the above:

5. Switch CIs to use `tox` instead of the Makefile, and update `CONTRIBUTING.rst` to refer to tox. Deprecate the Makefile
6. (Bonus) Integrate [codecov.io](https://codecov.io) to make use of the coverage stats we now have

### Relates
- N/A