### PR TITLE
Fix #4617: quickstart: PROJECT_DIR argument is required

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #4608: epub: Invalid meta tag is generated
 * #4260: autodoc: keyword only argument separator is not disappeared if it is
   appeared at top of the argument list
+* #4617: quickstart: PROJECT_DIR argument is required
 
 Testing
 --------

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -533,7 +533,7 @@ Makefile to be used with sphinx-build.
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
 
-    parser.add_argument('path', metavar='PROJECT_DIR', default='.',
+    parser.add_argument('path', metavar='PROJECT_DIR', default='.', nargs='?',
                         help='output path')
 
     group = parser.add_argument_group('Structure options')


### PR DESCRIPTION
refs #4617 