### PR TITLE
#1428 update websupport API doc

### DIFF
--- a/doc/web/api.rst
+++ b/doc/web/api.rst
@@ -44,13 +44,13 @@ The WebSupport Class
        **and not in** ``'/static'``, this should be a string with the name of
        that location (e.g. ``builddir + '/static_files'``).
 
-   staticroot
-       If the static files are not served from ``'/static'``, this should be a
-       string with the name of that location (e.g. ``'/static_files'``).
-
    .. note::
        If you specify ``staticdir``, you will typically want to adjust
        ``staticroot`` accordingly.
+
+   staticroot
+       If the static files are not served from ``'/static'``, this should be a
+       string with the name of that location (e.g. ``'/static_files'``).
 
    docroot
        If the documentation is not served from the base path of a URL, this

--- a/doc/web/api.rst
+++ b/doc/web/api.rst
@@ -40,9 +40,17 @@ The WebSupport Class
        comment that was added.
 
    staticdir
-       If static files are served from a location besides ``'/static'``, this
-       should be a string with the name of that location
-       (e.g. ``'/static_files'``).
+       If the static files should be created in a different location
+       **and not in** ``'/static'``, this should be a string with the name of
+       that location (e.g. ``builddir + '/static_files'``).
+
+   staticroot
+       If the static files are not served from ``'/static'``, this should be a
+       string with the name of that location (e.g. ``'/static_files'``).
+
+   .. note::
+       If you specify ``staticdir``, you will typically want to adjust
+       ``staticroot`` accordingly.
 
    docroot
        If the documentation is not served from the base path of a URL, this

--- a/doc/web/api.rst
+++ b/doc/web/api.rst
@@ -44,9 +44,9 @@ The WebSupport Class
        **and not in** ``'/static'``, this should be a string with the name of
        that location (e.g. ``builddir + '/static_files'``).
 
-   .. note::
-       If you specify ``staticdir``, you will typically want to adjust
-       ``staticroot`` accordingly.
+       .. note::
+           If you specify ``staticdir``, you will typically want to adjust
+           ``staticroot`` accordingly.
 
    staticroot
        If the static files are not served from ``'/static'``, this should be a


### PR DESCRIPTION
Subject: update websupport API doc

### Feature or Bugfix
- Docs

### Purpose
* ``staticdir`` was not correctly documented
* ``staticroot`` was not documented at all

### Detail
- Closes #1428

### Relates
- #1428

