### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/EXAMPLES
+++ b/EXAMPLES
@@ -317,7 +317,7 @@ Documentation using a custom theme or integrated in a website
 * PSI4: http://www.psicode.org/psi4manual/master/index.html
 * PyMOTW: https://pymotw.com/2/
 * python-aspectlib: https://python-aspectlib.readthedocs.io/
-  (`sphinx_py3doc_enhanced_theme <https://pypi.python.org/pypi/sphinx_py3doc_enhanced_theme>`__)
+  (`sphinx_py3doc_enhanced_theme <https://pypi.org/project/sphinx_py3doc_enhanced_theme/>`__)
 * QGIS: https://qgis.org/en/docs/index.html
 * qooxdoo: http://www.qooxdoo.org/current/
 * Roundup: http://www.roundup-tracker.org/

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 ========
 
 .. image:: https://img.shields.io/pypi/v/sphinx.svg
-   :target: https://pypi.python.org/pypi/Sphinx
+   :target: https://pypi.org/project/Sphinx/
    :alt: Package on PyPi
 
 .. image:: https://readthedocs.org/projects/sphinx/badge/
@@ -71,7 +71,7 @@ We also publish beta releases::
 If you wish to install `Sphinx` for development purposes, refer to `the
 contributors guide`__.
 
-__ https://pypi.python.org/pypi/Sphinx
+__ https://pypi.org/project/Sphinx/
 __ http://www.sphinx-doc.org/en/master/devguide.html
 
 Documentation

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -8,11 +8,11 @@
   not released yet.{%endtrans%}</p>
 <p>{%trans%}You can use it from the
   <a href="https://github.com/sphinx-doc/sphinx/">Git repo</a> or look for
-  released versions in the <a href="https://pypi.python.org/pypi/Sphinx">Python
+  released versions in the <a href="https://pypi.org/project/Sphinx/">Python
     Package Index</a>.{%endtrans%}</p>
 {% else %}
 <p>{%trans%}Current version: <b><a href="changes.html">{{ version }}</a></b>{%endtrans%}</p>
-<p>{%trans%}Get Sphinx from the <a href="https://pypi.python.org/pypi/Sphinx">Python Package
+<p>{%trans%}Get Sphinx from the <a href="https://pypi.org/project/Sphinx/">Python Package
 Index</a>, or install it with:{%endtrans%}</p>
 <pre>pip install -U Sphinx</pre>
 {% endif %}

--- a/doc/builders.rst
+++ b/doc/builders.rst
@@ -288,7 +288,7 @@ name is ``rinoh``. Refer to the `rinohtype manual`_ for details.
             globalcontext_filename = 'globalcontext.phpdump'
             searchindex_filename = 'searchindex.phpdump'
 
-   .. _PHP serialization: https://pypi.python.org/pypi/phpserialize
+   .. _PHP serialization: https://pypi.org/project/phpserialize/
 
    .. attribute:: implementation
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1147,8 +1147,8 @@ that use Sphinx's HTMLWriter class.
       Sphinx uses a Python implementation by default.  You can use a C
       implementation to accelerate building the index file.
 
-      * `PorterStemmer <https://pypi.python.org/pypi/PorterStemmer>`_ (``en``)
-      * `PyStemmer <https://pypi.python.org/pypi/PyStemmer>`_ (all languages)
+      * `PorterStemmer <https://pypi.org/project/PorterStemmer/>`_ (``en``)
+      * `PyStemmer <https://pypi.org/project/PyStemmer/>`_ (all languages)
 
    .. versionadded:: 1.1
       With support for ``en`` and ``ja``.
@@ -1180,7 +1180,7 @@ that use Sphinx's HTMLWriter class.
          library ('libmecab.so' for linux, 'libmecab.dll' for windows) is required.
       :'sphinx.search.ja.JanomeSplitter':
          Janome binding. To use this splitter,
-         `Janome <https://pypi.python.org/pypi/Janome>`_ is required.
+         `Janome <https://pypi.org/project/Janome/>`_ is required.
 
       To keep compatibility, ``'mecab'``, ``'janome'`` and ``'default'`` are also
       acceptable. However it will be deprecated in Sphinx-1.6.

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -141,5 +141,5 @@ own extensions.
 .. _inlinesyntaxhighlight: https://sphinxcontrib-inlinesyntaxhighlight.readthedocs.io/
 .. _CMake: https://cmake.org
 .. _domaintools: https://bitbucket.org/klorenz/sphinxcontrib-domaintools
-.. _restbuilder: https://pypi.python.org/pypi/sphinxcontrib-restbuilder
+.. _restbuilder: https://pypi.org/project/sphinxcontrib-restbuilder/
 .. _Lasso: http://www.lassosoft.com/

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -268,7 +268,7 @@ The following is a list of deprecated interface.
    * - ``sphinx.websupport``
      - 1.6
      - 2.0
-     - `sphinxcontrib-websupport <https://pypi.python.org/pypi/sphinxcontrib-websupport>`_
+     - `sphinxcontrib-websupport <https://pypi.org/project/sphinxcontrib-websupport/>`_
 
    * - ``StandaloneHTMLBuilder.css_files``
      - 1.6

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -72,7 +72,7 @@ SCons
 
 PyPI
    Jannis Leidel wrote a `setuptools command
-   <https://pypi.python.org/pypi/Sphinx-PyPI-upload>`_ that automatically
+   <https://pypi.org/project/Sphinx-PyPI-upload/>`_ that automatically
    uploads Sphinx documentation to the PyPI package documentation area at
    https://pythonhosted.org/.
 

--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -322,8 +322,8 @@ There is `sphinx translation page`_ for Sphinx (master) documentation.
 .. [2] Because nobody expects the Spanish Inquisition!
 
 
-.. _`transifex-client`: https://pypi.python.org/pypi/transifex-client
-.. _`sphinx-intl`: https://pypi.python.org/pypi/sphinx-intl
+.. _`transifex-client`: https://pypi.org/project/transifex-client/
+.. _`sphinx-intl`: https://pypi.org/project/sphinx-intl/
 .. _Transifex: https://www.transifex.com/
 .. _`sphinx translation page`: https://www.transifex.com/sphinx-doc/sphinx-doc/
 .. _`Transifex Client documentation`: http://docs.transifex.com/developer/client/

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -29,7 +29,7 @@ This section is intended to collect helpful hints for those wanting to migrate
 to reStructuredText/Sphinx from other documentation systems.
 
 * Gerard Flanagan has written a script to convert pure HTML to reST; it can be
-  found at the `Python Package Index <https://pypi.python.org/pypi/html2rest>`_.
+  found at the `Python Package Index <https://pypi.org/project/html2rest/>`_.
 
 * For converting the old Python docs to Sphinx, a converter was written which
   can be found at `the Python SVN repository
@@ -40,7 +40,7 @@ to reStructuredText/Sphinx from other documentation systems.
   markup; it is at `GitHub <https://github.com/wojdyr/db2rst>`_.
 
 * Christophe de Vienne wrote a tool to convert from Open/LibreOffice documents
-  to Sphinx: `odt2sphinx <https://pypi.python.org/pypi/odt2sphinx/>`_.
+  to Sphinx: `odt2sphinx <https://pypi.org/project/odt2sphinx/>`_.
 
 * To convert different markups, `Pandoc <https://pandoc.org/>`_ is
   a very helpful tool.

--- a/doc/theming.rst
+++ b/doc/theming.rst
@@ -134,7 +134,7 @@ These themes are:
   Check out at its `installation page`_ how to set up properly
   :confval:`html_sidebars` for its use.
 
-  .. _Alabaster theme: https://pypi.python.org/pypi/alabaster
+  .. _Alabaster theme: https://pypi.org/project/alabaster/
   .. _installation page: https://alabaster.readthedocs.io/en/latest/installation.html
 
 * **classic** -- This is the classic theme, which looks like `the Python 2
@@ -418,7 +418,7 @@ Third Party Themes
   View a working demo over on readthedocs.org. You can get install and options
   information at `Read the Docs Sphinx Theme`_ page.
 
-  .. _Read the Docs Sphinx Theme: https://pypi.python.org/pypi/sphinx_rtd_theme
+  .. _Read the Docs Sphinx Theme: https://pypi.org/project/sphinx_rtd_theme/
 
   .. versionchanged:: 1.4
      **sphinx_rtd_theme** has become optional.

--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -132,7 +132,7 @@ Installation from PyPI
 ----------------------
 
 Sphinx packages are published on the `Python Package Index
-<https://pypi.python.org/pypi/Sphinx>`_.  The preferred tool for installing
+<https://pypi.org/project/Sphinx/>`_.  The preferred tool for installing
 packages from *PyPI* is :command:`pip`.  This tool is provided with all modern
 versions of Python.
 

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1287,18 +1287,18 @@ Jinja_, Operation_, and Scala_.
 
 .. _sphinx-contrib: https://bitbucket.org/birkenfeld/sphinx-contrib/
 
-.. _Ada: https://pypi.python.org/pypi/sphinxcontrib-adadomain
-.. _Chapel: https://pypi.python.org/pypi/sphinxcontrib-chapeldomain
-.. _CoffeeScript: https://pypi.python.org/pypi/sphinxcontrib-coffee
-.. _Common Lisp: https://pypi.python.org/pypi/sphinxcontrib-cldomain
-.. _dqn: https://pypi.python.org/pypi/sphinxcontrib-dqndomain
-.. _Erlang: https://pypi.python.org/pypi/sphinxcontrib-erlangdomain
-.. _Go: https://pypi.python.org/pypi/sphinxcontrib-golangdomain
-.. _HTTP: https://pypi.python.org/pypi/sphinxcontrib-httpdomain
-.. _Jinja: https://pypi.python.org/pypi/sphinxcontrib-jinjadomain
-.. _Lasso: https://pypi.python.org/pypi/sphinxcontrib-lassodomain
-.. _MATLAB: https://pypi.python.org/pypi/sphinxcontrib-matlabdomain
-.. _Operation: https://pypi.python.org/pypi/sphinxcontrib-operationdomain
-.. _PHP: https://pypi.python.org/pypi/sphinxcontrib-phpdomain
+.. _Ada: https://pypi.org/project/sphinxcontrib-adadomain/
+.. _Chapel: https://pypi.org/project/sphinxcontrib-chapeldomain/
+.. _CoffeeScript: https://pypi.org/project/sphinxcontrib-coffee/
+.. _Common Lisp: https://pypi.org/project/sphinxcontrib-cldomain/
+.. _dqn: https://pypi.org/project/sphinxcontrib-dqndomain/
+.. _Erlang: https://pypi.org/project/sphinxcontrib-erlangdomain/
+.. _Go: https://pypi.org/project/sphinxcontrib-golangdomain/
+.. _HTTP: https://pypi.org/project/sphinxcontrib-httpdomain/
+.. _Jinja: https://pypi.org/project/sphinxcontrib-jinjadomain/
+.. _Lasso: https://pypi.org/project/sphinxcontrib-lassodomain/
+.. _MATLAB: https://pypi.org/project/sphinxcontrib-matlabdomain/
+.. _Operation: https://pypi.org/project/sphinxcontrib-operationdomain/
+.. _PHP: https://pypi.org/project/sphinxcontrib-phpdomain/
 .. _Ruby: https://bitbucket.org/birkenfeld/sphinx-contrib/src/default/rubydomain
-.. _Scala: https://pypi.python.org/pypi/sphinxcontrib-scaladomain
+.. _Scala: https://pypi.org/project/sphinxcontrib-scaladomain/

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ setup(
     name='Sphinx',
     version=sphinx.__version__,
     url='http://sphinx-doc.org/',
-    download_url='https://pypi.python.org/pypi/Sphinx',
+    download_url='https://pypi.org/project/Sphinx/',
     license='BSD',
     author='Georg Brandl',
     author_email='georg@python.org',

--- a/tests/roots/test-intl/refs.txt
+++ b/tests/roots/test-intl/refs.txt
@@ -4,7 +4,7 @@ References
 Translation Tips
 -----------------
 
-.. _download Sphinx: https://pypi.python.org/pypi/sphinx
+.. _download Sphinx: https://pypi.org/project/Sphinx/
 .. _Docutils site: http://docutils.sourceforge.net/
 .. _Sphinx site: http://sphinx-doc.org/
 

--- a/utils/release-checklist
+++ b/utils/release-checklist
@@ -12,7 +12,7 @@ for stable releases
 * ``git commit -am 'Bump to X.Y.Z final'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist upload --identity=[your key]``
-* open https://pypi.python.org/pypi/Sphinx and check there are no obvious errors
+* open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.Z``
 * ``python utils/bump_version.py --in-develop X.Y.Zb0`` (ex. 1.5.3b0)
 * Check diff by ``git diff``
@@ -38,7 +38,7 @@ for first beta releases
 * ``git commit -am 'Bump to X.Y.0 beta1'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist upload --identity=[your key]``
-* open https://pypi.python.org/pypi/Sphinx and check there are no obvious errors
+* open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.0b1``
 * ``python utils/bump_version.py --in-develop X.Y.0b2`` (ex. 1.6.0b2)
 * Check diff by ``git diff``
@@ -67,7 +67,7 @@ for other beta releases
 * ``git commit -am 'Bump to X.Y.0 betaN'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist upload --identity=[your key]``
-* open https://pypi.python.org/pypi/Sphinx and check there are no obvious errors
+* open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.0bN``
 * ``python utils/bump_version.py --in-develop X.Y.0bM`` (ex. 1.6.0b3)
 * Check diff by `git diff``
@@ -95,7 +95,7 @@ for major releases
 * ``git commit -am 'Bump to X.Y.0 final'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist upload --identity=[your key]``
-* open https://pypi.python.org/pypi/Sphinx and check there are no obvious errors
+* open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.0``
 * ``python utils/bump_version.py --in-develop X.Y.1b0`` (ex. 1.6.1b0)
 * Check diff by ``git diff``


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html