### PR TITLE
Fix #4623: sphinx.build_main no longer exists in 1.7.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ Incompatible changes
 Deprecated
 ----------
 
+* #4623: ``sphinx.build_main()`` is deprecated. Use
+  ``sphinx.cmd.build.build_main()`` instead.
+
 Features added
 --------------
 
@@ -19,6 +22,7 @@ Bugs fixed
 * #4608: epub: Invalid meta tag is generated
 * #4260: autodoc: keyword only argument separator is not disappeared if it is
   appeared at top of the argument list
+* #4623: sphinx.build_main no longer exists in 1.7.0
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ Bugs fixed
 * #4260: autodoc: keyword only argument separator is not disappeared if it is
   appeared at top of the argument list
 * #4623: sphinx.build_main no longer exists in 1.7.0
+* #4615: The argument of ``sphinx.build`` has been changed in 1.7.0
 
 Testing
 --------

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import os
+import sys
 import warnings
 from os import path
 
@@ -67,6 +68,26 @@ def main(*args, **kwargs):
         stacklevel=2,
     )
     return build.main(*args, **kwargs)
+
+
+def build_main(argv=sys.argv[1:]):
+    """Sphinx build "main" command-line entry."""
+    warnings.warn(
+        '`sphinx.build_main()` has moved to `sphinx.cmd.build.build_main()`.',
+        RemovedInSphinx20Warning,
+        stacklevel=2,
+    )
+    return build.build_main(argv)
+
+
+def make_main(argv=sys.argv[1:]):
+    """Sphinx build "make mode" entry."""
+    warnings.warn(
+        '`sphinx.build_main()` has moved to `sphinx.cmd.build.make_main()`.',
+        RemovedInSphinx20Warning,
+        stacklevel=2,
+    )
+    return build.make_main(argv)
 
 
 if __name__ == '__main__':

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -67,27 +67,28 @@ def main(*args, **kwargs):
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
+    args = args[1:]  # skip first argument to adjust arguments (refs: #4615)
     return build.main(*args, **kwargs)
 
 
-def build_main(argv=sys.argv[1:]):
+def build_main(argv=sys.argv):
     """Sphinx build "main" command-line entry."""
     warnings.warn(
         '`sphinx.build_main()` has moved to `sphinx.cmd.build.build_main()`.',
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
-    return build.build_main(argv)
+    return build.build_main(argv[1:])  # skip first argument to adjust arguments (refs: #4615)
 
 
-def make_main(argv=sys.argv[1:]):
+def make_main(argv=sys.argv):
     """Sphinx build "make mode" entry."""
     warnings.warn(
         '`sphinx.build_main()` has moved to `sphinx.cmd.build.make_main()`.',
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
-    return build.make_main(argv)
+    return build.make_main(argv[1:])  # skip first argument to adjust arguments (refs: #4615)
 
 
 if __name__ == '__main__':

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -21,6 +21,7 @@ def main(*args, **kwargs):
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
+    args = args[1:]  # skip first argument to adjust arguments (refs: #4615)
     _main(*args, **kwargs)
 
 

--- a/sphinx/quickstart.py
+++ b/sphinx/quickstart.py
@@ -22,6 +22,7 @@ def main(*args, **kwargs):
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
+    args = args[1:]  # skip first argument to adjust arguments (refs: #4615)
     _main(*args, **kwargs)
 
 


### PR DESCRIPTION
refs: #4623 