### PR TITLE
Theme: Move body tag into a block

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -170,7 +170,7 @@
 {%- endblock %}
 {%- block extrahead %} {% endblock %}
   </head>
-  <body>
+  {%- block body_tag %}<body>{% endblock %}
 {%- block header %}{% endblock %}
 
 {%- block relbar1 %}{{ relbar() }}{% endblock %}


### PR DESCRIPTION

### Feature or Bugfix
- Feature

### Purpose
Sometimes users might want to override this tag to include custom information such as `id`s.

### Detail

Example:

`<body id="page-top">`

Can be done with `{%- block body_tag %}<body id="page-top">{% endblock %}`


### Relates
None
