### PR TITLE
The exit code for 'python -msphinx' is incorrect

### DIFF
--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -66,7 +66,7 @@ def main(*args, **kwargs):
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
-    build.main(*args, **kwargs)
+    return build.main(*args, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Subject: Sphinx did not exit with the correct exit code

### Feature or Bugfix
- Bugfix

### Purpose
The exit code of the sphinx main method was ignored, so the process always exited with an exit code of 0, even if there were warnings and the -W flag was set.

### Relates
- #508 

