### PR TITLE
[RFC] Add ability to format :doc:

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -782,11 +782,15 @@ class StandardDomain(Domain):
         if docname not in env.all_docs:
             return None
         else:
+            title = clean_astext(env.titles[docname])
             if node['refexplicit']:
                 # reference with explicit title
                 caption = node.astext()
+                if '{name}' in caption or '{number}' in caption:
+                    number = env.toc_secnumbers[docname].get('')
+                    caption = caption.format(name=title, number=number)
             else:
-                caption = clean_astext(env.titles[docname])
+                caption = title
             innernode = nodes.inline(caption, caption, classes=['doc'])
             return make_refnode(builder, fromdocname, docname, None, innernode)
 


### PR DESCRIPTION
Teach `:doc:` to format references, by replacing `{name}` and `{number}` in explicit link text, a la `:numref:`. This makes it possible to include the section number in a `:doc:` reference, which is not otherwise possible, since `:numref:` does not resolve document names.

This is a request for comment, as the PR is obviously incomplete in its current state (needs doc, possibly tests). Particularly, is this a useful feature and a reasonable implementation thereof? If so, what work needs to be done to make it merge-ready? (If it's interesting, I will make the necessary changes and update the PR.)