### PR TITLE
Fix pydomain: always strip parenthesis if empty (refs: #1042)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #4669: sphinx.build_main and sphinx.make_main throw NameError
 * #4685: autosummary emits meaningless warnings
+* pydomain: always strip parenthesis if empty (refs: #1042)
 
 Testing
 --------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 py_sig_re = re.compile(
     r'''^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
-          (?: \((.*)\)           # optional: arguments
+          (?: \(\s*(.*)\s*\)     # optional: arguments
            (?:\s* -> \s* (.*))?  #           return annotation
           )? $                   # and nothing more
           ''', re.VERBOSE)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- `py:class` directive should strip parenthesis always if empty (refs: #1042)
