### PR TITLE
Fix invalid __file__ variable is passed to conf.py

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -187,7 +187,7 @@ class Sphinx(object):
 
         # read config
         self.tags = Tags(tags)
-        self.config = Config(confdir, CONFIG_FILENAME,
+        self.config = Config(self.confdir, CONFIG_FILENAME,
                              confoverrides or {}, self.tags)
         self.config.check_unicode()
         # defer checking types until i18n has been initialized


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since #4436, the `confdir` parameter for `Sphinx` application class is not an abspath. As a result, the `__file__` variable on reading `conf.py` was broken unintentionally.