### PR TITLE
Add missing literalinclude options documentation

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -596,7 +596,8 @@ __ http://pygments.org/docs/lexers/
    ``start-after`` is given as a string option, only lines that follow the
    first line containing that string are included.  If ``end-before`` is given
    as a string option, only lines that precede the first lines containing that
-   string are included.
+   string are included. The ``start-at`` and ``end-at`` options behave in a
+   similar way, but the lines containing the matched string are included.
 
    With lines selected using ``start-after`` it is still possible to use
    ``lines``, the first allowed line having by convention the line number
@@ -637,6 +638,9 @@ __ http://pygments.org/docs/lexers/
    .. versionchanged:: 1.3
       Added the ``diff``, ``lineno-match``, ``caption``, ``name``, and
       ``dedent`` options.
+
+   .. versionchanged:: 1.5
+      Added the ``start-at``, and ``end-at`` options.
 
    .. versionchanged:: 1.6
       With both ``start-after`` and ``lines`` in use, the first line as per


### PR DESCRIPTION
Subject: The `start-at` and `end-at` options `literalinclude` options weren't documented

### Feature or Bugfix
- Bugfix

### Purpose
- The `start-at` and `end-at` options were added in v1.5a1, but there was no documentation for these options on the directives (or old code) pages.

### Detail
- Only found that they were already implemented whilst investigating the code to see how hard the feature would be to implement myself; the file I wanted to include had only blank lines before the line I wanted to select.
- These *were* mentioned in the documentation, but only under the 1.5 release notes

### Relates
- Issue #625
- Pull request https://github.com/sphinx-doc/sphinx/pull/2843

