### PR TITLE
autodoc: prefer _MockImporter over other importers in sys.meta_path

### DIFF
--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -87,7 +87,7 @@ class _MockImporter(object):
         self.names = names
         self.mocked_modules = []  # type: List[str]
         # enable hook by adding itself to meta_path
-        sys.meta_path = sys.meta_path + [self]
+        sys.meta_path.insert(0, self)
 
     def disable(self):
         # remove `self` from `sys.meta_path` to disable import hook


### PR DESCRIPTION


Subject: Add _MockImporter in front of other importers in sys.meta_path

### Feature or Bugfix
- Bugfix

### Purpose
In case we want to mock modules which are actually available in the current
environment, we need to add the _MockImporter before other importers. We ran
into this problem in our application, where importing the existing modules
caused side effects which were not fixed by autodoc_mock_imports.

### Detail
-/-

### Relates
-/-

This is debatable, i am not sure whether this is the intended behaviour of autodoc_mock_imports. At least from my point of view, the documentation implied that it not only mocked missing modules, but in sys.path available modules as well.

A backport to stable would be needed as well. Thanks for your time and work on sphinx 👍 