### PR TITLE
Use HTTPS URL's

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Other contributors, listed alphabetically, are:
 * Will Maier -- directory HTML builder
 * Jacob Mason -- websupport library (GSOC project)
 * Glenn Matthews -- python domain signature improvements
+* Kurt McKee -- documentation updates
 * Roland Meister -- epub builder
 * Ezio Melotti -- collapsible sidebar JavaScript
 * Bruce Mitchener -- Minor epub improvement

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -98,7 +98,7 @@
   <p>{%trans%}There is a <a href="http://docs.sphinx-users.jp/">Japanese translation</a>
     of this documentation, thanks to the Japanese Sphinx user group.{%endtrans%}</p>
   <p>{%trans%}A Japanese book about Sphinx has been published by O'Reilly:
-    <a href="http://www.oreilly.co.jp/books/9784873116488/">Sphinxをはじめよう /
+    <a href="https://www.oreilly.co.jp/books/9784873116488/">Sphinxをはじめよう /
       Learning Sphinx</a>.{%endtrans%}</p>
   <!-- <p><img src="{{ pathto("_static/bookcover.png", 1) }}"/></p> -->
 

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -1,4 +1,4 @@
-<p class="logo">A <a href="http://pocoo.org/">
+<p class="logo">A <a href="https://www.pocoo.org/">
   <img src="{{ pathto("_static/pocoo.png", 1) }}" alt="Pocoo" /></a>
   {%trans%}project{%endtrans%}</p>
 
@@ -19,9 +19,9 @@ Index</a>, or install it with:{%endtrans%}</p>
 
 <h3>{%trans%}Questions? Suggestions?{%endtrans%}</h3>
 
-<p>{%trans%}Join the <a href="http://groups.google.com/group/sphinx-users">sphinx-users</a> mailing list on Google Groups:{%endtrans%}</p>
+<p>{%trans%}Join the <a href="https://groups.google.com/group/sphinx-users">sphinx-users</a> mailing list on Google Groups:{%endtrans%}</p>
 <div class="subscribeformwrapper">
-<form action="http://groups.google.com/group/sphinx-users/boxsubscribe"
+<form action="https://groups.google.com/group/sphinx-users/boxsubscribe"
       class="subscribeform">
   <input type="text" name="email" value="your@email"
          onfocus="$(this).val('');" />

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -216,7 +216,7 @@ instructions.
 .. _rinohtype: https://github.com/brechtm/rinohtype
 .. _rinohtype manual: http://www.mos6581.org/rinohtype/quickstart.html#sphinx-builder
 .. _rst2pdf: https://github.com/rst2pdf/rst2pdf
-.. _rst2pdf manual: http://ralsina.me/static/manual.pdf
+.. _rst2pdf manual: https://ralsina.me/static/manual.pdf
 
 .. module:: sphinx.builders.text
 .. class:: TextBuilder

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -12,7 +12,7 @@ Sphinx is a maintained by a group of volunteers.  We value every contribution!
 * The mailing list for development is at `Google Groups
   <https://groups.google.com/forum/#!forum/sphinx-dev>`_.
 * There is also the #sphinx-doc IRC channel on `freenode
-  <http://freenode.net/>`_.
+  <https://freenode.net/>`_.
 
 For more about our development process and methods, see the :doc:`devguide`.
 
@@ -106,37 +106,37 @@ own extensions.
 
 .. _aafigure: https://launchpad.net/aafigure
 .. _gnuplot: http://www.gnuplot.info/
-.. _paver: http://paver.github.io/paver/
-.. _Sword: http://www.crosswire.org/sword/
+.. _paver: https://paver.readthedocs.io/en/latest/
+.. _Sword: https://www.crosswire.org/sword/
 .. _Lilypond: http://lilypond.org/
 .. _sdedit: http://sdedit.sourceforge.net/
-.. _Trac: http://trac.edgewall.org
-.. _TracLinks: http://trac.edgewall.org/wiki/TracLinks
-.. _OmegaT: http://www.omegat.org/
+.. _Trac: https://trac.edgewall.org/
+.. _TracLinks: https://trac.edgewall.org/wiki/TracLinks
+.. _OmegaT: https://omegat.org/
 .. _PlantUML: http://plantuml.com/
-.. _PyEnchant: http://www.rfk.id.au/software/pyenchant/
+.. _PyEnchant: https://pythonhosted.org/pyenchant/
 .. _sadisplay: https://bitbucket.org/estin/sadisplay/wiki/Home
 .. _blockdiag: http://blockdiag.com/en/
 .. _seqdiag: http://blockdiag.com/en/
 .. _actdiag: http://blockdiag.com/en/
 .. _nwdiag: http://blockdiag.com/en/
-.. _Google Analytics: http://www.google.com/analytics/
+.. _Google Analytics: https://www.google.com/analytics/
 .. _Google Chart: https://developers.google.com/chart/
 .. _Google Maps: https://www.google.com/maps
 .. _Google style: https://google.github.io/styleguide/pyguide.html
 .. _NumPy style: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 .. _hyphenator: https://github.com/mnater/hyphenator
-.. _exceltable: http://pythonhosted.org/sphinxcontrib-exceltable/
+.. _exceltable: https://pythonhosted.org/sphinxcontrib-exceltable/
 .. _YouTube: http://www.youtube.com/
-.. _ClearQuest: http://www-03.ibm.com/software/products/en/clearquest
-.. _Zope interfaces: http://docs.zope.org/zope.interface/README.html
-.. _slideshare: http://www.slideshare.net/
+.. _ClearQuest: https://www.ibm.com/us-en/marketplace/rational-clearquest
+.. _Zope interfaces: https://zopeinterface.readthedocs.io/en/latest/README.html
+.. _slideshare: https://www.slideshare.net/
 .. _TikZ/PGF LaTeX package: https://sourceforge.net/projects/pgf/
-.. _MATLAB: http://www.mathworks.com/products/matlab/
+.. _MATLAB: https://www.mathworks.com/products/matlab.html
 .. _swf: https://bitbucket.org/klorenz/sphinxcontrib-swf
 .. _findanything: https://bitbucket.org/klorenz/sphinxcontrib-findanything
 .. _cmakedomain: https://bitbucket.org/klorenz/sphinxcontrib-cmakedomain
-.. _GNU Make: http://www.gnu.org/software/make/
+.. _GNU Make: https://www.gnu.org/software/make/
 .. _makedomain: https://bitbucket.org/klorenz/sphinxcontrib-makedomain
 .. _inlinesyntaxhighlight: https://sphinxcontrib-inlinesyntaxhighlight.readthedocs.io/
 .. _CMake: https://cmake.org

--- a/doc/ext/example_google.py
+++ b/doc/ext/example_google.py
@@ -29,7 +29,7 @@ Todo:
     * You have to also use ``sphinx.ext.todo`` extension
 
 .. _Google Python Style Guide:
-   http://google.github.io/styleguide/pyguide.html
+   https://google.github.io/styleguide/pyguide.html
 
 """
 

--- a/doc/ext/graphviz.rst
+++ b/doc/ext/graphviz.rst
@@ -8,7 +8,7 @@
 
 .. versionadded:: 0.6
 
-This extension allows you to embed `Graphviz <http://graphviz.org/>`_ graphs in
+This extension allows you to embed `Graphviz <https://graphviz.org/>`_ graphs in
 your documents.
 
 It adds these directives:

--- a/doc/ext/linkcode.rst
+++ b/doc/ext/linkcode.rst
@@ -44,4 +44,4 @@ function that returns an URL based on the object.
           if not info['module']:
               return None
           filename = info['module'].replace('.', '/')
-          return "http://somesite/sourcerepo/%s.py" % filename
+          return "https://somesite/sourcerepo/%s.py" % filename

--- a/doc/ext/math.rst
+++ b/doc/ext/math.rst
@@ -248,7 +248,7 @@ Sphinx.
 
    __ https://cdjns.com
 
-   __ http://docs.mathjax.org/en/latest/start.html
+   __ https://docs.mathjax.org/en/latest/start.html
 
    The path can be absolute or relative; if it is relative, it is relative to
    the ``_static`` directory of the built docs.
@@ -258,7 +258,7 @@ Sphinx.
    documentation set on one server, it is advisable to install MathJax in a
    shared location.
 
-   You can also give a full ``http://`` URL different from the CDN URL.
+   You can also give a full ``https://`` URL different from the CDN URL.
 
 
 :mod:`sphinx.ext.jsmath` -- Render math via JavaScript
@@ -284,9 +284,9 @@ package jsMath_.  It provides this config value:
    a shared location.
 
 
-.. _dvipng: http://savannah.nongnu.org/projects/dvipng/
+.. _dvipng: https://savannah.nongnu.org/projects/dvipng/
 .. _dvisvgm: http://dvisvgm.bplaced.net/
 .. _MathJax: https://www.mathjax.org/
 .. _jsMath: http://www.math.union.edu/~dpvc/jsmath/
-.. _preview-latex package: http://www.gnu.org/software/auctex/preview-latex.html
-.. _AmSMath LaTeX package: http://www.ams.org/publications/authors/tex/amslatex
+.. _preview-latex package: https://www.gnu.org/software/auctex/preview-latex.html
+.. _AmSMath LaTeX package: https://www.ams.org/publications/authors/tex/amslatex

--- a/doc/ext/napoleon.rst
+++ b/doc/ext/napoleon.rst
@@ -52,9 +52,9 @@ source code files.
 .. _ReStructuredText: http://docutils.sourceforge.net/rst.html
 .. _docstrings: https://www.python.org/dev/peps/pep-0287/
 .. _Google Python Style Guide:
-   http://google.github.io/styleguide/pyguide.html
+   https://google.github.io/styleguide/pyguide.html
 .. _Google:
-   http://google.github.io/styleguide/pyguide.html#Comments
+   https://google.github.io/styleguide/pyguide.html#Comments
 .. _NumPy:
    https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 .. _Khan Academy:
@@ -267,7 +267,7 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
     napoleon_use_rtype = True
 
 .. _Google style:
-   http://google-styleguide.googlecode.com/svn/trunk/pyguide.html
+   https://google.github.io/styleguide/pyguide.html
 .. _NumPy style:
    https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -77,7 +77,7 @@ PyPI
    Jannis Leidel wrote a `setuptools command
    <https://pypi.python.org/pypi/Sphinx-PyPI-upload>`_ that automatically
    uploads Sphinx documentation to the PyPI package documentation area at
-   http://pythonhosted.org/.
+   https://pythonhosted.org/.
 
 GitHub Pages
    Directories starting with underscores are ignored by default which breaks
@@ -106,7 +106,7 @@ Google Analytics
 
       {% block footer %}
       {{ super() }}
-      <div class="footer">This page uses <a href="http://analytics.google.com/">
+      <div class="footer">This page uses <a href="https://analytics.google.com/">
       Google Analytics</a> to collect statistics. You can disable it by blocking
       the JavaScript coming from www.google-analytics.com.
       <script type="text/javascript">
@@ -122,7 +122,7 @@ Google Analytics
       {% endblock %}
 
 
-.. _api role: http://git.savannah.gnu.org/cgit/kenozooid.git/tree/doc/extapi.py
+.. _api role: https://git.savannah.gnu.org/cgit/kenozooid.git/tree/doc/extapi.py
 .. _xhtml to reST: http://docutils.sourceforge.net/sandbox/xhtml2rest/xhtml2rest.py
 
 

--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -13,7 +13,7 @@ in itself.  See the :ref:`intl-options` for details on configuration.
    :width: 100%
 
    Workflow visualization of translations in Sphinx.  (The stick-figure is taken
-   from an `XKCD comic <http://xkcd.com/779/>`_.)
+   from an `XKCD comic <https://xkcd.com/779/>`_.)
 
 .. contents::
    :local:
@@ -302,7 +302,7 @@ There is `sphinx translation page`_ for Sphinx-1.3 documentation.
 .. rubric:: Footnotes
 
 .. [1] See the `GNU gettext utilities
-       <http://www.gnu.org/software/gettext/manual/gettext.html#Introduction>`_
+       <https://www.gnu.org/software/gettext/manual/gettext.html#Introduction>`_
        for details on that software suite.
 .. [2] Because nobody expects the Spanish Inquisition!
 
@@ -311,4 +311,4 @@ There is `sphinx translation page`_ for Sphinx-1.3 documentation.
 .. _`sphinx-intl`: https://pypi.python.org/pypi/sphinx-intl
 .. _Transifex: https://www.transifex.com/
 .. _`sphinx translation page`: https://www.transifex.com/sphinx-doc/sphinx-doc-1_3/
-.. _`Transifex Client v0.8 &mdash; Transifex documentation`: http://docs.transifex.com/developer/client/
+.. _`Transifex Client v0.8 &mdash; Transifex documentation`: https://docs.transifex.com/client/introduction/

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -34,7 +34,7 @@ to reStructuredText/Sphinx from other documentation systems.
 
 * For converting the old Python docs to Sphinx, a converter was written which
   can be found at `the Python SVN repository
-  <http://svn.python.org/projects/doctools/converter>`_.  It contains generic
+  <https://svn.python.org/projects/doctools/converter/>`_.  It contains generic
   code to convert Python-doc-style LaTeX markup to Sphinx reST.
 
 * Marcin Wojdyr has written a script to convert Docbook to reST with Sphinx
@@ -43,7 +43,7 @@ to reStructuredText/Sphinx from other documentation systems.
 * Christophe de Vienne wrote a tool to convert from Open/LibreOffice documents
   to Sphinx: `odt2sphinx <https://pypi.python.org/pypi/odt2sphinx/>`_.
 
-* To convert different markups, `Pandoc <http://pandoc.org/>`_ is
+* To convert different markups, `Pandoc <https://pandoc.org/>`_ is
   a very helpful tool.
 
 

--- a/doc/markdown.rst
+++ b/doc/markdown.rst
@@ -9,7 +9,7 @@ Markdown support
 text formatting syntax.
 It exists in many syntactically different *flavors*.
 To support Markdown-based documentation, Sphinx can use
-`recommonmark <http://recommonmark.readthedocs.io/en/latest/index.html>`__.
+`recommonmark <https://recommonmark.readthedocs.io/en/latest/index.html>`__.
 recommonmark is a Docutils bridge to `CommonMark-py <https://github.com/rtfd/CommonMark-py>`__, a
 Python package for parsing the `CommonMark <http://commonmark.org/>`__ Markdown flavor.
 
@@ -42,4 +42,4 @@ To configure your Sphinx project for Markdown support, proceed as follows:
       source_suffix = ['.rst', '.md']
 
 #. You can further configure recommonmark to allow custom syntax that standard CommonMark doesn't support. Read more in
-   the `recommonmark documentation <http://recommonmark.readthedocs.io/en/latest/auto_structify.html>`__.
+   the `recommonmark documentation <https://recommonmark.readthedocs.io/en/latest/auto_structify.html>`__.

--- a/doc/rest.rst
+++ b/doc/rest.rst
@@ -194,7 +194,7 @@ Hyperlinks
 External links
 ^^^^^^^^^^^^^^
 
-Use ```Link text <http://example.com/>`_`` for inline web links.  If the link
+Use ```Link text <https://domain.invalid/>`_`` for inline web links.  If the link
 text should be the web address, you don't need special markup at all, the parser
 finds links and mail addresses in ordinary text.
 
@@ -205,7 +205,7 @@ You can also separate the link and the target definition (:duref:`ref
 
    This is a paragraph that contains `a link`_.
 
-   .. _a link: http://example.com/
+   .. _a link: https://domain.invalid/
 
 
 Internal links

--- a/doc/templating.rst
+++ b/doc/templating.rst
@@ -62,7 +62,7 @@ following contents::
 
     {% extends "!layout.html" %}
     {% block rootrellink %}
-        <li><a href="http://project.invalid/">Project Homepage</a> &raquo;</li>
+        <li><a href="https://project.invalid/">Project Homepage</a> &raquo;</li>
         {{ super() }}
     {% endblock %}
 

--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -135,7 +135,7 @@ These themes are:
   :confval:`html_sidebars` for its use.
 
   .. _Alabaster theme: https://pypi.python.org/pypi/alabaster
-  .. _installation page: http://alabaster.readthedocs.io/en/latest/installation.html
+  .. _installation page: https://alabaster.readthedocs.io/en/latest/installation.html
 
 * **classic** -- This is the classic theme, which looks like `the Python 2
   documentation <https://docs.python.org/2/>`_.  It can be customized via

--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -5,7 +5,7 @@
 
     Build HTML documentation and Devhelp_ support files.
 
-    .. _Devhelp: http://live.gnome.org/devhelp
+    .. _Devhelp: https://wiki.gnome.org/Apps/Devhelp
 
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
           It is not the actual old code, but a replication of the behaviour.
     - v2: 1.3 <= version < now
           Standardised mangling scheme from
-          http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
+          https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
           though not completely implemented.
     All versions are generated and attached to elements. The newest is used for
     the index. All of the versions should work as permalinks.

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -9,7 +9,7 @@
 
     This is derived from the "sphinx-autopackage" script, which is:
     Copyright 2008 Société des arts technologiques (SAT),
-    http://www.sat.qc.ca/
+    https://sat.qc.ca/
 
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -8,11 +8,11 @@
 
     This adds a new config value called ``extlinks`` that is created like this::
 
-       extlinks = {'exmpl': ('http://example.com/%s.html', prefix), ...}
+       extlinks = {'exmpl': ('https://example.invalid/%s.html', prefix), ...}
 
     Now you can use e.g. :exmpl:`foo` in your documents.  This will create a
-    link to ``http://example.com/foo.html``.  The link caption depends on the
-    *prefix* value given:
+    link to ``https://example.invalid/foo.html``.  The link caption depends on
+    the *prefix* value given:
 
     - If it is ``None``, the caption will be the full URL.
     - If it is a string (empty or not), the caption will be the prefix prepended

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -3,7 +3,7 @@
     sphinx.ext.mathjax
     ~~~~~~~~~~~~~~~~~~
 
-    Allow `MathJax <http://mathjax.org/>`_ to be used to display math in
+    Allow `MathJax <https://www.mathjax.org/>`_ to be used to display math in
     Sphinx's HTML writer -- requires the MathJax JavaScript library on your
     webserver/computer.
 
@@ -74,7 +74,7 @@ def setup(app):
         raise ExtensionError('sphinx.ext.mathjax: other math package is already loaded')
 
     # more information for mathjax secure url is here:
-    # http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn
+    # https://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn
     app.add_config_value('mathjax_path',
                          'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?'
                          'config=TeX-AMS-MML_HTMLorMML', False)

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -49,7 +49,7 @@ class Config(object):
         napoleon_use_keyword = True
 
     .. _Google style:
-       http://google.github.io/styleguide/pyguide.html
+       https://google.github.io/styleguide/pyguide.html
     .. _NumPy style:
        https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -120,7 +120,7 @@ class BuildDoc(Command):
 
     # Overriding distutils' Command._ensure_stringlike which doesn't support
     # unicode, causing finalize_options to fail if invoked again. Workaround
-    # for http://bugs.python.org/issue19570
+    # for https://bugs.python.org/issue19570
     def _ensure_stringlike(self, option, what, default=None):
         # type: (unicode, unicode, Any) -> Any
         val = getattr(self, option)

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -4,10 +4,10 @@
 %%
 %% Package: footnotehyper-sphinx
 %% Version: based on footnotehyper.sty 2017/03/07 v1.0
-%% as available at http://www.ctan.org/pkg/footnotehyper
+%% as available at https://www.ctan.org/pkg/footnotehyper
 %% License: the one applying to Sphinx
 %%
-%% Refer to the PDF documentation  at http://www.ctan.org/pkg/footnotehyper for
+%% Refer to the PDF documentation  at https://www.ctan.org/pkg/footnotehyper for
 %% the code comments.
 %%
 %% Differences:

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -196,7 +196,7 @@ def ustrftime(format, *args):
         return time.strftime(text_type(format).encode(enc), *args).decode(enc)
     else:  # Py3
         # On Windows, time.strftime() and Unicode characters will raise UnicodeEncodeError.
-        # http://bugs.python.org/issue8304
+        # https://bugs.python.org/issue8304
         try:
             return time.strftime(format, *args)
         except UnicodeEncodeError:

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -19,8 +19,8 @@
        notices and this notice are preserved.
        This file is offered as-is, without any warranty.
 
-    .. _SmartyPants: http://daringfireball.net/projects/smartypants/
-    .. _2-Clause BSD license: http://www.spdx.org/licenses/BSD-2-Clause
+    .. _SmartyPants: https://daringfireball.net/projects/smartypants/
+    .. _2-Clause BSD license: https://spdx.org/licenses/BSD-2-Clause
 
     See the LICENSE file and the original docutils code for details.
 
@@ -68,7 +68,7 @@ langquotes = {'af':           u'“”‘’',
               'he':           u'”“»«',  # Hebrew is RTL, test position:
               'he-x-altquot': u'„”‚’',  # low quotation marks are opening.
               # 'he-x-altquot': u'“„‘‚',  # RTL: low quotation marks opening
-              'hr':           u'„”‘’',  # http://hrvatska-tipografija.com/polunavodnici/
+              'hr':           u'„”‘’',  # https://hrvatska-tipografija.com/polunavodnici/
               'hr-x-altquot': u'»«›‹',
               'hsb':          u'„“‚‘',
               'hsb-x-altquot': u'»«›‹',

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1775,7 +1775,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 (0, 'center'): ('{\\hspace*{\\fill}', '\\hspace*{\\fill}}'),
                 # These 2 don't exactly do the right thing.  The image should
                 # be floated alongside the paragraph.  See
-                # http://www.w3.org/TR/html4/struct/objects.html#adef-align-IMG
+                # https://www.w3.org/TR/html4/struct/objects.html#adef-align-IMG
                 (0, 'left'): ('{', '\\hspace*{\\fill}}'),
                 (0, 'right'): ('{\\hspace*{\\fill}', '}'),
             }


### PR DESCRIPTION
The patch modifies many URL's to use HTTPS. This includes URL's in:

* Documentation
* Translation files
* Code

The following URL's and files were excluded from consideration:

* XML namespace URL's
* Theme files (Javascript, CSS, etc.)

I'm not sure where to put a note about the change in the CHANGES file, though. Do I create a "Documentation" header? And under 1.7.0 or 1.8.0? I'm open to instructions for how to modify the file, or for someone else to make the change later! =)