### PR TITLE
Add html stylesheets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,7 +35,8 @@ Features added
 * :confval:`source_suffix` allows a mapping fileext to file types
 * Add :confval:`author` as a configuration value
 * #2852: imgconverter: Support to convert GIF to PNG
-* Add :confval:`html_stylesheets` and :confval:`html_javascripts`
+* Add :confval:`html_stylesheets`, :confval:`html_javascripts` and
+  :confval:`epub_stylesheets`
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Features added
 * :confval:`source_suffix` allows a mapping fileext to file types
 * Add :confval:`author` as a configuration value
 * #2852: imgconverter: Support to convert GIF to PNG
+* Add :confval:`html_stylesheets` and :confval:`html_javascripts`
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ Deprecated
   based directives.
 * :confval:`html_style` is deprecated. Please use :confval:`html_stylesheets`
   instead
+* ``builder.script_files`` is deprecated.  Please use ``add_javascript()``
+  instead.
 
 Features added
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,8 @@ Deprecated
   ``sphinx.util.import_object()`` instead.
 * Drop function based directive support.  For now, Sphinx only supports class
   based directives.
+* :confval:`html_style` is deprecated. Please use :confval:`html_stylesheets`
+  instead
 
 Features added
 --------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -59,9 +59,6 @@ Important points to note:
   Note that the current builder tag is not available in ``conf.py``, as it is
   created *after* the builder is initialized.
 
-.. seealso:: Additional configurations, such as adding stylesheets,
-   javascripts, builders, etc. can be made through the :doc:`/extdev/appapi`.
-
 
 General configuration
 ---------------------
@@ -878,6 +875,14 @@ that use Sphinx's HTMLWriter class.
       The dotfiles in the extra directory will be copied to the output directory.
       And it refers :confval:`exclude_patterns` on copying extra files and
       directories, and ignores if path matches to patterns.
+
+.. confval:: html_stylesheets
+
+   .. versionadded:: 1.8
+
+.. confval:: html_javascripts
+
+   .. versionadded:: 1.8
 
 .. confval:: html_last_updated_fmt
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -797,6 +797,9 @@ that use Sphinx's HTMLWriter class.
    theme.  If you only want to add or override a few things compared to the
    theme's stylesheet, use CSS ``@import`` to import the theme's stylesheet.
 
+   .. deprecated:: 1.8
+      Use :confval:`html_stylesheets` instead.
+
 .. confval:: html_title
 
    The "title" for HTML documentation generated with Sphinx's own templates.

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -878,9 +878,23 @@ that use Sphinx's HTMLWriter class.
 
 .. confval:: html_stylesheets
 
+   A list of CSS files.  The entry must be a *filename* string or a tuple
+   containing the *filename* string, the *alternate* (of boolean type) and
+   *title* (a string).  The *filename* must be relative to the
+   :confval:`html_static_path`, or a full URI with scheme like
+   ``http://example.org/style.css``.  It defaults to an empty list.
+
+   For more information about *alternate*, refer to the `MDN web docs`__.
+
+   __ https://mdn.io/Web/CSS/Alternative_style_sheets
+
    .. versionadded:: 1.8
 
 .. confval:: html_javascripts
+
+   A list of JavaScript *filename*.  The *filename* must be relative to the
+   :confval:`html_static_path`, or a full URI with scheme.  It defaults to
+   an empty list.
 
    .. versionadded:: 1.8
 
@@ -1543,6 +1557,13 @@ the `Dublin Core metadata <http://dublincore.org/>`_.
    It is a list of tuples containing the file name and the title.  This option
    can be used to add an appendix.  If the title is empty, no entry is added
    to :file:`toc.ncx`.  The default value is ``[]``.
+
+.. confval:: epub_stylesheets
+
+   A list of CSS files.  See :confval:`html_stylesheets` for details.  By
+   default, it defaults to the value of ``html_stylesheets``.
+
+   .. versionadded:: 1.8
 
 .. confval:: epub_exclude_files
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -13,7 +13,6 @@
 from __future__ import print_function
 
 import os
-import posixpath
 import sys
 import warnings
 from collections import deque
@@ -979,13 +978,7 @@ class Sphinx(object):
 
         .. versionadded:: 0.5
         """
-        logger.debug('[app] adding javascript: %r', filename)
-        from sphinx.builders.html import StandaloneHTMLBuilder
-        if '://' in filename:
-            StandaloneHTMLBuilder.script_files.append(filename)
-        else:
-            StandaloneHTMLBuilder.script_files.append(
-                posixpath.join('_static', filename))
+        self.registry.add_javascript(filename)
 
     def add_stylesheet(self, filename, alternate=False, title=None):
         # type: (unicode, bool, unicode) -> None
@@ -1004,16 +997,7 @@ class Sphinx(object):
            more information, refer to the `documentation
            <https://mdn.io/Web/CSS/Alternative_style_sheets>`__.
         """
-        logger.debug('[app] adding stylesheet: %r', filename)
-        from sphinx.builders.html import StandaloneHTMLBuilder, Stylesheet
-        if '://' not in filename:
-            filename = posixpath.join('_static', filename)
-        if alternate:
-            rel = u'alternate stylesheet'
-        else:
-            rel = u'stylesheet'
-        css = Stylesheet(filename, title, rel)  # type: ignore
-        StandaloneHTMLBuilder.css_files.append(css)
+        self.registry.add_stylesheet(filename, alternate, title)
 
     def add_latex_package(self, packagename, options=None):
         # type: (unicode, unicode) -> None

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -985,17 +985,16 @@ class Sphinx(object):
         """Register a stylesheet to include in the HTML output.
 
         Add *filename* to the list of CSS files that the default HTML template
-        will include.  Like for :meth:`add_javascript`, the filename must be
-        relative to the HTML static path, or a full URI with scheme.
+        will include.  The filename must be relative to the HTML static path,
+        or a full URI with scheme.  See :confval:`html_stylesheets` for
+        details.
 
         .. versionadded:: 1.0
 
         .. versionchanged:: 1.6
            Optional ``alternate`` and/or ``title`` attributes can be supplied
            with the *alternate* (of boolean type) and *title* (a string)
-           arguments. The default is no title and *alternate* = ``False``. For
-           more information, refer to the `documentation
-           <https://mdn.io/Web/CSS/Alternative_style_sheets>`__.
+           arguments. The default is no title and *alternate* = ``False``.
         """
         self.registry.add_stylesheet(filename, alternate, title)
 

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -243,6 +243,7 @@ def setup(app):
     app.add_config_value('epub_guide', (), 'env')
     app.add_config_value('epub_pre_files', [], 'env')
     app.add_config_value('epub_post_files', [], 'env')
+    app.add_config_value('epub_stylesheets', lambda config: config.html_stylesheets, 'epub')
     app.add_config_value('epub_exclude_files', [], 'env')
     app.add_config_value('epub_tocdepth', 3, 'env')
     app.add_config_value('epub_tocdup', True, 'env')

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -90,7 +90,7 @@ def get_stable_hash(obj):
 
 
 class CSSContainer(list):
-    """The container of stylesheets.
+    """The container for stylesheets.
 
     To support the extensions which access the container directly, this wraps
     the entry with Stylesheet class.
@@ -151,6 +151,39 @@ class Stylesheet(text_type):
         self.rel = rel
 
         return self
+
+
+class JSContainer(list):
+    """The container for javascripts."""
+    def insert(self, index, obj):
+        # type: (int, unicode) -> None
+        warnings.warn('builder.script_files is deprecated. '
+                      'Please use app.add_javascript() instead.',
+                      RemovedInSphinx30Warning)
+        super(JSContainer, self).insert(index, obj)
+
+    def extend(self, other):  # type: ignore
+        # type: (List[unicode]) -> None
+        warnings.warn('builder.script_files is deprecated. '
+                      'Please use app.add_javascript() instead.',
+                      RemovedInSphinx30Warning)
+        for item in other:
+            self.append(item)
+
+    def __iadd__(self, other):  # type: ignore
+        # type: (List[unicode]) -> JSContainer
+        warnings.warn('builder.script_files is deprecated. '
+                      'Please use app.add_javascript() instead.',
+                      RemovedInSphinx30Warning)
+        for item in other:
+            self.append(item)
+        return self
+
+    def __add__(self, other):
+        # type: (List[unicode]) -> JSContainer
+        ret = JSContainer(self)
+        ret += other
+        return ret
 
 
 class BuildInfo(object):
@@ -248,9 +281,9 @@ class StandaloneHTMLBuilder(Builder):
         super(StandaloneHTMLBuilder, self).__init__(app)
 
         # javascript files
-        self.script_files = ['_static/jquery.js',
-                             '_static/underscore.js',
-                             '_static/doctools.js']  # type: List[unicode]
+        self.script_files = JSContainer(['_static/jquery.js',
+                                         '_static/underscore.js',
+                                         '_static/doctools.js'])  # type: List[unicode]
         # stylesheet files
         self.css_files = CSSContainer()  # type: List[Dict[unicode, unicode]]
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -237,17 +237,22 @@ class StandaloneHTMLBuilder(Builder):
     # use html5 translator by default
     default_html5_translator = False
 
-    # This is a class attribute because it is mutated by Sphinx.add_javascript.
-    script_files = ['_static/jquery.js', '_static/underscore.js',
-                    '_static/doctools.js']  # type: List[unicode]
-    # Ditto for this one (Sphinx.add_stylesheet).
-    css_files = CSSContainer()  # type: List[Dict[unicode, unicode]]
-
     imgpath = None          # type: unicode
     domain_indices = []     # type: List[Tuple[unicode, Type[Index], List[Tuple[unicode, List[List[Union[unicode, int]]]]], bool]]  # NOQA
 
     # cached publisher object for snippets
     _publisher = None
+
+    def __init__(self, app):
+        # type: (Sphinx) -> None
+        super(StandaloneHTMLBuilder, self).__init__(app)
+
+        # javascript files
+        self.script_files = ['_static/jquery.js',
+                             '_static/underscore.js',
+                             '_static/doctools.js']  # type: List[unicode]
+        # stylesheet files
+        self.css_files = CSSContainer()  # type: List[Dict[unicode, unicode]]
 
     def init(self):
         # type: () -> None
@@ -269,10 +274,9 @@ class StandaloneHTMLBuilder(Builder):
         else:
             self.link_suffix = self.out_suffix
 
-        if self.config.language is not None:
-            if self._get_translations_js():
-                self.script_files.append('_static/translations.js')
         self.use_index = self.get_builder_config('use_index', 'html')
+        self.init_script_files()
+        self.init_css_files()
 
         if self.config.html_experimental_html5_writer and not html5_ready:
             self.app.warn(('html_experimental_html5_writer is set, but current version '
@@ -283,10 +287,41 @@ class StandaloneHTMLBuilder(Builder):
         # type: () -> BuildInfo
         return BuildInfo(self.config, self.tags, ['html'])
 
+    def init_css_files(self):
+        # type: () -> None
+        for filename, alternate, title in self.app.registry.stylesheets:
+            self.add_stylesheet(filename, alternate, title)
+
+    def add_stylesheet(self, filename, alternate, title):
+        # type: (unicode, bool, unicode) -> None
+        if '://' not in filename:
+            # make a new path; the css file will be copied to ``_static`` directory
+            filename = posixpath.join('_static', filename)
+        if alternate:
+            rel = u'alternate stylesheet'
+        else:
+            rel = u'stylesheet'
+        css = Stylesheet(filename, title, rel)  # type: ignore
+        self.css_files.append(css)
+
+    def init_script_files(self):
+        # type: () -> None
+        for filename in self.app.registry.javascripts:
+            self.add_javascript(filename)
+
+        if self.config.language and self._get_translations_js():
+            self.add_javascript('translations.js')
+
+    def add_javascript(self, filename):
+        # type: (unicode) -> None
+        if '://' not in filename:
+            filename = posixpath.join('_static', filename)
+
+        self.script_files.append(filename)
+
     def _get_translations_js(self):
         # type: () -> unicode
-        candidates = [path.join(dir, self.config.language,
-                                'LC_MESSAGES', 'sphinx.js')
+        candidates = [path.join(dir, self.config.language, 'LC_MESSAGES', 'sphinx.js')
                       for dir in self.config.locale_dirs] + \
                      [path.join(package_dir, 'locale', self.config.language,
                                 'LC_MESSAGES', 'sphinx.js'),
@@ -1309,6 +1344,8 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         self.templates = None   # no template bridge necessary
         self.init_templates()
         self.init_highlighter()
+        self.init_script_files()
+        self.init_css_files()
         self.use_index = self.get_builder_config('use_index', 'html')
 
     def get_target_uri(self, docname, typ=None):

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -292,7 +292,17 @@ class StandaloneHTMLBuilder(Builder):
         for filename, alternate, title in self.app.registry.stylesheets:
             self.add_stylesheet(filename, alternate, title)
 
-    def add_stylesheet(self, filename, alternate, title):
+        for stylesheet in self.get_builder_config('stylesheets', 'html'):
+            if isinstance(stylesheet, string_types):
+                self.add_stylesheet(stylesheet)
+            else:
+                try:
+                    filename, alternate, title = stylesheet
+                    self.add_stylesheet(filename, alternate, title)
+                except (TypeError, ValueError):
+                    logger.warning('invalid stylesheet: %r', stylesheet)
+
+    def add_stylesheet(self, filename, alternate=False, title=None):
         # type: (unicode, bool, unicode) -> None
         if '://' not in filename:
             # make a new path; the css file will be copied to ``_static`` directory
@@ -307,6 +317,9 @@ class StandaloneHTMLBuilder(Builder):
     def init_script_files(self):
         # type: () -> None
         for filename in self.app.registry.javascripts:
+            self.add_javascript(filename)
+
+        for filename in self.get_builder_config('javascripts', 'html'):
             self.add_javascript(filename)
 
         if self.config.language and self._get_translations_js():
@@ -1470,6 +1483,8 @@ def setup(app):
     app.add_config_value('html_style', None, 'html', string_classes)
     app.add_config_value('html_logo', None, 'html', string_classes)
     app.add_config_value('html_favicon', None, 'html', string_classes)
+    app.add_config_value('html_stylesheets', [], 'html')
+    app.add_config_value('html_javascripts', [], 'html')
     app.add_config_value('html_static_path', [], 'html')
     app.add_config_value('html_extra_path', [], 'html')
     app.add_config_value('html_last_updated_fmt', None, 'html', string_classes)

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -154,7 +154,7 @@ class Stylesheet(text_type):
 
 
 class JSContainer(list):
-    """The container for javascripts."""
+    """The container for JavaScript scripts."""
     def insert(self, index, obj):
         # type: (int, unicode) -> None
         warnings.warn('builder.script_files is deprecated. '

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -31,7 +31,7 @@ from sphinx import package_dir, __display_version__
 from sphinx.application import ENV_PICKLE_FILENAME
 from sphinx.builders import Builder
 from sphinx.config import string_classes
-from sphinx.deprecation import RemovedInSphinx20Warning
+from sphinx.deprecation import RemovedInSphinx20Warning, RemovedInSphinx30Warning
 from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.environment.adapters.toctree import TocTree
@@ -1463,6 +1463,15 @@ class JSONHTMLBuilder(SerializingHTMLBuilder):
         SerializingHTMLBuilder.init(self)
 
 
+def deprecate_html_style(app, config):
+    # type: (Sphinx, Config) -> None
+    if config.html_style:
+        warnings.warn('The confval: html_style is deprecated. '
+                      'Please use html_stylesheets instead.',
+                      RemovedInSphinx30Warning)
+        config.html_stylesheets.insert(0, config.html_style)
+
+
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     # builders
@@ -1511,6 +1520,9 @@ def setup(app):
     app.add_config_value('html_search_scorer', '', None)
     app.add_config_value('html_scaled_image_link', True, 'html')
     app.add_config_value('html_experimental_html5_writer', None, 'html')
+
+    # events
+    app.connect('config-inited', deprecate_html_style)
 
     return {
         'version': 'builtin',

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -30,7 +30,7 @@ from sphinx.util.docutils import directive_helper
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterator, List, Type, Union  # NOQA
+    from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, Union  # NOQA
     from docutils import nodes  # NOQA
     from docutils.io import Input  # NOQA
     from docutils.parsers import Parser  # NOQA
@@ -82,6 +82,9 @@ class SphinxComponentRegistry(object):
         #: a dict of domain name -> dict of role name -> role impl.
         self.domain_roles = {}          # type: Dict[unicode, Dict[unicode, Union[RoleFunction, XRefRole]]]  # NOQA
 
+        #: javascripts; list of JS paths or URLs
+        self.javascripts = []           # type: List[unicode]
+
         #: post transforms; list of transforms
         self.post_transforms = []       # type: List[Type[Transform]]
 
@@ -93,6 +96,9 @@ class SphinxComponentRegistry(object):
 
         #: source suffix: suffix -> file type
         self.source_suffix = {}         # type: Dict[unicode, unicode]
+
+        #: stylesheets; list of CSS info
+        self.stylesheets = []           # type: List[Tuple[unicode, bool, unicode]]
 
         #: custom translators; builder name -> translator class
         self.translators = {}           # type: Dict[unicode, nodes.NodeVisitor]
@@ -340,6 +346,16 @@ class SphinxComponentRegistry(object):
     def add_autodoc_attrgetter(self, typ, attrgetter):
         # type: (Type, Callable[[Any, unicode, Any], Any]) -> None
         self.autodoc_attrgettrs[typ] = attrgetter
+
+    def add_javascript(self, filename):
+        # type: (unicode) -> None
+        logger.debug('[app] adding javascript: %r', filename)
+        self.javascripts.append(filename)
+
+    def add_stylesheet(self, filename, alternate=False, title=None):
+        # type: (unicode, bool, unicode) -> None
+        logger.debug('[app] adding stylesheet: %r', filename)
+        self.stylesheets.append((filename, alternate, title))
 
     def load_extension(self, app, extname):
         # type: (Sphinx, unicode) -> None

--- a/tests/roots/test-html_assets/conf.py
+++ b/tests/roots/test-html_assets/conf.py
@@ -6,4 +6,7 @@ version = '1.4.4'
 
 html_static_path = ['static', 'subdir']
 html_extra_path = ['extra', 'subdir']
+html_stylesheets = ['css/style.css',
+                    ('https://example.com/custom.css', True, 'title')]
+html_javascripts = ['js/custom.js']
 exclude_patterns = ['**/_build', '**/.htpasswd']

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -245,3 +245,30 @@ def test_epub_writing_mode(app):
     # vertical / writing-mode (CSS)
     css = (app.outdir / '_static' / 'epub.css').text()
     assert 'writing-mode: vertical-rl;' in css
+
+
+@pytest.mark.sphinx('epub', testroot='html_assets')
+def test_epub_assets(app):
+    app.builder.build_all()
+
+    # epub_sytlesheets (same as html_stylesheets)
+    content = (app.outdir / 'index.xhtml').text()
+    assert '<link rel="stylesheet" href="_static/css/style.css" type="text/css" />' in content
+    assert ('<link rel="alternate stylesheet" href="https://example.com/custom.css" '
+            'type="text/css" title="title" />' in content)
+
+
+@pytest.mark.sphinx('epub', testroot='html_assets',
+                    confoverrides={'epub_stylesheets': ['css/epub.css']})
+def test_epub_stylesheets(app):
+    app.builder.build_all()
+
+    # epub_sytlesheets
+    content = (app.outdir / 'index.xhtml').text()
+    assert '<link rel="stylesheet" href="_static/css/epub.css" type="text/css" />' in content
+
+    # files in html_stylesheets are not outputed
+    assert ('<link rel="stylesheet" href="_static/css/style.css" type="text/css" />'
+            not in content)
+    assert ('<link rel="alternate stylesheet" href="https://example.com/custom.css" '
+            'type="text/css" title="title" />' not in content)

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1095,9 +1095,10 @@ def test_html_assets(app):
     assert not (app.outdir / '_static' / '.htpasswd').exists()
     assert (app.outdir / '_static' / 'API.html').exists()
     assert (app.outdir / '_static' / 'API.html').text() == 'Sphinx-1.4.4'
-    assert (app.outdir / '_static' / 'css/style.css').exists()
+    assert (app.outdir / '_static' / 'css' / 'style.css').exists()
+    assert (app.outdir / '_static' / 'js' / 'custom.js').exists()
     assert (app.outdir / '_static' / 'rimg.png').exists()
-    assert not (app.outdir / '_static' / '_build/index.html').exists()
+    assert not (app.outdir / '_static' / '_build' / 'index.html').exists()
     assert (app.outdir / '_static' / 'background.png').exists()
     assert not (app.outdir / '_static' / 'subdir' / '.htaccess').exists()
     assert not (app.outdir / '_static' / 'subdir' / '.htpasswd').exists()
@@ -1108,10 +1109,19 @@ def test_html_assets(app):
     assert (app.outdir / 'API.html_t').exists()
     assert (app.outdir / 'css/style.css').exists()
     assert (app.outdir / 'rimg.png').exists()
-    assert not (app.outdir / '_build/index.html').exists()
+    assert not (app.outdir / '_build' / 'index.html').exists()
     assert (app.outdir / 'background.png').exists()
     assert (app.outdir / 'subdir' / '.htaccess').exists()
     assert not (app.outdir / 'subdir' / '.htpasswd').exists()
+
+    # html_sytlesheets
+    content = (app.outdir / 'index.html').text()
+    assert '<link rel="stylesheet" href="_static/css/style.css" type="text/css" />' in content
+    assert ('<link rel="alternate stylesheet" href="https://example.com/custom.css" '
+            'type="text/css" title="title" />' in content)
+
+    # html_javascripts
+    assert '<script type="text/javascript" src="_static/js/custom.js"></script>' in content
 
 
 @pytest.mark.sphinx('html', testroot='basic', confoverrides={'html_copy_source': False})


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Refactor

### Purpose
- Make HTML output more easier to customize by users. So far, users need to call APIs to add own CSS and JS.
- This enables to add them simply without any codes.

### Relates
- #4439
- #2442

