### PR TITLE
Fix #4744: Add canonical URL to docs

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -13,6 +13,11 @@
 {% block sidebar1 %}{{ sidebar() }}{% endblock %}
 {% block sidebar2 %}{% endblock %}
 
+{% block linktags %}
+{{ super() }}
+    <link rel="canonical" href="http://www.sphinx-doc.org/en/master/{{ pagename }}{{ file_suffix }}" />
+{% endblock %}
+
 {% block extrahead %}
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,700'
           rel='stylesheet' type='text/css' />


### PR DESCRIPTION
### Feature or Bugfix
- Docs

### Purpose
- To avoid to index old documents, this sets canonical URL to each pages.
- I'd like to copy this into other old documents

### Relates
- #4744 