### PR TITLE
util.requests: Support SPHINX_NO_NETWORK kill-switch

### DIFF
--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -11,6 +11,7 @@
 
 from __future__ import absolute_import
 
+import os
 import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
@@ -135,6 +136,9 @@ def get(url, **kwargs):
     """Sends a GET request like requests.get().
 
     This sets up User-Agent header and TLS verification automatically."""
+    if os.environ.get('SPHINX_NO_NETWORK', ''):
+        raise RuntimeError('Network use disabled via SPHINX_NO_NETWORK')
+
     kwargs.setdefault('headers', dict(useragent_header))
     config = kwargs.pop('config', None)
     if config:
@@ -149,6 +153,9 @@ def head(url, **kwargs):
     """Sends a HEAD request like requests.head().
 
     This sets up User-Agent header and TLS verification automatically."""
+    if os.environ.get('SPHINX_NO_NETWORK', ''):
+        raise RuntimeError('Network use disabled via SPHINX_NO_NETWORK')
+
     kwargs.setdefault('headers', dict(useragent_header))
     config = kwargs.pop('config', None)
     if config:


### PR DESCRIPTION
Subject: Make it possible to disable all network access while building documentation

### Feature or Bugfix
- Feature

### Purpose
Support a global kill-switch to disable network use in all Sphinx
processes. When SPHINX_NO_NETWORK is defined to a non-null value
in the environment, all attempts to fetch remote data via Sphinx
util.requests module will fail via exception.
    
The main use case is building documentation in environments where
network access is undesired. A lot of modern packages use Intersphinx
and disabling it per-package became really unfeasible. I have originally
considered patching Sphinx locally for Gentoo but I've reached
the conclusion that there might be other users who would benefit
from an option to disable network access.

### Detail
A detailed reasoning for disabling network access is explained
in the Gentoo developer documentation. The particular article pertains
to use of network in tests but it most of the arguments apply also
to building documentation and other build-related activities:
https://devmanual.gentoo.org/ebuild-writing/functions/src_test/index.html#tests-that-require-network-or-service-access


### Relates
- https://bugs.gentoo.org/634790

