### PR TITLE
Use typing.type checking

### DIFF
--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -18,7 +18,6 @@ import os
 import warnings
 from os import path
 
-from .cmd import build
 from .deprecation import RemovedInNextVersionWarning
 from .deprecation import RemovedInSphinx20Warning
 
@@ -61,6 +60,7 @@ if __version__.endswith('+'):
 
 
 def main(*args, **kwargs):
+    from .cmd import build
     warnings.warn(
         '`sphinx.main()` has moved to `sphinx.cmd.build.main()`.',
         RemovedInSphinx20Warning,
@@ -70,6 +70,7 @@ def main(*args, **kwargs):
 
 
 if __name__ == '__main__':
+    from .cmd import build
     warnings.warn(
         '`sphinx` has moved to `sphinx.build`.',
         RemovedInSphinx20Warning,

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -9,10 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import List, Sequence  # NOQA
 
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -122,7 +122,7 @@ class Sphinx(object):
         self.enumerable_nodes = {}              # type: Dict[nodes.Node, Tuple[unicode, Callable]]  # NOQA
         self.html_themes = {}                   # type: Dict[unicode, unicode]
 
-        self.srcdir = srcdir
+        self.srcdir = srcdir                    # type: unicode
         self.confdir = confdir
         self.outdir = outdir
         self.doctreedir = doctreedir

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -18,6 +18,7 @@ import sys
 import warnings
 from collections import deque
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
@@ -43,8 +44,7 @@ from sphinx.util.i18n import find_catalog_source_files
 from sphinx.util.osutil import ENOENT, ensuredir
 from sphinx.util.tags import Tags
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Tuple, Type, Union  # NOQA
     from docutils.parsers import Parser  # NOQA
     from docutils.transform import Transform  # NOQA

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -11,6 +11,7 @@
 
 import warnings
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 
@@ -32,8 +33,7 @@ try:
 except ImportError:
     multiprocessing = None
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterable, List, Sequence, Set, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -13,6 +13,7 @@ import os
 import re
 from collections import namedtuple
 from os import path
+from typing import TYPE_CHECKING
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
 from docutils import nodes
@@ -34,8 +35,7 @@ except ImportError:
     except ImportError:
         Image = None
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -16,6 +16,7 @@ import plistlib
 import shlex
 import subprocess
 from os import path, environ
+from typing import TYPE_CHECKING
 
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.config import string_classes
@@ -27,8 +28,7 @@ from sphinx.util.matching import Matcher
 from sphinx.util.osutil import copyfile, ensuredir, make_filename
 from sphinx.util.pycompat import htmlescape
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -11,6 +11,7 @@
 
 import codecs
 from os import path
+from typing import TYPE_CHECKING
 
 from six import iteritems
 
@@ -24,8 +25,7 @@ from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.util.pycompat import htmlescape
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import gzip
 import re
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 
@@ -29,8 +30,7 @@ try:
 except ImportError:
     import lxml.etree as etree  # type: ignore
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/dummy.py
+++ b/sphinx/builders/dummy.py
@@ -9,11 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
 
 from sphinx.builders import Builder
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -12,6 +12,7 @@
 
 from collections import namedtuple
 from os import path
+from typing import TYPE_CHECKING
 
 from sphinx import package_dir
 from sphinx.builders import _epub_base
@@ -21,8 +22,7 @@ from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.i18n import format_date
 from sphinx.util.osutil import make_filename
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from datetime import datetime, tzinfo, timedelta
 from os import path, walk, getenv
 from time import time
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from six import iteritems, StringIO
@@ -29,8 +30,7 @@ from sphinx.util.nodes import extract_messages, traverse_translatable_index
 from sphinx.util.osutil import safe_relpath, ensuredir, canon_path
 from sphinx.util.tags import Tags
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, DefaultDict, Dict, Iterable, List, Set, Tuple  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.util.i18n import CatalogInfo  # NOQA

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -16,6 +16,7 @@ import sys
 import warnings
 from hashlib import md5
 from os import path
+from typing import TYPE_CHECKING
 
 import docutils
 from docutils import nodes
@@ -51,8 +52,7 @@ from sphinx.util.osutil import SEP, os_path, relative_uri, ensuredir, \
     movefile, copyfile
 from sphinx.writers.html import HTMLWriter, HTMLTranslator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, Iterable, Iterator, List, Type, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -594,9 +594,9 @@ class StandaloneHTMLBuilder(Builder):
         doctree.settings = self.docsettings
 
         self.secnumbers = self.env.toc_secnumbers.get(docname, {})
-        self.fignumbers = self.env.toc_fignumbers.get(docname, {})
+        self.fignumbers = self.env.toc_fignumbers.get(docname, {})  # type: Dict[unicode, Dict[unicode, Tuple[int, ...]]]  # NOQA
         self.imgpath = relative_uri(self.get_target_uri(docname), '_images')
-        self.dlpath = relative_uri(self.get_target_uri(docname), '_downloads')
+        self.dlpath = relative_uri(self.get_target_uri(docname), '_downloads')  # type: unicode
         self.current_docname = docname
         self.docwriter.write(doctree, destination)
         self.docwriter.assemble_parts()

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import codecs
 import os
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 
@@ -24,8 +25,7 @@ from sphinx.util import logging
 from sphinx.util.osutil import make_filename
 from sphinx.util.pycompat import htmlescape
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -11,6 +11,7 @@
 
 import os
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.frontend import OptionParser
@@ -32,8 +33,7 @@ from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import SEP, make_filename
 from sphinx.writers.latex import LaTeXWriter, LaTeXTranslator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -14,6 +14,7 @@ import re
 import socket
 import threading
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from requests.exceptions import HTTPError
@@ -37,8 +38,7 @@ from sphinx.util.console import (  # type: ignore
 )
 from sphinx.util.requests import is_ssl_error
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Set, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.util.requests.requests import Response  # NOQA

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -10,6 +10,7 @@
 """
 
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils.frontend import OptionParser
 from docutils.io import FileOutput
@@ -24,8 +25,7 @@ from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import make_filename
 from sphinx.writers.manpage import ManualPageWriter, ManualPageTranslator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Set, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -14,6 +14,7 @@ import os
 import posixpath
 import re
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from six import text_type
@@ -26,8 +27,7 @@ from sphinx.util import force_decode, logging
 from sphinx.util.osutil import make_filename
 from sphinx.util.pycompat import htmlescape
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -11,6 +11,7 @@
 
 import os
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.frontend import OptionParser
@@ -30,8 +31,7 @@ from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import SEP, make_filename
 from sphinx.writers.texinfo import TexinfoWriter, TexinfoTranslator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx  # NOQA
     from typing import Any, Dict, Iterable, List, Tuple, Union  # NOQA
 

--- a/sphinx/builders/text.py
+++ b/sphinx/builders/text.py
@@ -11,6 +11,7 @@
 
 import codecs
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils.io import StringOutput
 
@@ -19,8 +20,7 @@ from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.writers.text import TextWriter, TextTranslator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, Set, Tuple  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/builders/websupport.py
+++ b/sphinx/builders/websupport.py
@@ -9,8 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
-if False:
-    # For type annotation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
     from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -11,6 +11,7 @@
 
 import codecs
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.io import StringOutput
@@ -21,8 +22,7 @@ from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.writers.xml import XMLWriter, PseudoXMLWriter
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, Set  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -10,9 +10,9 @@
 """
 
 import sys
+from typing import TYPE_CHECKING
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import List  # NOQA
 
 

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -19,6 +19,7 @@ import time
 from collections import OrderedDict
 from io import open
 from os import path
+from typing import TYPE_CHECKING
 
 # try to import readline, unix specific enhancement
 try:
@@ -43,8 +44,7 @@ from sphinx.util.console import (  # type: ignore
 from sphinx.util.osutil import ensuredir, make_filename
 from sphinx.util.template import SphinxRenderer
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Pattern, Union  # NOQA
 
 TERM_ENCODING = getattr(sys.stdin, 'encoding', None)

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -15,6 +15,7 @@ import multiprocessing
 import sys
 import traceback
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils.utils import SystemMessage
 from six import text_type, binary_type
@@ -28,8 +29,7 @@ from sphinx.util.docutils import docutils_namespace, patch_docutils
 from sphinx.util.osutil import abspath, fs_encoding
 from sphinx.util.pycompat import terminal_safe
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, IO, List, Union  # NOQA
 
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -12,7 +12,7 @@
 import re
 import traceback
 from os import path, getenv
-from typing import Any, NamedTuple, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Union
 
 from six import PY2, PY3, iteritems, string_types, binary_type, text_type, integer_types
 
@@ -23,8 +23,7 @@ from sphinx.util.i18n import format_date
 from sphinx.util.osutil import cd
 from sphinx.util.pycompat import execfile_, NoneType
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple, Union  # NOQA
     from sphinx.util.tags import Tags  # NOQA
 

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -10,6 +10,7 @@
 """
 
 import re
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives, roles
@@ -29,8 +30,7 @@ from sphinx.directives.patches import (  # noqa
     Figure, Meta
 )
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -10,6 +10,7 @@
 import codecs
 import sys
 from difflib import unified_diff
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -21,8 +22,7 @@ from sphinx.util import logging
 from sphinx.util import parselinenos
 from sphinx.util.nodes import set_source_info
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -7,6 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
@@ -21,8 +23,7 @@ from sphinx.util.matching import patfilter
 from sphinx.util.nodes import explicit_title_re, set_source_info, \
     process_index_entry
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -7,6 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives import images, html, tables
@@ -14,8 +16,7 @@ from docutils.parsers.rst.directives import images, html, tables
 from sphinx import addnodes
 from sphinx.util.nodes import set_source_info
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -11,14 +11,14 @@
 """
 
 import copy
+from typing import TYPE_CHECKING
 
 from six import iteritems
 
 from sphinx.errors import SphinxError
 from sphinx.locale import _
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, Union  # NOQA
     from docutils import nodes  # NOQA
     from docutils.parsers.rst.states import Inliner  # NOQA

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -11,6 +11,7 @@
 
 import re
 import string
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 
@@ -22,8 +23,7 @@ from sphinx.roles import XRefRole
 from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -11,6 +11,7 @@
 
 import re
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -28,8 +29,7 @@ from sphinx.util.nodes import make_refnode
 from sphinx.util.pycompat import UnicodeMixin
 
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterator, List, Match, Pattern, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
@@ -21,8 +23,7 @@ from sphinx.roles import XRefRole
 from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.nodes import make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Tuple  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -10,6 +10,7 @@
 """
 
 import re
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -24,8 +25,7 @@ from sphinx.util import logging
 from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.nodes import make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Iterator, List, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -10,6 +10,7 @@
 """
 
 import re
+from typing import TYPE_CHECKING
 
 from six import iteritems
 
@@ -20,8 +21,7 @@ from sphinx.locale import l_, _
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Tuple  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -11,6 +11,7 @@
 
 import re
 import unicodedata
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -25,8 +26,7 @@ from sphinx.roles import XRefRole
 from sphinx.util import ws_re, logging, docname_join
 from sphinx.util.nodes import clean_astext, make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -169,8 +169,8 @@ class BuildEnvironment(object):
         # type: (Sphinx) -> None
         self.app = app
         self.doctreedir = app.doctreedir
-        self.srcdir = app.srcdir
-        self.config = app.config
+        self.srcdir = app.srcdir  # type: unicode
+        self.config = app.config  # type: Config
 
         # the method of doctree versioning; see set_versioning_method
         self.versioning_condition = None  # type: Union[bool, Callable]
@@ -187,7 +187,7 @@ class BuildEnvironment(object):
         self._warnfunc = None  # type: Callable
 
         # this is to invalidate old pickles
-        self.version = ENV_VERSION
+        self.version = ENV_VERSION  # type: int
 
         # All "docnames" here are /-separated and relative and exclude
         # the source suffix.
@@ -252,8 +252,8 @@ class BuildEnvironment(object):
                                     # lineno, module, descname, content)
 
         # these map absolute path -> (docnames, unique filename)
-        self.images = FilenameUniqDict()
-        self.dlfiles = FilenameUniqDict()
+        self.images = FilenameUniqDict()    # type: FilenameUniqDict
+        self.dlfiles = FilenameUniqDict()   # type: FilenameUniqDict
 
         # the original URI for images
         self.original_image_uri = {}  # type: Dict[unicode, unicode]

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -18,6 +18,7 @@ import warnings
 from collections import defaultdict
 from copy import copy
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils.frontend import OptionParser
 from docutils.utils import Reporter, get_source_line
@@ -42,8 +43,7 @@ from sphinx.util.osutil import SEP, ensuredir
 from sphinx.util.parallel import ParallelTasks, parallel_available, make_chunks
 from sphinx.util.websupport import is_commentable
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, IO, Iterator, List, Optional, Pattern, Set, Tuple, Type, Union, Generator  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/environment/adapters/asset.py
+++ b/sphinx/environment/adapters/asset.py
@@ -9,8 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
-if False:
-    # For type annotation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment  # NOQA
 
 

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -12,14 +12,14 @@ import bisect
 import re
 import unicodedata
 from itertools import groupby
+from typing import TYPE_CHECKING
 
 from six import text_type, iteritems
 
 from sphinx.locale import _
 from sphinx.util import split_into, logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Pattern, List, Tuple  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from six import iteritems
 
@@ -16,8 +18,7 @@ from sphinx import addnodes
 from sphinx.util import url_re, logging
 from sphinx.util.nodes import clean_astext, process_only_nodes
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/environment/collectors/__init__.py
+++ b/sphinx/environment/collectors/__init__.py
@@ -9,10 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from six import itervalues
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, List, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -12,6 +12,7 @@
 import os
 from glob import glob
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.utils import relative_path
@@ -23,8 +24,7 @@ from sphinx.util import logging
 from sphinx.util.i18n import get_image_filename_for_language, search_image_for_language
 from sphinx.util.images import guess_mimetype
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, List, Set, Tuple  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA

--- a/sphinx/environment/collectors/dependencies.py
+++ b/sphinx/environment/collectors/dependencies.py
@@ -10,14 +10,14 @@
 """
 
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils.utils import relative_path
 
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.util.osutil import getcwd, fs_encoding
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA

--- a/sphinx/environment/collectors/indexentries.py
+++ b/sphinx/environment/collectors/indexentries.py
@@ -9,12 +9,13 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx import addnodes
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.util import split_index_msg, logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.applicatin import Sphinx  # NOQA

--- a/sphinx/environment/collectors/metadata.py
+++ b/sphinx/environment/collectors/metadata.py
@@ -9,12 +9,13 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
 from sphinx.environment.collectors import EnvironmentCollector
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA

--- a/sphinx/environment/collectors/title.py
+++ b/sphinx/environment/collectors/title.py
@@ -9,13 +9,14 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.transforms import SphinxContentsFilter
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from six import iteritems
 
@@ -18,8 +20,7 @@ from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.transforms import SphinxContentsFilter
 from sphinx.util import url_re, logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -10,8 +10,9 @@
     :license: BSD, see LICENSE for details.
 """
 
-if False:
-    # For type annotation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
     from typing import Any  # NOQA
 
 

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -13,14 +13,14 @@
 from __future__ import print_function
 
 from collections import OrderedDict, defaultdict
+from typing import TYPE_CHECKING
 
 from six import itervalues
 
 from sphinx.errors import ExtensionError
 from sphinx.locale import __
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List  # NOQA
 
 

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -23,6 +23,7 @@ import os
 import sys
 from fnmatch import fnmatch
 from os import path
+from typing import TYPE_CHECKING
 
 from six import binary_type
 
@@ -31,8 +32,7 @@ from sphinx.cmd.quickstart import EXTENSIONS
 from sphinx.util import rst
 from sphinx.util.osutil import FileAvoidWrite, ensuredir, walk
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, List, Tuple  # NOQA
 
 # automodule options

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from docutils import nodes  # NOQA
     from docutils.utils import Reporter  # NOQA
     from sphinx.application import Sphinx  # NOQA
+    from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.ext.autodoc.directive import DocumenterBridge  # NOQA
 
 logger = logging.getLogger(__name__)
@@ -281,7 +282,7 @@ class Documenter(object):
     def __init__(self, directive, name, indent=u''):
         # type: (DocumenterBridge, unicode, unicode) -> None
         self.directive = directive
-        self.env = directive.env
+        self.env = directive.env    # type: BuildEnvironment
         self.options = directive.genopt
         self.name = name
         self.indent = indent
@@ -745,7 +746,7 @@ class Documenter(object):
         # where the attribute documentation would actually be found in.
         # This is used for situations where you have a module that collects the
         # functions and classes of internal submodules.
-        self.real_modname = real_modname or self.get_real_modname()
+        self.real_modname = real_modname or self.get_real_modname()  # type: str
 
         # try to also get a source code analyzer for attribute docs
         try:

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -15,6 +15,7 @@ import inspect
 import re
 import sys
 import warnings
+from typing import TYPE_CHECKING
 
 from docutils.statemachine import ViewList
 from six import iteritems, itervalues, text_type, class_types, string_types
@@ -34,8 +35,7 @@ from sphinx.util.inspect import Signature, isdescriptor, safe_getmembers, \
     safe_getattr, object_description, is_builtin_class_method, \
     isenumattribute, isclassmethod, isstaticmethod, getdoc
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from types import ModuleType  # NOQA
     from typing import Any, Callable, Dict, Iterator, List, Sequence, Set, Tuple, Type, Union  # NOQA
     from docutils import nodes  # NOQA

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -7,6 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
@@ -17,8 +19,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import switch_source_input
 from sphinx.util.nodes import nested_parse_with_titles
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Set, Type  # NOQA
     from docutils.statemachine import State, StateMachine, StringList  # NOQA
     from docutils.utils import Reporter  # NOQA

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -15,14 +15,14 @@ import traceback
 import warnings
 from collections import namedtuple
 from types import FunctionType, MethodType, ModuleType
+from typing import TYPE_CHECKING
 
 from six import PY2
 
 from sphinx.util import logging
 from sphinx.util.inspect import isenumclass, safe_getattr
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Generator, List, Optional  # NOQA
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/autodoc/inspector.py
+++ b/sphinx/ext/autodoc/inspector.py
@@ -11,14 +11,14 @@
 
 import typing
 import warnings
+from typing import TYPE_CHECKING
 
 from six import StringIO, string_types
 
 from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.util.inspect import object_description
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Tuple  # NOQA
 
 

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
 from sphinx.util import logging
@@ -16,7 +18,7 @@ from sphinx.util.nodes import clean_astext
 
 logger = logging.getLogger(__name__)
 
-if False:
+if TYPE_CHECKING:
     # For type annotation
     from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -59,6 +59,7 @@ import posixpath
 import re
 import sys
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -75,8 +76,7 @@ from sphinx.ext.autodoc.importer import import_module
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.util import import_object, rst, logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, Type, Union  # NOQA
     from docutils.utils import Inliner  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -25,6 +25,7 @@ import os
 import pydoc
 import re
 import sys
+from typing import TYPE_CHECKING
 
 from jinja2 import FileSystemLoader, TemplateNotFound
 from jinja2.sandbox import SandboxedEnvironment
@@ -38,8 +39,7 @@ from sphinx.util.inspect import safe_getattr
 from sphinx.util.osutil import ensuredir
 from sphinx.util.rst import escape as rst_escape
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Tuple, List  # NOQA
     from jinja2 import BaseLoader  # NOQA
     from sphinx import addnodes  # NOQA

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -14,6 +14,7 @@ import glob
 import inspect
 import re
 from os import path
+from typing import TYPE_CHECKING
 
 from six import iteritems
 from six.moves import cPickle as pickle
@@ -23,8 +24,7 @@ from sphinx.builders import Builder
 from sphinx.util import logging
 from sphinx.util.inspect import safe_getattr
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, IO, List, Pattern, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -17,6 +17,7 @@ import re
 import sys
 import time
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -32,8 +33,7 @@ from sphinx.util.console import bold  # type: ignore
 from sphinx.util.nodes import set_source_info
 from sphinx.util.osutil import fs_encoding
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, IO, Iterable, List, Optional, Sequence, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -16,6 +16,7 @@ import re
 from hashlib import sha1
 from os import path
 from subprocess import Popen, PIPE
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -29,8 +30,7 @@ from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/ext/ifconfig.py
+++ b/sphinx/ext/ifconfig.py
@@ -20,14 +20,15 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
 import sphinx
 from sphinx.util.nodes import set_source_info
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 import subprocess
+from typing import TYPE_CHECKING
 
 from sphinx.errors import ExtensionError
 from sphinx.locale import __
@@ -16,8 +17,7 @@ from sphinx.transforms.post_transforms.images import ImageConverter
 from sphinx.util import logging
 from sphinx.util.osutil import ENOENT, EPIPE, EINVAL
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -17,6 +17,7 @@ import tempfile
 from hashlib import sha1
 from os import path
 from subprocess import Popen, PIPE
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from six import text_type
@@ -31,8 +32,7 @@ from sphinx.util.osutil import ensuredir, ENOENT, cd
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.pycompat import sys_encoding
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -40,6 +40,7 @@ import inspect
 import re
 import sys
 from hashlib import md5
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -52,8 +53,7 @@ from sphinx.ext.graphviz import render_dot_html, render_dot_latex, \
 from sphinx.pycode import ModuleAnalyzer
 from sphinx.util import force_decode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, Dict, Optional  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -31,6 +31,7 @@ import posixpath
 import sys
 import time
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.utils import relative_path
@@ -43,8 +44,7 @@ from sphinx.locale import _
 from sphinx.util import requests, logging
 from sphinx.util.inventory import InventoryFile
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, List, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/ext/linkcode.py
+++ b/sphinx/ext/linkcode.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
 import sphinx
@@ -16,8 +18,7 @@ from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.locale import _
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Set  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes, utils
 from docutils.nodes import make_id
 from docutils.parsers.rst import Directive, directives
@@ -20,8 +22,7 @@ from sphinx.roles import XRefRole
 from sphinx.util import logging
 from sphinx.util.nodes import make_refnode, set_source_info
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterable, List, Tuple  # NOQA
     from docutils.parsers.rst.states import Inliner  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -10,6 +10,7 @@
 """
 
 import sys
+from typing import TYPE_CHECKING
 
 from six import PY2, iteritems
 
@@ -17,8 +18,7 @@ import sphinx
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List  # NOQA
 
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -14,6 +14,7 @@
 import collections
 import inspect
 import re
+from typing import TYPE_CHECKING
 
 from six import string_types, u
 from six.moves import range
@@ -21,8 +22,7 @@ from six.moves import range
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.util.pycompat import UnicodeMixin
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config as SphinxConfig  # NOQA

--- a/sphinx/ext/napoleon/iterators.py
+++ b/sphinx/ext/napoleon/iterators.py
@@ -12,9 +12,9 @@
 """
 
 import collections
+from typing import TYPE_CHECKING
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Iterable  # NOQA
 
 

--- a/sphinx/ext/pngmath.py
+++ b/sphinx/ext/pngmath.py
@@ -18,6 +18,7 @@ import tempfile
 from hashlib import sha1
 from os import path
 from subprocess import Popen, PIPE
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from six import text_type
@@ -31,8 +32,7 @@ from sphinx.util.osutil import ensuredir, ENOENT, cd
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.pycompat import sys_encoding
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.ext.mathbase import math as math_node, displaymath  # NOQA

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -12,6 +12,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
@@ -24,8 +26,7 @@ from sphinx.util import logging
 from sphinx.util.nodes import set_source_info
 from sphinx.util.texescape import tex_escape_map
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -10,6 +10,7 @@
 """
 
 import traceback
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from six import iteritems, text_type
@@ -21,8 +22,7 @@ from sphinx.pycode import ModuleAnalyzer
 from sphinx.util import get_full_modname, logging, status_iterator
 from sphinx.util.nodes import make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Iterator, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -9,14 +9,15 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from six import iteritems
 
 from sphinx.errors import VersionRequirementError
 from sphinx.locale import __
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from pygments import highlight
 from pygments.filters import ErrorToken
 from pygments.formatters import HtmlFormatter, LatexFormatter
@@ -26,8 +28,7 @@ from sphinx.util import logging
 from sphinx.util.pycompat import htmlescape
 from sphinx.util.texescape import tex_hl_escape_map_new
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict  # NOQA
     from pygments.formatter import Formatter  # NOQA
 

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -10,6 +10,7 @@
 """
 import codecs
 import re
+from typing import TYPE_CHECKING
 
 from docutils.core import Publisher
 from docutils.io import FileInput, NullOutput
@@ -33,8 +34,7 @@ from sphinx.transforms.i18n import (
 from sphinx.util import logging
 from sphinx.util.docutils import LoggingReporter
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, Union  # NOQA
     from docutils import nodes  # NOQA
     from docutils.io import Input  # NOQA

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -289,7 +289,7 @@ def read_doc(app, env, filename):
                     source_class=SphinxDummySourceClass,
                     destination=NullOutput())
     pub.set_components(None, 'restructuredtext', None)
-    pub.process_programmatic_settings(None, env.settings, None)
+    pub.process_programmatic_settings(None, env.settings, None)  # type: ignore
     pub.set_source(source, filename)
     pub.publish()
     return pub.document

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -11,7 +11,7 @@
 
 from os import path
 from pprint import pformat
-from typing import Any, Callable, Iterator, Tuple  # NOQA
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Tuple  # NOQA
 
 from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
     contextfunction
@@ -22,8 +22,7 @@ from six import string_types
 from sphinx.application import TemplateBridge
 from sphinx.util.osutil import mtimes_of_files
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Iterator, Tuple  # NOQA
     from jinja2.environment import Environment  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -10,12 +10,12 @@
 """
 
 import gettext
+from typing import TYPE_CHECKING
 
 from six import PY3, text_type
 from six.moves import UserString
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterator, List, Tuple  # NOQA
 
 

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -20,14 +20,14 @@ import os
 import subprocess
 import sys
 from os import path
+from typing import TYPE_CHECKING
 
 import sphinx
 from sphinx import cmdline
 from sphinx.util.console import color_terminal, nocolor, bold, blue  # type: ignore
 from sphinx.util.osutil import cd, rmtree
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import List  # NOQA
 
 proj_name = os.getenv('SPHINXPROJ', '<project>')

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -9,14 +9,15 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 import docutils.parsers
 import docutils.parsers.rst
 from docutils.parsers.rst import states
 from docutils.statemachine import StringList
 from docutils.transforms.universal import SmartQuotes
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Type  # NOQA
     from docutils import nodes  # NOQA
     from docutils.transforms import Transform  # NOQA

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -10,14 +10,15 @@
 """
 from __future__ import print_function
 
+from typing import TYPE_CHECKING
+
 from six import iteritems, BytesIO, StringIO
 
 from sphinx.errors import PycodeError
 from sphinx.pycode.parser import Parser
 from sphinx.util import get_module_source, detect_encoding
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, List, Tuple  # NOQA
 
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -15,11 +15,11 @@ import re
 import tokenize
 from token import NAME, NEWLINE, INDENT, DEDENT, NUMBER, OP, STRING
 from tokenize import COMMENT, NL
+from typing import TYPE_CHECKING
 
 from six import PY2, text_type
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, List, Tuple  # NOQA
 
 comment_re = re.compile(u'^\\s*#: ?(.*)\r?\n?$')

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 import traceback
+from typing import TYPE_CHECKING
 
 from pkg_resources import iter_entry_points
 from six import iteritems, itervalues, string_types
@@ -27,8 +28,7 @@ from sphinx.util import logging
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.docutils import directive_helper
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterator, List, Type, Union  # NOQA
     from docutils import nodes  # NOQA
     from docutils.io import Input  # NOQA

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -10,6 +10,7 @@
 """
 
 import re
+from typing import TYPE_CHECKING
 
 from docutils import nodes, utils
 from six import iteritems
@@ -21,8 +22,7 @@ from sphinx.util import ws_re
 from sphinx.util.nodes import split_explicit_title, process_index_entry, \
     set_role_source_info
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple, Type  # NOQA
     from docutils.parsers.rst.states import Inliner  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -10,6 +10,7 @@
 """
 import re
 from os import path
+from typing import TYPE_CHECKING
 
 from six import iteritems, itervalues, text_type, string_types
 from six.moves import cPickle as pickle
@@ -21,8 +22,7 @@ from sphinx.util import jsdump, rpartition
 from sphinx.util.pycompat import htmlescape
 from sphinx.search.jssplitter import splitter_code
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, Iterable, List, Tuple, Type, Set  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/search/da.py
+++ b/sphinx/search/da.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/de.py
+++ b/sphinx/search/de.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/en.py
+++ b/sphinx/search/en.py
@@ -9,11 +9,12 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage
 from sphinx.util.stemmer import get_stemmer
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict  # NOQA
 
 english_stopwords = set(u"""

--- a/sphinx/search/es.py
+++ b/sphinx/search/es.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/fi.py
+++ b/sphinx/search/fi.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/fr.py
+++ b/sphinx/search/fr.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/hu.py
+++ b/sphinx/search/hu.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/it.py
+++ b/sphinx/search/it.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -20,6 +20,7 @@
 import os
 import re
 import sys
+from typing import TYPE_CHECKING
 
 from six import iteritems, PY3
 
@@ -39,8 +40,7 @@ from sphinx.errors import SphinxError, ExtensionError
 from sphinx.search import SearchLanguage
 from sphinx.util import import_object
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List  # NOQA
 
 

--- a/sphinx/search/nl.py
+++ b/sphinx/search/nl.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/no.py
+++ b/sphinx/search/no.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/pt.py
+++ b/sphinx/search/pt.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/ro.py
+++ b/sphinx/search/ro.py
@@ -9,12 +9,13 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage
 
 import snowballstemmer
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, Set  # NOQA
 
 js_stemmer = u"""

--- a/sphinx/search/ru.py
+++ b/sphinx/search/ru.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/sv.py
+++ b/sphinx/search/sv.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage, parse_stop_word
 
 import snowballstemmer

--- a/sphinx/search/tr.py
+++ b/sphinx/search/tr.py
@@ -9,12 +9,13 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from sphinx.search import SearchLanguage
 
 import snowballstemmer
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, Set  # NOQA
 
 js_stemmer = u"""

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -11,6 +11,7 @@
 
 import os
 import re
+from typing import TYPE_CHECKING
 
 from sphinx.search import SearchLanguage
 from sphinx.util.stemmer import get_stemmer
@@ -21,8 +22,7 @@ try:
 except ImportError:
     JIEBA = False
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, List  # NOQA
 
 english_stopwords = set(u"""

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -17,6 +17,7 @@ import os
 import sys
 from distutils.cmd import Command
 from distutils.errors import DistutilsOptionError, DistutilsExecError  # type: ignore
+from typing import TYPE_CHECKING
 
 from six import StringIO, string_types
 
@@ -26,8 +27,7 @@ from sphinx.util.console import nocolor, color_terminal
 from sphinx.util.docutils import docutils_namespace, patch_docutils
 from sphinx.util.osutil import abspath
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, List, Tuple  # NOQA
 
 

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -15,13 +15,14 @@ import subprocess
 import sys
 from collections import namedtuple
 from tempfile import gettempdir
+from typing import TYPE_CHECKING
 
 import pytest
 from six import StringIO, string_types
 
 from . import util
 
-if False:
+if TYPE_CHECKING:
     from typing import Dict, Union  # NOQA
 
 

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import warnings
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
 from docutils import nodes
@@ -24,7 +25,7 @@ from sphinx.ext.autodoc import AutoDirective
 from sphinx.pycode import ModuleAnalyzer
 from sphinx.testing.path import path
 
-if False:
+if TYPE_CHECKING:
     from typing import List  # NOQA
 
 

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -14,6 +14,7 @@ import shutil
 import tempfile
 import warnings
 from os import path
+from typing import TYPE_CHECKING
 from zipfile import ZipFile
 
 import pkg_resources
@@ -29,8 +30,7 @@ from sphinx.util.osutil import ensuredir
 
 logger = logging.getLogger(__name__)
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -374,7 +374,7 @@ class SphinxSmartQuotes(SmartQuotes, SphinxTransform):
             return False
 
         # confirm selected language supports smart_quotes or not
-        language = self.env.settings['language_code']
+        language = self.env.settings['language_code']  # type: ignore
         for tag in normalize_language_tag(language):
             if tag in smartchars.quotes:
                 return True

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -10,6 +10,7 @@
 """
 
 import re
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.transforms import Transform, Transformer
@@ -25,8 +26,7 @@ from sphinx.util.docutils import new_document
 from sphinx.util.i18n import format_date
 from sphinx.util.nodes import apply_source_workaround, is_smartquotable
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.domain.std import StandardDomain  # NOQA

--- a/sphinx/transforms/compact_bullet_list.py
+++ b/sphinx/transforms/compact_bullet_list.py
@@ -9,13 +9,14 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.transforms import SphinxTransform
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import List  # NOQA
 
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -10,6 +10,7 @@
 """
 
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.io import StringInput
@@ -27,8 +28,7 @@ from sphinx.util.nodes import (
 )
 from sphinx.util.pycompat import indent
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -10,6 +10,7 @@
 """
 
 import warnings
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.utils import get_source_line
@@ -22,8 +23,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx.util import logging
 from sphinx.util.nodes import process_only_nodes
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.domains import Domain  # NOQA

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -12,6 +12,7 @@
 import os
 from hashlib import sha1
 from math import ceil
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from six import text_type
@@ -22,8 +23,7 @@ from sphinx.util import logging, requests
 from sphinx.util.images import guess_mimetype, get_image_extension, parse_data_uri
 from sphinx.util.osutil import ensuredir, movefile
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -23,6 +23,7 @@ from collections import deque
 from datetime import datetime
 from os import path
 from time import mktime, strptime
+from typing import TYPE_CHECKING
 
 from docutils.utils import relative_path
 from six import text_type, binary_type, itervalues
@@ -46,8 +47,7 @@ from sphinx.util.nodes import (   # noqa
     caption_ref_re)
 from sphinx.util.matching import patfilter  # noqa
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, Sequence, Set, Tuple, Union  # NOQA
 
 

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -8,10 +8,12 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import os
 import re
 import sys
+from typing import TYPE_CHECKING
 
 try:
     # check if colorama is installed to support color on Windows
@@ -19,8 +21,7 @@ try:
 except ImportError:
     colorama = None
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict  # NOQA
 
 

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -11,12 +11,13 @@
 """
 from __future__ import absolute_import
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 
 from sphinx import addnodes
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, List, Tuple  # NOQA
     from sphinx.domains import Domain  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/util/docstrings.py
+++ b/sphinx/util/docstrings.py
@@ -8,11 +8,12 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import sys
+from typing import TYPE_CHECKING
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import List  # NOQA
 
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -15,6 +15,7 @@ import types
 from contextlib import contextmanager
 from copy import copy
 from distutils.version import LooseVersion
+from typing import TYPE_CHECKING
 
 import docutils
 from docutils import nodes
@@ -30,8 +31,7 @@ from sphinx.util import logging
 logger = logging.getLogger(__name__)
 report_re = re.compile('^(.+?:(?:\\d+)?): \\((DEBUG|INFO|WARNING|ERROR|SEVERE)/(\\d+)?\\) ')
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Generator, Iterator, List, Tuple  # NOQA
     from docutils.statemachine import State, ViewList  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -13,13 +13,13 @@ from __future__ import absolute_import
 import codecs
 import os
 import posixpath
+from typing import TYPE_CHECKING
 
 from docutils.utils import relative_path
 
 from sphinx.util.osutil import copyfile, ensuredir, walk
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Callable, Dict, Union  # NOQA
     from sphinx.util.matching import Matcher  # NOQA
     from sphinx.util.template import BaseRenderer  # NOQA

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -8,6 +8,8 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
+
 import gettext
 import io
 import os
@@ -15,6 +17,7 @@ import re
 from collections import namedtuple
 from datetime import datetime
 from os import path
+from typing import TYPE_CHECKING
 
 import babel.dates
 from babel.messages.mofile import write_mo
@@ -26,8 +29,7 @@ from sphinx.util.osutil import SEP, walk
 
 logger = logging.getLogger(__name__)
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Callable, List, Set  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -14,7 +14,7 @@ import base64
 import imghdr
 from collections import OrderedDict
 from os import path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import imagesize
 from six import PY3, BytesIO, iteritems
@@ -27,8 +27,7 @@ except ImportError:
     except ImportError:
         Image = None
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict, IO, List, Tuple  # NOQA
 
 if PY3:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -15,14 +15,14 @@ import re
 import sys
 import typing
 from collections import OrderedDict
+from typing import TYPE_CHECKING
 
 from six import PY2, PY3, StringIO, binary_type, string_types, itervalues
 from six.moves import builtins
 
 from sphinx.util import force_decode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Tuple, Type  # NOQA
 
 memory_address_re = re.compile(r' at 0x[0-9a-f]{8,16}(?=>)', re.IGNORECASE)

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -8,16 +8,18 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
+
 import os
 import re
 import zlib
+from typing import TYPE_CHECKING
 
 from six import PY3
 
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Callable, Dict, IO, Iterator, Tuple  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -9,15 +9,16 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import re
+from typing import TYPE_CHECKING
 
 from six import iteritems, integer_types, string_types
 
 from sphinx.util.pycompat import u
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, IO, List, Match, Union  # NOQA
 
 _str_re = re.compile(r'"(\\\\|\\"|[^"])*"')

--- a/sphinx/util/jsonimpl.py
+++ b/sphinx/util/jsonimpl.py
@@ -8,14 +8,15 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import json
+from typing import TYPE_CHECKING
 
 from six import text_type
 from six.moves import UserString
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, IO  # NOQA
 
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -14,6 +14,7 @@ import logging
 import logging.handlers
 from collections import defaultdict
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.utils import get_source_line
@@ -22,8 +23,7 @@ from six import PY2, StringIO
 from sphinx.errors import SphinxWarning
 from sphinx.util.console import colorize
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Dict, Generator, IO, List, Tuple, Union  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA

--- a/sphinx/util/matching.py
+++ b/sphinx/util/matching.py
@@ -8,11 +8,12 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import re
+from typing import TYPE_CHECKING
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Callable, Dict, List, Match, Pattern  # NOQA
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import re
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from six import text_type
@@ -19,8 +20,7 @@ from sphinx import addnodes
 from sphinx.locale import pairindextypes
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Iterable, List, Set, Tuple, Union  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.utils.tags import Tags  # NOQA

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -8,6 +8,7 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 from __future__ import print_function
 
 import contextlib
@@ -21,11 +22,11 @@ import sys
 import time
 from io import BytesIO, StringIO
 from os import path
+from typing import TYPE_CHECKING
 
 from six import PY2, PY3, text_type
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Iterator, List, Tuple, Union  # NOQA
 
 # Errnos that we need.

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -8,11 +8,13 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import os
 import time
 import traceback
 from math import sqrt
+from typing import TYPE_CHECKING
 
 from six import iteritems
 
@@ -24,8 +26,7 @@ except ImportError:
 from sphinx.errors import SphinxParallelError
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Sequence  # NOQA
 
 logger = logging.getLogger(__name__)

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -8,14 +8,15 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import codecs
 import sys
+from typing import TYPE_CHECKING
 
 from six import PY3, text_type, exec_
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Generator  # NOQA
 
 

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import
 
 import warnings
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import pkg_resources
 import requests
@@ -75,8 +76,7 @@ else:
             'install requests-2.4.1+.'
         )
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Generator, Union  # NOQA
     from sphinx.config import Config  # NOQA
 

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 
 import re
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from docutils.parsers.rst import roles
 from docutils.parsers.rst.languages import en as english
@@ -19,8 +20,7 @@ from docutils.utils import Reporter
 
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Generator  # NOQA
 
 symbols_re = re.compile(r'([!--/:-@\[-`{-~])')  # symbols without dot(0x2e)

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -28,12 +28,13 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
+from typing import TYPE_CHECKING
 
 from docutils.utils import smartquotes
 
 from sphinx.util.docutils import __version_info__ as docutils_version
 
-if False:  # For type annotation
+if TYPE_CHECKING:
     from typing import Iterable, Iterator, Tuple  # NOQA
 
 

--- a/sphinx/util/tags.py
+++ b/sphinx/util/tags.py
@@ -6,6 +6,9 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
+
+from typing import TYPE_CHECKING
 
 # (ab)use the Jinja parser for parsing our boolean expressions
 from jinja2 import nodes
@@ -14,8 +17,7 @@ from jinja2.parser import Parser
 
 env = Environment()
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Iterator, List  # NOQA
 
 

--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -8,8 +8,10 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import os
+from typing import TYPE_CHECKING
 
 from jinja2.sandbox import SandboxedEnvironment
 
@@ -17,8 +19,7 @@ from sphinx import package_dir
 from sphinx.jinja2glue import SphinxFileSystemLoader
 from sphinx.locale import get_translator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Dict  # NOQA
     from jinja2.loaders import BaseLoader  # NOQA
 

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -11,6 +11,7 @@
 """
 from itertools import product
 from operator import itemgetter
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from six import iteritems
@@ -19,8 +20,7 @@ from six.moves import range, zip_longest
 
 from sphinx.transforms import SphinxTransform
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Iterator  # NOQA
     from docutils import nodes  # NOQA
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -13,6 +13,7 @@ import copy
 import os
 import posixpath
 import sys
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.writers.html4css1 import Writer, HTMLTranslator as BaseTranslator
@@ -23,8 +24,7 @@ from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
 from sphinx.util.images import get_image_size
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any  # NOQA
     from sphinx.builders.html import StandaloneHTMLBuilder  # NOQA
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -12,6 +12,7 @@
 import os
 import posixpath
 import sys
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.writers.html5_polyglot import HTMLTranslator as BaseTranslator
@@ -22,8 +23,7 @@ from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
 from sphinx.util.images import get_image_size
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any  # NOQA
     from sphinx.builders.html import StandaloneHTMLBuilder  # NOQA
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -16,6 +16,7 @@ import re
 import sys
 from collections import defaultdict
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes, writers
 from docutils.writers.latex2e import Babel
@@ -32,8 +33,7 @@ from sphinx.util.nodes import clean_astext, traverse_parent
 from sphinx.util.template import LaTeXRenderer
 from sphinx.util.texescape import tex_escape_map, tex_replace_map
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterator, List, Pattern, Tuple, Set, Union  # NOQA
     from sphinx.builder import Builder  # NOQA
 

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import nodes
 from docutils.writers.manpage import (
     MACRO_DEF,
@@ -22,8 +24,7 @@ from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
 from sphinx.util.i18n import format_date
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any  # NOQA
     from sphinx.builders import Builder  # NOQA
 

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -12,6 +12,7 @@
 import re
 import textwrap
 from os import path
+from typing import TYPE_CHECKING
 
 from docutils import nodes, writers
 from six import itervalues
@@ -24,8 +25,7 @@ from sphinx.util import logging
 from sphinx.util.i18n import format_date
 from sphinx.writers.latex import collected_footnote
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Iterator, List, Pattern, Set, Tuple, Union  # NOQA
     from sphinx.builders.texinfo import TexinfoBuilder  # NOQA
 

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -12,6 +12,7 @@ import os
 import re
 import textwrap
 from itertools import groupby
+from typing import TYPE_CHECKING
 
 from docutils import nodes, writers
 from docutils.utils import column_width
@@ -21,8 +22,7 @@ from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Tuple, Union  # NOQA
     from sphinx.builders.text import TextBuilder  # NOQA
 

--- a/sphinx/writers/xml.py
+++ b/sphinx/writers/xml.py
@@ -9,11 +9,12 @@
     :license: BSD, see LICENSE for details.
 """
 
+from typing import TYPE_CHECKING
+
 from docutils import writers
 from docutils.writers.docutils_xml import Writer as BaseXMLWriter
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from typing import Any, Tuple  # NOQA
     from sphinx.builders import Builder  # NOQA
 


### PR DESCRIPTION
It seems using `typing.TYPE_CHECKING` is better for static typing tools.
https://docs.python.org/3.6/library/typing.html#typing.TYPE_CHECKING

I'd like to merge this into 1.7 branch for easier merging (if merged into only master, merging 1.7 to master will be conflicted often.)
I think this is not breaking change.