### PR TITLE
Add new config value highlight_failures.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -137,6 +137,8 @@ Features added
 * html: Output ``canonical_url`` metadata if :confval:`html_baseurl` set (refs:
   #4193)
 * #5029: autosummary: expose ``inherited_members`` to template
+* New :confval:`highlight_failures` configuration variable to control
+  behavior of highlighting failures.
 
 Bugs fixed
 ----------
@@ -154,6 +156,9 @@ Features removed
 ----------------
 
 * ``sphinx.ext.pngmath`` extension
+* module-wide ``sphinx.highlighting.lexers`` dictionary of lexers, use the
+  ``add_lexer()`` method of the application object or the ``extra_lexers``
+  kwarg of the ``sphinx.highlighting.PygmentsBridge`` constructor instead
 
 Release 1.7.6 (in development)
 ==============================

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -535,6 +535,23 @@ Project information
       languages will emit warning if failed.  If you prefer Python 2
       only highlighting, you can set it back to ``'python'``.
 
+.. confval:: highlight_failures
+
+   The behavior to adopt when highlighting of a code block fails:
+
+   - ``'skip_block'`` to skip highlighting the entire code block and
+     display it in a plain style instead; this is the default behavior
+   - ``'highlight'`` to display just the problematic parts of the code in a
+     special style for errors while highlighting the rest of the block normally
+   - ``'hide'`` to display just the problematic parts of the code in a plain
+     style while highlighting the rest of the block normally
+
+   In all cases, highlighting failures will also be reported as warnings. This
+   can be controlled with :confval:`suppress_warnings` (see
+   misc.highlighting_failure).
+
+   .. versionadded:: 1.8
+
 .. confval:: highlight_options
 
    A dictionary of options that modify how the lexer specified by

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -53,6 +53,7 @@ if False:
     from docutils import nodes  # NOQA
     from docutils.parsers import Parser  # NOQA
     from docutils.transforms import Transform  # NOQA
+    from pygments.lexer import Lexer  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.domains import Domain, Index  # NOQA
     from sphinx.environment.collectors import EnvironmentCollector  # NOQA
@@ -186,6 +187,8 @@ class Sphinx(object):
 
         # status code for command-line application
         self.statuscode = 0
+
+        self.extra_lexers = {}  # type: Dict[unicode, Lexer]
 
         # read config
         self.tags = Tags(tags)
@@ -1116,10 +1119,7 @@ class Sphinx(object):
         .. versionadded:: 0.6
         """
         logger.debug('[app] adding lexer: %r', (alias, lexer))
-        from sphinx.highlighting import lexers
-        if lexers is None:
-            return
-        lexers[alias] = lexer
+        self.extra_lexers[alias] = lexer
 
     def add_autodocumenter(self, cls):
         # type: (Any) -> None

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -387,7 +387,9 @@ class StandaloneHTMLBuilder(Builder):
         else:
             style = 'sphinx'
         self.highlighter = PygmentsBridge('html', style,
-                                          self.config.trim_doctest_flags)
+                                          self.config.trim_doctest_flags,
+                                          extra_lexers=self.app.extra_lexers,
+                                          failure_policy=self.config.highlight_failures)
 
     def init_css_files(self):
         # type: () -> None

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -110,7 +110,9 @@ class LaTeXBuilder(Builder):
     def write_stylesheet(self):
         # type: () -> None
         highlighter = highlighting.PygmentsBridge(
-            'latex', self.config.pygments_style, self.config.trim_doctest_flags)
+            'latex', self.config.pygments_style, self.config.trim_doctest_flags,
+            extra_lexers=self.app.extra_lexers,
+            failure_policy=self.config.highlight_failures)
         stylesheet = path.join(self.outdir, 'sphinxhighlight.sty')
         with open(stylesheet, 'w') as f:
             f.write('\\NeedsTeXFormat{LaTeX2e}[1995/12/01]\n')

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -120,6 +120,7 @@ class Config(object):
         show_authors = (False, 'env', []),
         pygments_style = (None, 'html', string_classes),
         highlight_language = ('default', 'env', []),
+        highlight_failures = (None, 'skip_block', string_classes),
         highlight_options = ({}, 'env', []),
         templates_path = ([], 'html', []),
         template_bridge = (None, 'html', string_classes),

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -77,6 +77,9 @@ language = {{ language | repr }}
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [{{ exclude_patterns }}]
 
+# The policy for handling failures during highlighting
+highlight_failures = 'skip_block'
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -673,7 +673,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
         self.highlighter = highlighting.PygmentsBridge(
             'latex',
-            builder.config.pygments_style, builder.config.trim_doctest_flags)
+            builder.config.pygments_style, builder.config.trim_doctest_flags,
+            extra_lexers=builder.app.extra_lexers,
+            failure_policy=builder.config.highlight_failures)
         self.context = []               # type: List[Any]
         self.descstack = []             # type: List[unicode]
         self.table = None               # type: Table


### PR DESCRIPTION
# New feature

Implement new behaviours when highlighting a code block fails, controlled by a new config value `highlight_features`:

- `'skip_block'` to skip highlighting the entire code block and display
  it in a plain style instead; this is the same behaviour as before and
  the default
- `'highlight'` to display just the problematic parts of the code in a
  special style for errors while highlighting the rest of the block
  normally
- `'hide'` to display just the problematic parts of the code in a plain
  style while highlighting the rest of the block normally

In all cases a warning is also emitted when highlighting encounters a failure. The user can control that with the existing `suppress_warnings` config value.

I believe this sort of functionality this has been a popular request, as per #2310 or my own #3088.

# PR checklist

- tests pass on Python 2.7.14 & Python 3.6.2, but I couldn't run tox in my environment
- `make style-check` & `make type-check` pass
- CHANGES entry & doc changes
- new testcase

# Breaking changes

On master `sphinx.highlighting.lexers` is a module-wide dictionary of lexers. Because the goal of this PR is to parametrise the lexer behaviour over a config value, it had to go. Instead the (default) lexers are per instance of `sphinx.highlighting.PygmentsBridge` (+ extra runtime lookups delegated to Pygments) and have their behaviour set at construction time. In addition the application object maintains a dictionary of extra, user-supplied lexers via `add_lexer()`. These are not influenced by the config value: this is in fact the same behaviour as today.

Because of these constraints and the fact that `sphinx.highlighting.lexers` is a variable I believe deprecation was not an option. If this is not the right call let me know.