### PR TITLE
C++, add refs role

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -61,6 +61,8 @@ Features added
   fontsize in code-blocks (refs: #4793)
 * Add :confval:`html_css_files` and :confval:`epub_css_files` for adding CSS
   files from configuration
+* C++, add a ``cpp:refs`` role as a sibling to ``cpp:expr`` for references
+  inside normal text
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -724,8 +724,8 @@ visibility statement (``public``, ``private`` or ``protected``).
 
          **Valid Expressions**
 
-         - :cpp:expr:`*r`, when :cpp:expr:`r` is dereferenceable.
-         - :cpp:expr:`++r`, with return type :cpp:expr:`It&`, when :cpp:expr:`r` is incrementable.
+         - :cpp:expr:`*r`, when :cpp:any:`r` is dereferenceable.
+         - :cpp:expr:`++r`, with return type :cpp:refs:`It&`, when :cpp:any:`r` is incrementable.
 
    This will render as follows:
 
@@ -742,9 +742,8 @@ visibility statement (``public``, ``private`` or ``protected``).
 
       **Valid Expressions**
 
-      - :cpp:expr:`*r`, when :cpp:expr:`r` is dereferenceable.
-      - :cpp:expr:`++r`, with return type :cpp:expr:`It&`, when :cpp:expr:`r`
-        is incrementable.
+      - :cpp:expr:`*r`, when :cpp:any:`r` is dereferenceable.
+      - :cpp:expr:`++r`, with return type :cpp:refs:`It&`, when :cpp:any:`r` is incrementable.
 
 Options
 ^^^^^^^
@@ -810,29 +809,6 @@ They are rendered as follows.
 Note however that no checking is performed with respect to parameter
 compatibility. E.g., ``Iterator{A, B, C}`` will be accepted as an introduction
 even though it would not be valid C++.
-
-Inline Expressions and Tpes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. rst:role:: cpp:expr
-
-   A role for inserting a C++ expression or type as inline text.  For example::
-
-      .. cpp:var:: int a = 42
-
-      .. cpp:function:: int f(int i)
-
-      An expression: :cpp:expr:`a * f(a)`.
-      A type: :cpp:expr:`const MySortedContainer<int>&`.
-
-   will be rendered as follows:
-
-  .. cpp:var:: int a = 42
-
-  .. cpp:function:: int f(int i)
-
-  An expression: :cpp:expr:`a * f(a)`.  A type: :cpp:expr:`const
-  MySortedContainer<int>&`.
 
 Namespacing
 ~~~~~~~~~~~
@@ -945,24 +921,77 @@ These roles link to the given declaration types:
               cpp:enumerator
 
    Reference a C++ declaration by name (see below for details).  The name must
-   be properly qualified relative to the position of the link.
+   be properly qualified relative to the position of the link.  Note that these
+   roles follow the Sphinx :ref:`xref-syntax` rules.  This means care must be
+   taken when referencing a template specialization, e.g. if the link looks like
+   this: ``:cpp:class:`MyClass<int>```.  This is interpreted as a link to
+   ``int`` with a title of ``MyClass``.  In this case, escape the opening angle
+   bracket with a backslash, like this: ``:cpp:class:`MyClass\<int>```.
 
-.. admonition:: Note on References with Templates Parameters/Arguments
+There are alternative roles for cross-referencing which do not support custom
+titles, but instead treat angle brackets as template parameter lists:
 
-   Sphinx's syntax to give references a custom title can interfere with linking
-   to class templates, if nothing follows the closing angle bracket, i.e. if
-   the link looks like this: ``:cpp:class:`MyClass<int>```.  This is
-   interpreted as a link to ``int`` with a title of ``MyClass``.  In this case,
-   please escape the opening angle bracket with a backslash, like this:
-   ``:cpp:class:`MyClass\<int>```.
+.. rst:role:: cpp:refs
+              cpp:expr
+
+   Create references to the individual parts of a C++ expression or type. For
+   example::
+
+      .. cpp:var:: int a = 42
+
+      .. cpp:function:: int f(int i)
+
+      Break down this expression: :cpp:expr:`a * f(a)`.
+
+      Break down this type: :cpp:refs:`const MySortedContainer<MyType>&`.
+
+   will be rendered as follows:
+
+   .. cpp:var:: int a = 42
+
+   .. cpp:function:: int f(int i)
+
+   Break down this expression: :cpp:expr:`a * f(a)`.
+
+   Break down this type: :cpp:refs:`const MySortedContainer<MyType>&`.
+
+   Both :rst:role:`cpp:refs` and :rst:role:`cpp:expr` can indifferently accept
+   an expression or a type. The difference between the two roles is stylistic
+   and semantic: the former indicates one or more cross-references inside normal
+   text, whereas the latter indicates references in inline code. This makes them
+   the respective C++-aware counterparts to :rst:role:`cpp:any` and
+   :rst:role:`code` (or ````inline code```` syntax):
+
+   .. |cpp-code-role| replace:: :code:`const MySortedContainer<MyType>&`
+   .. |cpp-refs-role| replace:: :cpp:refs:`const MySortedContainer<MyType>&`
+   .. |cpp-expr-role| replace:: :cpp:expr:`const MySortedContainer<MyType>&`
+
+   .. table::
+      :widths: auto
+
+      +-----------------------------------+-----------------------------------+
+      | uses :ref:`Sphinx syntax          | uses C++ syntax                   |
+      | <xref-syntax>`                    |                                   |
+      +--------------+--------------------+--------------+--------------------+
+      | Role         | Styling            | Role         | Styling            |
+      +==============+====================+==============+====================+
+      | :rst:role:`\ | :cpp:any:`MySorted\| :rst:role:`\ | |cpp-refs-role|    |
+      | cpp:any`,    | Container\<MyType>`| cpp:refs`    |                    |
+      | etc.         |                    |              |                    |
+      |              |                    |              |                    |
+      +--------------+--------------------+--------------+--------------------+
+      | ````code```` | |cpp-code-role|    | :rst:role:`\ | |cpp-expr-role|    |
+      |              |                    | cpp:expr`    |                    |
+      |              |                    |              |                    |
+      +--------------+--------------------+--------------+--------------------+
 
 .. admonition:: Note on References to Overloaded Functions
 
    It is currently impossible to link to a specific version of an overloaded
-   method.  Currently the C++ domain is the first domain that has basic support
-   for overloaded methods and until there is more data for comparison we don't
-   want to select a bad syntax to reference a specific overload.  Currently
-   Sphinx will link to the first overloaded version of the method / function.
+   function.  Currently the C++ domain is the first domain that has basic
+   support for overloaded functions and until there is more data for comparison
+   we don't want to select a bad syntax to reference a specific overload.
+   Currently Sphinx will link to the first overloaded version of the function.
 
 Declarations without template parameters and template arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -983,13 +1012,13 @@ Assume the following declarations.
       .. cpp:class:: template<typename TInner> \
                      Inner
 
-In general the reference must include the template paraemter declarations,
+In general the reference must include the template parameter declarations,
 e.g., ``template\<typename TOuter> Wrapper::Outer``
 (:cpp:class:`template\<typename TOuter> Wrapper::Outer`).  Currently the lookup
 only succeed if the template parameter identifiers are equal strings. That is,
 ``template\<typename UOuter> Wrapper::Outer`` will not work.
 
-The inner class template can not be directly referenced, unless the current
+The inner class template cannot be directly referenced, unless the current
 namespace is changed or the following shorthand is used.  If a template
 parameter list is omitted, then the lookup will assume either a template or a
 non-template, but not a partial template specialisation.  This means the

--- a/tests/roots/test-domain-cpp/xref_consistency.rst
+++ b/tests/roots/test-domain-cpp/xref_consistency.rst
@@ -1,0 +1,12 @@
+xref consistency
+----------------
+
+.. cpp:namespace:: xref_consistency
+
+.. cpp:class:: item
+
+code-role:     :code:`item`
+any-role:      :any:`item`
+cpp-any-role:  :cpp:any:`item`
+cpp-refs-role: :cpp:refs:`item`
+cpp-expr-role: :cpp:expr:`item`

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -735,3 +735,68 @@ def test_build_domain_cpp_with_add_function_parentheses_is_False(app, status, wa
     t = (app.outdir / f).text()
     for s in parenPatterns:
         check(s, t, f)
+
+
+@pytest.mark.sphinx(testroot='domain-cpp')
+def test_xref_consistency(app, status, warning):
+    app.builder.build_all()
+
+    test = 'xref_consistency.html'
+    output = (app.outdir / test).text()
+
+    def classes(role, tag):
+        pattern = (r'{role}-role:.*?'
+                    '<(?P<tag>{tag}) .*?class=["\'](?P<classes>.*?)["\'].*?>'
+                    '.*'
+                    '</(?P=tag)>').format(role=role, tag=tag)
+        result = re.search(pattern, output)
+        expect = '''\
+Pattern for role `{role}` with tag `{tag}`
+\t{pattern}
+not found in `{test}`
+'''.format(role=role, tag=tag, pattern=pattern, test=test)
+        assert result, expect
+        return set(result.group('classes').split())
+
+    class RoleClasses(object):
+        """Collect the classes from the layout that was generated for a given role."""
+
+        def __init__(self, role, root, contents):
+            self.name = role
+            self.classes = classes(role, root)
+            self.content_classes = dict()
+            for tag in contents:
+                self.content_classes[tag] = classes(role, tag)
+
+    # not actually used as a reference point
+    #code_role = RoleClasses('code', 'code', [])
+    any_role = RoleClasses('any', 'a', ['code'])
+    cpp_any_role = RoleClasses('cpp-any', 'a', ['code'])
+    # NYI: consistent looks
+    #refs_role = RoleClasses('cpp-refs', 'span', ['a', 'code'])
+    refs_role = RoleClasses('cpp-refs', 'span', ['a', 'span'])
+    expr_role = RoleClasses('cpp-expr', 'code', ['a'])
+
+    # XRefRole-style classes
+
+    ## any and cpp:any do not put these classes at the root
+
+    # n.b. the generic any machinery finds the specific 'cpp-class' object type
+    expect = 'any uses XRefRole classes'
+    assert {'xref', 'any', 'cpp', 'cpp-class'} <= any_role.content_classes['code'], expect
+
+    expect = 'cpp:any uses XRefRole classes'
+    assert {'xref', 'cpp-any', 'cpp'} <= cpp_any_role.content_classes['code'], expect
+
+    for role in (refs_role, expr_role):
+        name = role.name
+        expect = '`{name}` puts the domain and role classes at its root'.format(name=name)
+        # NYI: xref should go in the references
+        assert {'xref', 'cpp', name} <= role.classes, expect
+
+    # reference classes
+
+    expect = 'the xref roles use the same reference classes'
+    assert any_role.classes == cpp_any_role.classes, expect
+    assert any_role.classes == refs_role.content_classes['a'], expect
+    assert any_role.classes == expr_role.content_classes['a'], expect


### PR DESCRIPTION
ping @jakobandersen 

The tagline of this PR is to make the C++ domain parser more available since it's so great. In particular this adds a `cpp:refs` role to insert cross-references with normal text styling---acting as a sibling to `cpp:expr` which already does the same, but with inline code styling. As discussed this mitigates, but arguably does not entirely solve #3271. Breakdown of the contents:

- implement `cpp:refs`
- update docs to help the user choose the right cross-reference role for the job
- add testcase for ensuring that the cross-references generated by e.g. `any` and `cpp:any` are consistent with those generated by `cpp:refs` and `cpp:expr`---since the role objects associated with the latters don't inherit from `XRefRole`, we want to be told when there is a change (partial implementation, more on this below)

see the effects for yourself:

- [demo of the current state of affairs](http://mickk-on-cpp.github.io/sphinx-demo/2018-04/alabaster/master/index.html), for reference
- [demo of the PR](http://mickk-on-cpp.github.io/sphinx-demo/2018-04/alabaster/inline/index.html)
- [generated docs](http://mickk-on-cpp.github.io/sphinx-demo/2018-04/docs/usage/restructuredtext/domains.html#cross-referencing)

This makes the changes non-intrusive and non-breaking, but I dislike the inconsistency between the various kind of references. I have some work to ensure [looks consistency](http://mickk-on-cpp.github.io/sphinx-demo/2018-04/alabaster/code/index.html), but it's not done yet (the generated layout for the `cpp:expr` text ends up wonky). I thought I'd submit this first and ask for consensus before doing more work.

I'm also open to suggestions for the name of the role.