### PR TITLE
Implement math_renderer framework

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -102,6 +102,7 @@ Deprecated
 * ``sphinx.ext.mathbase.eqref`` node is deprecated
 * ``sphinx.ext.mathbase.is_in_section_title()`` is deprecated
 * ``sphinx.ext.mathbase.MathDomain`` is deprecated
+* ``sphinx.ext.mathbase.setup_math()`` is deprecated
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_
@@ -163,6 +164,7 @@ Features added
 * #4976: ``SphinxLoggerAdapter.info()`` now supports ``location`` parameter
 * #5122: setuptools: support nitpicky option
 * #2820: autoclass directive supports nested class
+* Add ``app.add_html_math_renderer()`` to register a math renderer for HTML
 
 Bugs fixed
 ----------

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -93,6 +93,8 @@ package.
 
 .. automethod:: Sphinx.add_html_theme(name, theme_path)
 
+.. automethod:: Sphinx.add_html_math_renderer(name, inline_renderers, block_renderers)
+
 .. automethod:: Sphinx.add_message_catalog(catalog, locale_dir)
 
 .. automethod:: Sphinx.is_parallel_allowed(typ)

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -136,6 +136,11 @@ The following is a list of deprecated interface.
      - 3.0
      - ``sphinx.domains.math.MathDomain``
 
+   * - ``sphinx.ext.mathbase.setup_math()``
+     - 1.8
+     - 3.0
+     - :meth:`~sphinx.application.Sphinx.add_html_math_renderer()`
+
    * - ``sphinx.ext.mathbase.is_in_section_title()``
      - 1.8
      - 3.0

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -773,6 +773,35 @@ documentation on :ref:`intl` for details.
       Added ``{path}`` and ``{basename}`` tokens.
 
 
+.. _math-options:
+
+Options for Math
+----------------
+
+These options influence Math notations.
+
+.. confval:: math_number_all
+
+   Set this option to ``True`` if you want all displayed math to be numbered.
+   The default is ``False``.
+
+.. confval:: math_eqref_format
+
+   A string that are used for format of label of references to equations.
+   As a special character, ``{number}`` will be replaced to equaition number.
+
+   Example: ``'Eq.{number}'`` is rendered as ``Eq.10``
+
+.. confval:: math_numfig
+
+   If ``True``, displayed math equations are numbered across pages when
+   :confval:`numfig` is enabled.  The :confval:`numfig_secnum_depth` setting
+   is respected.  The :rst:role:`eq`, not :rst:role:`numref`, role
+   must be used to reference equation numbers.  Default is ``True``.
+
+   .. versionadded:: 1.7
+
+
 .. _html-options:
 
 Options for HTML output
@@ -1289,6 +1318,13 @@ that use Sphinx's HTMLWriter class.
    The default is ``True``.
 
    .. versionadded:: 1.3
+
+.. confval:: html_math_renderer
+
+   The name of math_renderer extension for HTML output.  The default is
+   ``'mathjax'``.
+
+   .. versionadded:: 1.8
 
 .. confval:: html_experimental_html5_writer
 

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -2,123 +2,20 @@
 
 .. _math-support:
 
-Math support in Sphinx
-======================
+Math support for HTML outputs in Sphinx
+=======================================
 
 .. module:: sphinx.ext.mathbase
    :synopsis: Common math support for imgmath and mathjax / jsmath.
 
 .. versionadded:: 0.5
+.. versionchanged:: 1.8
+
+   Math support for non-HTML builders is integrated to sphinx-core.
+   So mathbase extension is no longer needed.
 
 Since mathematical notation isn't natively supported by HTML in any way, Sphinx
-supports math in documentation with several extensions.
-
-The basic math support is contained in :mod:`sphinx.ext.mathbase`. Other math
-support extensions should, if possible, reuse that support too.
-
-.. note::
-
-   :mod:`.mathbase` is not meant to be added to the :confval:`extensions` config
-   value, instead, use either :mod:`sphinx.ext.imgmath` or
-   :mod:`sphinx.ext.mathjax` as described below.
-
-The input language for mathematics is LaTeX markup.  This is the de-facto
-standard for plain-text math notation and has the added advantage that no
-further translation is necessary when building LaTeX output.
-
-Keep in mind that when you put math markup in **Python docstrings** read by
-:mod:`autodoc <sphinx.ext.autodoc>`, you either have to double all backslashes,
-or use Python raw strings (``r"raw"``).
-
-:mod:`.mathbase` provides the following config values:
-
-.. confval:: math_number_all
-
-   Set this option to ``True`` if you want all displayed math to be numbered.
-   The default is ``False``.
-
-.. confval:: math_eqref_format
-
-   A string that are used for format of label of references to equations.
-   As a special character, ``{number}`` will be replaced to equaition number.
-
-   Example: ``'Eq.{number}'`` is rendered as ``Eq.10``
-
-.. confval:: math_numfig
-
-   If ``True``, displayed math equations are numbered across pages when
-   :confval:`numfig` is enabled.  The :confval:`numfig_secnum_depth` setting
-   is respected.  The :rst:role:`eq`, not :rst:role:`numref`, role
-   must be used to reference equation numbers.  Default is ``True``.
-
-   .. versionadded:: 1.7
-
-:mod:`.mathbase` defines these new markup elements:
-
-.. rst:role:: math
-
-   Role for inline math.  Use like this::
-
-      Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
-
-.. rst:directive:: math
-
-   Directive for displayed math (math that takes the whole line for itself).
-
-   The directive supports multiple equations, which should be separated by a
-   blank line::
-
-      .. math::
-
-         (a + b)^2 = a^2 + 2ab + b^2
-
-         (a - b)^2 = a^2 - 2ab + b^2
-
-   In addition, each single equation is set within a ``split`` environment,
-   which means that you can have multiple aligned lines in an equation,
-   aligned at ``&`` and separated by ``\\``::
-
-      .. math::
-
-         (a + b)^2  &=  (a + b)(a + b) \\
-                    &=  a^2 + 2ab + b^2
-
-   For more details, look into the documentation of the `AmSMath LaTeX
-   package`_.
-
-   When the math is only one line of text, it can also be given as a directive
-   argument::
-
-      .. math:: (a + b)^2 = a^2 + 2ab + b^2
-
-   Normally, equations are not numbered.  If you want your equation to get a
-   number, use the ``label`` option.  When given, it selects an internal label
-   for the equation, by which it can be cross-referenced, and causes an equation
-   number to be issued.  See :rst:role:`eq` for an example.  The numbering
-   style depends on the output format.
-
-   There is also an option ``nowrap`` that prevents any wrapping of the given
-   math in a math environment.  When you give this option, you must make sure
-   yourself that the math is properly set up.  For example::
-
-      .. math::
-         :nowrap:
-
-         \begin{eqnarray}
-            y    & = & ax^2 + bx + c \\
-            f(x) & = & x^2 + 2xy + y^2
-         \end{eqnarray}
-
-.. rst:role:: eq
-
-   Role for cross-referencing equations via their label.  Example::
-
-      .. math:: e^{i\pi} + 1 = 0
-         :label: euler
-
-      Euler's identity, equation :eq:`euler`, was elected one of the most
-      beautiful mathematical formulas.
-
+gives a math support to HTML document with several extensions.
 
 :mod:`sphinx.ext.imgmath` -- Render math as images
 --------------------------------------------------
@@ -299,4 +196,3 @@ package jsMath_.  It provides this config value:
 .. _MathJax: https://www.mathjax.org/
 .. _jsMath: http://www.math.union.edu/~dpvc/jsmath/
 .. _preview-latex package: https://www.gnu.org/software/auctex/preview-latex.html
-.. _AmSMath LaTeX package: https://www.ams.org/publications/authors/tex/amslatex

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -1005,9 +1005,63 @@ this reason, the following directive exists:
 Math
 ----
 
-.. todo:: Move this in here.
+The input language for mathematics is LaTeX markup.  This is the de-facto
+standard for plain-text math notation and has the added advantage that no
+further translation is necessary when building LaTeX output.
 
-See :ref:`math-support`.
+Keep in mind that when you put math markup in **Python docstrings** read by
+:mod:`autodoc <sphinx.ext.autodoc>`, you either have to double all backslashes,
+or use Python raw strings (``r"raw"``).
+
+.. rst:directive:: math
+
+   Directive for displayed math (math that takes the whole line for itself).
+
+   The directive supports multiple equations, which should be separated by a
+   blank line::
+
+      .. math::
+
+         (a + b)^2 = a^2 + 2ab + b^2
+
+         (a - b)^2 = a^2 - 2ab + b^2
+
+   In addition, each single equation is set within a ``split`` environment,
+   which means that you can have multiple aligned lines in an equation,
+   aligned at ``&`` and separated by ``\\``::
+
+      .. math::
+
+         (a + b)^2  &=  (a + b)(a + b) \\
+                    &=  a^2 + 2ab + b^2
+
+   For more details, look into the documentation of the `AmSMath LaTeX
+   package`_.
+
+   When the math is only one line of text, it can also be given as a directive
+   argument::
+
+      .. math:: (a + b)^2 = a^2 + 2ab + b^2
+
+   Normally, equations are not numbered.  If you want your equation to get a
+   number, use the ``label`` option.  When given, it selects an internal label
+   for the equation, by which it can be cross-referenced, and causes an equation
+   number to be issued.  See :rst:role:`eq` for an example.  The numbering
+   style depends on the output format.
+
+   There is also an option ``nowrap`` that prevents any wrapping of the given
+   math in a math environment.  When you give this option, you must make sure
+   yourself that the math is properly set up.  For example::
+
+      .. math::
+         :nowrap:
+
+         \begin{eqnarray}
+            y    & = & ax^2 + bx + c \\
+            f(x) & = & x^2 + 2xy + y^2
+         \end{eqnarray}
+
+.. _AmSMath LaTeX package: https://www.ams.org/publications/authors/tex/amslatex
 
 
 Grammar production displays

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -277,6 +277,26 @@ The following role creates a cross-reference to a term in a
    during build.
 
 
+Math
+----
+
+.. rst:role:: math
+
+   Role for inline math.  Use like this::
+
+      Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
+
+.. rst:role:: eq
+
+   Role for cross-referencing equations via their label.  Example::
+
+      .. math:: e^{i\pi} + 1 = 0
+         :label: euler
+
+      Euler's identity, equation :eq:`euler`, was elected one of the most
+      beautiful mathematical formulas.
+
+
 Other semantic markup
 ---------------------
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1220,6 +1220,20 @@ class Sphinx(object):
         logger.debug('[app] adding HTML theme: %r, %r', name, theme_path)
         self.html_themes[name] = theme_path
 
+    def add_html_math_renderer(self, name, inline_renderers=None, block_renderers=None):
+        # type: (unicode, Tuple[Callable, Callable], Tuple[Callable, Callable]) -> None
+        """Register a math renderer for HTML.
+
+        The *name* is a name of the math renderer.  Both *inline_renderers* and
+        *block_renderes* are used as visitor functions for HTML writer.
+        *inline_renderers* is used for inline math node (``nodes.math`)).  The
+        another is used for block math node (``nodes.math_block``).  About
+        visitor functions, see :meth:`add_node` for more details.
+
+        .. versionadded:: 1.8
+        """
+        self.registry.add_html_math_renderer(name, inline_renderers, block_renderers)
+
     def add_message_catalog(self, catalog, locale_dir):
         # type: (unicode, unicode) -> None
         """Register a message catalog.

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -22,9 +22,9 @@ from docutils import nodes
 from six import text_type
 
 import sphinx
-from sphinx.errors import SphinxError, ExtensionError
+from sphinx.errors import SphinxError
 from sphinx.ext.mathbase import get_node_equation_number
-from sphinx.ext.mathbase import setup_math as mathbase_setup, wrap_displaymath
+from sphinx.ext.mathbase import wrap_displaymath
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, ENOENT, cd
@@ -349,10 +349,9 @@ def html_visit_displaymath(self, node):
 
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
-    try:
-        mathbase_setup(app, (html_visit_math, None), (html_visit_displaymath, None))
-    except ExtensionError:
-        raise ExtensionError('sphinx.ext.imgmath: other math package is already loaded')
+    app.add_html_math_renderer('imgmath',
+                               (html_visit_math, None),
+                               (html_visit_displaymath, None))
 
     app.add_config_value('imgmath_image_format', 'png', 'html')
     app.add_config_value('imgmath_dvipng', 'dvipng', 'html')

--- a/sphinx/ext/jsmath.py
+++ b/sphinx/ext/jsmath.py
@@ -15,7 +15,6 @@ from docutils import nodes
 import sphinx
 from sphinx.errors import ExtensionError
 from sphinx.ext.mathbase import get_node_equation_number
-from sphinx.ext.mathbase import setup_math as mathbase_setup
 from sphinx.locale import _
 
 if False:
@@ -61,7 +60,9 @@ def html_visit_displaymath(self, node):
 
 def builder_inited(app):
     # type: (Sphinx) -> None
-    if not app.config.jsmath_path:
+    if app.builder.format != 'html' or app.builder.math_renderer_name != 'jsmath':  # type: ignore  # NOQA
+        pass
+    elif not app.config.jsmath_path:
         raise ExtensionError('jsmath_path config value must be set for the '
                              'jsmath extension to work')
     if app.builder.format == 'html':
@@ -70,10 +71,9 @@ def builder_inited(app):
 
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
-    try:
-        mathbase_setup(app, (html_visit_math, None), (html_visit_displaymath, None))
-    except ExtensionError:
-        raise ExtensionError('sphinx.ext.jsmath: other math package is already loaded')
+    app.add_html_math_renderer('jsmath',
+                               (html_visit_math, None),
+                               (html_visit_displaymath, None))
 
     app.add_config_value('jsmath_path', '', False)
     app.connect('builder-inited', builder_inited)

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -13,7 +13,7 @@ import warnings
 
 from docutils import nodes
 
-from sphinx.addnodes import math, math_block as displaymath
+from sphinx.addnodes import math, math_block as displaymath  # NOQA  # to keep compatibility
 from sphinx.builders.latex.nodes import math_reference as eqref  # NOQA  # to keep compatibility
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.domains.math import MathDomain  # NOQA  # to keep compatibility
@@ -44,7 +44,7 @@ def get_node_equation_number(writer, node):
     return number
 
 
-def wrap_displaymath(math, label, numbering):
+def wrap_displaymath(text, label, numbering):
     # type: (unicode, unicode, bool) -> unicode
     def is_equation(part):
         # type: (unicode) -> unicode
@@ -56,7 +56,7 @@ def wrap_displaymath(math, label, numbering):
         labeldef = r'\label{%s}' % label
         numbering = True
 
-    parts = list(filter(is_equation, math.split('\n\n')))
+    parts = list(filter(is_equation, text.split('\n\n')))
     equations = []
     if len(parts) == 0:
         return ''
@@ -97,8 +97,9 @@ def is_in_section_title(node):
 
 
 def setup_math(app, htmlinlinevisitors, htmldisplayvisitors):
-    # type: (Sphinx, Tuple[Callable, Any], Tuple[Callable, Any]) -> None
-    app.add_node(math, override=True,
-                 html=htmlinlinevisitors)
-    app.add_node(displaymath, override=True,
-                 html=htmldisplayvisitors)
+    # type: (Sphinx, Tuple[Callable, Callable], Tuple[Callable, Callable]) -> None
+    warnings.warn('setup_math() is deprecated. '
+                  'Please use app.add_html_math_renderer() instead.',
+                  RemovedInSphinx30Warning)
+
+    app.add_html_math_renderer('unknown', htmlinlinevisitors, htmldisplayvisitors)

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -16,7 +16,6 @@ from docutils import nodes
 import sphinx
 from sphinx.errors import ExtensionError
 from sphinx.ext.mathbase import get_node_equation_number
-from sphinx.ext.mathbase import setup_math as mathbase_setup
 from sphinx.locale import _
 
 if False:
@@ -69,7 +68,9 @@ def html_visit_displaymath(self, node):
 
 def builder_inited(app):
     # type: (Sphinx) -> None
-    if not app.config.mathjax_path:
+    if app.builder.format != 'html' or app.builder.math_renderer_name != 'mathjax':  # type: ignore  # NOQA
+        pass
+    elif not app.config.mathjax_path:
         raise ExtensionError('mathjax_path config value must be set for the '
                              'mathjax extension to work')
     if app.builder.format == 'html':
@@ -81,10 +82,9 @@ def builder_inited(app):
 
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
-    try:
-        mathbase_setup(app, (html_visit_math, None), (html_visit_displaymath, None))
-    except ExtensionError:
-        raise ExtensionError('sphinx.ext.mathjax: other math package is already loaded')
+    app.add_html_math_renderer('mathjax',
+                               (html_visit_math, None),
+                               (html_visit_displaymath, None))
 
     # more information for mathjax secure url is here:
     # https://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -92,6 +92,11 @@ class SphinxComponentRegistry(object):
         #: a dict of node class -> tuple of figtype and title_getter function
         self.enumerable_nodes = {}      # type: Dict[nodes.Node, Tuple[unicode, TitleGetter]]
 
+        #: HTML inline and block math renderers
+        #: a dict of name -> tuple of visit function and depart function
+        self.html_inline_math_renderers = {}    # type: Dict[unicode, Tuple[Callable, Callable]]  # NOQA
+        self.html_block_math_renderers = {}     # type: Dict[unicode, Tuple[Callable, Callable]]  # NOQA
+
         #: js_files; list of JS paths or URLs
         self.js_files = []              # type: List[Tuple[unicode, Dict[unicode, unicode]]]
 
@@ -438,6 +443,16 @@ class SphinxComponentRegistry(object):
         if node in self.enumerable_nodes and not override:
             raise ExtensionError(__('enumerable_node %r already registered') % node)
         self.enumerable_nodes[node] = (figtype, title_getter)
+
+    def add_html_math_renderer(self, name, inline_renderers, block_renderers):
+        # type: (unicode, Tuple[Callable, Callable], Tuple[Callable, Callable]) -> None
+        logger.debug('[app] adding html_math_renderer: %s, %r, %r',
+                     name, inline_renderers, block_renderers)
+        if name in self.html_inline_math_renderers:
+            raise ExtensionError(__('math renderer %s is already registred') % name)
+
+        self.html_inline_math_renderers[name] = inline_renderers
+        self.html_block_math_renderers[name] = block_renderers
 
     def load_extension(self, app, extname):
         # type: (Sphinx, unicode) -> None

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -874,11 +874,29 @@ class HTMLTranslator(BaseTranslator):
 
     def visit_math(self, node, math_env=''):
         # type: (nodes.Node, unicode) -> None
-        logger.warning(__('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/en/master/ext/math.html'),
-                       location=(self.builder.current_docname, node.line))
-        raise nodes.SkipNode
+        name = self.builder.math_renderer_name
+        visit, _ = self.builder.app.registry.html_inline_math_renderers[name]
+        visit(self, node)
+
+    def depart_math(self, node, math_env=''):
+        # type: (nodes.Node, unicode) -> None
+        name = self.builder.math_renderer_name
+        _, depart = self.builder.app.registry.html_inline_math_renderers[name]
+        if depart:
+            depart(self, node)
+
+    def visit_math_block(self, node, math_env=''):
+        # type: (nodes.Node, unicode) -> None
+        name = self.builder.math_renderer_name
+        visit, _ = self.builder.app.registry.html_block_math_renderers[name]
+        visit(self, node)
+
+    def depart_math_block(self, node, math_env=''):
+        # type: (nodes.Node, unicode) -> None
+        name = self.builder.math_renderer_name
+        _, depart = self.builder.app.registry.html_block_math_renderers[name]
+        if depart:
+            depart(self, node)
 
     def unknown_visit(self, node):
         # type: (nodes.Node) -> None

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -825,11 +825,29 @@ class HTML5Translator(BaseTranslator):
 
     def visit_math(self, node, math_env=''):
         # type: (nodes.Node, unicode) -> None
-        logger.warning(__('using "math" markup without a Sphinx math extension '
-                          'active, please use one of the math extensions '
-                          'described at http://sphinx-doc.org/en/master/ext/math.html'),
-                       location=(self.builder.current_docname, node.line))
-        raise nodes.SkipNode
+        name = self.builder.math_renderer_name
+        visit, _ = self.builder.app.registry.html_inline_math_renderers[name]
+        visit(self, node)
+
+    def depart_math(self, node, math_env=''):
+        # type: (nodes.Node, unicode) -> None
+        name = self.builder.math_renderer_name
+        _, depart = self.builder.app.registry.html_inline_math_renderers[name]
+        if depart:
+            depart(self, node)
+
+    def visit_math_block(self, node, math_env=''):
+        # type: (nodes.Node, unicode) -> None
+        name = self.builder.math_renderer_name
+        visit, _ = self.builder.app.registry.html_block_math_renderers[name]
+        visit(self, node)
+
+    def depart_math_block(self, node, math_env=''):
+        # type: (nodes.Node, unicode) -> None
+        name = self.builder.math_renderer_name
+        _, depart = self.builder.app.registry.html_block_math_renderers[name]
+        if depart:
+            depart(self, node)
 
     def unknown_visit(self, node):
         # type: (nodes.Node) -> None


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Add `html_math_renderer` module to switch a math renderer of HTML writer.
- This is new style of math extension (for HTML)
- The default math renderer is mathjax.


### Remaining tasks

* [x] update docs
* [x] deprecate whole of `sphinx.ext.mathbase` module
* [x] Add `:math:numref` role (an alternative of `:eq:`)