### PR TITLE
i18n: Ignore dot-directories like .git/ in LC_MESSAGES/.

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -19,6 +19,7 @@ from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.util import i18n, logging, status_iterator
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.i18n import find_catalog
+from sphinx.util.matching import Matcher
 from sphinx.util.osutil import SEP, ensuredir, relative_uri, relpath
 from sphinx.util.parallel import ParallelTasks, SerialTasks, make_chunks, \
     parallel_available
@@ -252,7 +253,8 @@ class Builder(object):
             self.config.language,
             charset=self.config.source_encoding,
             gettext_compact=self.config.gettext_compact,
-            force_all=True)
+            force_all=True,
+            excluded=Matcher(['**/.?**']))
         message = 'all of %d po files' % len(catalogs)
         self.compile_catalogs(catalogs, message)
 
@@ -273,7 +275,8 @@ class Builder(object):
             self.config.language,
             domains=list(specified_domains),
             charset=self.config.source_encoding,
-            gettext_compact=self.config.gettext_compact)
+            gettext_compact=self.config.gettext_compact,
+            excluded=Matcher(['**/.?**']))
         message = 'targets for %d po files that are specified' % len(catalogs)
         self.compile_catalogs(catalogs, message)
 
@@ -283,7 +286,8 @@ class Builder(object):
             [path.join(self.srcdir, x) for x in self.config.locale_dirs],
             self.config.language,
             charset=self.config.source_encoding,
-            gettext_compact=self.config.gettext_compact)
+            gettext_compact=self.config.gettext_compact,
+            excluded=Matcher(['**/.?**']))
         message = 'targets for %d po files that are out of date' % len(catalogs)
         self.compile_catalogs(catalogs, message)
 

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -24,6 +24,12 @@ from sphinx.errors import SphinxError
 from sphinx.util import logging
 from sphinx.util.osutil import SEP, relpath, walk
 
+if False:
+    # For type annotation
+    from typing import Union  # NOQA
+    from sphinx.util.matching import Matcher  # NOQA
+
+
 logger = logging.getLogger(__name__)
 
 if False:
@@ -101,8 +107,9 @@ def find_catalog_files(docname, srcdir, locale_dirs, lang, compaction):
 
 
 def find_catalog_source_files(locale_dirs, locale, domains=None, gettext_compact=False,
-                              charset='utf-8', force_all=False):
-    # type: (List[unicode], unicode, List[unicode], bool, unicode, bool) -> Set[CatalogInfo]
+                              charset='utf-8', force_all=False,
+                              excluded=lambda path: False):
+    # type: (List[unicode], unicode, List[unicode], bool, unicode, bool, Union[Callable[[unicode], bool], Matcher]) -> Set[CatalogInfo]  # NOQA
     """
     :param list locale_dirs:
        list of path as `['locale_dir1', 'locale_dir2', ...]` to find
@@ -136,6 +143,8 @@ def find_catalog_source_files(locale_dirs, locale, domains=None, gettext_compact
         for dirpath, dirnames, filenames in walk(base_dir, followlinks=True):
             filenames = [f for f in filenames if f.endswith('.po')]
             for filename in filenames:
+                if excluded(path.join(relpath(dirpath, base_dir), filename)):
+                    continue
                 base = path.splitext(filename)[0]
                 domain = relpath(path.join(dirpath, base), base_dir)
                 if gettext_compact and path.sep in domain:

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -22,12 +22,8 @@ from babel.messages.pofile import read_po
 
 from sphinx.errors import SphinxError
 from sphinx.util import logging
+from sphinx.util.matching import Matcher
 from sphinx.util.osutil import SEP, relpath, walk
-
-if False:
-    # For type annotation
-    from typing import Union  # NOQA
-    from sphinx.util.matching import Matcher  # NOQA
 
 
 logger = logging.getLogger(__name__)
@@ -108,8 +104,8 @@ def find_catalog_files(docname, srcdir, locale_dirs, lang, compaction):
 
 def find_catalog_source_files(locale_dirs, locale, domains=None, gettext_compact=False,
                               charset='utf-8', force_all=False,
-                              excluded=lambda path: False):
-    # type: (List[unicode], unicode, List[unicode], bool, unicode, bool, Union[Callable[[unicode], bool], Matcher]) -> Set[CatalogInfo]  # NOQA
+                              excluded=Matcher([])):
+    # type: (List[unicode], unicode, List[unicode], bool, unicode, bool, Matcher) -> Set[CatalogInfo]  # NOQA
     """
     :param list locale_dirs:
        list of path as `['locale_dir1', 'locale_dir2', ...]` to find

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -157,6 +157,17 @@ def test_get_catalogs_with_compact(tempdir):
     assert domains == set(['test1', 'test2', 'sub'])
 
 
+def test_get_catalogs_excluded(tempdir):
+    (tempdir / 'loc1' / 'en' / 'LC_MESSAGES' / '.git').makedirs()
+    (tempdir / 'loc1' / 'en' / 'LC_MESSAGES' / 'en_dom.po').write_text('#')
+    (tempdir / 'loc1' / 'en' / 'LC_MESSAGES' / '.git' / 'no_no.po').write_text('#')
+
+    catalogs = i18n.find_catalog_source_files(
+        [tempdir / 'loc1'], 'en', force_all=False, excluded=lambda path: '.git' in path)
+    domains = set(c.domain for c in catalogs)
+    assert domains == set(['en_dom'])
+
+
 def test_format_date():
     date = datetime.date(2016, 2, 7)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

This avoids warnings when find_catalog_source_files returns files
found in .git/ like:

```
WARNING: Start of line didn't match any expected keyword./refs/heads/freezed-library/colorsys.mo
WARNING: Problem on line 1: 0000000000000000000000000000000000000000 032a00a7391ec8a155bbc54d66ba72fb1b7bdbf1 Julien Palard <julien@palard.fr> 1521582790 +0100 branch: Created from freezed/library/colorsys.po
```

`.po` files can typically be found in .git/refs/heads/ if some branches
name end with .po, (in which case they contain a SHA1).

Yes, it hapened: https://github.com/freezed/python-docs-fr/tree/library/colorsys.po :]
