### PR TITLE
Refactor autodoc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Deprecated
   values will be accepted at 2.0.
 * ``format_annotation()`` and ``formatargspec()`` is deprecated.  Please use
   ``sphinx.util.inspect.Signature`` instead.
+* ``sphinx.ext.autodoc.add_documenter()`` and ``AutoDirective._register`` is now
+  deprecated.  Please use ``app.add_autodocumenter()``
 
 Features added
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -22,7 +22,9 @@ Deprecated
 * ``format_annotation()`` and ``formatargspec()`` is deprecated.  Please use
   ``sphinx.util.inspect.Signature`` instead.
 * ``sphinx.ext.autodoc.add_documenter()`` and ``AutoDirective._register`` is now
-  deprecated.  Please use ``app.add_autodocumenter()``
+  deprecated.  Please use ``app.add_autodocumenter()`` instead.
+* ``AutoDirective._special_attrgetters`` is now deprecated.  Please use
+  ``app.add_autodoc_attrgetter()`` instead.
 
 Features added
 --------------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -642,9 +642,9 @@ class Sphinx(object):
     def add_autodocumenter(self, cls):
         # type: (Any) -> None
         logger.debug('[app] adding autodocumenter: %r', cls)
-        from sphinx.ext import autodoc
-        autodoc.add_documenter(cls)
-        self.add_directive('auto' + cls.objtype, autodoc.AutoDirective)
+        from sphinx.ext.autodoc import AutoDirective
+        self.add_directive('auto' + cls.objtype, AutoDirective)
+        self.registry.add_documenter(cls.objtype, cls)
 
     def add_autodoc_attrgetter(self, type, getter):
         # type: (Any, Callable) -> None

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -646,11 +646,10 @@ class Sphinx(object):
         self.add_directive('auto' + cls.objtype, AutoDirective)
         self.registry.add_documenter(cls.objtype, cls)
 
-    def add_autodoc_attrgetter(self, type, getter):
-        # type: (Any, Callable) -> None
-        logger.debug('[app] adding autodoc attrgetter: %r', (type, getter))
-        from sphinx.ext import autodoc
-        autodoc.AutoDirective._special_attrgetters[type] = getter
+    def add_autodoc_attrgetter(self, typ, getter):
+        # type: (Type, Callable[[Any, unicode, Any], Any]) -> None
+        logger.debug('[app] adding autodoc attrgetter: %r', (typ, getter))
+        self.registy.add_autodoc_attrgetter(typ, getter)
 
     def add_search_language(self, cls):
         # type: (Any) -> None

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -649,7 +649,7 @@ class Sphinx(object):
     def add_autodoc_attrgetter(self, typ, getter):
         # type: (Type, Callable[[Any, unicode, Any], Any]) -> None
         logger.debug('[app] adding autodoc attrgetter: %r', (typ, getter))
-        self.registy.add_autodoc_attrgetter(typ, getter)
+        self.registry.add_autodoc_attrgetter(typ, getter)
 
     def add_search_language(self, cls):
         # type: (Any) -> None

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -296,9 +296,7 @@ class Documenter(object):
     def documenters(self):
         # type: () -> Dict[unicode, Type[Documenter]]
         """Returns registered Documenter classes"""
-        classes = dict(AutoDirective._registry)  # registered directly
-        classes.update(self.env.app.registry.documenters)  # registered by API
-        return classes
+        return get_documenters(self.env.app)
 
     def add_line(self, line, source, *lineno):
         # type: (unicode, unicode, int) -> None

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -12,7 +12,7 @@ from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from docutils.utils import assemble_option_dict
 
-from sphinx.ext.autodoc import AutoDirective, get_documenters
+from sphinx.ext.autodoc import get_documenters
 from sphinx.util import logging
 from sphinx.util.docutils import switch_source_input
 from sphinx.util.nodes import nested_parse_with_titles

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -151,7 +151,7 @@ def import_module(modname, warningiserror=False):
 
 
 def import_object(modname, objpath, objtype='', attrgetter=safe_getattr, warningiserror=False):
-    # type: (str, List[unicode], str, Callable[[Any, unicode], Any]) -> Any
+    # type: (str, List[unicode], str, Callable[[Any, unicode], Any], bool) -> Any
     if objpath:
         logger.debug('[autodoc] from %s import %s', modname, '.'.join(objpath))
     else:

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -19,7 +19,7 @@ from types import FunctionType, MethodType, ModuleType
 from six import PY2
 
 from sphinx.util import logging
-from sphinx.util.inspect import safe_getattr
+from sphinx.util.inspect import isenumclass, safe_getattr
 
 if False:
     # For type annotation
@@ -205,6 +205,12 @@ def get_object_members(subject, objpath, attrgetter, analyzer=None):
     """Get members and attributes of target object."""
     # the members directly defined in the class
     obj_dict = attrgetter(subject, '__dict__', {})
+
+    # Py34 doesn't have enum members in __dict__.
+    if sys.version_info[:2] == (3, 4) and isenumclass(subject):
+        obj_dict = dict(obj_dict)
+        for name, value in subject.__members__.items():
+            obj_dict[name] = value
 
     members = {}
     for name in dir(subject):

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -51,10 +51,12 @@ class DummyApplication(object):
     """Dummy Application class for sphinx-autogen command."""
 
     def __init__(self):
+        # type: () -> None
         self.registry = SphinxComponentRegistry()
 
 
 def setup_documenters(app):
+    # type: (Any) -> None
     from sphinx.ext.autodoc import (
         ModuleDocumenter, ClassDocumenter, ExceptionDocumenter, DataDocumenter,
         FunctionDocumenter, MethodDocumenter, AttributeDocumenter,
@@ -91,7 +93,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                               warn=_simple_warn, info=_simple_info,
                               base_path=None, builder=None, template_dir=None,
                               imported_members=False, app=None):
-    # type: (List[unicode], unicode, unicode, Callable, Callable, unicode, Builder, unicode, bool) -> None  # NOQA
+    # type: (List[unicode], unicode, unicode, Callable, Callable, unicode, Builder, unicode, bool, Any) -> None  # NOQA
 
     showed_sources = list(sorted(sources))
     if len(showed_sources) > 20:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -52,6 +52,7 @@ EXTENSION_BLACKLIST = {
 
 class SphinxComponentRegistry(object):
     def __init__(self):
+        self.autodoc_attrgettrs = {}    # type: Dict[Type, Callable[[Any, unicode, Any], Any]]
         self.builders = {}              # type: Dict[unicode, Type[Builder]]
         self.documenters = {}           # type: Dict[unicode, Type[Documenter]]
         self.domains = {}               # type: Dict[unicode, Type[Domain]]
@@ -289,6 +290,10 @@ class SphinxComponentRegistry(object):
     def add_documenter(self, objtype, documenter):
         # type: (unicode, Type[Documenter]) -> None
         self.documenters[objtype] = documenter
+
+    def add_autodoc_attrgetter(self, typ, attrgetter):
+        # type: (Type, Callable[[Any, unicode, Any], Any]) -> None
+        self.autodoc_attrgettrs[typ] = attrgetter
 
     def load_extension(self, app, extname):
         # type: (Sphinx, unicode) -> None

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -38,6 +38,7 @@ if False:
     from sphinx.builders import Builder  # NOQA
     from sphinx.domains import Domain, Index  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
+    from sphinx.ext.autodoc import Documenter  # NOQA
     from sphinx.util.typing import RoleFunction  # NOQA
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ EXTENSION_BLACKLIST = {
 class SphinxComponentRegistry(object):
     def __init__(self):
         self.builders = {}              # type: Dict[unicode, Type[Builder]]
+        self.documenters = {}           # type: Dict[unicode, Type[Documenter]]
         self.domains = {}               # type: Dict[unicode, Type[Domain]]
         self.domain_directives = {}     # type: Dict[unicode, Dict[unicode, Any]]
         self.domain_indices = {}        # type: Dict[unicode, List[Type[Index]]]
@@ -283,6 +285,10 @@ class SphinxComponentRegistry(object):
     def get_post_transforms(self):
         # type: () -> List[Type[Transform]]
         return self.post_transforms
+
+    def add_documenter(self, objtype, documenter):
+        # type: (unicode, Type[Documenter]) -> None
+        self.documenters[objtype] = documenter
 
     def load_extension(self, app, extname):
         # type: (Sphinx, unicode) -> None

--- a/tests/py35/test_autodoc_py35.py
+++ b/tests/py35/test_autodoc_py35.py
@@ -112,7 +112,7 @@ def skip_member(app, what, name, obj, skip, options):
 @pytest.mark.usefixtures('setup_test')
 def test_generate():
     def assert_warns(warn_str, objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         assert len(directive.result) == 0, directive.result
         assert len(_warnings) == 1, _warnings
@@ -120,7 +120,7 @@ def test_generate():
         del _warnings[:]
 
     def assert_works(objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         assert directive.result
         # print '\n'.join(directive.result)
@@ -134,7 +134,7 @@ def test_generate():
         assert set(processed_docstrings) | set(processed_signatures) == set(items)
 
     def assert_result_contains(item, objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         # print '\n'.join(directive.result)
         assert len(_warnings) == 0, _warnings
@@ -142,7 +142,7 @@ def test_generate():
         del directive.result[:]
 
     def assert_order(items, objtype, name, member_order, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.options.member_order = member_order
         inst.generate(**kw)
         assert len(_warnings) == 0, _warnings

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -121,7 +121,7 @@ def skip_member(app, what, name, obj, skip, options):
 @pytest.mark.usefixtures('setup_test')
 def test_parse_name():
     def verify(objtype, name, result):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         assert inst.parse_name()
         assert (inst.modname, inst.objpath, inst.args, inst.retann) == result
 
@@ -164,7 +164,7 @@ def test_parse_name():
 @pytest.mark.usefixtures('setup_test')
 def test_format_signature():
     def formatsig(objtype, name, obj, args, retann):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.fullname = name
         inst.doc_as_attr = False  # for class objtype
         inst.object = obj
@@ -270,7 +270,7 @@ def test_format_signature():
 @pytest.mark.usefixtures('setup_test')
 def test_get_doc():
     def getdocl(objtype, obj, encoding=None):
-        inst = AutoDirective._registry[objtype](directive, 'tmp')
+        inst = app.registry.documenters[objtype](directive, 'tmp')
         inst.object = obj
         inst.objpath = [obj.__name__]
         inst.doc_as_attr = False
@@ -449,7 +449,7 @@ def test_get_doc():
 @pytest.mark.usefixtures('setup_test')
 def test_docstring_processing():
     def process(objtype, name, obj):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.object = obj
         inst.fullname = name
         return list(inst.process_doc(inst.get_doc()))
@@ -506,7 +506,7 @@ def test_docstring_property_processing():
     def genarate_docstring(objtype, name, **kw):
         del processed_docstrings[:]
         del processed_signatures[:]
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         results = list(directive.result)
         docstrings = inst.get_doc()[0]
@@ -555,7 +555,7 @@ def test_new_documenter():
     add_documenter(MyDocumenter)
 
     def assert_result_contains(item, objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         # print '\n'.join(directive.result)
         assert len(_warnings) == 0, _warnings
@@ -581,7 +581,7 @@ def test_attrgetter_using():
         AutoDirective._special_attrgetters[type] = special_getattr
 
         del getattr_spy[:]
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
 
         hooked_members = [s[1] for s in getattr_spy]
@@ -603,7 +603,7 @@ def test_attrgetter_using():
 @pytest.mark.usefixtures('setup_test')
 def test_generate():
     def assert_warns(warn_str, objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         assert len(directive.result) == 0, directive.result
         assert len(_warnings) == 1, _warnings
@@ -611,7 +611,7 @@ def test_generate():
         del _warnings[:]
 
     def assert_works(objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         assert directive.result
         # print '\n'.join(directive.result)
@@ -625,7 +625,7 @@ def test_generate():
         assert set(processed_docstrings) | set(processed_signatures) == set(items)
 
     def assert_result_contains(item, objtype, name, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.generate(**kw)
         # print '\n'.join(directive.result)
         assert len(_warnings) == 0, _warnings
@@ -633,7 +633,7 @@ def test_generate():
         del directive.result[:]
 
     def assert_order(items, objtype, name, member_order, **kw):
-        inst = AutoDirective._registry[objtype](directive, name)
+        inst = app.registry.documenters[objtype](directive, name)
         inst.options.member_order = member_order
         inst.generate(**kw)
         assert len(_warnings) == 0, _warnings

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -60,9 +60,9 @@ def test_mangle_signature():
 def test_get_items_summary(make_app, app_params):
     import sphinx.ext.autosummary
     import sphinx.ext.autosummary.generate
-    sphinx.ext.autosummary.generate.setup_documenters()
     args, kwargs = app_params
     app = make_app(*args, **kwargs)
+    sphinx.ext.autosummary.generate.setup_documenters(app)
     # monkey-patch Autosummary.get_items so we can easily get access to it's
     # results..
     orig_get_items = sphinx.ext.autosummary.Autosummary.get_items

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -57,10 +57,14 @@ def test_mangle_signature():
 
 
 @pytest.mark.sphinx('dummy', **default_kw)
-def test_get_items_summary(app, status, warning):
+def test_get_items_summary(make_app, app_params):
+    import sphinx.ext.autosummary
+    import sphinx.ext.autosummary.generate
+    sphinx.ext.autosummary.generate.setup_documenters()
+    args, kwargs = app_params
+    app = make_app(*args, **kwargs)
     # monkey-patch Autosummary.get_items so we can easily get access to it's
     # results..
-    import sphinx.ext.autosummary
     orig_get_items = sphinx.ext.autosummary.Autosummary.get_items
 
     autosummary_items = {}
@@ -81,7 +85,7 @@ def test_get_items_summary(app, status, warning):
     finally:
         sphinx.ext.autosummary.Autosummary.get_items = orig_get_items
 
-    html_warnings = warning.getvalue()
+    html_warnings = app._warning.getvalue()
     assert html_warnings == ''
 
     expected_values = {

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -15,9 +15,9 @@ from sphinx.ext.autosummary.generate import setup_documenters
 
 @pytest.mark.sphinx('html', testroot='templating')
 def test_layout_overloading(make_app, app_params):
-    setup_documenters()
     args, kwargs = app_params
     app = make_app(*args, **kwargs)
+    setup_documenters(app)
     app.builder.build_update()
 
     result = (app.outdir / 'contents.html').text(encoding='utf-8')
@@ -27,9 +27,9 @@ def test_layout_overloading(make_app, app_params):
 
 @pytest.mark.sphinx('html', testroot='templating')
 def test_autosummary_class_template_overloading(make_app, app_params):
-    setup_documenters()
     args, kwargs = app_params
     app = make_app(*args, **kwargs)
+    setup_documenters(app)
     app.builder.build_update()
 
     result = (app.outdir / 'generated' / 'sphinx.application.TemplateBridge.html').text(

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -10,10 +10,14 @@
 """
 
 import pytest
+from sphinx.ext.autosummary.generate import setup_documenters
 
 
 @pytest.mark.sphinx('html', testroot='templating')
-def test_layout_overloading(app, status, warning):
+def test_layout_overloading(make_app, app_params):
+    setup_documenters()
+    args, kwargs = app_params
+    app = make_app(*args, **kwargs)
     app.builder.build_update()
 
     result = (app.outdir / 'contents.html').text(encoding='utf-8')
@@ -22,7 +26,10 @@ def test_layout_overloading(app, status, warning):
 
 
 @pytest.mark.sphinx('html', testroot='templating')
-def test_autosummary_class_template_overloading(app, status, warning):
+def test_autosummary_class_template_overloading(make_app, app_params):
+    setup_documenters()
+    args, kwargs = app_params
+    app = make_app(*args, **kwargs)
     app.builder.build_update()
 
     result = (app.outdir / 'generated' / 'sphinx.application.TemplateBridge.html').text(


### PR DESCRIPTION
This is a second step of autodoc.

This contains two changes:

* deprecating `sphinx.ext.autodoc.add_documenter()` and register methods of `AutoDirective`. They are not public API, so we can deprecate it. But I'll keep its interface during 1.x.
* Move importing features to `sphinx.ext.autodoc.importer`.