### PR TITLE
Fix issue in usage of import_module in autosummary

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -391,9 +391,9 @@ class Documenter(object):
         import_hook = _MockImporter(self.env.config.autodoc_mock_imports)
         try:
             logger.debug('[autodoc] import %s', self.modname)
-            import_module(self.modname, self.env.config.autodoc_warningiserror)
+            obj = import_module(self.modname, self.env.config.autodoc_warningiserror)
             parent = None
-            obj = self.module = sys.modules[self.modname]
+            self.module = obj
             logger.debug('[autodoc] => %r', obj)
             for part in self.objpath:
                 parent = obj

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -128,7 +128,8 @@ def import_module(modname, warningiserror=False):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=ImportWarning)
             with logging.skip_warningiserror(not warningiserror):
-                return __import__(modname)
+                __import__(modname)
+                return sys.modules[modname]
     except BaseException:
         # Importing modules may cause any side effects, including
         # SystemExit, so we need to catch all errors.

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -11,7 +11,7 @@
 
 from six import iteritems, StringIO
 
-from sphinx.ext.autosummary import mangle_signature
+from sphinx.ext.autosummary import mangle_signature, import_by_name
 
 from sphinx.testing.util import etree_parse
 
@@ -145,3 +145,26 @@ def test_autosummary_generate(app, status, warning):
             '      ~Foo.__init__\n'
             '      ~Foo.bar\n'
             '   \n' in Foo)
+
+
+def test_import_by_name():
+    import sphinx
+    import sphinx.ext.autosummary
+
+    prefixed_name, obj, parent, modname = import_by_name('sphinx')
+    assert prefixed_name == 'sphinx'
+    assert obj is sphinx
+    assert parent is None
+    assert modname == 'sphinx'
+
+    prefixed_name, obj, parent, modname = import_by_name('sphinx.ext.autosummary.__name__')
+    assert prefixed_name == 'sphinx.ext.autosummary.__name__'
+    assert obj is sphinx.ext.autosummary.__name__
+    assert parent is sphinx.ext.autosummary
+    assert modname == 'sphinx.ext.autosummary'
+
+    prefixed_name, obj, parent, modname = import_by_name('sphinx.ext.autosummary.Autosummary.get_items')
+    assert prefixed_name == 'sphinx.ext.autosummary.Autosummary.get_items'
+    assert obj == sphinx.ext.autosummary.Autosummary.get_items
+    assert parent is sphinx.ext.autosummary.Autosummary
+    assert modname == 'sphinx.ext.autosummary'


### PR DESCRIPTION
Fixup for #4232 :
```
__import__(name)
mod = sys.modules[name]
```
returns a different module than
```
mod = __import__(name)
```