### PR TITLE
Fixes bug when evaluating entry to bool

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -71,12 +71,12 @@ def doctree_read(app, doctree):
             code = analyzer.code.decode(analyzer.encoding)
         else:
             code = analyzer.code
-        if entry is None or entry[0] != code:
+        if entry is False:
+            return
+        elif entry is None or entry[0] != code:
             analyzer.find_tags()
             entry = code, analyzer.tags, {}, refname
             env._viewcode_modules[modname] = entry  # type: ignore
-        elif entry is False:
-            return
         _, tags, used, _ = entry
         if fullname in tags:
             used[fullname] = docname


### PR DESCRIPTION
As reported here: https://github.com/rtfd/readthedocs.org/issues/3411 sphinx sometimes fails with the error:
```python
  File "/home/docs/checkouts/readthedocs.org/user_builds/drf-yasg/envs/latest/lib/python3.5/site-packages/sphinx/ext/viewcode.py", line 74, in has_tag
    if entry is None or entry[0] != code:
TypeError: 'bool' object is not subscriptable
```
This is not critical as whipping the build or even just running it again fixes it, but the error is confusing...  
I believe switching the two if statement above should prevent this from happening.

Subject: <short purpose of this pull request>

### Feature or Bugfix
- Bugfix

See #4397 for details