### PR TITLE
Instructions to view build result in devhelp

### DIFF
--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -45,8 +45,8 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
     """
     name = 'devhelp'
     epilog = __('To view the help file:\n'
-                '$ mkdir -p $HOME/.local/share/devhelp/%(project)s\n'
-                '$ ln -s %(outdir)s $HOME/.local/share/devhelp/%(project)s\n'
+                '$ mkdir -p $HOME/.local/share/devhelp/books\n'
+                '$ ln -s $PWD/%(outdir)s $HOME/.local/share/devhelp/books/%(project)s\n'
                 '$ devhelp')
 
     # don't copy the reST source


### PR DESCRIPTION
Fix instructions to see doc on devhelp

### Feature or Bugfix
- Bugfix

### Purpose
- instruction to see doc results in devhelp
- No additional deps

### Detail

### Relates

