### PR TITLE
epub: Use sphinx.util.i18n.format_date to get reproducible date header

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -13,7 +13,6 @@ import os
 import re
 from os import path
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
-from datetime import datetime
 from collections import namedtuple
 
 try:
@@ -33,6 +32,7 @@ from sphinx.util import logging
 from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir, copyfile
 from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.i18n import format_date
 
 if False:
     # For type annotation
@@ -486,7 +486,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         metadata['copyright'] = self.esc(self.config.epub_copyright)
         metadata['scheme'] = self.esc(self.config.epub_scheme)
         metadata['id'] = self.esc(self.config.epub_identifier)
-        metadata['date'] = self.esc(datetime.utcnow().strftime("%Y-%m-%d"))
+        metadata['date'] = format_date("%Y-%m-%d")
         metadata['manifest_items'] = []
         metadata['spines'] = []
         metadata['guides'] = []

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -11,7 +11,6 @@
 """
 
 from os import path
-from datetime import datetime
 from collections import namedtuple
 
 from sphinx import package_dir
@@ -19,6 +18,7 @@ from sphinx.config import string_classes, ENUM
 from sphinx.builders import _epub_base
 from sphinx.util import logging, xmlname_checker
 from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.i18n import format_date
 
 if False:
     # For type annotation
@@ -129,7 +129,7 @@ class Epub3Builder(_epub_base.EpubBuilder):
         metadata['contributor'] = self.esc(self.config.epub_contributor)
         metadata['page_progression_direction'] = PAGE_PROGRESSION_DIRECTIONS.get(writing_mode)
         metadata['ibook_scroll_axis'] = IBOOK_SCROLL_AXIS.get(writing_mode)
-        metadata['date'] = self.esc(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
+        metadata['date'] = format_date("%Y-%m-%dT%H:%M:%SZ")
         metadata['version'] = self.esc(self.config.version)
         return metadata
 


### PR DESCRIPTION
I noticed that epub files have timestamp embedded into them (in `dc:date` and `dcterms:modified` headers), and those dates do not follow the [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) environment variable. This pull request fixes that.