### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,7 @@ setup(
             'build_sphinx = sphinx.setup_command:BuildDoc',
         ],
     },
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=install_requires,
     extras_require=extras_require,
     cmdclass=cmdclass,


### PR DESCRIPTION
Helps pip decide what version of the library to install.

https://packaging.python.org/tutorials/distributing-packages/#python-requires

> If your project only runs on certain Python versions, setting the python_requires argument to the appropriate PEP 440 version specifier string will prevent pip from installing the project on other Python versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440) for the Python version, used to specify the Requires-Python defined in PEP 345.