### PR TITLE
doc: Add missing sphinx-apidocs opt, envvar

### DIFF
--- a/doc/man/sphinx-apidoc.rst
+++ b/doc/man/sphinx-apidoc.rst
@@ -91,7 +91,7 @@ Options
 
    Interpret paths recursively according to PEP-0420.
 
-.. option:: -M
+.. option:: -M, --module-first
 
    Put module documentation before submodule documentation.
 
@@ -117,6 +117,14 @@ These options are used when :option:`--full` is specified:
 .. option:: -R <release>
 
    Sets the project release to put in generated files (see :confval:`release`).
+
+Environment
+-----------
+
+.. envvar:: SPHINX_APIDOC_OPTIONS
+
+   A comma-separated list of option to append to generated ``automodule``
+   directives. Defaults to ``members,undoc-members,show-inheritance``.
 
 See also
 --------


### PR DESCRIPTION
Add docs for `--module-first` option and `SPHINX_APIDOC_OPTIONS` environment variable. Per the closest thing we have to official man page guidelines [1]:

    ENVIRONMENT

    lists all environment variables that affect the program or function
    and how they affect it.

[1] https://linux.die.net/man/7/man-pages
Fixes #2250