### PR TITLE
usage strings should not contain "usage:"

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -106,7 +106,7 @@ def jobs_argument(value):
 def get_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(
-        usage='usage: %(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]',
+        usage='%(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]',
         epilog=__('For more information, visit <http://sphinx-doc.org/>.'),
         description=__("""
 Generate documentation from source files.

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -298,7 +298,7 @@ def is_excluded(root, excludes):
 def get_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(
-        usage='usage: %(prog)s [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> '
+        usage='%(prog)s [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> '
               '[EXCLUDE_PATTERN, ...]',
         epilog=__('For more information, visit <http://sphinx-doc.org/>.'),
         description=__("""


### PR DESCRIPTION
```
$ sphinx-build
usage: usage: sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
sphinx-build: error: too few arguments
```