### PR TITLE
Sort .hhp file list

### DIFF
--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -247,6 +247,8 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                 outdir += os.sep
             olen = len(outdir)
             for root, dirs, files in os.walk(outdir):
+                dirs.sort()
+                files.sort()
                 staticdir = root.startswith(path.join(outdir, '_static'))
                 for fn in sorted(files):
                     if (staticdir and not fn.endswith('.js')) or \


### PR DESCRIPTION
Without this change, the pgadmin3 openSUSE package differed for every build
(happens in a disposable VM) because pgadmin3.hhp contained entries
in indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this matters.

https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/readdir also has some details on this topic.