### PR TITLE
Let LaTeX with XeTeX/LuaTeX use normal sized typeface in code-blocks

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2007,7 +2007,7 @@ These options influence LaTeX output. See further :doc:`latex`.
         ``'\\fvset{fontsize=auto}'``, because the default fonts are part of
         one unified typeface family (Latin Modern OpenType).
 
-        .. versionadded:: 1.7.3
+        .. versionadded:: 1.8
    * Keys that are set by other options and therefore should not be overridden
      are:
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1998,7 +1998,16 @@ These options influence LaTeX output. See further :doc:`latex`.
         differently or append some content after the index. For example
         ``'\\footnotesize\\raggedright\\printindex'`` is advisable when the
         index is full of long entries.
+     ``'fvset'``
+        Customization of ``fancyvrb`` LaTeX package. Defaults to
+        ``'\\fvset{fontsize=\\small}'``, because default font (Courier) used in
+        code-blocks is wider and taller than default text font (Times).
 
+        For ``'xelatex'`` and ``'lualatex'``, defaults to
+        ``'\\fvset{fontsize=auto}'``, because the default fonts are part of
+        one unified typeface family (Latin Modern OpenType).
+
+        .. versionadded:: 1.7.3
    * Keys that are set by other options and therefore should not be overridden
      are:
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -385,13 +385,6 @@ Macros
      multiple paragraphs in header cells of tables.
   .. versionadded:: 1.6.3
      ``\sphinxstylecodecontinued`` and ``\sphinxstylecodecontinues``.
-- by default the Sphinx style file ``sphinx.sty`` executes the command
-  ``\fvset{fontsize=\small}`` as part of its configuration of
-  ``fancyvrb.sty``. This may be overriden for example via
-  ``\fvset{fontsize=auto}`` which will let code listings use the ambient font
-  size. Refer to ``fancyvrb.sty``'s documentation for further keys.
-
-  .. versionadded:: 1.5
 - the table of contents is typeset via ``\sphinxtableofcontents`` which is a
   wrapper (whose definition can be found in :file:`sphinxhowto.cls` or in
   :file:`sphinxmanual.cls`) of standard ``\tableofcontents``.

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -25,6 +25,7 @@
 <%= fncychap %>
 \usepackage<%= sphinxpkgoptions %>{sphinx}
 <%= sphinxsetup %>
+<%= fvset %>
 <%= geometry %>
 <%= usepackages %>
 <%= hyperref %>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2018/03/11 v1.7.2 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2018/03/28 v1.7.3 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -164,7 +164,6 @@
 }
 % For highlighted code.
 \RequirePackage{fancyvrb}
-\fvset{fontsize=\small}
 \define@key{FV}{hllines}{\def\sphinx@verbatim@checkifhl##1{\in@{, ##1,}{#1}}}
 % For hyperlinked footnotes in tables; also for gathering footnotes from
 % topic and warning blocks. Also to allow code-blocks in footnotes.

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2018/03/28 v1.7.3 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2018/03/28 v1.8 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -61,6 +61,7 @@ DEFAULT_SETTINGS = {
     'maxlistdepth':    '',
     'sphinxpkgoptions':     '',
     'sphinxsetup':     '',
+    'fvset':           '\\fvset{fontsize=\\small}',
     'passoptionstopackages': '',
     'geometry':        '\\usepackage{geometry}',
     'inputenc':        '',
@@ -132,6 +133,7 @@ ADDITIONAL_SETTINGS = {
         'fontpkg':      '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'
                         '{\\leavevmode\\nobreak\\ }'),
+        'fvset':        '\\fvset{fontsize=auto}',
     },
     'lualatex': {
         'latex_engine': 'lualatex',
@@ -141,6 +143,7 @@ ADDITIONAL_SETTINGS = {
         'fontpkg':      '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'
                         '{\\leavevmode\\nobreak\\ }'),
+        'fvset':        '\\fvset{fontsize=auto}',
     },
     'platex': {
         'latex_engine': 'platex',


### PR DESCRIPTION
closes: #4791

I have tested normal size typeface in codeblocks with xelatex as latex engine for a build of the v1.0.0 SciPy docs, and it looks much better with normal size than small size, because the monospaced font is already of the same design family as the font for main text.