### PR TITLE
setup: Install mock for Python 3 too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,13 +68,13 @@ extras_require = {
         'whoosh>=2.0',
     ],
     'test': [
+        'mock',
         'pytest',
         'pytest-cov',
         'html5lib',
     ],
     'test:python_version<"3"': [
         'enum34',
-        'mock',
     ],
     'test:python_version>="3"': [
         'mypy',


### PR DESCRIPTION
'mock' is part of the standard library in Python 3 since Python 3.3.
However, it's found in 'unittest.mock' - not 'mock'. We should install
the version for PyPi in all cases to minimize differences between the
two. When Python 2.7 support is dropped, we can consider switching to
the standard library version.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Fixes #4284

Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

