### PR TITLE
Display a warning when invalid values are passed to linenothreshold parameter of Highlight directive

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -53,8 +53,14 @@ class Highlight(SphinxDirective):
         if 'linenothreshold' in self.options:
             try:
                 linenothreshold = int(self.options['linenothreshold'])
-            except Exception:
-                linenothreshold = 10
+            except ValueError:
+                default_linenothreshold = 10
+                location = self.state_machine.get_source_and_line(self.lineno)
+                logger.warning(__('linenothreshold value must be int typed. '
+                                  'Passed %r. Using default value (10).'
+                                  % self.options['linenothreshold']),
+                              location=location)
+                linenothreshold = default_linenothreshold
         else:
             linenothreshold = sys.maxsize
         return [addnodes.highlightlang(lang=self.arguments[0].strip(),

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -57,8 +57,9 @@ class Highlight(SphinxDirective):
                 default_linenothreshold = 10
                 location = self.state_machine.get_source_and_line(self.lineno)
                 logger.warning(__('linenothreshold value must be int typed. '
-                                  'Passed %r. Using default value (10).'
-                                  % self.options['linenothreshold']),
+                                  'Passed %r. Using default value (%d).'
+                                  % (self.options['linenothreshold'],
+                                     default_linenothreshold)),
                               location=location)
                 linenothreshold = default_linenothreshold
         else:


### PR DESCRIPTION
Display a warning in `Highlight` directive if `linenothreshold` parameter value isn't valid and coerce exception cacthing to `ValueError` instead of a general `Exception` object bacuse `ValueError` is the unique possible error raised at that context.

Subject: Display a warning passing invalid values to `Highlight` directive

### Feature or Bugfix
- Feature

### Purpose
- Code refactoring and manage explicitly uncached errors.
