### PR TITLE
Fix #4378: tox: use usedevelop option instead skipsdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 minversion = 2.0
 envlist = docs,flake8,mypy,coverage,py{27,34,35,36,py},du{11,12,13,14}
-skipsdist = True
 
 [testenv]
+usedevelop = True
 passenv =
     https_proxy http_proxy no_proxy PERL PERL5LIB
 description =


### PR DESCRIPTION
refs: #4378 