### PR TITLE
Fix #4817: wrong URLs on warning messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #4790: autosummary: too wide two column tables in PDF builds
 * #4795: Latex customization via ``_templates/longtable.tex_t`` is broken
 * #4789: imgconverter: confused by convert.exe of Windows
+* #4817: wrong URLs on warning messages
 
 Testing
 --------

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -4,7 +4,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/stable/config
+# http://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -873,7 +873,7 @@ class HTMLTranslator(BaseTranslator):
         # type: (nodes.Node, unicode) -> None
         logger.warning('using "math" markup without a Sphinx math extension '
                        'active, please use one of the math extensions '
-                       'described at http://sphinx-doc.org/ext/math.html',
+                       'described at http://sphinx-doc.org/en/master/ext/math.html',
                        location=(self.builder.current_docname, node.line))
         raise nodes.SkipNode
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -827,7 +827,7 @@ class HTML5Translator(BaseTranslator):
         # type: (nodes.Node, unicode) -> None
         logger.warning('using "math" markup without a Sphinx math extension '
                        'active, please use one of the math extensions '
-                       'described at http://sphinx-doc.org/ext/math.html',
+                       'described at http://sphinx-doc.org/en/master/ext/math.html',
                        location=(self.builder.current_docname, node.line))
         raise nodes.SkipNode
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2630,7 +2630,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         logger.warning('using "math" markup without a Sphinx math extension '
                        'active, please use one of the math extensions '
-                       'described at http://sphinx-doc.org/ext/math.html',
+                       'described at http://sphinx-doc.org/en/master/ext/math.html',
                        location=(self.curfilestack[-1], node.line))
         raise nodes.SkipNode
 

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -515,7 +515,7 @@ class ManualPageTranslator(BaseTranslator):
         # type: (nodes.Node) -> None
         logger.warning('using "math" markup without a Sphinx math extension '
                        'active, please use one of the math extensions '
-                       'described at http://sphinx-doc.org/ext/math.html')
+                       'described at http://sphinx-doc.org/en/master/ext/math.html')
         raise nodes.SkipNode
 
     visit_math_block = visit_math

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1745,7 +1745,7 @@ class TexinfoTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         logger.warning('using "math" markup without a Sphinx math extension '
                        'active, please use one of the math extensions '
-                       'described at http://sphinx-doc.org/ext/math.html')
+                       'described at http://sphinx-doc.org/en/master/ext/math.html')
         raise nodes.SkipNode
 
     visit_math_block = visit_math

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -1185,7 +1185,7 @@ class TextTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         logger.warning('using "math" markup without a Sphinx math extension '
                        'active, please use one of the math extensions '
-                       'described at http://sphinx-doc.org/ext/math.html',
+                       'described at http://sphinx-doc.org/en/master/ext/math.html',
                        location=(self.builder.current_docname, node.line))
         raise nodes.SkipNode
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- See #4817 
