### PR TITLE
Typo: cocstring => docstring

### DIFF
--- a/doc/ext/autodoc.rst
+++ b/doc/ext/autodoc.rst
@@ -398,7 +398,7 @@ There are also new config values that you can set:
 .. confval:: autodoc_inherit_docstrings
 
    This value controls the docstrings inheritance.
-   If set to True the cocstring for classes or methods, if not explicitly set,
+   If set to True the docstring for classes or methods, if not explicitly set,
    is inherited form parents.
 
    The default is ``True``.


### PR DESCRIPTION
Fix small typo.