### PR TITLE
Fix #3739: ``:module:`` option is ignored at content of pyobjects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Bugs fixed
 * #4169: Chinese language doesn't trigger Chinese search automatically
 * #1020: ext.todo todolist not linking to the page in pdflatex
 * #3965: New quickstart generates wrong SPHINXBUILD in Makefile
+* #3739: ``:module:`` option is ignored at content of pyobjects
 
 Testing
 --------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -348,6 +348,10 @@ class PyObject(ObjectDescription):
             if self.allow_nesting:
                 classes = self.env.ref_context.setdefault('py:classes', [])
                 classes.append(prefix)
+        if 'module' in self.options:
+            modules = self.env.ref_context.setdefault('py:modules', [])
+            modules.append(self.env.ref_context.get('py:module'))
+            self.env.ref_context['py:module'] = self.options['module']
 
     def after_content(self):
         # type: () -> None
@@ -368,6 +372,12 @@ class PyObject(ObjectDescription):
                 pass
         self.env.ref_context['py:class'] = (classes[-1] if len(classes) > 0
                                             else None)
+        if 'module' in self.options:
+            modules = self.env.ref_context.setdefault('py:modules', [])
+            if modules:
+                self.env.ref_context['py:module'] = modules.pop()
+            else:
+                self.env.ref_context.pop('py:module')
 
 
 class PyModulelevel(PyObject):

--- a/tests/roots/test-domain-py/module_option.rst
+++ b/tests/roots/test-domain-py/module_option.rst
@@ -1,0 +1,25 @@
+module_option
+=============
+
+.. py:class:: B
+   :module: test.extra
+
+   This is also a test.
+
+
+   .. py:method:: B.baz()
+      :module: test.extra
+
+      Does something similar to :meth:`foo`.
+
+
+   .. py:method:: B.foo()
+      :module: test.extra
+
+      Does something.
+
+
+   .. py:method:: B.test()
+      :module: test.extra
+
+      Does something completely unrelated to :meth:`foo`

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -115,6 +115,15 @@ def test_domain_py_xrefs(app, status, warning):
     assert_refnode(refnodes[10], False, False, 'float', 'obj')
     assert len(refnodes) == 11
 
+    doctree = app.env.get_doctree('module_option')
+    refnodes = list(doctree.traverse(addnodes.pending_xref))
+    print(refnodes)
+    print(refnodes[0])
+    print(refnodes[1])
+    assert_refnode(refnodes[0], 'test.extra', 'B', 'foo', 'meth')
+    assert_refnode(refnodes[1], 'test.extra', 'B', 'foo', 'meth')
+    assert len(refnodes) == 2
+
 
 @pytest.mark.sphinx('dummy', testroot='domain-py')
 def test_domain_py_objects(app, status, warning):


### PR DESCRIPTION
refs: #3739