### PR TITLE
Fix #4789: imgconverter: confused by converter.exe of Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #4769: autodoc loses the first staticmethod parameter
 * #4790: autosummary: too wide two column tables in PDF builds
 * #4795: Latex customization via ``_templates/longtable.tex_t`` is broken
+* #4789: imgconverter: confused by convert.exe of Windows
 
 Testing
 --------


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4789 
