### PR TITLE
prevent raising of FutureWarning in regex

### DIFF
--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -23,7 +23,7 @@ from sphinx.util import logging
 if TYPE_CHECKING:
     from typing import Generator  # NOQA
 
-symbols_re = re.compile(r'([!--/:-@\[-`{-~])')  # symbols without dot(0x2e)
+symbols_re = re.compile(r'([!-\-/:-@\[-`{-~])')  # symbols without dot(0x2e)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Subject: prevent raising of FutureWarning in regex

### Feature or Bugfix
- Bugfix

### Purpose
- In CPython 3.7, If a regex character set contains '--', a FutureWarning will be raised

### Relates
- https://docs.python.org/3.7/library/re.html#regular-expression-syntax

