### PR TITLE
Fix #4137: doctest: doctest block is always highlighted as python con…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -86,6 +86,8 @@ Features added
 * #4245: html themes: Add ``language`` to javascript vars list
 * #4079: html: Add ``notranslate`` class to each code-blocks, literals and maths
   to let Google Translate know they are not translatable
+* #4137: doctest: doctest block is always highlighted as python console (pycon)
+* #4137: doctest: testcode block is always highlighted as python
 
 Features removed
 ----------------

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -116,7 +116,11 @@ class TestDirective(Directive):
         if test is not None:
             # only save if it differs from code
             node['test'] = test
-        if self.name == 'testoutput':
+        if self.name == 'doctest':
+            node['language'] = 'pycon'
+        elif self.name == 'testcode':
+            node['language'] = 'python'
+        elif self.name == 'testoutput':
             # don't try to highlight output
             node['language'] = 'none'
         node['options'] = {}


### PR DESCRIPTION
…sole (pycon)

Fix #4137 