### PR TITLE
Fix #4769: autodoc loses the first staticmethod parameter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #4769: autodoc loses the first staticmethod parameter
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1300,7 +1300,10 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
                 inspect.ismethoddescriptor(self.object):
             # can never get arguments of a C function or method
             return None
-        args = Signature(self.object, bound_method=True).format_args()
+        if isstaticmethod(self.object, cls=self.parent, name=self.object_name):
+            args = Signature(self.object, bound_method=False).format_args()
+        else:
+            args = Signature(self.object, bound_method=True).format_args()
         # escape backslashes for reST
         args = args.replace('\\', '\\\\')
         return args

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -804,7 +804,7 @@ def test_generate():
                   '   .. py:attribute:: Class._private_inst_attr',
                   '   .. py:classmethod:: Class.inheritedclassmeth()',
                   '   .. py:method:: Class.inheritedmeth()',
-                  '   .. py:staticmethod:: Class.inheritedstaticmeth()',
+                  '   .. py:staticmethod:: Class.inheritedstaticmeth(cls)',
                   ],
                  'class', 'Class', member_order='bysource', all_members=True)
     del directive.env.ref_context['py:module']


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- see #4769 
