### PR TITLE
Let LaTeX obey :confval:`math_numfig` for equation numbering

### DIFF
--- a/doc/ext/math.rst
+++ b/doc/ext/math.rst
@@ -46,17 +46,12 @@ or use Python raw strings (``r"raw"``).
 
 .. confval:: math_numfig
 
-   If ``True``, displayed math equations are numbered across pages in html and
-   related (epub, ...) output (also with latex) when :confval:`numfig` is enabled.
-   :confval:`numfig_secnum_depth` is respected.  The :rst:role:`eq` role must
-   be used to reference equation numbers, not the :rst:role:`numref` role.
-   Default is ``True``.
+   If ``True``, displayed math equations are numbered across pages when
+   :confval:`numfig` is enabled.  The :confval:`numfig_secnum_depth` setting
+   is respected.  The :rst:role:`eq`, not :rst:role:`numref`, role
+   must be used to reference equation numbers.  Default is ``True``.
 
    .. versionadded:: 1.7
-      If ``False``, latex behaves as in former releases i.e. for ``'manual'``
-      docclass (and ``'howto'`` for Japanese) it resets by default the
-      equation numbers per each toplevel section, and for ``'howto'`` it uses
-      continuous numbering across entire PDF.
 
 :mod:`.mathbase` defines these new markup elements:
 

--- a/doc/ext/math.rst
+++ b/doc/ext/math.rst
@@ -47,12 +47,16 @@ or use Python raw strings (``r"raw"``).
 .. confval:: math_numfig
 
    If ``True``, displayed math equations are numbered across pages in html and
-   related (epub, ...) output when :confval:`numfig` is enabled.
+   related (epub, ...) output (also with latex) when :confval:`numfig` is enabled.
    :confval:`numfig_secnum_depth` is respected.  The :rst:role:`eq` role must
    be used to reference equation numbers, not the :rst:role:`numref` role.
    Default is ``True``.
 
    .. versionadded:: 1.7
+      If ``False``, latex behaves as in former releases i.e. for ``'manual'``
+      docclass (and ``'howto'`` for Japanese) it resets by default the
+      equation numbers per each toplevel section, and for ``'howto'`` it uses
+      continuous numbering across entire PDF.
 
 :mod:`.mathbase` defines these new markup elements:
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -249,6 +249,7 @@
 \DeclareStringOption[0]{maxlistdepth}% \newcommand*\spx@opt@maxlistdepth{0}
 \DeclareStringOption[-1]{numfigreset}
 \DeclareBoolOption[false]{nonumfigreset}
+\DeclareBoolOption[false]{mathnumfig}
 % \DeclareBoolOption[false]{usespart}% not used
 % dimensions, we declare the \dimen registers here.
 \newdimen\sphinxverbatimsep
@@ -353,6 +354,7 @@
 \DisableKeyvalOption{sphinx}{maxlistdepth}
 \DisableKeyvalOption{sphinx}{numfigreset}
 \DisableKeyvalOption{sphinx}{nonumfigreset}
+\DisableKeyvalOption{sphinx}{mathnumfig}
 % user interface: options can be changed midway in a document!
 \newcommand\sphinxsetup[1]{\setkeys{sphinx}{#1}}
 
@@ -682,11 +684,16 @@
       \@removefromreset{figure}{chapter}%
       \@removefromreset{table}{chapter}%
       \@removefromreset{literalblock}{chapter}%
+      \ifspx@opt@mathnumfig
+        \@removefromreset{equation}{chapter}%
+      \fi
     }%
     \def\thefigure{\arabic{figure}}%
     \def\thetable {\arabic{table}}%
     \def\theliteralblock{\arabic{literalblock}}%
-    %\let\theHliteralblock\theliteralblock
+    \ifspx@opt@mathnumfig
+      \def\theequation{\arabic{equation}}%
+    \fi
 \else
 \let\spx@preAthefigure\@empty
 \let\spx@preBthefigure\@empty
@@ -709,6 +716,9 @@
     \@addtoreset{figure}{section}%
     \@addtoreset{table}{section}%
     \@addtoreset{literalblock}{section}%
+    \ifspx@opt@mathnumfig
+      \@addtoreset{equation}{section}%
+    \fi
     \g@addto@macro\spx@preAthefigure{\ifnum\c@section>\z@\arabic{section}.}%
     \g@addto@macro\spx@preBthefigure{\fi}%
 \fi
@@ -716,6 +726,9 @@
     \@addtoreset{figure}{subsection}%
     \@addtoreset{table}{subsection}%
     \@addtoreset{literalblock}{subsection}%
+    \ifspx@opt@mathnumfig
+      \@addtoreset{equation}{subsection}%
+    \fi
     \g@addto@macro\spx@preAthefigure{\ifnum\c@subsection>\z@\arabic{subsection}.}%
     \g@addto@macro\spx@preBthefigure{\fi}%
 \fi
@@ -723,6 +736,9 @@
     \@addtoreset{figure}{subsubsection}%
     \@addtoreset{table}{subsubsection}%
     \@addtoreset{literalblock}{subsubsection}%
+    \ifspx@opt@mathnumfig
+      \@addtoreset{equation}{subsubsection}%
+    \fi
     \g@addto@macro\spx@preAthefigure{\ifnum\c@subsubsection>\z@\arabic{subsubsection}.}%
     \g@addto@macro\spx@preBthefigure{\fi}%
 \fi
@@ -730,6 +746,9 @@
     \@addtoreset{figure}{paragraph}%
     \@addtoreset{table}{paragraph}%
     \@addtoreset{literalblock}{paragraph}%
+    \ifspx@opt@mathnumfig
+      \@addtoreset{equation}{paragraph}%
+    \fi
     \g@addto@macro\spx@preAthefigure{\ifnum\c@subparagraph>\z@\arabic{subparagraph}.}%
     \g@addto@macro\spx@preBthefigure{\fi}%
 \fi
@@ -737,6 +756,9 @@
     \@addtoreset{figure}{subparagraph}%
     \@addtoreset{table}{subparagraph}%
     \@addtoreset{literalblock}{subparagraph}%
+    \ifspx@opt@mathnumfig
+      \@addtoreset{equation}{subparagraph}%
+    \fi
     \g@addto@macro\spx@preAthefigure{\ifnum\c@subsubparagraph>\z@\arabic{subsubparagraph}.}%
     \g@addto@macro\spx@preBthefigure{\fi}%
 \fi
@@ -748,6 +770,10 @@
 \g@addto@macro\thefigure{\arabic{figure}}%
 \g@addto@macro\thetable{\arabic{table}}%
 \g@addto@macro\theliteralblock{\arabic{literalblock}}%
+  \ifspx@opt@mathnumfig
+    \let\theequation\spx@preAthefigure
+    \g@addto@macro\theequation{\arabic{equation}}%
+  \fi
 \fi
 
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -601,6 +601,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     (',numfigreset=%s' % self.numfig_secnum_depth)
             else:
                 self.elements['sphinxpkgoptions'] += ',nonumfigreset'
+            try:
+                if builder.config.math_numfig:
+                    self.elements['sphinxpkgoptions'] += ',mathnumfig'
+            except:
+                pass
 
         if builder.config.latex_logo:
             # no need for \\noindent here, used in flushright

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -604,7 +604,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             try:
                 if builder.config.math_numfig:
                     self.elements['sphinxpkgoptions'] += ',mathnumfig'
-            except:
+            except AttributeError:
                 pass
 
         if builder.config.latex_logo:

--- a/tests/roots/test-latex-numfig/conf.py
+++ b/tests/roots/test-latex-numfig/conf.py
@@ -2,6 +2,8 @@
 
 master_doc = 'index'
 
+extensions = ['sphinx.ext.imgmath']  # for math_numfig
+
 latex_documents = [
     ('indexmanual', 'SphinxManual.tex', 'Test numfig manual',
      'Sphinx', 'manual'),

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -353,10 +353,10 @@ def test_latex_obey_numfig_secnum_depth_is_zero(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'SphinxManual.tex').text(encoding='utf8')
-    assert '\\usepackage[,nonumfigreset]{sphinx}' in result
+    assert '\\usepackage[,nonumfigreset,mathnumfig]{sphinx}' in result
 
     result = (app.outdir / 'SphinxHowTo.tex').text(encoding='utf8')
-    assert '\\usepackage[,nonumfigreset]{sphinx}' in result
+    assert '\\usepackage[,nonumfigreset,mathnumfig]{sphinx}' in result
 
 
 @pytest.mark.sphinx(
@@ -366,10 +366,23 @@ def test_latex_obey_numfig_secnum_depth_is_two(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'SphinxManual.tex').text(encoding='utf8')
-    assert '\\usepackage[,numfigreset=2]{sphinx}' in result
+    assert '\\usepackage[,numfigreset=2,mathnumfig]{sphinx}' in result
 
     result = (app.outdir / 'SphinxHowTo.tex').text(encoding='utf8')
-    assert '\\usepackage[,numfigreset=3]{sphinx}' in result
+    assert '\\usepackage[,numfigreset=3,mathnumfig]{sphinx}' in result
+
+
+@pytest.mark.sphinx(
+    'latex', testroot='latex-numfig',
+    confoverrides={'numfig': True, 'math_numfig': False})
+def test_latex_obey_numfig_but_math_numfig_false(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'SphinxManual.tex').text(encoding='utf8')
+    assert '\\usepackage[,numfigreset=1]{sphinx}' in result
+
+    result = (app.outdir / 'SphinxHowTo.tex').text(encoding='utf8')
+    assert '\\usepackage[,numfigreset=2]{sphinx}' in result
 
 
 @pytest.mark.sphinx('latex')


### PR DESCRIPTION
Implements #4166 for LaTeX PDF output. This is continuation of #4311.

Note that #4311 added no latex config value to say not to obey config setting `numfig` it it is True. Thus, here I don't either add some extra config value which would allow to obey `math_numfig` for html like outputs but not for LaTeX. If activated for html, it affects LaTeX too.