### PR TITLE
Handle missing LC_MESSAGES attribute on Windows

### DIFF
--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -253,7 +253,13 @@ def init_console(locale_dir, catalog):
 
     .. versionadded:: 1.8
     """
-    language, _ = locale.getlocale(locale.LC_MESSAGES)  # encoding is ignored
+    try:
+        # encoding is ignored
+        language, _ = locale.getlocale(locale.LC_MESSAGES)
+    except AttributeError:
+        # LC_MESSAGES is not always defined. Fallback to the default language
+        # in case it is not.
+        language = None
     return init([locale_dir], language, catalog, 'console')
 
 


### PR DESCRIPTION
This small fix handles the case where LC_MESSAGES is not defined
in Python's locale module (e.g., on Windows).

### Feature or Bugfix

- Bugfix

### Relates

- See comment : https://github.com/sphinx-doc/sphinx/commit/ed403ad8ff80659a190dbd36129de59a54cfe84a#commitcomment-28240299

