### PR TITLE
Use "%r" to stringify exceptions

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
+from six import text_type
 
 from sphinx import addnodes
 from sphinx.locale import __
@@ -159,7 +160,7 @@ class CodeBlock(Directive):
             try:
                 literal = container_wrapper(self, literal, caption)
             except ValueError as exc:
-                return [document.reporter.warning(str(exc), line=self.lineno)]
+                return [document.reporter.warning(text_type(exc), line=self.lineno)]
 
         # literal will be note_implicit_target that is linked from caption and numref.
         # when options['name'] is provided, it should be primary ID.
@@ -456,7 +457,7 @@ class LiteralInclude(Directive):
 
             return [retnode]
         except Exception as exc:
-            return [document.reporter.warning(str(exc), line=self.lineno)]
+            return [document.reporter.warning(text_type(exc), line=self.lineno)]
 
 
 def setup(app):

--- a/sphinx/environment/collectors/indexentries.py
+++ b/sphinx/environment/collectors/indexentries.py
@@ -11,6 +11,8 @@
 
 from typing import TYPE_CHECKING
 
+from six import text_type
+
 from sphinx import addnodes
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.util import split_index_msg, logging
@@ -45,7 +47,7 @@ class IndexEntriesCollector(EnvironmentCollector):
                 for entry in node['entries']:
                     split_index_msg(entry[0], entry[1])
             except ValueError as exc:
-                logger.warning(str(exc), location=node)
+                logger.warning(text_type(exc), location=node)
                 node.parent.remove(node)
             else:
                 for entry in node['entries']:

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -277,7 +277,7 @@ def render_dot_html(self, node, code, options, prefix='graphviz',
                                    "'svg', but is %r") % format)
         fname, outfn = render_dot(self, code, options, format, prefix)
     except GraphvizError as exc:
-        logger.warning('dot code %r: ' % code + str(exc))
+        logger.warning('dot code %r: %s', code, text_type(exc))
         raise nodes.SkipNode
 
     if fname is None:
@@ -321,7 +321,7 @@ def render_dot_latex(self, node, code, options, prefix='graphviz'):
     try:
         fname, outfn = render_dot(self, code, options, 'pdf', prefix)
     except GraphvizError as exc:
-        logger.warning('dot code %r: ' % code + str(exc))
+        logger.warning('dot code %r: %s', code, text_type(exc))
         raise nodes.SkipNode
 
     is_inline = self.is_inline(node)
@@ -359,7 +359,7 @@ def render_dot_texinfo(self, node, code, options, prefix='graphviz'):
     try:
         fname, outfn = render_dot(self, code, options, 'png', prefix)
     except GraphvizError as exc:
-        logger.warning('dot code %r: ' % code + str(exc))
+        logger.warning('dot code %r: %s', code, text_type(exc))
         raise nodes.SkipNode
     if fname is not None:
         self.body.append('@image{%s,,,[graphviz],png}\n' % fname[:-4])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
On py2, an exception having i18nized message causes UnicodeError on
stringify.  This uses format string "%r" to stringify them.

This is related with #4674.