### PR TITLE
Deprecate env._nitpick_ignore

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Deprecated
   deprecated
 * ``sphinx.locale.l_()`` is deprecated
 * #2157: helper function ``warn()`` for HTML themes is deprecated
+* ``env._nitpick_ignore`` is deprecated
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -113,6 +113,11 @@ The following is a list of deprecated interface.
      - (will be) Removed
      - Alternatives
 
+   * - ``BuildEnvironment._nitpick_ignore``
+     - 1.8
+     - 3.0
+     - :confval:`nitpick_ignore`
+
    * - ``warn()`` (template helper function)
      - 1.8
      - 3.0

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -532,9 +532,6 @@ class BuildEnvironment(object):
         self.config = config
         self._update_settings(config)
 
-        # this cache also needs to be updated every time
-        self._nitpick_ignore = set(self.config.nitpick_ignore)
-
         # return tuple of (changed, reason)
         return bool(changed_reason), changed_reason
 
@@ -864,3 +861,11 @@ class BuildEnvironment(object):
         warnings.warn('env._read_parallel() is deprecated. Please use builder.read() instead.',
                       RemovedInSphinx30Warning)
         return self.app.builder._read_parallel(docnames, nproc)
+
+    @property
+    def _nitpick_ignore(self):
+        # type: () -> List[unicode]
+        warnings.warn('env._nitpick_ignore is deprecated. '
+                      'Please use config.nitpick_ignore instead.',
+                      RemovedInSphinx30Warning)
+        return self.config.nitpick_ignore

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -156,13 +156,13 @@ class ReferencesResolver(SphinxTransform):
         warn = node.get('refwarn')
         if self.config.nitpicky:
             warn = True
-            if self.env._nitpick_ignore:
+            if self.config.nitpick_ignore:
                 dtype = domain and '%s:%s' % (domain.name, typ) or typ
-                if (dtype, target) in self.env._nitpick_ignore:
+                if (dtype, target) in self.config.nitpick_ignore:
                     warn = False
                 # for "std" types also try without domain name
                 if (not domain or domain.name == 'std') and \
-                   (typ, target) in self.env._nitpick_ignore:
+                   (typ, target) in self.config.nitpick_ignore:
                     warn = False
         if not warn:
             return


### PR DESCRIPTION
### Feature or Bugfix
- Refactor

### Purpose
- According to the comment, `env._nitpick_ignore` was added to be updated. But it never updated from anywhere.
- This drops it, and refers `config.nitpick_ignore` directly.
