### PR TITLE
Proposal: Define priority for transforms

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -968,7 +968,30 @@ class Sphinx(object):
         Add the standard docutils :class:`Transform` subclass *transform* to
         the list of transforms that are applied after Sphinx parses a reST
         document.
-        """
+
+        .. list-table:: priority range categories for Sphinx transforms
+
+           * - Priority
+             - Main purpose in Sphinx
+           * - 0-99
+             - Fix invalid nodes by docutils. Translate a doctree.
+           * - 100-299
+             - Preparation
+           * - 300-399
+             - early
+           * - 400-699
+             - main
+           * - 700-799
+             - Post processing. Deadline to modify text and referencing.
+           * - 800-899
+             - Collect referencing and referenced nodes. Domain processing.
+           * - 900-999
+             - Finalize and clean up.
+
+        refs: `Transform Priority Range Categories`__
+
+        __ http://docutils.sourceforge.net/docs/ref/transforms.html#transform-priority-range-categories
+        """  # NOQA
         self.registry.add_transform(transform)
 
     def add_post_transform(self, transform):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- docutils already provides [Transform Priority Range Categories](http://docutils.sourceforge.net/docs/ref/transforms.html#transform-priority-range-categories).
- But there are no standards for priority in Sphinx. So I guess developers are confused what priority they should use.
- In this PR, I made a priority table for Sphinx. I believe this will help developers to choose better priority.
