### PR TITLE
Fix ResourceWarning on pycode

### DIFF
--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -36,11 +36,11 @@ class ModuleAnalyzer(object):
         if ('file', filename) in cls.cache:
             return cls.cache['file', filename]
         try:
-            fileobj = open(filename, 'rb')
+            with open(filename, 'rb') as f:
+                obj = cls(f, modname, filename)
+                cls.cache['file', filename] = obj
         except Exception as err:
             raise PycodeError('error opening %r' % filename, err)
-        obj = cls(fileobj, modname, filename)
-        cls.cache['file', filename] = obj
         return obj
 
     @classmethod


### PR DESCRIPTION
This can reduce ResourceWarning like following:
```
  /home/travis/build/sphinx-doc/sphinx/sphinx/pycode/__init__.py:59: ResourceWarning: unclosed file <_io.BufferedReader name='/home/travis/build/sphinx-doc/sphinx/sphinx/ext/autodoc/__init__.py'>
    obj = cls.for_file(source, modname)
```