### PR TITLE
C++: remove function concepts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -68,6 +68,7 @@ Features removed
 * ``sphinx.util.nodes.process_only_nodes()``
 * LaTeX environment ``notice``, use ``sphinxadmonition`` instead
 * LaTeX ``\sphinxstylethead``, use ``\sphinxstyletheadfamily``
+* C++, support of function concepts
 
 Bugs fixed
 ----------

--- a/doc/domains.rst
+++ b/doc/domains.rst
@@ -720,13 +720,12 @@ a visibility statement (``public``, ``private`` or ``protected``).
 
 
 .. rst:directive:: .. cpp:concept:: template-parameter-list name
-                   .. cpp:concept:: template-parameter-list name()
 
    .. warning:: The support for concepts is experimental. It is based on the
       Concepts Technical Specification, and the features may change as the TS evolves.
 
-   Describe a variable concept or a function concept. Both must have exactly 1
-   template parameter list. The name may be a nested name. Examples::
+   Describe a concept. It must have exactly 1 template parameter list. The name may be a
+   nested name. Example::
 
       .. cpp:concept:: template<typename It> std::Iterator
 
@@ -744,12 +743,7 @@ a visibility statement (``public``, ``private`` or ``protected``).
          - :cpp:expr:`*r`, when :cpp:expr:`r` is dereferenceable.
          - :cpp:expr:`++r`, with return type :cpp:expr:`It&`, when :cpp:expr:`r` is incrementable.
 
-      .. cpp:concept:: template<typename Cont> std::Container()
-
-         Holder of elements, to which it can provide access via
-         :cpp:concept:`Iterator` s.
-
-   They will render as follows:
+   This will render as follows:
 
    .. cpp:concept:: template<typename It> std::Iterator
 
@@ -766,11 +760,6 @@ a visibility statement (``public``, ``private`` or ``protected``).
 
       - :cpp:expr:`*r`, when :cpp:expr:`r` is dereferenceable.
       - :cpp:expr:`++r`, with return type :cpp:expr:`It&`, when :cpp:expr:`r` is incrementable.
-
-   .. cpp:concept:: template<typename Cont> std::Container()
-
-      Holder of elements, to which it can provide access via
-      :cpp:concept:`Iterator` s.
 
 Options
 .......

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -231,10 +231,6 @@ def test_concept_definitions():
           {2:'I0EN1A1B7ConceptE'})
     check('concept', 'template<typename A, typename B, typename ...C> Foo',
           {2:'I00DpE3Foo'})
-    check('concept', 'template<typename Param> A::B::Concept()',
-          {2:'I0EN1A1B7ConceptE'})
-    check('concept', 'template<typename A, typename B, typename ...C> Foo()',
-          {2:'I00DpE3Foo'})
     with pytest.raises(DefinitionError):
         parse('concept', 'Foo')
     with pytest.raises(DefinitionError):


### PR DESCRIPTION
Work has resumed on concepts, and function concepts were finally given the axe. Because they had long been a contentious topic and were considered superfluous, I don't expect them to return. (Unlike other features such as template introductions which are currently not part of the active draft.) This PR removes support of function templates, with no deprecation.

- remove all mentions of 'function concepts'
- change mentions of 'variable concepts' to just 'concepts'
- concept directives now look like e.g. `.. cpp:concept:: template<typename It> Iterator`, no more trailing `()` allowed
- concepts are rendered as e.g. `template<typename It> concept Iterator`, no more `bool` displayed--to reflect actual C++ concept definitions
- update test case & docs

Currently the docs refer to the 'Concepts Technical Specification'. I believe all further work will take place in the C++ draft proper, and the TS (which has just been incorporated) will remain as-is. Since it's somewhat early and we still support things that are present in the old TS (e.g. template introductions) but not in the current draft, this PR does not update those references.

ping @jakobandersen 