### PR TITLE
Add support for list of abbreviations to LaTeX builder

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -382,6 +382,12 @@ into the generated ``.tex`` files.  Its ``'sphinxsetup'`` key is described
      .. versionadded:: 1.5
         Previously this was done from inside :file:`sphinx.sty`.
 
+  ``'glossaries'``
+     "glossaries" package inclusion, defaults to
+     ``'\\usepackage[acronym,toc]{glossaries}'``.
+
+     .. versionadded:: 2.1.2
+
   ``'maketitle'``
      "maketitle" call, default ``'\\sphinxmaketitle'``. Override
      if you want to generate a differently styled title page.
@@ -399,6 +405,13 @@ into the generated ``.tex`` files.  Its ``'sphinxsetup'`` key is described
      .. versionadded:: 1.8.3
         ``\sphinxbackoftitlepage`` optional macro.  It can also be defined
         inside ``'preamble'`` key rather than this one.
+
+  ``'printacronyms'``
+    "printacronyms" call, defaults to ``'\\printacronyms'``. Override if
+    you want to print the list of acronyms differently or append some
+    content afterwards.
+
+    .. versionadded:: 2.1.2
 
   ``'releasename'``
      value that prefixes ``'release'`` element on title page, default

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -45,6 +45,7 @@
 <%- endfor %>
 
 <%= hyperref %>
+<%= glossaries %>
 <%= contentsname %>
 \usepackage{sphinxmessages}
 <%= tocdepth %>
@@ -66,6 +67,8 @@
 \renewcommand{\releasename}{}
 <%- endif %>
 <%= makeindex %>
+<%= abbreviations %>
+<%= makeglossaries %>
 \begin{document}
 <%= shorthandoff %>
 \pagestyle{empty}
@@ -73,6 +76,7 @@
 \pagestyle{plain}
 <%= tableofcontents %>
 \pagestyle{normal}
+<%= printacronyms %>
 <%= body %>
 <%= atendofbody %>
 <%= indices %>

--- a/sphinx/texinputs/latexmkrc_t
+++ b/sphinx/texinputs/latexmkrc_t
@@ -26,7 +26,8 @@ sub xindy {
 {% else -%}
 $makeindex = 'makeindex -s python.ist %O -o %D %S';
 {% endif -%}
-add_cus_dep( "glo", "gls", 0, "makeglo" );
-sub makeglo {
- return system( "makeindex -s gglo.ist -o '$_[0].gls' '$_[0].glo'" );
+add_cus_dep( "glo", "gls", 0, "run_makeglossaries" );
+add_cus_dep( "acn", "acr", 0, "run_makeglossaries" );
+sub run_makeglossaries {
+  system "makeglossaries '$_[0]'";
 }

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -147,6 +147,7 @@ DEFAULT_SETTINGS = {
                         '\\usepackage{hypcap}% it must be loaded after hyperref.\n'
                         '% Set up styles of URL: it should be placed after hyperref.\n'
                         '\\urlstyle{same}'),
+    'glossaries':      '\\usepackage[acronym,toc]{glossaries}',
     'contentsname':    '',
     'preamble':        '',
     'title':           '',
@@ -154,11 +155,13 @@ DEFAULT_SETTINGS = {
     'author':          '',
     'releasename':     '',
     'makeindex':       '\\makeindex',
+    'makeglossaries':  '\\makeglossaries',
     'shorthandoff':    '',
     'maketitle':       '\\sphinxmaketitle',
     'tableofcontents': '\\sphinxtableofcontents',
     'atendofbody':     '',
     'printindex':      '\\printindex',
+    'printacronyms':   '\\printacronyms',
     'transition':      '\n\n\\bigskip\\hrule\\bigskip\n\n',
     'figure_align':    'htbp',
     'tocdepth':        '',
@@ -270,6 +273,7 @@ class Table:
         # type: (nodes.Element) -> None
         self.header = []                        # type: List[str]
         self.body = []                          # type: List[str]
+
         self.align = node.get('align')
         self.colcount = 0
         self.colspec = None                     # type: str
@@ -457,6 +461,7 @@ class LaTeXTranslator(SphinxTranslator):
         # type: (nodes.document, LaTeXBuilder) -> None
         super().__init__(document, builder)
         self.body = []  # type: List[str]
+        self.abbreviations = {}  # type: Dict[unicode, unicode]
 
         # flags
         self.in_title = 0
@@ -634,7 +639,6 @@ class LaTeXTranslator(SphinxTranslator):
         self.footnote_restricted = None     # type: nodes.Element
         self.pending_footnotes = []         # type: List[nodes.footnote_reference]
         self.curfilestack = []              # type: List[str]
-        self.handled_abbrs = set()          # type: Set[str]
 
     def pushbody(self, newbody):
         # type: (List[str]) -> None
@@ -659,7 +663,8 @@ class LaTeXTranslator(SphinxTranslator):
         # type: () -> str
         self.elements.update({
             'body': ''.join(self.body),
-            'indices': self.generate_indices()
+            'indices': self.generate_indices(),
+            'abbreviations': self.generate_abbreviations()
         })
         return self.render('latex.tex_t', self.elements)
 
@@ -745,6 +750,15 @@ class LaTeXTranslator(SphinxTranslator):
                     generate(content, collapsed)
 
         return ''.join(ret)
+
+    def generate_abbreviations(self):
+        # type: (Builder) -> unicode
+        gen_abbrs = ''
+        for abbr, explanation in self.abbreviations.items():
+            gen_abbrs += '\\newacronym{%s}{%s}{%s}\n' % (
+                    abbr, abbr, self.encode(explanation)
+            )
+        return gen_abbrs
 
     def render(self, template_name, variables):
         # type: (str, Dict) -> str
@@ -1975,13 +1989,12 @@ class LaTeXTranslator(SphinxTranslator):
     def visit_abbreviation(self, node):
         # type: (nodes.Element) -> None
         abbr = node.astext()
-        self.body.append(r'\sphinxstyleabbreviation{')
-        # spell out the explanation once
-        if node.hasattr('explanation') and abbr not in self.handled_abbrs:
-            self.context.append('} (%s)' % self.encode(node['explanation']))
-            self.handled_abbrs.add(abbr)
+        if node.hasattr('explanation'):
+            self.body.append(r'\gls{')
+            self.abbreviations[abbr] = node['explanation']
         else:
-            self.context.append('}')
+            self.body.append('{')
+        self.context.append('}')
 
     def depart_abbreviation(self, node):
         # type: (nodes.Element) -> None


### PR DESCRIPTION
Subject: Add support for list of abbreviations to LaTeX builder

### Feature or Bugfix
- Feature


### Purpose
Adds support for generating a list of abbreviations as well as cross-references in the LaTeX builder. All the heavy-lifting is done by the LaTeX ``glossaries`` package, not internally in Sphinx.

As index creation is already been done by LaTeX packages, I think it is only logical to use existing, well-tested tooling for creating acronyms and not reinvent the wheel in Sphinx. Therefore I'd also like to propose handling glossaries in the same way.