### PR TITLE
Fix #4520: Fix skipping none empty packages

### DIFF
--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -195,7 +195,7 @@ def shall_skip(module, opts, excludes=[]):
         return True
 
     # skip it if there is nothing (or just \n or \r\n) in the file
-    if path.exists(module) and path.getsize(module) <= 2:
+    if path.exists(module):
         if os.path.basename(module) == '__init__.py':
             # We only want to skip packages if they do not contain any
             # .py files other than __init__.py.


### PR DESCRIPTION
Subject: Fix skipping none empty packages

### Feature or Bugfix
- Bugfix

### Purpose
Packages that contain nothing but sub-packages
should not be skipped since they are in fact not empty.

### Detail

**Reproduce**:
```bash
pip install django
django-admin startproject example .
mkdir -p example/management/commands
touch example/management/__init__.py
touch example/management/commands/__init__.py
echo '"""Docstring"""' > example/management/commands/my_customer_command.py
```

### Relates
- #4520

