### PR TITLE
Fix #4543: test for autodoc fails with python 3.5.3

### DIFF
--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -950,7 +950,7 @@ def test_partialmethod():
         '      Update state of cell to *state*.',
         '      ',
     ]
-    if sys.version_info < (3, 5):
+    if sys.version_info < (3, 5, 4):
         expected = '\n'.join(expected).replace(' -> None', '').split('\n')
 
     assert call_autodoc('class', 'target.partialmethod.Cell') == expected


### PR DESCRIPTION
refs: #4543 