### PR TITLE
Avoid duplicate calls to autodoc-process-docstring

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -324,7 +324,7 @@ class Autosummary(Directive):
             # -- Grab the summary
 
             documenter.add_content(None)
-            doc = list(documenter.process_doc([self.result.data]))
+            doc = [self.result.data]
 
             while doc and not doc[0].strip():
                 doc.pop(0)

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -324,7 +324,7 @@ class Autosummary(Directive):
             # -- Grab the summary
 
             documenter.add_content(None)
-            doc = [self.result.data]
+            doc = self.result.data
 
             while doc and not doc[0].strip():
                 doc.pop(0)

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -73,6 +73,10 @@ def test_get_items_summary(app, status, warning):
 
     def handler(app, what, name, obj, options, lines):
         assert isinstance(lines, list)
+
+        # ensure no docstring is processed twice:
+        assert 'THIS HAS BEEN HANDLED' not in lines
+        lines.append('THIS HAS BEEN HANDLED')
     app.connect('autodoc-process-docstring', handler)
 
     sphinx.ext.autosummary.Autosummary.get_items = new_get_items


### PR DESCRIPTION
Subject: Avoid duplicate calls to autodoc-process-docstring

### Feature or Bugfix
- Bugfix

### Purpose
Autosummary appears to be emitting 'autodoc-process-docstring' on docstrings that have already been processed by 'autodoc-process-docstring'. It does so by calling `Documenter.add_content`, which calls its `process_doc`, and then immediately calling `process_doc` on the output. This PR removes the second call.

~I do not yet have a test, and advice on constructing one is welcome.~

### Relates
- https://github.com/numpy/numpydoc/issues/134

