### PR TITLE
Apply fixFirefoxAnchorBug only under Firefox

### DIFF
--- a/sphinx/themes/basic/static/doctools.js_t
+++ b/sphinx/themes/basic/static/doctools.js_t
@@ -206,7 +206,7 @@ var Documentation = {
    * see: https://bugzilla.mozilla.org/show_bug.cgi?id=645075
    */
   fixFirefoxAnchorBug : function() {
-    if (document.location.hash)
+    if (document.location.hash && $.browser.mozilla)
       window.setTimeout(function() {
         document.location.href += '';
       }, 10);


### PR DESCRIPTION
A compatibility shim for `$.browser` was added in
c608af4babe140626877be08535af095ff633c00.

Fixes #3549