### PR TITLE
Themes: Add a canonical_url option

### DIFF
--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -116,6 +116,12 @@ These themes are:
 
   - **sidebarwidth** (an integer): Width of the sidebar in pixels.  (Do not
     include ``px`` in the value.)  Defaults to 230 pixels.
+  
+  - **canonical_url** (sting): A `canonical url`_ to let search engines know
+    they should give higher ranking to latest version of the docs.  The url
+    points to the root of the documentation and requires a trailing slash.
+
+.. cronical url: https://en.wikipedia.org/wiki/Canonical_link_element
 
 * **alabaster** -- `Alabaster theme`_ is a modified "Kr" Sphinx theme from @kennethreitz
   (especially as used in his Requests project), which was itself originally based on

--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -121,7 +121,7 @@ These themes are:
     they should give higher ranking to latest version of the docs.  The url
     points to the root of the documentation and requires a trailing slash.
 
-.. cronical url: https://en.wikipedia.org/wiki/Canonical_link_element
+    .. _cronical url: https://en.wikipedia.org/wiki/Canonical_link_element
 
 * **alabaster** -- `Alabaster theme`_ is a modified "Kr" Sphinx theme from @kennethreitz
   (especially as used in his Requests project), which was itself originally based on

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -139,6 +139,9 @@
     {%- block scripts %}
     {{- script() }}
     {%- endblock %}
+    {%- if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    {%- endif %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -140,7 +140,7 @@
     {{- script() }}
     {%- endblock %}
     {%- if theme_canonical_url %}
-    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.{{ html_file_suffix }}"/>
     {%- endif %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"

--- a/sphinx/themes/basic/theme.conf
+++ b/sphinx/themes/basic/theme.conf
@@ -7,3 +7,4 @@ pygments_style = none
 nosidebar = false
 sidebarwidth = 230
 navigation_with_keys = False
+canonical_url =


### PR DESCRIPTION
Subject: Provide better SEO for themes

### Feature or Bugfix
- Feature

### Purpose
A canonical url will let search engines know they should give higher ranking to latest version of the docs. The url points to the root of the documentation and requires a trailing slash.

