### PR TITLE
io: Choose FileInput using ``supported`` attribute (refs: #4564)

### DIFF
--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -208,7 +208,7 @@ class SphinxBaseFileInput(FileInput):
 
 class SphinxFileInput(SphinxBaseFileInput):
     """A basic FileInput for Sphinx."""
-    pass
+    supported = ('*',)  # special source input
 
 
 class SphinxRSTFileInput(SphinxBaseFileInput):
@@ -225,6 +225,7 @@ class SphinxRSTFileInput(SphinxBaseFileInput):
        For that reason, ``sphinx.parsers.RSTParser`` should be used with this to parse
        a content correctly.
     """
+    supported = ('restructuredtext',)
 
     def prepend_prolog(self, text, prolog):
         # type: (StringList, unicode) -> None
@@ -295,8 +296,9 @@ def read_doc(app, env, filename):
 
 
 def setup(app):
-    app.registry.add_source_input('*', SphinxFileInput)
-    app.registry.add_source_input('restructuredtext', SphinxRSTFileInput)
+    # type: (Sphinx) -> Dict[unicode, Any]
+    app.registry.add_source_input(SphinxFileInput)
+    app.registry.add_source_input(SphinxRSTFileInput)
 
     return {
         'version': 'builtin',

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -232,11 +232,13 @@ class SphinxComponentRegistry(object):
             parser.set_application(app)
         return parser
 
-    def add_source_input(self, filetype, input_class):
-        # type: (unicode, Type[Input]) -> None
-        if filetype in self.source_inputs:
-            raise ExtensionError(__('source_input for %r is already registered') % filetype)
-        self.source_inputs[filetype] = input_class
+    def add_source_input(self, input_class):
+        # type: (Type[Input]) -> None
+        for filetype in input_class.supported:
+            if filetype in self.source_inputs:
+                raise ExtensionError(__('source_input for %r is already registered') %
+                                     filetype)
+            self.source_inputs[filetype] = input_class
 
     def get_source_input(self, filename):
         # type: (unicode) -> Type[Input]


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Use ``supported`` column to represent what format `FileInput` supports (following standards of docutils component)

### Detail
- `FileInput` is introduced in 1.7 (new feature), so this change does not break compatibility
- `registry.add_file_input()` is not a public interface (registry is also private).

### Relates
- #4579

