### PR TITLE
Themes: Rename 'csss' block to 'css'

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -123,7 +123,7 @@
     {%- block htmltitle %}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- endblock %}
-    {%- block csss %}
+    {%- block css %}
     {{- css() }}
     {%- endblock %}
     {%- if not embedded %}

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -10,7 +10,7 @@
 #}
 {%- extends "basic/layout.html" %}
 {% set script_files = script_files + ['_static/theme_extras.js'] %}
-{%- block csss %}
+{%- block css %}
   {{ super() }}
     <link rel="stylesheet" href="_static/print.css" type="text/css" />
 {%- endblock %}

--- a/tests/roots/test-stylesheets/_templates/layout.html
+++ b/tests/roots/test-stylesheets/_templates/layout.html
@@ -1,5 +1,5 @@
 {% extends "!layout.html" %}
-{%- block csss %}
+{%- block css %}
   {{ super() }}
     <link rel="stylesheet" href="_static/more_persistent.css" type="text/css" />
     <link rel="stylesheet" href="_static/more_default.css" type="text/css" title="Default" />


### PR DESCRIPTION
Was a mistake in 618ef6492c89c50f263c4c6c5794e40e35f91be8

