### PR TITLE
Fix #4689: autosummary: unexpectedly strips docstrings containing "i.e."

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #4685: autosummary emits meaningless warnings
 * autodoc: crashed when invalid options given
 * pydomain: always strip parenthesis if empty (refs: #1042)
+* #4689: autosummary: unexpectedly strips docstrings containing "i.e."
 
 Testing
 --------

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -90,6 +90,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+periods_re = re.compile('\.(?:\s+)')
+
+
 # -- autosummary_toc node ------------------------------------------------------
 
 class autosummary_toc(nodes.comment):
@@ -466,7 +469,7 @@ def extract_summary(doc, document):
             break
 
     # Try to find the "first sentence", which may span multiple lines
-    sentences = " ".join(doc).split('.')
+    sentences = periods_re.split(" ".join(doc))  # type: ignore
     if len(sentences) == 1:
         summary = sentences[0].strip()
     else:

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -77,6 +77,10 @@ def test_extract_summary(capsys):
            'it does not break sentence.']
     assert extract_summary(doc, document) == ' '.join(doc)
 
+    # abbreviations
+    doc = ['Blabla, i.e. bla.']
+    assert extract_summary(doc, document) == 'Blabla, i.e.'
+
     _, err = capsys.readouterr()
     assert err == ''
 


### PR DESCRIPTION
refs: #4689 