### PR TITLE
Fix #4260: autodoc: keyword only argument separator is not disappeared

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #4260: autodoc: keyword only argument separator is not disappeared if it is
+  appeared at top of the argument list
+
 Testing
 --------
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -390,7 +390,8 @@ class Signature(object):
             # insert '*' between POSITIONAL args and KEYWORD_ONLY args::
             #     func(a, b, *, c, d):
             if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
-                                                                  param.POSITIONAL_ONLY):
+                                                                  param.POSITIONAL_ONLY,
+                                                                  None):
                 args.append('*')
 
             if param.kind in (param.POSITIONAL_ONLY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,9 @@ pytest_plugins = 'sphinx.testing.fixtures'
 collect_ignore = ['roots']
 
 # Disable Python version-specific
+if sys.version_info < (3,):
+    collect_ignore += ['py3']
+
 if sys.version_info < (3, 5):
     collect_ignore += ['py35']
 

--- a/tests/py3/test_util_inspect_py3.py
+++ b/tests/py3/test_util_inspect_py3.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+    py3/test_util_inspect
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Tests util.inspect functions.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from sphinx.util import inspect
+
+
+def test_Signature_keyword_only_arguments():
+    def func1(arg1, arg2, *, arg3=None, arg4=None):
+        pass
+
+    def func2(*, arg3, arg4):
+        pass
+
+    sig = inspect.Signature(func1).format_args()
+    assert sig == '(arg1, arg2, *, arg3=None, arg4=None)'
+
+    sig = inspect.Signature(func2).format_args()
+    assert sig == '(*, arg3, arg4)'


### PR DESCRIPTION
refs: #4260 