### PR TITLE
Let docutils know the location of ``docutils.conf`` for Sphinx

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Incompatible changes
   :py:meth:`.Sphinx.add_transform()`
 * #4827: All ``substitution_definition`` nodes are removed from doctree on
   reading phase
+* ``docutils.conf`` on ``$HOME`` and ``/etc`` directories are ignored.  Only
+  ``docutils.conf`` on confdir is refered.
 
 Deprecated
 ----------

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -293,7 +293,8 @@ def build_main(argv=sys.argv[1:]):  # type: ignore
 
     app = None
     try:
-        with patch_docutils(), docutils_namespace():
+        confdir = args.confdir or args.sourcedir
+        with patch_docutils(confdir), docutils_namespace():
             app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
                          args.doctreedir, args.builder, confoverrides, status,
                          warning, args.freshenv, args.warningiserror,

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 from copy import copy
 from os import path
 
-from docutils.frontend import OptionParser
 from docutils.utils import Reporter, get_source_line
 from six import BytesIO, class_types, next
 from six.moves import cPickle as pickle
@@ -561,9 +560,8 @@ class BuildEnvironment(object):
         """Parse a file and add/update inventory entries for the doctree."""
         self.prepare_settings(docname)
 
-        docutilsconf = path.join(self.srcdir, 'docutils.conf')
-        # read docutils.conf from source dir, not from current dir
-        OptionParser.standard_config_files[1] = docutilsconf
+        # Add confdir/docutils.conf to dependencies list if exists
+        docutilsconf = path.join(self.app.confdir, 'docutils.conf')
         if path.isfile(docutilsconf):
             self.note_dependency(docutilsconf)
 

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -179,7 +179,8 @@ class BuildDoc(Command):
             app = None
 
             try:
-                with patch_docutils(), docutils_namespace():
+                confdir = self.config_dir or self.source_dir
+                with patch_docutils(confdir), docutils_namespace():
                     app = Sphinx(self.source_dir, self.config_dir,
                                  builder_target_dir, self.doctree_dir,
                                  builder, confoverrides, status_stream,

--- a/tests/test_docutilsconf.py
+++ b/tests/test_docutilsconf.py
@@ -15,6 +15,7 @@ import sys
 import pytest
 
 from sphinx.testing.path import path
+from sphinx.util.docutils import patch_docutils
 
 
 def regex_count(expr, result):
@@ -23,7 +24,9 @@ def regex_count(expr, result):
 
 @pytest.mark.sphinx('html', testroot='docutilsconf', freshenv=True, docutilsconf='')
 def test_html_with_default_docutilsconf(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.confdir):
+        app.builder.build(['contents'])
+
     result = (app.outdir / 'contents.html').text(encoding='utf-8')
 
     assert regex_count(r'<th class="field-name">', result) == 1
@@ -39,7 +42,9 @@ def test_html_with_default_docutilsconf(app, status, warning):
     '\n')
 )
 def test_html_with_docutilsconf(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.confdir):
+        app.builder.build(['contents'])
+
     result = (app.outdir / 'contents.html').text(encoding='utf-8')
 
     assert regex_count(r'<th class="field-name">', result) == 0
@@ -50,25 +55,29 @@ def test_html_with_docutilsconf(app, status, warning):
 
 @pytest.mark.sphinx('html', testroot='docutilsconf')
 def test_html(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.confdir):
+        app.builder.build(['contents'])
     assert warning.getvalue() == ''
 
 
 @pytest.mark.sphinx('latex', testroot='docutilsconf')
 def test_latex(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.confdir):
+        app.builder.build(['contents'])
     assert warning.getvalue() == ''
 
 
 @pytest.mark.sphinx('man', testroot='docutilsconf')
 def test_man(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.confdir):
+        app.builder.build(['contents'])
     assert warning.getvalue() == ''
 
 
 @pytest.mark.sphinx('texinfo', testroot='docutilsconf')
 def test_texinfo(app, status, warning):
-    app.builder.build(['contents'])
+    with patch_docutils(app.confdir):
+        app.builder.build(['contents'])
 
 
 @pytest.mark.sphinx('html', testroot='docutilsconf',
@@ -87,4 +96,5 @@ def test_docutils_source_link_with_nonascii_file(app, status, warning):
             'nonascii filename not supported on this filesystem encoding: '
             '%s', FILESYSTEMENCODING)
 
-    app.builder.build_all()
+    with patch_docutils(app.confdir):
+        app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
- Bugfix

### Purpose
- refs: #4798
- Let docutils know correct location of `docutils.conf` through envvar `$DOCUTILSCONF`
- After the change, we don't have to override class variable of `OptionParser` class directly.
- This introduces an breaking change; Sphinx ignores `docutils.conf` on `$HOME` or `/etc`.