### PR TITLE
installation.rst: correct Windows Run keyboard shortcut

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -108,7 +108,7 @@ Windows
 
 Most Windows users do not have Python installed by default, so we begin with
 the installation of Python itself.  If you are unsure, open the *Command
-Prompt* (:kbd:`Control-r` and type :command:`cmd`).  Once the command prompt is
+Prompt* (:kbd:`⊞Win-r` and type :command:`cmd`).  Once the command prompt is
 open, type :command:`python --version` and press Enter.  If Python is
 available, you will see the version of Python printed to the screen.  If you do
 not have Python installed, refer to the `Hitchhikers Guide to Python's`__
@@ -140,7 +140,7 @@ On Linux or MacOS, you should open your terminal and run the following command.
 
    $ pip install -U sphinx
 
-On Windows, you should open *Command Prompt* (:kbd:`Control-r` and type
+On Windows, you should open *Command Prompt* (:kbd:`⊞Win-r` and type
 :command:`cmd`) and run the same command.
 
 .. code-block:: bat


### PR DESCRIPTION
You type Windows-R to get the Run dialog, not Control-R.