### PR TITLE
Fix #4727: Option clash for package textcomp

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ Bugs fixed
 * #4689: autosummary: unexpectedly strips docstrings containing "i.e."
 * #4701: viewcode: Misplaced ``<div>`` in viewcode html output
 * #4444: Don't require numfig to use :numref: on sections
+* #4727: Option clash for package textcomp
 
 Testing
 --------

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -14,6 +14,7 @@
    \let\sphinxpxdimen\pdfpxdimen\else\newdimen\sphinxpxdimen
 \fi \sphinxpxdimen=<%= pxunit %>\relax
 <%= passoptionstopackages %>
+\PassOptionsToPackage{warn}{textcomp}
 <%= inputenc %>
 <%= utf8extra %>
 <%= cmappkg %>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2017/12/12 v1.7 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2018/03/11 v1.7.2 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -39,7 +39,7 @@
 \@ifclassloaded{memoir}{}{\RequirePackage{fancyhdr}}
 % for \text macro and \iffirstchoice@ conditional even if amsmath not loaded
 \RequirePackage{amstext}
-\RequirePackage[warn]{textcomp}
+\RequirePackage{textcomp}% "warn" option issued from template
 \RequirePackage{titlesec}
 \@ifpackagelater{titlesec}{2016/03/15}%
  {\@ifpackagelater{titlesec}{2016/03/21}%


### PR DESCRIPTION
Some packages loaded from user customized 'fontpkg' key may load
textcomp with no option, clashing with sphinx.sty which comes later
and wants it with "warn" option. This makes sure textcomp receives
always "warn" option, even if loaded prior to sphinx.

	modified:   CHANGES
	modified:   sphinx/templates/latex/latex.tex_t
	modified:   sphinx/texinputs/sphinx.sty

Relates #4727 