### PR TITLE
viewcode does not import when viewcode_import is False

### DIFF
--- a/doc/ext/viewcode.rst
+++ b/doc/ext/viewcode.rst
@@ -62,3 +62,14 @@ There is an additional config value:
       Some reader's rendering result are corrupted and
       `epubcheck <https://github.com/IDPF/epubcheck>`_'s score
       becomes worse even if the reader supports.
+
+.. confval:: viewcode_source_dirs
+
+   If the source code of the modules cannot be found by importing them,
+   or if :confval:`viewcode_import` is ``False``,
+   the directories in this list will be searched for the source code.
+
+   The default is an empty list,
+   so the directories on :attr:`sys.path` will be searched instead.
+
+   .. versionadded:: 1.8

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -51,8 +51,8 @@ def _get_full_modname(app, modname, attribute):
         return None
 
 
-def _find_module_source(modname):
-    current_paths = None
+def _find_module_source(modname, current_paths=None):
+    current_paths = current_paths or None
 
     try:
         module_parts = modname.split('.')
@@ -86,7 +86,7 @@ def doctree_read(app, doctree):
             except Exception:
                 pass
         if not analyzer:
-            module_file = _find_module_source(modname)
+            module_file = _find_module_source(modname, app.config.viewcode_source_dirs)
             if module_file:
                 try:
                     analyzer = ModuleAnalyzer.for_file(module_file, modname)
@@ -266,6 +266,7 @@ def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_config_value('viewcode_import', True, False)
     app.add_config_value('viewcode_enable_epub', False, False)
+    app.add_config_value('viewcode_source_dirs', [], False)
     app.connect('doctree-read', doctree_read)
     app.connect('env-merge-info', env_merge_info)
     app.connect('html-collect-pages', collect_pages)

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import imp
+import os
 import traceback
 
 from docutils import nodes
@@ -49,6 +51,23 @@ def _get_full_modname(app, modname, attribute):
         return None
 
 
+def _find_module_source(modname):
+    current_paths = None
+
+    try:
+        module_parts = modname.split('.')
+        for module_part in module_parts:
+            module_spec = imp.find_module(module_part, current_paths)
+            current_paths = [module_spec[1]]
+    except ImportError:
+        current_paths = None
+    else:
+        if current_paths and not current_paths[0].endswith('.py'):
+            current_paths[0] = os.path.join(current_paths[0], '__init__.py')
+
+    return current_paths[0] if current_paths else None
+
+
 def doctree_read(app, doctree):
     # type: (Sphinx, nodes.Node) -> None
     env = app.builder.env
@@ -60,16 +79,29 @@ def doctree_read(app, doctree):
         return
 
     def has_tag(modname, fullname, docname, refname):
-        entry = env._viewcode_modules.get(modname, None)  # type: ignore
-        try:
-            analyzer = ModuleAnalyzer.for_module(modname)
-        except Exception:
+        analyzer = None
+        if app.config.viewcode_import:
+            try:
+                analyzer = ModuleAnalyzer.for_module(modname)
+            except Exception:
+                pass
+        if not analyzer:
+            module_file = _find_module_source(modname)
+            if module_file:
+                try:
+                    analyzer = ModuleAnalyzer.for_file(module_file, modname)
+                except Exception:
+                    pass
+        if not analyzer:
             env._viewcode_modules[modname] = False  # type: ignore
             return
+
         if not isinstance(analyzer.code, text_type):
             code = analyzer.code.decode(analyzer.encoding)
         else:
             code = analyzer.code
+
+        entry = env._viewcode_modules.get(modname, None)  # type: ignore
         if entry is False:
             return
         elif entry is None or entry[0] != code:

--- a/tests/roots/test-ext-viewcode/conf.py
+++ b/tests/roots/test-ext-viewcode/conf.py
@@ -3,7 +3,9 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath('.'))
+source_dir = os.path.abspath('.')
+if source_dir not in sys.path:
+    sys.path.insert(0, source_dir)
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
 master_doc = 'index'
 exclude_patterns = ['_build']
@@ -23,3 +25,7 @@ if 'test_linkcode' in tags:
             return "http://foobar/%s/%s" % (domain,  "".join(info['names']))
         else:
             raise AssertionError()
+
+if 'test_source_files' in tags:
+    viewcode_import = False
+    viewcode_source_dirs = [source_dir]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix and Feature

### Purpose
With the `viewcode` extension loaded, and `viewcode_import` set to `False`, `viewcode` will still attempt to load documented modules.

### Detail
- Fixes #4035 
- Added `viewcode_source_dirs` config variable to tell viewcode where to search for module source code (instead of sys.path).

### Relates
- #4035
