### PR TITLE
Fix issue #4158

### DIFF
--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -62,6 +62,8 @@ def get_lvar_names(node, self=None):
             raise TypeError('The assignment %r is not instance variable' % node)
     elif node_name == 'str':
         return [node]  # type: ignore
+    elif node_name == 'Starred' and node.value.__class__.__name__ == 'Name':
+        return [node.value.id]
     else:
         raise NotImplementedError('Unexpected node name %r' % node_name)
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -43,6 +43,11 @@ def get_lvar_names(node, self=None):
         else:
             self_id = self.arg
 
+    # if node is something like *foo, *self.foo, *map['bar'] resulting from
+    # sequence unpacking (PEP3132)
+    if node.__class__.__name__ == 'Starred':
+        # unwrap the real value
+        node = node.value
     node_name = node.__class__.__name__
     if node_name in ('Index', 'Num', 'Slice', 'Str', 'Subscript'):
         raise TypeError('%r does not create new variable' % node)
@@ -62,8 +67,6 @@ def get_lvar_names(node, self=None):
             raise TypeError('The assignment %r is not instance variable' % node)
     elif node_name == 'str':
         return [node]  # type: ignore
-    elif node_name == 'Starred' and node.value.__class__.__name__ == 'Name':
-        return [node.value.id]
     else:
         raise NotImplementedError('Unexpected node name %r' % node_name)
 

--- a/tests/test_pycode.py
+++ b/tests/test_pycode.py
@@ -153,3 +153,16 @@ def test_ModuleAnalyzer_find_attr_docs():
                                  'Qux': 15,
                                  'Qux.attr1': 16,
                                  'Qux.attr2': 17}
+
+def test_ModuleAnalyzer_pep3132():
+    code = ('class Foo(object):\n'
+            '    """class Foo!"""\n'
+            '    #: comment before attr1\n'
+            '    attr1 = None\n'
+            '\n'
+            '    def bar(self, *args, **kwargs):\n'
+            '       """method Foo.bar"""\n'
+            '       head, *tail = kwargs\n')
+    analyzer = ModuleAnalyzer.for_string(code, 'module')
+    docs = analyzer.find_attr_docs()
+    assert set(docs) == {('Foo', 'attr1')}


### PR DESCRIPTION
Subject: Fix issue #4158

### Feature or Bugfix
- Bugfix

### Purpose
Avoid raising an error when an ast.Starred instance is analyzed, extract variable name information instead.
### Relates
- #4158
- The accumulator variable used in PEP3132 
- See also http://greentreesnakes.readthedocs.io/en/latest/nodes.html#Starred