### PR TITLE
[WIP] LaTeX: estimate colwidths via Python for better tables

### DIFF
--- a/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-problematic-cell}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{2}{\X{1}{2}|}}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\Y{0.800}|l|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-both-stub-columns-and-problematic-cell}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{3}{\X{1}{3}|}}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\Y{0.698}|l|l|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-verbatim}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{2}{\X{1}{2}|}}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\Y{0.873}|l|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/table_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_problematic_cell.tex
@@ -2,7 +2,7 @@
 
 \begin{savenotes}\sphinxattablestart
 \centering
-\begin{tabular}[t]{|*{2}{\X{1}{2}|}}
+\begin{tabular}[t]{|\Y{0.800}|l|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/table_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_stub_columns_and_problematic_cell.tex
@@ -2,7 +2,7 @@
 
 \begin{savenotes}\sphinxattablestart
 \centering
-\begin{tabular}[t]{|*{3}{\X{1}{3}|}}
+\begin{tabular}[t]{|\Y{0.698}|l|l|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/table_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/table_having_verbatim.tex
@@ -2,7 +2,7 @@
 
 \begin{savenotes}\sphinxattablestart
 \centering
-\begin{tabular}[t]{|*{2}{\X{1}{2}|}}
+\begin{tabular}[t]{|\Y{0.873}|l|}
 \hline
 \sphinxstyletheadfamily 
 header1


### PR DESCRIPTION
Relates #3447, #4506 

This is proof of concept.

Some aspects need improvement (see review below), but I also tested that it gives better results in some cases than LaTeX macro package `tabulary`. Indeed, it may open possibility to remove entirely usage of `tabulary` at some point. For example with this

```rst
.. table::

   ========= ======== =======================================================
   Tag       Required Description
   ========= ======== =======================================================
   columns   No       Columns of the content to return. Each content listing
                      has a set of defaults columns that make sense for that
                      particular content type. By default, these columns are
                      returned in addition to what was requested here.
   xquery    No       A  xquery
   filter    No       Return files containing the specified filter string
   ========= ======== =======================================================
```

and modifying latex.py to not use tabulary but tabular with the `\Y` columns as determined by latex writer itself one gets this:

![capture d ecran 2018-01-27 a 22 10 53](https://user-images.githubusercontent.com/2589111/35476819-e8f7a0f8-03b6-11e8-9a25-06ffc44e4d7f.png)

which is better than the currently produced output using tabulary:

![capture d ecran 2018-01-27 a 22 59 44](https://user-images.githubusercontent.com/2589111/35476825-f9d289ec-03b6-11e8-8217-289f57b1a2f6.png)

(such table currently needs to be fixed by using tabularcolumns, but image above shows Sphinx could get it wright itself)