### PR TITLE
autodoc: only mock specified modules with their descendants.

### DIFF
--- a/tests/roots/test-root/autodoc_missing_imports.py
+++ b/tests/roots/test-root/autodoc_missing_imports.py
@@ -4,6 +4,8 @@ from missing_module import missing_name
 import missing_package1.missing_module1
 from missing_package2 import missing_module2
 from missing_package3.missing_module3 import missing_name
+import sphinx.missing_module4
+from sphinx.missing_module4 import missing_name2
 
 @missing_name
 def decoratedFunction():
@@ -16,3 +18,5 @@ class TestAutodoc(object):
     def decoratedMethod(self):
         """TestAutodoc::decoratedMethod docstring"""
         return None
+
+sphinx.missing_module4.missing_function(len(missing_name2))

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -69,9 +69,10 @@ extlinks = {'issue': ('http://bugs.python.org/issue%s', 'issue '),
 
 autodoc_mock_imports = [
     'missing_module',
-    'missing_package1.missing_module1',
-    'missing_package2.missing_module2',
-    'missing_package3.missing_module3',
+    'missing_package1',
+    'missing_package2',
+    'missing_package3',
+    'sphinx.missing_module4',
 ]
 
 # modify tags from conf.py


### PR DESCRIPTION
Do not mock the ancestors of the specified modules in `autodoc_mock_imports`. Only mock the modules themselves and their descendants (as specified in the docs). This changes behavior compared to the original mock import implementation that was done in version 1.3 where all ancestors were also mocked implicitly (may require warning in release notes?).

I fixed the test configs accordingly.

Fixes #2557