### PR TITLE
Fix #4669: sphinx.build_main and sphinx.make_main throw NameError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #4669: sphinx.build_main and sphinx.make_main throw NameError
+
 Testing
 --------
 

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -73,6 +73,7 @@ def main(*args, **kwargs):
 
 def build_main(argv=sys.argv):
     """Sphinx build "main" command-line entry."""
+    from .cmd import build
     warnings.warn(
         '`sphinx.build_main()` has moved to `sphinx.cmd.build.build_main()`.',
         RemovedInSphinx20Warning,
@@ -83,6 +84,7 @@ def build_main(argv=sys.argv):
 
 def make_main(argv=sys.argv):
     """Sphinx build "make mode" entry."""
+    from .cmd import build
     warnings.warn(
         '`sphinx.build_main()` has moved to `sphinx.cmd.build.make_main()`.',
         RemovedInSphinx20Warning,


### PR DESCRIPTION
refs: #4669 