### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 dist: trusty
-cache:
-  directories:
-    - $HOME/.cache/pip
+cache: pip
 python:
   - "pypy-5.4.1"
   - "3.6"


### PR DESCRIPTION
Can speed up builds and reduce load on PyPI servers.

For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache