### PR TITLE
parallel build: ValueError: too many values to unpack

### DIFF
--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -70,7 +70,7 @@ class MathDomain(Domain):
 
     def merge_domaindata(self, docnames, otherdata):
         # type: (Iterable[unicode], Dict) -> None
-        for labelid, (doc, eqno) in otherdata['objects'].items():
+        for labelid, doc in otherdata['objects'].items():
             if doc in docnames:
                 self.data['objects'][labelid] = doc
 


### PR DESCRIPTION
I tried to use the parallel build option -j8 and got stuck in this function where the eqno variable is not unpacked (sequential build is ok):
```
def merge_domaindata(self, docnames, otherdata):
        # type: (Iterable[unicode], Dict) -> None
        for labelid, (doc, eqno) in otherdata['objects'].items():
            if doc in docnames:
                self.data['objects'][labelid] = doc
```
This pattern is used in several other files, careful review needed.


Here's the full log:

```
# Sphinx version: 1.6.6
# Python version: 3.5.2 (CPython)
# Docutils version: 0.14 
# Jinja2 version: 2.10
# Last messages:
#   reading sources... [ 92%] user_manual/_generated/openturns.coupling_tools.get_line_col .. user_manual/response_surface/_generated/openturns.FittingAlgorithm
#   
#   reading sources... [ 96%] user_manual/response_surface/_generated/openturns.FixedStrategy .. user_manual/response_surface/_generated/openturns.SVDMethod
#   
#   reading sources... [100%] user_manual/response_surface/_generated/openturns.SequentialStrategy .. user_manual/user_manual
#   
#   
#   
#   waiting for workers...
#   
# Loaded extensions:
#   sphinx.ext.doctest (1.6.6) from /home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/doctest.py
#   alabaster (0.7.10) from /home/schueller/.local/lib/python3.5/site-packages/alabaster/__init__.py
#   sphinx.ext.todo (1.6.6) from /home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/todo.py
#   sphinx.ext.coverage (1.6.6) from /home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/coverage.py
#   sphinx.ext.autodoc (1.6.6) from /home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/autodoc.py
#   execforresourcemap_directive (0) from /home/schueller/projects/openturns/schueller2/build/python/src/sphinx_build/sphinxext/execforresourcemap_directive.py
#   sphinx.ext.autosummary (1.6.6) from /home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/autosummary/__init__.py
#   sphinx.ext.imgmath (1.6.6) from /home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/imgmath.py
#   numpydoc (unknown version) from /home/schueller/.local/lib/python3.5/site-packages/numpydoc/__init__.py
#   matplotlib.sphinxext.plot_directive (unknown version) from /home/schueller/.local/lib/python3.5/site-packages/matplotlib/sphinxext/plot_directive.py
Traceback (most recent call last):
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/cmdline.py", line 306, in main
    app.build(opts.force_all, filenames)
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/application.py", line 339, in build
    self.builder.build_update()
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/builders/__init__.py", line 329, in build_update
    'out of date' % len(to_build))
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/builders/__init__.py", line 342, in build
    updated_docnames = set(self.env.update(self.config, self.srcdir, self.doctreedir))
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/environment/__init__.py", line 599, in update
    self._read_parallel(docnames, self.app, nproc=self.app.parallel)
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/environment/__init__.py", line 653, in _read_parallel
    tasks.join()
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/util/parallel.py", line 112, in join
    self._join_one()
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/util/parallel.py", line 123, in _join_one
    self._result_funcs.pop(tid)(self._args.pop(tid), result)
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/environment/__init__.py", line 642, in merge
    self.merge_info_from(docs, env, app)
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/environment/__init__.py", line 360, in merge_info_from
    domain.merge_domaindata(docnames, other.domaindata[domainname])
  File "/home/schueller/.local/lib/python3.5/site-packages/sphinx/ext/mathbase.py", line 68, in merge_domaindata
    for labelid, (doc, eqno) in otherdata['objects'].items():
ValueError: too many values to unpack (expected 2)
```

