### PR TITLE
Fix #4885: jsdomain also crashed with duplicated objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,7 @@ Features added
 Bugs fixed
 ----------
 
-* #4885, #4887: py domain: Crashed with duplicated objects
+* #4885, #4887: domains: Crashed with duplicated objects
 
 Testing
 --------

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -262,7 +262,7 @@ class JSModule(Directive):
             if mod_name in modules:
                 self.state_machine.reporter.warning(
                     'duplicate module description of %s, ' % mod_name +
-                    'other instance in ' + self.env.doc2path(modules[mod_name]),
+                    'other instance in ' + env.doc2path(modules[mod_name]),
                     line=self.lineno)
             env.domaindata['js']['modules'][mod_name] = env.docname
             # Make a duplicate entry in 'objects' to facilitate searching for


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4885.
- javascript domain also crashes with duplicated objects

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

