### PR TITLE
Check that if ref. file exists prior to calling `samefile`

### DIFF
--- a/utils/checks.py
+++ b/utils/checks.py
@@ -48,7 +48,8 @@ def sphinx_has_header(physical_line, filename, lines, line_number):
     # ignore specific errors on a file-level basis yet [1]. Simply skip it.
     #
     # [1] https://gitlab.com/pycqa/flake8/issues/347
-    if os.path.samefile(filename, './sphinx/util/smartypants.py'):
+    smrt_pnts = './sphinx/util/smartypants.py'
+    if os.path.exists(smrt_pnts) and os.path.samefile(filename, smrt_pnts):
         return
 
     # if the top-level package or not inside the package, ignore


### PR DESCRIPTION
Closes https://github.com/sphinx-doc/sphinx/issues/4492

Prior to running `os.path.samefile(fn, 'path/to/file')` check that `'path/to/file/` exists.

This prevents the OSError  from being raised, but perhaps a better solution is in order (use absolute path?)