### PR TITLE
Drop `document.settings.gettext_compact`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Incompatible changes
 * The default value of :confval:`epub_author` and :confval:`epub_publisher` are
   changed from ``'unknown'`` to the value of :confval:`author`.  This is same as
   a ``conf.py`` file sphinx-build generates.
+* The ``gettext_compact`` attribute is removed from ``document.settings``
+  object.  Please use ``config.gettext_compact`` instead.
 
 Deprecated
 ----------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -269,6 +269,11 @@ The following is a list of deprecated interface.
      - 2.0
      - :meth:`~sphinx.application.Sphinx.add_stylesheet()`
 
+   * - ``document.settings.gettext_compact``
+     - 1.8
+     - 1.8
+     - :confval:`gettext_compact`
+
    * - ``Sphinx.status_iterator()``
      - 1.6
      - 1.7

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -540,7 +540,6 @@ class BuildEnvironment(object):
         """Update settings by new config."""
         self.settings['input_encoding'] = config.source_encoding
         self.settings['trim_footnote_reference_space'] = config.trim_footnote_reference_space
-        self.settings['gettext_compact'] = config.gettext_compact
         self.settings['language_code'] = config.language or 'en'
 
         # Allow to disable by 3rd party extension (workaround)

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -92,8 +92,7 @@ class Locale(SphinxTransform):
         assert source.startswith(self.env.srcdir)
         docname = path.splitext(relative_path(path.join(self.env.srcdir, 'dummy'),
                                               source))[0]
-        textdomain = find_catalog(docname,
-                                  self.document.settings.gettext_compact)
+        textdomain = find_catalog(docname, self.config.gettext_compact)
 
         # fetch translations
         dirs = [path.join(self.env.srcdir, directory)


### PR DESCRIPTION
### Feature or Bugfix
- Refactor

### Purpose
- No reason to use settings to pass configurations to each component. We can pass config object directly.
