### PR TITLE
doc: Resolve inconsistent 'sphinx-apidoc' docs

### DIFF
--- a/doc/man/sphinx-apidoc.rst
+++ b/doc/man/sphinx-apidoc.rst
@@ -4,7 +4,7 @@ sphinx-apidoc
 Synopsis
 --------
 
-**sphinx-apidoc** [*options*] -o <*outputdir*> <*sourcedir*> [*pathnames* ...]
+**sphinx-apidoc** [*OPTIONS*] -o <*OUTPUT_PATH*> <*MODULE_PATH*> [*EXCLUDE_PATTERN*, ...]
 
 Description
 -----------
@@ -13,9 +13,10 @@ Description
 that, using the :rst:dir:`autodoc` extension, document a whole package in the
 style of other automatic API documentation tools.
 
-*sourcedir* is the path to a Python package to document, and *outputdir* is the
-directory where the generated sources are placed. Any *pathnames* given are
-paths to be excluded from the generation.
+*MODULE_PATH* is the path to a Python package to document, and *OUTPUT_PATH* is
+the directory where the generated sources are placed. Any *EXCLUDE_PATTERN*\s
+given are `fnmatch-style <fnmatch>`_ file and/or directory patterns that will
+be excluded from generation.
 
 .. warning::
 
@@ -31,7 +32,7 @@ Options
 
 .. program:: sphinx-apidoc
 
-.. option:: -o <outputdir>
+.. option:: -o <OUTPUT_PATH>
 
    Directory to place the output files. If it does not exist, it is created.
 
@@ -51,7 +52,7 @@ Options
 
    Suffix for the source files generated. Defaults to ``rst``.
 
-.. option:: -d <maxdepth>
+.. option:: -d <MAXDEPTH>
 
    Maximum depth for the generated table of contents file.
 
@@ -130,3 +131,5 @@ See also
 --------
 
 :manpage:`sphinx-build(1)`, :manpage:`sphinx-autogen(1)`
+
+.. _fnmatch: https://docs.python.org/3/library/fnmatch.html


### PR DESCRIPTION
The signature for the 'sphinx-apidoc' call differs between the man page and the output of `sphinx-apidoc --help`. Resolve this by considering the `sphinx-apidoc --help` output the canonical reference.

Fixes: #4451