### PR TITLE
Include the exception when logging PO/MO file read/write

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -67,15 +67,15 @@ class CatalogInfo(LocaleFileInfoBase):
         with io.open(self.po_path, 'rt', encoding=self.charset) as file_po:
             try:
                 po = read_po(file_po, locale)
-            except Exception:
-                logger.warning('reading error: %s', self.po_path)
+            except Exception as ex:
+                logger.warning('reading error: %s, %s', self.po_path, ex)
                 return
 
         with io.open(self.mo_path, 'wb') as file_mo:
             try:
                 write_mo(file_mo, po)
-            except Exception:
-                logger.warning('writing error: %s', self.mo_path)
+            except Exception as ex:
+                logger.warning('writing error: %s, %s', self.mo_path, ex)
 
 
 def find_catalog(docname, compaction):

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -67,15 +67,15 @@ class CatalogInfo(LocaleFileInfoBase):
         with io.open(self.po_path, 'rt', encoding=self.charset) as file_po:
             try:
                 po = read_po(file_po, locale)
-            except Exception as ex:
-                logger.warning('reading error: %s, %s', self.po_path, ex)
+            except Exception as exc:
+                logger.warning('reading error: %s, %s', self.po_path, exc)
                 return
 
         with io.open(self.mo_path, 'wb') as file_mo:
             try:
                 write_mo(file_mo, po)
-            except Exception as ex:
-                logger.warning('writing error: %s, %s', self.mo_path, ex)
+            except Exception as exc:
+                logger.warning('writing error: %s, %s', self.mo_path, exc)
 
 
 def find_catalog(docname, compaction):


### PR DESCRIPTION
Without this there is no way to troubleshoot why (read/write)_po fails.

Our project ran into an error where all translations fail, there was no simple way to find out why, without local edits to `i18n.py`

Subject: log exception messages

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Help troubleshoot errors

### Detail
None.
