### PR TITLE
Display reference texts of original and translated passages

### DIFF
--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -273,7 +273,11 @@ class Locale(SphinxTransform):
             old_foot_refs = node.traverse(is_autonumber_footnote_ref)
             new_foot_refs = patch.traverse(is_autonumber_footnote_ref)
             if len(old_foot_refs) != len(new_foot_refs):
-                logger.warning('inconsistent footnote references in translated message',
+                old_foot_ref_rawsources = [ref.rawsource for ref in old_foot_refs]
+                new_foot_ref_rawsources = [ref.rawsource for ref in new_foot_refs]
+                logger.warning('inconsistent footnote references in translated message.' +
+                               ' original: {0}, translated: {1}'
+                               .format(old_foot_ref_rawsources, new_foot_ref_rawsources),
                                location=node)
             old_foot_namerefs = {}  # type: Dict[unicode, List[nodes.footnote_reference]]
             for r in old_foot_refs:
@@ -309,7 +313,11 @@ class Locale(SphinxTransform):
             old_refs = node.traverse(is_refnamed_ref)
             new_refs = patch.traverse(is_refnamed_ref)
             if len(old_refs) != len(new_refs):
-                logger.warning('inconsistent references in translated message',
+                old_ref_rawsources = [ref.rawsource for ref in old_refs]
+                new_ref_rawsources = [ref.rawsource for ref in new_refs]
+                logger.warning('inconsistent references in translated message.' +
+                               ' original: {0}, translated: {1}'
+                               .format(old_ref_rawsources, new_ref_rawsources),
                                location=node)
             old_ref_names = [r['refname'] for r in old_refs]
             new_ref_names = [r['refname'] for r in new_refs]
@@ -336,7 +344,11 @@ class Locale(SphinxTransform):
             new_foot_refs = patch.traverse(is_refnamed_footnote_ref)
             refname_ids_map = {}
             if len(old_foot_refs) != len(new_foot_refs):
-                logger.warning('inconsistent footnote references in translated message',
+                old_foot_ref_rawsources = [ref.rawsource for ref in old_foot_refs]
+                new_foot_ref_rawsources = [ref.rawsource for ref in new_foot_refs]
+                logger.warning('inconsistent footnote references in translated message.' +
+                               ' original: {0}, translated: {1}'
+                               .format(old_foot_ref_rawsources, new_foot_ref_rawsources),
                                location=node)
             for old in old_foot_refs:
                 refname_ids_map[old["refname"]] = old["ids"]
@@ -354,7 +366,11 @@ class Locale(SphinxTransform):
             new_cite_refs = patch.traverse(is_citation_ref)
             refname_ids_map = {}
             if len(old_cite_refs) != len(new_cite_refs):
-                logger.warning('inconsistent citation references in translated message',
+                old_cite_ref_rawsources = [ref.rawsource for ref in old_cite_refs]
+                new_cite_ref_rawsources = [ref.rawsource for ref in new_cite_refs]
+                logger.warning('inconsistent citation references in translated message.' +
+                               ' original: {0}, translated: {1}'
+                               .format(old_cite_ref_rawsources, new_cite_ref_rawsources),
                                location=node)
             for old in old_cite_refs:
                 refname_ids_map[old["refname"]] = old["ids"]
@@ -370,7 +386,11 @@ class Locale(SphinxTransform):
             new_refs = patch.traverse(addnodes.pending_xref)
             xref_reftarget_map = {}
             if len(old_refs) != len(new_refs):
-                logger.warning('inconsistent term references in translated message',
+                old_ref_rawsources = [ref.rawsource for ref in old_refs]
+                new_ref_rawsources = [ref.rawsource for ref in new_refs]
+                logger.warning('inconsistent term references in translated message.' +
+                               ' original: {0}, translated: {1}'
+                               .format(old_ref_rawsources, new_ref_rawsources),
                                location=node)
 
             def get_ref_key(node):

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -192,11 +192,29 @@ def test_text_inconsistency_warnings(app, warning):
 
     warnings = getwarning(warning)
     warning_fmt = u'.*/refs_inconsistency.txt:\\d+: ' \
-                  u'WARNING: inconsistent %s in translated message\n'
+                  u'WARNING: inconsistent %(reftype)s in translated message.' \
+                  u' original: %(original)s, translated: %(translated)s\n'
     expected_warning_expr = (
-        warning_fmt % 'footnote references' +
-        warning_fmt % 'references' +
-        warning_fmt % 'references')
+        warning_fmt % {
+            u'reftype': u'footnote references',
+            u'original': u"\['\[#\]_'\]",
+            u'translated': u"\[\]"
+        } +
+        warning_fmt % {
+            u'reftype': u'footnote references',
+            u'original': u"\['\[100\]_'\]",
+            u'translated': u"\[\]"
+        } +
+        warning_fmt % {
+            u'reftype': u'references',
+            u'original': u"\['reference_'\]",
+            u'translated': u"\['reference_', 'reference_'\]"
+        } +
+        warning_fmt % {
+            u'reftype': u'references',
+            u'original': u"\[\]",
+            u'translated': u"\['`I18N WITH REFS INCONSISTENCY`_'\]"
+        })
     assert_re_search(expected_warning_expr, warnings)
 
     expected_citation_warning_expr = (
@@ -281,7 +299,8 @@ def test_text_glossary_term_inconsistencies(app, warning):
     warnings = getwarning(warning)
     expected_warning_expr = (
         u'.*/glossary_terms_inconsistency.txt:\\d+: '
-        u'WARNING: inconsistent term references in translated message\n')
+        u'WARNING: inconsistent term references in translated message.'
+        u" original: \[':term:`Some term`', ':term:`Some other term`'\], translated: \[':term:`SOME NEW TERM`'\]\n")
     assert_re_search(expected_warning_expr, warnings)
 
 

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -197,23 +197,23 @@ def test_text_inconsistency_warnings(app, warning):
     expected_warning_expr = (
         warning_fmt % {
             u'reftype': u'footnote references',
-            u'original': u"\['\[#\]_'\]",
+            u'original': u"\[u?'\[#\]_'\]",
             u'translated': u"\[\]"
         } +
         warning_fmt % {
             u'reftype': u'footnote references',
-            u'original': u"\['\[100\]_'\]",
+            u'original': u"\[u?'\[100\]_'\]",
             u'translated': u"\[\]"
         } +
         warning_fmt % {
             u'reftype': u'references',
-            u'original': u"\['reference_'\]",
-            u'translated': u"\['reference_', 'reference_'\]"
+            u'original': u"\[u?'reference_'\]",
+            u'translated': u"\[u?'reference_', u?'reference_'\]"
         } +
         warning_fmt % {
             u'reftype': u'references',
             u'original': u"\[\]",
-            u'translated': u"\['`I18N WITH REFS INCONSISTENCY`_'\]"
+            u'translated': u"\[u?'`I18N WITH REFS INCONSISTENCY`_'\]"
         })
     assert_re_search(expected_warning_expr, warnings)
 
@@ -300,8 +300,8 @@ def test_text_glossary_term_inconsistencies(app, warning):
     expected_warning_expr = (
         u'.*/glossary_terms_inconsistency.txt:\\d+: '
         u'WARNING: inconsistent term references in translated message.'
-        u" original: \[':term:`Some term`', ':term:`Some other term`'\],"
-        u" translated: \[':term:`SOME NEW TERM`'\]\n")
+        u" original: \[u?':term:`Some term`', u?':term:`Some other term`'\],"
+        u" translated: \[u?':term:`SOME NEW TERM`'\]\n")
     assert_re_search(expected_warning_expr, warnings)
 
 

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -300,7 +300,8 @@ def test_text_glossary_term_inconsistencies(app, warning):
     expected_warning_expr = (
         u'.*/glossary_terms_inconsistency.txt:\\d+: '
         u'WARNING: inconsistent term references in translated message.'
-        u" original: \[':term:`Some term`', ':term:`Some other term`'\], translated: \[':term:`SOME NEW TERM`'\]\n")
+        u" original: \[':term:`Some term`', ':term:`Some other term`'\],"
+        u" translated: \[':term:`SOME NEW TERM`'\]\n")
     assert_re_search(expected_warning_expr, warnings)
 
 


### PR DESCRIPTION
Subject:  In order to clarify causes of inconsistencies between original and translated passages.

### Feature or Bugfix
- Feature

### Purpose
- To help us to recognize cases of inconsistencies, Sphinx should display reference texts contained in original and translated passages

### Detail
- Use node.rawsource as a reference text

### Relates
- issue: #4106 

