### PR TITLE
Add :confval:`latex_use_wrapfig`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,9 @@ __ https://github.com/sphinx-contrib/sphinx-pretty-searchresults
 * #4182: autodoc: Support :confval:`suppress_warnings`
 * #4018: htmlhelp: Add :confval:`htmlhelp_file_suffix` and
   :confval:`htmlhelp_link_suffix`
+* #3289: LaTeX builder: emit warnings for aligned figures due to wrapfig
+  limitations (e.g. if a list follows.)
+* #4430: Add :confval:`latex_use_wrapfig` (refs: #3289)
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1984,6 +1984,16 @@ information.
 
    .. versionadded:: 1.8
 
+.. confval:: latex_use_wrapfig
+
+   The default is ``True``: figures with ``:align:`` option will be rendered
+   using ``wrapfig`` macros for flowing text. But, this is known to have
+   layouting issues in some cases. Set the option to ``False`` to replace
+   usage of ``wrapfig`` by standard LaTeX ``figure``: text will precede or
+   follow image, but not flow around it.
+
+   .. versionadded:: 2.0
+
 .. confval:: latex_elements
 
    .. versionadded:: 0.5

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -467,6 +467,7 @@ def setup(app):
     app.add_config_value('latex_show_pagerefs', False, None)
     app.add_config_value('latex_elements', {}, None)
     app.add_config_value('latex_additional_files', [], None)
+    app.add_config_value('latex_use_wrapfig', True, None)
 
     app.add_config_value('latex_docclass', default_latex_docclass, None)
 


### PR DESCRIPTION
This builds upon #4426 (and incorporates #4429).

However I am not satisfied with this, mainly because most projects using figures will now receive many warnings when trying to build PDF (from cherry-picked #4426).

I don't know good solution yet. It would be better if after first warning next ones would be less verbose and just tell where in sources is the problem, and user could fix it by adding a new figure option ``:nowrapfig:`` if needed to not use wrapfig, or to use wrapfig ``:nowrapfigwarn:`` with no warning.

Thus, this PR is for discussion.

both

- Feature
- Bugfix

refs: #3289