### PR TITLE
Set LaTeX default tocdepth to 2 for howto documents (fixes #4330)

### DIFF
--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -25,6 +25,7 @@
 % reset these counters in your preamble.
 %
 \setcounter{secnumdepth}{2}
+\setcounter{tocdepth}{2}% i.e. section and subsection
 
 % Change the title page to look a bit better, and fit in with the fncychap
 % ``Bjarne'' style a bit better.


### PR DESCRIPTION
Memo: for Japanese documents, jreport.cls already does that, so this
commit changes nothing. However as the class uses ``\chapter``, this
means that by default howto documents table of contents in PDF have
three levels, whereas manual documents only  have two.

Fixes #4330 for non-Japanese documents.

