### PR TITLE
Refactor reporter

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 from copy import copy
 from os import path
 
-from docutils.utils import Reporter, get_source_line
+from docutils.utils import get_source_line
 from six import BytesIO, class_types, next
 from six.moves import cPickle as pickle
 
@@ -31,7 +31,7 @@ from sphinx.locale import __
 from sphinx.transforms import SphinxTransformer
 from sphinx.util import get_matching_docs, FilenameUniqDict
 from sphinx.util import logging
-from sphinx.util.docutils import WarningStream
+from sphinx.util.docutils import LoggingReporter
 from sphinx.util.i18n import find_catalog_files
 from sphinx.util.matching import compile_matchers
 from sphinx.util.nodes import is_translatable
@@ -652,7 +652,7 @@ class BuildEnvironment(object):
         with open(doctree_filename, 'rb') as f:
             doctree = pickle.load(f)
         doctree.settings.env = self
-        doctree.reporter = Reporter(self.doc2path(docname), 2, 5, stream=WarningStream())
+        doctree.reporter = LoggingReporter(self.doc2path(docname))
         return doctree
 
     def get_and_resolve_doctree(self, docname, builder, doctree=None,

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -241,8 +241,9 @@ class LoggingReporter(Reporter):
         return cls(reporter.source, reporter.report_level, reporter.halt_level,
                    reporter.debug_flag, reporter.error_handler)
 
-    def __init__(self, source, report_level, halt_level,
-                 debug=False, error_handler='backslashreplace'):
+    def __init__(self, source, report_level=Reporter.WARNING_LEVEL,
+                 halt_level=Reporter.SEVERE_LEVEL, debug=False,
+                 error_handler='backslashreplace'):
         # type: (unicode, int, int, bool, unicode) -> None
         stream = WarningStream()
         Reporter.__init__(self, source, report_level, halt_level,


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To make our code simple, replace raw `Reporter` class with `LoggingReporter` class.
- It can reduce magic numbers for Reporter (mainly about log levels). 