### PR TITLE
Argparse integration (continued)

### DIFF
--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -378,17 +378,14 @@ imgmath has been deselected.''')
         do_prompt(d, 'ext_githubpages', 'githubpages: create .nojekyll file '
                   'to publish the document on GitHub pages (y/n)', 'n', boolean)
 
-    if 'no_makefile' in d:
-        d['makefile'] = False
-    elif 'makefile' not in d:
+    if 'makefile' not in d:
         print('''
 A Makefile and a Windows command file can be generated for you so that you
 only have to run e.g. `make html' instead of invoking sphinx-build
 directly.''')
         do_prompt(d, 'makefile', 'Create Makefile? (y/n)', 'y', boolean)
-    if 'no_batchfile' in d:
-        d['batchfile'] = False
-    elif 'batchfile' not in d:
+
+    if 'batchfile' not in d:
         do_prompt(d, 'batchfile', 'Create Windows command file? (y/n)',
                   'y', boolean)
     print()
@@ -593,22 +590,22 @@ Makefile to be used with sphinx-build.
     group.add_argument('--extensions', metavar='EXTENSIONS', dest='extensions',
                        action='append', help='enable extensions')
 
-    # TODO(stephenfin): Consider using mutually exclusive groups here
     group = parser.add_argument_group('Makefile and Batchfile creation')
-    group.add_argument('--makefile', action='store_true', default=False,
+    group.add_argument('--makefile', action='store_true', dest='makefile',
                        help='create makefile')
-    group.add_argument('--no-makefile', action='store_true', default=False,
-                       help='not create makefile')
-    group.add_argument('--batchfile', action='store_true', default=False,
+    group.add_argument('--no-makefile', action='store_false', dest='makefile',
+                       help='do not create makefile')
+    group.add_argument('--batchfile', action='store_true', dest='batchfile',
                        help='create batchfile')
-    group.add_argument('--no-batchfile', action='store_true', default=False,
-                       help='not create batchfile')
-    group.add_argument('-M', '--no-use-make-mode', action='store_false',
-                       dest='make_mode', default=False,
-                       help='not use make-mode for Makefile/make.bat')
+    group.add_argument('--no-batchfile', action='store_false',
+                       dest='batchfile',
+                       help='do not create batchfile')
     group.add_argument('-m', '--use-make-mode', action='store_true',
-                       dest='make_mode', default=True,
+                       dest='make_mode',
                        help='use make-mode for Makefile/make.bat')
+    group.add_argument('-M', '--no-use-make-mode', action='store_false',
+                       dest='make_mode',
+                       help='do not use make-mode for Makefile/make.bat')
 
     group = parser.add_argument_group('Project templating')
     group.add_argument('-t', '--templatedir', metavar='TEMPLATEDIR',
@@ -652,10 +649,6 @@ def main(argv=sys.argv[1:]):
             d2.update(dict(("ext_" + ext, False) for ext in EXTENSIONS))
             d2.update(d)
             d = d2
-            if 'no_makefile' in d:
-                d['makefile'] = False
-            if 'no_batchfile' in d:
-                d['batchfile'] = False
 
             if not valid_dir(d):
                 print()

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -159,8 +159,8 @@ def term_decode(text):
         return text.decode('latin1')
 
 
-def do_prompt(d, key, text, default=None, validator=nonempty):
-    # type: (Dict, unicode, unicode, unicode, Callable[[unicode], Any]) -> None
+def do_prompt(text, default=None, validator=nonempty):
+    # type: (unicode, unicode, Callable[[unicode], Any]) -> Union[unicode, bool]
     while True:
         if default is not None:
             prompt = PROMPT_PREFIX + '%s [%s]: ' % (text, default)  # type: unicode
@@ -191,7 +191,7 @@ def do_prompt(d, key, text, default=None, validator=nonempty):
             print(red('* ' + str(err)))
             continue
         break
-    d[key] = x
+    return x
 
 
 def convert_python_source(source, rex=re.compile(r"[uU]('.*?')")):
@@ -251,7 +251,7 @@ Selected root path: %s''' % d['path']))
     else:
         print('''
 Enter the root path for documentation.''')
-        do_prompt(d, 'path', 'Root path for the documentation', '.', is_path)
+        d['path'] = do_prompt('Root path for the documentation', '.', is_path)
 
     while path.isfile(path.join(d['path'], 'conf.py')) or \
             path.isfile(path.join(d['path'], 'source', 'conf.py')):
@@ -260,8 +260,8 @@ Enter the root path for documentation.''')
                    'selected root path.'))
         print('sphinx-quickstart will not overwrite existing Sphinx projects.')
         print()
-        do_prompt(d, 'path', 'Please enter a new root path (or just Enter '
-                  'to exit)', '', is_path)
+        d['path'] = do_prompt('Please enter a new root path (or just Enter '
+                              'to exit)', '', is_path)
         if not d['path']:
             sys.exit(1)
 
@@ -270,22 +270,22 @@ Enter the root path for documentation.''')
 You have two options for placing the build directory for Sphinx output.
 Either, you use a directory "_build" within the root path, or you separate
 "source" and "build" directories within the root path.''')
-        do_prompt(d, 'sep', 'Separate source and build directories (y/n)', 'n',
-                  boolean)
+        d['sep'] = do_prompt('Separate source and build directories (y/n)',
+                             'n', boolean)
 
     if 'dot' not in d:
         print('''
 Inside the root directory, two more directories will be created; "_templates"
 for custom HTML templates and "_static" for custom stylesheets and other static
 files. You can enter another prefix (such as ".") to replace the underscore.''')
-        do_prompt(d, 'dot', 'Name prefix for templates and static dir', '_', ok)
+        d['dot'] = do_prompt('Name prefix for templates and static dir', '_', ok)
 
     if 'project' not in d:
         print('''
 The project name will occur in several places in the built documentation.''')
-        do_prompt(d, 'project', 'Project name')
+        d['project'] = do_prompt('Project name')
     if 'author' not in d:
-        do_prompt(d, 'author', 'Author name(s)')
+        d['author'] = do_prompt('Author name(s)')
 
     if 'version' not in d:
         print('''
@@ -294,9 +294,9 @@ software. Each version can have multiple releases. For example, for
 Python the version is something like 2.5 or 3.0, while the release is
 something like 2.5.1 or 3.0a1.  If you don't need this dual structure,
 just set both to the same value.''')
-        do_prompt(d, 'version', 'Project version', '', allow_empty)
+        d['version'] = do_prompt('Project version', '', allow_empty)
     if 'release' not in d:
-        do_prompt(d, 'release', 'Project release', d['version'], allow_empty)
+        d['release'] = do_prompt('Project release', d['version'], allow_empty)
 
     if 'language' not in d:
         print('''
@@ -306,7 +306,7 @@ translate text that it generates into that language.
 
 For a list of supported codes, see
 http://sphinx-doc.org/config.html#confval-language.''')
-        do_prompt(d, 'language', 'Project language', 'en')
+        d['language'] = do_prompt('Project language', 'en')
         if d['language'] == 'en':
             d['language'] = None
 
@@ -314,7 +314,7 @@ http://sphinx-doc.org/config.html#confval-language.''')
         print('''
 The file name suffix for source files. Commonly, this is either ".txt"
 or ".rst".  Only files with this suffix are considered documents.''')
-        do_prompt(d, 'suffix', 'Source file suffix', '.rst', suffix)
+        d['suffix'] = do_prompt('Source file suffix', '.rst', suffix)
 
     if 'master' not in d:
         print('''
@@ -322,8 +322,8 @@ One document is special in that it is considered the top node of the
 "contents tree", that is, it is the root of the hierarchical structure
 of the documents. Normally, this is "index", but if your "index"
 document is a custom template, you can also set this to another filename.''')
-        do_prompt(d, 'master', 'Name of your master document (without suffix)',
-                  'index')
+        d['master'] = do_prompt('Name of your master document (without suffix)',
+                                'index')
 
     while path.isfile(path.join(d['path'], d['master'] + d['suffix'])) or \
             path.isfile(path.join(d['path'], 'source', d['master'] + d['suffix'])):
@@ -332,62 +332,66 @@ document is a custom template, you can also set this to another filename.''')
                    'selected root path.' % (d['master'] + d['suffix'])))
         print('sphinx-quickstart will not overwrite the existing file.')
         print()
-        do_prompt(d, 'master', 'Please enter a new file name, or rename the '
-                  'existing file and press Enter', d['master'])
+        d['master'] = do_prompt('Please enter a new file name, or rename the '
+                                'existing file and press Enter', d['master'])
 
     if 'epub' not in d:
         print('''
 Sphinx can also add configuration for epub output:''')
-        do_prompt(d, 'epub', 'Do you want to use the epub builder (y/n)',
-                  'n', boolean)
+        d['epub'] = do_prompt('Do you want to use the epub builder (y/n)',
+                              'n', boolean)
 
     if 'ext_autodoc' not in d:
         print('''
 Please indicate if you want to use one of the following Sphinx extensions:''')
-        do_prompt(d, 'ext_autodoc', 'autodoc: automatically insert docstrings '
-                  'from modules (y/n)', 'n', boolean)
+        d['ext_autodoc'] = do_prompt('autodoc: automatically insert docstrings '
+                                     'from modules (y/n)', 'n', boolean)
     if 'ext_doctest' not in d:
-        do_prompt(d, 'ext_doctest', 'doctest: automatically test code snippets '
-                  'in doctest blocks (y/n)', 'n', boolean)
+        d['ext_doctest'] = do_prompt('doctest: automatically test code snippets '
+                                     'in doctest blocks (y/n)', 'n', boolean)
     if 'ext_intersphinx' not in d:
-        do_prompt(d, 'ext_intersphinx', 'intersphinx: link between Sphinx '
-                  'documentation of different projects (y/n)', 'n', boolean)
+        d['ext_intersphinx'] = do_prompt('intersphinx: link between Sphinx '
+                                         'documentation of different projects (y/n)',
+                                         'n', boolean)
     if 'ext_todo' not in d:
-        do_prompt(d, 'ext_todo', 'todo: write "todo" entries '
-                  'that can be shown or hidden on build (y/n)', 'n', boolean)
+        d['ext_todo'] = do_prompt('todo: write "todo" entries that can be '
+                                  'shown or hidden on build (y/n)', 'n', boolean)
     if 'ext_coverage' not in d:
-        do_prompt(d, 'ext_coverage', 'coverage: checks for documentation '
-                  'coverage (y/n)', 'n', boolean)
+        d['ext_coverage'] = do_prompt('coverage: checks for documentation '
+                                      'coverage (y/n)', 'n', boolean)
     if 'ext_imgmath' not in d:
-        do_prompt(d, 'ext_imgmath', 'imgmath: include math, rendered '
-                  'as PNG or SVG images (y/n)', 'n', boolean)
+        d['ext_imgmath'] = do_prompt('imgmath: include math, rendered as PNG '
+                                     'or SVG images (y/n)', 'n', boolean)
     if 'ext_mathjax' not in d:
-        do_prompt(d, 'ext_mathjax', 'mathjax: include math, rendered in the '
-                  'browser by MathJax (y/n)', 'n', boolean)
+        d['ext_mathjax'] = do_prompt('mathjax: include math, rendered in the '
+                                     'browser by MathJax (y/n)', 'n', boolean)
     if d['ext_imgmath'] and d['ext_mathjax']:
         print('''Note: imgmath and mathjax cannot be enabled at the same time.
 imgmath has been deselected.''')
         d['ext_imgmath'] = False
     if 'ext_ifconfig' not in d:
-        do_prompt(d, 'ext_ifconfig', 'ifconfig: conditional inclusion of '
-                  'content based on config values (y/n)', 'n', boolean)
+        d['ext_ifconfig'] = do_prompt('ifconfig: conditional inclusion of '
+                                      'content based on config values (y/n)',
+                                      'n', boolean)
     if 'ext_viewcode' not in d:
-        do_prompt(d, 'ext_viewcode', 'viewcode: include links to the source '
-                  'code of documented Python objects (y/n)', 'n', boolean)
+        d['ext_viewcode'] = do_prompt('viewcode: include links to the source '
+                                      'code of documented Python objects (y/n)',
+                                      'n', boolean)
     if 'ext_githubpages' not in d:
-        do_prompt(d, 'ext_githubpages', 'githubpages: create .nojekyll file '
-                  'to publish the document on GitHub pages (y/n)', 'n', boolean)
+        d['ext_githubpages'] = do_prompt('githubpages: create .nojekyll file '
+                                         'to publish the document on GitHub '
+                                         'pages (y/n)', 'n', boolean)
 
     if 'makefile' not in d:
         print('''
 A Makefile and a Windows command file can be generated for you so that you
 only have to run e.g. `make html' instead of invoking sphinx-build
 directly.''')
-        do_prompt(d, 'makefile', 'Create Makefile? (y/n)', 'y', boolean)
+        d['makefile'] = do_prompt('Create Makefile? (y/n)', 'y', boolean)
 
     if 'batchfile' not in d:
-        do_prompt(d, 'batchfile', 'Create Windows command file? (y/n)',
-                  'y', boolean)
+        d['batchfile'] = do_prompt('Create Windows command file? (y/n)',
+                                   'y', boolean)
     print()
 
 

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -358,8 +358,8 @@ Note: By default this script will not overwrite already created files.""")
 
     group = parser.add_argument_group('extension options')
     for ext in EXTENSIONS:
-        group.add_argument('--ext-' + ext, action='store_true',
-                           dest='ext_' + ext, default=False,
+        group.add_argument('--ext-%s' % ext, action='append_const',
+                           const='sphinx.ext.%s' % ext, dest='extensions',
                            help='enable %s extension' % ext)
 
     return parser
@@ -408,9 +408,8 @@ def main(argv=sys.argv[1:]):
             suffix = '.' + args.suffix,
             master = 'index',
             epub = True,
-            ext_autodoc = True,
-            ext_viewcode = True,
-            ext_todo = True,
+            extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode',
+                          'sphinx.ext.todo'],
             makefile = True,
             batchfile = True,
             make_mode = True,
@@ -420,9 +419,8 @@ def main(argv=sys.argv[1:]):
             module_path = rootpath,
             append_syspath = args.append_syspath,
         )
-        enabled_exts = {'ext_' + ext: getattr(args, 'ext_' + ext)
-                        for ext in EXTENSIONS if getattr(args, 'ext_' + ext)}
-        d.update(enabled_exts)
+        if args.extensions:
+            d['extensions'].extend(args.extensions)
 
         if isinstance(args.header, binary_type):
             d['project'] = d['project'].decode('utf-8')

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -42,7 +42,11 @@ sys.path.insert(0, u'{{ module_path }}')
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [{{ extensions }}]
+extensions = [
+{%- for ext in extensions %}
+    '{{ ext }}',
+{%- endfor %}
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['{{ dot }}templates']
@@ -84,9 +88,6 @@ exclude_patterns = [{{ exclude_patterns }}]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
-
-# If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = {{ ext_todo }}
 
 
 # -- Options for HTML output ----------------------------------------------
@@ -173,8 +174,8 @@ texinfo_documents = [
      author, '{{ project_fn }}', 'One line description of project.',
      'Miscellaneous'),
 ]
+{%- if epub %}
 
-{% if epub %}
 
 # -- Options for Epub output ----------------------------------------------
 
@@ -195,9 +196,23 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
-{% endif %}
+{%- endif %}
+{%- if extensions %}
 
-{% if ext_intersphinx %}
+
+# -- Extension configuration ----------------------------------------------
+{%- endif %}
+{%- if 'sphinx.ext.intersphinx' in extensions %}
+
+# -- Options for intersphinx extension ------------------------------------
+
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
-{% endif %}
+{%- endif %}
+{%- if 'sphinx.ext.todo' in extensions %}
+
+# -- Options for todo extension -------------------------------------------
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
+{%- endif %}

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -61,27 +61,7 @@ def teardown_module():
     coloron()
 
 
-def test_quickstart_inputstrip():
-    d = {}
-    answers = {
-        'Q1': 'Y',
-        'Q2': ' Yes ',
-        'Q3': 'N',
-        'Q4': 'N ',
-    }
-    qs.term_input = mock_input(answers)
-    qs.do_prompt(d, 'k1', 'Q1')
-    assert d['k1'] == 'Y'
-    qs.do_prompt(d, 'k2', 'Q2')
-    assert d['k2'] == 'Yes'
-    qs.do_prompt(d, 'k3', 'Q3')
-    assert d['k3'] == 'N'
-    qs.do_prompt(d, 'k4', 'Q4')
-    assert d['k4'] == 'N'
-
-
 def test_do_prompt():
-    d = {}
     answers = {
         'Q2': 'v2',
         'Q3': 'v3',
@@ -90,24 +70,29 @@ def test_do_prompt():
         'Q6': 'foo',
     }
     qs.term_input = mock_input(answers)
-    try:
-        qs.do_prompt(d, 'k1', 'Q1')
-    except AssertionError:
-        assert 'k1' not in d
-    else:
-        assert False, 'AssertionError not raised'
-    qs.do_prompt(d, 'k1', 'Q1', default='v1')
-    assert d['k1'] == 'v1'
-    qs.do_prompt(d, 'k3', 'Q3', default='v3_default')
-    assert d['k3'] == 'v3'
-    qs.do_prompt(d, 'k2', 'Q2')
-    assert d['k2'] == 'v2'
-    qs.do_prompt(d, 'k4', 'Q4', validator=qs.boolean)
-    assert d['k4'] is True
-    qs.do_prompt(d, 'k5', 'Q5', validator=qs.boolean)
-    assert d['k5'] is False
+
+    assert qs.do_prompt('Q1', default='v1') == 'v1'
+    assert qs.do_prompt('Q3', default='v3_default') == 'v3'
+    assert qs.do_prompt('Q2') == 'v2'
+    assert qs.do_prompt('Q4', validator=qs.boolean) is True
+    assert qs.do_prompt('Q5', validator=qs.boolean) is False
     with pytest.raises(AssertionError):
-        qs.do_prompt(d, 'k6', 'Q6', validator=qs.boolean)
+        qs.do_prompt('Q6', validator=qs.boolean)
+
+
+def test_do_prompt_inputstrip():
+    answers = {
+        'Q1': 'Y',
+        'Q2': ' Yes ',
+        'Q3': 'N',
+        'Q4': 'N ',
+    }
+    qs.term_input = mock_input(answers)
+
+    assert qs.do_prompt('Q1') == 'Y'
+    assert qs.do_prompt('Q2') == 'Yes'
+    assert qs.do_prompt('Q3') == 'N'
+    assert qs.do_prompt('Q4') == 'N'
 
 
 def test_do_prompt_with_nonascii():
@@ -117,12 +102,12 @@ def test_do_prompt_with_nonascii():
     }
     qs.term_input = mock_input(answers)
     try:
-        qs.do_prompt(d, 'k1', 'Q1', default=u'\u65e5\u672c')
+        result = qs.do_prompt('Q1', default=u'\u65e5\u672c')
     except UnicodeEncodeError:
         raise pytest.skip.Exception(
             'non-ASCII console input not supported on this encoding: %s',
             qs.TERM_ENCODING)
-    assert d['k1'] == u'\u30c9\u30a4\u30c4'
+    assert result == u'\u30c9\u30a4\u30c4'
 
 
 def test_quickstart_defaults(tempdir):

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -134,7 +134,6 @@ def test_quickstart_defaults(tempdir):
     assert ns['copyright'] == '%s, Georg Brandl' % time.strftime('%Y')
     assert ns['version'] == '0.1'
     assert ns['release'] == '0.1'
-    assert ns['todo_include_todos'] is False
     assert ns['html_static_path'] == ['_static']
     assert ns['latex_documents'] == [
         ('index', 'SphinxTest.tex', 'Sphinx Test Documentation',


### PR DESCRIPTION
Subject: Continued argparse-ification of the Sphinx utilities.

### Feature or Bugfix
Refactor

### Purpose
This continues the work on argparse, cleaning up some stuff that wasn't included in #4097 so as to keep it as simple as possible. Refer to #3259 and #4097 for more information.

### Detail
- quickstart: Rework how we collect extensions

  This is a little more flexible than the existing set up and makes maximum use of argparse capabilities.

  This has the side-effect of no longer including configuration for the `sphinx.ext.todo` extension when said extension is not enabled.

This requires two additional changes.

- quickstart: Rework 'do_prompt' function

  The 'd' and 'key' values are used on a single line. Move these outside the function to allow us to do other things with this function.

- quickstart: Simplify `--(no-)option` handling

  The standard pattern for doing this is to use a common 'dest'.

### Relates
- #3259 
- #4097 
