### PR TITLE
refactor: Move math_reference node to sphinx.builders.latex.nodes

### DIFF
--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -149,7 +149,7 @@ The following is a list of deprecated interface.
    * - ``sphinx.ext.mathbase.eqref`` (node)
      - 1.8
      - 3.0
-     - ``sphinx.addnodes.math_reference``
+     - ``sphinx.builders.latex.nodes.math_reference``
 
    * - ``viewcode_import`` (config value)
      - 1.8

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -240,11 +240,6 @@ class displaymath(math_block):
     """
 
 
-class math_reference(nodes.Inline, nodes.Referential, nodes.TextElement):
-    """Node for a reference for equation."""
-    pass
-
-
 # other directive-level nodes
 
 class index(nodes.Invisible, nodes.Inline, nodes.TextElement):

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -19,7 +19,7 @@ from six import text_type
 from sphinx import package_dir, addnodes, highlighting
 from sphinx.builders import Builder
 from sphinx.builders.latex.transforms import (
-    BibliographyTransform, CitationReferenceTransform,
+    BibliographyTransform, CitationReferenceTransform, MathReferenceTransform,
     FootnoteDocnameUpdater, LaTeXFootnoteTransform, ShowUrlsTransform
 )
 from sphinx.config import string_classes, ENUM
@@ -320,6 +320,7 @@ def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_builder(LaTeXBuilder)
     app.add_post_transform(CitationReferenceTransform)
+    app.add_post_transform(MathReferenceTransform)
     app.connect('config-inited', validate_config_values)
     app.add_transform(FootnoteDocnameUpdater)
 

--- a/sphinx/builders/latex/nodes.py
+++ b/sphinx/builders/latex/nodes.py
@@ -22,6 +22,11 @@ class footnotetext(nodes.General, nodes.BackLinkable, nodes.Element,
     """A node represents ``\footnotetext``."""
 
 
+class math_reference(nodes.Inline, nodes.Referential, nodes.TextElement):
+    """A node for a reference for equation."""
+    pass
+
+
 class thebibliography(nodes.container):
     """A node for wrapping bibliographies."""
     pass

--- a/sphinx/domains/math.py
+++ b/sphinx/domains/math.py
@@ -12,7 +12,7 @@
 from docutils import nodes
 from docutils.nodes import make_id
 
-from sphinx.addnodes import math_block as displaymath, math_reference
+from sphinx.addnodes import math_block as displaymath
 from sphinx.domains import Domain
 from sphinx.locale import __
 from sphinx.roles import XRefRole
@@ -69,29 +69,23 @@ class MathDomain(Domain):
         assert typ == 'eq'
         docname, number = self.data['objects'].get(target, (None, None))
         if docname:
-            if builder.name == 'latex':
-                newnode = math_reference('', **node.attributes)
-                newnode['docname'] = docname
-                newnode['target'] = target
-                return newnode
-            else:
-                # TODO: perhaps use rather a sphinx-core provided prefix here?
-                node_id = make_id('equation-%s' % target)
-                if env.config.math_numfig and env.config.numfig:
-                    if docname in env.toc_fignumbers:
-                        number = env.toc_fignumbers[docname]['displaymath'].get(node_id, ())
-                        number = '.'.join(map(str, number))
-                    else:
-                        number = ''
-                try:
-                    eqref_format = env.config.math_eqref_format or "({number})"
-                    title = nodes.Text(eqref_format.format(number=number))
-                except KeyError as exc:
-                    logger.warning(__('Invalid math_eqref_format: %r'), exc,
-                                   location=node)
-                    title = nodes.Text("(%d)" % number)
-                    title = nodes.Text("(%d)" % number)
-                return make_refnode(builder, fromdocname, docname, node_id, title)
+            # TODO: perhaps use rather a sphinx-core provided prefix here?
+            node_id = make_id('equation-%s' % target)
+            if env.config.math_numfig and env.config.numfig:
+                if docname in env.toc_fignumbers:
+                    number = env.toc_fignumbers[docname]['displaymath'].get(node_id, ())
+                    number = '.'.join(map(str, number))
+                else:
+                    number = ''
+            try:
+                eqref_format = env.config.math_eqref_format or "({number})"
+                title = nodes.Text(eqref_format.format(number=number))
+            except KeyError as exc:
+                logger.warning(__('Invalid math_eqref_format: %r'), exc,
+                               location=node)
+                title = nodes.Text("(%d)" % number)
+                title = nodes.Text("(%d)" % number)
+            return make_refnode(builder, fromdocname, docname, node_id, title)
         else:
             return None
 

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -14,7 +14,7 @@ import warnings
 from docutils import nodes
 
 from sphinx.addnodes import math, math_block as displaymath
-from sphinx.addnodes import math_reference as eqref  # NOQA  # to keep compatibility
+from sphinx.builders.latex.nodes import math_reference as eqref  # NOQA  # to keep compatibility
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.domains.math import MathDomain  # NOQA  # to keep compatibility
 from sphinx.domains.math import MathReferenceRole as EqXRefRole  # NOQA  # to keep compatibility


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The `math_reference` node is only used in latex builder.  So this makes it builder-specific node.
