### PR TITLE
Make the log message more translation-friendly

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -687,8 +687,10 @@ class Sphinx(object):
         """
         if typ == 'read':
             attrname = 'parallel_read_safe'
+            gerund_typ = __("reading")
         elif typ == 'write':
             attrname = 'parallel_write_safe'
+            gerund_typ = __("writing")
         else:
             raise ValueError('parallel type %s is not supported' % typ)
 
@@ -696,9 +698,9 @@ class Sphinx(object):
             allowed = getattr(ext, attrname, None)
             if allowed is None:
                 logger.warning(__("the %s extension does not declare if it is safe "
-                                  "for parallel %sing, assuming it isn't - please "
+                                  "for parallel %s, assuming it isn't - please "
                                   "ask the extension author to check and make it "
-                                  "explicit"), ext.name, typ)
+                                  "explicit"), ext.name, gerund_typ)
                 logger.warning('doing serial %s', typ)
                 return False
             elif not allowed:

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -687,20 +687,23 @@ class Sphinx(object):
         """
         if typ == 'read':
             attrname = 'parallel_read_safe'
-            gerund_typ = __("reading")
+            message = __("the %s extension does not declare if it is safe "
+                         "for parallel reading, assuming it isn't - please "
+                         "ask the extension author to check and make it "
+                         "explicit")
         elif typ == 'write':
             attrname = 'parallel_write_safe'
-            gerund_typ = __("writing")
+            message = __("the %s extension does not declare if it is safe "
+                         "for parallel writing, assuming it isn't - please "
+                         "ask the extension author to check and make it "
+                         "explicit")
         else:
             raise ValueError('parallel type %s is not supported' % typ)
 
         for ext in itervalues(self.extensions):
             allowed = getattr(ext, attrname, None)
             if allowed is None:
-                logger.warning(__("the %s extension does not declare if it is safe "
-                                  "for parallel %s, assuming it isn't - please "
-                                  "ask the extension author to check and make it "
-                                  "explicit"), ext.name, gerund_typ)
+                logger.warning(message, ext.name)
                 logger.warning('doing serial %s', typ)
                 return False
             elif not allowed:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -106,7 +106,8 @@ def test_add_is_parallel_allowed(app, status, warning):
     app.setup_extension('write_parallel')
     assert app.is_parallel_allowed('read') is False
     assert app.is_parallel_allowed('write') is True
-    assert 'the write_parallel extension does not declare' in warning.getvalue()
+    assert ("the write_parallel extension does not declare if it is safe "
+            "for parallel reading, assuming it isn't - please ") in warning.getvalue()
     app.extensions.pop('write_parallel')
     warning.truncate(0)  # reset warnings
 
@@ -119,6 +120,7 @@ def test_add_is_parallel_allowed(app, status, warning):
     app.setup_extension('write_serial')
     assert app.is_parallel_allowed('read') is False
     assert app.is_parallel_allowed('write') is False
-    assert 'the write_serial extension does not declare' in warning.getvalue()
+    assert ("the write_serial extension does not declare if it is safe "
+            "for parallel reading, assuming it isn't - please ") in warning.getvalue()
     app.extensions.pop('write_serial')
     warning.truncate(0)  # reset warnings


### PR DESCRIPTION
Subject: Make the log message more translation-friendly

### Feature or Bugfix
- Bugfix

### Purpose
- Since current log message is not suitable for translation, so this PR organize log message templates in order to make the messages more translation-friendly.
- Since current log message may produce an incorrectly spelled word, so this PR fix that bug.

### Detail
- ~~Separate a gerund of a processing type from the log message~~
- ~~Make a gerund of a processing type translatable~~
- Separate a log message for read processing from for write processing

### Relates
- N/A

