### PR TITLE
Re-arrange WARNING messages about reference inconsistencies

### DIFF
--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -258,11 +258,10 @@ class Locale(SphinxTransform):
                     (nodes.paragraph,) + LITERAL_TYPE_NODES + IMAGE_TYPE_NODES):
                 continue  # skip for now
 
-            # auto-numbered foot note reference should use original 'ids'.
-            def is_autonumber_footnote_ref(node):
+            # foot note reference should use original 'ids'.
+            def is_footnote_ref(node):
                 # type: (nodes.Node) -> bool
-                return isinstance(node, nodes.footnote_reference) and \
-                    node.get('auto') == 1
+                return isinstance(node, nodes.footnote_reference)
 
             def list_replace_or_append(lst, old, new):
                 # type: (List, Any, Any) -> None
@@ -270,8 +269,8 @@ class Locale(SphinxTransform):
                     lst[lst.index(old)] = new
                 else:
                     lst.append(new)
-            old_foot_refs = node.traverse(is_autonumber_footnote_ref)
-            new_foot_refs = patch.traverse(is_autonumber_footnote_ref)
+            old_foot_refs = node.traverse(is_footnote_ref)
+            new_foot_refs = patch.traverse(is_footnote_ref)
             if len(old_foot_refs) != len(new_foot_refs):
                 logger.warning('inconsistent footnote references in translated message',
                                location=node)
@@ -326,26 +325,6 @@ class Locale(SphinxTransform):
                         pass
 
                 self.document.note_refname(new)
-
-            # refnamed footnote and citation should use original 'ids'.
-            def is_refnamed_footnote_ref(node):
-                # type: (nodes.Node) -> bool
-                footnote_ref_classes = (nodes.footnote_reference,
-                                        nodes.citation_reference)
-                return isinstance(node, footnote_ref_classes) and \
-                    'refname' in node
-            old_refs = node.traverse(is_refnamed_footnote_ref)
-            new_refs = patch.traverse(is_refnamed_footnote_ref)
-            refname_ids_map = {}
-            if len(old_refs) != len(new_refs):
-                logger.warning('inconsistent references in translated message',
-                               location=node)
-            for old in old_refs:
-                refname_ids_map[old["refname"]] = old["ids"]
-            for new in new_refs:
-                refname = new["refname"]
-                if refname in refname_ids_map:
-                    new["ids"] = refname_ids_map[refname]
 
             # Original pending_xref['reftarget'] contain not-translated
             # target name, new pending_xref must use original one.

--- a/tests/roots/test-intl/refs_inconsistency.po
+++ b/tests/roots/test-intl/refs_inconsistency.po
@@ -19,8 +19,8 @@ msgstr ""
 msgid "i18n with refs inconsistency"
 msgstr "I18N WITH REFS INCONSISTENCY"
 
-msgid "[100]_ for [#]_ footnote [ref2]_."
-msgstr "FOR FOOTNOTE [ref2]_."
+msgid "[100]_ for [#]_ citation [ref2]_."
+msgstr "FOR CITATION [ref3]_."
 
 msgid "for reference_."
 msgstr "reference_ FOR reference_."
@@ -31,8 +31,8 @@ msgstr "ORPHAN REFERENCE: `I18N WITH REFS INCONSISTENCY`_."
 msgid "This is a auto numbered footnote."
 msgstr "THIS IS A AUTO NUMBERED FOOTNOTE."
 
-msgid "This is a named footnote."
-msgstr "THIS IS A NAMED FOOTNOTE."
+msgid "This is a citation."
+msgstr "THIS IS A CITATION."
 
 msgid "This is a numbered footnote."
 msgstr "THIS IS A NUMBERED FOOTNOTE."

--- a/tests/roots/test-intl/refs_inconsistency.txt
+++ b/tests/roots/test-intl/refs_inconsistency.txt
@@ -3,11 +3,11 @@
 i18n with refs inconsistency
 =============================
 
-* [100]_ for [#]_ footnote [ref2]_.
+* [100]_ for [#]_ citation [ref2]_.
 * for reference_.
 * normal text.
 
 .. [#] This is a auto numbered footnote.
-.. [ref2] This is a named footnote.
+.. [ref2] This is a citation.
 .. [100] This is a numbered footnote.
 .. _reference: http://www.example.com

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -182,11 +182,11 @@ def test_text_inconsistency_warnings(app, warning):
     result = (app.outdir / 'refs_inconsistency.txt').text(encoding='utf-8')
     expect = (u"I18N WITH REFS INCONSISTENCY"
               u"\n****************************\n"
-              u"\n* FOR FOOTNOTE [ref2].\n"
+              u"\n* FOR CITATION [ref3].\n"
               u"\n* reference FOR reference.\n"
               u"\n* ORPHAN REFERENCE: I18N WITH REFS INCONSISTENCY.\n"
               u"\n[1] THIS IS A AUTO NUMBERED FOOTNOTE.\n"
-              u"\n[ref2] THIS IS A NAMED FOOTNOTE.\n"
+              u"\n[ref2] THIS IS A CITATION.\n"
               u"\n[100] THIS IS A NUMBERED FOOTNOTE.\n")
     assert result == expect
 
@@ -199,6 +199,10 @@ def test_text_inconsistency_warnings(app, warning):
         warning_fmt % 'references')
     assert_re_search(expected_warning_expr, warnings)
 
+    expected_citation_warning_expr = (
+        u'.*/refs_inconsistency.txt:\\d+: WARNING: Citation \[ref2\] is not referenced.\n' +
+        u'.*/refs_inconsistency.txt:\\d+: WARNING: citation not found: ref3')
+    assert_re_search(expected_citation_warning_expr, warnings)
 
 @sphinx_intl
 @pytest.mark.sphinx('text')


### PR DESCRIPTION
Subject: Display appropriate WARNING messages about reference inconsistencies

### Feature or Bugfix

<!-- please choose -->
- Bugfix

### Purpose

- Separate correctly causes for each WARNING message. (Which message is about which cause?)

### Detail

For reference inconsistencies, now, Sphinx outputs four messages:

1. auto-numbered footnote: "inconsistent footnote references in translated message"
2. reference with refname: "inconsistent references in translated message"
3. reference: "inconsistent term references in translated message"
4. named footnote & citation: "inconsistent references in translated message"

(these messages are all implemented in sphinx/transforms/i18n.py.)

However, reST specification do not define "named footnote", which is actually citation.
Furthermore, citation inconsistencies are reported from warn_missing_reference method of ReferencesResolver class (which is located in sphinx/transforms/post_transforms/__init__.py) and
check_consistency function of StandardDomain class (which is located in sphinx/domains/std.py).

In conclusion, Sphinx should output four messages:

1. footnote: "inconsistent footnote references in translated message"
2. reference with refname: "inconsistent references in translated message"
3. reference: "inconsistent term references in translated message"
4. citation: "Citation [hoge] is not referenced." and "citation not found: fuga"

### Relates
- This PR is a preparation for #4106 .

