### PR TITLE
Fix infinit loop on make-mode

### DIFF
--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -23,7 +23,7 @@ from os import path
 from typing import TYPE_CHECKING
 
 import sphinx
-from sphinx import cmdline
+from sphinx.cmd.build import build_main
 from sphinx.util.console import color_terminal, nocolor, bold, blue  # type: ignore
 from sphinx.util.osutil import cd, rmtree
 
@@ -139,7 +139,7 @@ class Make(object):
                 '-d', doctreedir,
                 self.srcdir,
                 self.builddir_join(builder)]
-        return cmdline.main(args + opts)
+        return build_main(args + opts)
 
 
 def run_make_mode(args):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix a bug caused by #4631.
- `sphinx-build` crashes with recursion error on make-mode.

