### PR TITLE
Reimplement needs_extensions checker as a config-init handler

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -33,7 +33,6 @@ from sphinx.errors import (
     ApplicationError, ConfigError, ExtensionError, VersionRequirementError
 )
 from sphinx.events import EventManager
-from sphinx.extension import verify_required_extensions
 from sphinx.locale import __
 from sphinx.registry import SphinxComponentRegistry
 from sphinx.util import import_object
@@ -86,6 +85,7 @@ builtin_extensions = (
     'sphinx.directives.code',
     'sphinx.directives.other',
     'sphinx.directives.patches',
+    'sphinx.extension',
     'sphinx.io',
     'sphinx.parsers',
     'sphinx.registry',
@@ -237,9 +237,6 @@ class Sphinx(object):
         # now that we know all config values, collect them from conf.py
         self.config.init_values()
         self.emit('config-inited', self.config)
-
-        # check extension versions if requested
-        verify_required_extensions(self, self.config.needs_extensions)
 
         # check primary_domain if requested
         primary_domain = self.config.primary_domain

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -17,8 +17,9 @@ from sphinx.util import logging
 
 if False:
     # For type annotation
-    from typing import Dict  # NOQA
+    from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
+    from sphinx.config import Config  # NOQA
 
 logger = logging.getLogger(__name__)
 
@@ -41,13 +42,13 @@ class Extension(object):
         self.parallel_write_safe = kwargs.pop('parallel_write_safe', True)
 
 
-def verify_required_extensions(app, requirements):
-    # type: (Sphinx, Dict[unicode, unicode]) -> None
+def verify_needs_extensions(app, config):
+    # type: (Sphinx, Config) -> None
     """Verify the required Sphinx extensions are loaded."""
-    if requirements is None:
+    if config.needs_extensions is None:
         return
 
-    for extname, reqversion in iteritems(requirements):
+    for extname, reqversion in iteritems(config.needs_extensions):
         extension = app.extensions.get(extname)
         if extension is None:
             logger.warning(__('The %s extension is required by needs_extensions settings,'
@@ -59,3 +60,14 @@ def verify_required_extensions(app, requirements):
                                              'version %s and therefore cannot be built with '
                                              'the loaded version (%s).') %
                                           (extname, reqversion, extension.version))
+
+
+def setup(app):
+    # type: (Sphinx) -> Dict[unicode, Any]
+    app.connect('config-inited', verify_needs_extensions)
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
This is refactoring.

Note: I feel merging `needs_sphinx` and `extensions` is better.