### PR TITLE
Prevent python class/instance variables from linking to objects

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -178,7 +178,7 @@ class PyObject(ObjectDescription):
                             'keyword', 'kwarg', 'kwparam'),
                      typerolename='class', typenames=('paramtype', 'type'),
                      can_collapse=True),
-        PyTypedField('variable', label=l_('Variables'), rolename='obj',
+        PyTypedField('variable', label=l_('Variables'),
                      names=('var', 'ivar', 'cvar'),
                      typerolename='class', typenames=('vartype',),
                      can_collapse=True),


### PR DESCRIPTION
Previously, python variables were given a rolename of `obj`, which allowed any `:ivar foo:` or `:cvar foo:` to link as a cross-reference to any object in the entire build. I believe that this is almost never desirable behavior, since variables often have very simple names that can collide badly with other parts of the project.

Take, for instance, a class with a variable named `size`. It should not link to a method in a different class that is also named `size`. A user seeing that the variable is a link would be very confused by what they are linked to.

I believe the solution is to remove the ability for variable names to link anywhere. I'm open to discussion on this one, but I don't the way people write code is such that the name of a variable can be found elsewhere sphinx will know about and will be related in a meaningful way.