### PR TITLE
Cope with List node_name in get_lvar_namesl

### DIFF
--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -100,7 +100,7 @@ class ModuleAnalyzer(object):
             self.tags = parser.definitions
             self.tagorder = parser.deforders
         except Exception as exc:
-            raise PycodeError('parsing failed: %r' % exc)
+            raise PycodeError('parsing %r failed: %r' % (self.srcname, exc))
 
     def find_attr_docs(self):
         # type: () -> Dict[Tuple[unicode, unicode], List[unicode]]

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -63,7 +63,7 @@ def get_lvar_names(node, self=None):
     elif node_name == 'str':
         return [node]  # type: ignore
     else:
-        raise NotImplementedError
+        raise NotImplementedError('Unexpected node name %r' % node_name)
 
 
 def dedent_docstring(s):

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -51,7 +51,7 @@ def get_lvar_names(node, self=None):
             return [node.id]  # type: ignore
         else:
             raise TypeError('The assignment %r is not instance variable' % node)
-    elif node_name == 'Tuple':
+    elif node_name in ('Tuple', 'List'):
         members = [get_lvar_names(elt) for elt in node.elts]  # type: ignore
         return sum(members, [])
     elif node_name == 'Attribute':

--- a/tests/test_pycode_parser.py
+++ b/tests/test_pycode_parser.py
@@ -96,7 +96,10 @@ def test_complex_assignment():
               'c, d = (1, 1)  #: unpack assignment\n'
               'e = True  #: first assignment\n'
               'e = False  #: second assignment\n'
-              'f = g = None  #: multiple assignment at once\n')
+              'f = g = None  #: multiple assignment at once\n'
+              '(theta, phi) = (0, 0.5)  #: unpack assignment via tuple\n'
+              '[x, y] = (5, 6)  #: unpack assignment via list\n'
+              )
     parser = Parser(source)
     parser.parse()
     assert parser.comments == {('', 'b'): 'compound statement',
@@ -104,7 +107,12 @@ def test_complex_assignment():
                                ('', 'd'): 'unpack assignment',
                                ('', 'e'): 'second assignment',
                                ('', 'f'): 'multiple assignment at once',
-                               ('', 'g'): 'multiple assignment at once'}
+                               ('', 'g'): 'multiple assignment at once',
+                               ('', 'theta'): 'unpack assignment via tuple',
+                               ('', 'phi'): 'unpack assignment via tuple',
+                               ('', 'x'): 'unpack assignment via list',
+                               ('', 'y'): 'unpack assignment via list',
+                               }
     assert parser.definitions == {}
 
 


### PR DESCRIPTION
Subject: Hack to solve a crash I was seeing locally under Python 3.4 using latest Sphinx from GitHub, but for which I have not produced a minimal test case (*Update: See below for minimal test case*).

### Feature or Bugfix
- Bugfix

### Purpose

- First, gives a clearer exception

Before:

```
$ more  /var/folders/x9/9z4wpg753_v3fvwq7qs1llhc0000gn/T/sphinx-err-ux021d4c.log 
# Sphinx version: 1.7+
# Python version: 3.4.1 (CPython)
# Docutils version: 0.13.1 release
# Jinja2 version: 2.9.5
# Last messages:
#   reading sources... [ 35%] Bio.MaxEntropy
#   
#   reading sources... [ 36%] Bio.Medline
#   
#   reading sources... [ 36%] Bio.NMR
#   
#   reading sources... [ 36%] Bio.NMR.NOEtools
#   
#   reading sources... [ 37%] Bio.NMR.xpktools
#   
# Loaded extensions:
#   sphinx.ext.viewcode (1.7+) from /Users/peterjc/lib/python3.4/site-packages/sphinx/ext/viewcode.py
#   sphinx.ext.todo (1.7+) from /Users/peterjc/lib/python3.4/site-packages/sphinx/ext/todo.py
#   alabaster (0.7.10) from /Users/peterjc/lib/python3.4/site-packages/alabaster/__init__.py
#   sphinx.ext.autodoc (1.7+) from /Users/peterjc/lib/python3.4/site-packages/sphinx/ext/autodoc/__init__.py
Traceback (most recent call last):
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/__init__.py", line 91, in parse
    parser.parse()
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 446, in parse
    self.parse_comments()
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 454, in parse_comments
    picker.visit(tree)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 273, in visit
    super(VariableCommentPicker, self).visit(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 245, in visit
    return visitor(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 253, in generic_visit
    self.visit(item)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 273, in visit
    super(VariableCommentPicker, self).visit(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 245, in visit
    return visitor(node)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 352, in visit_FunctionDef
    self.visit(child)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 273, in visit
    super(VariableCommentPicker, self).visit(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 245, in visit
    return visitor(node)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 280, in visit_Assign
    varnames = sum([get_lvar_names(t, self=self.get_self()) for t in node.targets], [])  # type: ignore  # NOQA
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 280, in <listcomp>
    varnames = sum([get_lvar_names(t, self=self.get_self()) for t in node.targets], [])  # type: ignore  # NOQA
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/parser.py", line 66, in get_lvar_names
    raise NotImplementedError
NotImplementedError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/cmdline.py", line 306, in main
    app.build(opts.force_all, filenames)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/application.py", line 330, in build
    self.builder.build_update()
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/builders/__init__.py", line 328, in build_update
    'out of date' % len(to_build))
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/builders/__init__.py", line 341, in build
    updated_docnames = set(self.env.update(self.config, self.srcdir, self.doctreedir))
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/environment/__init__.py", line 583, in update
    self._read_serial(docnames, self.app)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/environment/__init__.py", line 602, in _read_serial
    self.read_doc(docname, app)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/environment/__init__.py", line 725, in read_doc
    app.emit('doctree-read', doctree)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/application.py", line 436, in emit
    return self.events.emit(event, self, *args)
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/events.py", line 79, in emit
    results.append(callback(*args))
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/ext/viewcode.py", line 100, in doctree_read
    if not has_tag(modname, fullname, env.docname, refname):
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/ext/viewcode.py", line 75, in has_tag
    analyzer.find_tags()
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/__init__.py", line 117, in find_tags
    self.parse()
  File "/Users/peterjc/lib/python3.4/site-packages/sphinx/pycode/__init__.py", line 103, in parse
    raise PycodeError('parsing failed: %r' % exc)
sphinx.errors.PycodeError: parsing failed: NotImplementedError()
```

After:

```
$ more  /var/folders/x9/9z4wpg753_v3fvwq7qs1llhc0000gn/T/sphinx-err-9xh9tmvo.log
# Sphinx version: 1.7+
# Python version: 3.4.1 (CPython)
# Docutils version: 0.13.1 release
# Jinja2 version: 2.9.5
# Last messages:
#   reading sources... [ 35%] Bio.MaxEntropy
#   
#   reading sources... [ 36%] Bio.Medline
#   
#   reading sources... [ 36%] Bio.NMR
#   
#   reading sources... [ 36%] Bio.NMR.NOEtools
#   
#   reading sources... [ 37%] Bio.NMR.xpktools
#   
# Loaded extensions:
#   sphinx.ext.todo (1.7+) from /Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/ext/todo.py
#   sphinx.ext.viewcode (1.7+) from /Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/ext/viewcode.py
#   sphinx.ext.autodoc (1.7+) from /Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/ext/autodoc/__init__.py
#   alabaster (0.7.10) from /Users/peterjc/lib/python3.4/site-packages/alabaster/__init__.py
Traceback (most recent call last):
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/__init__.py", line 91, in parse
    parser.parse()
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 446, in parse
    self.parse_comments()
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 454, in parse_comments
    picker.visit(tree)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 273, in visit
    super(VariableCommentPicker, self).visit(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 245, in visit
    return visitor(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 253, in generic_visit
    self.visit(item)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 273, in visit
    super(VariableCommentPicker, self).visit(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 245, in visit
    return visitor(node)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 352, in visit_FunctionDef
    self.visit(child)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 273, in visit
    super(VariableCommentPicker, self).visit(node)
  File "/Users/peterjc/lib/python3.4/ast.py", line 245, in visit
    return visitor(node)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 280, in visit_Assign
    varnames = sum([get_lvar_names(t, self=self.get_self()) for t in node.targets], [])  # type: ignore  # NOQA
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 280, in <listcomp>
    varnames = sum([get_lvar_names(t, self=self.get_self()) for t in node.targets], [])  # type: ignore  # NOQA
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/parser.py", line 66, in get_lvar_names
    raise NotImplementedError('Unexpected node name %r' % node_name)
NotImplementedError: Unexpected node name 'List'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/cmdline.py", line 306, in main
    app.build(opts.force_all, filenames)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/application.py", line 330, in build
    self.builder.build_update()
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/builders/__init__.py", line 328, in build_update
    'out of date' % len(to_build))
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/builders/__init__.py", line 341, in build
    updated_docnames = set(self.env.update(self.config, self.srcdir, self.doctreedir))
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/environment/__init__.py", line 583, in update
    self._read_serial(docnames, self.app)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/environment/__init__.py", line 602, in _read_serial
    self.read_doc(docname, app)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/environment/__init__.py", line 725, in read_doc
    app.emit('doctree-read', doctree)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/application.py", line 436, in emit
    return self.events.emit(event, self, *args)
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/events.py", line 79, in emit
    results.append(callback(*args))
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/ext/viewcode.py", line 100, in doctree_read
    if not has_tag(modname, fullname, env.docname, refname):
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/ext/viewcode.py", line 75, in has_tag
    analyzer.find_tags()
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/__init__.py", line 117, in find_tags
    self.parse()
  File "/Users/peterjc/lib/python3.4/site-packages/Sphinx-1.7.dev20171010-py3.4.egg/sphinx/pycode/__init__.py", line 103, in parse
    raise PycodeError('parsing failed: %r' % exc)
sphinx.errors.PycodeError: parsing failed: NotImplementedError("Unexpected node name 'List'",)
```

- Second, since my local example was giving a ``List``, looked sensible to re-use ``Tuple`` implementation NOTE: I do not understand the context of this function, and so am unsure if this really is the right fix. *Update: I now understand why this happens and think this is the right fix.*

