### PR TITLE
Fix (very) minor typo in sphinx-quickstart man page

### DIFF
--- a/doc/man/sphinx-quickstart.rst
+++ b/doc/man/sphinx-quickstart.rst
@@ -20,7 +20,7 @@ Options
 
 .. option:: -q, --quiet
 
-   Quiet mode that will skips interactive wizard to specify options.
+   Quiet mode that will skip interactive wizard to specify options.
    This option requires `-p`, `-a` and `-v` options.
 
 .. option:: -h, --help, --version


### PR DESCRIPTION
Subject: Fix minor typo in sphinx-quickstart

### Feature or Bugfix

- Bugfix

### Purpose

Fix typo
