### PR TITLE
Fix #4828: Allow to override numfig_format partially

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,8 @@ Features added
 * Add :confval:`html_css_files` and :confval:`epub_css_files` for adding CSS
   files from configuration
 * #4834: Ensure set object descriptions are reproducible.
+* #4828: Allow to override :confval:`numfig_format` partially.  Full definition
+  is not needed.
 
 Bugs fixed
 ----------

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -144,11 +144,7 @@ class Config(object):
         nitpick_ignore = ([], None),
         numfig = (False, 'env'),
         numfig_secnum_depth = (1, 'env'),
-        numfig_format = ({'section': _('Section %s'),
-                          'figure': _('Fig. %s'),
-                          'table': _('Table %s'),
-                          'code-block': _('Listing %s')},
-                         'env'),
+        numfig_format = ({}, 'env'),  # will be initialized in init_numfig_format()
 
         tls_verify = (True, 'env'),
         tls_cacerts = (None, 'env'),
@@ -391,9 +387,23 @@ def convert_source_suffix(app, config):
                           "But `%r' is given." % source_suffix))
 
 
+def init_numfig_format(app, config):
+    # type: (Sphinx, Config) -> None
+    """Initialize :confval:`numfig_format`."""
+    numfig_format = {'section': _('Section %s'),
+                     'figure': _('Fig. %s'),
+                     'table': _('Table %s'),
+                     'code-block': _('Listing %s')}
+
+    # override default labels by configuration
+    numfig_format.update(config.numfig_format)
+    config.numfig_format = numfig_format  # type: ignore
+
+
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.connect('config-inited', convert_source_suffix)
+    app.connect('config-inited', init_numfig_format)
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs #4828
