### PR TITLE
test: allows to drop 0.05% coverages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        # allowed to drop X% and still result in a "success" commit status
+        threshold: 0.05


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since enabling codecov, almost of PR marked as failed
- To prevent it, this allows to drop small coverages
