### PR TITLE
sphinx: Call 'sphinx.cmd.build.main' function

### DIFF
--- a/sphinx/__main__.py
+++ b/sphinx/__main__.py
@@ -8,7 +8,9 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+
 import sys
-from sphinx import main
+
+from sphinx.cmd.build import main
 
 sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This was missed in commit '89f9c7cab'.

Fixes: #4470