### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ directory = sphinx/locale/
 [wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [flake8]
 max-line-length = 95
 ignore = E116,E241,E251


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file