### PR TITLE
Fix #4724: doc: an example of autogen is incorrect

### DIFF
--- a/doc/man/sphinx-autogen.rst
+++ b/doc/man/sphinx-autogen.rst
@@ -73,7 +73,7 @@ If you run the following:
 
 .. code-block:: bash
 
-    $ sphinx-autodoc doc/index.rst
+    $ PYTHONPATH=. sphinx-autodoc doc/index.rst
 
 then the following stub files will be created in ``docs``::
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4724 
