### PR TITLE
Remove the remaining traces of sphinx.pycode.pgen2 module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -31,64 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Licenses for incorporated software
 ==================================
 
-The pgen2 package, included in this distribution under the name
-sphinx.pycode.pgen2, is available in the Python 2.6 distribution under
-the PSF license agreement for Python:
-
-----------------------------------------------------------------------
-Copyright © 2001-2008 Python Software Foundation; All Rights Reserved.
-
-PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
---------------------------------------------
-
-1. This LICENSE AGREEMENT is between the Python Software Foundation
-   ("PSF"), and the Individual or Organization ("Licensee") accessing
-   and otherwise using Python 2.6 software in source or binary form
-   and its associated documentation.
-
-2. Subject to the terms and conditions of this License Agreement, PSF
-   hereby grants Licensee a nonexclusive, royalty-free, world-wide
-   license to reproduce, analyze, test, perform and/or display
-   publicly, prepare derivative works, distribute, and otherwise use
-   Python 2.6 alone or in any derivative version, provided, however,
-   that PSF's License Agreement and PSF's notice of copyright, i.e.,
-   "Copyright © 2001-2008 Python Software Foundation; All Rights
-   Reserved" are retained in Python 2.6 alone or in any derivative
-   version prepared by Licensee.
-
-3. In the event Licensee prepares a derivative work that is based on
-   or incorporates Python 2.6 or any part thereof, and wants to make
-   the derivative work available to others as provided herein, then
-   Licensee hereby agrees to include in any such work a brief summary
-   of the changes made to Python 2.6.
-
-4. PSF is making Python 2.6 available to Licensee on an "AS IS" basis.
-   PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY
-   WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY
-   REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY
-   PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 2.6 WILL NOT INFRINGE
-   ANY THIRD PARTY RIGHTS.
-
-5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
-   2.6 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
-   AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON
-   2.6, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY
-   THEREOF.
-
-6. This License Agreement will automatically terminate upon a material
-   breach of its terms and conditions.
-
-7. Nothing in this License Agreement shall be deemed to create any
-   relationship of agency, partnership, or joint venture between PSF
-   and Licensee.  This License Agreement does not grant permission to
-   use PSF trademarks or trade name in a trademark sense to endorse or
-   promote products or services of Licensee, or any third party.
-
-8. By copying, installing or otherwise using Python 2.6, Licensee
-   agrees to be bound by the terms and conditions of this License
-   Agreement.
-----------------------------------------------------------------------
-
 The included smartypants module, included as sphinx.util.smartypants,
 is available under the following license:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ directory = sphinx/locale/
 [flake8]
 max-line-length = 95
 ignore = E116,E241,E251,E741,I101
-exclude = .git,.tox,.venv,tests/*,build/*,doc/_build/*,sphinx/search/*,sphinx/pycode/pgen2/*,doc/ext/example*.py
+exclude = .git,.tox,.venv,tests/*,build/*,doc/_build/*,sphinx/search/*,doc/ext/example*.py
 application-import-names = sphinx
 import-order-style = smarkets
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import os
 import sys
 from distutils import log
-from distutils.cmd import Command
 
 from setuptools import find_packages, setup
 
@@ -150,32 +149,6 @@ else:
                     outfile.write(');')
 
     cmdclass['compile_catalog'] = compile_catalog_plusjs
-
-
-class CompileGrammarCommand(Command):
-    description = 'Compile python grammar file for pycode'
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        from sphinx.pycode.pgen2.driver import compile_grammar
-
-        compile_grammar('sphinx/pycode/Grammar-py2.txt')
-        print('sphinx/pycode/Grammar-py2.txt ... done')
-
-        compile_grammar('sphinx/pycode/Grammar-py3.txt')
-        print('sphinx/pycode/Grammar-py3.txt ... done')
-
-    def sub_commands(self):
-        pass
-
-
-cmdclass['compile_grammar'] = CompileGrammarCommand
 
 
 setup(


### PR DESCRIPTION
The `sphinx/pycode/pgen2` module was removed in #3937, however some parts of the code still referred to it.

Most importantly, the `setup.py compile_grammar` command still existed and was failing with:
```python
Traceback (most recent call last):
  File "./setup.py", line 233, in <module>
    cmdclass=cmdclass,
  File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "./setup.py", line 166, in run
    from sphinx.pycode.pgen2.driver import compile_grammar
ModuleNotFoundError: No module named 'sphinx.pycode.pgen2'
```

I think we no longer need this command, so I removed it.