### PR TITLE
Readme improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,23 @@
 
 .. image:: https://img.shields.io/pypi/v/sphinx.svg
    :target: https://pypi.python.org/pypi/Sphinx
+   :alt: Package on PyPi
+
 .. image:: https://readthedocs.org/projects/sphinx/badge/
    :target: http://www.sphinx-doc.org/
    :alt: Documentation Status
+
 .. image:: https://travis-ci.org/sphinx-doc/sphinx.svg?branch=master
    :target: https://travis-ci.org/sphinx-doc/sphinx
+   :alt: Build Status (Travis CI)
+
+.. image:: https://ci.appveyor.com/api/projects/status/github/sphinx-doc/sphinx?branch=master&svg=true
+   :target: https://ci.appveyor.com/project/sphinxdoc/sphinx
+   :alt: Build Status (AppVeyor)
+
+.. image:: https://circleci.com/gh/sphinx-doc/sphinx.svg?style=shield
+   :target: https://circleci.com/gh/sphinx-doc/sphinx
+   :alt: Build Status (CircleCI)
 
 Sphinx is a tool that makes it easy to create intelligent and beautiful
 documentation for Python projects (or other documents consisting of multiple

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+========
+ Sphinx
+========
+
 .. image:: https://img.shields.io/pypi/v/sphinx.svg
    :target: https://pypi.python.org/pypi/Sphinx
 .. image:: https://readthedocs.org/projects/sphinx/badge/
@@ -6,40 +10,81 @@
 .. image:: https://travis-ci.org/sphinx-doc/sphinx.svg?branch=master
    :target: https://travis-ci.org/sphinx-doc/sphinx
 
-=================
-README for Sphinx
-=================
+Sphinx is a tool that makes it easy to create intelligent and beautiful
+documentation for Python projects (or other documents consisting of multiple
+reStructuredText sources), written by Georg Brandl.  It was originally created
+for the new Python documentation, and has excellent facilities for Python
+project documentation, but C/C++ is supported as well, and more languages are
+planned.
 
-This is the Sphinx documentation generator, see http://www.sphinx-doc.org/.
+Sphinx uses reStructuredText as its markup language, and many of its strengths
+come from the power and straightforwardness of reStructuredText and its parsing
+and translating suite, the Docutils.
 
+Among its features are the following:
 
-Installing
-==========
+* Output formats: HTML (including derivative formats such as HTML Help, Epub
+  and Qt Help), plain text, manual pages and LaTeX or direct PDF output
+  using rst2pdf
+* Extensive cross-references: semantic markup and automatic links
+  for functions, classes, glossary terms and similar pieces of information
+* Hierarchical structure: easy definition of a document tree, with automatic
+  links to siblings, parents and children
+* Automatic indices: general index as well as a module index
+* Code handling: automatic highlighting using the Pygments highlighter
+* Flexible HTML output using the Jinja 2 templating engine
+* Various extensions are available, e.g. for automatic testing of snippets
+  and inclusion of appropriately formatted docstrings
+* Setuptools integration
 
-Install from PyPI to use stable version::
+For more information, refer to the `the documentation`__.
+
+__ http://www.sphinx-doc.org/
+
+Installation
+============
+
+Sphinx is published on `PyPI`__ and can be installed from there::
 
    pip install -U sphinx
 
-Install from PyPI to use beta version::
+We also publish beta releases::
 
    pip install -U --pre sphinx
 
-Install from newest dev version in stable branch::
+If you wish to install `Sphinx` for development purposes, refer to `the
+contributors guide`__.
 
-   pip install git+https://github.com/sphinx-doc/sphinx@stable
+__ https://pypi.python.org/pypi/Sphinx
+__ CONTRIBUTING.rst
 
-Install from newest dev version in master branch::
+Documentation
+=============
 
-   pip install git+https://github.com/sphinx-doc/sphinx
+Documentation is available from `sphinx-doc.org`__.
 
-Install from cloned source::
+__ http://www.sphinx-doc.org/
 
-   pip install .
+Testing
+=======
 
-Install from cloned source as editable::
+Continuous testing is provided by `Travis`__ (for unit tests and style checks
+on Linux), `AppVeyor`__ (for unit tests on Windows), and `CircleCI`__ (for
+large processes like TeX compilation).
 
-   pip install -e .
+For information on running tests locally, refer to `the contributors guide`__.
 
+__ https://travis-ci.org/sphinx-doc/sphinx
+__ https://ci.appveyor.com/project/sphinxdoc/sphinx
+__ https://circleci.com/gh/sphinx-doc/sphinx
+__ CONTRIBUTING.rst
+
+Contributing
+============
+
+Refer to `the contributors guide`_.
+
+__ CONTRIBUTING.rst
 
 Release signatures
 ==================
@@ -48,37 +93,3 @@ Releases are signed with following keys:
 
 * `498D6B9E <https://pgp.mit.edu/pks/lookup?op=vindex&search=0x102C2C17498D6B9E>`_
 * `5EBA0E07 <https://pgp.mit.edu/pks/lookup?op=vindex&search=0x1425F8CE5EBA0E07>`_
-
-Reading the docs
-================
-
-You can read them online at <http://www.sphinx-doc.org/>.
-
-Or, after installing::
-
-   cd doc
-   make html
-
-Then, direct your browser to ``_build/html/index.html``.
-
-Testing
-=======
-
-To run the tests with the interpreter available as ``python``, use::
-
-    make test
-
-If you want to use a different interpreter, e.g. ``python3``, use::
-
-    PYTHON=python3 make test
-
-Continuous testing runs on travis: https://travis-ci.org/sphinx-doc/sphinx
-
-
-Contributing
-============
-
-See `CONTRIBUTING.rst`__
-
-.. __: CONTRIBUTING.rst
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,19 @@
+[metadata]
+license_file = LICENSE
+
 [egg_info]
 tag_build = .dev
 tag_date = true
 
+[bdist_wheel]
+universal = 1
+
 [aliases]
 release = egg_info -Db ''
 upload = upload --sign --identity=36580288
+
+[build_sphinx]
+warning-is-error = 1
 
 [extract_messages]
 mapping_file = babel.cfg
@@ -20,12 +29,6 @@ output_dir = sphinx/locale/
 domain = sphinx
 directory = sphinx/locale/
 
-[bdist_wheel]
-universal = 1
-
-[metadata]
-license_file = LICENSE
-
 [flake8]
 max-line-length = 95
 ignore = E116,E241,E251,E741
@@ -40,6 +43,3 @@ follow_imports = skip
 incremental = True
 check_untyped_defs = True
 warn_unused_ignores = True
-
-[build_sphinx]
-warning-is-error = 1

--- a/setup.py
+++ b/setup.py
@@ -8,34 +8,8 @@ from distutils.cmd import Command
 
 import sphinx
 
-long_desc = '''
-Sphinx is a tool that makes it easy to create intelligent and beautiful
-documentation for Python projects (or other documents consisting of multiple
-reStructuredText sources), written by Georg Brandl.  It was originally created
-for the new Python documentation, and has excellent facilities for Python
-project documentation, but C/C++ is supported as well, and more languages are
-planned.
-
-Sphinx uses reStructuredText as its markup language, and many of its strengths
-come from the power and straightforwardness of reStructuredText and its parsing
-and translating suite, the Docutils.
-
-Among its features are the following:
-
-* Output formats: HTML (including derivative formats such as HTML Help, Epub
-  and Qt Help), plain text, manual pages and LaTeX or direct PDF output
-  using rst2pdf
-* Extensive cross-references: semantic markup and automatic links
-  for functions, classes, glossary terms and similar pieces of information
-* Hierarchical structure: easy definition of a document tree, with automatic
-  links to siblings, parents and children
-* Automatic indices: general index as well as a module index
-* Code handling: automatic highlighting using the Pygments highlighter
-* Flexible HTML output using the Jinja 2 templating engine
-* Various extensions are available, e.g. for automatic testing of snippets
-  and inclusion of appropriately formatted docstrings
-* Setuptools integration
-'''
+with open('README.rst') as f:
+    long_desc = f.read()
 
 if sys.version_info < (2, 7) or (3, 0) <= sys.version_info < (3, 4):
     print('ERROR: Sphinx requires at least Python 2.7 or 3.4 to run.')


### PR DESCRIPTION
Subject: Improve the README

### Feature or Bugfix
Refactor

### Purpose
Move the contents of `long_desc` from `setup.py` into the README, and simply use this README for `long_desc`.

### Detail
- setup.cfg: Restructure file

  Place configuration of the package itself first in the file, followed by configuration of other tools.

- Improve README

  We're going to be adding additional badges to this but, before we do that, we should improve the README and remove a lot of the duplication that has built up here.

  The 'long_description' from 'setup.py' is moved into the README as there is serious value in displaying this on GitHub, as much as there is value in including the badges and other content from README.

- README: Cleanup badges

  Add AppVeyor badge and include 'alt' attributes for the others.

