### PR TITLE
key changes to 'scheme' in epub3 opf template

### DIFF
--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -11,7 +11,7 @@
     <dc:contributor>{{ contributor }}</dc:contributor>
     <dc:publisher>{{ publisher }}</dc:publisher>
     <dc:rights>{{ copyright }}</dc:rights>
-    <dc:identifier opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
+    <dc:identifier id="doc-id" opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
     <dc:date>{{ date }}</dc:date>
     <meta property="dcterms:modified">{{ date }}</meta>
     <meta property="ibooks:version">{{ version }}</meta>

--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -11,7 +11,7 @@
     <dc:contributor>{{ contributor }}</dc:contributor>
     <dc:publisher>{{ publisher }}</dc:publisher>
     <dc:rights>{{ copyright }}</dc:rights>
-    <dc:identifier id="{{ uid }}">{{ id }}</dc:identifier>
+    <dc:identifier id="{{ scheme }}">{{ id }}</dc:identifier>
     <dc:date>{{ date }}</dc:date>
     <meta property="dcterms:modified">{{ date }}</meta>
     <meta property="ibooks:version">{{ version }}</meta>

--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -11,7 +11,7 @@
     <dc:contributor>{{ contributor }}</dc:contributor>
     <dc:publisher>{{ publisher }}</dc:publisher>
     <dc:rights>{{ copyright }}</dc:rights>
-    <dc:identifier id="doc-id" opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
+    <dc:identifier id="{{ uid }}" opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
     <dc:date>{{ date }}</dc:date>
     <meta property="dcterms:modified">{{ date }}</meta>
     <meta property="ibooks:version">{{ version }}</meta>

--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -11,7 +11,7 @@
     <dc:contributor>{{ contributor }}</dc:contributor>
     <dc:publisher>{{ publisher }}</dc:publisher>
     <dc:rights>{{ copyright }}</dc:rights>
-    <dc:identifier id="{{ scheme }}">{{ id }}</dc:identifier>
+    <dc:identifier opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
     <dc:date>{{ date }}</dc:date>
     <meta property="dcterms:modified">{{ date }}</meta>
     <meta property="ibooks:version">{{ version }}</meta>


### PR DESCRIPTION
Subject: fix 'epub_scheme' parameter doesn't refrect into content.opf

### Feature or Bugfix
- Bugfix

### Purpose
- epub_scheme paprameter in conf.py is specify identifier scheme. but it doesn't work. This PR fix typo
in opf template in /sphinx/templates/epub3/content.opf_t
