### PR TITLE
Fix #4490: autodoc: type annotation is broken with python 3.7.0a4+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 * #4415: autodoc classifies inherited classmethods as regular methods
 * #4415: autodoc classifies inherited staticmethods as regular methods
 * #4472: DOCUMENTATION_OPTIONS is not defined
+* #4490: autodoc: type annotation is broken with python 3.7.0a4+
 
 Testing
 --------

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -215,12 +215,7 @@ def test_Signature_annotations():
 
     # TypeVars and generic types with TypeVars
     sig = inspect.Signature(f2).format_args()
-    if sys.version_info < (3, 7):
-        sig == ('(x: typing.List[T], y: typing.List[T_co], z: T) -> '
-                'typing.List[T_contra]')
-    else:
-        sig == ('(x: typing.List[~T], y: typing.List[+T_co], z: T) -> '
-                'typing.List[-T_contra]')
+    assert sig == '(x: List[T], y: List[T_co], z: T) -> List[T_contra]'
 
     # Union types
     sig = inspect.Signature(f3).format_args()


### PR DESCRIPTION
refs: #4490 