### PR TITLE
autosummary: catch all exceptions when importing modules

### DIFF
--- a/tests/roots/test-ext-autosummary/autosummary_importfail.py
+++ b/tests/roots/test-ext-autosummary/autosummary_importfail.py
@@ -1,0 +1,4 @@
+import sys
+
+# Fail module import in a catastrophic way
+sys.exit(1)

--- a/tests/roots/test-ext-autosummary/contents.rst
+++ b/tests/roots/test-ext-autosummary/contents.rst
@@ -1,6 +1,11 @@
 
+:autolink:`autosummary_dummy_module.Foo`
+
+:autolink:`autosummary_importfail`
+
 .. autosummary::
    :toctree: generated
 
    autosummary_dummy_module
    autosummary_dummy_module.Foo
+   autosummary_importfail


### PR DESCRIPTION
Subject: autosummary: catch all exceptions when importing modules

### Feature or Bugfix
- Bugfix

### Purpose

Similarly to autodoc, autosummary/autolink try to import modules.
Module import may, in addition to ImportError, raise any exception, 
including SystemExit. These need to be caught, since failing module
import should not cause a documentation build to fail.

Tests updated with examples that failed previously.

autodoc already does similar catching of exceptions.