### PR TITLE
Unify expression of terms in the log message

### DIFF
--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -214,7 +214,7 @@ class SphinxComponentRegistry(object):
             parser_class = self.source_parsers.get('*')
 
         if parser_class is None:
-            raise SphinxError(__('Source parser for %s not registered') % filename)
+            raise SphinxError(__('source_parser for %s not registered') % filename)
         else:
             if isinstance(parser_class, string_types):
                 parser_class = import_object(parser_class, 'source parser')  # type: ignore


### PR DESCRIPTION
Subject: Unify expression of terms in the log message

### Feature or Bugfix
- Bugfix

### Purpose
- Unify expression of terms in the log message

### Detail
- Replace `Source input` with `source_input`

### Relates
- N/A

