### PR TITLE
Use flake8-import-order

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,6 +3,7 @@
 # Sphinx documentation build configuration file
 
 import re
+
 import sphinx
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,10 @@ directory = sphinx/locale/
 
 [flake8]
 max-line-length = 95
-ignore = E116,E241,E251,E741
+ignore = E116,E241,E251,E741,I101
 exclude = .git,.tox,.venv,tests/*,build/*,doc/_build/*,sphinx/search/*,sphinx/pycode/pgen2/*,doc/ext/example*.py
+application-import-names = sphinx
+import-order-style = smarkets
 
 [mypy]
 python_version = 2.7

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
-
 import os
 import sys
 from distutils import log
 from distutils.cmd import Command
+
+from setuptools import find_packages, setup
 
 import sphinx
 
@@ -48,6 +48,7 @@ extras_require = {
         'pytest-cov',
         'html5lib',
         'flake8',
+        'flake8-import-order',
     ],
     'test:python_version<"3"': [
         'enum34',

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -13,36 +13,35 @@
 from __future__ import print_function
 
 import os
+import posixpath
 import sys
 import warnings
-import posixpath
-from os import path
 from collections import deque
-
-from six import iteritems, itervalues
-from six.moves import cStringIO
+from os import path
 
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
+from six import iteritems, itervalues
+from six.moves import cStringIO
 
 import sphinx
 from sphinx import package_dir, locale
 from sphinx.config import Config
-from sphinx.errors import ConfigError, ExtensionError, VersionRequirementError
 from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.environment import BuildEnvironment
+from sphinx.errors import ConfigError, ExtensionError, VersionRequirementError
 from sphinx.events import EventManager
 from sphinx.extension import verify_required_extensions
 from sphinx.locale import __
 from sphinx.registry import SphinxComponentRegistry
-from sphinx.util import pycompat  # noqa: F401
 from sphinx.util import import_object
 from sphinx.util import logging
-from sphinx.util.tags import Tags
-from sphinx.util.osutil import ENOENT, ensuredir
+from sphinx.util import pycompat  # noqa: F401
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.docutils import is_html5_writer_available, directive_helper
 from sphinx.util.i18n import find_catalog_source_files
+from sphinx.util.osutil import ENOENT, ensuredir
+from sphinx.util.tags import Tags
 
 if False:
     # For type annotation

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -9,28 +9,28 @@
     :license: BSD, see LICENSE for details.
 """
 
-from os import path
 import warnings
-
-try:
-    import multiprocessing
-except ImportError:
-    multiprocessing = None
+from os import path
 
 from docutils import nodes
 
 from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.util import i18n, path_stabilize, logging, status_iterator
-from sphinx.util.osutil import SEP, ensuredir, relative_uri
-from sphinx.util.i18n import find_catalog
 from sphinx.util.console import bold  # type: ignore
+from sphinx.util.i18n import find_catalog
+from sphinx.util.osutil import SEP, ensuredir, relative_uri
 from sphinx.util.parallel import ParallelTasks, SerialTasks, make_chunks, \
     parallel_available
 
 # side effect: registers roles and directives
 from sphinx import roles       # noqa
 from sphinx import directives  # noqa
+
+try:
+    import multiprocessing
+except ImportError:
+    multiprocessing = None
 
 if False:
     # For type annotation

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -11,18 +11,9 @@
 
 import os
 import re
-from os import path
-from sphinx.util.i18n import format_date
-from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 from collections import namedtuple
-
-try:
-    from PIL import Image
-except ImportError:
-    try:
-        import Image
-    except ImportError:
-        Image = None
+from os import path
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
 from docutils import nodes
 from docutils.utils import smartquotes
@@ -31,8 +22,17 @@ from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.util import logging
 from sphinx.util import status_iterator
-from sphinx.util.osutil import ensuredir, copyfile
 from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.i18n import format_date
+from sphinx.util.osutil import ensuredir, copyfile
+
+try:
+    from PIL import Image
+except ImportError:
+    try:
+        import Image
+    except ImportError:
+        Image = None
 
 if False:
     # For type annotation

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -12,22 +12,20 @@ from __future__ import print_function
 
 import codecs
 import pipes
-
-from os import path, environ
+import plistlib
 import shlex
+import subprocess
+from os import path, environ
 
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.config import string_classes
+from sphinx.errors import SphinxError
 from sphinx.util import logging
-from sphinx.util.osutil import copyfile, ensuredir, make_filename
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.fileutil import copy_asset
-from sphinx.util.pycompat import htmlescape
 from sphinx.util.matching import Matcher
-from sphinx.errors import SphinxError
-
-import plistlib
-import subprocess
+from sphinx.util.osutil import copyfile, ensuredir, make_filename
+from sphinx.util.pycompat import htmlescape
 
 if False:
     # For type annotation

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -15,13 +15,13 @@ from os import path
 from six import iteritems
 
 from sphinx import package_dir
+from sphinx.builders import Builder
 from sphinx.locale import _
 from sphinx.theming import HTMLThemeFactory
-from sphinx.builders import Builder
 from sphinx.util import logging
-from sphinx.util.osutil import ensuredir, os_path
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.osutil import ensuredir, os_path
 from sphinx.util.pycompat import htmlescape
 
 if False:

--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -12,17 +12,17 @@
 """
 from __future__ import absolute_import
 
-import re
 import gzip
+import re
 from os import path
 
 from docutils import nodes
 
 from sphinx import addnodes
-from sphinx.util import logging
-from sphinx.util.osutil import make_filename
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment.adapters.indexentries import IndexEntries
+from sphinx.util import logging
+from sphinx.util.osutil import make_filename
 
 try:
     import xml.etree.ElementTree as etree

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -10,12 +10,12 @@
     :license: BSD, see LICENSE for details.
 """
 
-from os import path
 from collections import namedtuple
+from os import path
 
 from sphinx import package_dir
-from sphinx.config import string_classes, ENUM
 from sphinx.builders import _epub_base
+from sphinx.config import string_classes, ENUM
 from sphinx.util import logging, xmlname_checker
 from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.i18n import format_date

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -11,23 +11,23 @@
 
 from __future__ import unicode_literals
 
-from os import path, walk, getenv
 from codecs import open
-from time import time
-from datetime import datetime, tzinfo, timedelta
 from collections import defaultdict
+from datetime import datetime, tzinfo, timedelta
+from os import path, walk, getenv
+from time import time
 from uuid import uuid4
 
 from six import iteritems, StringIO
 
 from sphinx.builders import Builder
+from sphinx.locale import pairindextypes
 from sphinx.util import split_index_msg, logging, status_iterator
-from sphinx.util.tags import Tags
+from sphinx.util.console import bold  # type: ignore
+from sphinx.util.i18n import find_catalog
 from sphinx.util.nodes import extract_messages, traverse_translatable_index
 from sphinx.util.osutil import safe_relpath, ensuredir, canon_path
-from sphinx.util.i18n import find_catalog
-from sphinx.util.console import bold  # type: ignore
-from sphinx.locale import pairindextypes
+from sphinx.util.tags import Tags
 
 if False:
     # For type annotation

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -9,48 +9,47 @@
     :license: BSD, see LICENSE for details.
 """
 
+import codecs
+import posixpath
 import re
 import sys
-import codecs
 import warnings
-import posixpath
-from os import path
 from hashlib import md5
-
-from six import iteritems, text_type, string_types
-from six.moves import cPickle as pickle
+from os import path
 
 import docutils
 from docutils import nodes
-from docutils.io import DocTreeInput, StringOutput
 from docutils.core import Publisher
-from docutils.utils import new_document, relative_path
 from docutils.frontend import OptionParser
+from docutils.io import DocTreeInput, StringOutput
 from docutils.readers.doctree import Reader as DoctreeReader
+from docutils.utils import new_document, relative_path
+from six import iteritems, text_type, string_types
+from six.moves import cPickle as pickle
 
 from sphinx import package_dir, __display_version__
-from sphinx.util import jsonimpl, logging, status_iterator
-from sphinx.util.i18n import format_date
-from sphinx.util.inventory import InventoryFile
-from sphinx.util.osutil import SEP, os_path, relative_uri, ensuredir, \
-    movefile, copyfile
-from sphinx.util.nodes import inline_all_toctrees
-from sphinx.util.docutils import is_html5_writer_available
-from sphinx.util.fileutil import copy_asset
-from sphinx.util.matching import patmatch, Matcher, DOTFILES
+from sphinx.application import ENV_PICKLE_FILENAME
+from sphinx.builders import Builder
 from sphinx.config import string_classes
 from sphinx.deprecation import RemovedInSphinx20Warning
+from sphinx.environment.adapters.asset import ImageAdapter
+from sphinx.environment.adapters.indexentries import IndexEntries
+from sphinx.environment.adapters.toctree import TocTree
+from sphinx.highlighting import PygmentsBridge
 from sphinx.locale import _, l_
 from sphinx.search import js_index
 from sphinx.theming import HTMLThemeFactory
-from sphinx.builders import Builder
-from sphinx.application import ENV_PICKLE_FILENAME
-from sphinx.highlighting import PygmentsBridge
+from sphinx.util import jsonimpl, logging, status_iterator
 from sphinx.util.console import bold, darkgreen  # type: ignore
+from sphinx.util.docutils import is_html5_writer_available
+from sphinx.util.fileutil import copy_asset
+from sphinx.util.i18n import format_date
+from sphinx.util.inventory import InventoryFile
+from sphinx.util.matching import patmatch, Matcher, DOTFILES
+from sphinx.util.nodes import inline_all_toctrees
+from sphinx.util.osutil import SEP, os_path, relative_uri, ensuredir, \
+    movefile, copyfile
 from sphinx.writers.html import HTMLWriter, HTMLTranslator
-from sphinx.environment.adapters.asset import ImageAdapter
-from sphinx.environment.adapters.toctree import TocTree
-from sphinx.environment.adapters.indexentries import IndexEntries
 
 if False:
     # For type annotation

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -11,8 +11,8 @@
 """
 from __future__ import print_function
 
-import os
 import codecs
+import os
 from os import path
 
 from docutils import nodes

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -12,25 +12,24 @@
 import os
 from os import path
 
-from six import text_type
-
 from docutils import nodes
+from docutils.frontend import OptionParser
 from docutils.io import FileOutput
 from docutils.utils import new_document
-from docutils.frontend import OptionParser
+from six import text_type
 
 from sphinx import package_dir, addnodes, highlighting
-from sphinx.config import string_classes, ENUM
-from sphinx.errors import SphinxError, ConfigError
-from sphinx.locale import _
 from sphinx.builders import Builder
+from sphinx.config import string_classes, ENUM
 from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
+from sphinx.errors import SphinxError, ConfigError
+from sphinx.locale import _
 from sphinx.util import texescape, logging, status_iterator
-from sphinx.util.nodes import inline_all_toctrees
-from sphinx.util.fileutil import copy_asset_file
-from sphinx.util.osutil import SEP, make_filename
 from sphinx.util.console import bold, darkgreen  # type: ignore
+from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.nodes import inline_all_toctrees
+from sphinx.util.osutil import SEP, make_filename
 from sphinx.writers.latex import LaTeXWriter, LaTeXTranslator
 
 if False:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -9,16 +9,16 @@
     :license: BSD, see LICENSE for details.
 """
 
+import codecs
 import re
 import socket
-import codecs
 import threading
 from os import path
 
+from docutils import nodes
 from requests.exceptions import HTTPError
 from six.moves import queue, html_parser
 from six.moves.urllib.parse import unquote
-from docutils import nodes
 
 # 2015-06-25 barry@python.org.  This exception was deprecated in Python 3.3 and
 # removed in Python 3.5, however for backward compatibility reasons, we're not

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -11,18 +11,17 @@
 
 from os import path
 
-from six import string_types
-
-from docutils.io import FileOutput
 from docutils.frontend import OptionParser
+from docutils.io import FileOutput
+from six import string_types
 
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
 from sphinx.util import logging
+from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import make_filename
-from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.writers.manpage import ManualPageWriter, ManualPageTranslator
 
 if False:

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -9,15 +9,14 @@
     :license: BSD, see LICENSE for details.
 """
 
-import os
-import re
 import codecs
+import os
 import posixpath
+import re
 from os import path
 
-from six import text_type
-
 from docutils import nodes
+from six import text_type
 
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -13,21 +13,21 @@ import os
 from os import path
 
 from docutils import nodes
+from docutils.frontend import OptionParser
 from docutils.io import FileOutput
 from docutils.utils import new_document
-from docutils.frontend import OptionParser
 
 from sphinx import addnodes
-from sphinx.locale import _
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
+from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util import status_iterator
+from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import SEP, make_filename
-from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.writers.texinfo import TexinfoWriter, TexinfoTranslator
 
 if False:

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -8,8 +8,8 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
 
 import argparse
 import os
@@ -30,18 +30,18 @@ try:
 except ImportError:
     pass
 
+from docutils.utils import column_width
 from six import PY2, PY3, text_type, binary_type
 from six.moves import input
 from six.moves.urllib.parse import quote as urlquote
-from docutils.utils import column_width
 
 from sphinx import __display_version__, package_dir
-from sphinx.util.osutil import ensuredir, make_filename
+from sphinx.util import texescape
 from sphinx.util.console import (  # type: ignore
     purple, bold, red, turquoise, nocolor, color_terminal
 )
+from sphinx.util.osutil import ensuredir, make_filename
 from sphinx.util.template import SphinxRenderer
-from sphinx.util import texescape
 
 if False:
     # For type annotation

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -20,8 +20,8 @@ from docutils.utils import SystemMessage
 from six import text_type, binary_type
 
 from sphinx import __display_version__
-from sphinx.errors import SphinxError
 from sphinx.application import Sphinx
+from sphinx.errors import SphinxError
 from sphinx.util import Tee, format_exception_cut_frames, save_traceback
 from sphinx.util.console import red, nocolor, color_terminal  # type: ignore
 from sphinx.util.docutils import docutils_namespace, patch_docutils

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -12,9 +12,9 @@
 import re
 import traceback
 from os import path, getenv
+from typing import Any, NamedTuple, Union
 
 from six import PY2, PY3, iteritems, string_types, binary_type, text_type, integer_types
-from typing import Any, NamedTuple, Union
 
 from sphinx.errors import ConfigError
 from sphinx.locale import l_, __

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -7,8 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import sys
 import codecs
+import sys
 from difflib import unified_diff
 
 from docutils import nodes

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -7,20 +7,19 @@
     :license: BSD, see LICENSE for details.
 """
 
-from six.moves import range
-
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 from docutils.parsers.rst.directives.misc import Class
 from docutils.parsers.rst.directives.misc import Include as BaseInclude
+from six.moves import range
 
 from sphinx import addnodes
 from sphinx.locale import versionlabels, _
 from sphinx.util import url_re, docname_join
+from sphinx.util.matching import patfilter
 from sphinx.util.nodes import explicit_title_re, set_source_info, \
     process_index_entry
-from sphinx.util.matching import patfilter
 
 if False:
     # For type annotation

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -15,12 +15,12 @@ import string
 from docutils import nodes
 
 from sphinx import addnodes
-from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
-from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
-from sphinx.util.nodes import make_refnode
+from sphinx.domains import Domain, ObjType
+from sphinx.locale import l_, _
+from sphinx.roles import XRefRole
 from sphinx.util.docfields import Field, TypedField
+from sphinx.util.nodes import make_refnode
 
 if False:
     # For type annotation

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -12,21 +12,20 @@
 import re
 from copy import deepcopy
 
-from six import iteritems, text_type
-
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from six import iteritems, text_type
 
 from sphinx import addnodes
-from sphinx.environment import NoUri
-from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
-from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, ObjType
+from sphinx.environment import NoUri
+from sphinx.locale import l_, _
+from sphinx.roles import XRefRole
 from sphinx.util import logging
+from sphinx.util.docfields import Field, GroupedField
 from sphinx.util.nodes import make_refnode
 from sphinx.util.pycompat import UnicodeMixin
-from sphinx.util.docfields import Field, GroupedField
 
 
 if False:

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -13,13 +13,13 @@ from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
 from sphinx import addnodes
-from sphinx.domains import Domain, ObjType
-from sphinx.locale import l_, _
 from sphinx.directives import ObjectDescription
-from sphinx.roles import XRefRole
+from sphinx.domains import Domain, ObjType
 from sphinx.domains.python import _pseudo_parse_arglist
-from sphinx.util.nodes import make_refnode
+from sphinx.locale import l_, _
+from sphinx.roles import XRefRole
 from sphinx.util.docfields import Field, GroupedField, TypedField
+from sphinx.util.nodes import make_refnode
 
 if False:
     # For type annotation

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -11,19 +11,18 @@
 
 import re
 
-from six import iteritems
-
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from six import iteritems
 
 from sphinx import addnodes
-from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
-from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, ObjType, Index
+from sphinx.locale import l_, _
+from sphinx.roles import XRefRole
 from sphinx.util import logging
-from sphinx.util.nodes import make_refnode
 from sphinx.util.docfields import Field, GroupedField, TypedField
+from sphinx.util.nodes import make_refnode
 
 if False:
     # For type annotation

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -14,9 +14,9 @@ import re
 from six import iteritems
 
 from sphinx import addnodes
+from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.locale import l_, _
-from sphinx.directives import ObjectDescription
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -12,17 +12,16 @@
 import re
 import unicodedata
 
-from six import iteritems
-
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
+from six import iteritems
 
 from sphinx import addnodes
-from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
-from sphinx.domains import Domain, ObjType
 from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, ObjType
+from sphinx.locale import l_, _
+from sphinx.roles import XRefRole
 from sphinx.util import ws_re, logging, docname_join
 from sphinx.util.nodes import clean_astext, make_refnode
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -9,40 +9,39 @@
     :license: BSD, see LICENSE for details.
 """
 
-import re
+import fnmatch
 import os
+import re
 import sys
 import time
 import types
-import fnmatch
 import warnings
-from os import path
-from copy import copy
 from collections import defaultdict
+from copy import copy
+from os import path
 
+from docutils.frontend import OptionParser
+from docutils.utils import Reporter, get_source_line
 from six import BytesIO, itervalues, class_types, next
 from six.moves import cPickle as pickle
 
-from docutils.utils import Reporter, get_source_line
-from docutils.frontend import OptionParser
-
 from sphinx import addnodes, versioning
-from sphinx.io import read_doc
-from sphinx.util import logging, rst
-from sphinx.util import get_matching_docs, FilenameUniqDict, status_iterator
-from sphinx.util.nodes import is_translatable
-from sphinx.util.osutil import SEP, ensuredir
-from sphinx.util.i18n import find_catalog_files
-from sphinx.util.console import bold  # type: ignore
-from sphinx.util.docutils import sphinx_domains, WarningStream
-from sphinx.util.matching import compile_matchers
-from sphinx.util.parallel import ParallelTasks, parallel_available, make_chunks
-from sphinx.util.websupport import is_commentable
-from sphinx.errors import SphinxError, ExtensionError
-from sphinx.transforms import SphinxTransformer
 from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.environment.adapters.toctree import TocTree
+from sphinx.errors import SphinxError, ExtensionError
+from sphinx.io import read_doc
+from sphinx.transforms import SphinxTransformer
+from sphinx.util import get_matching_docs, FilenameUniqDict, status_iterator
+from sphinx.util import logging, rst
+from sphinx.util.console import bold  # type: ignore
+from sphinx.util.docutils import sphinx_domains, WarningStream
+from sphinx.util.i18n import find_catalog_files
+from sphinx.util.matching import compile_matchers
+from sphinx.util.nodes import is_translatable
+from sphinx.util.osutil import SEP, ensuredir
+from sphinx.util.parallel import ParallelTasks, parallel_available, make_chunks
+from sphinx.util.websupport import is_commentable
 
 if False:
     # For type annotation

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -8,8 +8,8 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import re
 import bisect
+import re
 import unicodedata
 from itertools import groupby
 

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -9,9 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-from six import iteritems
-
 from docutils import nodes
+from six import iteritems
 
 from sphinx import addnodes
 from sphinx.util import url_re, logging

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -10,13 +10,12 @@
 """
 
 import os
-from os import path
 from glob import glob
-
-from six import iteritems, itervalues
+from os import path
 
 from docutils import nodes
 from docutils.utils import relative_path
+from six import iteritems, itervalues
 
 from sphinx import addnodes
 from sphinx.environment.collectors import EnvironmentCollector

--- a/sphinx/environment/collectors/dependencies.py
+++ b/sphinx/environment/collectors/dependencies.py
@@ -13,8 +13,8 @@ from os import path
 
 from docutils.utils import relative_path
 
-from sphinx.util.osutil import getcwd, fs_encoding
 from sphinx.environment.collectors import EnvironmentCollector
+from sphinx.util.osutil import getcwd, fs_encoding
 
 if False:
     # For type annotation

--- a/sphinx/environment/collectors/indexentries.py
+++ b/sphinx/environment/collectors/indexentries.py
@@ -10,8 +10,8 @@
 """
 
 from sphinx import addnodes
-from sphinx.util import split_index_msg, logging
 from sphinx.environment.collectors import EnvironmentCollector
+from sphinx.util import split_index_msg, logging
 
 if False:
     # For type annotation

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -9,15 +9,14 @@
     :license: BSD, see LICENSE for details.
 """
 
+from docutils import nodes
 from six import iteritems
 
-from docutils import nodes
-
 from sphinx import addnodes
-from sphinx.util import url_re, logging
-from sphinx.transforms import SphinxContentsFilter
 from sphinx.environment.adapters.toctree import TocTree
 from sphinx.environment.collectors import EnvironmentCollector
+from sphinx.transforms import SphinxContentsFilter
+from sphinx.util import url_re, logging
 
 if False:
     # For type annotation

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -21,9 +21,10 @@ import argparse
 import glob
 import os
 import sys
-from os import path
-from six import binary_type
 from fnmatch import fnmatch
+from os import path
+
+from six import binary_type
 
 from sphinx import __display_version__
 from sphinx.cmd.quickstart import EXTENSIONS

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -11,29 +11,28 @@
     :license: BSD, see LICENSE for details.
 """
 
+import inspect
 import re
 import sys
-import inspect
 import warnings
 
+from docutils.statemachine import ViewList
 from six import iteritems, itervalues, text_type, class_types, string_types
 
-from docutils.statemachine import ViewList
-
 import sphinx
+from sphinx.application import ExtensionError
 from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.ext.autodoc.importer import mock, import_object, get_object_members
 from sphinx.ext.autodoc.importer import _MockImporter  # to keep compatibility  # NOQA
 from sphinx.ext.autodoc.inspector import format_annotation, formatargspec  # to keep compatibility  # NOQA
-from sphinx.util import rpartition, force_decode
 from sphinx.locale import _
 from sphinx.pycode import ModuleAnalyzer, PycodeError
-from sphinx.application import ExtensionError
 from sphinx.util import logging
+from sphinx.util import rpartition, force_decode
+from sphinx.util.docstrings import prepare_docstring
 from sphinx.util.inspect import Signature, isdescriptor, safe_getmembers, \
     safe_getattr, object_description, is_builtin_class_method, \
     isenumattribute, isclassmethod, isstaticmethod, getdoc
-from sphinx.util.docstrings import prepare_docstring
 
 if False:
     # For type annotation

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -9,10 +9,10 @@
     :license: BSD, see LICENSE for details.
 """
 
-import sys
-import warnings
-import traceback
 import contextlib
+import sys
+import traceback
+import warnings
 from collections import namedtuple
 from types import FunctionType, MethodType, ModuleType
 

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -10,6 +10,7 @@
 """
 
 from docutils import nodes
+
 from sphinx.util import logging
 from sphinx.util.nodes import clean_astext
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -53,28 +53,27 @@
     :license: BSD, see LICENSE for details.
 """
 
+import inspect
 import os
+import posixpath
 import re
 import sys
-import inspect
-import posixpath
-from six import string_types
 from types import ModuleType
 
-from six import text_type
-
+from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
-from docutils import nodes
+from six import string_types
+from six import text_type
 
 import sphinx
 from sphinx import addnodes
 from sphinx.environment.adapters.toctree import TocTree
-from sphinx.util import import_object, rst, logging
-from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.ext.autodoc import get_documenters
 from sphinx.ext.autodoc.directive import DocumenterBridge, Options
 from sphinx.ext.autodoc.importer import import_module
+from sphinx.pycode import ModuleAnalyzer, PycodeError
+from sphinx.util import import_object, rst, logging
 
 if False:
     # For type annotation

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -34,8 +34,8 @@ from sphinx import package_dir
 from sphinx.ext.autosummary import import_by_name, get_documenter
 from sphinx.jinja2glue import BuiltinTemplateLoader
 from sphinx.registry import SphinxComponentRegistry
-from sphinx.util.osutil import ensuredir
 from sphinx.util.inspect import safe_getattr
+from sphinx.util.osutil import ensuredir
 from sphinx.util.rst import escape as rst_escape
 
 if False:

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -10,9 +10,9 @@
     :license: BSD, see LICENSE for details.
 """
 
-import re
 import glob
 import inspect
+import re
 from os import path
 
 from six import iteritems

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -11,27 +11,26 @@
 """
 from __future__ import absolute_import
 
+import codecs
+import doctest
 import re
 import sys
 import time
-import codecs
 from os import path
-import doctest
-
-from six import itervalues, StringIO, binary_type, text_type, PY2
-from packaging.specifiers import SpecifierSet, InvalidSpecifier
-from packaging.version import Version
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from packaging.specifiers import SpecifierSet, InvalidSpecifier
+from packaging.version import Version
+from six import itervalues, StringIO, binary_type, text_type, PY2
 
 import sphinx
 from sphinx.builders import Builder
-from sphinx.util import force_decode, logging
-from sphinx.util.nodes import set_source_info
-from sphinx.util.console import bold  # type: ignore
-from sphinx.util.osutil import fs_encoding
 from sphinx.locale import _
+from sphinx.util import force_decode, logging
+from sphinx.util.console import bold  # type: ignore
+from sphinx.util.nodes import set_source_info
+from sphinx.util.osutil import fs_encoding
 
 if False:
     # For type annotation

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -24,8 +24,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-from six import iteritems
 from docutils import nodes, utils
+from six import iteritems
 
 import sphinx
 from sphinx.util.nodes import split_explicit_title

--- a/sphinx/ext/githubpages.py
+++ b/sphinx/ext/githubpages.py
@@ -10,6 +10,7 @@
 """
 
 import os
+
 import sphinx
 
 

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -10,18 +10,17 @@
     :license: BSD, see LICENSE for details.
 """
 
-import re
 import codecs
 import posixpath
+import re
+from hashlib import sha1
 from os import path
 from subprocess import Popen, PIPE
-from hashlib import sha1
-
-from six import text_type
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
+from six import text_type
 
 import sphinx
 from sphinx.errors import SphinxError

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -9,28 +9,27 @@
     :license: BSD, see LICENSE for details.
 """
 
-import re
 import codecs
+import posixpath
+import re
 import shutil
 import tempfile
-import posixpath
+from hashlib import sha1
 from os import path
 from subprocess import Popen, PIPE
-from hashlib import sha1
-
-from six import text_type
 
 from docutils import nodes
+from six import text_type
 
 import sphinx
-from sphinx.locale import _
 from sphinx.errors import SphinxError, ExtensionError
-from sphinx.util import logging
-from sphinx.util.png import read_png_depth, write_png_depth
-from sphinx.util.osutil import ensuredir, ENOENT, cd
-from sphinx.util.pycompat import sys_encoding
-from sphinx.ext.mathbase import setup_math as mathbase_setup, wrap_displaymath
 from sphinx.ext.mathbase import get_node_equation_number
+from sphinx.ext.mathbase import setup_math as mathbase_setup, wrap_displaymath
+from sphinx.locale import _
+from sphinx.util import logging
+from sphinx.util.osutil import ensuredir, ENOENT, cd
+from sphinx.util.png import read_png_depth, write_png_depth
+from sphinx.util.pycompat import sys_encoding
 
 if False:
     # For type annotation

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -36,16 +36,15 @@ r"""
     :license: BSD, see LICENSE for details.
 """
 
+import inspect
 import re
 import sys
-import inspect
 from hashlib import md5
-
-from six import text_type
-from six.moves import builtins
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from six import text_type
+from six.moves import builtins
 
 import sphinx
 from sphinx.ext.graphviz import render_dot_html, render_dot_latex, \

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -26,21 +26,20 @@
 
 from __future__ import print_function
 
-import sys
-import time
 import functools
 import posixpath
+import sys
+import time
 from os import path
-
-from six import PY3, iteritems, string_types
-from six.moves.urllib.parse import urlsplit, urlunsplit
 
 from docutils import nodes
 from docutils.utils import relative_path
+from six import PY3, iteritems, string_types
+from six.moves.urllib.parse import urlsplit, urlunsplit
 
 import sphinx
-from sphinx.locale import _
 from sphinx.builders.html import INVENTORY_FILENAME
+from sphinx.locale import _
 from sphinx.util import requests, logging
 from sphinx.util.inventory import InventoryFile
 

--- a/sphinx/ext/jsmath.py
+++ b/sphinx/ext/jsmath.py
@@ -13,10 +13,10 @@
 from docutils import nodes
 
 import sphinx
-from sphinx.locale import _
 from sphinx.application import ExtensionError
-from sphinx.ext.mathbase import setup_math as mathbase_setup
 from sphinx.ext.mathbase import get_node_equation_number
+from sphinx.ext.mathbase import setup_math as mathbase_setup
+from sphinx.locale import _
 
 
 def html_visit_math(self, node):

--- a/sphinx/ext/linkcode.py
+++ b/sphinx/ext/linkcode.py
@@ -13,8 +13,8 @@ from docutils import nodes
 
 import sphinx
 from sphinx import addnodes
-from sphinx.locale import _
 from sphinx.errors import SphinxError
+from sphinx.locale import _
 
 if False:
     # For type annotation

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -14,9 +14,9 @@ from docutils.nodes import make_id
 from docutils.parsers.rst import Directive, directives
 
 from sphinx.config import string_classes
-from sphinx.roles import XRefRole
-from sphinx.locale import __
 from sphinx.domains import Domain
+from sphinx.locale import __
+from sphinx.roles import XRefRole
 from sphinx.util import logging
 from sphinx.util.nodes import make_refnode, set_source_info
 

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -14,10 +14,10 @@
 from docutils import nodes
 
 import sphinx
-from sphinx.locale import _
 from sphinx.errors import ExtensionError
-from sphinx.ext.mathbase import setup_math as mathbase_setup
 from sphinx.ext.mathbase import get_node_equation_number
+from sphinx.ext.mathbase import setup_math as mathbase_setup
+from sphinx.locale import _
 
 
 def html_visit_math(self, node):

--- a/sphinx/ext/pngmath.py
+++ b/sphinx/ext/pngmath.py
@@ -10,27 +10,26 @@
     :license: BSD, see LICENSE for details.
 """
 
-import re
 import codecs
+import posixpath
+import re
 import shutil
 import tempfile
-import posixpath
+from hashlib import sha1
 from os import path
 from subprocess import Popen, PIPE
-from hashlib import sha1
-
-from six import text_type
 
 from docutils import nodes
+from six import text_type
 
 import sphinx
 from sphinx.errors import SphinxError, ExtensionError
-from sphinx.util import logging
-from sphinx.util.png import read_png_depth, write_png_depth
-from sphinx.util.osutil import ensuredir, ENOENT, cd
-from sphinx.util.pycompat import sys_encoding
-from sphinx.ext.mathbase import setup_math as mathbase_setup, wrap_displaymath
 from sphinx.ext.mathbase import get_node_equation_number
+from sphinx.ext.mathbase import setup_math as mathbase_setup, wrap_displaymath
+from sphinx.util import logging
+from sphinx.util.osutil import ensuredir, ENOENT, cd
+from sphinx.util.png import read_png_depth, write_png_depth
+from sphinx.util.pycompat import sys_encoding
 
 if False:
     # For type annotation

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -13,16 +13,16 @@
 """
 
 from docutils import nodes
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
+from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 
 import sphinx
-from sphinx.locale import _
 from sphinx.environment import NoUri
+from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.nodes import set_source_info
 from sphinx.util.texescape import tex_escape_map
-from docutils.parsers.rst import Directive
-from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 
 if False:
     # For type annotation

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -11,9 +11,8 @@
 
 import traceback
 
-from six import iteritems, text_type
-
 from docutils import nodes
+from six import iteritems, text_type
 
 import sphinx
 from sphinx import addnodes

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -9,23 +9,22 @@
     :license: BSD, see LICENSE for details.
 """
 
+from pygments import highlight
+from pygments.filters import ErrorToken
+from pygments.formatters import HtmlFormatter, LatexFormatter
+from pygments.lexer import Lexer  # NOQA
+from pygments.lexers import get_lexer_by_name, guess_lexer
+from pygments.lexers import PythonLexer, Python3Lexer, PythonConsoleLexer, \
+    CLexer, TextLexer, RstLexer
+from pygments.styles import get_style_by_name
+from pygments.util import ClassNotFound
 from six import text_type
 
+from sphinx.ext import doctest
+from sphinx.pygments_styles import SphinxStyle, NoneStyle
 from sphinx.util import logging
 from sphinx.util.pycompat import htmlescape
 from sphinx.util.texescape import tex_hl_escape_map_new
-from sphinx.ext import doctest
-
-from pygments import highlight
-from pygments.lexer import Lexer  # NOQA
-from pygments.lexers import PythonLexer, Python3Lexer, PythonConsoleLexer, \
-    CLexer, TextLexer, RstLexer
-from pygments.lexers import get_lexer_by_name, guess_lexer
-from pygments.formatters import HtmlFormatter, LatexFormatter
-from pygments.filters import ErrorToken
-from pygments.styles import get_style_by_name
-from pygments.util import ClassNotFound
-from sphinx.pygments_styles import SphinxStyle, NoneStyle
 
 if False:
     # For type annotation

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -8,24 +8,24 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import re
 import codecs
+import re
 
-from docutils.io import FileInput, NullOutput
 from docutils.core import Publisher
+from docutils.io import FileInput, NullOutput
 from docutils.readers import standalone
 from docutils.statemachine import StringList, string2lines
 from docutils.writers import UnfilteredWriter
 from six import text_type
 from typing import Any, Union  # NOQA
 
-from sphinx.transforms import SphinxTransformer
 from sphinx.transforms import (
     ApplySourceWorkaround, ExtraTranslatableNodes, CitationReferences,
     DefaultSubstitutions, MoveModuleTargets, HandleCodeBlocks, SortIds,
     AutoNumbering, AutoIndexUpgrader, FilterSystemMessages,
     UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink
 )
+from sphinx.transforms import SphinxTransformer
 from sphinx.transforms.compact_bullet_list import RefOnlyBulletListTransform
 from sphinx.transforms.i18n import (
     PreserveTranslatableMessages, Locale, RemoveTranslatableInline,

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -11,13 +11,13 @@
 
 from os import path
 from pprint import pformat
+from typing import Any, Callable, Iterator, Tuple  # NOQA
 
-from six import string_types
 from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
     contextfunction
-from jinja2.utils import open_if_exists
 from jinja2.sandbox import SandboxedEnvironment
-from typing import Any, Callable, Iterator, Tuple  # NOQA
+from jinja2.utils import open_if_exists
+from six import string_types
 
 from sphinx.application import TemplateBridge
 from sphinx.util.osutil import mtimes_of_files

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -17,8 +17,8 @@
 from __future__ import print_function
 
 import os
-import sys
 import subprocess
+import sys
 from os import path
 
 import sphinx

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -8,11 +8,11 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import re
 import ast
 import inspect
-import tokenize
 import itertools
+import re
+import tokenize
 from token import NAME, NEWLINE, INDENT, DEDENT, NUMBER, OP, STRING
 from tokenize import COMMENT, NL
 

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -11,8 +11,8 @@
 
 import warnings
 
-from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.cmd.quickstart import main as _main
+from sphinx.deprecation import RemovedInSphinx20Warning
 
 
 def main(*args, **kwargs):

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -15,15 +15,15 @@ import traceback
 from pkg_resources import iter_entry_points
 from six import iteritems, itervalues, string_types
 
-from sphinx.errors import ExtensionError, SphinxError, VersionRequirementError
-from sphinx.extension import Extension
 from sphinx.domains import ObjType
 from sphinx.domains.std import GenericObject, Target
+from sphinx.errors import ExtensionError, SphinxError, VersionRequirementError
+from sphinx.extension import Extension
 from sphinx.locale import __
 from sphinx.parsers import Parser as SphinxParser
 from sphinx.roles import XRefRole
-from sphinx.util import logging
 from sphinx.util import import_object
+from sphinx.util import logging
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.docutils import directive_helper
 

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -11,12 +11,12 @@
 
 import re
 
-from six import iteritems
 from docutils import nodes, utils
+from six import iteritems
 
 from sphinx import addnodes
-from sphinx.locale import _
 from sphinx.errors import SphinxError
+from sphinx.locale import _
 from sphinx.util import ws_re
 from sphinx.util.nodes import split_explicit_title, process_index_entry, \
     set_role_source_info

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -13,12 +13,12 @@
 """
 from __future__ import print_function
 
-import sys
 import os
-
-from six import StringIO, string_types
+import sys
 from distutils.cmd import Command
 from distutils.errors import DistutilsOptionError, DistutilsExecError  # type: ignore
+
+from six import StringIO, string_types
 
 from sphinx.application import Sphinx
 from sphinx.cmdline import handle_exception

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -7,8 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 import os
-import sys
 import shutil
+import sys
 from io import open
 
 from six import PY2, text_type

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -14,16 +14,14 @@ import sys
 import warnings
 from xml.etree import ElementTree
 
-from six import string_types
-
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
+from six import string_types
 
 from sphinx import application
 from sphinx.builders.latex import LaTeXBuilder
 from sphinx.ext.autodoc import AutoDirective
 from sphinx.pycode import ModuleAnalyzer
-
 from sphinx.testing.path import path
 
 if False:

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -16,6 +16,9 @@ from docutils.io import StringInput
 from docutils.utils import relative_path
 
 from sphinx import addnodes
+from sphinx.domains.std import make_glossary_term, split_term_classifiers
+from sphinx.locale import init as init_locale
+from sphinx.transforms import SphinxTransform
 from sphinx.util import split_index_msg, logging
 from sphinx.util.i18n import find_catalog
 from sphinx.util.nodes import (
@@ -23,9 +26,6 @@ from sphinx.util.nodes import (
     extract_messages, is_pending_meta, traverse_translatable_index,
 )
 from sphinx.util.pycompat import indent
-from sphinx.locale import init as init_locale
-from sphinx.transforms import SphinxTransform
-from sphinx.domains.std import make_glossary_term, split_term_classifiers
 
 if False:
     # For type annotation

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -10,15 +10,15 @@
 """
 
 import os
-from math import ceil
 from hashlib import sha1
+from math import ceil
 
-from six import text_type
 from docutils import nodes
+from six import text_type
 
 from sphinx.transforms import SphinxTransform
-from sphinx.util import logging, requests
 from sphinx.util import epoch_to_rfc1123, rfc1123_to_epoch
+from sphinx.util import logging, requests
 from sphinx.util.images import guess_mimetype, get_image_extension, parse_data_uri
 from sphinx.util.osutil import ensuredir, movefile
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -10,24 +10,24 @@
 """
 from __future__ import absolute_import
 
+import fnmatch
 import os
+import posixpath
 import re
 import sys
-import fnmatch
 import tempfile
-import posixpath
 import traceback
 import unicodedata
+from codecs import BOM_UTF8
+from collections import deque
+from datetime import datetime
 from os import path
 from time import mktime, strptime
-from codecs import BOM_UTF8
-from datetime import datetime
-from collections import deque
 
+from docutils.utils import relative_path
 from six import text_type, binary_type, itervalues
 from six.moves import range
 from six.moves.urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
-from docutils.utils import relative_path
 
 from sphinx.errors import PycodeError, SphinxParallelError, ExtensionError
 from sphinx.util import logging

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -10,8 +10,8 @@
 """
 
 import os
-import sys
 import re
+import sys
 
 try:
     # check if colorama is installed to support color on Windows

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -12,14 +12,14 @@ from __future__ import absolute_import
 
 import re
 import types
+from contextlib import contextmanager
 from copy import copy
 from distutils.version import LooseVersion
-from contextlib import contextmanager
 
 import docutils
 from docutils.languages import get_language
-from docutils.statemachine import StateMachine
 from docutils.parsers.rst import directives, roles, convert_directive_function
+from docutils.statemachine import StateMachine
 from docutils.utils import Reporter
 
 from sphinx.errors import ExtensionError

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -10,10 +10,12 @@
 """
 from __future__ import absolute_import
 
-import os
 import codecs
+import os
 import posixpath
+
 from docutils.utils import relative_path
+
 from sphinx.util.osutil import copyfile, ensuredir, walk
 
 if False:

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -12,13 +12,13 @@ import gettext
 import io
 import os
 import re
-from os import path
-from datetime import datetime
 from collections import namedtuple
+from datetime import datetime
+from os import path
 
 import babel.dates
-from babel.messages.pofile import read_po
 from babel.messages.mofile import write_mo
+from babel.messages.pofile import read_po
 
 from sphinx.errors import SphinxError
 from sphinx.util import logging

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -12,12 +12,12 @@ from __future__ import absolute_import
 
 import base64
 import imghdr
-import imagesize
-from os import path
 from collections import OrderedDict
-
-from six import PY3, BytesIO, iteritems
+from os import path
 from typing import NamedTuple
+
+import imagesize
+from six import PY3, BytesIO, iteritems
 
 try:
     from PIL import Image        # check for the Python Imaging Library

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -10,10 +10,10 @@
 """
 from __future__ import absolute_import
 
+import inspect
 import re
 import sys
 import typing
-import inspect
 from collections import OrderedDict
 
 from six import PY2, PY3, StringIO, binary_type, string_types, itervalues

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -8,8 +8,8 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import re
 import os
+import re
 import zlib
 
 from six import PY3

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -12,12 +12,12 @@ from __future__ import absolute_import
 
 import logging
 import logging.handlers
-from contextlib import contextmanager
 from collections import defaultdict
+from contextlib import contextmanager
 
-from six import PY2, StringIO
 from docutils import nodes
 from docutils.utils import get_source_line
+from six import PY2, StringIO
 
 from sphinx.errors import SphinxWarning
 from sphinx.util.console import colorize

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -12,9 +12,8 @@ from __future__ import absolute_import
 
 import re
 
-from six import text_type
-
 from docutils import nodes
+from six import text_type
 
 from sphinx import addnodes
 from sphinx.locale import pairindextypes

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -10,17 +10,18 @@
 """
 from __future__ import print_function
 
+import contextlib
+import errno
+import filecmp
+import locale
 import os
 import re
+import shutil
 import sys
 import time
-import errno
-import locale
-import shutil
-import filecmp
-from os import path
-import contextlib
 from io import BytesIO, StringIO
+from os import path
+
 from six import PY2, PY3, text_type
 
 if False:

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -13,6 +13,7 @@ import os
 import time
 import traceback
 from math import sqrt
+
 from six import iteritems
 
 try:

--- a/sphinx/util/png.py
+++ b/sphinx/util/png.py
@@ -9,8 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import struct
 import binascii
+import struct
 
 
 LEN_IEND = 12

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -9,8 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import sys
 import codecs
+import sys
 
 from six import PY3, text_type, exec_
 

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -14,11 +14,11 @@ from __future__ import absolute_import
 import warnings
 from contextlib import contextmanager
 
-import requests
 import pkg_resources
-
+import requests
 from six import string_types
 from six.moves.urllib.parse import urlsplit
+
 try:
     from requests.packages.urllib3.exceptions import SSLError
 except ImportError:

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -28,7 +28,9 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
+
 from docutils.utils import smartquotes
+
 from sphinx.util.docutils import __version_info__ as docutils_version
 
 if False:  # For type annotation

--- a/sphinx/util/tags.py
+++ b/sphinx/util/tags.py
@@ -9,8 +9,8 @@
 
 # (ab)use the Jinja parser for parsing our boolean expressions
 from jinja2 import nodes
-from jinja2.parser import Parser
 from jinja2.environment import Environment
+from jinja2.parser import Parser
 
 env = Environment()
 

--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -10,6 +10,7 @@
 """
 
 import os
+
 from jinja2.sandbox import SandboxedEnvironment
 
 from sphinx import package_dir

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -9,11 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 
-from six import PY3
 from typing import Callable, Dict, List, Tuple
 
 from docutils import nodes
 from docutils.parsers.rst.states import Inliner
+from six import PY3
 
 
 if PY3:

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -9,13 +9,13 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from uuid import uuid4
-from operator import itemgetter
 from itertools import product
+from operator import itemgetter
+from uuid import uuid4
 
 from six import iteritems
-from six.moves import range, zip_longest
 from six.moves import cPickle as pickle
+from six.moves import range, zip_longest
 
 from sphinx.transforms import SphinxTransform
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -9,14 +9,14 @@
     :license: BSD, see LICENSE for details.
 """
 
-import sys
-import posixpath
-import os
 import copy
+import os
+import posixpath
+import sys
 
-from six import string_types
 from docutils import nodes
 from docutils.writers.html4css1 import Writer, HTMLTranslator as BaseTranslator
+from six import string_types
 
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -9,13 +9,13 @@
     :license: BSD, see LICENSE for details.
 """
 
-import sys
-import posixpath
 import os
+import posixpath
+import sys
 
-from six import string_types
 from docutils import nodes
 from docutils.writers.html5_polyglot import HTMLTranslator as BaseTranslator
+from six import string_types
 
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -14,12 +14,12 @@
 
 import re
 import sys
-from os import path
 from collections import defaultdict
+from os import path
 
-from six import itervalues, text_type
 from docutils import nodes, writers
 from docutils.writers.latex2e import Babel
+from six import itervalues, text_type
 
 from sphinx import addnodes
 from sphinx import highlighting

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -16,10 +16,10 @@ from docutils.writers.manpage import (
     Translator as BaseTranslator
 )
 
+import sphinx.util.docutils
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
-import sphinx.util.docutils
 from sphinx.util.i18n import format_date
 
 if False:

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -13,10 +13,9 @@ import re
 import textwrap
 from os import path
 
+from docutils import nodes, writers
 from six import itervalues
 from six.moves import range
-
-from docutils import nodes, writers
 
 from sphinx import addnodes, __display_version__
 from sphinx.errors import ExtensionError

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -13,10 +13,9 @@ import re
 import textwrap
 from itertools import groupby
 
-from six.moves import zip_longest
-
 from docutils import nodes, writers
 from docutils.utils import column_width
+from six.moves import zip_longest
 
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -2,12 +2,12 @@
 
 from __future__ import print_function
 
+import argparse
 import os
 import re
 import sys
-import argparse
-from datetime import datetime
 from contextlib import contextmanager
+from datetime import datetime
 
 script_dir = os.path.dirname(__file__)
 package_dir = os.path.abspath(os.path.join(script_dir, '..'))

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -11,6 +11,7 @@
 
 import os
 import re
+
 import sphinx
 
 name_mail_re = r'[\w ]+(<.*?>)?'

--- a/utils/jssplitter_generator.py
+++ b/utils/jssplitter_generator.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import re
 import json
+import re
 import subprocess
 import sys
+
 import six
 
 # find char codes they are matched with Python's (?u)\\w


### PR DESCRIPTION
### Feature or Bugfix
- Coding styles

### Purpose
- To regulate order of imports
    - standard libraries
    - third parties
    - Sphinx modules