### PR TITLE
Stop testings for graphviz on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ matrix:
     - python: '2.7'
       env: TOXENV=flake8
 
-addons:
-  apt:
-    packages:
-      - graphviz
-      - imagemagick
-
 install:
   - pip install -U tox codecov
 


### PR DESCRIPTION
To make our test faster, this stops testings for graphviz on Travis CI.
Instead of that, Circle CI confirms they are passed.
