### PR TITLE
Fix issue #4885

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -584,7 +584,7 @@ class PyModule(Directive):
                 self.state_machine.reporter.warning(
                     'duplicate module description of %s, '
                     'other instance in %s, use :noindex: for one of them' %
-                    (modname, self.env.doc2path(modules[modname])),
+                    (modname, env.doc2path(modules[modname][0])),
                     line=self.lineno)
             modules[modname] = (env.docname,
                                 self.options.get('synopsis', ''),


### PR DESCRIPTION
Subject: Fix issue reported in #4885

### Feature or Bugfix

- Bugfix

### Purpose
- I got same error as #4885 and I want to fix it.

### Detail
- `self.env` is not defined
  - `self.env` -> `env`
- `modules[modname]` is tuple
  - `modules[modname]` -> `modules[modname][0]`

### Relates
- https://github.com/sphinx-doc/sphinx/issues/4885

