### PR TITLE
apidoc: correct logic for skipping files

### DIFF
--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -200,9 +200,13 @@ def shall_skip(module, opts, excludes=[]):
             # We only want to skip packages if they do not contain any
             # .py files other than __init__.py.
             basemodule = path.dirname(module)
-            for module in glob.glob(path.join(basemodule, '*.py')):
-                if not is_excluded(path.join(basemodule, module), excludes):
-                    return True
+            for pyfile in glob.glob(path.join(basemodule, '*.py')):
+                if (not is_excluded(path.join(basemodule, pyfile), excludes)
+                        and os.path.basename(pyfile) != '__init__.py'):
+                    # found at least one non empty file which should not
+                    # be skipped
+                    return False
+            return True
         else:
             return True
 


### PR DESCRIPTION
The logic for deciding which files should be excluded from the apidoc extension changed in 
1.7.0 seems slightly flawed to me which results in all my autodoc files being excluded from the TOC. 
This aims to correct that.

### Feature or Bugfix
- Bugfix

### Purpose
The logic in shall_skip iterates through all .py files in a given directory if called on an  `__init__.py` file.

Currently it makes the `__init__` file as shall_skip if at least on file is found that is *not* marked as excluded. That seems wrong to me. This pr changes to logic to check all files and mark as not shall_skip if at least one file which is not the `__init__.py` file is found, which is not marked for exclusion. 

There is still a potential issue if all `*.py` files in a given directory are excluded but a sub directory contains non excluded python files. Fixing this would require replacing the glob pattern with a recursive detection of all files below a certain dir (glob supports recursive detection from 3.5 on wards out of the box) 

This should probably have a test? 
