### PR TITLE
Fit graphviz images to page.

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -341,7 +341,7 @@ def render_dot_latex(self, node, code, options, prefix='graphviz'):
                 post = r'\hspace*{\fill}}'
         self.body.append('\n%s' % pre)
 
-    self.body.append(r'\includegraphics{%s}' % fname)
+    self.body.append(r'\sphinxincludegraphics[]{%s}' % fname)
 
     if not is_inline:
         self.body.append('%s\n' % post)

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -91,20 +91,20 @@ def test_graphviz_latex(app, status, warning):
 
     content = (app.outdir / 'SphinxTests.tex').text()
     macro = ('\\\\begin{figure}\\[htbp\\]\n\\\\centering\n\\\\capstart\n\n'
-             '\\\\includegraphics{graphviz-\\w+.pdf}\n'
+             '\\\\sphinxincludegraphics\\[\\]{graphviz-\\w+.pdf}\n'
              '\\\\caption{caption of graph}\\\\label{.*}\\\\end{figure}')
     assert re.search(macro, content, re.S)
 
-    macro = 'Hello \\\\includegraphics{graphviz-\\w+.pdf} graphviz world'
+    macro = 'Hello \\\\sphinxincludegraphics\\[\\]{graphviz-\\w+.pdf} graphviz world'
     assert re.search(macro, content, re.S)
 
     macro = ('\\\\begin{wrapfigure}{r}{0pt}\n\\\\centering\n'
-             '\\\\includegraphics{graphviz-\\w+.pdf}\n'
+             '\\\\sphinxincludegraphics\\[\\]{graphviz-\\w+.pdf}\n'
              '\\\\caption{on right}\\\\label{.*}\\\\end{wrapfigure}')
     assert re.search(macro, content, re.S)
 
     macro = (r'\{\\hfill'
-             r'\\includegraphics{graphviz-.*}'
+             r'\\sphinxincludegraphics\[\]{graphviz-.*}'
              r'\\hspace\*{\\fill}}')
     assert re.search(macro, content, re.S)
 

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -40,7 +40,7 @@ def test_inheritance_diagram_latex(app, status, warning):
     content = (app.outdir / 'Python.tex').text()
 
     pattern = ('\\\\begin{figure}\\[htbp]\n\\\\centering\n\\\\capstart\n\n'
-               '\\\\includegraphics{inheritance-\\w+.pdf}\n'
+               '\\\\sphinxincludegraphics\\[\\]{inheritance-\\w+.pdf}\n'
                '\\\\caption{Test Foo!}\\\\label{\\\\detokenize{index:id1}}\\\\end{figure}')
     assert re.search(pattern, content, re.M)
 


### PR DESCRIPTION
Use \sphinxincludegraphics, that's what the core image directives use.

I understand this can be a breaking change for someone, but I hope the end result is much better -- images are correctly shrinked to fit the page.