### PR TITLE
Initialize _fieldlist_row_index just like _table_row_index

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -89,6 +89,7 @@ class HTMLTranslator(BaseTranslator):
         self.param_separator = ''
         self.optional_param_level = 0
         self._table_row_index = 0
+        self._fieldlist_row_index = 0
         self.required_params_left = 0
 
     def visit_start_of_file(self, node):


### PR DESCRIPTION
Subject: Make it possible to start a document with a field list

### Feature or Bugfix
- Bugfix

### Purpose
- visit_field can be called before visit_field_list if the field list is at the beginning of the document.
By initializing _fieldlist_row_index in __init__ this is supported.

### Relates
Closes #4145

