### PR TITLE
Specify version in README.rst readthedocs shield

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
    :target: https://pypi.org/project/Sphinx/
    :alt: Package on PyPi
 
-.. image:: https://readthedocs.org/projects/sphinx/badge/
+.. image:: https://readthedocs.org/projects/sphinx/badge/?version=master
    :target: http://www.sphinx-doc.org/
    :alt: Documentation Status
 


### PR DESCRIPTION
### Subject
Fix readthedocs shield in README.rst file

### Feature or Bugfix
Readthedocs status is shown as `docs unknown` before this change because any version is specified on image url.
