### PR TITLE
Show warnings for deprecated html_search_options

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1194,8 +1194,10 @@ that use Sphinx's HTMLWriter class.
          Janome binding. To use this splitter,
          `Janome <https://pypi.org/project/Janome/>`_ is required.
 
-      To keep compatibility, ``'mecab'``, ``'janome'`` and ``'default'`` are also
-      acceptable. However it will be deprecated in Sphinx-1.6.
+      .. deprecated:: 1.6
+         ``'mecab'``, ``'janome'`` and ``'default'`` is deprecated.
+         To keep compatibility, ``'mecab'``, ``'janome'`` and ``'default'`` are
+         also acceptable.
 
 
    Other option values depend on splitter value which you choose.

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -121,6 +121,11 @@ The following is a list of deprecated interface.
      - 4.0
      - :meth:`~sphinx.application.Sphinx.add_css_file()`
 
+   * - The value of :confval:`html_search_options`
+     - 1.8
+     - 3.0
+     - see :confval:`html_search_options`
+
    * - ``sphinx.versioning.prepare()``
      - 1.8
      - 3.0

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -20,6 +20,7 @@
 import os
 import re
 import sys
+import warnings
 
 from six import iteritems, PY3
 
@@ -35,6 +36,7 @@ try:
 except ImportError:
     janome_module = False
 
+from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.errors import SphinxError, ExtensionError
 from sphinx.search import SearchLanguage
 from sphinx.util import import_object
@@ -556,9 +558,12 @@ class SearchJapanese(SearchLanguage):
 
     def init(self, options):
         # type: (Dict) -> None
-        type = options.get('type', 'default')
+        type = options.get('type', 'sphinx.search.ja.DefaultSplitter')
         if type in self.splitters:
             dotted_path = self.splitters[type]
+            warnings.warn('html_search_options["type"]: %s is deprecated. '
+                          'Please give "%s" instead.' % (type, dotted_path),
+                          RemovedInSphinx30Warning)
         else:
             dotted_path = type
         try:


### PR DESCRIPTION
### Feature or Bugfix
- Deprecation

### Purpose
- some options for `html_search_options` was deprecated since 1.6. This emits warnings for them.
