### PR TITLE
Small label/comma fix

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -3,7 +3,7 @@ Introduction
 
 This is the documentation for the Sphinx documentation builder.  Sphinx is a
 tool that translates a set of reStructuredText_ source files into various output
-formats, automatically producing cross-references, indices etc.  That is, if
+formats, automatically producing cross-references, indices, etc.  That is, if
 you have a directory containing a bunch of reST-formatted documents (and
 possibly subdirectories of docs in there as well), Sphinx can generate a
 nicely-organized arrangement of HTML files (in some other directory) for easy
@@ -38,7 +38,7 @@ to reStructuredText/Sphinx from other documentation systems.
   code to convert Python-doc-style LaTeX markup to Sphinx reST.
 
 * Marcin Wojdyr has written a script to convert Docbook to reST with Sphinx
-  markup; it is at `Google Code <https://github.com/wojdyr/db2rst>`_.
+  markup; it is at `GitHub <https://github.com/wojdyr/db2rst>`_.
 
 * Christophe de Vienne wrote a tool to convert from Open/LibreOffice documents
   to Sphinx: `odt2sphinx <https://pypi.python.org/pypi/odt2sphinx/>`_.


### PR DESCRIPTION
Subject: Update a link label under "Conversion from other systems", add comma

### Feature or Bugfix
- Bugfix (doc update)

I'm a new user and was reading through the documentation when I spotted what appears to be two minor issues. I've previously thumbed through the docs, so haven't read from the beginning like I'm doing now. Please let me know if this sort of PR is acceptable and if you would appreciate further small contributions.

Thanks!

P.S.

I'm really enjoying working with Sphinx. Thanks for such a great tool.
