### PR TITLE
Fix missing metainfo for sphinx.io

### DIFF
--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -285,3 +285,9 @@ def read_doc(app, env, filename):
 def setup(app):
     app.registry.add_source_input('*', SphinxFileInput)
     app.registry.add_source_input('restructuredtext', SphinxRSTFileInput)
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
Subject: ``sphinx.io`` extension disables parallel reading/writing

The PR simply adds missing metainfo, asserting that parallel reading/writing is ok.
Note: I don't know what extension is doing and haven't actually checked if the change is safe. However, I guess a builtin extension shouldn't disable parallel builds.

(Would it be possible to have a generic parallel build test that fails if not all builtin extensions are parallel read/write safe?)