### PR TITLE
Fix #4873: Adjust word-break of deprecated-APIs table

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -302,6 +302,10 @@ cite, code, tt {
     letter-spacing: -0.02em;
 }
 
+table.deprecated code.literal {
+    word-break: break-all;
+}
+
 tt {
     background-color: #f2f2f2;
     border: 1px solid #ddd;

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -99,6 +99,8 @@ The following is a list of deprecated interface.
 
 .. list-table:: deprecated APIs
    :header-rows: 1
+   :class: deprecated
+   :widths: 40, 10, 10, 40
 
    * - Target
      - Deprecated


### PR DESCRIPTION
### Feature or Bugfix
- Docs

### Purpose
- refs: #4873