### PR TITLE
Support for Python coroutines

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -290,6 +290,16 @@ argument support), you can use brackets to specify the optional parts:
 
 It is customary to put the opening bracket before the comma.
 
+.. _coroutines:
+
+Coroutines
+~~~~~~~~~~
+
+If a function or method is a coroutine, you can add the ``:async:`` option::
+
+   .. py:function:: compile(source : string, filename, symbol='file') -> ast object
+      :async:
+
 .. _info-field-lists:
 
 Info field lists

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -189,6 +189,7 @@ class PyObject(ObjectDescription):
         'noindex': directives.flag,
         'module': directives.unchanged,
         'annotation': directives.unchanged,
+        'async': directives.flag,
     }
 
     doc_field_types = [
@@ -272,6 +273,8 @@ class PyObject(ObjectDescription):
         signode['fullname'] = fullname
 
         sig_prefix = self.get_signature_prefix(sig)
+        if 'async' in self.options:
+            sig_prefix = 'async ' + sig_prefix
         if sig_prefix:
             signode += addnodes.desc_annotation(sig_prefix, sig_prefix)
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -32,7 +32,7 @@ from sphinx.util import rpartition, force_decode
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.util.inspect import Signature, isdescriptor, safe_getmembers, \
     safe_getattr, object_description, is_builtin_class_method, \
-    isenumattribute, isclassmethod, isstaticmethod, getdoc
+    isenumattribute, isclassmethod, isstaticmethod, isasync, getdoc
 
 if False:
     # For type annotation
@@ -469,6 +469,8 @@ class Documenter(object):
             # Be explicit about the module, this is necessary since .. class::
             # etc. don't support a prepended module name
             self.add_line(u'   :module: %s' % self.modname, sourcename)
+        if isasync(self.object):
+            self.add_line(u'   :async:', sourcename)
 
     def get_doc(self, encoding=None, ignore=1):
         # type: (unicode, int) -> List[List[unicode]]

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -385,6 +385,8 @@ class VariableCommentPicker(ast.NodeVisitor):
             self.context.pop()
             self.current_function = None
 
+    visit_AsyncFunctionDef = visit_FunctionDef
+
 
 class DefinitionFinder(TokenProcessor):
     def __init__(self, lines):

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -197,6 +197,24 @@ def isdescriptor(x):
     return False
 
 
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
+
+
+def isasync(x):
+    """Check if the object is asynchronous."""
+    if asyncio is None:
+        return False
+    try:
+        return asyncio.iscoroutinefunction(x)
+    except AttributeError:
+        # calling iscoroutinefunction() on functools.partial
+        # wrappers may cause AttributeError.
+        return False
+
+
 def safe_getattr(obj, name, *defargs):
     # type: (Any, unicode, unicode) -> object
     """A getattr() that turns all exceptions into AttributeErrors."""


### PR DESCRIPTION
Subject: Add support for Python coroutines

This feature was proposed in #4777.

I've split the patch I proposed into 3 different changesets, and simplified the autodoc part by putting the async check into the common Documenter.add_directive_header instead of its subclasses, which may or may not be to your liking. I can go back to overriding add_directive_header in the subclasses if you prefer that, but I doubt it makes much practical difference.