### PR TITLE
The great toxification (part 5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - pip install -U pip setuptools
   - pip install docutils==$DOCUTILS
   - pip install .[test,websupport]
-  - pip install flake8
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then python3.6 -m pip install mypy typed-ast; fi
 script:
   - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then python3.6 -m pip install mypy typed-ast; fi
 script:
   - flake8
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make type-check test-async; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make type-check test; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '3.6' ]]; then make test; fi

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ reindent:
 
 .PHONY: test
 test:
-	@cd tests; $(PYTHON) run.py --ignore py35 -v $(TEST)
+	@cd tests; $(PYTHON) run.py -v $(TEST)
 
 .PHONY: test-async
 test-async:
-	@cd tests; $(PYTHON) run.py -v $(TEST)
+	@echo "This target no longer does anything and will be removed imminently"
 
 .PHONY: covertest
 covertest:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ extras_require = {
         'pytest',
         'pytest-cov',
         'html5lib',
+        'flake8',
     ],
     'test:python_version<"3"': [
         'enum34',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,12 @@ from sphinx.testing.path import path
 
 pytest_plugins = 'sphinx.testing.fixtures'
 
+# Exclude 'roots' dirs for pytest test collector
+collect_ignore = ['roots']
+
 # Disable Python version-specific
 if sys.version_info < (3, 5):
-    collect_ignore = ['py35']
+    collect_ignore += ['py35']
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,16 @@
 """
 
 import os
+import sys
 
 import pytest
 from sphinx.testing.path import path
 
 pytest_plugins = 'sphinx.testing.fixtures'
+
+# Disable Python version-specific
+if sys.version_info < (3, 5):
+    collect_ignore = ['py35']
 
 
 @pytest.fixture(scope='session')

--- a/tests/run.py
+++ b/tests/run.py
@@ -55,14 +55,5 @@ os.makedirs(tempdir)
 print('Running Sphinx test suite (with Python %s)...' % sys.version.split()[0])
 sys.stdout.flush()
 
-# exclude 'roots' dirs for pytest test collector
-ignore_paths = [
-    os.path.relpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), sub))
-    for sub in ('roots',)
-]
-args = sys.argv[1:]
-for ignore_path in ignore_paths:
-    args.extend(['--ignore', ignore_path])
-
 import pytest  # NOQA
-sys.exit(pytest.main(args))
+sys.exit(pytest.main(sys.argv[1:]))

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -9,9 +9,23 @@
     :license: BSD, see LICENSE for details.
 """
 
+import os
 import re
+import subprocess
 
 import pytest
+
+
+def has_binary(binary):
+    try:
+        subprocess.check_output([binary])
+    except OSError as e:
+        if e.errno == os.errno.ENOENT:
+            # handle file not found error.
+            return False
+        else:
+            return True
+    return True
 
 
 @pytest.mark.sphinx(
@@ -34,6 +48,8 @@ def test_jsmath(app, status, warning):
     assert '<div class="math">\na + 1 &lt; b</div>' in content
 
 
+@pytest.mark.skipif(not has_binary('dvipng'),
+                    reason='Requires dvipng" binary')
 @pytest.mark.sphinx('html', testroot='ext-math-simple',
                     confoverrides = {'extensions': ['sphinx.ext.imgmath']})
 def test_imgmath_png(app, status, warning):
@@ -49,6 +65,8 @@ def test_imgmath_png(app, status, warning):
     assert re.search(html, content, re.S)
 
 
+@pytest.mark.skipif(not has_binary('dvisvgm'),
+                    reason='Requires dvisvgm" binary')
 @pytest.mark.sphinx('html', testroot='ext-math-simple',
                     confoverrides={'extensions': ['sphinx.ext.imgmath'],
                                    'imgmath_image_format': 'svg'})

--- a/tox.ini
+++ b/tox.ini
@@ -10,31 +10,15 @@ passenv = https_proxy http_proxy no_proxy
 # https://tox.readthedocs.io/en/latest/config.html#confval-extras=MULTI-LINE-LIST
 deps =
     .[test,websupport]
+    du11: docutils==0.11
+    du12: docutils==0.12
+    du13: docutils==0.13.1
+    du14: docutils==0.14
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
     coverage: PYTEST_ADDOPTS = --cov sphinx
 commands=
     {envpython} -Wall tests/run.py --durations 25 {posargs}
-
-[testenv:du11]
-deps=
-    docutils==0.11
-    {[testenv]deps}
-
-[testenv:du12]
-deps=
-    docutils==0.12
-    {[testenv]deps}
-
-[testenv:du13]
-deps=
-    docutils==0.13.1
-    {[testenv]deps}
-
-[testenv:du14]
-deps=
-    docutils==0.14
-    {[testenv]deps}
 
 [testenv:flake8]
 commands=flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.0
-envlist=flake8,mypy,py{27,34,35,36},pypy,du{11,12,13,14}
+envlist=docs,flake8,mypy,py{27,34,35,36},pypy,du{11,12,13,14}
 
 [testenv]
 passenv = https_proxy http_proxy no_proxy
@@ -13,9 +13,7 @@ deps =
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
 commands=
-    {envpython} -Wall tests/run.py --ignore tests/py35 --cov=sphinx \
-        --durations 25 {posargs}
-    sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
+    {envpython} -Wall tests/run.py --cov sphinx --durations 25 {posargs}
 
 [testenv:du11]
 deps=
@@ -46,15 +44,6 @@ deps=
     {[testenv]deps}
 commands=
     pylint --rcfile utils/pylintrc sphinx
-
-[testenv:py27]
-deps=
-    {[testenv]deps}
-
-[testenv:py35]
-commands=
-    {envpython} -Wall tests/run.py --cov=sphinx --durations 25 {posargs}
-    sphinx-build -q -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:mypy]
 basepython=python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.0
-envlist=docs,flake8,mypy,py{27,34,35,36},pypy,du{11,12,13,14}
+envlist=docs,flake8,mypy,coverage,py{27,34,35,36,py},du{11,12,13,14}
 
 [testenv]
 passenv = https_proxy http_proxy no_proxy
@@ -12,8 +12,9 @@ deps =
     .[test,websupport]
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
+    coverage: PYTEST_ADDOPTS = --cov sphinx
 commands=
-    {envpython} -Wall tests/run.py --cov sphinx --durations 25 {posargs}
+    {envpython} -Wall tests/run.py --durations 25 {posargs}
 
 [testenv:du11]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ deps=
     {[testenv]deps}
 
 [testenv:flake8]
-deps=flake8
 commands=flake8
 
 [testenv:pylint]


### PR DESCRIPTION
Subject: Finish things off in preparation for switching CIs to `tox`.

We want to switch CIs to use `tox` instead of the Makefile. Before we can do so, we need to close out a few more small things. In this series, we make the following changes:

- Take advantage of pytest features to dynamically disable tests if:
  - Dependencies are missing (e.g. `dvipng` or `dvisvgm`)
  - The version of Python is not high enough (e.g. only Python > 3.6 supports the `async` keyword)
- Take advantage of `tox` features to massively reduce the amount of duplication in the tox file

This is best reviewed by looking at commits individually [here](https://github.com/sphinx-doc/sphinx/pull/4175/commits). I use commits to break this up into readable chunks so it can be reviewed.

### Feature or Bugfix
- Feature

### Purpose
To paraphrase the Zen of Python (import this):

> tox is one honking great idea -- let's use more of it!

Start modernizing the test infrastructure that's using make and other hand-crafted tools by replacing them with tox-based derivatives.

**This is part five, step one.**

### Detail
This is a multi-step process, with the end goal of completely removing the Makefile and running everything through `tox`. The first fours steps of these can be done in parallel, but combined they block the final two.

1. Make `tox` a little more friendly by enabling extras like coverage, test profiling etc. by default, and closing gaps with the current Makefile targets such as PyLint and building docs in particular formats
2. Replace/remove custom tooling found in `utils` in favor of modern alternatives like `flake8`
3. Centralize as much configuration as possible inside `setup.cfg` and `tox.ini`, to avoid polluting the top level directory.
4. Clean up requirements (`test-reqs.txt`, `setup.py`) to ensure virtualenv and non-virtualenv builds are identical

The remaining two steps are blocked by the above:

5. Switch CIs to use `tox` instead of the Makefile, and update `CONTRIBUTING.rst` to refer to tox. Deprecate the Makefile  (**this change**)
6. (Bonus) Integrate [codecov.io](https://codecov.io) to make use of the coverage stats we now have

### Relates
- N/A