### PR TITLE
Fix #4716: Generation PDF file with TexLive on Windows, file not found error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * pydomain: always strip parenthesis if empty (refs: #1042)
 * #4689: autosummary: unexpectedly strips docstrings containing "i.e."
 * #4701: viewcode: Misplaced ``<div>`` in viewcode html output
+* #4716: Generation PDF file with TexLive on Windows, file not found error
 
 Testing
 --------

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -101,22 +101,34 @@ class Make(object):
         # type: () -> int
         if self.run_generic_build('latex') > 0:
             return 1
-        with cd(self.builddir_join('latex')):
-            return subprocess.call([self.makecmd, 'all-pdf'])
+        try:
+            with cd(self.builddir_join('latex')):
+                return subprocess.call([self.makecmd, 'all-pdf'])
+        except OSError:
+            print('Error: Failed to run: %s' % self.makecmd)
+            return 1
 
     def build_latexpdfja(self):
         # type: () -> int
         if self.run_generic_build('latex') > 0:
             return 1
-        with cd(self.builddir_join('latex')):
-            return subprocess.call([self.makecmd, 'all-pdf-ja'])
+        try:
+            with cd(self.builddir_join('latex')):
+                return subprocess.call([self.makecmd, 'all-pdf-ja'])
+        except OSError:
+            print('Error: Failed to run: %s' % self.makecmd)
+            return 1
 
     def build_info(self):
         # type: () -> int
         if self.run_generic_build('texinfo') > 0:
             return 1
-        with cd(self.builddir_join('texinfo')):
-            return subprocess.call([self.makecmd, 'info'])
+        try:
+            with cd(self.builddir_join('texinfo')):
+                return subprocess.call([self.makecmd, 'info'])
+        except OSError:
+            print('Error: Failed to run: %s' % self.makecmd)
+            return 1
 
     def build_gettext(self):
         # type: () -> int


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Don't show stacktrace on `make` command not found (refs: #4716)
