### PR TITLE
Remove incorrectly formatted translation

### DIFF
--- a/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
@@ -1295,7 +1295,7 @@ msgstr "目录"
 #: sphinx/transforms/post_transforms/__init__.py:139
 #, python-format
 msgid "more than one target found for 'any' cross-reference %r: could be %s"
-msgstr "'any' 交叉引用的目标不唯一：可能是 %s"
+msgstr ""
 
 #: sphinx/transforms/post_transforms/__init__.py:169
 #, python-format


### PR DESCRIPTION
Subject: Removing a broken translation

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix

### Purpose
- Running compiletranslations on this .po file causes an error of `number of format specifications in 'msgid' and 'msgstr' does not match` due to the missing `%r` reference in the translation. This removes the translation because I don't know the language to fix it. A fixed translation would be preferred but this is outside of my skillset.

This translation was added in bc068e41435fea05b419133f23b33e7c19f4f39c. Prior to that, it was an empty string, so this reverts to the empty string.

