### PR TITLE
Fix #4019: exception treatment for AttributeError stopping make process

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Other contributors, listed alphabetically, are:
 * Joel Wurtz -- cellspanning support in LaTeX
 * Hong Xu -- svg support in imgmath extension and various bug fixes
 * Stephen Finucane -- setup command improvements and documentation
+* Daniel Pizetta -- inheritance diagram improvements
 
 Many thanks for all contributions!
 

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Features added
 
 Bugs fixed
 ----------
+* #4019: inheritance_diagram AttributeError stoping make process
 
 Testing
 --------

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -76,18 +76,20 @@ def try_import(objname):
         __import__(objname)
         return sys.modules.get(objname)  # type: ignore
     except ImportError:
-        try:
-            modname, attrname = module_sig_re.match(objname).groups()  # type: ignore
-        except AttributeError:
+        matched = module_sig_re.match(objname)  # type: ignore
+
+        if not matched:
             return None
-        else:
-            if modname is None:
-                return None
-            try:
-                __import__(modname)
-                return getattr(sys.modules.get(modname), attrname, None)
-            except ImportError:
-                return None
+
+        modname, attrname = matched.groups()
+
+        if modname is None:
+            return None
+        try:
+            __import__(modname)
+            return getattr(sys.modules.get(modname), attrname, None)
+        except ImportError:
+            return None
 
 
 def import_classes(name, currmodule):

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -80,14 +80,18 @@ def try_import(objname):
         __import__(objname)
         return sys.modules.get(objname)  # type: ignore
     except ImportError:
-        modname, attrname = module_sig_re.match(objname).groups()  # type: ignore
-        if modname is None:
-            return None
         try:
-            __import__(modname)
-            return getattr(sys.modules.get(modname), attrname, None)
-        except ImportError:
+            modname, attrname = module_sig_re.match(objname).groups()  # type: ignore
+        except AttributeError:
             return None
+        else:
+            if modname is None:
+                return None
+            try:
+                __import__(modname)
+                return getattr(sys.modules.get(modname), attrname, None)
+            except ImportError:
+                return None
 
 
 def import_classes(name, currmodule):

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -75,7 +75,7 @@ def try_import(objname):
     try:
         __import__(objname)
         return sys.modules.get(objname)  # type: ignore
-    except ImportError:
+    except (ImportError, ValueError):  # ValueError,py27 -> ImportError,py3
         matched = module_sig_re.match(objname)  # type: ignore
 
         if not matched:
@@ -88,7 +88,7 @@ def try_import(objname):
         try:
             __import__(modname)
             return getattr(sys.modules.get(modname), attrname, None)
-        except ImportError:
+        except (ImportError, ValueError):  # ValueError,py27 -> ImportError,py3
             return None
 
 

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -83,6 +83,15 @@ def test_import_classes(rootdir):
         with pytest.raises(InheritanceException):
             import_classes('unknown.Unknown', None)
 
+        # got exception InheritanceException for wrong class or module
+        # not AttributeError (refs: #4019)
+        with pytest.raises(InheritanceException):
+            import_classes('unknown', '.')
+        with pytest.raises(InheritanceException):
+            import_classes('unknown.Unknown', '.')
+        with pytest.raises(InheritanceException):
+            import_classes('.', None)
+
         # a module having no classes
         classes = import_classes('sphinx', None)
         assert classes == []


### PR DESCRIPTION
Subject: AttributeError/ValueError exceptions are stopping make process

### Feature or Bugfix
- Bugfix

### Purpose
- These should not stop make process, after all, the warning about missing module is still showed. 

### Detail
- Insert treatment for attribute error when trying to get group attribute from a None object. It is caused by a not found module name inserted in inheritance diagram.
- Add author
- Add changes
- Add tests
- Catch ValueError when importing for compatibility with Python 2.7 (ImportError for Python 3)

### Relates
- #4019 
