### PR TITLE
Fix #4091: Private members not documented without :undoc-members:

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,7 @@ Bugs fixed
   ``\chapter`` commands 
 * #4214: Two todolist directives break sphinx-1.6.5
 * Fix links to external option docs with intersphinx (refs: #3769)
+* #4091: Private members not documented without :undoc-members:
 
 Testing
 --------

--- a/sphinx/ext/autodoc.py
+++ b/sphinx/ext/autodoc.py
@@ -965,8 +965,7 @@ class Documenter(object):
             elif (namespace, membername) in attr_docs:
                 if want_all and membername.startswith('_'):
                     # ignore members whose name starts with _ by default
-                    keep = self.options.private_members and \
-                        (has_doc or self.options.undoc_members)
+                    keep = self.options.private_members
                 else:
                     # keep documented attributes
                     keep = True


### PR DESCRIPTION
refs: #4091 