### PR TITLE
Minor conf.py cleanup

### DIFF
--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 #
-# {{ project }} documentation build configuration file, created by
-# sphinx-quickstart on {{ now }}.
+# Configuration file for the Sphinx documentation builder.
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/stable/config
 
-# -- Path setup -----------------------------------------------------------
+# -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -27,7 +26,7 @@ sys.path.insert(0, u'{{ module_path }}')
 {% endif -%}
 {% endif %}
 
-# -- Project information --------------------------------------------------
+# -- Project information -----------------------------------------------------
 
 project = u'{{ project_str }}'
 copyright = u'{{ copyright_str }}'
@@ -39,7 +38,7 @@ version = u'{{ version_str }}'
 release = u'{{ release_str }}'
 
 
-# -- General configuration ------------------------------------------------
+# -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
@@ -82,7 +81,7 @@ exclude_patterns = [{{ exclude_patterns }}]
 pygments_style = 'sphinx'
 
 
-# -- Options for HTML output ----------------------------------------------
+# -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -111,13 +110,13 @@ html_static_path = ['{{ dot }}static']
 # html_sidebars = {}
 
 
-# -- Options for HTMLHelp output ------------------------------------------
+# -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = '{{ project_fn }}doc'
 
 
-# -- Options for LaTeX output ---------------------------------------------
+# -- Options for LaTeX output ------------------------------------------------
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
@@ -146,7 +145,7 @@ latex_documents = [
 ]
 
 
-# -- Options for manual page output ---------------------------------------
+# -- Options for manual page output ------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
@@ -156,7 +155,7 @@ man_pages = [
 ]
 
 
-# -- Options for Texinfo output -------------------------------------------
+# -- Options for Texinfo output ----------------------------------------------
 
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
@@ -169,7 +168,7 @@ texinfo_documents = [
 {%- if epub %}
 
 
-# -- Options for Epub output ----------------------------------------------
+# -- Options for Epub output -------------------------------------------------
 
 # Bibliographic Dublin Core info.
 epub_title = project
@@ -192,18 +191,18 @@ epub_exclude_files = ['search.html']
 {%- if extensions %}
 
 
-# -- Extension configuration ----------------------------------------------
+# -- Extension configuration -------------------------------------------------
 {%- endif %}
 {%- if 'sphinx.ext.intersphinx' in extensions %}
 
-# -- Options for intersphinx extension ------------------------------------
+# -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
 {%- endif %}
 {%- if 'sphinx.ext.todo' in extensions %}
 
-# -- Options for todo extension -------------------------------------------
+# -- Options for todo extension ----------------------------------------------
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True


### PR DESCRIPTION
Follow-up to #4385. As discussed there:

- Make the section delimiters 79 char wide.
- Simplify the text in the header. I now just says:
  ~~~
  # Configuration file for the Sphinx documentation builder.
  ~~~
  instead of 
  ~~~
  # Flaboo documentation build configuration file, created by
  # sphinx-quickstart on Sat Jan  6 19:23:50 2018.
  ~~~
  Motivation: created-by and creation date are not relevant. The project name is also given in `project`.
  All of this information is usually also available via the context of the file. It will be part of a VCS repository. If really needed, one can look up the creation date there.. Also the user will know what project this is for. However, he may not know that `conf.py` is a config file for sphinx. So that's important to mention.
  
