### PR TITLE
Don't require numfig to use :numref: on sections

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -715,14 +715,14 @@ class StandardDomain(Domain):
         if not docname:
             return None
 
-        if env.config.numfig is False:
-            logger.warning('numfig is disabled. :numref: is ignored.', location=node)
-            return contnode
-
         target_node = env.get_doctree(docname).ids.get(labelid)
         figtype = self.get_figtype(target_node)
         if figtype is None:
             return None
+
+        if figtype != 'section' and env.config.numfig is False:
+            logger.warning('numfig is disabled. :numref: is ignored.', location=node)
+            return contnode
 
         try:
             fignumber = self.get_fignumber(env, builder, figtype, docname, target_node)


### PR DESCRIPTION
Tweak logic that rejects a `:numref:` if `numfig` is not on to bypass this check if the reference is a section. Section numbers are applied independent of `numfig`, so the check is not needed, and makes it needlessly difficult to use `:numref:` if the user only cares about using it on sections.