### PR TITLE
codecov: Disable status checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,9 +2,7 @@ coverage:
   status:
     project:
       default:
-        # allowed to drop X% and still result in a "success" commit status
-        threshold: 0.05
+        enabled: no
     patch:
       default:
-        # allowed to drop X% and still result in a "success" commit status
-        threshold: 0.05
+        enabled: no


### PR DESCRIPTION
We don't currently care if a commit changes our coverage metrics, so we
can disable the status checks that would enforce that.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Fixes: #4738