### PR TITLE
refactor: Patch docutils.frontend.OptionParser only during Sphinx processing

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -293,7 +293,7 @@ def build_main(argv=sys.argv[1:]):  # type: ignore
 
     app = None
     try:
-        with patch_docutils(), docutils_namespace():
+        with patch_docutils(args.sourcedir), docutils_namespace():
             app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
                          args.doctreedir, args.builder, confoverrides, status,
                          warning, args.freshenv, args.warningiserror,

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 from copy import copy
 from os import path
 
-from docutils.frontend import OptionParser
 from docutils.utils import Reporter, get_source_line
 from six import BytesIO, itervalues, class_types, next
 from six.moves import cPickle as pickle
@@ -562,9 +561,8 @@ class BuildEnvironment(object):
         """Parse a file and add/update inventory entries for the doctree."""
         self.prepare_settings(docname)
 
+        # Add srccdir/docutils.conf to dependencies list if exists
         docutilsconf = path.join(self.srcdir, 'docutils.conf')
-        # read docutils.conf from source dir, not from current dir
-        OptionParser.standard_config_files[1] = docutilsconf
         if path.isfile(docutilsconf):
             self.note_dependency(docutilsconf)
 

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -179,7 +179,7 @@ class BuildDoc(Command):
             app = None
 
             try:
-                with patch_docutils(), docutils_namespace():
+                with patch_docutils(self.source_dir), docutils_namespace():
                     app = Sphinx(self.source_dir, self.config_dir,
                                  builder_target_dir, self.doctree_dir,
                                  builder, confoverrides, status_stream,

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -35,7 +35,7 @@ report_re = re.compile('^(.+?:(?:\\d+)?): \\((DEBUG|INFO|WARNING|ERROR|SEVERE)/(
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Generator, Iterator, List, Set, Tuple  # NOQA
+    from typing import Any, Callable, Generator, List, Set, Tuple  # NOQA
     from docutils.statemachine import State, ViewList  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.io import SphinxFileInput  # NOQA
@@ -47,7 +47,7 @@ additional_nodes = set()  # type: Set[nodes.Node]
 
 @contextmanager
 def docutils_namespace():
-    # type: () -> Iterator[None]
+    # type: () -> Generator[None, None, None]
     """Create namespace for reST parsers."""
     try:
         _directives = copy(directives._directives)
@@ -96,7 +96,7 @@ def unregister_node(node):
 
 @contextmanager
 def patched_get_language():
-    # type: (unicode) -> Iterator[None]
+    # type: () -> Generator[None, None, None]
     """Patch docutils.languages.get_language() temporarily.
 
     This ignores the second argument ``reporter`` to suppress warnings.
@@ -118,7 +118,7 @@ def patched_get_language():
 
 @contextmanager
 def using_user_docutils_conf(srcdir):
-    # type: (unicode) -> Iterator[None]
+    # type: (unicode) -> Generator[None, None, None]
     """Make docutils read ``docutils.conf`` on srcdir instead of current directory."""
     try:
         _standard_config_files = OptionParser.standard_config_files
@@ -135,7 +135,7 @@ def using_user_docutils_conf(srcdir):
 
 @contextmanager
 def patch_docutils(srcdir=None):
-    # type: (unicode) -> Iterator[None]
+    # type: (unicode) -> Generator[None, None, None]
     """Patch to docutils temporarily."""
     with patched_get_language(), using_user_docutils_conf(srcdir):
         yield
@@ -281,7 +281,7 @@ def directive_helper(obj, has_content=None, argument_spec=None, **option_spec):
 
 @contextmanager
 def switch_source_input(state, content):
-    # type: (State, ViewList) -> Generator
+    # type: (State, ViewList) -> Generator[None, None, None]
     """Switch current source input of state temporarily."""
     try:
         # remember the original ``get_source_and_line()`` method

--- a/tests/test_docutilsconf.py
+++ b/tests/test_docutilsconf.py
@@ -15,6 +15,7 @@ import sys
 import pytest
 
 from sphinx.testing.path import path
+from sphinx.util.docutils import patch_docutils
 
 
 def regex_count(expr, result):
@@ -23,7 +24,9 @@ def regex_count(expr, result):
 
 @pytest.mark.sphinx('html', testroot='docutilsconf', freshenv=True, docutilsconf='')
 def test_html_with_default_docutilsconf(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.srcdir):
+        app.builder.build(['contents'])
+
     result = (app.outdir / 'contents.html').text(encoding='utf-8')
 
     assert regex_count(r'<th class="field-name">', result) == 1
@@ -39,7 +42,9 @@ def test_html_with_default_docutilsconf(app, status, warning):
     '\n')
 )
 def test_html_with_docutilsconf(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.srcdir):
+        app.builder.build(['contents'])
+
     result = (app.outdir / 'contents.html').text(encoding='utf-8')
 
     assert regex_count(r'<th class="field-name">', result) == 0
@@ -50,25 +55,29 @@ def test_html_with_docutilsconf(app, status, warning):
 
 @pytest.mark.sphinx('html', testroot='docutilsconf')
 def test_html(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.srcdir):
+        app.builder.build(['contents'])
     assert warning.getvalue() == ''
 
 
 @pytest.mark.sphinx('latex', testroot='docutilsconf')
 def test_latex(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.srcdir):
+        app.builder.build(['contents'])
     assert warning.getvalue() == ''
 
 
 @pytest.mark.sphinx('man', testroot='docutilsconf')
 def test_man(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.srcdir):
+        app.builder.build(['contents'])
     assert warning.getvalue() == ''
 
 
 @pytest.mark.sphinx('texinfo', testroot='docutilsconf')
 def test_texinfo(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.srcdir):
+        app.builder.build(['contents'])
 
 
 @pytest.mark.sphinx('html', testroot='docutilsconf',
@@ -87,4 +96,5 @@ def test_docutils_source_link_with_nonascii_file(app, status, warning):
             'nonascii filename not supported on this filesystem encoding: '
             '%s', FILESYSTEMENCODING)
 
-    app.builder.build_all()
+    with patch_docutils(app.srcdir):
+        app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Refactor

### Purpose
- So far, Sphinx overrides the attributes of `OptionParser`. And they are not restored after builds.
- This tries to patch it only during builds.
