### PR TITLE
Mark raw string as such

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -91,7 +91,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-periods_re = re.compile('\.(?:\s+)')
+periods_re = re.compile(r'\.(?:\s+)')
 
 
 # -- autosummary_toc node ------------------------------------------------------


### PR DESCRIPTION
Resolves the following warning when building docs:

    sphinx/ext/autosummary/__init__.py:94: DeprecationWarning: invalid escape sequence \.
      periods_re = re.compile('\.(?:\s+)')

Signed-off-by: Stephen Finucane <stephen@that.guru>