### PR TITLE
Closes #3160: Use <kbd> tag for :kbd: role in html writers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -73,6 +73,7 @@ Features removed
 Bugs fixed
 ----------
 
+* #3160: Why doesn't Sphinx translate :kbd: roles to HTML's <kbd> tags?
 * #3882: Update the order of files for HTMLHelp and QTHelp
 * #3962: sphinx-apidoc does not recognize implicit namespace packages correctly
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -491,14 +491,21 @@ class HTMLTranslator(BaseTranslator):
     # overwritten
     def visit_literal(self, node):
         # type: (nodes.Node) -> None
-        self.body.append(self.starttag(node, 'code', '',
-                                       CLASS='docutils literal'))
-        self.protect_literal_text += 1
+        if 'kbd' in node['classes']:
+            self.body.append(self.starttag(node, 'kbd', '',
+                                           CLASS='docutils literal'))
+        else:
+            self.body.append(self.starttag(node, 'code', '',
+                                           CLASS='docutils literal'))
+            self.protect_literal_text += 1
 
     def depart_literal(self, node):
         # type: (nodes.Node) -> None
-        self.protect_literal_text -= 1
-        self.body.append('</code>')
+        if 'kbd' in node['classes']:
+            self.body.append('</kbd>')
+        else:
+            self.protect_literal_text -= 1
+            self.body.append('</code>')
 
     def visit_productionlist(self, node):
         # type: (nodes.Node) -> None

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -437,14 +437,21 @@ class HTML5Translator(BaseTranslator):
     # overwritten
     def visit_literal(self, node):
         # type: (nodes.Node) -> None
-        self.body.append(self.starttag(node, 'code', '',
-                                       CLASS='docutils literal'))
-        self.protect_literal_text += 1
+        if 'kbd' in node['classes']:
+            self.body.append(self.starttag(node, 'kbd', '',
+                                           CLASS='docutils literal'))
+        else:
+            self.body.append(self.starttag(node, 'code', '',
+                                           CLASS='docutils literal'))
+            self.protect_literal_text += 1
 
     def depart_literal(self, node):
         # type: (nodes.Node) -> None
-        self.protect_literal_text -= 1
-        self.body.append('</code>')
+        if 'kbd' in node['classes']:
+            self.body.append('</kbd>')
+        else:
+            self.protect_literal_text -= 1
+            self.body.append('</code>')
 
     def visit_productionlist(self, node):
         # type: (nodes.Node) -> None

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -238,7 +238,7 @@ def test_static_output(app):
         (".//li/strong", r'^command\\n$'),
         (".//li/strong", r'^program\\n$'),
         (".//li/em", r'^dfn\\n$'),
-        (".//li/code/span[@class='pre']", r'^kbd\\n$'),
+        (".//li/kbd", r'^kbd\\n$'),
         (".//li/span", u'File \N{TRIANGULAR BULLET} Close'),
         (".//li/code/span[@class='pre']", '^a/$'),
         (".//li/code/em/span[@class='pre']", '^varpart$'),

--- a/tests/test_build_html5.py
+++ b/tests/test_build_html5.py
@@ -119,7 +119,7 @@ def cached_etree_parse():
         (".//li/p/strong", r'^command\\n$'),
         (".//li/p/strong", r'^program\\n$'),
         (".//li/p/em", r'^dfn\\n$'),
-        (".//li/p/code/span[@class='pre']", r'^kbd\\n$'),
+        (".//li/p/kbd", r'^kbd\\n$'),
         (".//li/p/span", u'File \N{TRIANGULAR BULLET} Close'),
         (".//li/p/code/span[@class='pre']", '^a/$'),
         (".//li/p/code/em/span[@class='pre']", '^varpart$'),


### PR DESCRIPTION
Subject: Modify html writers to use `<kbd>` tags for `:kbd:` role.

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Both?

### Purpose
- HTML has a `<kbd>` tag to represent keyboard keys, so we should use it.

### Relates
- #3160

