### PR TITLE
Add section labels for intersphinx

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -1,5 +1,7 @@
 .. highlightlang:: rst
 
+-.. _rst-primer:
+
 =======================
 reStructuredText Primer
 =======================

--- a/doc/usage/restructuredtext/index.rst
+++ b/doc/usage/restructuredtext/index.rst
@@ -1,3 +1,5 @@
+.. _rst-index:
+
 ================
 reStructuredText
 ================


### PR DESCRIPTION
`rst-primer` was removed in 9c2ab8c3bb3069c75ca7d9cf8bd2fa9742dd6493 which broke a link from Django's docs. I think there's no way to link to these documents if they don't have labels, correct?