### PR TITLE
Move env.update() to Builder class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,8 @@ Deprecated
 * ``Sphinx.add_source_parser()`` has changed;  the *suffix* argument has
   been deprecated.  Please use ``Sphinx.add_source_suffix()`` instead.
 * ``sphinx.util.docutils.directive_helper()`` is deprecated.
+* All ``env.update()``, ``env._read_serial()`` and ``env._read_parallel()`` are
+  deprecated.  Please use ``builder.read()`` instead.
 
 Features added
 --------------

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -530,6 +530,7 @@ class BuildEnvironment(object):
         self.doctreedir = doctreedir
         self.find_files(config, self.app.builder)
         self.config = config
+        self._update_settings(config)
 
         # this cache also needs to be updated every time
         self._nitpick_ignore = set(self.config.nitpick_ignore)
@@ -632,6 +633,17 @@ class BuildEnvironment(object):
             if docname not in already:
                 yield docname
 
+    def _update_settings(self, config):
+        # type: (Config) -> None
+        """Update settings by new config."""
+        self.settings['input_encoding'] = config.source_encoding
+        self.settings['trim_footnote_reference_space'] = config.trim_footnote_reference_space
+        self.settings['gettext_compact'] = config.gettext_compact
+        self.settings['language_code'] = config.language or 'en'
+
+        # Allow to disable by 3rd party extension (workaround)
+        self.settings.setdefault('smart_quotes', True)
+
     # --------- SINGLE FILE READING --------------------------------------------
 
     def prepare_settings(self, docname):
@@ -642,16 +654,6 @@ class BuildEnvironment(object):
         self.temp_data['default_role'] = self.config.default_role
         self.temp_data['default_domain'] = \
             self.domains.get(self.config.primary_domain)
-
-        self.settings['input_encoding'] = self.config.source_encoding
-        self.settings['trim_footnote_reference_space'] = \
-            self.config.trim_footnote_reference_space
-        self.settings['gettext_compact'] = self.config.gettext_compact
-
-        self.settings['language_code'] = self.config.language or 'en'
-
-        # Allow to disable by 3rd party extension (workaround)
-        self.settings.setdefault('smart_quotes', True)
 
     def read_doc(self, docname, app=None):
         # type: (unicode, Sphinx) -> None

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+    test_builder
+    ~~~~~~~~
+
+    Test the Builder class.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+import pytest
+
+
+@pytest.mark.sphinx('dummy', srcdir="test_builder")
+def test_incremental_reading(app):
+    # first reading
+    updated = app.builder.read()
+    assert set(updated) == app.env.found_docs == set(app.env.all_docs)
+
+    # test if exclude_patterns works ok
+    assert 'subdir/excluded' not in app.env.found_docs
+
+    # before second reading, add, modify and remove source files
+    (app.srcdir / 'new.txt').write_text('New file\n========\n')
+    app.env.all_docs['contents'] = 0  # mark as modified
+    (app.srcdir / 'autodoc.txt').unlink()
+
+    # second reading
+    updated = app.builder.read()
+
+    # "includes" and "images" are in there because they contain references
+    # to nonexisting downloadable or image files, which are given another
+    # chance to exist
+    assert set(updated) == set(['contents', 'new', 'includes', 'images'])
+    assert 'autodoc' not in app.env.all_docs
+    assert 'autodoc' not in app.env.found_docs
+
+
+@pytest.mark.sphinx('dummy')
+def test_env_read_docs(app):
+    """By default, docnames are read in alphanumeric order"""
+    def on_env_read_docs_1(app, env, docnames):
+        pass
+
+    app.connect('env-before-read-docs', on_env_read_docs_1)
+
+    read_docnames = app.builder.read()
+    assert len(read_docnames) > 2 and read_docnames == sorted(read_docnames)
+
+    def on_env_read_docs_2(app, env, docnames):
+        docnames.remove('images')
+
+    app.connect('env-before-read-docs', on_env_read_docs_2)
+
+    read_docnames = app.builder.read()
+    assert len(read_docnames) == 2

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -12,38 +12,15 @@ import pytest
 
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.builders.latex import LaTeXBuilder
-from sphinx.testing.util import SphinxTestApp, path
-
-app = env = None
 
 
-@pytest.fixture(scope='module', autouse=True)
-def setup_module(rootdir, sphinx_test_tempdir):
-    global app, env
-    srcdir = sphinx_test_tempdir / 'root-envtest'
-    if not srcdir.exists():
-        (rootdir / 'test-root').copytree(srcdir)
-    app = SphinxTestApp(srcdir=srcdir)
-    env = app.env
-    yield
-    app.cleanup()
-
-
-# Tests are run in the order they appear in the file, therefore we can
-# afford to not run update() in the setup but in its own test
-
-def test_first_update():
-    updated = env.update(app.config, app.srcdir, app.doctreedir)
-    assert set(updated) == env.found_docs == set(env.all_docs)
-    # test if exclude_patterns works ok
-    assert 'subdir/excluded' not in env.found_docs
-
-
-def test_images():
+@pytest.mark.sphinx('dummy')
+def test_images(app):
+    app.build()
     assert ('image file not readable: foo.png'
             in app._warning.getvalue())
 
-    tree = env.get_doctree('images')
+    tree = app.env.get_doctree('images')
     htmlbuilder = StandaloneHTMLBuilder(app)
     htmlbuilder.set_environment(app.env)
     htmlbuilder.init()
@@ -67,44 +44,10 @@ def test_images():
              'svgimg.pdf', 'img.foo.png'])
 
 
-def test_second_update():
-    # delete, add and "edit" (change saved mtime) some files and update again
-    env.all_docs['contents'] = 0
-    root = path(app.srcdir)
-    # important: using "autodoc" because it is the last one to be included in
-    # the contents.txt toctree; otherwise section numbers would shift
-    (root / 'autodoc.txt').unlink()
-    (root / 'new.txt').write_text('New file\n========\n')
-    updated = env.update(app.config, app.srcdir, app.doctreedir)
-    # "includes" and "images" are in there because they contain references
-    # to nonexisting downloadable or image files, which are given another
-    # chance to exist
-    assert set(updated) == set(['contents', 'new', 'includes', 'images'])
-    assert 'autodoc' not in env.all_docs
-    assert 'autodoc' not in env.found_docs
-
-
-def test_env_read_docs():
-    """By default, docnames are read in alphanumeric order"""
-    def on_env_read_docs_1(app, env, docnames):
-        pass
-
-    app.connect('env-before-read-docs', on_env_read_docs_1)
-
-    read_docnames = env.update(app.config, app.srcdir, app.doctreedir)
-    assert len(read_docnames) > 2 and read_docnames == sorted(read_docnames)
-
-    def on_env_read_docs_2(app, env, docnames):
-        docnames.remove('images')
-
-    app.connect('env-before-read-docs', on_env_read_docs_2)
-
-    read_docnames = env.update(app.config, app.srcdir, app.doctreedir)
-    assert len(read_docnames) == 2
-
-
-def test_object_inventory():
-    refs = env.domaindata['py']['objects']
+@pytest.mark.sphinx('dummy')
+def test_object_inventory(app):
+    app.build()
+    refs = app.env.domaindata['py']['objects']
 
     assert 'func_without_module' in refs
     assert refs['func_without_module'] == ('objects', 'function')
@@ -121,8 +64,8 @@ def test_object_inventory():
     assert 'func_in_module' not in refs
     assert 'func_noindex' not in refs
 
-    assert env.domaindata['py']['modules']['mod'] == \
+    assert app.env.domaindata['py']['modules']['mod'] == \
         ('objects', 'Module synopsis.', 'UNIX', False)
 
-    assert env.domains['py'].data is env.domaindata['py']
-    assert env.domains['c'].data is env.domaindata['c']
+    assert app.env.domains['py'].data is app.env.domaindata['py']
+    assert app.env.domains['c'].data is app.env.domaindata['c']

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -525,7 +525,8 @@ def test_gettext_buildr_ignores_only_directive(app):
 def test_gettext_dont_rebuild_mo(make_app, app_params, build_mo):
     # --- don't rebuild by .mo mtime
     def get_number_of_update_targets(app_):
-        updated = app_.env.update(app_.config, app_.srcdir, app_.doctreedir)
+        app_.env.find_files(app_.config, app_.builder)
+        _, updated, _ = app_.env.get_outdated_files(config_changed=False)
         return len(updated)
 
     args, kwargs = app_params
@@ -706,12 +707,14 @@ def test_html_rebuild_mo(app):
     app.build()
     # --- rebuild by .mo mtime
     app.builder.build_update()
-    updated = app.env.update(app.config, app.srcdir, app.doctreedir)
+    app.env.find_files(app.config, app.builder)
+    _, updated, _ = app.env.get_outdated_files(config_changed=False)
     assert len(updated) == 0
 
     mtime = (app.srcdir / 'xx' / 'LC_MESSAGES' / 'bom.mo').stat().st_mtime
     (app.srcdir / 'xx' / 'LC_MESSAGES' / 'bom.mo').utime((mtime + 5, mtime + 5))
-    updated = app.env.update(app.config, app.srcdir, app.doctreedir)
+    app.env.find_files(app.config, app.builder)
+    _, updated, _ = app.env.get_outdated_files(config_changed=False)
     assert len(updated) == 1
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- So far, `BuildEnvironment` has two large responsibilities. The one is storing environment data, and another is converting source files to doctrees.
- This PR moves the second responsibility to `Builder` class. The reading process is a part of builds. And it is never environment's. I thnk the `Builder` class is much appropriate than `BuildEnvironment`.


### Note

I'll also separate `env.read_doc()` method later. This is step 1 of the refactoring.
My goal is simplify `BuildEnvironment` class.