### PR TITLE
Fix #1435: qthelp builder should htmlescape keywords

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * #4727: Option clash for package textcomp
 * #4725: Sphinx does not work with python 3.5.0 and 3.5.1
 * #4716: Generation PDF file with TexLive on Windows, file not found error
+* #1435: qthelp builder should htmlescape keywords
 
 Testing
 --------

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -300,9 +300,9 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
 
         if id:
             item = ' ' * 12 + '<keyword name="%s" id="%s" ref="%s"/>' % (
-                name, id, ref[1])
+                name, id, htmlescape(ref[1]))
         else:
-            item = ' ' * 12 + '<keyword name="%s" ref="%s"/>' % (name, ref[1])
+            item = ' ' * 12 + '<keyword name="%s" ref="%s"/>' % (name, htmlescape(ref[1]))
         item.encode('ascii', 'xmlcharrefreplace')
         return item
 


### PR DESCRIPTION
refs: #1435.

This does not contain last change of the patch (attached at #1435).
I think it is too escaped because the `ref` argument will be escaped inside `keyword_item()` method.