### PR TITLE
test: Reduce DeprecationWarning on testing (from docutils)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,10 @@ incremental = True
 check_untyped_defs = True
 warn_unused_ignores = True
 
+[tool:pytest]
+filterwarnings =
+    ignore::DeprecationWarning:docutils.io
+
 [coverage:run]
 branch = True
 source = sphinx


### PR DESCRIPTION
It seems many DeprecationWarnings are shown on Travis CI.
```
  /home/travis/build/sphinx-doc/sphinx/.tox/py36/lib/python3.6/site-packages/docutils/io.py:245: DeprecationWarning: 'U' mode is deprecated
    self.source = open(source_path, mode, **kwargs)
```

This try to filter them.