### PR TITLE
optimize: Don't use transform to process only nodes on resolving toctree

### DIFF
--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -14,7 +14,7 @@ from six import iteritems
 
 from sphinx import addnodes
 from sphinx.util import url_re, logging
-from sphinx.util.nodes import clean_astext
+from sphinx.util.nodes import clean_astext, process_only_nodes
 
 if False:
     # For type annotation
@@ -157,7 +157,7 @@ class TocTree(object):
                         maxdepth = self.env.metadata[ref].get('tocdepth', 0)
                         if ref not in toctree_ancestors or (prune and maxdepth > 0):
                             self._toctree_prune(toc, 2, maxdepth, collapse)
-                        self.process_only_nodes(toc)
+                        process_only_nodes(toc, builder.tags)
                         if title and toc.children and len(toc.children) == 1:
                             child = toc.children[0]
                             for refnode in child.traverse(nodes.reference):
@@ -297,7 +297,7 @@ class TocTree(object):
             # the document does not exist anymore: return a dummy node that
             # renders to nothing
             return nodes.paragraph()
-        self.process_only_nodes(toc)
+        process_only_nodes(toc, builder.tags)
         for node in toc.traverse(nodes.reference):
             node['refuri'] = node['anchorname'] or '#'
         return toc
@@ -322,14 +322,3 @@ class TocTree(object):
         for toctree in toctrees[1:]:
             result.extend(toctree.children)
         return result
-
-    def process_only_nodes(self, doctree):
-        # type: (nodes.Node) -> None
-        # Lazy loading
-        from sphinx.transforms import SphinxTransformer
-        from sphinx.transforms.post_transforms import OnlyNodeTransform
-
-        transformer = SphinxTransformer(doctree)
-        transformer.set_environment(self.env)
-        transformer.add_transform(OnlyNodeTransform)
-        transformer.apply_transforms()

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -20,6 +20,7 @@ from sphinx.environment import NoUri
 from sphinx.locale import __
 from sphinx.transforms import SphinxTransform
 from sphinx.util import logging
+from sphinx.util.nodes import process_only_nodes
 
 if False:
     # For type annotation
@@ -183,18 +184,7 @@ class OnlyNodeTransform(SphinxTransform):
         # result in a "Losing ids" exception if there is a target node before
         # the only node, so we make sure docutils can transfer the id to
         # something, even if it's just a comment and will lose the id anyway...
-        for node in self.document.traverse(addnodes.only):
-            try:
-                ret = self.app.builder.tags.eval_condition(node['expr'])
-            except Exception as err:
-                logger.warning('exception while evaluating only directive expression: %s', err,
-                               location=node)
-                node.replace_self(node.children or nodes.comment())
-            else:
-                if ret:
-                    node.replace_self(node.children or nodes.comment())
-                else:
-                    node.replace_self(nodes.comment())
+        process_only_nodes(self.document, self.app.builder.tags)
 
 
 def setup(app):

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -361,6 +361,27 @@ def is_smartquotable(node):
         return True
 
 
+def process_only_nodes(document, tags):
+    # type: (nodes.Node, Tags) -> None
+    """Filter ``only`` nodes which does not match *tags*."""
+    for node in document.traverse(addnodes.only):
+        try:
+            ret = tags.eval_condition(node['expr'])
+        except Exception as err:
+            logger.warning('exception while evaluating only directive expression: %s', err,
+                           location=node)
+            node.replace_self(node.children or nodes.comment())
+        else:
+            if ret:
+                node.replace_self(node.children or nodes.comment())
+            else:
+                # A comment on the comment() nodes being inserted: replacing by [] would
+                # result in a "Losing ids" exception if there is a target node before
+                # the only node, so we make sure docutils can transfer the id to
+                # something, even if it's just a comment and will lose the id anyway...
+                node.replace_self(nodes.comment())
+
+
 # monkey-patch Element.copy to copy the rawsource and line
 
 def _new_copy(self):


### PR DESCRIPTION
This avoid to use ``SphinxTransformer`` to apply ``process_only_nodes``
on resolving toctree.  It can skip to generate documentation node.  The
generation is too heavy process only for single transformation.

This is a first step for #4576.