### PR TITLE
latex: Do not display Release label if :confval:`release` is not set

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -113,6 +113,7 @@ Bugs fixed
 * #4198: autosummary emits multiple 'autodoc-process-docstring' event. Thanks
   to Joel Nothman.
 * #4081: Warnings and errors colored the same when building
+* latex: Do not display 'Release' label if :confval:`release` is not set
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -549,7 +549,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             'author':       document.settings.author,   # treat as a raw LaTeX code
             'indexname':    _('Index'),
         })
-        if not self.elements['releasename']:
+        if not self.elements['releasename'] and self.elements['release']:
             self.elements.update({
                 'releasename':  _('Release'),
             })

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -165,13 +165,15 @@ def test_latex_warnings(app, status, warning):
 
 
 @pytest.mark.sphinx('latex', testroot='basic')
-def test_latex_title(app, status, warning):
+def test_latex_basic(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').text(encoding='utf8')
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\title{The basic Sphinx documentation for testing}' in result
+    assert r'\title{The basic Sphinx documentation for testing}' in result
+    assert r'\release{}' in result
+    assert r'\renewcommand{\releasename}{}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-title')
@@ -182,6 +184,18 @@ def test_latex_title_after_admonitions(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert '\\title{test-latex-title}' in result
+
+
+@pytest.mark.sphinx('latex', testroot='basic',
+                    confoverrides={'release': '1.0'})
+def test_latex_release(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'test.tex').text(encoding='utf8')
+    print(result)
+    print(status.getvalue())
+    print(warning.getvalue())
+    assert r'\release{1.0}' in result
+    assert r'\renewcommand{\releasename}{Release}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='numfig',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 1.6, we can omit `release` configuration, but LaTeX writer expects required
- This allows to omit it for LaTeX output

### Relates
- https://groups.google.com/forum/#!topic/sphinx-users/L5PUfwVu8f0

