### PR TITLE
Make Config and BuildEnvironment pickable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,12 @@ Deprecated
 * ``sphinx.writers.latex.LaTeXWriter.restrict_footnote()`` is deprecated
 * ``sphinx.writers.latex.LaTeXWriter.unrestrict_footnote()`` is deprecated
 * ``LaTeXWriter.bibitems`` is deprecated
+* ``BuildEnvironment.load()`` is deprecated
+* ``BuildEnvironment.loads()`` is deprecated
+* ``BuildEnvironment.frompickle()`` is deprecated
+* ``BuildEnvironment.dump()`` is deprecated
+* ``BuildEnvironment.dumps()`` is deprecated
+* ``BuildEnvironment.topickle()`` is deprecated
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -192,6 +192,36 @@ The following is a list of deprecated interface.
      - 3.0
      - :meth:`~sphinx.application.Sphinx.add_domain()`
 
+   * - ``BuildEnvironment.load()``
+     - 1.8
+     - 3.0
+     - ``pickle.load()``
+
+   * - ``BuildEnvironment.loads()``
+     - 1.8
+     - 3.0
+     - ``pickle.loads()``
+
+   * - ``BuildEnvironment.frompickle()``
+     - 1.8
+     - 3.0
+     - ``pickle.load()``
+
+   * - ``BuildEnvironment.dump()``
+     - 1.8
+     - 3.0
+     - ``pickle.dump()``
+
+   * - ``BuildEnvironment.dumps()``
+     - 1.8
+     - 3.0
+     - ``pickle.dumps()``
+
+   * - ``BuildEnvironment.topickle()``
+     - 1.8
+     - 3.0
+     - ``pickle.dump()``
+
    * - ``BuildEnvironment._nitpick_ignore``
      - 1.8
      - 3.0

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -22,6 +22,7 @@ from os import path
 
 from docutils.parsers.rst import Directive, directives, roles
 from six import itervalues
+from six.moves import cPickle as pickle
 from six.moves import cStringIO
 
 import sphinx
@@ -291,7 +292,10 @@ class Sphinx(object):
         else:
             try:
                 logger.info(bold(__('loading pickled environment... ')), nonl=True)
-                self.env = BuildEnvironment.frompickle(filename, self)
+                with open(filename, 'rb') as f:
+                    self.env = pickle.load(f)
+                    self.env.app = self
+                    self.env.config.values = self.config.values
                 needed, reason = self.env.need_refresh(self)
                 if needed:
                     raise IOError(reason)

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -122,15 +122,7 @@ class BuildEnvironment(object):
     @staticmethod
     def dump(env, f):
         # type: (BuildEnvironment, IO) -> None
-        # remove unpicklable attributes
-        app = env.app
-        del env.app
-        domains = env.domains
-        del env.domains
         pickle.dump(env, f, pickle.HIGHEST_PROTOCOL)
-        # reset attributes
-        env.domains = domains
-        env.app = app
 
     @classmethod
     def dumps(cls, env):
@@ -245,6 +237,17 @@ class BuildEnvironment(object):
         # this is similar to temp_data, but will for example be copied to
         # attributes of "any" cross references
         self.ref_context = {}       # type: Dict[unicode, Any]
+
+    def __getstate__(self):
+        # type: () -> Dict
+        """Obtains serializable data for pickling."""
+        __dict__ = self.__dict__.copy()
+        __dict__.update(app=None, domains={})  # clear unpickable attributes
+        return __dict__
+
+    def __setstate__(self, state):
+        # type: (Dict) -> None
+        self.__dict__.update(state)
 
     def set_warnfunc(self, func):
         # type: (Callable) -> None

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -91,51 +91,6 @@ class BuildEnvironment(object):
 
     domains = None  # type: Dict[unicode, Domain]
 
-    # --------- ENVIRONMENT PERSISTENCE ----------------------------------------
-
-    @staticmethod
-    def load(f, app=None):
-        # type: (IO, Sphinx) -> BuildEnvironment
-        try:
-            env = pickle.load(f)
-        except Exception as exc:
-            # This can happen for example when the pickle is from a
-            # different version of Sphinx.
-            raise IOError(exc)
-        if app:
-            env.app = app
-            env.config.values = app.config.values
-        return env
-
-    @classmethod
-    def loads(cls, string, app=None):
-        # type: (unicode, Sphinx) -> BuildEnvironment
-        io = BytesIO(string)
-        return cls.load(io, app)
-
-    @classmethod
-    def frompickle(cls, filename, app):
-        # type: (unicode, Sphinx) -> BuildEnvironment
-        with open(filename, 'rb') as f:
-            return cls.load(f, app)
-
-    @staticmethod
-    def dump(env, f):
-        # type: (BuildEnvironment, IO) -> None
-        pickle.dump(env, f, pickle.HIGHEST_PROTOCOL)
-
-    @classmethod
-    def dumps(cls, env):
-        # type: (BuildEnvironment) -> unicode
-        io = BytesIO()
-        cls.dump(env, io)
-        return io.getvalue()
-
-    def topickle(self, filename):
-        # type: (unicode) -> None
-        with open(filename, 'wb') as f:
-            self.dump(self, f)
-
     # --------- ENVIRONMENT INITIALIZATION -------------------------------------
 
     def __init__(self, app):
@@ -816,3 +771,64 @@ class BuildEnvironment(object):
                       'Please use config.nitpick_ignore instead.',
                       RemovedInSphinx30Warning)
         return self.config.nitpick_ignore
+
+    @staticmethod
+    def load(f, app=None):
+        # type: (IO, Sphinx) -> BuildEnvironment
+        warnings.warn('BuildEnvironment.load() is deprecated. '
+                      'Please use pickle.load() instead.',
+                      RemovedInSphinx30Warning)
+        try:
+            env = pickle.load(f)
+        except Exception as exc:
+            # This can happen for example when the pickle is from a
+            # different version of Sphinx.
+            raise IOError(exc)
+        if app:
+            env.app = app
+            env.config.values = app.config.values
+        return env
+
+    @classmethod
+    def loads(cls, string, app=None):
+        # type: (unicode, Sphinx) -> BuildEnvironment
+        warnings.warn('BuildEnvironment.loads() is deprecated. '
+                      'Please use pickle.loads() instead.',
+                      RemovedInSphinx30Warning)
+        io = BytesIO(string)
+        return cls.load(io, app)
+
+    @classmethod
+    def frompickle(cls, filename, app):
+        # type: (unicode, Sphinx) -> BuildEnvironment
+        warnings.warn('BuildEnvironment.frompickle() is deprecated. '
+                      'Please use pickle.load() instead.',
+                      RemovedInSphinx30Warning)
+        with open(filename, 'rb') as f:
+            return cls.load(f, app)
+
+    @staticmethod
+    def dump(env, f):
+        # type: (BuildEnvironment, IO) -> None
+        warnings.warn('BuildEnvironment.dump() is deprecated. '
+                      'Please use pickle.dump() instead.',
+                      RemovedInSphinx30Warning)
+        pickle.dump(env, f, pickle.HIGHEST_PROTOCOL)
+
+    @classmethod
+    def dumps(cls, env):
+        # type: (BuildEnvironment) -> unicode
+        warnings.warn('BuildEnvironment.dumps() is deprecated. '
+                      'Please use pickle.dumps() instead.',
+                      RemovedInSphinx30Warning)
+        io = BytesIO()
+        cls.dump(env, io)
+        return io.getvalue()
+
+    def topickle(self, filename):
+        # type: (unicode) -> None
+        warnings.warn('env.topickle() is deprecated. '
+                      'Please use pickle.dump() instead.',
+                      RemovedInSphinx30Warning)
+        with open(filename, 'wb') as f:
+            self.dump(self, f)

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -12,14 +12,13 @@
 import os
 import re
 import sys
-import types
 import warnings
 from collections import defaultdict
 from copy import copy
 from os import path
 
 from docutils.utils import Reporter, get_source_line
-from six import BytesIO, class_types, next
+from six import BytesIO, next
 from six.moves import cPickle as pickle
 
 from sphinx import addnodes
@@ -126,21 +125,11 @@ class BuildEnvironment(object):
         # remove unpicklable attributes
         app = env.app
         del env.app
-        values = env.config.values
-        del env.config.values
         domains = env.domains
         del env.domains
-        # remove potentially pickling-problematic values from config
-        for key, val in list(vars(env.config).items()):
-            if key.startswith('_') or \
-               isinstance(val, types.ModuleType) or \
-               isinstance(val, types.FunctionType) or \
-               isinstance(val, class_types):
-                del env.config[key]
         pickle.dump(env, f, pickle.HIGHEST_PROTOCOL)
         # reset attributes
         env.domains = domains
-        env.config.values = values
         env.app = app
 
     @classmethod

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -67,7 +67,7 @@ default_settings = {
 # or changed to properly invalidate pickle files.
 #
 # NOTE: increase base version by 2 to have distinct numbers for Py2 and 3
-ENV_VERSION = 52 + (sys.version_info[0] - 2)
+ENV_VERSION = 53 + (sys.version_info[0] - 2)
 
 
 versioning_conditions = {


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Add `__getstate__()` and `__setstate__()` helper to make `Config` and `BuildEnvironment` pickable
- It makes them simple and easy to understand
