### PR TITLE
Resolve "Missing location= in cpp domain warning "Duplicate declaration" name variant"

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6055,7 +6055,7 @@ class CPPDomain(Domain):
                     msg = "Duplicate declaration, also defined in '%s'.\n"
                     msg += "Name of declaration is '%s'."
                     msg = msg % (ourNames[name], name)
-                    logger.warning(msg, docname)
+                    logger.warning(msg, location=docname)
                 else:
                     ourNames[name] = docname
 


### PR DESCRIPTION
"Duplicate declarion" warning, name variant is missing the location=
specifier causing string formatting to fail

closes #4962 

Subject: Missing location= in cpp domain warning "Duplicate declaration" name variant

Again, because this is quite a trivial fix I didn't fill in most of the PR template. Hopefully you don't mind too much. :)

### Feature or Bugfix
- Bugfix