### PR TITLE
mathbase.py: Fix ValueError too many values to unpack

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Bugs fixed
 * #4514: graphviz: workaround for wrong map ID which graphviz generates
 * #4525: autosectionlabel does not support parallel build
 * #3953: Do not raise warning when there is a working intersphinx inventory
+* #4487: math: ValueError is raised on parallel build. Thanks to jschueller.
 
 Testing
 --------

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -68,7 +68,7 @@ class MathDomain(Domain):
         # type: (Iterable[unicode], Dict) -> None
         for labelid, (doc, eqno) in otherdata['objects'].items():
             if doc in docnames:
-                self.data['objects'][labelid] = doc
+                self.data['objects'][labelid] = (doc, eqno)
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         # type: (BuildEnvironment, unicode, Builder, unicode, unicode, nodes.Node, nodes.Node) -> nodes.Node  # NOQA


### PR DESCRIPTION
refs: #4487 
