### PR TITLE
test: Remove function based directives

### DIFF
--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -92,11 +92,6 @@ def userdesc_parse(env, sig, signode):
     return x
 
 
-def functional_directive(name, arguments, options, content, lineno,
-                         content_offset, block_text, state, state_machine):
-    return [nodes.strong(text='from function: %s' % options['opt'])]
-
-
 class ClassDirective(Directive):
     option_spec = {'opt': lambda x: x}
 
@@ -108,7 +103,6 @@ def setup(app):
     import parsermod
 
     app.add_config_value('value_from_conf_py', 42, False)
-    app.add_directive('funcdir', functional_directive, opt=lambda x: x)
     app.add_directive('clsdir', ClassDirective)
     app.add_object_type('userdesc', 'userdescrole', '%s (userdesc)',
                         userdesc_parse, objname='user desc')

--- a/tests/roots/test-root/extapi.txt
+++ b/tests/roots/test-root/extapi.txt
@@ -3,8 +3,5 @@ Extension API tests
 
 Testing directives:
 
-.. funcdir::
-   :opt: Foo
-
 .. clsdir::
    :opt: Bar

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -186,7 +186,6 @@ def test_html_warnings(app, warning):
         (".//dd/p", r'Return spam\.'),
     ],
     'extapi.html': [
-        (".//strong", 'from function: Foo'),
         (".//strong", 'from class: Bar'),
     ],
     'markup.html': [

--- a/tests/test_build_html5.py
+++ b/tests/test_build_html5.py
@@ -95,7 +95,6 @@ def cached_etree_parse():
         (".//dd/p", r'Return spam\.'),
     ],
     'extapi.html': [
-        (".//strong", 'from function: Foo'),
         (".//strong", 'from class: Bar'),
     ],
     'markup.html': [


### PR DESCRIPTION
After merging #4558, many deprecation warnings are shown on our test.
And the tests for function based directives are not needed now.

So I remove this from master branch.