### PR TITLE
a single string value for ``html_sidebars`` will be deprecated in 2.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,9 @@ Incompatible changes
 Deprecated
 ----------
 
+* using a string value for :confval:`html_sidebars` is deprecated and only list
+  values will be accepted at 2.0.
+
 Features added
 --------------
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -828,6 +828,10 @@ that use Sphinx's HTMLWriter class.
      between the ``'sourcelink.html'`` and ``'searchbox.html'`` entries.  This
      is for compatibility with Sphinx versions before 1.0.
 
+   .. deprecated:: 1.7
+
+      a single string value for ``html_sidebars`` will be removed in 2.0
+
    Builtin sidebar templates that can be rendered are:
 
    * **localtoc.html** -- a fine-grained table of contents of the current

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -888,6 +888,11 @@ class StandaloneHTMLBuilder(Builder):
             # 0.x compatible mode: insert custom sidebar before searchbox
             customsidebar = sidebars
             sidebars = None
+            warnings.warn('Now html_sidebars only allows list of sidebar '
+                          'templates as a value. Support for a string value '
+                          'will be removed at Sphinx-2.0.',
+                          RemovedInSphinx20Warning)
+
         ctx['sidebars'] = sidebars
         ctx['customsidebar'] = customsidebar
 


### PR DESCRIPTION
### Feature or Bugfix
- Deprecation

### Purpose
- `html_sidebars` accepts a string as a value to keep compatible with 0.x
- It does not emit any warnings for deprecation
- This emits deprecation warnings
- It will be deprecated in Sphinx-2.0
