### PR TITLE
epub: Fix docTitle elements of toc.ncx is not escaped

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #4688: Error to download remote images having long URL
 * #4754: sphinx/pycode/__init__.py raises AttributeError
 * #1435: qthelp builder should htmlescape keywords
+* epub: Fix docTitle elements of toc.ncx is not escaped
 
 Testing
 --------

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -672,7 +672,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """
         metadata = {}  # type: Dict[unicode, Any]
         metadata['uid'] = self.config.epub_uid
-        metadata['title'] = self.config.epub_title
+        metadata['title'] = self.esc(self.config.epub_title)
         metadata['level'] = level
         metadata['navpoints'] = navpoints
         return metadata


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- epub: Fix docTitle elements of toc.ncx is not escaped

