### PR TITLE
Fix #4979: latex: Incorrect escaping of curly braces in index entries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
 * #4969: autodoc: constructor method should not have return annotation
 * latex: deeply nested enumerated list which is beginning with non-1 causes
   LaTeX engine crashed
+* #4979: latex: Incorrect escaping of curly braces in index entries
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1608,6 +1608,10 @@
 % figure legend comes after caption and may contain arbitrary body elements
 \newenvironment{sphinxlegend}{\par\small}{\par}
 
+% For curly braces inside \index macro
+\def\sphinxleftcurlybrace{\{}
+\def\sphinxrightcurlybrace{\}}
+
 % Declare Unicode characters used by linux tree command to pdflatex utf8/utf8x
 \def\spx@bd#1#2{%
   \leavevmode

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1949,6 +1949,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
 
     def visit_index(self, node, scre=re.compile(r';\s*')):
         # type: (nodes.Node, Pattern) -> None
+        def escape(value):
+            value = self.encode(value)
+            value = value.replace(r'\{', r'\sphinxleftcurlybrace')
+            value = value.replace(r'\}', r'\sphinxrightcurlybrace')
+            return value
+
         if not node.get('inline', True):
             self.body.append('\n')
         entries = node['entries']
@@ -1958,24 +1964,23 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 m = '|textbf'
             try:
                 if type == 'single':
-                    p = scre.sub('!', self.encode(string))
+                    p = scre.sub('!', escape(string))
                     self.body.append(r'\index{%s%s}' % (p, m))
                 elif type == 'pair':
-                    p1, p2 = [self.encode(x) for x in split_into(2, 'pair', string)]
+                    p1, p2 = [escape(x) for x in split_into(2, 'pair', string)]
                     self.body.append(r'\index{%s!%s%s}\index{%s!%s%s}' %
                                      (p1, p2, m, p2, p1, m))
                 elif type == 'triple':
-                    p1, p2, p3 = [self.encode(x)
-                                  for x in split_into(3, 'triple', string)]
+                    p1, p2, p3 = [escape(x) for x in split_into(3, 'triple', string)]
                     self.body.append(
                         r'\index{%s!%s %s%s}\index{%s!%s, %s%s}'
                         r'\index{%s!%s %s%s}' %
                         (p1, p2, p3, m, p2, p3, p1, m, p3, p1, p2, m))
                 elif type == 'see':
-                    p1, p2 = [self.encode(x) for x in split_into(2, 'see', string)]
+                    p1, p2 = [escape(x) for x in split_into(2, 'see', string)]
                     self.body.append(r'\index{%s|see{%s}}' % (p1, p2))
                 elif type == 'seealso':
-                    p1, p2 = [self.encode(x) for x in split_into(2, 'seealso', string)]
+                    p1, p2 = [escape(x) for x in split_into(2, 'seealso', string)]
                     self.body.append(r'\index{%s|see{%s}}' % (p1, p2))
                 else:
                     logger.warning('unknown index entry type %s found', type)

--- a/tests/roots/test-latex-index/index.rst
+++ b/tests/roots/test-latex-index/index.rst
@@ -10,3 +10,7 @@ A :index:`famous` :index:`equation`:
 .. index:: Einstein, relativity
 
 and some text.
+
+.. index:: main {
+
+An index entry containing non paired curly brace

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1209,6 +1209,7 @@ def test_latex_index(app, status, warning):
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
     assert 'A \\index{famous}famous \\index{equation}equation:\n' in result
     assert '\n\\index{Einstein}\\index{relativity}\\ignorespaces \nand' in result
+    assert '\n\\index{main \\sphinxleftcurlybrace}\\ignorespaces ' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-equations')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- see #4979 
