### PR TITLE
BUG: autosummary to list all class members

### DIFF
--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -159,7 +159,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                 except TemplateNotFound:
                     template = template_env.get_template('autosummary/base.rst')
 
-            def get_members(obj, typ, include_public=[], imported=False):
+            def get_members(obj, typ, include_public=[], imported=True):
                 # type: (Any, unicode, List[unicode], bool) -> Tuple[List[unicode], List[unicode]]  # NOQA
                 items = []  # type: List[unicode]
                 for name in dir(obj):
@@ -169,9 +169,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                         continue
                     documenter = get_documenter(value, obj)
                     if documenter.objtype == typ:
-                        if typ == 'method':
-                            items.append(name)
-                        elif imported or getattr(value, '__module__', None) == obj.__name__:
+                        if imported or getattr(value, '__module__', None) == obj.__name__:
                             # skip imported members if expected
                             items.append(name)
                 public = [x for x in items
@@ -191,9 +189,9 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
             elif doc.objtype == 'class':
                 ns['members'] = dir(obj)
                 ns['methods'], ns['all_methods'] = \
-                    get_members(obj, 'method', ['__init__'], imported=imported_members)
+                    get_members(obj, 'method', ['__init__'])
                 ns['attributes'], ns['all_attributes'] = \
-                    get_members(obj, 'attribute', imported=imported_members)
+                    get_members(obj, 'attribute')
 
             parts = name.split('.')
             if doc.objtype in ('method', 'attribute'):

--- a/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
@@ -7,3 +7,7 @@ class Foo:
 
     def bar(self):
         pass
+
+    @property
+    def baz(self):
+        pass

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -145,6 +145,10 @@ def test_autosummary_generate(app, status, warning):
             '      ~Foo.__init__\n'
             '      ~Foo.bar\n'
             '   \n' in Foo)
+    assert ('   .. autosummary::\n'
+            '   \n'
+            '      ~Foo.baz\n'
+            '   \n' in Foo)
 
 
 def test_import_by_name():


### PR DESCRIPTION
Fixes the availability of the list of attributes in the autosummary template.

### Feature or Bugfix
- Bugfix

### Purpose

This PR intends to be a more general fix for https://github.com/sphinx-doc/sphinx/commit/b3e0e29f4cd3a3bec12a07336ebbda430e25e27e. That commit fixed issue https://github.com/sphinx-doc/sphinx/issues/3900 for the methods being no longer available in the autosummary template. This generalizes that so also the Attributes are again available in the autosummary template.

The fact that those methods/attributes are no longer available is/was a regression in the 1.6.x line.

### Detail
The rationale of the fix is that the "imported_members=False" (which is the default) is not relevant for a class, but only for a module. Therefore I removed this in the `elif doc.objtype == 'class':` branch.


### Relates
- https://github.com/sphinx-doc/sphinx/issues/2336, https://github.com/sphinx-doc/sphinx/pull/3235
- https://github.com/sphinx-doc/sphinx/issues/3900
- https://github.com/sphinx-doc/sphinx/issues/4058
