### PR TITLE
Fix toctree directive tries to glob for URL having query_string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #4837: latex with class memoir Error: Font command ``\sf`` is not supported
 * #4803: latex: too slow in proportion to number of auto numbered footnotes
 * #4838: htmlhelp: The entries in .hhp file is not ordered
+* toctree directive tries to glob for URL having query_string
 
 Testing
 --------

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -99,7 +99,8 @@ class TocTree(Directive):
                 continue
             # look for explicit titles ("Some Title <document>")
             explicit = explicit_title_re.match(entry)
-            if toctree['glob'] and glob_re.match(entry) and not explicit:
+            if (toctree['glob'] and glob_re.match(entry) and
+                    not explicit and not url_re.match(entry)):
                 patname = docname_join(env.docname, entry)
                 docnames = sorted(patfilter(all_docnames, patname))
                 for docname in docnames:
@@ -139,7 +140,7 @@ class TocTree(Directive):
 
         # entries contains all entries (self references, external links etc.)
         if 'reversed' in self.options:
-            toctree['entries'] = toctree['entries'].reverse()
+            toctree['entries'] = list(reversed(toctree['entries']))
 
         return ret
 

--- a/tests/roots/test-toctree-glob/index.rst
+++ b/tests/roots/test-toctree-glob/index.rst
@@ -15,7 +15,7 @@ normal order
    hyperref <https://sphinx-doc.org/?q=sphinx>
 
 reversed order
--------------
+--------------
 
 .. toctree::
    :glob:

--- a/tests/test_directive_other.py
+++ b/tests/test_directive_other.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""
+    test_directive_other
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Test the other directives.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+from docutils import nodes
+from docutils.core import publish_doctree
+
+from sphinx import addnodes
+from sphinx.io import SphinxStandaloneReader
+from sphinx.parsers import RSTParser
+from sphinx.testing.util import assert_node
+
+
+def parse(app, docname, text):
+    app.env.temp_data['docname'] = docname
+    return publish_doctree(text, app.srcdir / docname + '.rst',
+                           reader=SphinxStandaloneReader(app),
+                           parser=RSTParser(),
+                           settings_overrides={'env': app.env,
+                                               'gettext_compact': True})
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree(app):
+    text = (".. toctree::\n"
+            "\n"
+            "   foo\n"
+            "   bar/index\n"
+            "   baz\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'foo'), (None, 'bar/index'), (None, 'baz')],
+                includefiles=['foo', 'bar/index', 'baz'])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_relative_toctree(app):
+    text = (".. toctree::\n"
+            "\n"
+            "   bar_1\n"
+            "   bar_2\n"
+            "   bar_3\n"
+            "   ../quux\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'bar/index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'bar/bar_1'), (None, 'bar/bar_2'), (None, 'bar/bar_3'),
+                         (None, 'quux')],
+                includefiles=['bar/bar_1', 'bar/bar_2', 'bar/bar_3', 'quux'])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_urls_and_titles(app):
+    text = (".. toctree::\n"
+            "\n"
+            "   Sphinx <https://www.sphinx-doc.org/>\n"
+            "   https://readthedocs.org/\n"
+            "   The BAR <bar/index>\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[('Sphinx', 'https://www.sphinx-doc.org/'),
+                         (None, 'https://readthedocs.org/'),
+                         ('The BAR', 'bar/index')],
+                includefiles=['bar/index'])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_glob(app):
+    text = (".. toctree::\n"
+            "   :glob:\n"
+            "\n"
+            "   *\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'baz'), (None, 'foo'), (None, 'quux')],
+                includefiles=['baz', 'foo', 'quux'])
+
+    # give both docname and glob (case1)
+    text = (".. toctree::\n"
+            "   :glob:\n"
+            "\n"
+            "   foo\n"
+            "   *\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'foo'), (None, 'baz'), (None, 'quux')],
+                includefiles=['foo', 'baz', 'quux'])
+
+    # give both docname and glob (case2)
+    text = (".. toctree::\n"
+            "   :glob:\n"
+            "\n"
+            "   *\n"
+            "   foo\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'baz'), (None, 'foo'), (None, 'quux'), (None, 'foo')],
+                includefiles=['baz', 'foo', 'quux', 'foo'])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_twice(app):
+    text = (".. toctree::\n"
+            "\n"
+            "   foo\n"
+            "   foo\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'foo'), (None, 'foo')],
+                includefiles=['foo', 'foo'])

--- a/tests/test_directive_other.py
+++ b/tests/test_directive_other.py
@@ -124,6 +124,21 @@ def test_toctree_glob(app):
 
 
 @pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_glob_and_url(app):
+    text = (".. toctree::\n"
+            "   :glob:\n"
+            "\n"
+            "   https://example.com/?q=sphinx\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = parse(app, 'index', text)
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'https://example.com/?q=sphinx')],
+                includefiles=[])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
 def test_toctree_twice(app):
     text = (".. toctree::\n"
             "\n"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- toctree directive misdetect URLs having query_string (e.g. https://example.com/?q=sphinx) as a glob string (because it contains `?`!)
- This PR also refactors the directive (separation a large method to small ones)