### PR TITLE
Fix #4784: latex_show_urls assigns incorrect footnote numbers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@ Bugs fixed
   different
 * #4812: autodoc ignores type annotated variables
 * #4817: wrong URLs on warning messages
+* #4784: latex: :confval:`latex_show_urls` assigns incorrect footnote numbers if
+  hyperlinks exists inside substitutions
 
 Testing
 --------

--- a/sphinx/builders/latex.py
+++ b/sphinx/builders/latex.py
@@ -24,6 +24,8 @@ from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.errors import SphinxError, ConfigError
 from sphinx.locale import _
+from sphinx.transforms import SphinxTransformer
+from sphinx.transforms.references import SubstitutionDefinitionsRemover
 from sphinx.util import texescape, logging, status_iterator
 from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.util.docutils import new_document
@@ -144,6 +146,7 @@ class LaTeXBuilder(Builder):
                 docname, toctree_only,
                 appendices=((docclass != 'howto') and self.config.latex_appendices or []))
             doctree['tocdepth'] = tocdepth
+            self.apply_transforms(doctree)
             self.post_process_images(doctree)
             logger.info("writing... ", nonl=1)
             doctree.settings = docsettings
@@ -209,6 +212,13 @@ class LaTeXBuilder(Builder):
                 pass
             pendingnode.replace_self(newnodes)
         return largetree
+
+    def apply_transforms(self, doctree):
+        # type: (nodes.document) -> None
+        transformer = SphinxTransformer(doctree)
+        transformer.set_environment(self.env)
+        transformer.add_transforms([SubstitutionDefinitionsRemover])
+        transformer.apply_transforms()
 
     def finish(self):
         # type: () -> None

--- a/sphinx/transforms/references.py
+++ b/sphinx/transforms/references.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.transforms.references
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Docutils transforms used by Sphinx.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from docutils import nodes
+from docutils.transforms.references import Substitutions
+
+from sphinx.transforms import SphinxTransform
+
+
+class SubstitutionDefinitionsRemover(SphinxTransform):
+    """Remove ``substitution_definition node from doctrees.
+
+    .. note:: In Sphinx-1.7, this transform is only used in LaTeX builder.
+    """
+
+    # should be invoked after Substitutions process
+    default_priority = Substitutions.default_priority + 1
+
+    def apply(self):
+        # type: () -> None
+        for node in self.document.traverse(nodes.substitution_definition):
+            node.parent.remove(node)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -750,6 +750,15 @@ def test_latex_show_urls_is_no(app, status, warning):
             '{sphinx-dev@googlegroups.com}\n') in result
 
 
+@pytest.mark.sphinx(
+    'latex', testroot='footnotes',
+    confoverrides={'latex_show_urls': 'footnote',
+                   'rst_prolog': '.. |URL| replace:: `text <http://www.example.com/>`__'})
+def test_latex_show_urls_footnote_and_substitutions(app, status, warning):
+    # hyperlinks in substitutions should not effect to make footnotes (refs: #4784)
+    test_latex_show_urls_is_footnote(app, status, warning)
+
+
 @pytest.mark.sphinx('latex', testroot='image-in-section')
 def test_image_in_section(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4784 
