### PR TITLE
Let LaTeX obey :confval:`numfig_secnum_depth` for figures, tables, ...

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -341,19 +341,18 @@ General configuration
      starting at ``1``.
    - if ``1`` (default) numbers will be ``x.1``, ``x.2``, ... with ``x``
      the section number (top level sectioning; no ``x.`` if no section).
-     This naturally applies only if  section numbering has been activated via
+     This naturally applies only if section numbering has been activated via
      the ``:numbered:`` option of the :rst:dir:`toctree` directive.
    - ``2`` means that numbers will be ``x.y.1``, ``x.y.2``, ... if located in
      a sub-section (but still ``x.1``, ``x.2``, ... if located directly under a
      section and ``1``, ``2``, ... if not in any top level section.)
    - etc...
 
-   .. note::
-
-      The LaTeX builder currently ignores this configuration setting. It will
-      obey it at Sphinx 1.7.
-
    .. versionadded:: 1.3
+
+   .. versionchanged:: 1.7
+      The LaTeX builder obeys this setting (if :confval:`numfig` is set to
+      ``True``).
 
 .. confval:: tls_verify
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -183,7 +183,7 @@
 % control caption around literal-block
 \RequirePackage{capt-of}
 \RequirePackage{needspace}
-
+\RequirePackage{remreset}% provides \@removefromreset
 % to make pdf with correct encoded bookmarks in Japanese
 % this should precede the hyperref package
 \ifx\kanjiskip\@undefined
@@ -247,7 +247,9 @@
 \fi
 
 \DeclareStringOption[0]{maxlistdepth}% \newcommand*\spx@opt@maxlistdepth{0}
-
+\DeclareStringOption[-1]{numfigreset}
+\DeclareBoolOption[false]{nonumfigreset}
+% \DeclareBoolOption[false]{usespart}% not used
 % dimensions, we declare the \dimen registers here.
 \newdimen\sphinxverbatimsep
 \newdimen\sphinxverbatimborder
@@ -349,6 +351,8 @@
 \ProcessKeyvalOptions*
 % don't allow use of maxlistdepth via \sphinxsetup.
 \DisableKeyvalOption{sphinx}{maxlistdepth}
+\DisableKeyvalOption{sphinx}{numfigreset}
+\DisableKeyvalOption{sphinx}{nonumfigreset}
 % user interface: options can be changed midway in a document!
 \newcommand\sphinxsetup[1]{\setkeys{sphinx}{#1}}
 
@@ -657,12 +661,94 @@
   {\abovecaptionskip\smallskipamount
    \belowcaptionskip\smallskipamount}
 
+
 %% FOOTNOTES
 %
 % Support large numbered footnotes in minipage
 % But now obsolete due to systematic use of \savenotes/\spewnotes
 % when minipages are in use in the various macro definitions next.
 \def\thempfootnote{\arabic{mpfootnote}}
+
+
+%% NUMBERING OF FIGURES, TABLES, AND LITERAL BLOCKS
+\ltx@ifundefined{c@chapter}
+   {\newcounter{literalblock}}%
+   {\newcounter{literalblock}[chapter]%
+    \def\theliteralblock{\ifnum\c@chapter>\z@\arabic{chapter}.\fi
+                         \arabic{literalblock}}%
+    }%
+\ifspx@opt@nonumfigreset
+    \ltx@ifundefined{c@chapter}{}{%
+      \@removefromreset{figure}{chapter}%
+      \@removefromreset{table}{chapter}%
+      \@removefromreset{literalblock}{chapter}%
+    }%
+    \def\thefigure{\arabic{figure}}%
+    \def\thetable {\arabic{table}}%
+    \def\theliteralblock{\arabic{literalblock}}%
+    %\let\theHliteralblock\theliteralblock
+\else
+\let\spx@preAthefigure\@empty
+\let\spx@preBthefigure\@empty
+% \ifspx@opt@usespart  % <-- LaTeX writer could pass such a 'usespart' boolean
+%                      %     as sphinx.sty package option
+% If document uses \part, (triggered in Sphinx by latex_toplevel_sectioning)
+% LaTeX core per default does not reset chapter or section
+% counters at each part.
+% But if we modify this, we need to redefine \thechapter, \thesection to
+% include the part number and this will cause problems in table of contents
+% because of too wide numbering. Simplest is to do nothing.
+% \fi
+\ifnum\spx@opt@numfigreset>0
+    \ltx@ifundefined{c@chapter}
+      {}
+      {\g@addto@macro\spx@preAthefigure{\ifnum\c@chapter>\z@\arabic{chapter}.}%
+       \g@addto@macro\spx@preBthefigure{\fi}}%
+\fi
+\ifnum\spx@opt@numfigreset>1
+    \@addtoreset{figure}{section}%
+    \@addtoreset{table}{section}%
+    \@addtoreset{literalblock}{section}%
+    \g@addto@macro\spx@preAthefigure{\ifnum\c@section>\z@\arabic{section}.}%
+    \g@addto@macro\spx@preBthefigure{\fi}%
+\fi
+\ifnum\spx@opt@numfigreset>2
+    \@addtoreset{figure}{subsection}%
+    \@addtoreset{table}{subsection}%
+    \@addtoreset{literalblock}{subsection}%
+    \g@addto@macro\spx@preAthefigure{\ifnum\c@subsection>\z@\arabic{subsection}.}%
+    \g@addto@macro\spx@preBthefigure{\fi}%
+\fi
+\ifnum\spx@opt@numfigreset>3
+    \@addtoreset{figure}{subsubsection}%
+    \@addtoreset{table}{subsubsection}%
+    \@addtoreset{literalblock}{subsubsection}%
+    \g@addto@macro\spx@preAthefigure{\ifnum\c@subsubsection>\z@\arabic{subsubsection}.}%
+    \g@addto@macro\spx@preBthefigure{\fi}%
+\fi
+\ifnum\spx@opt@numfigreset>4
+    \@addtoreset{figure}{paragraph}%
+    \@addtoreset{table}{paragraph}%
+    \@addtoreset{literalblock}{paragraph}%
+    \g@addto@macro\spx@preAthefigure{\ifnum\c@subparagraph>\z@\arabic{subparagraph}.}%
+    \g@addto@macro\spx@preBthefigure{\fi}%
+\fi
+\ifnum\spx@opt@numfigreset>5
+    \@addtoreset{figure}{subparagraph}%
+    \@addtoreset{table}{subparagraph}%
+    \@addtoreset{literalblock}{subparagraph}%
+    \g@addto@macro\spx@preAthefigure{\ifnum\c@subsubparagraph>\z@\arabic{subsubparagraph}.}%
+    \g@addto@macro\spx@preBthefigure{\fi}%
+\fi
+\expandafter\g@addto@macro
+\expandafter\spx@preAthefigure\expandafter{\spx@preBthefigure}%
+\let\thefigure\spx@preAthefigure
+\let\thetable\spx@preAthefigure
+\let\theliteralblock\spx@preAthefigure
+\g@addto@macro\thefigure{\arabic{figure}}%
+\g@addto@macro\thetable{\arabic{table}}%
+\g@addto@macro\theliteralblock{\arabic{literalblock}}%
+\fi
 
 
 %% LITERAL BLOCKS
@@ -680,15 +766,6 @@
 \let\endOriginalVerbatim\endVerbatim
 
 % for captions of literal blocks
-% also define `\theH...` macros for hyperref
-\newcounter{literalblock}
-\ltx@ifundefined{c@chapter}
-  {\@addtoreset{literalblock}{section}
-  \def\theliteralblock {\ifnum\c@section>\z@ \thesection.\fi\arabic{literalblock}}
-  \def\theHliteralblock {\theHsection.\arabic{literalblock}}}
-  {\@addtoreset{literalblock}{chapter}
-  \def\theliteralblock {\ifnum\c@chapter>\z@ \thechapter.\fi\arabic{literalblock}}
-  \def\theHliteralblock {\theHchapter.\arabic{literalblock}}}
 % at start of caption title
 \newcommand*{\fnum@literalblock}{\literalblockname\nobreakspace\theliteralblock}
 % this will be overwritten in document preamble by Babel translation

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -588,12 +588,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
             if self.numfig_secnum_depth > 0:  # default is 1
                 # numfig_secnum_depth as passed to sphinx.sty indices same names as in
                 # LATEXSECTIONNAMES but with -1 for part, 0 for chapter, 1 for section...
-                if len(self.sectionnames) < 7 and self.top_sectionlevel > 0:
+                if len(self.sectionnames) < len(LATEXSECTIONNAMES) and \
+                   self.top_sectionlevel > 0:
                     self.numfig_secnum_depth += self.top_sectionlevel
                 else:
                     self.numfig_secnum_depth += self.top_sectionlevel - 1
-                if self.numfig_secnum_depth >= len(self.sectionnames):
-                    self.numfig_secnum_depth = len(self.sectionnames) - 1
+                # this (minus one) will serve as minimum to LaTeX's secnumdepth
+                self.numfig_secnum_depth = min(self.numfig_secnum_depth,
+                                               len(LATEXSECTIONNAMES) - 1)
                 # if passed key value is < 1 LaTeX will act as if 0; see sphinx.sty
                 self.elements['sphinxpkgoptions'] += \
                     (',numfigreset=%s' % self.numfig_secnum_depth)
@@ -665,13 +667,13 @@ class LaTeXTranslator(nodes.NodeVisitor):
             #   tocdepth =  1: show parts, chapters and sections
             #   tocdepth =  2: show parts, chapters, sections and subsections
             #   ...
-
             tocdepth = document['tocdepth'] + self.top_sectionlevel - 2
-            if len(self.sectionnames) < 7 and self.top_sectionlevel > 0:
+            if len(self.sectionnames) < len(LATEXSECTIONNAMES) and \
+               self.top_sectionlevel > 0:
                 tocdepth += 1  # because top_sectionlevel is shifted by -1
-            if tocdepth > 5:   # 5 corresponds to subparagraph
+            if tocdepth > len(LATEXSECTIONNAMES) - 2:  # default is 5 <-> subparagraph
                 logger.warning('too large :maxdepth:, ignored.')
-                tocdepth = 5
+                tocdepth = len(LATEXSECTIONNAMES) - 2
 
             self.elements['tocdepth'] = '\\setcounter{tocdepth}{%d}' % tocdepth
             minsecnumdepth = max(minsecnumdepth, tocdepth)

--- a/tests/roots/test-latex-numfig/conf.py
+++ b/tests/roots/test-latex-numfig/conf.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+
+latex_documents = [
+    ('indexmanual', 'SphinxManual.tex', 'Test numfig manual',
+     'Sphinx', 'manual'),
+    ('indexhowto', 'SphinxHowTo.tex', 'Test numfig howto',
+     'Sphinx', 'howto'),
+]

--- a/tests/roots/test-latex-numfig/index.rst
+++ b/tests/roots/test-latex-numfig/index.rst
@@ -1,0 +1,9 @@
+=================
+test-latex-numfig
+=================
+
+.. toctree::
+   :numbered:
+
+   indexmanual
+   indexhowto

--- a/tests/roots/test-latex-numfig/indexhowto.rst
+++ b/tests/roots/test-latex-numfig/indexhowto.rst
@@ -1,0 +1,10 @@
+=======================
+test-latex-numfig-howto
+=======================
+
+This is a part
+==============
+
+This is a section
+-----------------
+

--- a/tests/roots/test-latex-numfig/indexmanual.rst
+++ b/tests/roots/test-latex-numfig/indexmanual.rst
@@ -1,0 +1,13 @@
+========================
+test-latex-numfig-manual
+========================
+
+First part
+==========
+
+This is chapter
+---------------
+
+This is section
+~~~~~~~~~~~~~~~
+

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -335,6 +335,43 @@ def test_numref_with_language_ja(app, status, warning):
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
 
+@pytest.mark.sphinx('latex', testroot='latex-numfig')
+def test_latex_obey_numfig_is_false(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'SphinxManual.tex').text(encoding='utf8')
+    assert '\\usepackage{sphinx}' in result
+
+    result = (app.outdir / 'SphinxHowTo.tex').text(encoding='utf8')
+    assert '\\usepackage{sphinx}' in result
+
+
+@pytest.mark.sphinx(
+    'latex', testroot='latex-numfig',
+    confoverrides={'numfig': True, 'numfig_secnum_depth': 0})
+def test_latex_obey_numfig_secnum_depth_is_zero(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'SphinxManual.tex').text(encoding='utf8')
+    assert '\\usepackage[,nonumfigreset]{sphinx}' in result
+
+    result = (app.outdir / 'SphinxHowTo.tex').text(encoding='utf8')
+    assert '\\usepackage[,nonumfigreset]{sphinx}' in result
+
+
+@pytest.mark.sphinx(
+    'latex', testroot='latex-numfig',
+    confoverrides={'numfig': True, 'numfig_secnum_depth': 2})
+def test_latex_obey_numfig_secnum_depth_is_two(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'SphinxManual.tex').text(encoding='utf8')
+    assert '\\usepackage[,numfigreset=2]{sphinx}' in result
+
+    result = (app.outdir / 'SphinxHowTo.tex').text(encoding='utf8')
+    assert '\\usepackage[,numfigreset=3]{sphinx}' in result
+
+
 @pytest.mark.sphinx('latex')
 def test_latex_add_latex_package(app, status, warning):
     app.add_latex_package('foo')


### PR DESCRIPTION
... and code-blocks.

This is new feature and a bit of bugfix.

I I noticed in passing that prior to this PR, there is some non-coherent behaviour of code-block counter compared to figure and table, particularly when docclass is ``'howto'``, and I need to document the change. Documentation not yet added.

The aim is that figure, table, and code-block numbering will be the same in LaTeX as in HTML when ``numfig`` is activated. Thus it is breaking change. Possibly I could add an option to keep LaTeX ignore the ``numfig_secnum_depth`` setting.

It is independent of PR #4166, but motivated by it. Next step will be to get equation numbering obey the new html feature from #4166.