### PR TITLE
Fix #4183: doctest: ``:pyversion:`` allows comma separated version specs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -101,6 +101,7 @@ Features added
 --------------
 
 * #4181: autodoc: Sort dictionary keys when possible
+* #4183: doctest: ``:pyversion:`` allows comma separated version specs
 
 Bugs fixed
 ----------

--- a/doc/ext/doctest.rst
+++ b/doc/ext/doctest.rst
@@ -86,6 +86,9 @@ a comma-separated list of group names.
 
      .. versionadded:: 1.6
 
+     .. versionchanged:: 1.7
+        ``:pyversion:`` allows comma separated version specs.
+
    Note that like with standard doctests, you have to use ``<BLANKLINE>`` to
    signal a blank line in the expected output.  The ``<BLANKLINE>`` is removed
    when building presentation output (HTML, LaTeX etc.).

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -143,13 +143,13 @@ class TestDirective(Directive):
                 node['options'][flag] = (option[0] == '+')
         if self.name == 'doctest' and 'pyversion' in self.options:
             try:
-                option = self.options['pyversion']
-                # :pyversion: >= 3.6   -->   operand='>=', option_version='3.6'
-                operand, option_version = [item.strip() for item in option.split()]
-                running_version = platform.python_version()
-                if not compare_version(running_version, option_version, operand):
-                    flag = doctest.OPTIONFLAGS_BY_NAME['SKIP']
-                    node['options'][flag] = True  # Skip the test
+                for option in self.options['pyversion'].split(','):
+                    # :pyversion: >= 3.6   -->   operand='>=', option_version='3.6'
+                    operand, option_version = [item.strip() for item in option.split()]
+                    running_version = platform.python_version()
+                    if not compare_version(running_version, option_version, operand):
+                        flag = doctest.OPTIONFLAGS_BY_NAME['SKIP']
+                        node['options'][flag] = True  # Skip the test
             except ValueError:
                 self.state.document.reporter.warning(
                     _("'%s' is not a valid pyversion option") % option,

--- a/tests/roots/test-ext-doctest/doctest.txt
+++ b/tests/roots/test-ext-doctest/doctest.txt
@@ -96,6 +96,13 @@ Special directives
      >>> a
      4
 
+  .. doctest::
+     :pyversion: >= 2.0, < 2.1
+
+     >>> a = 3
+     >>> a
+     3
+
 * grouping
 
   .. testsetup:: group1


### PR DESCRIPTION
To resolve #4183 and to keep compatible with earlier version, I propose you to support multiple pyversion specs like following:
```
.. doctest::
   :pyversion: >= 3.6, < 3.7
```
It allows you to this test with 3.6.x series.