### PR TITLE
Fix #4577: Enumerated sublists with explicit start with wrong number

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * #4622: epub: :confval:`epub_scheme` does not effect to content.opf
 * #4627: graphviz: Fit graphviz images to page
 * #4617: quickstart: PROJECT_DIR argument is required
+* #4577: Enumerated sublists with explicit start with wrong number
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1581,9 +1581,19 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_enumerated_list(self, node):
         # type: (nodes.Node) -> None
+        def get_nested_level(node):
+            # type: (nodes.Node) -> int
+            if node is None:
+                return 0
+            elif isinstance(node, nodes.enumerated_list):
+                return get_nested_level(node.parent) + 1
+            else:
+                return get_nested_level(node.parent)
+
         self.body.append('\\begin{enumerate}\n')
         if 'start' in node:
-            self.body.append('\\setcounter{enumi}{%d}\n' % (node['start'] - 1))
+            nested = get_nested_level(node)
+            self.body.append('\\setcounter{enum%s}{%d}\n' % ('i' * nested, node['start'] - 1))
         if self.table:
             self.table.has_problematic = True
 

--- a/tests/roots/test-nested-enumerated-list/conf.py
+++ b/tests/roots/test-nested-enumerated-list/conf.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'test.tex', 'The basic Sphinx documentation for testing', 'Sphinx', 'report')
+]

--- a/tests/roots/test-nested-enumerated-list/index.rst
+++ b/tests/roots/test-nested-enumerated-list/index.rst
@@ -1,0 +1,15 @@
+nested-enumerated-list
+======================
+
+5. Sphinx
+
+   d. Documentation builder
+   e. Egypt
+
+      10) Pyramid
+      11) Nile River
+
+6. Markup
+
+   iii. reStructuredText
+   iv. Markdown

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1143,3 +1143,14 @@ def test_latex_image_in_parsed_literal(app, status, warning):
     assert ('{\\sphinxunactivateextrasandspace \\raisebox{-0.5\\height}'
             '{\\scalebox{2.000000}{\\sphinxincludegraphics[height=1cm]{{pic}.png}}}'
             '}AFTER') in result
+
+
+@pytest.mark.sphinx('latex', testroot='nested-enumerated-list')
+def test_latex_nested_enumerated_list(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'test.tex').text(encoding='utf8')
+    assert r'\setcounter{enumi}{4}' in result
+    assert r'\setcounter{enumii}{3}' in result
+    assert r'\setcounter{enumiii}{9}' in result
+    assert r'\setcounter{enumii}{2}' in result


### PR DESCRIPTION
refs: #4577 