### PR TITLE
Fix #3447: latex: longtable may render "horizontally" and overflow in right margin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@ Bugs fixed
 * #4472: DOCUMENTATION_OPTIONS is not defined
 * #4491: autodoc: prefer _MockImporter over other importers in sys.meta_path
 * #4490: autodoc: type annotation is broken with python 3.7.0a4+
+* #3447: latex: longtable may render "horizontally" and overflow in right margin
+
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -407,6 +407,13 @@ class Table(object):
             return '{|' + ('T|' * self.colcount) + '}\n'
         elif self.has_oldproblematic:
             return '{|*{%d}{\\X{1}{%d}|}}\n' % (self.colcount, self.colcount)
+        elif self.is_longtable():
+            # Workaround: Give a default colspec to avoid overflows if ``:widths:`` or
+            # ``tabularcolumns`` are not specified.
+            # see https://github.com/sphinx-doc/sphinx/issues/3447
+            total = self.width
+            colspecs = ['\\X{%d}{%d}' % (1, total) for _ in range(total)]
+            return '{|%s|}\n' % '|'.join(colspecs)
         else:
             return '{|' + ('l|' * self.colcount) + '}\n'
 
@@ -437,6 +444,24 @@ class Table(object):
             return TableCell(self, row, col)
         except IndexError:
             return None
+
+    @property
+    def width(self):
+        # type: () -> int
+        """Returns the table width."""
+        width = 0
+        while self.cells[(0, width)]:
+            width += 1
+        return width
+
+    @property
+    def height(self):
+        # type: () -> int
+        """Returns the table height."""
+        height = 0
+        while self.cells[(height, 0)]:
+            height += 1
+        return height
 
 
 class TableCell(object):

--- a/tests/roots/test-latex-table/expects/longtable.tex
+++ b/tests/roots/test-latex-table/expects/longtable.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{1}{2}|\X{1}{2}|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_align.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_align.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-align-option}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[r]{|l|l|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[r]{|\X{1}{2}|\X{1}{2}|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-caption}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{1}{2}|\X{1}{2}|}
 \caption{caption for longtable\strut}\label{\detokenize{longtable:id1}}\\*[\sphinxlongtablecapskipadjust]
 \hline
 \sphinxstyletheadfamily 


### PR DESCRIPTION
refs: #3447

This is just an idea. But it seems working fine.
@jfbu could you give me a comment for this?