### PR TITLE
add debug log for patching/extracting i18n nodes

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -99,7 +99,8 @@ def get_full_module_name(node):
 
 
 def get_domxml(node, length=80):
-    text = node.asdom().toxml()
+    # text = node.asdom().toxml()  # crush if node has secnumber with tuple value
+    text = str(node)
     if len(text) > length:
         text = text[:length] + '...'
     return text

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 
 from docutils import nodes
 from docutils.utils import get_source_line
-from six import PY2, StringIO
+from six import PY2, StringIO, text_type
 
 from sphinx.errors import SphinxWarning
 from sphinx.util.console import colorize
@@ -106,7 +106,7 @@ def get_full_module_name(node):
 
 
 def repr_domxml(node, length=80):
-    # type: (nodes.Node, Optional[int]) -> str
+    # type: (nodes.Node, Optional[int]) -> unicode
     """
     return DOM XML representation of the specified node like:
     '<paragraph translatable="False"><inline classes="versionmodified">New in version...'
@@ -118,7 +118,7 @@ def repr_domxml(node, length=80):
     :return: DOM XML representation
     """
     # text = node.asdom().toxml()  # #4919 crush if node has secnumber with tuple value
-    text = str(node)  # workaround for #4919
+    text = text_type(node)  # workaround for #4919
     if length and len(text) > length:
         text = text[:length] + '...'
     return text

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -94,6 +94,17 @@ def convert_serializable(records):
             r.location = get_node_location(location)  # type: ignore
 
 
+def get_full_module_name(node):
+    return '{}.{}'.format(node.__module__, node.__class__.__name__)
+
+
+def get_domxml(node, length=80):
+    text = node.asdom().toxml()
+    if len(text) > length:
+        text = text[:length] + '...'
+    return text
+
+
 class SphinxWarningLogRecord(logging.LogRecord):
     """Log record class supporting location"""
     location = None  # type: Any

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -24,7 +24,7 @@ from sphinx.util.console import colorize
 
 if False:
     # For type annotation
-    from typing import Any, Dict, Generator, IO, List, Tuple, Union  # NOQA
+    from typing import Any, Dict, Generator, IO, List, Tuple, Union, Optional  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
@@ -95,13 +95,31 @@ def convert_serializable(records):
 
 
 def get_full_module_name(node):
+    # type: (nodes.Node) -> str
+    """
+    return full module dotted path like: 'docutils.nodes.paragraph'
+
+    :param nodes.Node node: target node
+    :return: full module dotted path
+    """
     return '{}.{}'.format(node.__module__, node.__class__.__name__)
 
 
-def get_domxml(node, length=80):
-    # text = node.asdom().toxml()  # crush if node has secnumber with tuple value
-    text = str(node)
-    if len(text) > length:
+def repr_domxml(node, length=80):
+    # type: (nodes.Node, Optional[int]) -> str
+    """
+    return DOM XML representation of the specified node like:
+    '<paragraph translatable="False"><inline classes="versionmodified">New in version...'
+
+    :param nodes.Node node: target node
+    :param int length:
+       length of return value to be striped. if false-value is specified, repr_domxml
+       returns full of DOM XML representation.
+    :return: DOM XML representation
+    """
+    # text = node.asdom().toxml()  # #4919 crush if node has secnumber with tuple value
+    text = str(node) # workaround for #4919
+    if length and len(text) > length:
         text = text[:length] + '...'
     return text
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -118,7 +118,7 @@ def repr_domxml(node, length=80):
     :return: DOM XML representation
     """
     # text = node.asdom().toxml()  # #4919 crush if node has secnumber with tuple value
-    text = str(node) # workaround for #4919
+    text = str(node)  # workaround for #4919
     if length and len(text) > length:
         text = text[:length] + '...'
     return text

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -18,7 +18,6 @@ from six import text_type
 from sphinx import addnodes
 from sphinx.locale import __
 from sphinx.util import logging
-from sphinx.util.logging import get_full_module_name, get_domxml
 
 if False:
     # For type annotation
@@ -43,18 +42,18 @@ def apply_source_workaround(node):
     # * rawsource of classifier node will be None
     if isinstance(node, nodes.classifier) and not node.rawsource:
         logger.debug('[i18n] PATCH: %r to have source, line and rawsource: %s',
-                     get_full_module_name(node), get_domxml(node))
+                     logging.get_full_module_name(node), logging.repr_domxml(node))
         definition_list_item = node.parent
         node.source = definition_list_item.source
         node.line = definition_list_item.line - 1
         node.rawsource = node.astext()  # set 'classifier1' (or 'classifier2')
     if isinstance(node, nodes.image) and node.source is None:
         logger.debug('[i18n] PATCH: %r to have source, line: %s',
-                     get_full_module_name(node), get_domxml(node))
+                     logging.get_full_module_name(node), logging.repr_domxml(node))
         node.source, node.line = node.parent.source, node.parent.line
     if isinstance(node, nodes.term):
         logger.debug('[i18n] PATCH: %r to have rawsource: %s',
-                     get_full_module_name(node), get_domxml(node))
+                     logging.get_full_module_name(node), logging.repr_domxml(node))
         # strip classifier from rawsource of term
         for classifier in reversed(node.parent.traverse(nodes.classifier)):
             node.rawsource = re.sub(r'\s*:\s*%s' % re.escape(classifier.astext()),
@@ -75,7 +74,7 @@ def apply_source_workaround(node):
             nodes.field_name,  # #3335 field list syntax
     ))):
         logger.debug('[i18n] PATCH: %r to have source and line: %s',
-                     get_full_module_name(node), get_domxml(node))
+                     logging.get_full_module_name(node), logging.repr_domxml(node))
         node.source = find_source_node(node)
         node.line = 0  # need fix docutils to get `node.line`
         return
@@ -111,23 +110,23 @@ def is_translatable(node):
     if isinstance(node, nodes.TextElement):
         if not node.source:
             logger.debug('[i18n] SKIP %r because no node.source: %s',
-                         get_full_module_name(node), get_domxml(node))
+                         logging.get_full_module_name(node), logging.repr_domxml(node))
             return False  # built-in message
         if isinstance(node, IGNORED_NODES) and 'translatable' not in node:
             logger.debug("[i18n] SKIP %r because node is in IGNORED_NODES "
                          "and no node['translatable']: %s",
-                         get_full_module_name(node), get_domxml(node))
+                         logging.get_full_module_name(node), logging.repr_domxml(node))
             return False
         if not node.get('translatable', True):
             # not(node['translatable'] == True or node['translatable'] is None)
             logger.debug("[i18n] SKIP %r because not node['translatable']: %s",
-                         get_full_module_name(node), get_domxml(node))
+                         logging.get_full_module_name(node), logging.repr_domxml(node))
             return False
         # <field_name>orphan</field_name>
         # XXX ignore all metadata (== docinfo)
         if isinstance(node, nodes.field_name) and node.children[0] == 'orphan':
             logger.debug('[i18n] SKIP %r because orphan node: %s',
-                         get_full_module_name(node), get_domxml(node))
+                         logging.get_full_module_name(node), logging.repr_domxml(node))
             return False
         return True
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -18,10 +18,11 @@ from six import text_type
 from sphinx import addnodes
 from sphinx.locale import __
 from sphinx.util import logging
+from sphinx.util.logging import get_full_module_name, get_domxml
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Iterable, List, Set, Tuple, Union  # NOQA
+    from typing import Any, Callable, Iterable, List, Set, Tuple  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.utils.tags import Tags  # NOQA
 
@@ -41,13 +42,19 @@ def apply_source_workaround(node):
     # * rawsource of term node will have: ``term text : classifier1 : classifier2``
     # * rawsource of classifier node will be None
     if isinstance(node, nodes.classifier) and not node.rawsource:
+        logger.debug('[i18n] PATCH: %r to have source, line and rawsource: %s',
+                     get_full_module_name(node), get_domxml(node))
         definition_list_item = node.parent
         node.source = definition_list_item.source
         node.line = definition_list_item.line - 1
         node.rawsource = node.astext()  # set 'classifier1' (or 'classifier2')
     if isinstance(node, nodes.image) and node.source is None:
+        logger.debug('[i18n] PATCH: %r to have source, line: %s',
+                     get_full_module_name(node), get_domxml(node))
         node.source, node.line = node.parent.source, node.parent.line
     if isinstance(node, nodes.term):
+        logger.debug('[i18n] PATCH: %r to have rawsource: %s',
+                     get_full_module_name(node), get_domxml(node))
         # strip classifier from rawsource of term
         for classifier in reversed(node.parent.traverse(nodes.classifier)):
             node.rawsource = re.sub(r'\s*:\s*%s' % re.escape(classifier.astext()),
@@ -67,6 +74,8 @@ def apply_source_workaround(node):
             nodes.image,  # #3093 image directive in substitution
             nodes.field_name,  # #3335 field list syntax
     ))):
+        logger.debug('[i18n] PATCH: %r to have source and line: %s',
+                     get_full_module_name(node), get_domxml(node))
         node.source = find_source_node(node)
         node.line = 0  # need fix docutils to get `node.line`
         return
@@ -74,7 +83,6 @@ def apply_source_workaround(node):
 
 IGNORED_NODES = (
     nodes.Invisible,
-    nodes.Inline,
     nodes.literal_block,
     nodes.doctest_block,
     addnodes.versionmodified,
@@ -96,17 +104,30 @@ def is_translatable(node):
     if isinstance(node, addnodes.translatable):
         return True
 
+    if isinstance(node, nodes.Inline):
+        # inline node must not be translated
+        return False
+
     if isinstance(node, nodes.TextElement):
         if not node.source:
+            logger.debug('[i18n] SKIP %r because no node.source: %s',
+                         get_full_module_name(node), get_domxml(node))
             return False  # built-in message
         if isinstance(node, IGNORED_NODES) and 'translatable' not in node:
+            logger.debug("[i18n] SKIP %r because node is in IGNORED_NODES "
+                         "and no node['translatable']: %s",
+                         get_full_module_name(node), get_domxml(node))
             return False
         if not node.get('translatable', True):
             # not(node['translatable'] == True or node['translatable'] is None)
+            logger.debug("[i18n] SKIP %r because not node['translatable']: %s",
+                         get_full_module_name(node), get_domxml(node))
             return False
         # <field_name>orphan</field_name>
         # XXX ignore all metadata (== docinfo)
         if isinstance(node, nodes.field_name) and node.children[0] == 'orphan':
+            logger.debug('[i18n] SKIP %r because orphan node: %s',
+                         get_full_module_name(node), get_domxml(node))
             return False
         return True
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -104,8 +104,8 @@ def is_translatable(node):
     if isinstance(node, addnodes.translatable):
         return True
 
-    if isinstance(node, nodes.Inline):
-        # inline node must not be translated
+    if isinstance(node, nodes.Inline) and 'translatable' not in node:
+        # inline node must not be translated if 'translatable' is not set
         return False
 
     if isinstance(node, nodes.TextElement):


### PR DESCRIPTION
### Feature or Bugfix
- Feature for debugging

### Purpose
- ease to debug of i18n

### Detail
- To know what happen on `make gettext` and `make html` with using i18n feature.

for example:
```
sphinx-build -M gettext  . _build -vvv
...
[i18n] PATCH: 'docutils.nodes.field_name' to have source and line: <field_name>pep</field_name>
[app] emitting event: 'doctree-read'(<document: <docinfo...><target...><section "changes in sphinx; chan ...>,)
[i18n] SKIP 'sphinx.addnodes.versionmodified' because node is in IGNORED_NODES and no node['translatable']: <versionmodified type="versionadded" version="1.1"><paragraph translatable="Fals...
[i18n] SKIP 'docutils.nodes.paragraph' because not node['translatable']: <paragraph translatable="False"><inline classes="versionmodified">New in version...
[i18n] SKIP 'docutils.nodes.literal_block' because no node.source: <literal_block xml:space="preserve">.. autoclass:: my.Class
   :members:
   :pri...
```