### PR TITLE
Fix error reporting for parameterless ImportErrors

### DIFF
--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -179,7 +179,7 @@ def import_object(modname, objpath, objtype='', attrgetter=safe_getattr, warning
             if isinstance(real_exc, SystemExit):
                 errmsg += ('; the module executes module level statement '
                            'and it might call sys.exit().')
-            elif isinstance(real_exc, ImportError):
+            elif isinstance(real_exc, ImportError) and real_exc.args:
                 errmsg += '; the following exception was raised:\n%s' % real_exc.args[0]
             else:
                 errmsg += '; the following exception was raised:\n%s' % traceback_msg


### PR DESCRIPTION
In some cases, a module may raise an `ImportError` without any arguments, e.g.

```python
if not_allowed():
    raise ImportError
```

In this case, the exception has no args.  This is bad practice, but it happens.

Currently, autodoc will crash with
```
IndexError: tuple index out of range
```

Subject: Fix a crash in autodoc.
### Feature or Bugfix
- Bugfix

### Purpose
- Fix a crash on bad code.
