### PR TITLE
Fix #1020: ext.todo todolist not linking to the page in pdflatex

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Other contributors, listed alphabetically, are:
 * Kevin Dunn -- MathJax extension
 * Josip Dzolonga -- coverage builder
 * Buck Evan -- dummy builder
+* Matthew Fernandez -- todo extension fix
 * Hernan Grecco -- search improvements
 * Horst Gutmann -- internationalization support
 * Martin Hans -- autodoc improvements

--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Bugs fixed
 * #3692: Unable to build HTML if writing .buildinfo failed
 * #4152: HTML writer crashes if a field list is placed on top of the document
 * #4063: Sphinx crashes when labeling directive ``.. todolist::``
+* #1020: ext.todo todolist not linking to the page in pdflatex
 
 Testing
 --------

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -69,6 +69,8 @@ class Todo(BaseAdmonition):
 
         env = self.state.document.settings.env
         targetid = 'index-%s' % env.new_serialno('index')
+        # Stash the target to be retrieved later in latex_visit_todo_node.
+        todo['targetref'] = '%s:%s' % (env.docname, targetid)
         targetnode = nodes.target('', '', ids=[targetid])
         return [targetnode, todo]
 
@@ -173,8 +175,12 @@ def process_todo_nodes(app, doctree, fromdocname):
             para += newnode
             para += nodes.Text(desc2, desc2)
 
-            # (Recursively) resolve references in the todo content
             todo_entry = todo_info['todo']
+            # Remove targetref from the (copied) node to avoid emitting a
+            # duplicate label of the original entry when we walk this node.
+            del todo_entry['targetref']
+
+            # (Recursively) resolve references in the todo content
             env.resolve_references(todo_entry, todo_info['docname'],
                                    app.builder)
 
@@ -216,7 +222,13 @@ def depart_todo_node(self, node):
 def latex_visit_todo_node(self, node):
     # type: (nodes.NodeVisitor, todo_node) -> None
     title = node.pop(0).astext().translate(tex_escape_map)
-    self.body.append(u'\n\\begin{sphinxadmonition}{note}{%s:}' % title)
+    self.body.append(u'\n\\begin{sphinxadmonition}{note}{')
+    # If this is the original todo node, emit a label that will be referenced by
+    # a hyperref in the todolist.
+    target = node.get('targetref')
+    if target is not None:
+        self.body.append(u'\\label{%s}' % target)
+    self.body.append('%s:}' % title)
 
 
 def latex_depart_todo_node(self, node):

--- a/tests/roots/test-ext-todo/conf.py
+++ b/tests/roots/test-ext-todo/conf.py
@@ -2,3 +2,8 @@
 
 extensions = ['sphinx.ext.todo']
 master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'TodoTests.tex', 'Todo Tests Documentation',
+     'Robin Banks', 'manual'),
+]

--- a/tests/test_writer_latex.py
+++ b/tests/test_writer_latex.py
@@ -27,7 +27,7 @@ def test_rstdim_to_latexdim():
     assert rstdim_to_latexdim('30%') == '0.300\\linewidth'
     assert rstdim_to_latexdim('160') == '160\\sphinxpxdimen'
 
-    # flaot values
+    # float values
     assert rstdim_to_latexdim('160.0em') == '160.0em'
     assert rstdim_to_latexdim('.5em') == '.5em'
 


### PR DESCRIPTION
Subject: Fix #1020: ext.todo todolist not linking to the page in pdflatex

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
This patch series fixes an issue where items created using the todo extension are not linked from the `todolist` summary when using the LaTeX back end. Following these changes, the "original entry" text in the resulting PDF correctly links to the todo entry to which it refers. There is also a trivial typo fix included in these changes.

### Detail
- #1020: ext.todo todolist not linking to the page in pdflatex

These changes are perhaps not as clean as they could be, so if there are any suggestions on improving them they are most welcome. I discovered some oddities while working on this in relation to the way LaTeX output is manually constructed as text blocks in this extension. For example, an exception block in this extension has the comment "ignore if no URI can be determined, e.g. for LaTeX output" but the LaTeX back end does not actually trigger the exception in question. My changes could probably do with some review from the original author of this extension, Daniel Bültmann, if he is contactable.

### Relates
N/A