### PR TITLE
Fix #4978: latex: shorthandoff is not set up for Brazil locale

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * #4825: C++, properly parse expr roles and give better error messages when
   (escaped) line breaks are present.
 * #4915, #4916: links on search page are broken when using dirhtml builder
+* #4978: latex: shorthandoff is not set up for Brazil locale
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -196,7 +196,7 @@ class ExtBabel(Babel):
         shortlang = self.language.split('_')[0]
         if shortlang in ('de', 'ngerman', 'sl', 'slovene', 'pt', 'portuges',
                          'es', 'spanish', 'nl', 'dutch', 'pl', 'polish', 'it',
-                         'italian'):
+                         'italian', 'pt-BR', 'brazil'):
             return '\\ifnum\\catcode`\\"=\\active\\shorthandoff{"}\\fi'
         elif shortlang in ('tr', 'turkish'):
             # memo: if ever Sphinx starts supporting 'Latin', do as for Turkish


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4978
