### PR TITLE
Added support for reading .pyi files.

### DIFF
--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -156,6 +156,17 @@ def import_object(modname, objpath, objtype='', attrgetter=safe_getattr, warning
 
     try:
         module = import_module(modname, warningiserror=warningiserror)
+        import os
+        if hasattr(module, '__file__') and os.path.isfile('{}i'.format(module.__file__)):
+            try:
+                from importlib._bootstrap import spec_from_loader
+                from importlib._bootstrap_external import SourceFileLoader
+                from importlib._bootstrap import module_from_spec
+                spec = spec_from_loader(modname, SourceFileLoader(modname, '{}i'.format(module.__file__)))
+                module = module_from_spec(spec)
+                spec.loader.exec_module(module)
+            except BaseException as e:
+                raise e
         logger.debug('[autodoc] => %r', module)
         obj = module
         parent = None


### PR DESCRIPTION
Subject: Added support for reading .pyi files

### Feature or Bugfix
- Feature

### Purpose
I created a class that dynamically builds its methods at runtime and wanted to create some docs for it. 
So, I made a .pyi file with the dynamic methods defined and with docstrings. PyCharm was able to read this file and provide code completion and documentation, but sphinx required a little changing. The change in this commit is more of a proof of concept than anything. I REALLY don't know this codebase or how best to incorporate this--as a change to sphinx or as an extension. I'd really appreciate any thoughts or guidance on what I can do to expose this functionality.  

### Detail
- When importing a module, checks if a .pyi file exists by using `os.path.isfile('{}i'.format(module.__file__))`.
- Imports the .pyi file using `importlib`.
- Replaces the original module with the one imported from the .pyi file.
- From testing, sphinx doesn't seem to have any issues using the object imported from .pyi file. 


