### PR TITLE
Set LaTeX bibitem id to citation node id

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -919,7 +919,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 target = self.hypertarget(bi[2] + ':' + bi[3],
                                           withdoc=False)
                 self.body.append(u'\\bibitem[%s]{%s}{%s %s}\n' %
-                                 (self.encode(bi[0]), self.idescape(bi[0]),
+                                 (self.encode(bi[3]), self.idescape(bi[0]),
                                   target, bi[1]))
             self.body.append(u'\\end{sphinxthebibliography}\n')
             self.bibitems = []


### PR DESCRIPTION
Subject: LaTeX writer uses `\bibitem[label]{label}` when it should use `\bibitem[id]{label}`

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

In the unusual case that the textual label differs from the ID, the ID should be preferred. This comes up in a proposed change to numpydoc.

These IDs are not currently used for referencing within sphinx-produced TeX documents, as sphinx explicitly adds a `\label` to reference text.