### PR TITLE
Remove unused SPHINXPROJ from new Makefile/make.bat.

### DIFF
--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -30,8 +30,6 @@ if False:
     # For type annotation
     from typing import List  # NOQA
 
-proj_name = os.getenv('SPHINXPROJ', '<project>')
-
 
 BUILDERS = [
     ("",      "html",        "to make standalone HTML files"),

--- a/sphinx/templates/quickstart/Makefile.new_t
+++ b/sphinx/templates/quickstart/Makefile.new_t
@@ -4,7 +4,6 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = {{ project_fn }}
 SOURCEDIR     = {{ rsrcdir }}
 BUILDDIR      = {{ rbuilddir }}
 

--- a/sphinx/templates/quickstart/make.bat.new_t
+++ b/sphinx/templates/quickstart/make.bat.new_t
@@ -9,7 +9,6 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR={{ rsrcdir }}
 set BUILDDIR={{ rbuilddir }}
-set SPHINXPROJ={{ project_fn }}
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
Subject: Remove unused SPHINXPROJ from new Makefile/make.bat.

### Feature or Bugfix
<!-- please choose -->
Bugfix

### Purpose
The SPHINXPROJ makefile variable has become unused since #4354.  Remove it.

### Detail
See above.

### Relates
N/A