### PR TITLE
Fix latex: deeply nested enumerated list which is beginning with non-1 causes LaTeX engine crashed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Bugs fixed
   topic, admonition, table and section.
 * #4913: i18n: literal blocks in bullet list are not translated
 * #4962: cpp domain: raises TypeError on duplicate declaration
+* latex: deeply nested enumerated list which is beginning with non-1 causes
+  LaTeX engine crashed
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from os import path
 
 from docutils import nodes, writers
+from docutils.utils.roman import toRoman
 from docutils.writers.latex2e import Babel
 from six import itervalues, text_type
 
@@ -1514,8 +1515,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
         self.body.append('\\begin{enumerate}\n')
         if 'start' in node:
-            nested = get_nested_level(node)
-            self.body.append('\\setcounter{enum%s}{%d}\n' % ('i' * nested, node['start'] - 1))
+            enum_depth = "enum%s" % toRoman(get_nested_level(node)).lower()
+            self.body.append('\\setcounter{%s}{%d}\n' % (enum_depth, node['start'] - 1))
         if self.table:
             self.table.has_problematic = True
 

--- a/tests/roots/test-nested-enumerated-list/index.rst
+++ b/tests/roots/test-nested-enumerated-list/index.rst
@@ -9,6 +9,12 @@ nested-enumerated-list
       10) Pyramid
       11) Nile River
 
+          (x) Atbara
+          (y) Blue Nile
+          (#) Sobat
+          (#) Semliki
+          (#) Kagera
+
 6. Markup
 
    iii. reStructuredText

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1239,4 +1239,5 @@ def test_latex_nested_enumerated_list(app, status, warning):
     assert r'\setcounter{enumi}{4}' in result
     assert r'\setcounter{enumii}{3}' in result
     assert r'\setcounter{enumiii}{9}' in result
+    assert r'\setcounter{enumiv}{23}' in result
     assert r'\setcounter{enumii}{2}' in result


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/pull/4639/files#r188023439

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

