### PR TITLE
Re-add Alabaster specific html_sidebars conditionally

### DIFF
--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -112,12 +112,16 @@ html_static_path = ['{{ dot }}static']
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-    ]
-}
+if html_theme == 'alabaster':
+    html_sidebars = {
+        '**': [
+            'about.html',
+            'navigation.html',
+            'relations.html',  # needs 'show_related': True theme option to display
+            'searchbox.html',
+            'donate.html',
+        ]
+    }
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
Subject: Re-add Alabaster specific html_sidebars conditionally

### Feature or Bugfix
- Bugfix

### Purpose
- Making Alabaster look right in a newly created project.

### Detail
A second attempt of #3849, reverting #4002. Should keep #3987 fixed while also making sure Alabaster looks right in a newly created project.

This was fixed in a different way for 1.7, moving the default sidebars config into the theme.conf in b78f309.

### Relates
- #3849
- #3987
- #4002

