### PR TITLE
Fix autosectionlabel does not support parallel build

### DIFF
--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -16,8 +16,14 @@ from sphinx.util.nodes import clean_astext
 
 logger = logging.getLogger(__name__)
 
+if False:
+    # For type annotation
+    from typing import Any, Dict  # NOQA
+    from sphinx.application import Sphinx  # NOQA
+
 
 def register_sections_as_label(app, document):
+    # type: (Sphinx, nodes.Node) -> None
     labels = app.env.domaindata['std']['labels']
     anonlabels = app.env.domaindata['std']['anonlabels']
     for node in document.traverse(nodes.section):
@@ -39,5 +45,12 @@ def register_sections_as_label(app, document):
 
 
 def setup(app):
+    # type: (Sphinx) -> Dict[unicode, Any]
     app.add_config_value('autosectionlabel_prefix_document', False, 'env')
     app.connect('doctree-read', register_sections_as_label)
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
Unfortunately, autosectionlabel extension does not returns its metadata...