### PR TITLE
latex: Emit warnings if the document contains aligned figures (refs: #3289)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Incompatible changes
 * autodoc does not generate warnings messages to the generated document even if
   :confval:`keep_warnings` is True.  They are only emitted to stderr.
 * shebang line is removed from generated conf.py
+* #3289: latex: Emit warnings if the document contains aligned figures because
+  it might not be layouted well by wrapfig-macro's limitation
 
 Deprecated
 ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -250,6 +250,7 @@ General configuration
    * misc.highlighting_failure
    * toc.secnum
    * epub.unknown_project_files
+   * latex.wrapfig
 
    You can choose from these types.
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -24,7 +24,7 @@ from docutils.writers.latex2e import Babel
 from sphinx import addnodes
 from sphinx import highlighting
 from sphinx.errors import SphinxError
-from sphinx.locale import admonitionlabels, _
+from sphinx.locale import admonitionlabels, _, __
 from sphinx.transforms import SphinxTransform
 from sphinx.util import split_into, logging
 from sphinx.util.i18n import format_date
@@ -1852,6 +1852,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
             self.body.append('\\begin{wrapfigure}{%s}{%s}\n\\centering' %
                              (node['align'] == 'right' and 'r' or 'l', length or '0pt'))
             self.context.append(ids + '\\end{wrapfigure}\n')
+
+            # emit a warning about wrapfig (refs: #3289)
+            logger.warning(__('A figure having :align: option has detected. '
+                              'LaTeX might not layout it well. Please check generated PDF.'),
+                           location=node, type='latex', subtype='wrapfig')
         elif self.in_minipage:
             if ('align' not in node.attributes or
                     node.attributes['align'] == 'center'):


### PR DESCRIPTION
refs: #3289 

This is not fix for #3289. But this emits warnings to users to check aligned figures layouted fine.
@jfbu what do you think? is this useful?