### PR TITLE
potential typo

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -75,8 +75,8 @@
   <p>{%trans%}
     You can also download PDF/EPUB versions of the Sphinx documentation:
     a <a href="https://media.readthedocs.org/pdf/sphinx/stable/sphinx.pdf">PDF version</a> generated from
-    the LaTeX Sphinx produces, and
-    a <a href="https://media.readthedocs.org/epub/sphinx/stable/sphinx.epub">EPUB version</a>.
+    the LaTeX Sphinx producer, and
+    an <a href="https://media.readthedocs.org/epub/sphinx/stable/sphinx.epub">EPUB version</a>.
    {%endtrans%}
   </p>
 


### PR DESCRIPTION
Subject: Fixes typo

`You can also download PDF/EPUB versions of the Sphinx documentation: a PDF version generated from the LaTeX Sphinx produces, and an EPUB version.`

Either a typo or maybe wrong sentence structure.

### Feature or Bugfix
<!-- please choose -->
- Bugfix (typo)

### Purpose
- rectifies potential typographical errors.


### Relates
- http://www.sphinx-doc.org/en/stable/
