### PR TITLE
Builder's interrupt event. Fix #1649

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -99,6 +99,7 @@ class Builder(object):
 
         # these get set later
         self.parallel_ok = False
+        self.interrupt_tasks = None  # type: Any
         self.finish_tasks = None  # type: Any
 
     def set_environment(self, env):
@@ -361,6 +362,9 @@ class Builder(object):
         else:
             if method == 'update' and not docnames:
                 logger.info(bold('no targets are out of date.'))
+                self.interrupt_tasks = SerialTasks()
+                self.interrupt()
+                self.interrupt_tasks.join()
                 return
 
         # filter "docnames" (list of outdated files) by the updated
@@ -474,6 +478,14 @@ class Builder(object):
         # type: (unicode, nodes.Node) -> None
         """Handle parts of write_doc that must be called in the main process
         if parallel build is active.
+        """
+        pass
+
+    def interrupt(self):
+        # type: () -> None
+        """Interrupt the building process.
+
+        The default implementation does nothing.
         """
         pass
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -157,6 +157,7 @@ class StandaloneHTMLBuilder(Builder):
     allow_parallel = True
     out_suffix = '.html'
     link_suffix = '.html'  # defaults to matching out_suffix
+    indexer = None  # type: Any
     indexer_format = js_index  # type: Any
     indexer_dumps_unicode = True
     # create links to original images from images [True/False]
@@ -353,8 +354,6 @@ class StandaloneHTMLBuilder(Builder):
 
     def prepare_writing(self, docnames):
         # type: (Iterable[unicode]) -> nodes.Node
-        # create the search indexer
-        self.indexer = None
         if self.search:
             from sphinx.search import IndexBuilder, languages
             lang = self.config.html_search_language or self.config.language
@@ -580,6 +579,14 @@ class StandaloneHTMLBuilder(Builder):
 
         # dump the search index
         self.handle_finish()
+
+    def interrupt(self):
+        # type: () -> None
+        self.interrupt_tasks.add_task(self.copy_image_files)
+        self.interrupt_tasks.add_task(self.copy_download_files)
+        # not only copying, generating.
+        # self.interrupt_tasks.add_task(self.copy_static_files)
+        self.interrupt_tasks.add_task(self.copy_extra_files)
 
     def gen_indices(self):
         # type: () -> None
@@ -1231,6 +1238,14 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         self.copy_extra_files()
         self.write_buildinfo()
         self.dump_inventory()
+
+    def interrupt(self):
+        # type: () -> None
+        self.copy_image_files()
+        self.copy_download_files()
+        # not only copying, generating.
+        # self.copy_static_files()
+        self.copy_extra_files()
 
 
 class SerializingHTMLBuilder(StandaloneHTMLBuilder):


### PR DESCRIPTION
Subject: Builder's finish event can be separate some events.

### Feature or Bugfix
<!-- please choose -->
- Feature
### Purpose
- By design, build process can be interrupted or finished.
  Some tasks executed in finish state should also be executed in interrupt state.

### Detail
- Introduce interrupt event hook point at Builder
- Fix #1649 by execute copying tasks also in interrupt case

### Relates
- #1649