### PR TITLE
Fixed the German HTML search again, this time from the 1.7 branch

### DIFF
--- a/sphinx/search/de.py
+++ b/sphinx/search/de.py
@@ -311,4 +311,4 @@ class SearchGerman(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('german')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())


### PR DESCRIPTION
Dear @tk0miya, I recreated my fix from the correct branch. This one should be much easier to merge. Thanks for your patience. 

### Feature or Bugfix
- Bugfix

### Purpose

We noticed some HTML search glitches in our internal documentation when searching for uppercase parameters like `PAR_APP_TITLE` or `FOO_BAR`. Searching for these returned no results while the words were clearly visible on the pages. 

We found PR #4396 (Grâce à la France!) and applied the same fix to the German stemmer, regenerated the `de.pyc` file and everything started to work as expected after the next `build html`.  

### Detail

Please see the attached [index.txt](https://github.com/sphinx-doc/sphinx/files/1931054/index.txt) for a minimal example when used with a freshly created `sphinx-quickstart` German language (de) project. To reproduce please rename to `index.rst`, GitHub would not let me upload `.rst`-files...

Maybe this also applies to more languages than French and German? Is it possible to catch this behaviour via unit tests?

Please apply this PR to the following versions of this fantastic documentation system.

Thank you everybody for your great work.

Dennis
  
### Relates
- Issue #1922 
- PR #4396 