### PR TITLE
tox: Add 'PERL5LIB' to 'passenv' list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = docs,flake8,mypy,coverage,py{27,34,35,36,py},du{11,12,13,14}
 
 [testenv]
 passenv =
-    https_proxy http_proxy no_proxy
+    https_proxy http_proxy no_proxy PERL PERL5LIB
 description =
     py{27,34,35,36,py}: Run unit tests against {envname}.
     du{11,12,13,14}: Run unit tests with the given version of docutils.


### PR DESCRIPTION
This is required by 'makeinfo'.

Fixes #4339