### PR TITLE
cpp domain: Fix assert when describing undefined symbol.

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6205,7 +6205,7 @@ class CPPDomain(Domain):
         if target is None:
             return None
         parentKey = node.get("cpp:parent_key", None)
-        if parentKey is None:
+        if parentKey is None or len(parentKey) <= 0:
             return None
 
         rootSymbol = self.data['root_symbol']


### PR DESCRIPTION
Subject: Prevent assert when generating undefined symbol message in CPP domain.

### Feature or Bugfix
- Bugfix

### Purpose
Frequently when there is a reference in the CPP domain to an undefined system, Sphinx 1.7.0 asserts instead of generating a message. This makes it extremely difficult to determine the cause of the problem.

### Detail
The typical assertion stack looks like this -
```
# Sphinx version: 1.7.0
# Python version: 2.7.14 (CPython)
# Docutils version: 0.14 
# Jinja2 version: 2.10
# Last messages:
#   writing output... [ 78%] developer-guide/api/types/TSServerSessionSharingPoolType.en
#   writing output... [ 79%] developer-guide/api/types/TSServerState.en
#   writing output... [ 79%] developer-guide/api/types/TSStatPeristence.en
#   writing output... [ 79%] developer-guide/api/types/TSStatSync.en
#   writing output... [ 79%] developer-guide/api/types/TSThreadPool.en
#   writing output... [ 80%] developer-guide/api/types/TSUuid.en
#   writing output... [ 80%] developer-guide/api/types/TSVConnCloseFlags.en
#   writing output... [ 80%] developer-guide/api/types/index.en
#   writing output... [ 80%] developer-guide/architecture/api-functions.en
#   writing output... [ 80%] developer-guide/architecture/architecture.en
# Loaded extensions:
#   sphinx.ext.coverage (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/coverage.pyc
#   sphinx.ext.imgmath (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/imgmath.pyc
#   sphinx.ext.viewcode (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/viewcode.pyc
#   sphinx.ext.todo (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/todo.pyc
#   traffic-server (unknown version) from /home/solidwallofcode/git/7.1.x/doc/ext/traffic-server.pyc
#   sphinx.ext.autodoc (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/autodoc/__init__.pyc
#   sphinx.ext.intersphinx (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/intersphinx.pyc
#   sphinx.ext.graphviz (1.7.0) from /usr/lib/python2.7/site-packages/sphinx/ext/graphviz.pyc
#   alabaster (0.7.10) from /usr/lib/python2.7/site-packages/alabaster/__init__.pyc
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/cmdline.py", line 304, in main
    app.build(args.force_all, filenames)
  File "/usr/lib/python2.7/site-packages/sphinx/application.py", line 330, in build
    self.builder.build_update()
  File "/usr/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 333, in build_update
    'out of date' % len(to_build))
  File "/usr/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 394, in build
    self.write(docnames, list(updated_docnames), method)
  File "/usr/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 431, in write
    self._write_serial(sorted(docnames))
  File "/usr/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 438, in _write_serial
    doctree = self.env.get_and_resolve_doctree(docname, self)
  File "/usr/lib/python2.7/site-packages/sphinx/environment/__init__.py", line 813, in get_and_resolve_doctree
    self.apply_post_transforms(doctree, docname)
  File "/usr/lib/python2.7/site-packages/sphinx/environment/__init__.py", line 860, in apply_post_transforms
    transformer.apply_transforms()
  File "/usr/lib/python2.7/site-packages/sphinx/transforms/__init__.py", line 96, in apply_transforms
    Transformer.apply_transforms(self)
  File "/usr/lib/python2.7/site-packages/docutils/transforms/__init__.py", line 171, in apply_transforms
    transform.apply(**kwargs)
  File "/usr/lib/python2.7/site-packages/sphinx/transforms/post_transforms/__init__.py", line 97, in apply
    node, contnode)
  File "/usr/lib/python2.7/site-packages/sphinx/application.py", line 447, in emit_firstresult
    return self.events.emit_firstresult(event, self, *args)
  File "/usr/lib/python2.7/site-packages/sphinx/events.py", line 84, in emit_firstresult
    for result in self.emit(name, *args):
  File "/usr/lib/python2.7/site-packages/sphinx/events.py", line 79, in emit
    results.append(callback(*args))
  File "/usr/lib/python2.7/site-packages/sphinx/ext/intersphinx.py", line 315, in missing_reference
    full_qualified_name = env.get_domain(domain).get_full_qualified_name(node)
  File "/usr/lib/python2.7/site-packages/sphinx/domains/cpp.py", line 6088, in get_full_qualified_name
    parentName = parentSymbol.get_full_nested_name()
  File "/usr/lib/python2.7/site-packages/sphinx/domains/cpp.py", line 3420, in get_full_nested_name
    return ASTNestedName(names, templates, rooted=False)
  File "/usr/lib/python2.7/site-packages/sphinx/domains/cpp.py", line 1824, in __init__
    assert len(names) > 0
AssertionError
```
The problems seems to be that `node.get("cpp:parent_key", None)` returns `[]` on a miss, not `None`. In that case the code continues on to get the parent data and eventually hits the assert. With this change `None` is returned from `get_full_qualified_name` in this case (e.g. no parent information).

I was unable to get my Sphinx docs to build until I made this patch locally, after which I was able to locate and fix all of my undefined symbols.

### Relates

