### PR TITLE
Improved sidebar search field style

### DIFF
--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -10,12 +10,14 @@
 {%- if pagename != "search" and builder != "singlehtml" %}
 <div id="searchbox" style="display: none" role="search">
   <h3>{{ _('Quick search') }}</h3>
+    <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <div><input type="text" name="q" /></div>
-      <div><input type="submit" value="{{ _('Go') }}" /></div>
+      <input type="text" name="q" />
+      <input type="submit" value="{{ _('Go') }}" />
       <input type="hidden" name="check_keywords" value="yes" />
       <input type="hidden" name="area" value="default" />
     </form>
+    </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script>
 {%- endif %}

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -82,8 +82,20 @@ div.sphinxsidebar input {
 }
 
 div.sphinxsidebar #searchbox input[type="text"] {
-    width: 170px;
+    float: left;
+    width: 80%;
+    padding: 0.25em;
+    box-sizing: border-box;
 }
+
+div.sphinxsidebar #searchbox input[type="submit"] {
+    float: left;
+    width: 20%;
+    border-left: none;
+    padding: 0.25em;
+    box-sizing: border-box;
+}
+
 
 img {
     border: 0;

--- a/sphinx/themes/nature/static/nature.css_t
+++ b/sphinx/themes/nature/static/nature.css_t
@@ -125,14 +125,11 @@ div.sphinxsidebar input {
     font-size: 1em;
 }
 
-div.sphinxsidebar input[type=text]{
+div.sphinxsidebar .searchformwrapper {
     margin-left: 20px;
+    margin-right: 20px;
 }
 
-div.sphinxsidebar input[type=submit]{
-    margin-left: 20px;
-}
- 
 /* -- body styles ----------------------------------------------------------- */
  
 a {

--- a/sphinx/themes/pyramid/static/pyramid.css_t
+++ b/sphinx/themes/pyramid/static/pyramid.css_t
@@ -148,12 +148,9 @@ div.sphinxsidebar input {
     font-size: 1em;
 }
 
-div.sphinxsidebar input[type=text]{
+div.sphinxsidebar .searchformwrapper {
     margin-left: 20px;
-}
-
-div.sphinxsidebar input[type=submit]{
-    margin-left: 20px;
+    margin-right: 20px;
 }
 
 /* -- sidebars -------------------------------------------------------------- */


### PR DESCRIPTION
### Feature: Improved sidebar search field style

The current sidebar search does not align the search button nicely:

![grafik](https://user-images.githubusercontent.com/2836374/34591494-3a5694f0-f1be-11e7-9d12-aebfe281a57c.png)

This is a tuning of the CSS of the side bar search field inspired by: https://www.w3schools.com/howto/howto_css_search_button.asp

See below for the looks in different themes.

*Note:* As opposed to the above template, I have not used the magnifying glass icon for the button, because I did not want to introduce the FontAwesome deprendency. The text button may become an issue when the text is translated to a longer one. Then the button may still wrap below the input field.
If you're ok with the dependency, I could use the icon.

### Examples

bizstyle
![grafik](https://user-images.githubusercontent.com/2836374/34590974-79a5cc10-f1ba-11e7-8ca2-c9af57563853.png)

classic
![grafik](https://user-images.githubusercontent.com/2836374/34591012-af5375a6-f1ba-11e7-82c3-e62748436087.png)

nature
![grafik](https://user-images.githubusercontent.com/2836374/34591026-cfca47a6-f1ba-11e7-9e10-d1c3dc3fc9ea.png)

pyramid
![grafik](https://user-images.githubusercontent.com/2836374/34591048-ee97eba2-f1ba-11e7-86d5-46a12780821f.png)

sphinxdoc
![grafik](https://user-images.githubusercontent.com/2836374/34591063-104bf0ae-f1bb-11e7-9aeb-8e2fe0633759.png)




