### PR TITLE
Fix #4754: sphinx/pycode/__init__.py raises AttributeError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #4574: vertical space before equation in latex
 * #4720: message when an image is mismatched for builder is not clear
 * #4655, #4684: Incomplete localization strings in Polish and Chinese
+* #4754: sphinx/pycode/__init__.py raises AttributeError
 
 Testing
 --------

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -117,23 +117,3 @@ class ModuleAnalyzer(object):
             self.parse()
 
         return self.tags
-
-
-if __name__ == '__main__':
-    import time
-    import pprint
-    x0 = time.time()
-    # ma = ModuleAnalyzer.for_file(__file__.rstrip('c'), 'sphinx.builders.html')
-    ma = ModuleAnalyzer.for_file('sphinx/environment.py',
-                                 'sphinx.environment')
-    ma.tokenize()
-    x1 = time.time()
-    ma.parse()
-    x2 = time.time()
-    # for (ns, name), doc in iteritems(ma.find_attr_docs()):
-    #     print '>>', ns, name
-    #     print '\n'.join(doc)
-    pprint.pprint(ma.find_tags())
-    x3 = time.time()
-    # print nodes.nice_repr(ma.parsetree, number2name)
-    print("tokenizing %.4f, parsing %.4f, finding %.4f" % (x1 - x0, x2 - x1, x3 - x2))


### PR DESCRIPTION
refs: #4754.

The code is a test code of pycode. And it is no longer worked (since 1.5).
Now we have better test code under `tests` directory.
So I would like to remove this.