### PR TITLE
Fix #4081: Warnings and errors colored the same when building

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -58,7 +58,6 @@ Features added
 * #4332: Let LaTeX obey :confval:`math_numfig` for equation numbering
 * #4093: sphinx-build creates empty directories for unknown targets/builders
 
-
 Features removed
 ----------------
 
@@ -105,6 +104,7 @@ Bugs fixed
   setting
 * #4198: autosummary emits multiple 'autodoc-process-docstring' event. Thanks
   to Joel Nothman.
+* #4081: Warnings and errors colored the same when building
 
 Testing
 --------

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -53,7 +53,7 @@ VERBOSITY_MAP.update({
 COLOR_MAP = defaultdict(lambda: 'blue')  # type: Dict[int, unicode]
 COLOR_MAP.update({
     logging.ERROR: 'darkred',
-    logging.WARNING: 'darkred',
+    logging.WARNING: 'red',
     logging.DEBUG: 'darkgray',
 })
 

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -183,7 +183,7 @@ def test_warning_location(app, status, warning):
     assert 'index.txt:10: WARNING: message2' in warning.getvalue()
 
     logger.warning('message3', location=None)
-    assert colorize('darkred', 'WARNING: message3') in warning.getvalue()
+    assert colorize('red', 'WARNING: message3') in warning.getvalue()
 
     node = nodes.Node()
     node.source, node.line = ('index.txt', 10)
@@ -200,7 +200,7 @@ def test_warning_location(app, status, warning):
 
     node.source, node.line = (None, None)
     logger.warning('message7', location=node)
-    assert colorize('darkred', 'WARNING: message7') in warning.getvalue()
+    assert colorize('red', 'WARNING: message7') in warning.getvalue()
 
 
 def test_pending_warnings(app, status, warning):
@@ -236,7 +236,7 @@ def test_colored_logs(app, status, warning):
     assert colorize('darkgray', 'message1') in status.getvalue()
     assert 'message2\n' in status.getvalue()  # not colored
     assert 'message3\n' in status.getvalue()  # not colored
-    assert colorize('darkred', 'WARNING: message4') in warning.getvalue()
+    assert colorize('red', 'WARNING: message4') in warning.getvalue()
     assert 'WARNING: message5\n' in warning.getvalue()  # not colored
     assert colorize('darkred', 'WARNING: message6') in warning.getvalue()
 


### PR DESCRIPTION
refs: #4081 

With this change, warnings are shown as following:
![2018-01-08 12 17 39](https://user-images.githubusercontent.com/748828/34657946-56a69f1c-f46e-11e7-913e-e8415fb39c65.png)
