### PR TITLE
Fix #4408: sphinx 1.6.6 fails test_metadata.py::test_docinfo

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -24,6 +24,9 @@ def test_docinfo(app, status, warning):
     'dedication' blocks, or the 'meta' role. Doing otherwise is probably more
     messing with the internals of sphinx than this rare use case merits.
     """
+    # remove doctree cache to rebuild forcely
+    (app.doctreedir / 'metadata.doctree').rmtree(ignore_errors=True)
+
     app.builder.build(['metadata'])
     env = app.env
     exampledocinfo = env.metadata['metadata']


### PR DESCRIPTION
refs: #4408