### PR TITLE
The great toxification (part 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ TAGS
 .tox
 .venv
 .coverage
+htmlcov
 .DS_Store
 sphinx/pycode/Grammar*pickle
 distribute-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,17 @@ matrix:
     - python: 'pypy'
       env: TOXENV=pypy
     - python: '2.7'
-      env: TOXENV=du13
+      env:
+        - TOXENV=du13
+        - PYTEST_ADDOPTS = --cov sphinx --cov-append --cov-config setup.cfg
     - python: '3.4'
       env: TOXENV=py34
     - python: '3.5'
       env: TOXENV=py35
     - python: '3.6'
-      env: TOXENV=py36
+      env:
+        - TOXENV=py36
+        - PYTEST_ADDOPTS = --cov sphinx --cov-append --cov-config setup.cfg
     - python: 'nightly'
       env: TOXENV=py37
     - python: '3.6'
@@ -35,7 +39,10 @@ addons:
       - imagemagick
 
 install:
-  - pip install -U tox
+  - pip install -U tox codecov
 
 script:
   - tox -- -v
+
+after_success:
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@
    :target: https://circleci.com/gh/sphinx-doc/sphinx
    :alt: Build Status (CircleCI)
 
+.. image:: https://codecov.io/gh/sphinx-doc/sphinx/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/sphinx-doc/sphinx
+   :alt: Code Coverage Status (Codecov)
+
 Sphinx is a tool that makes it easy to create intelligent and beautiful
 documentation for Python projects (or other documents consisting of multiple
 reStructuredText sources), written by Georg Brandl.  It was originally created

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,17 @@ follow_imports = skip
 incremental = True
 check_untyped_defs = True
 warn_unused_ignores = True
+
+[coverage:run]
+branch = True
+source = sphinx
+
+[coverage:report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    # Don't complain if tests don't hit defensive assertion code:
+    raise NotImplementedError
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+ignore_errors = True

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     du14: docutils==0.14
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
-    coverage: PYTEST_ADDOPTS = --cov sphinx
+    coverage: PYTEST_ADDOPTS = --cov sphinx --cov-config {toxinidir}/setup.cfg
 commands=
     {envpython} -Wall tests/run.py --durations 25 {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ passenv =
 description =
     py{27,34,35,36,py}: Run unit tests against {envname}.
     du{11,12,13,14}: Run unit tests with the given version of docutils.
-    coverage: Run code coverage checks.
 
 # TODO(stephenfin) Replace this with the 'extras' config option when tox 2.4 is
 # widely available, likely some time after the Ubuntu 18.04 release
@@ -22,7 +21,6 @@ deps =
     du14: docutils==0.14
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
-    coverage: PYTEST_ADDOPTS = --cov sphinx --cov-config {toxinidir}/setup.cfg
 commands=
     {envpython} -Wall tests/run.py --durations 25 {posargs}
 
@@ -40,6 +38,15 @@ deps =
     {[testenv]deps}
 commands =
     pylint --rcfile utils/pylintrc sphinx
+
+[testenv:coverage]
+description =
+    Run code coverage checks.
+setenv =
+    PYTEST_ADDOPTS = --cov sphinx --cov-config {toxinidir}/setup.cfg
+commands =
+    {[testenv]commands}
+    coverage report
 
 [testenv:mypy]
 description =


### PR DESCRIPTION
Subject: Integrate [codecov.io](https://codecov.io).

Let's start running and using coverage stats in our CI. This will allow us to figure out where the gaps are in testing. From the looks of things, our coverage is already pretty high 🎆 🍾 

### Feature or Bugfix
- Feature

### Purpose
To paraphrase the Zen of Python (import this):

> tox is one honking great idea -- let's use more of it!

Start modernizing the test infrastructure that's using make and other hand-crafted tools by replacing them with tox-based derivatives.

**This is part six.**

### Detail
This is a multi-step process, with the end goal of completely removing the Makefile and running everything through `tox`. The first fours steps of these can be done in parallel, but combined they block the final two.

1. Make `tox` a little more friendly by enabling extras like coverage, test profiling etc. by default, and closing gaps with the current Makefile targets such as PyLint and building docs in particular formats
2. Replace/remove custom tooling found in `utils` in favor of modern alternatives like `flake8`
3. Centralize as much configuration as possible inside `setup.cfg` and `tox.ini`, to avoid polluting the top level directory.
4. Clean up requirements (`test-reqs.txt`, `setup.py`) to ensure virtualenv and non-virtualenv builds are identical

The remaining two steps are blocked by the above:

5. Switch CIs to use `tox` instead of the Makefile, and update `CONTRIBUTING.rst` to refer to tox. Deprecate the Makefile  (**this change**)
6. (Bonus) Integrate [codecov.io](https://codecov.io) to make use of the coverage stats we now have

In this part, we make the following changes:

- gitignore: Ignore 'htmlcov' directory

  This is generated if you run 'coverage html'. Hide it from Git.

- tox: Report coverage to user

  Run 'coverage report' after a successful coverage run. There's enough coverage-related stuff here at this point to warrant its own section.

- travis: Enable codecov coverage

  This necessitates adding some basic coverage-py configuration [1] and making sure the pytest-cov plugin uses said configuration [2]. Badges are included.

  Note that we do not run the 'coverage' tox target, which is reserved for users.

  [1] https://github.com/codecov/example-python
  [2] https://bitbucket.org/ned/coveragepy/issues/512/


### Relates
- N/A