### PR TITLE
tox: Ignore distutils deprecation warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     du13: docutils==0.13.1
     du14: docutils==0.14
 setenv =
-    PYTHONWARNINGS = all,ignore::ImportWarning:pkgutil,ignore::ImportWarning:importlib._bootstrap,ignore::ImportWarning:importlib._bootstrap_external,ignore::ImportWarning:pytest_cov.plugin,ignore::DeprecationWarning:site,ignore::DeprecationWarning:_pytest.assertion.rewrite,ignore::DeprecationWarning:_pytest.fixtures
+    PYTHONWARNINGS = all,ignore::ImportWarning:pkgutil,ignore::ImportWarning:importlib._bootstrap,ignore::ImportWarning:importlib._bootstrap_external,ignore::ImportWarning:pytest_cov.plugin,ignore::DeprecationWarning:site,ignore::DeprecationWarning:_pytest.assertion.rewrite,ignore::DeprecationWarning:_pytest.fixtures,ignore::DeprecationWarning:distutils
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
 commands=
     pytest -Wall --durations 25 {posargs}


### PR DESCRIPTION
Hide the following deprecation warning.

    distutils/__init__.py:4: DeprecationWarning: the imp module is
    deprecated in favour of importlib; see the module's documentation
    for alternative uses
      import imp