### PR TITLE
Fixed the HTML search for uppercase words in all languages

### DIFF
--- a/sphinx/search/da.py
+++ b/sphinx/search/da.py
@@ -128,4 +128,4 @@ class SearchDanish(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('danish')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/es.py
+++ b/sphinx/search/es.py
@@ -371,4 +371,4 @@ class SearchSpanish(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('spanish')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/fi.py
+++ b/sphinx/search/fi.py
@@ -121,4 +121,4 @@ class SearchFinnish(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('finnish')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/hu.py
+++ b/sphinx/search/hu.py
@@ -235,4 +235,4 @@ class SearchHungarian(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('hungarian')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/it.py
+++ b/sphinx/search/it.py
@@ -324,4 +324,4 @@ class SearchItalian(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('italian')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/nl.py
+++ b/sphinx/search/nl.py
@@ -135,4 +135,4 @@ class SearchDutch(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('dutch')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/no.py
+++ b/sphinx/search/no.py
@@ -210,4 +210,4 @@ class SearchNorwegian(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('norwegian')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/pt.py
+++ b/sphinx/search/pt.py
@@ -270,4 +270,4 @@ class SearchPortuguese(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('portuguese')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/ro.py
+++ b/sphinx/search/ro.py
@@ -36,4 +36,4 @@ class SearchRomanian(SearchLanguage):
 
     def stem(self, word):
         # type: (unicode) -> unicode
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/ru.py
+++ b/sphinx/search/ru.py
@@ -259,4 +259,4 @@ class SearchRussian(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('russian')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/sv.py
+++ b/sphinx/search/sv.py
@@ -148,4 +148,4 @@ class SearchSwedish(SearchLanguage):
         self.stemmer = snowballstemmer.stemmer('swedish')
 
     def stem(self, word):
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/tr.py
+++ b/sphinx/search/tr.py
@@ -36,4 +36,4 @@ class SearchTurkish(SearchLanguage):
 
     def stem(self, word):
         # type: (unicode) -> unicode
-        return self.stemmer.stemWord(word)
+        return self.stemmer.stemWord(word.lower())

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -259,4 +259,4 @@ class SearchChinese(SearchLanguage):
 
     def stem(self, word):
         # type: (unicode) -> unicode
-        return self.stemmer.stem(word)
+        return self.stemmer.stem(word.lower())


### PR DESCRIPTION
After testing the HTML search for all uppercase words like `PAR_APP_TITLE` with different settings for `language` in `conf.py` I applied the same fix as in PR #4871 to all unfixed languages.

English, French and German were already fixed. 

### Feature or Bugfix
- Bugfix

### Relates
Issue #1922
PR #4396
PR #4871
