### PR TITLE
fix lang_COUNTRY not fallback correctly for IndexBuilder

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -103,6 +103,7 @@ Bugs fixed
 
 * i18n: message catalogs were reset on each initialization
 * #4850: latex: footnote inside footnote was not rendered
+* i18n: fix lang_COUNTRY not fallback correctly for IndexBuilder
 
 Testing
 --------

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -444,9 +444,9 @@ class StandaloneHTMLBuilder(Builder):
         # create the search indexer
         self.indexer = None
         if self.search:
-            from sphinx.search import IndexBuilder, languages
+            from sphinx.search import IndexBuilder
             lang = self.config.html_search_language or self.config.language
-            if not lang or lang not in languages:
+            if not lang:
                 lang = 'en'
             self.indexer = IndexBuilder(self.env, lang,
                                         self.config.html_search_options,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

In IndexBuilder, it will fallback to `<lang>` when the lang
is passed as `<lang_COUNTRY>`, and will fallback to en when
not found.

https://github.com/sphinx-doc/sphinx/blob/169297d0b76bf0b503033dadeb14f9a2b735e422/sphinx/search/__init__.py#L266-L274

So there's no need to check lang before creating the IndexBuilder
instance.



