### PR TITLE
Fix #4767: html: search highlighting breaks mathjax equations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,7 @@ Bugs fixed
 * #1435: qthelp builder should htmlescape keywords
 * epub: Fix docTitle elements of toc.ncx is not escaped
 * #4520: apidoc: Subpackage not in toc (introduced in 1.6.6) now fixed
+* #4767: html: search highlighting breaks mathjax equations
 
 Release 1.7.1 (released Feb 23, 2018)
 =====================================

--- a/sphinx/ext/jsmath.py
+++ b/sphinx/ext/jsmath.py
@@ -20,14 +20,14 @@ from sphinx.locale import _
 
 
 def html_visit_math(self, node):
-    self.body.append(self.starttag(node, 'span', '', CLASS='math notranslate'))
+    self.body.append(self.starttag(node, 'span', '', CLASS='math notranslate nohighlight'))
     self.body.append(self.encode(node['latex']) + '</span>')
     raise nodes.SkipNode
 
 
 def html_visit_displaymath(self, node):
     if node['nowrap']:
-        self.body.append(self.starttag(node, 'div', CLASS='math notranslate'))
+        self.body.append(self.starttag(node, 'div', CLASS='math notranslate nohighlight'))
         self.body.append(self.encode(node['latex']))
         self.body.append('</div>')
         raise nodes.SkipNode
@@ -40,7 +40,7 @@ def html_visit_displaymath(self, node):
                 self.body.append('<span class="eqno">(%s)' % number)
                 self.add_permalink_ref(node, _('Permalink to this equation'))
                 self.body.append('</span>')
-            self.body.append(self.starttag(node, 'div', CLASS='math notranslate'))
+            self.body.append(self.starttag(node, 'div', CLASS='math notranslate nohighlight'))
         else:
             # but only once!
             self.body.append('<div class="math">')

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -21,7 +21,7 @@ from sphinx.locale import _
 
 
 def html_visit_math(self, node):
-    self.body.append(self.starttag(node, 'span', '', CLASS='math notranslate'))
+    self.body.append(self.starttag(node, 'span', '', CLASS='math notranslate nohighlight'))
     self.body.append(self.builder.config.mathjax_inline[0] +
                      self.encode(node['latex']) +
                      self.builder.config.mathjax_inline[1] + '</span>')
@@ -29,7 +29,7 @@ def html_visit_math(self, node):
 
 
 def html_visit_displaymath(self, node):
-    self.body.append(self.starttag(node, 'div', CLASS='math notranslate'))
+    self.body.append(self.starttag(node, 'div', CLASS='math notranslate nohighlight'))
     if node['nowrap']:
         self.body.append(self.encode(node['latex']))
         self.body.append('</div>')

--- a/sphinx/themes/basic/static/doctools.js_t
+++ b/sphinx/themes/basic/static/doctools.js_t
@@ -70,7 +70,9 @@ jQuery.fn.highlightText = function(text, className) {
     if (node.nodeType === 3) {
       var val = node.nodeValue;
       var pos = val.toLowerCase().indexOf(text);
-      if (pos >= 0 && !jQuery(node.parentNode).hasClass(className)) {
+      if (pos >= 0 &&
+          !jQuery(node.parentNode).hasClass(className) &&
+          !jQuery(node.parentNode).hasClass("nohighlight")) {
         var span;
         var isInSVG = jQuery(node).closest("body, svg, foreignObject").is("svg");
         if (isInSVG) {

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -35,19 +35,19 @@ def test_jsmath(app, status, warning):
     app.builder.build_all()
     content = (app.outdir / 'math.html').text()
 
-    assert '<div class="math notranslate">\na^2 + b^2 = c^2</div>' in content
-    assert ('<div class="math notranslate">\n\\begin{split}a + 1 &lt; b\\end{split}</div>'
-            in content)
+    assert '<div class="math notranslate nohighlight">\na^2 + b^2 = c^2</div>' in content
+    assert ('<div class="math notranslate nohighlight">\n\\begin{split}a + 1 &lt; '
+            'b\\end{split}</div>' in content)
     assert (u'<span class="eqno">(1)<a class="headerlink" href="#equation-foo" '
             u'title="Permalink to this equation">\xb6</a></span>'
-            u'<div class="math notranslate" id="equation-foo">\ne^{i\\pi} = 1</div>'
-            in content)
+            u'<div class="math notranslate nohighlight" id="equation-foo">'
+            '\ne^{i\\pi} = 1</div>' in content)
     assert (u'<span class="eqno">(2)<a class="headerlink" href="#equation-math-0" '
             u'title="Permalink to this equation">\xb6</a></span>'
-            u'<div class="math notranslate" id="equation-math-0">\n'
+            u'<div class="math notranslate nohighlight" id="equation-math-0">\n'
             u'e^{ix} = \\cos x + i\\sin x</div>' in content)
-    assert '<div class="math notranslate">\nn \\in \\mathbb N</div>' in content
-    assert '<div class="math notranslate">\na + 1 &lt; b</div>' in content
+    assert '<div class="math notranslate nohighlight">\nn \\in \\mathbb N</div>' in content
+    assert '<div class="math notranslate nohighlight">\na + 1 &lt; b</div>' in content
 
 
 @pytest.mark.skipif(not has_binary('dvipng'),
@@ -91,7 +91,7 @@ def test_mathjax_align(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').text()
-    html = (r'<div class="math notranslate">\s*'
+    html = (r'<div class="math notranslate nohighlight">\s*'
             r'\\\[ \\begin\{align\}\\begin\{aligned\}S \&amp;= \\pi r\^2\\\\'
             r'V \&amp;= \\frac\{4\}\{3\} \\pi r\^3\\end\{aligned\}\\end\{align\} \\\]</div>')
     assert re.search(html, content, re.S)
@@ -104,7 +104,7 @@ def test_math_number_all_mathjax(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').text()
-    html = (r'<div class="math notranslate" id="equation-index-0">\s*'
+    html = (r'<div class="math notranslate nohighlight" id="equation-index-0">\s*'
             r'<span class="eqno">\(1\)<a .*>\xb6</a></span>\\\[a\^2\+b\^2=c\^2\\\]</div>')
     assert re.search(html, content, re.S)
 
@@ -169,7 +169,7 @@ def test_mathjax_numfig_html(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'math.html').text()
-    html = ('<div class="math notranslate" id="equation-math-0">\n'
+    html = ('<div class="math notranslate nohighlight" id="equation-math-0">\n'
             '<span class="eqno">(1.2)')
     assert html in content
     html = ('<p>Referencing equation <a class="reference internal" '


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4767 
