### PR TITLE
Fix "Undefined control sequence \\hlineSomeText" (#4431; refs: #3435)

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1477,8 +1477,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
             context = ('\\par\n\\vskip-\\baselineskip'
                        '\\vbox{\\hbox{\\strut}}\\end{varwidth}%\n') + context
             self.needs_linetrimming = 1
-        if len(node) > 2 and len(node.astext().split('\n')) > 2:
-            self.needs_linetrimming = 1
         if len(node.traverse(nodes.paragraph)) >= 2:
             self.table.has_oldproblematic = True
         if isinstance(node.parent.parent, nodes.thead) or (cell.col in self.table.stubs):

--- a/tests/roots/test-latex-table/expects/table_having_threeparagraphs_cell_in_first_col.tex
+++ b/tests/roots/test-latex-table/expects/table_having_threeparagraphs_cell_in_first_col.tex
@@ -1,0 +1,20 @@
+\label{\detokenize{tabular:table-with-cell-in-first-column-having-three-paragraphs}}
+
+\begin{savenotes}\sphinxattablestart
+\centering
+\begin{tabulary}{\linewidth}[t]{|T|}
+\hline
+\sphinxstylethead{\sphinxstyletheadfamily 
+header1
+\unskip}\relax \\
+\hline
+cell1-1-par1
+
+cell1-1-par2
+
+cell1-1-par3
+\\
+\hline
+\end{tabulary}
+\par
+\sphinxattableend\end{savenotes}

--- a/tests/roots/test-latex-table/tabular.rst
+++ b/tests/roots/test-latex-table/tabular.rst
@@ -68,6 +68,20 @@ cell2-1 cell2-2
 cell3-1 cell3-2
 ======= =======
 
+table with cell in first column having three paragraphs
+-------------------------------------------------------
+
++--------------+
+| header1      |
++==============+
+| cell1-1-par1 |
+|              |
+| cell1-1-par2 |
+|              |
+| cell1-1-par3 |
++--------------+
+
+
 table having caption
 --------------------
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -877,7 +877,7 @@ def test_maxlistdepth_at_ten(app, status, warning):
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
                     reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('latex', testroot='latex-table')
-@pytest.mark.test_params(shared_result='test_latex_table')
+@pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_tabulars(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').text(encoding='utf8')
@@ -914,6 +914,11 @@ def test_latex_table_tabulars(app, status, warning):
     expected = get_expected('tabularcolumn')
     assert actual == expected
 
+    # table with cell in first column having three paragraphs
+    actual = tables['table with cell in first column having three paragraphs']
+    expected = get_expected('table_having_threeparagraphs_cell_in_first_col')
+    assert actual == expected
+
     # table having caption
     actual = tables['table having caption']
     expected = get_expected('table_having_caption')
@@ -943,7 +948,7 @@ def test_latex_table_tabulars(app, status, warning):
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
                     reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('latex', testroot='latex-table')
-@pytest.mark.test_params(shared_result='test_latex_table')
+@pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_longtable(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').text(encoding='utf8')
@@ -1004,7 +1009,7 @@ def test_latex_table_longtable(app, status, warning):
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
                     reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('latex', testroot='latex-table')
-@pytest.mark.test_params(shared_result='test_latex_table')
+@pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_complex_tables(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').text(encoding='utf8')


### PR DESCRIPTION
Actually, the cause is some oversight of mine at #3435 which kept a test for cells with three or more paragraphs whereas original did it only for merged cells.

Also our tests with tables (although numerous) did not have a single example of a non-merged cell in first column with three or more paragraphs...

In my testing simply removing the two bad lines fixes it, and I could not find bad effect. 

