### PR TITLE
app: Centralize directory validation

### DIFF
--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -28,6 +28,11 @@ class SphinxWarning(SphinxError):
     category = 'Warning, treated as error'
 
 
+class ApplicationError(SphinxError):
+    """Application initialization error."""
+    category = 'Application error'
+
+
 class ExtensionError(SphinxError):
     """Raised if something's wrong with the configuration."""
     category = 'Extension error'

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -148,16 +148,12 @@ class BuildDoc(Command):
         if self.build_dir is None:
             build = self.get_finalized_command('build')
             self.build_dir = os.path.join(abspath(build.build_base), 'sphinx')  # type: ignore
-            self.mkpath(self.build_dir)  # type: ignore
 
         self.doctree_dir = os.path.join(self.build_dir, 'doctrees')
 
-        self.mkpath(self.doctree_dir)  # type: ignore
         self.builder_target_dirs = [
             (builder, os.path.join(self.build_dir, builder))
             for builder in self.builder]  # type: List[Tuple[str, unicode]]
-        for _, builder_target_dir in self.builder_target_dirs:
-            self.mkpath(builder_target_dir)  # type: ignore
 
     def run(self):
         # type: () -> None

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -116,7 +116,7 @@ class BuildDoc(Command):
             for root, dirnames, filenames in os.walk(guess):
                 if 'conf.py' in filenames:
                     return root
-        return None
+        return os.curdir
 
     # Overriding distutils' Command._ensure_stringlike which doesn't support
     # unicode, causing finalize_options to fail if invoked again. Workaround
@@ -134,24 +134,24 @@ class BuildDoc(Command):
 
     def finalize_options(self):
         # type: () -> None
+        self.ensure_string_list('builder')
+
         if self.source_dir is None:
             self.source_dir = self._guess_source_dir()
             self.announce('Using source directory %s' % self.source_dir)
+
         self.ensure_dirname('source_dir')
-        if self.source_dir is None:
-            self.source_dir = os.curdir
-        self.source_dir = abspath(self.source_dir)
+
         if self.config_dir is None:
             self.config_dir = self.source_dir
-        self.config_dir = abspath(self.config_dir)
 
-        self.ensure_string_list('builder')
         if self.build_dir is None:
             build = self.get_finalized_command('build')
             self.build_dir = os.path.join(abspath(build.build_base), 'sphinx')  # type: ignore
             self.mkpath(self.build_dir)  # type: ignore
-        self.build_dir = abspath(self.build_dir)
+
         self.doctree_dir = os.path.join(self.build_dir, 'doctrees')
+
         self.mkpath(self.doctree_dir)  # type: ignore
         self.builder_target_dirs = [
             (builder, os.path.join(self.build_dir, builder))

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -137,12 +137,14 @@ def warning(app):
 
 
 @pytest.fixture()
-def make_app(test_params):
+def make_app(test_params, monkeypatch):
     """
     provides make_app function to initialize SphinxTestApp instance.
     if you want to initialize 'app' in your test function. please use this
     instead of using SphinxTestApp class directory.
     """
+    monkeypatch.setattr('sphinx.application.abspath', lambda x: x)
+
     apps = []
     syspath = sys.path[:]
 

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -219,7 +219,12 @@ def abspath(pathdir):
     # type: (unicode) -> unicode
     pathdir = path.abspath(pathdir)
     if isinstance(pathdir, bytes):
-        pathdir = pathdir.decode(fs_encoding)
+        try:
+            pathdir = pathdir.decode(fs_encoding)
+        except UnicodeDecodeError:
+            raise UnicodeDecodeError('multibyte filename not supported on '
+                                     'this filesystem encoding '
+                                     '(%r)' % fs_encoding)
     return pathdir
 
 


### PR DESCRIPTION
This allows us to avoid duplication of code and ensure validation happens regardless of who's initializing the class.