### PR TITLE
Diet tests on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,19 +6,12 @@ environment:
 
   matrix:
     - PYTHON: 27
-      DOCUTILS: 0.13.1
-      TEST_IGNORE: --ignore py35
-    - PYTHON: 27
-      DOCUTILS: 0.14
       TEST_IGNORE: --ignore py35
     - PYTHON: 36
-      DOCUTILS: 0.14
     - PYTHON: 36-x64
-      DOCUTILS: 0.14
 
 install:
   - C:\Python%PYTHON%\python.exe -m pip install -U pip setuptools
-  - C:\Python%PYTHON%\python.exe -m pip install docutils==%DOCUTILS% mock
   - C:\Python%PYTHON%\python.exe -m pip install .[test,websupport]
 
 # No automatic build, just run python tests


### PR DESCRIPTION
I dropped a test pattern for docutils-0.13.1 and py27 on Windows in this commit.

Because we already runs tests for several versions of docutils on Travis CI.
So I think it is unnecessary.

@shimizukawa Is there any special reason for it?