### PR TITLE
Fix #3952: apidoc: module header is too escaped

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * #4472: DOCUMENTATION_OPTIONS is not defined
 * #4491: autodoc: prefer _MockImporter over other importers in sys.meta_path
 * #4490: autodoc: type annotation is broken with python 3.7.0a4+
+* #3952: apidoc: module header is too escaped
 
 Testing
 --------

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -23,13 +23,15 @@ if False:
     # For type annotation
     from typing import Generator  # NOQA
 
-symbols_re = re.compile(r'([!-/:-@\[-`{-~])')
+symbols_re = re.compile(r'([!--/:-@\[-`{-~])')  # symbols without dot(0x2e)
 logger = logging.getLogger(__name__)
 
 
 def escape(text):
     # type: (unicode) -> unicode
-    return symbols_re.sub(r'\\\1', text)  # type: ignore
+    text = symbols_re.sub(r'\\\1', text)  # type: ignore
+    text = re.sub(r'^\.', r'\.', text)  # escape a dot at top
+    return text
 
 
 @contextmanager

--- a/tests/test_util_rst.py
+++ b/tests/test_util_rst.py
@@ -14,3 +14,5 @@ from sphinx.util.rst import escape
 def test_escape():
     assert escape(':ref:`id`') == r'\:ref\:\`id\`'
     assert escape('footnote [#]_') == r'footnote \[\#\]\_'
+    assert escape('sphinx.application') == r'sphinx.application'
+    assert escape('.. toctree::') == r'\.. toctree\:\:'


### PR DESCRIPTION
refs: #3952 