### PR TITLE
Cleanup formatting of some sidebar items

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -20,12 +20,14 @@ Index</a>, or install it with:{%endtrans%}</p>
 <h3>{%trans%}Questions? Suggestions?{%endtrans%}</h3>
 
 <p>{%trans%}Join the <a href="http://groups.google.com/group/sphinx-users">sphinx-users</a> mailing list on Google Groups:{%endtrans%}</p>
+<div class="subscribeformwrapper">
 <form action="http://groups.google.com/group/sphinx-users/boxsubscribe"
-      style="padding-left: 0.5em">
-  <input type="text" name="email" value="your@email" style="font-size: 90%; width: 120px"
-         onfocus="$(this).val('');"/>
-  <input type="submit" name="sub" value="Subscribe" style="font-size: 90%; width: 70px"/>
+      class="subscribeform">
+  <input type="text" name="email" value="your@email"
+         onfocus="$(this).val('');" />
+  <input type="submit" name="sub" value="Subscribe" />
 </form>
+</div>
 <p>{%trans%}or come to the <tt>#sphinx-doc</tt> channel on FreeNode.{%endtrans%}</p>
 <p>{%trans%}You can also open an issue at the
   <a href="https://github.com/sphinx-doc/sphinx/issues">tracker</a>.{%endtrans%}</p>

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -140,11 +140,37 @@ div.sphinxsidebar .logo img {
     vertical-align: middle;
 }
 
+div.subscribeformwrapper {
+    display: block;
+    overflow: auto;
+    margin-bottom: 1.2em;
+}
+
 div.sphinxsidebar input {
     border: 1px solid #aaa;
     font-family: 'Open Sans', 'Lucida Grande', 'Lucida Sans Unicode', 'Geneva',
                  'Verdana', sans-serif;
-    font-size: 1em;
+}
+
+div.sphinxsidebar .subscribeform {
+    margin-top: 0;
+}
+
+div.sphinxsidebar .subscribeform input {
+    border: 1px solid #aaa;
+    font-size: 0.9em;
+    float: left;
+    padding: 0.25em 0.5em;
+    box-sizing: border-box;
+}
+
+div.sphinxsidebar .subscribeform input[type="text"] {
+    width: 60%;
+}
+
+div.sphinxsidebar .subscribeform input[type="submit"] {
+    width: 40%;
+    border-left: none;
 }
 
 div.sphinxsidebar h3 {
@@ -281,7 +307,7 @@ tt {
     border: 1px solid #ddd;
     border-radius: 2px;
     color: #333;
-    padding: 1px;
+    padding: 1px 0.2em;
 }
 
 tt.descname, tt.descclassname, tt.xref {


### PR DESCRIPTION
A bit nicer formatting of the Questions section in  the sphinx documentation sidebar. In particular:

- styling of the subscribe form
- some margin adaptions

Here's what it looks like:

before:
![grafik](https://user-images.githubusercontent.com/2836374/34641848-7a376f98-f30a-11e7-95fd-003017be404b.png)

now:
![grafik](https://user-images.githubusercontent.com/2836374/34641812-fd9132da-f309-11e7-9a24-886f921ca077.png)
