### PR TITLE
Fix #4543: testcase for partialmethod is failed with py3.6.5

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -313,7 +313,10 @@ class Signature(object):
             try:
                 self.signature = inspect.signature(subject)
             except IndexError:
-                if hasattr(subject, '_partialmethod'):  # partialmethod with no argument
+                # Until python 3.6.4, cpython has been crashed on inspection for
+                # partialmethods not having any arguments.
+                # https://bugs.python.org/issue33009
+                if hasattr(subject, '_partialmethod'):
                     self.signature = None
                     self.partialmethod_with_noargs = True
                 else:

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -952,7 +952,10 @@ def test_partialmethod():
         '      Update state of cell to *state*.',
         '      ',
     ]
-    if sys.version_info < (3, 5, 4):
+    if (sys.version_info < (3, 5, 4) or
+            (3, 6, 5) <= sys.version_info < (3, 7) or
+            (3, 7, 0, 'beta', 3) <= sys.version_info):
+        # TODO: this condition should be updated after 3.7-final release.
         expected = '\n'.join(expected).replace(' -> None', '').split('\n')
 
     assert call_autodoc('class', 'target.partialmethod.Cell') == expected


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- see #4543
