### PR TITLE
[RFC] Implement delayed resolution in TOC

### DIFF
--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -263,6 +263,16 @@ class pending_xref(nodes.Inline, nodes.Element):
     """
 
 
+class pending_xtext(nodes.Inline, nodes.Element):
+    """Node for textual cross-references that cannot be resolved without
+    complete information about all documents.
+
+    These nodes are text-only nodes whose text depends on the resolution of
+    a pending_xref.  They are resolved before writing output, in
+    BuildEnvironment.resolve_references.
+    """
+
+
 class number_reference(nodes.reference):
     """Node for number references, similar to pending_xref."""
 

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -324,8 +324,9 @@ class SphinxContentsFilter(ContentsFilter):
     """
     def visit_pending_xref(self, node):
         # type: (nodes.Node) -> None
-        text = node.astext()
-        self.parent.append(nodes.literal(text, text))
+        pending = addnodes.pending_xtext()
+        pending += node.deepcopy()
+        self.parent.append(pending)
         raise nodes.SkipNode
 
     def visit_image(self, node):

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -174,6 +174,21 @@ class ReferencesResolver(SphinxTransform):
                        location=node, type='ref', subtype=typ)
 
 
+class DeferredTextResolver(SphinxTransform):
+    """
+    Resolves text derived from cross-references.
+    """
+
+    default_priority = 15  # after ReferencesResolver
+
+    def apply(self):
+        # type: () -> None
+        for node in self.document.traverse(addnodes.pending_xtext):
+            text = node.astext()
+            newnode = nodes.Text(text, text)
+            node.replace_self(newnode)
+
+
 class OnlyNodeTransform(SphinxTransform):
     default_priority = 50
 
@@ -201,6 +216,7 @@ def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_post_transform(DocReferenceMigrator)
     app.add_post_transform(ReferencesResolver)
+    app.add_post_transform(DeferredTextResolver)
     app.add_post_transform(OnlyNodeTransform)
 
     return {


### PR DESCRIPTION
Implement a new node that converts its contents to text (via `astext()`), but delays doing so until the post-transform stage. Modify TOC collection to use this. Modify TOC extraction to perform post-transforms (specifically, reference resolution and resolution of the aforementioned new nodes).

This fixes an annoying behavior where the use of an external reference in a section name would use the raw reference text rather than the resolved reference text in the sidebar table of contents, resulting in a mismatch between the section title as it appears in said table of contents and how it appears in the document body.

Fixes #4448.

I'm labelling this as RFC for now because it has a couple of potential issues, in addition to the question of whether this is even a reasonable approach:

1. It wasn't immediately obvious to me how to extract the document name for `_entries_from_toctree`. (OTOH, this looks like it might be dead code?)
2. Currently, I am creating a `pending_xtext` for ALL TOC entries, when probably this should only be done if the entry contains an xref. (This should be an easy fix, which I am happy to address if the patch is otherwise acceptable.)