### PR TITLE
Fix #3570: autodoc: Do not display typing. module for type hints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,7 @@ Features added
 * #4093: sphinx-build creates empty directories for unknown targets/builders
 * Add ``top-classes`` option for the ``sphinx.ext.inheritance_diagram``
   extension to limit the scope of inheritance graphs.
+* #3570: autodoc: Do not display 'typing.' module for type hints
 
 Features removed
 ----------------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -404,10 +404,18 @@ class Signature(object):
         if annotation == Ellipsis:
             return '...'
         if not isinstance(annotation, type):
-            return repr(annotation)
+            qualified_name = repr(annotation)
+            if qualified_name.startswith('typing.'):  # for typing.Union
+                return qualified_name.split('.', 1)[1]
+            else:
+                return qualified_name
 
-        qualified_name = (annotation.__module__ + '.' + annotation.__qualname__  # type: ignore
-                          if annotation else repr(annotation))
+        if not annotation:
+            qualified_name = repr(annotation)
+        elif annotation.__module__ == 'typing':
+            qualified_name = annotation.__qualname__  # type: ignore
+        else:
+            qualified_name = (annotation.__module__ + '.' + annotation.__qualname__)  # type: ignore  # NOQA
 
         if annotation.__module__ == 'builtins':
             return annotation.__qualname__  # type: ignore

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -211,15 +211,15 @@ def test_Signature_annotations():
 
     # Generic types with concrete parameters
     sig = inspect.Signature(f1).format_args()
-    assert sig == '(x: typing.List[int]) -> typing.List[int]'
+    assert sig == '(x: List[int]) -> List[int]'
 
     # TypeVars and generic types with TypeVars
     sig = inspect.Signature(f2).format_args()
-    assert sig == '(x: typing.List[T], y: typing.List[T_co], z: T) -> typing.List[T_contra]'
+    assert sig == '(x: List[T], y: List[T_co], z: T) -> List[T_contra]'
 
     # Union types
     sig = inspect.Signature(f3).format_args()
-    assert sig == '(x: typing.Union[str, numbers.Integral]) -> None'
+    assert sig == '(x: Union[str, numbers.Integral]) -> None'
 
     # Quoted annotations
     sig = inspect.Signature(f4).format_args()
@@ -239,14 +239,14 @@ def test_Signature_annotations():
 
     # Callable types
     sig = inspect.Signature(f8).format_args()
-    assert sig == '(x: typing.Callable[[int, str], int]) -> None'
+    assert sig == '(x: Callable[[int, str], int]) -> None'
 
     sig = inspect.Signature(f9).format_args()
-    assert sig == '(x: typing.Callable) -> None'
+    assert sig == '(x: Callable) -> None'
 
     # Tuple types
     sig = inspect.Signature(f10).format_args()
-    assert sig == '(x: typing.Tuple[int, str], y: typing.Tuple[int, ...]) -> None'
+    assert sig == '(x: Tuple[int, str], y: Tuple[int, ...]) -> None'
 
     # Instance annotations
     sig = inspect.Signature(f11).format_args()


### PR DESCRIPTION
refs #3570 