### PR TITLE
latex: use \cite for citation references

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,7 @@ Deprecated
 * ``sphinx.writers.latex.LaTeXWriter.footnotestack`` is deprecated
 * ``sphinx.writers.latex.LaTeXWriter.restrict_footnote()`` is deprecated
 * ``sphinx.writers.latex.LaTeXWriter.unrestrict_footnote()`` is deprecated
+* ``LaTeXWriter.bibitems`` is deprecated
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_

--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Incompatible changes
 * #789: ``:samp:`` role supports to escape curly braces with backslash
 * #4811: The files under :confval:`html_static_path` are excluded from source
   files.
+* latex: Use ``\cite`` for citation references instead ``\hyperref``
 
 Deprecated
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -28,7 +28,7 @@ Incompatible changes
 * #789: ``:samp:`` role supports to escape curly braces with backslash
 * #4811: The files under :confval:`html_static_path` are excluded from source
   files.
-* latex: Use ``\cite`` for citation references instead ``\hyperref``
+* latex: Use ``\sphinxcite`` for citation references instead ``\hyperref``
 
 Deprecated
 ----------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -151,6 +151,11 @@ The following is a list of deprecated interface.
      - 3.0
      - -
 
+   * - ``sphinx.writers.latex.LaTeXWriter.bibitems``
+     - 1.8
+     - 3.0
+     - Nothing
+
    * - ``sphinx.application.CONFIG_FILENAME``
      - 1.8
      - 3.0

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -397,6 +397,8 @@ Macros
      formerly, the meaning of ``\tableofcontents`` was modified by Sphinx.
 - the ``\maketitle`` command is redefined by the class files
   :file:`sphinxmanual.cls` and :file:`sphinxhowto.cls`.
+- the citation reference is typeset via ``\sphinxcite`` which is a wrapper
+  of standard ``\cite``.
 
 Environments
 ~~~~~~~~~~~~

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -174,7 +174,7 @@ class LaTeXBuilder(Builder):
 
     def assemble_doctree(self, indexfile, toctree_only, appendices):
         # type: (unicode, bool, List[unicode]) -> nodes.Node
-        from docutils import nodes
+        from docutils import nodes  # NOQA
         self.docnames = set([indexfile] + appendices)
         logger.info(darkgreen(indexfile) + " ", nonl=1)
         tree = self.env.get_doctree(indexfile)

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -20,7 +20,8 @@ from six import text_type
 from sphinx import package_dir, addnodes, highlighting
 from sphinx.builders import Builder
 from sphinx.builders.latex.transforms import (
-    FootnoteDocnameUpdater, LaTeXFootnoteTransform, ShowUrlsTransform
+    BibliographyTransform, FootnoteDocnameUpdater, LaTeXFootnoteTransform,
+    ShowUrlsTransform
 )
 from sphinx.config import string_classes, ENUM
 from sphinx.environment import NoUri
@@ -219,7 +220,8 @@ class LaTeXBuilder(Builder):
         # type: (nodes.document) -> None
         transformer = SphinxTransformer(doctree)
         transformer.set_environment(self.env)
-        transformer.add_transforms([ShowUrlsTransform,
+        transformer.add_transforms([BibliographyTransform,
+                                    ShowUrlsTransform,
                                     LaTeXFootnoteTransform])
         transformer.apply_transforms()
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -12,7 +12,6 @@
 import os
 from os import path
 
-from docutils import nodes
 from docutils.frontend import OptionParser
 from docutils.io import FileOutput
 from six import text_type
@@ -39,6 +38,7 @@ from sphinx.writers.latex import LaTeXWriter, LaTeXTranslator
 
 if False:
     # For type annotation
+    from docutils import nodes  # NOQA
     from typing import Any, Dict, Iterable, List, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
@@ -174,6 +174,7 @@ class LaTeXBuilder(Builder):
 
     def assemble_doctree(self, indexfile, toctree_only, appendices):
         # type: (unicode, bool, List[unicode]) -> nodes.Node
+        from docutils import nodes
         self.docnames = set([indexfile] + appendices)
         logger.info(darkgreen(indexfile) + " ", nonl=1)
         tree = self.env.get_doctree(indexfile)

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -20,8 +20,8 @@ from six import text_type
 from sphinx import package_dir, addnodes, highlighting
 from sphinx.builders import Builder
 from sphinx.builders.latex.transforms import (
-    BibliographyTransform, FootnoteDocnameUpdater, LaTeXFootnoteTransform,
-    ShowUrlsTransform
+    BibliographyTransform, CitationReferenceTransform,
+    FootnoteDocnameUpdater, LaTeXFootnoteTransform, ShowUrlsTransform
 )
 from sphinx.config import string_classes, ENUM
 from sphinx.environment import NoUri
@@ -318,6 +318,7 @@ def default_latex_docclass(config):
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_builder(LaTeXBuilder)
+    app.add_post_transform(CitationReferenceTransform)
     app.connect('config-inited', validate_config_values)
     app.add_transform(FootnoteDocnameUpdater)
 

--- a/sphinx/builders/latex/nodes.py
+++ b/sphinx/builders/latex/nodes.py
@@ -3,7 +3,7 @@
     sphinx.builders.latex.nodes
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    docutils nodes for LaTeX builder.
+    Additional nodes for LaTeX writer.
 
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -20,4 +20,8 @@ class footnotemark(nodes.Inline, nodes.Referential, nodes.TextElement):
 class footnotetext(nodes.General, nodes.BackLinkable, nodes.Element,
                    nodes.Labeled, nodes.Targetable):
     """A node represents ``\footnotetext``."""
+
+
+class thebibliography(nodes.container):
+    """A node for wrapping bibliographies."""
     pass

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -12,7 +12,7 @@
 from docutils import nodes
 
 from sphinx import addnodes
-from sphinx.builders.latex.nodes import footnotemark, footnotetext
+from sphinx.builders.latex.nodes import footnotemark, footnotetext, thebibliography
 from sphinx.transforms import SphinxTransform
 
 if False:
@@ -476,3 +476,46 @@ class LaTeXFootnoteVisitor(nodes.NodeVisitor):
                 return footnote
 
         return None
+
+
+class BibliographyTransform(SphinxTransform):
+    """Gather bibliography entries to tail of document.
+
+    Before::
+
+        <document>
+            <paragraph>
+                blah blah blah
+            <citation>
+                ...
+            <paragraph>
+                blah blah blah
+            <citation>
+                ...
+            ...
+
+    After::
+
+        <document>
+            <paragraph>
+                blah blah blah
+            <paragraph>
+                blah blah blah
+            ...
+            <thebibliography>
+                <citation>
+                    ...
+                <citation>
+                    ...
+    """
+    default_priority = 750
+
+    def apply(self):
+        # type: () -> None
+        citations = thebibliography()
+        for node in self.document.traverse(nodes.citation):
+            node.parent.remove(node)
+            citations += node
+
+        if len(citations) > 0:
+            self.document += citations

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -590,6 +590,7 @@ class StandardDomain(Domain):
     def note_citations(self, env, docname, document):
         # type: (BuildEnvironment, unicode, nodes.Node) -> None
         for node in document.traverse(nodes.citation):
+            node['docname'] = docname
             label = node[0].astext()
             if label in self.data['citations']:
                 path = env.doc2path(self.data['citations'][label][0])

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -663,6 +663,10 @@
    \belowcaptionskip\smallskipamount}
 
 
+%% CITATIONS
+%
+\protected\def\sphinxcite{\cite}
+
 %% FOOTNOTES
 %
 % Support large numbered footnotes in minipage

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -446,7 +446,7 @@
 
   \renewenvironment{sphinxthebibliography}[1]
     {\cleardoublepage% \phantomsection % not needed here since TeXLive 2010's hyperref
-     \begin{thebibliography}{1}}
+     \begin{thebibliography}{#1}}
     {\end{thebibliography}}
 \fi
 

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -80,7 +80,7 @@
 %
 \newenvironment{sphinxthebibliography}[1]{%
   % \phantomsection % not needed here since TeXLive 2010's hyperref
-  \begin{thebibliography}{1}%
+  \begin{thebibliography}{#1}%
   \addcontentsline{toc}{section}{\ifdefined\refname\refname\else\ifdefined\bibname\bibname\fi\fi}}{\end{thebibliography}}
 
 

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -99,7 +99,7 @@
 \newenvironment{sphinxthebibliography}[1]{%
   \if@openright\cleardoublepage\else\clearpage\fi
   % \phantomsection % not needed here since TeXLive 2010's hyperref
-  \begin{thebibliography}{1}%
+  \begin{thebibliography}{#1}%
   \addcontentsline{toc}{chapter}{\bibname}}{\end{thebibliography}}
 
 % Same for the indices.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -49,6 +49,7 @@ BEGIN_DOC = r'''
 '''
 
 
+MAX_CITATION_LABEL_LENGTH = 16
 LATEXSECTIONNAMES = ["part", "chapter", "section", "subsection",
                      "subsubsection", "paragraph", "subparagraph"]
 
@@ -2134,6 +2135,10 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_thebibliography(self, node):
         # type: (nodes.Node) -> None
         longest_label = max((subnode[0].astext() for subnode in node), key=len)
+        if len(longest_label) > MAX_CITATION_LABEL_LENGTH:
+            # adjust max width of citation labels not to break the layout
+            longest_label = longest_label[:MAX_CITATION_LABEL_LENGTH]
+
         self.body.append(u'\n\\begin{sphinxthebibliography}{%s}\n' % longest_label)
 
     def depart_thebibliography(self, node):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -49,7 +49,7 @@ BEGIN_DOC = r'''
 '''
 
 
-MAX_CITATION_LABEL_LENGTH = 16
+MAX_CITATION_LABEL_LENGTH = 8
 LATEXSECTIONNAMES = ["part", "chapter", "section", "subsection",
                      "subsubsection", "paragraph", "subparagraph"]
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2143,9 +2143,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_citation(self, node):
         # type: (nodes.Node) -> None
         label = node[0].astext()
-        target = self.hypertarget(node['docname'] + ':' + node['ids'][0], withdoc=False)
-        self.body.append(u'\\bibitem[%s]{%s}{%s ' %
-                         (self.encode(label), self.idescape(label), target))
+        self.body.append(u'\\bibitem[%s]{%s:%s}{' %
+                         (self.encode(label), node['docname'], node['ids'][0]))
 
     def depart_citation(self, node):
         # type: (nodes.Node) -> None
@@ -2153,10 +2152,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_citation_reference(self, node):
         # type: (nodes.Node) -> None
-        # This is currently never encountered, since citation_reference nodes
-        # are already replaced by pending_xref nodes in the environment.
-        self.body.append('\\cite{%s}' % self.idescape(node.astext()))
-        raise nodes.SkipNode
+        if self.in_title:
+            pass
+        else:
+            self.body.append('\\cite{%s:%s}' % (node['docname'], node['refname']))
+            raise nodes.SkipNode
+
+    def depart_citation_reference(self, node):
+        # type: (nodes.Node) -> None
+        pass
 
     def visit_literal(self, node):
         # type: (nodes.Node) -> None

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2139,7 +2139,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             # adjust max width of citation labels not to break the layout
             longest_label = longest_label[:MAX_CITATION_LABEL_LENGTH]
 
-        self.body.append(u'\n\\begin{sphinxthebibliography}{%s}\n' % longest_label)
+        self.body.append(u'\n\\begin{sphinxthebibliography}{%s}\n' %
+                         self.encode(longest_label))
 
     def depart_thebibliography(self, node):
         # type: (nodes.Node) -> None

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2148,12 +2148,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_citation(self, node):
         # type: (nodes.Node) -> None
         label = node[0].astext()
-        self.body.append(u'\\bibitem[%s]{%s:%s}{' %
+        self.body.append(u'\\bibitem[%s]{%s:%s}' %
                          (self.encode(label), node['docname'], node['ids'][0]))
 
     def depart_citation(self, node):
         # type: (nodes.Node) -> None
-        self.body.append('}\n')
+        pass
 
     def visit_citation_reference(self, node):
         # type: (nodes.Node) -> None

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2161,7 +2161,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.in_title:
             pass
         else:
-            self.body.append('\\cite{%s:%s}' % (node['docname'], node['refname']))
+            self.body.append('\\sphinxcite{%s:%s}' % (node['docname'], node['refname']))
             raise nodes.SkipNode
 
     def depart_citation_reference(self, node):

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -591,8 +591,7 @@ def test_footnote(app, status, warning):
             '\\end{footnote}') in result
     assert '\\begin{footnote}[3]\\sphinxAtStartFootnote\nnamed\n%\n\\end{footnote}' in result
     assert '\\cite{footnote:bar}' in result
-    assert ('\\bibitem[bar]{footnote:bar}'
-            '{\ncite\n}\n') in result
+    assert ('\\bibitem[bar]{footnote:bar}\ncite\n') in result
     assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
             'footnote in table caption\n%\n\\end{footnotetext}\\ignorespaces %\n'
@@ -1242,8 +1241,7 @@ def test_latex_thebibliography(app, status, warning):
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
     print(result)
     assert ('\\begin{sphinxthebibliography}{AuthorYear}\n'
-            '\\bibitem[AuthorYear]{index:authoryear}{\n'
+            '\\bibitem[AuthorYear]{index:authoryear}\n'
             'Author, Title, Year\n'
-            '}\n'
             '\\end{sphinxthebibliography}\n' in result)
     assert '\\cite{index:authoryear}' in result

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -590,7 +590,7 @@ def test_footnote(app, status, warning):
     assert ('\\begin{footnote}[2]\\sphinxAtStartFootnote\nauto numbered\n%\n'
             '\\end{footnote}') in result
     assert '\\begin{footnote}[3]\\sphinxAtStartFootnote\nnamed\n%\n\\end{footnote}' in result
-    assert '\\cite{footnote:bar}' in result
+    assert '\\sphinxcite{footnote:bar}' in result
     assert ('\\bibitem[bar]{footnote:bar}\ncite\n') in result
     assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
@@ -613,7 +613,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert ('\\caption{This is the figure caption with a reference to '
-            '\\cite{index:authoryear}.}' in result)
+            '\\sphinxcite{index:authoryear}.}' in result)
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
     assert ('\\sphinxcaption{The table title with a reference'
             ' to {[}AuthorYear{]}}' in result)
@@ -661,7 +661,7 @@ def test_latex_show_urls_is_inline(app, status, warning):
             '{\\hyperref[\\detokenize{index:the-section'
             '-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference to '
-            '\\cite{index:authoryear}}}}') in result
+            '\\sphinxcite{index:authoryear}}}}') in result
     assert ('\\phantomsection\\label{\\detokenize{index:id33}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
@@ -705,7 +705,7 @@ def test_latex_show_urls_is_footnote(app, status, warning):
     assert ('\\phantomsection\\label{\\detokenize{index:id32}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\cite{index:authoryear}}}}') in result
+            'to \\sphinxcite{index:authoryear}}}}') in result
     assert ('\\phantomsection\\label{\\detokenize{index:id33}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}') in result
@@ -759,7 +759,7 @@ def test_latex_show_urls_is_no(app, status, warning):
     assert ('\\phantomsection\\label{\\detokenize{index:id32}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\cite{index:authoryear}}}}') in result
+            'to \\sphinxcite{index:authoryear}}}}') in result
     assert ('\\phantomsection\\label{\\detokenize{index:id33}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
@@ -1244,4 +1244,4 @@ def test_latex_thebibliography(app, status, warning):
             '\\bibitem[AuthorYear]{index:authoryear}\n'
             'Author, Title, Year\n'
             '\\end{sphinxthebibliography}\n' in result)
-    assert '\\cite{index:authoryear}' in result
+    assert '\\sphinxcite{index:authoryear}' in result

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1240,7 +1240,7 @@ def test_latex_thebibliography(app, status, warning):
 
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
     print(result)
-    assert ('\\begin{sphinxthebibliography}{AuthorYear}\n'
+    assert ('\\begin{sphinxthebibliography}{AuthorYe}\n'
             '\\bibitem[AuthorYear]{index:authoryear}\n'
             'Author, Title, Year\n'
             '\\end{sphinxthebibliography}\n' in result)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -590,15 +590,9 @@ def test_footnote(app, status, warning):
     assert ('\\begin{footnote}[2]\\sphinxAtStartFootnote\nauto numbered\n%\n'
             '\\end{footnote}') in result
     assert '\\begin{footnote}[3]\\sphinxAtStartFootnote\nnamed\n%\n\\end{footnote}' in result
-    assert '{\\hyperref[\\detokenize{footnote:bar}]{\\sphinxcrossref{{[}bar{]}}}}' in result
-    assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\label{\\detokenize{footnote:bar}} ') in result
-    assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
-            '\ncite') in result
-    assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
-            '\ncite\n}') in result
+    assert '\\cite{footnote:bar}' in result
+    assert ('\\bibitem[bar]{footnote:bar}'
+            '{\ncite\n}\n') in result
     assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
             'footnote in table caption\n%\n\\end{footnotetext}\\ignorespaces %\n'
@@ -620,9 +614,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert ('\\caption{This is the figure caption with a reference to '
-            '\\label{\\detokenize{index:id2}}'
-            '{\\hyperref[\\detokenize{index:authoryear}]'
-            '{\\sphinxcrossref{{[}AuthorYear{]}}}}.}' in result)
+            '\\cite{index:authoryear}.}' in result)
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
     assert ('\\sphinxcaption{The table title with a reference'
             ' to {[}AuthorYear{]}}' in result)
@@ -670,9 +662,7 @@ def test_latex_show_urls_is_inline(app, status, warning):
             '{\\hyperref[\\detokenize{index:the-section'
             '-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference to '
-            '\\phantomsection\\label{\\detokenize{index:id1}}'
-            '{\\hyperref[\\detokenize{index:authoryear}]'
-            '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
+            '\\cite{index:authoryear}}}}') in result
     assert ('\\phantomsection\\label{\\detokenize{index:id33}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
@@ -716,9 +706,7 @@ def test_latex_show_urls_is_footnote(app, status, warning):
     assert ('\\phantomsection\\label{\\detokenize{index:id32}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\phantomsection\\label{\\detokenize{index:id1}}'
-            '{\\hyperref[\\detokenize{index:authoryear}]'
-            '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
+            'to \\cite{index:authoryear}}}}') in result
     assert ('\\phantomsection\\label{\\detokenize{index:id33}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}') in result
@@ -772,9 +760,7 @@ def test_latex_show_urls_is_no(app, status, warning):
     assert ('\\phantomsection\\label{\\detokenize{index:id32}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\phantomsection\\label{\\detokenize{index:id1}}'
-            '{\\hyperref[\\detokenize{index:authoryear}]'
-            '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
+            'to \\cite{index:authoryear}}}}') in result
     assert ('\\phantomsection\\label{\\detokenize{index:id33}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
@@ -1256,11 +1242,8 @@ def test_latex_thebibliography(app, status, warning):
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
     print(result)
     assert ('\\begin{sphinxthebibliography}{AuthorYear}\n'
-            '\\bibitem[AuthorYear]{\\detokenize{AuthorYear}}'
-            '{\\phantomsection\\label{\\detokenize{index:authoryear}} \n'
+            '\\bibitem[AuthorYear]{index:authoryear}{\n'
             'Author, Title, Year\n'
             '}\n'
             '\\end{sphinxthebibliography}\n' in result)
-    assert ('{\\hyperref[\\detokenize{index:authoryear}]'
-            '{\\sphinxcrossref{{[}AuthorYear{]}}}}.}'
-            in result)
+    assert '\\cite{index:authoryear}' in result

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1247,3 +1247,20 @@ def test_latex_nested_enumerated_list(app, status, warning):
     assert r'\setcounter{enumii}{3}' in result
     assert r'\setcounter{enumiii}{9}' in result
     assert r'\setcounter{enumii}{2}' in result
+
+
+@pytest.mark.sphinx('latex', testroot='footnotes')
+def test_latex_thebibliography(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'Python.tex').text(encoding='utf8')
+    print(result)
+    assert ('\\begin{sphinxthebibliography}{AuthorYear}\n'
+            '\\bibitem[AuthorYear]{\\detokenize{AuthorYear}}'
+            '{\\phantomsection\\label{\\detokenize{index:authoryear}} \n'
+            'Author, Title, Year\n'
+            '}\n'
+            '\\end{sphinxthebibliography}\n' in result)
+    assert ('{\\hyperref[\\detokenize{index:authoryear}]'
+            '{\\sphinxcrossref{{[}AuthorYear{]}}}}.}'
+            in result)


### PR DESCRIPTION
### Feature or Bugfix
- Refactor

### Purpose
- Add BibliographyTransform to restructure doctree.
- Use \cite for citation references
