### PR TITLE
Give local-plugins.paths option to flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ exclude = .git,.tox,.venv,tests/*,build/*,doc/_build/*,sphinx/search/*,sphinx/py
 [flake8:local-plugins]
 extension =
     X101 = utils.checks:sphinx_has_header
+paths =
+    .
 
 [mypy]
 python_version = 2.7


### PR DESCRIPTION
It will be available on flake8-3.5.0+.
(see https://gitlab.com/pycqa/flake8/issues/379)

This is useful for global flake8 command (I usually uses flake8 command outside virtualenv).