### PR TITLE
Fix #1491 Adding option for generation of qthelp ID's without keywords

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2135,6 +2135,11 @@ builder, the HTML options also apply where appropriate.
    theme.  These are theme-specific.  For the options understood by the builtin
    themes, see :ref:`this section <builtin-themes>`.
 
+.. confval:: qthelp_id_lean
+
+   Configure id creation behavior. It defaults to ``False``. If activated the
+   keyword and ids are seperated and the id is no more prepended with the keyword.
+
 
 Options for the linkcheck builder
 ---------------------------------

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -283,6 +283,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
     def keyword_item(self, name, ref):
         # type: (unicode, Any) -> unicode
         matchobj = _idpattern.match(name)  # type: ignore
+        keyword_name = name
         if matchobj:
             groupdict = matchobj.groupdict()
             shortname = groupdict['title']
@@ -290,13 +291,17 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
             # descr = groupdict.get('descr')
             if shortname.endswith('()'):
                 shortname = shortname[:-2]
-            id = '%s.%s' % (id, shortname)
+            if self.config.qthelp_id_lean:
+                id = '%s' % (id)
+                keyword_name = shortname
+            else:
+                id = '%s.%s' % (id, shortname)
         else:
             id = None
 
         if id:
             item = ' ' * 12 + '<keyword name="%s" id="%s" ref="%s"/>' % (
-                name, id, ref[1])
+                keyword_name, id, ref[1])
         else:
             item = ' ' * 12 + '<keyword name="%s" ref="%s"/>' % (name, ref[1])
         item.encode('ascii', 'xmlcharrefreplace')
@@ -336,6 +341,7 @@ def setup(app):
     app.add_config_value('qthelp_namespace', None, 'html', string_classes)
     app.add_config_value('qthelp_theme', 'nonav', 'html')
     app.add_config_value('qthelp_theme_options', {}, 'html')
+    app.add_config_value('qthelp_id_lean',False,'html')
 
     return {
         'version': 'builtin',

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -341,7 +341,7 @@ def setup(app):
     app.add_config_value('qthelp_namespace', None, 'html', string_classes)
     app.add_config_value('qthelp_theme', 'nonav', 'html')
     app.add_config_value('qthelp_theme_options', {}, 'html')
-    app.add_config_value('qthelp_id_lean',False,'html')
+    app.add_config_value('qthelp_id_lean', False, 'html')
 
     return {
         'version': 'builtin',

--- a/tests/roots/test-index/conf.py
+++ b/tests/roots/test-index/conf.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'test.tex', 'The basic Sphinx documentation for testing', 'Sphinx', 'report')
+]

--- a/tests/roots/test-index/index.rst
+++ b/tests/roots/test-index/index.rst
@@ -1,0 +1,34 @@
+The basic Sphinx documentation for testing
+==========================================
+
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl.  It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+planned.
+
+Sphinx uses reStructuredText as its markup language, and many of its strengths
+come from the power and straightforwardness of reStructuredText and its parsing
+and translating suite, the Docutils.
+
+.. index:: features (ID_FEATURE)
+
+features
+--------
+
+Among its features are the following:
+
+* Output formats: HTML (including derivative formats such as HTML Help, Epub
+  and Qt Help), plain text, manual pages and LaTeX or direct PDF output
+  using rst2pdf
+* Extensive cross-references: semantic markup and automatic links
+  for functions, classes, glossary terms and similar pieces of information
+* Hierarchical structure: easy definition of a document tree, with automatic
+  links to siblings, parents and children
+* Automatic indices: general index as well as a module index
+* Code handling: automatic highlighting using the Pygments highlighter
+* Flexible HTML output using the Jinja 2 templating engine
+* Various extensions are available, e.g. for automatic testing of snippets
+  and inclusion of appropriately formatted docstrings
+* Setuptools integration

--- a/tests/test_build_qthelp_leanid.py
+++ b/tests/test_build_qthelp_leanid.py
@@ -5,7 +5,7 @@
 
     Test the Qt Help builder and check its output.  We don't need to
     test the HTML itself; that's already handled by
-    :file:`test_build_html.py`.
+    :file:`test_build_html.py`. Test for id generation in qhp files
 
     :copyright: Copyright 2007-2017 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/tests/test_build_qthelp_leanid.py
+++ b/tests/test_build_qthelp_leanid.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+    test_build_qthelp_leanid
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test the Qt Help builder and check its output.  We don't need to
+    test the HTML itself; that's already handled by
+    :file:`test_build_html.py`.
+
+    :copyright: Copyright 2007-2017 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+
+@pytest.mark.sphinx('qthelp', testroot='index')
+def test_qthelp_namespace(app, status, warning):
+    # default namespace
+    app.builder.build_all()
+    qhp = (app.outdir / 'Python.qhp').text()
+    assert '<keyword name="features (ID_FEATURE)" id="ID_FEATURE.features"' in qhp
+
+    # give a namespace
+    app.config.qthelp_id_lean = True
+    app.builder.build_all()
+    qhp = (app.outdir / 'Python.qhp').text()
+    assert '<keyword name="features" id="ID_FEATURE"' in qhp


### PR DESCRIPTION
Adding option to generate lean IDs for qthelp builder

### Feature or Bugfix
Bugfix

### Purpose
Create keyword independent ids in qthelp builder for refering language independent links

### Detail

### Relates
https://github.com/sphinx-doc/sphinx/issues/1491

