### PR TITLE
Change processing order of reading a document

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Incompatible changes
   a ``conf.py`` file sphinx-build generates.
 * The ``gettext_compact`` attribute is removed from ``document.settings``
   object.  Please use ``config.gettext_compact`` instead.
+* The order of smart_quotes is changed.  For more detail, please read a
+  description of :py:meth:`.Sphinx.add_transform()`
 
 Deprecated
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -18,8 +18,9 @@ Incompatible changes
 * The ``gettext_compact`` attribute is removed from ``document.settings``
   object.  Please use ``config.gettext_compact`` instead.
 * The processing order on reading phase is changed.  smart_quotes, sphinx
-  domains and :event:`doctree-read` event are invoked earlier.  For more
-  details, please read a description of :py:meth:`.Sphinx.add_transform()`
+  domains, :event:`doctree-read` event and versioning doctrees are invoked
+  earlier than so far.  For more details, please read a description of
+  :py:meth:`.Sphinx.add_transform()`
 
 Deprecated
 ----------
@@ -39,6 +40,7 @@ Deprecated
 * ``env._nitpick_ignore`` is deprecated
 * ``app.override_domain()`` is deprecated
 * ``app.add_stylesheet()`` is deprecated
+* ``sphinx.versioning.prepare()`` is deprecated
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_

--- a/CHANGES
+++ b/CHANGES
@@ -17,7 +17,8 @@ Incompatible changes
   a ``conf.py`` file sphinx-build generates.
 * The ``gettext_compact`` attribute is removed from ``document.settings``
   object.  Please use ``config.gettext_compact`` instead.
-* The processing order of smart_quotes and sphinx domains are changed.  For more
+* The processing order on reading phase is changed.  smart_quotes, sphinx
+  domains and :event:`doctree-read` event are invoked earlier.  For more
   details, please read a description of :py:meth:`.Sphinx.add_transform()`
 
 Deprecated

--- a/CHANGES
+++ b/CHANGES
@@ -17,8 +17,8 @@ Incompatible changes
   a ``conf.py`` file sphinx-build generates.
 * The ``gettext_compact`` attribute is removed from ``document.settings``
   object.  Please use ``config.gettext_compact`` instead.
-* The order of smart_quotes is changed.  For more detail, please read a
-  description of :py:meth:`.Sphinx.add_transform()`
+* The processing order of smart_quotes and sphinx domains are changed.  For more
+  details, please read a description of :py:meth:`.Sphinx.add_transform()`
 
 Deprecated
 ----------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -119,6 +119,11 @@ The following is a list of deprecated interface.
      - 4.0
      - :meth:`~sphinx.application.Sphinx.add_css_file()`
 
+   * - ``sphinx.versioning.prepare()``
+     - 1.8
+     - 3.0
+     - ``sphinx.versioning.UIDTransform``
+
    * - ``sphinx.application.Sphinx.override_domain()``
      - 1.8
      - 3.0

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -24,7 +24,7 @@ from docutils.utils import Reporter, get_source_line
 from six import BytesIO, class_types, next
 from six.moves import cPickle as pickle
 
-from sphinx import addnodes, versioning
+from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx20Warning, RemovedInSphinx30Warning
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.environment.adapters.toctree import TocTree
@@ -576,10 +576,6 @@ class BuildEnvironment(object):
         # For example, FAT32 has 2sec timestamp resolution.)
         self.all_docs[docname] = max(
             time.time(), path.getmtime(self.doc2path(docname)))
-
-        if self.versioning_condition:
-            # add uids for versioning
-            versioning.prepare(doctree)
 
         # cleanup
         self.temp_data.clear()

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -570,10 +570,6 @@ class BuildEnvironment(object):
         with sphinx_domains(self), rst.default_role(docname, self.config.default_role):
             doctree = read_doc(self.app, self, self.doc2path(docname))
 
-        # allow extension-specific post-processing
-        if app:
-            app.emit('doctree-read', doctree)
-
         # store time of reading, for outdated files detection
         # (Some filesystems have coarse timestamp resolution;
         # therefore time.time() can be older than filesystem's timestamp.

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -21,7 +21,7 @@ from os import path
 
 from docutils.frontend import OptionParser
 from docutils.utils import Reporter, get_source_line
-from six import BytesIO, itervalues, class_types, next
+from six import BytesIO, class_types, next
 from six.moves import cPickle as pickle
 
 from sphinx import addnodes, versioning
@@ -569,10 +569,6 @@ class BuildEnvironment(object):
 
         with sphinx_domains(self), rst.default_role(docname, self.config.default_role):
             doctree = read_doc(self.app, self, self.doc2path(docname))
-
-        # post-processing
-        for domain in itervalues(self.domains):
-            domain.process_doc(self, docname, doctree)
 
         # allow extension-specific post-processing
         if app:

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -34,6 +34,7 @@ from sphinx.transforms.i18n import (
 from sphinx.transforms.references import SphinxDomains
 from sphinx.util import logging
 from sphinx.util.docutils import LoggingReporter
+from sphinx.versioning import UIDTransform
 
 if False:
     # For type annotation
@@ -95,7 +96,7 @@ class SphinxStandaloneReader(SphinxBaseReader):
                   HandleCodeBlocks, AutoNumbering, AutoIndexUpgrader, SortIds,
                   RemoveTranslatableInline, FilterSystemMessages, RefOnlyBulletListTransform,
                   UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink,
-                  SphinxDomains, DoctreeReadEvent,
+                  SphinxDomains, DoctreeReadEvent, UIDTransform,
                   ]  # type: List[Transform]
 
     def __init__(self, app, *args, **kwargs):

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -24,7 +24,7 @@ from sphinx.transforms import (
     ApplySourceWorkaround, ExtraTranslatableNodes, CitationReferences,
     DefaultSubstitutions, MoveModuleTargets, HandleCodeBlocks, SortIds,
     AutoNumbering, AutoIndexUpgrader, FilterSystemMessages,
-    UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink
+    UnreferencedFootnotesDetector, SphinxSmartQuotes, DoctreeReadEvent, ManpageLink
 )
 from sphinx.transforms import SphinxTransformer
 from sphinx.transforms.compact_bullet_list import RefOnlyBulletListTransform
@@ -95,7 +95,7 @@ class SphinxStandaloneReader(SphinxBaseReader):
                   HandleCodeBlocks, AutoNumbering, AutoIndexUpgrader, SortIds,
                   RemoveTranslatableInline, FilterSystemMessages, RefOnlyBulletListTransform,
                   UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink,
-                  SphinxDomains,
+                  SphinxDomains, DoctreeReadEvent,
                   ]  # type: List[Transform]
 
     def __init__(self, app, *args, **kwargs):

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -31,6 +31,7 @@ from sphinx.transforms.compact_bullet_list import RefOnlyBulletListTransform
 from sphinx.transforms.i18n import (
     PreserveTranslatableMessages, Locale, RemoveTranslatableInline,
 )
+from sphinx.transforms.references import SphinxDomains
 from sphinx.util import logging
 from sphinx.util.docutils import LoggingReporter
 
@@ -93,7 +94,8 @@ class SphinxStandaloneReader(SphinxBaseReader):
                   Locale, CitationReferences, DefaultSubstitutions, MoveModuleTargets,
                   HandleCodeBlocks, AutoNumbering, AutoIndexUpgrader, SortIds,
                   RemoveTranslatableInline, FilterSystemMessages, RefOnlyBulletListTransform,
-                  UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink
+                  UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink,
+                  SphinxDomains,
                   ]  # type: List[Transform]
 
     def __init__(self, app, *args, **kwargs):

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -343,6 +343,8 @@ class SphinxSmartQuotes(SmartQuotes, SphinxTransform):
 
     refs: sphinx.parsers.RSTParser
     """
+    default_priority = 750
+
     def apply(self):
         # type: () -> None
         if not self.is_available():

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -399,6 +399,15 @@ class SphinxSmartQuotes(SmartQuotes, SphinxTransform):
             yield (texttype[notsmartquotable], txtnode.astext())
 
 
+class DoctreeReadEvent(SphinxTransform):
+    """Emit :event:`doctree-read` event."""
+    default_priority = 880
+
+    def apply(self):
+        # type: () -> None
+        self.app.emit('doctree-read', self.document)
+
+
 class ManpageLink(SphinxTransform):
     """Find manpage section numbers and names"""
     default_priority = 999

--- a/sphinx/transforms/references.py
+++ b/sphinx/transforms/references.py
@@ -11,6 +11,7 @@
 
 from docutils import nodes
 from docutils.transforms.references import Substitutions
+from six import itervalues
 
 from sphinx.transforms import SphinxTransform
 
@@ -28,3 +29,13 @@ class SubstitutionDefinitionsRemover(SphinxTransform):
         # type: () -> None
         for node in self.document.traverse(nodes.substitution_definition):
             node.parent.remove(node)
+
+
+class SphinxDomains(SphinxTransform):
+    """Collect objects to Sphinx domains for cross references."""
+    default_priority = 850
+
+    def apply(self):
+        # type: () -> None
+        for domain in itervalues(self.env.domains):
+            domain.process_doc(self, self.env.docname, self.document)

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -9,6 +9,7 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import warnings
 from itertools import product
 from operator import itemgetter
 from uuid import uuid4
@@ -17,6 +18,7 @@ from six import iteritems
 from six.moves import cPickle as pickle
 from six.moves import range, zip_longest
 
+from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.transforms import SphinxTransform
 
 if False:
@@ -155,12 +157,15 @@ def levenshtein_distance(a, b):
 
 class UIDTransform(SphinxTransform):
     """Add UIDs to doctree for versioning."""
-    default_priority = 100
+    default_priority = 880
 
     def apply(self):
         # type: () -> None
         env = self.env
         old_doctree = None
+        if not env.versioning_condition:
+            return
+
         if env.versioning_compare:
             # get old doctree
             try:
@@ -180,5 +185,7 @@ class UIDTransform(SphinxTransform):
 def prepare(document):
     # type: (nodes.Node) -> None
     """Simple wrapper for UIDTransform."""
+    warnings.warn('versioning.prepare() is deprecated. Use UIDTransform instead.',
+                  RemovedInSphinx30Warning)
     transform = UIDTransform(document)
     transform.apply()


### PR DESCRIPTION
### Feature or Bugfix
- Refactor

### Purpose
- To make `env.read_doc()` simple
- refs: #4810 
