### PR TITLE
WIP: Don't sort module and attribute members

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -562,12 +562,12 @@ class Documenter(object):
                 else:
                     logger.warning('missing attribute %s in object %s' %
                                    (name, self.fullname))
-            return False, sorted(selected)
+            return False, selected
         elif self.options.inherited_members:
-            return False, sorted((m.name, m.value) for m in itervalues(members))
+            return False, [(m.name, m.value) for m in itervalues(members)]
         else:
-            return False, sorted((m.name, m.value) for m in itervalues(members)
-                                 if m.directly_defined)
+            return False, [(m.name, m.value) for m in itervalues(members)
+                           if m.directly_defined]
 
     def filter_members(self, members, want_all):
         # type: (List[Tuple[unicode, Any]], bool) -> List[Tuple[unicode, Any, bool]]

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 from six import PY2
 
-from sphinx.util import logging
+from sphinx.util import dir_ordered, logging
 from sphinx.util.inspect import isenumclass, safe_getattr
 
 if TYPE_CHECKING:
@@ -210,7 +210,7 @@ def get_object_members(subject, objpath, attrgetter, analyzer=None):
             obj_dict[name] = value
 
     members = {}
-    for name in dir(subject):
+    for name in dir_ordered(subject):
         try:
             value = attrgetter(subject, name)
             directly_defined = name in obj_dict

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -37,6 +37,7 @@ from sphinx import package_dir
 from sphinx.ext.autosummary import import_by_name, get_documenter
 from sphinx.jinja2glue import BuiltinTemplateLoader
 from sphinx.registry import SphinxComponentRegistry
+from sphinx.util import dir_ordered
 from sphinx.util.inspect import safe_getattr
 from sphinx.util.osutil import ensuredir
 from sphinx.util.rst import escape as rst_escape
@@ -176,7 +177,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
             def get_members(obj, typ, include_public=[], imported=True):
                 # type: (Any, unicode, List[unicode], bool) -> Tuple[List[unicode], List[unicode]]  # NOQA
                 items = []  # type: List[unicode]
-                for name in dir(obj):
+                for name in dir_ordered(obj):
                     try:
                         value = safe_getattr(obj, name)
                     except AttributeError:
@@ -193,7 +194,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
             ns = {}  # type: Dict[unicode, Any]
 
             if doc.objtype == 'module':
-                ns['members'] = dir(obj)
+                ns['members'] = dir_ordered(obj)
                 ns['functions'], ns['all_functions'] = \
                     get_members(obj, 'function', imported=imported_members)
                 ns['classes'], ns['all_classes'] = \
@@ -201,7 +202,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                 ns['exceptions'], ns['all_exceptions'] = \
                     get_members(obj, 'exception', imported=imported_members)
             elif doc.objtype == 'class':
-                ns['members'] = dir(obj)
+                ns['members'] = dir_ordered(obj)
                 ns['methods'], ns['all_methods'] = \
                     get_members(obj, 'method', ['__init__'])
                 ns['attributes'], ns['all_attributes'] = \

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -661,3 +661,17 @@ def xmlname_checker():
     name_chars_regex = convert(name_chars)
     return re.compile(u'(%s)(%s|%s)*' % (
         start_chars_regex, start_chars_regex, name_chars_regex))
+
+
+def dir_ordered(obj):
+    # type: (Any) -> List[str]
+    attrs = []
+    parent = getattr(obj, '__class__', None)
+    if parent is not None:
+        attrs.extend(list(getattr(parent, '__dict__', {})))
+    attrs.extend(list(getattr(obj, '__dict__', {})))
+    attrs.extend(dir(obj))
+    # Drop duplicates
+    _seen = set()
+    attrs = [a for a in attrs if a not in _seen and not _seen.add(a)]
+    return attrs


### PR DESCRIPTION
Subject: Maintain definition order when using autosummary and autodoc in Python 3.6.

### Feature or Bugfix

- Feature

### Purpose

In Python 3.6, class definition order is preserved, due to [PEP 520](https://www.python.org/dev/peps/pep-0520/). One of the top reasons for PEP 520 was to enable documentation generators to maintain definition order in the generated documentation. A good example is NamedTuples, where you want do document parameters in the order in which they should be input (and not in alphabetical order, as is currently the case).

### Detail

- This is just a proof of concept. Not sure if this behaviour should be made configurable.

### Relates

- https://www.python.org/dev/peps/pep-0520/
- https://stackoverflow.com/a/4692947/2063031

