### PR TITLE
Fix autodoc: crashed when invalid options given

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #4669: sphinx.build_main and sphinx.make_main throw NameError
 * #4685: autosummary emits meaningless warnings
+* autodoc: crashed when invalid options given
 
 Testing
 --------

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -58,7 +58,7 @@ class DocumenterBridge(object):
 
     def warn(self, msg):
         # type: (unicode) -> None
-        logger.warning(msg, line=self.lineno)
+        logger.warning(msg, location=(self.env.docname, self.lineno))
 
 
 def process_documenter_options(documenter, config, options):
@@ -125,7 +125,7 @@ class AutodocDirective(Directive):
         except (KeyError, ValueError, TypeError) as exc:
             # an option is either unknown or has a wrong type
             logger.error('An option to %s is either unknown or has an invalid value: %s' %
-                         (self.name, exc), line=lineno)
+                         (self.name, exc), location=(source, lineno))
             return []
 
         # generate the output


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- autodoc crashes when invalid options are given (like `:invalid-option-name:`)
- The keyword argument for logging module was wrong.