### PR TITLE
Allow user to pass '-b' multiple times to 'sphinx-build'

### DIFF
--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -530,7 +530,7 @@ Makefile to be used with sphinx-build.
     parser.add_argument('-q', '--quiet', action='store_true', dest='quiet',
                         default=False,
                         help='quiet mode')
-    parser.add_argument('--version', action='version', dest='show_version',
+    parser.add_argument('--version', action='version',
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('path', metavar='PROJECT_DIR', default='.',

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -88,17 +88,18 @@ def get_parser():
     parser = argparse.ArgumentParser(
         usage='usage: %(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]',
         epilog='For more information, visit <http://sphinx-doc.org/>.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
 Generate documentation from source files.
 
-sphinx-build generates documentation from the files in SOURCEDIR and places it
-in OUTPUTDIR. It looks for 'conf.py' in SOURCEDIR for the configuration
-settings.  The 'sphinx-quickstart' tool may be used to generate template files,
-including 'conf.py'
+sphinx-build generates documentation from the files in SOURCEDIR and places
+it in OUTPUTDIR. It looks for 'conf.py' in SOURCEDIR for the configuration
+settings.  The 'sphinx-quickstart' tool may be used to generate template
+files, including 'conf.py'.
 
 sphinx-build can create documentation in different formats. A format is
-selected by specifying the builder name on the command line; it defaults to
-HTML. Builders can also perform other tasks related to documentation
+selected by specifying the builder name on the command line; it defaults
+to HTML. Builders can also perform other tasks related to documentation
 processing.
 
 By default, everything that is outdated is built. Output only for selected
@@ -113,7 +114,7 @@ files can be built by specifying individual filenames.
     parser.add_argument('outputdir',
                         help='path to output directory')
     parser.add_argument('filenames', nargs='*',
-                        help='a list of specific files to rebuild. Ignored '
+                        help='a list of specific files to rebuild, ignored '
                         'if -a is specified')
 
     group = parser.add_argument_group('general options')
@@ -147,14 +148,14 @@ files can be built by specifying individual filenames.
                        help='pass a value into HTML templates')
     group.add_argument('-t', metavar='TAG', action='append',
                        dest='tags', default=[],
-                       help='define tag: include "only" blocks with TAG')
+                       help='define tag, include "only" blocks with TAG')
     group.add_argument('-n', action='store_true', dest='nitpicky',
                        help='nit-picky mode, warn about all missing '
                        'references')
 
     group = parser.add_argument_group('console output options')
     group.add_argument('-v', action='count', dest='verbosity', default=0,
-                       help='increase verbosity (can be repeated)')
+                       help='increase verbosity, can be repeated')
     group.add_argument('-q', action='store_true', dest='quiet',
                        help='no output on stdout, just warnings on stderr')
     group.add_argument('-Q', action='store_true', dest='really_quiet',

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -106,7 +106,7 @@ By default, everything that is outdated is built. Output only for selected
 files can be built by specifying individual filenames.
 """)
 
-    parser.add_argument('--version', action='version', dest='show_version',
+    parser.add_argument('--version', action='version',
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('sourcedir',

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -293,7 +293,7 @@ excluded from generation.
 
 Note: By default this script will not overwrite already created files.""")
 
-    parser.add_argument('--version', action='version', dest='show_version',
+    parser.add_argument('--version', action='version',
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('module_path',

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -365,7 +365,7 @@ The format of the autosummary directive is documented in the
   pydoc sphinx.ext.autosummary
 """)
 
-    parser.add_argument('--version', action='version', dest='show_version',
+    parser.add_argument('--version', action='version',
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('source_file', nargs='+',


### PR DESCRIPTION
Subject: Allow multiple occurrences of of `-b` option to `sphinx-build`

### Feature or Bugfix
- Feature

### Purpose
- Allow user to specify multiple builders

### Detail

- sphinx-build: Preserve newlines

  The default formatter for a parser's description and epilog field strips out all whitespace. We have this whitespace included for a reason. Use `argparse.RawDescriptionHelpFormatter` [1] to ensure it is preserved.

  Some small nits are fixed in the process.

  [1] https://docs.python.org/2/library/argparse.html#argparse.RawDescriptionHelpFormatter

- sphinx-build: Allow user to request multiple builders

  Allow a user to request multiple different builders by providing the `-b BUILDER` option multiple times. For example:

      sphinx-build -b html -b latex doc build

  Builds are scheduled in the order in which they were defined. If one of the builders fails, 'sphinx-build' will exit immediately with the appropriate `statuscode`.

- trivial: Remove useless argument for 'version' opts

  The 'version' action neither needs nor uses the 'dest' argument.