### PR TITLE
Docstring inherit properties

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,7 +31,7 @@ Features added
 * #3872: Add latex key to configure literal blocks caption position in PDF
   output (refs #3792, #1723)
 * In case of missing docstring try to retrieve doc from base classes
-  (refs #3140, 4126)
+  (refs #3140, #4126)
 * #4023: Clarify error message when any role has more than one target.
 * #3973: epub: allow to override build date
 * #3972: epub: Sort manifest entries by filename

--- a/CHANGES
+++ b/CHANGES
@@ -30,7 +30,8 @@ Features added
   - ``ref.python`` (ref: #3866)
 * #3872: Add latex key to configure literal blocks caption position in PDF
   output (refs #3792, #1723)
-* In case of missing docstring try to retrieve doc from base classes (ref: #3140)
+* In case of missing docstring try to retrieve doc from base classes
+  (refs #3140, 4126)
 * #4023: Clarify error message when any role has more than one target.
 * #3973: epub: allow to override build date
 * #3972: epub: Sort manifest entries by filename

--- a/doc/ext/autodoc.rst
+++ b/doc/ext/autodoc.rst
@@ -396,8 +396,8 @@ There are also new config values that you can set:
 .. confval:: autodoc_inherit_docstrings
 
    This value controls the docstrings inheritance.
-   If set to True the cocstring for classes or methods, if not explicitly set,
-   is inherited form parents.
+   If set to True the docstring for classes, methods or properties, if not
+   explicitly set, is inherited from parents.
 
    The default is ``True``.
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ if sys.platform == 'win32':
 
 if sys.version_info < (3, 5):
     requires.append('typing')
+    requires.append('qualname')
 
 # Provide a "compile_catalog" command that also creates the translated
 # JavaScript files if Babel is available.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ extras_require = {
         'colorama>=0.3.5',
     ],
     ':python_version<"3.5"': [
-        'typing'
+        'typing',
+        'qualname'
     ],
     'websupport': [
         'sqlalchemy>=0.9',

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -464,6 +464,7 @@ if sys.version_info >= (3, 5):
 else:
     # code copied from the inspect.py module of the standard library
     # of Python 3.5
+    from qualname import qualname
 
     def _findclass(func):
         cls = sys.modules.get(func.__module__)
@@ -472,7 +473,7 @@ else:
         if hasattr(func, 'im_class'):
             cls = func.im_class
         else:
-            for name in func.__qualname__.split('.')[:-1]:
+            for name in qualname(func).split('.')[:-1]:
                 cls = getattr(cls, name)
         if not inspect.isclass(cls):
             return None
@@ -508,8 +509,7 @@ else:
         elif inspect.isbuiltin(obj):
             name = obj.__name__
             self = obj.__self__
-            if (inspect.isclass(self) and
-                    self.__qualname__ + '.' + name == obj.__qualname__):
+            if (inspect.isclass(self) and qualname(self) + '.' + name == qualname(obj)):
                 # classmethod
                 cls = self
             else:

--- a/test-reqs.txt
+++ b/test-reqs.txt
@@ -18,3 +18,4 @@ requests
 html5lib
 enum34
 typing
+qualname

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps=
     mock
     enum34
     typing
+    qualname
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
     PYTHONDONTWRITEBYTECODE = true


### PR DESCRIPTION
Subject: Properties can now inherit the docstring from parent classes

### Feature or Bugfix
- Feature

### Purpose
- In addition to methods and classes, Sphinx can now also inherit the docstring of properties.

### Detail
- The previous pull request used special members that are available only in Python 3.5+ and the property lookup did not work in older Python versions. The code has been made backward compatible with the help of the `qualname` pip module.

### Relates
- #3140 
- #4126 