### PR TITLE
Fix for reproducibility of htmlhelp and qthelp builds

### DIFF
--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -246,7 +246,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
             olen = len(outdir)
             for root, dirs, files in os.walk(outdir):
                 staticdir = root.startswith(path.join(outdir, '_static'))
-                for fn in files:
+                for fn in sorted(files):
                     if (staticdir and not fn.endswith('.js')) or \
                        fn.endswith('.html'):
                         print(path.join(root, fn)[olen:].replace(os.sep, '\\'),

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -188,7 +188,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         for root, dirs, files in os.walk(outdir):
             resourcedir = root.startswith(staticdir) or \
                 root.startswith(imagesdir)
-            for fn in files:
+            for fn in sorted(files):
                 if (resourcedir and not fn.endswith('.js')) or \
                    fn.endswith('.html'):
                     filename = path.join(root, fn)[olen:]


### PR DESCRIPTION
Make sure the generated list of files is sorted.
This is similar to what was applied to EPub builder in 0b7c73a981.

This addresses [Debian bug report #884010](https://bugs.debian.org/884010).