### PR TITLE
Fix #4641: A external link in TOC cannot contain "?" with ``:glob:`` option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
 * #4630: Have order on msgids in sphinx.pot deterministic
 * #4563: autosummary: Incorrect end of line punctuation detection
 * #4577: Enumerated sublists with explicit start with wrong number
+* #4641: A external link in TOC cannot contain "?" with ``:glob:`` option
 
 Testing
 --------

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -73,7 +73,9 @@ class TocTree(Directive):
         for entry in self.content:
             if not entry:
                 continue
-            if glob and ('*' in entry or '?' in entry or '[' in entry):
+            # look for explicit titles ("Some Title <document>")
+            explicit = explicit_title_re.match(entry)
+            if glob and ('*' in entry or '?' in entry or '[' in entry) and not explicit:
                 patname = docname_join(env.docname, entry)
                 docnames = sorted(patfilter(all_docnames, patname))
                 for docname in docnames:
@@ -85,11 +87,9 @@ class TocTree(Directive):
                         'toctree glob pattern %r didn\'t match any documents'
                         % entry, line=self.lineno))
             else:
-                # look for explicit titles ("Some Title <document>")
-                m = explicit_title_re.match(entry)
-                if m:
-                    ref = m.group(2)
-                    title = m.group(1)
+                if explicit:
+                    ref = explicit.group(2)
+                    title = explicit.group(1)
                     docname = ref
                 else:
                     ref = docname = entry

--- a/tests/roots/test-toctree-glob/index.rst
+++ b/tests/roots/test-toctree-glob/index.rst
@@ -12,6 +12,7 @@ normal order
    bar/*
    baz
    qux/index
+   hyperref <https://sphinx-doc.org/?q=sphinx>
 
 reversed order
 -------------

--- a/tests/test_environment_toctree.py
+++ b/tests/test_environment_toctree.py
@@ -113,7 +113,7 @@ def test_glob(app):
                 maxdepth=-1, numbered=0, includefiles=includefiles,
                 entries=[(None, 'foo'), (None, 'bar/index'), (None, 'bar/bar_1'),
                          (None, 'bar/bar_2'), (None, 'bar/bar_3'), (None, 'baz'),
-                         (None, 'qux/index')])
+                         (None, 'qux/index'), ('hyperref', 'https://sphinx-doc.org/?q=sphinx')])
     assert_node(toctree[0][1][1],
                 [list_item, ([compact_paragraph, reference, "reversed order"],
                              [bullet_list, addnodes.toctree])])  # [0][1][1][1][0]


### PR DESCRIPTION
refs: #4641 