### PR TITLE
Fix URLs for css in Windows

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -355,7 +355,7 @@ class StandaloneHTMLBuilder(Builder):
                     continue
 
             if '://' not in filename:
-                filename = path.join('_static', filename)
+                filename = posixpath.join('_static', filename)
 
             self.css_files.append(Stylesheet(filename, **attrs))  # type: ignore
 

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -269,7 +269,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
             resourcedir = root.startswith((staticdir, imagesdir))
             for fn in sorted(files):
                 if (resourcedir and not fn.endswith('.js')) or fn.endswith('.html'):
-                    filename = path.join(root, fn)[olen:]
+                    filename = posixpath.join(root, fn)[olen:]
                     project_files.append(filename)
 
         return project_files

--- a/tests/test_ext_doctest.py
+++ b/tests/test_ext_doctest.py
@@ -8,6 +8,7 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import os
 import pytest
 from packaging.specifiers import InvalidSpecifier
 from packaging.version import InvalidVersion
@@ -68,7 +69,7 @@ def test_reporting_with_autodoc(app, status, warning, capfd):
     written = []
     app.builder._warn_out = written.append
     app.builder.build_all()
-    lines = '\n'.join(written).split('\n')
+    lines = '\n'.join(written).replace(os.sep, '/').split('\n')
     failures = [l for l in lines if l.startswith('File')]
     expected = [
         'File "dir/inner.rst", line 1, in default',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- In Windows, a backslash is used for path separator for CSS URLs
