### PR TITLE
Fix #4932: apidoc: some subpackages is ignored if sibling subpackage contains underscored module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #4924: html search: Upper characters problem in any other languages
+* #4932: apidoc: some subpackage is ignored if sibling subpackage contains a
+  module starting with underscore
 
 Testing
 --------

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -199,8 +199,8 @@ def shall_skip(module, opts, excludes=[]):
         # Yes, check if we have any non-excluded modules at all here
         all_skipped = True
         basemodule = path.dirname(module)
-        for module in glob.glob(path.join(basemodule, '*.py')):
-            if not is_excluded(path.join(basemodule, module), excludes):
+        for submodule in glob.glob(path.join(basemodule, '*.py')):
+            if not is_excluded(path.join(basemodule, submodule), excludes):
                 # There's a non-excluded module here, we won't skip
                 all_skipped = False
         if all_skipped:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4932 
