### PR TITLE
Fix #4878: Crashed with extension which returns invalid metadata

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * toctree directive tries to glob for URL having query_string
 * #4871: html search: Upper characters problem in German
 * #4717: latex: Compilation for German docs failed with LuaLaTeX and XeLaTeX
+* #4878: Crashed with extension which returns invalid metadata
 
 Testing
 --------

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -340,6 +340,7 @@ class SphinxComponentRegistry(object):
             logger.warning(__('extension %r returned an unsupported object from '
                               'its setup() function; it should return None or a '
                               'metadata dictionary'), extname)
+            metadata = {}
 
         app.extensions[extname] = Extension(extname, mod, **metadata)
         app._setting_up_extension.pop()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4878 