### PR TITLE
inspect: Sort dictionary keys when possible

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -203,6 +203,14 @@ def safe_getmembers(object, predicate=None, attr_getter=safe_getattr):
 def object_description(object):
     # type: (Any) -> unicode
     """A repr() implementation that returns text safe to use in reST context."""
+    if isinstance(object, dict):
+        try:
+            sorted_keys = sorted(object)
+        except TypeError:
+            pass  # Cannot sort dict keys, fall back to generic repr
+        else:
+            items = ("%r: %r" % (key, object[key]) for key in sorted_keys)
+            return "{%s}" % ", ".join(items)
     try:
         s = repr(object)
     except Exception:

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -130,3 +130,23 @@ class TestSafeGetAttr(TestCase):
             self.assertEqual(exc.args[0], 'bar')
         else:
             self.fail('AttributeError not raised')
+
+
+class TestObjectDescription(TestCase):
+    def test_dictionary_sorting(self):
+        dictionary = {"c": 3, "a": 1, "d": 2, "b": 4}
+        description = inspect.object_description(dictionary)
+        assert description == "{'a': 1, 'b': 4, 'c': 3, 'd': 2}"
+
+    def test_dict_customtype(self):
+        class CustomType(object):
+            def __init__(self, value):
+                self._value = value
+
+            def __repr__(self):
+                return "<CustomType(%r)>" % self._value
+
+        dictionary = {CustomType(2): 2, CustomType(1): 1}
+        description = inspect.object_description(dictionary)
+        # Type is unsortable, just check that it does not crash
+        assert "<CustomType(2)>: 2" in description


### PR DESCRIPTION
I got this bug report in Debian: https://bugs.debian.org/877637.

This pull request should fix that bug, now dictionary keys will be sorted if possible. If not, the generic `repr()` implementation is used.

This should also help for finding items in large dictionaries.