### PR TITLE
improve zh search with jieba

### DIFF
--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -240,7 +240,7 @@ class SearchChinese(SearchLanguage):
         if JIEBA:
             dict_path = options.get('dict')
             if dict_path and os.path.isfile(dict_path):
-                jieba.set_dictionary(dict_path)
+                jieba.load_userdict(dict_path)
 
         self.stemmer = get_stemmer()
 


### PR DESCRIPTION
Subject: improve zh search with jieba

### Feature or Bugfix
- Feature

### Purpose
Currently, search function for Chinese (`zh`) optionally depends on `jieba` to tokenize the sentences. `jieba` provides functions to specify the dictionary: `set_dictionary()` to select (**overwrite**) the **main** dictionary, and `load_userdict()` to specify the **additional** dictionary (**not overwriting** the main dictionary).

Previously, the implementation in `sphinx-doc` uses `set_dictionary()`. However, it's more common that user just want to add some additional custom words.

### Detail
Simply change the relative `jieba` function.

This is clear and should not break any tests.

### Relates
https://github.com/fxsjy/jieba#load-dictionary

