### PR TITLE
Fix #4431: "Undefined control sequence \\hlineSomeText"

### DIFF
--- a/sphinx/templates/latex/longtable.tex_t
+++ b/sphinx/templates/latex/longtable.tex_t
@@ -10,17 +10,17 @@
 <%- if table.caption -%>
 \caption{<%= ''.join(table.caption) %>\strut}<%= labels %>\\*[\sphinxlongtablecapskipadjust]
 <% endif -%>
-\hline
+\hline 
 <%= ''.join(table.header) %>
 \endfirsthead
 
 \multicolumn{<%= table.colcount %>}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- <%= _('continued from previous page') %>}}}\\
-\hline
+\hline 
 <%= ''.join(table.header) %>
 \endhead
 
-\hline
+\hline 
 \multicolumn{<%= table.colcount %>}{r}{\makebox[0pt][r]{\sphinxtablecontinued{<%= _('Continued on next page') %>}}}\\
 \endfoot
 

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -16,7 +16,7 @@
 \sphinxaftercaption
 <% endif -%>
 \begin{tabular}[t]<%= table.get_colspec() -%>
-\hline
+\hline 
 <%= ''.join(table.header) %>
 <%- if table.caption_footnotetexts -%>
 <%= ''.join(table.caption_footnotetexts) -%>

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -16,7 +16,7 @@
 \sphinxaftercaption
 <% endif -%>
 \begin{tabulary}{\linewidth}[t]<%= table.get_colspec() -%>
-\hline
+\hline 
 <%= ''.join(table.header) %>
 <%- if table.caption_footnotetexts -%>
 <%= ''.join(table.caption_footnotetexts) -%>

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1438,7 +1438,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         cells = [self.table.cell(self.table.row, i) for i in range(self.table.colcount)]
         underlined = [cell.row + cell.height == self.table.row + 1 for cell in cells]
         if all(underlined):
-            self.body.append('\\hline')
+            self.body.append('\\hline ')
         else:
             i = 0
             underlined.extend([False])  # sentinel

--- a/tests/roots/test-latex-table/expects/complex_spanning_cell.tex
+++ b/tests/roots/test-latex-table/expects/complex_spanning_cell.tex
@@ -13,7 +13,7 @@ consecutive multirow at end of row (1-4 and 1-5)
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabulary}{\linewidth}[t]{|T|T|T|T|T|}
-\hline
+\hline 
 \sphinxmultirow{3}{1}{%
 \begin{varwidth}[t]{\sphinxcolwidth{1}{5}}
 cell1-1
@@ -51,7 +51,7 @@ cell2-3
 \cline{5-5}\sphinxtablestrut{1}&\sphinxtablestrut{2}&\sphinxtablestrut{6}&\sphinxtablestrut{4}&
 cell3-5
 \\
-\hline
+\hline 
 \end{tabulary}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/gridtable.tex
+++ b/tests/roots/test-latex-table/expects/gridtable.tex
@@ -3,7 +3,7 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabulary}{\linewidth}[t]{|T|T|T|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
@@ -11,7 +11,7 @@ header2
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header3
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &\sphinxmultirow{2}{5}{%
 \begin{varwidth}[t]{\sphinxcolwidth{1}{3}}
@@ -43,14 +43,14 @@ cell3-2
 \cline{1-1}
 cell4-1
 &\multicolumn{2}{l|}{\sphinxtablestrut{9}}\\
-\hline\sphinxstartmulticolumn{3}%
+\hline \sphinxstartmulticolumn{3}%
 \begin{varwidth}[t]{\sphinxcolwidth{3}{3}}
 cell5-1
 \par
 \vskip-\baselineskip\vbox{\hbox{\strut}}\end{varwidth}%
 \sphinxstopmulticolumn
 \\
-\hline
+\hline 
 \end{tabulary}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/list_table_having_threeparagraphs_cell.tex
+++ b/tests/roots/test-latex-table/expects/list_table_having_threeparagraphs_cell.tex
@@ -1,0 +1,19 @@
+\label{\detokenize{tabular:list-table-with-cell-having-three-paragraphs}}
+
+\begin{savenotes}\sphinxattablestart
+\centering
+\begin{tabulary}{\linewidth}[t]{|T|}
+\hline 
+\sphinxstylethead{\sphinxstyletheadfamily 
+header1
+\unskip}\relax \\
+\hline cell1-1
+
+in cell1-1
+
+still in cell1-1
+\\
+\hline 
+\end{tabulary}
+\par
+\sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable.tex
+++ b/tests/roots/test-latex-table/expects/longtable.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -31,15 +31,15 @@ cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_align.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_align.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable-having-align-option}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[r]{|l|l|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -31,15 +31,15 @@ cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -2,27 +2,27 @@
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
 \caption{caption for longtable\strut}\label{\detokenize{longtable:id1}}\\*[\sphinxlongtablecapskipadjust]
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -32,15 +32,15 @@ cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable-having-problematic-cell}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{2}{\X{1}{2}|}}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -37,15 +37,15 @@ item2
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
@@ -1,7 +1,7 @@
 \label{\detokenize{longtable:longtable-having-both-stub-columns-and-problematic-cell}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{3}{\X{1}{3}|}}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
@@ -9,12 +9,12 @@ header2
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header3
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{3}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
@@ -22,10 +22,10 @@ header2
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header3
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{3}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -43,12 +43,12 @@ instub1-2
 \unskip}\relax &
 notinstub1-3
 \\
-\hline\sphinxstylethead{\sphinxstyletheadfamily 
+\hline \sphinxstylethead{\sphinxstyletheadfamily 
 cell2-1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 cell2-2
 \unskip}\relax &
 cell2-3
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable-having-verbatim}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{2}{\X{1}{2}|}}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -34,15 +34,15 @@ header2
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable-having-widths-option}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -31,15 +31,15 @@ cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable-having-both-widths-and-problematic-cell}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -37,15 +37,15 @@ item2
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
@@ -1,27 +1,27 @@
 \label{\detokenize{longtable:longtable-with-tabularcolumn}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|c|c|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endfirsthead
 
 \multicolumn{2}{c}%
 {\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \endhead
 
-\hline
+\hline 
 \multicolumn{2}{r}{\makebox[0pt][r]{\sphinxtablecontinued{Continued on next page}}}\\
 \endfoot
 
@@ -31,15 +31,15 @@ cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{longtable}\sphinxatlongtableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/simple_table.tex
+++ b/tests/roots/test-latex-table/expects/simple_table.tex
@@ -3,28 +3,28 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabulary}{\linewidth}[t]{|T|T|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabulary}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/table_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/table_having_caption.tex
@@ -6,28 +6,28 @@
 \sphinxcaption{caption for table}\label{\detokenize{tabular:id1}}
 \sphinxaftercaption
 \begin{tabulary}{\linewidth}[t]{|T|T|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabulary}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/table_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_problematic_cell.tex
@@ -3,13 +3,13 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabular}[t]{|*{2}{\X{1}{2}|}}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline\begin{itemize}
+\hline \begin{itemize}
 \item {} 
 item1
 
@@ -20,17 +20,17 @@ item2
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/table_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_stub_columns_and_problematic_cell.tex
@@ -3,7 +3,7 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabular}[t]{|*{3}{\X{1}{3}|}}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
@@ -11,7 +11,7 @@ header2
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header3
 \unskip}\relax \\
-\hline\sphinxstylethead{\sphinxstyletheadfamily \begin{itemize}
+\hline \sphinxstylethead{\sphinxstyletheadfamily \begin{itemize}
 \item {} 
 instub1-1a
 
@@ -24,14 +24,14 @@ instub1-2
 \unskip}\relax &
 notinstub1-3
 \\
-\hline\sphinxstylethead{\sphinxstyletheadfamily 
+\hline \sphinxstylethead{\sphinxstyletheadfamily 
 cell2-1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 cell2-2
 \unskip}\relax &
 cell2-3
 \\
-\hline
+\hline 
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/table_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/table_having_verbatim.tex
@@ -3,13 +3,13 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabular}[t]{|*{2}{\X{1}{2}|}}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 \fvset{hllines={, ,}}%
 \begin{sphinxVerbatimintable}[commandchars=\\\{\}]
 \PYG{n}{hello} \PYG{n}{world}
@@ -17,17 +17,17 @@ header2
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/table_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths.tex
@@ -3,28 +3,28 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabular}[t]{|\X{30}{100}|\X{70}{100}|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/table_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths_and_problematic_cell.tex
@@ -3,13 +3,13 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabular}[t]{|\X{30}{100}|\X{70}{100}|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline\begin{itemize}
+\hline \begin{itemize}
 \item {} 
 item1
 
@@ -20,17 +20,17 @@ item2
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/tabular_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/tabular_having_widths.tex
@@ -3,28 +3,28 @@
 \begin{savenotes}\sphinxattablestart
 \raggedright
 \begin{tabular}[t]{|\X{30}{100}|\X{70}{100}|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/tabularcolumn.tex
@@ -3,28 +3,28 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \begin{tabulary}{\linewidth}[t]{|c|c|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabulary}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/expects/tabulary_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/tabulary_having_widths.tex
@@ -3,28 +3,28 @@
 \begin{savenotes}\sphinxattablestart
 \raggedleft
 \begin{tabulary}{\linewidth}[t]{|T|T|}
-\hline
+\hline 
 \sphinxstylethead{\sphinxstyletheadfamily 
 header1
 \unskip}\relax &\sphinxstylethead{\sphinxstyletheadfamily 
 header2
 \unskip}\relax \\
-\hline
+\hline 
 cell1-1
 &
 cell1-2
 \\
-\hline
+\hline 
 cell2-1
 &
 cell2-2
 \\
-\hline
+\hline 
 cell3-1
 &
 cell3-2
 \\
-\hline
+\hline 
 \end{tabulary}
 \par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/tabular.rst
+++ b/tests/roots/test-latex-table/tabular.rst
@@ -68,6 +68,23 @@ cell2-1 cell2-2
 cell3-1 cell3-2
 ======= =======
 
+list table with cell having three paragraphs
+--------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - header1
+
+
+   * - cell1-1
+
+       in cell1-1
+
+       still in cell1-1
+
+
+
 table having caption
 --------------------
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -493,14 +493,14 @@ def test_footnote(app, status, warning):
             '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
             '\ncite\n}') in result
     assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
-    assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
+    assert ('\\hline %\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
             'footnote in table caption\n%\n\\end{footnotetext}\\ignorespaces %\n'
             '\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'
             'footnote in table header\n%\n\\end{footnotetext}\\ignorespaces \n'
             'VIDIOC\\_CROPCAP\n&\n') in result
     assert ('Information about VIDIOC\\_CROPCAP %\n'
             '\\begin{footnote}[6]\\sphinxAtStartFootnote\n'
-            'footnote in table not in header\n%\n\\end{footnote}\n\\\\\n\\hline\n'
+            'footnote in table not in header\n%\n\\end{footnote}\n\\\\\n\\hline \n'
             '\\end{tabulary}\n'
             '\\par\n\\sphinxattableend\\end{savenotes}\n') in result
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -914,6 +914,11 @@ def test_latex_table_tabulars(app, status, warning):
     expected = get_expected('tabularcolumn')
     assert actual == expected
 
+    # list table with cell having three paragraphs
+    actual = tables['list table with cell having three paragraphs']
+    expected = get_expected('list_table_having_threeparagraphs_cell')
+    assert actual == expected
+
     # table having caption
     actual = tables['table having caption']
     expected = get_expected('table_having_caption')


### PR DESCRIPTION
I changed `\hline` to `\hline<space>` also in the templates, but that is only to ease up mass updates to tests... a specific test is added, but the real fix of #4431 should modify that probably.