### PR TITLE
Show opt:scheme attribute only for EPUB3.1 (refs: #4622)

### DIFF
--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -133,6 +133,7 @@ class Epub3Builder(_epub_base.EpubBuilder):
         metadata['ibook_scroll_axis'] = IBOOK_SCROLL_AXIS.get(writing_mode)
         metadata['date'] = self.esc(format_date("%Y-%m-%dT%H:%M:%SZ"))
         metadata['version'] = self.esc(self.config.version)
+        metadata['epub_version'] = self.config.epub_version
         return metadata
 
     def prepare_writing(self, docnames):
@@ -229,6 +230,7 @@ def setup(app):
 
     # config values
     app.add_config_value('epub_basename', lambda self: make_filename(self.project), None)
+    app.add_config_value('epub_version', 3.0, 'epub')  # experimental
     app.add_config_value('epub_theme', 'epub', 'epub')
     app.add_config_value('epub_theme_options', {}, 'epub')
     app.add_config_value('epub_title', lambda self: self.html_title, 'epub')

--- a/sphinx/templates/epub3/content.opf_t
+++ b/sphinx/templates/epub3/content.opf_t
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="{{ lang }}"
+<package xmlns="http://www.idpf.org/2007/opf" version="{{ epub_version }}" xml:lang="{{ lang }}"
  unique-identifier="{{ uid }}"
  prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0/">
   <metadata xmlns:opf="http://www.idpf.org/2007/opf"
@@ -11,7 +11,11 @@
     <dc:contributor>{{ contributor }}</dc:contributor>
     <dc:publisher>{{ publisher }}</dc:publisher>
     <dc:rights>{{ copyright }}</dc:rights>
+    {%- if epub_version == 3.1 %}
     <dc:identifier id="{{ uid }}" opf:scheme="{{ scheme }}">{{ id }}</dc:identifier>
+    {%- else %}
+    <dc:identifier id="{{ uid }}">{{ id }}</dc:identifier>
+    {%- endif %}
     <dc:date>{{ date }}</dc:date>
     <meta property="dcterms:modified">{{ date }}</meta>
     <meta property="ibooks:version">{{ version }}</meta>


### PR DESCRIPTION
refs: #4611 

@turky I investigated about `opt:scheme` again. And I found it is allowed since EPUB3.1, (not EPUB3.0). To generate valid EPUB, I'd like to generate the attribute only for EPUB3.1.
What do you think?

Note: In this PR, I added `epub_version` confval, but it is experimental, and undocumented variable.