### PR TITLE
Fix #4973: latex: glossary directive adds whitespace to each item

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,7 @@ Bugs fixed
 * #4979: latex: Incorrect escaping of curly braces in index entries
 * #4956: autodoc: Failed to extract document from a subclass of the class on
   mocked module
+* #4973: latex: glossary directive adds whitespace to each item
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1555,7 +1555,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_term(self, node):
         # type: (nodes.Node) -> None
         self.in_term += 1
-        ctx = ''.join(self.hypertarget(node_id) for node_id in node['ids'])
+        ctx = ''  # type: unicode
+        if node.get('ids'):
+            ctx = '\\phantomsection'
+            for node_id in node['ids']:
+                ctx += self.hypertarget(node_id, anchor=False)
         ctx += '}] \\leavevmode'
         self.body.append('\\item[{')
         self.restrict_footnote(node)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -725,7 +725,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (unicode, bool, bool) -> unicode
         if withdoc:
             id = self.curfilestack[-1] + ':' + id
-        return (anchor and '\\phantomsection' or '') + \
+        return (anchor and r'\phantomsection\relax' or '') + \
             '\\label{%s}' % self.idescape(id)
 
     def hyperlink(self, id):
@@ -1555,9 +1555,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def visit_term(self, node):
         # type: (nodes.Node) -> None
         self.in_term += 1
-        ctx = '}] \\leavevmode'  # type: unicode
-        if node.get('ids'):
-            ctx += self.hypertarget(node['ids'][0])
+        ctx = ''.join(self.hypertarget(node_id) for node_id in node['ids'])
+        ctx += '}] \\leavevmode'
         self.body.append('\\item[{')
         self.restrict_footnote(node)
         self.context.append(ctx)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -725,7 +725,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (unicode, bool, bool) -> unicode
         if withdoc:
             id = self.curfilestack[-1] + ':' + id
-        return (anchor and r'\phantomsection\relax' or '') + \
+        return (anchor and '\\phantomsection' or '') + \
             '\\label{%s}' % self.idescape(id)
 
     def hyperlink(self, id):

--- a/tests/roots/test-glossary/conf.py
+++ b/tests/roots/test-glossary/conf.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'test.tex', 'The basic Sphinx documentation for testing', 'Sphinx', 'report')
+]

--- a/tests/roots/test-glossary/index.rst
+++ b/tests/roots/test-glossary/index.rst
@@ -1,0 +1,22 @@
+test-glossary
+=============
+
+.. glossary::
+   :sorted:
+
+   boson
+      Particle with integer spin.
+
+   *fermion*
+      Particle with half-integer spin.
+
+   tauon
+   myon
+   electron
+      Examples for fermions.
+
+   über
+      Gewisse
+
+   änhlich
+      Dinge

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -592,12 +592,12 @@ def test_footnote(app, status, warning):
     assert '\\begin{footnote}[3]\\sphinxAtStartFootnote\nnamed\n%\n\\end{footnote}' in result
     assert '{\\hyperref[\\detokenize{footnote:bar}]{\\sphinxcrossref{{[}bar{]}}}}' in result
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\relax\\label{\\detokenize{footnote:bar}} ') in result
+            '{\\phantomsection\\label{\\detokenize{footnote:bar}} ') in result
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\relax\\label{\\detokenize{footnote:bar}} '
+            '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
             '\ncite') in result
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\relax\\label{\\detokenize{footnote:bar}} '
+            '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
             '\ncite\n}') in result
     assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
@@ -666,14 +666,14 @@ def test_latex_show_urls_is_inline(app, status, warning):
             'footnote in bar\n%\n\\end{footnote} in bar.rst') in result
     assert ('Auto footnote number %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'footnote in baz\n%\n\\end{footnote} in baz.rst') in result
-    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id30}}'
+    assert ('\\phantomsection\\label{\\detokenize{index:id30}}'
             '{\\hyperref[\\detokenize{index:the-section'
             '-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference to '
-            '\\phantomsection\\relax\\label{\\detokenize{index:id1}}'
+            '\\phantomsection\\label{\\detokenize{index:id1}}'
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
-    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id31}}'
+    assert ('\\phantomsection\\label{\\detokenize{index:id31}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
     assert ('First footnote: %\n\\begin{footnote}[2]\\sphinxAtStartFootnote\n'
@@ -711,13 +711,13 @@ def test_latex_show_urls_is_footnote(app, status, warning):
             'footnote in bar\n%\n\\end{footnote} in bar.rst') in result
     assert ('Auto footnote number %\n\\begin{footnote}[2]\\sphinxAtStartFootnote\n'
             'footnote in baz\n%\n\\end{footnote} in baz.rst') in result
-    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id30}}'
+    assert ('\\phantomsection\\label{\\detokenize{index:id30}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\phantomsection\\relax\\label{\\detokenize{index:id1}}'
+            'to \\phantomsection\\label{\\detokenize{index:id1}}'
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
-    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id31}}'
+    assert ('\\phantomsection\\label{\\detokenize{index:id31}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}') in result
     assert ('First footnote: %\n\\begin{footnote}[3]\\sphinxAtStartFootnote\n'
@@ -764,13 +764,13 @@ def test_latex_show_urls_is_no(app, status, warning):
             'footnote in bar\n%\n\\end{footnote} in bar.rst') in result
     assert ('Auto footnote number %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'footnote in baz\n%\n\\end{footnote} in baz.rst') in result
-    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id30}}'
+    assert ('\\phantomsection\\label{\\detokenize{index:id30}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\phantomsection\\relax\\label{\\detokenize{index:id1}}'
+            'to \\phantomsection\\label{\\detokenize{index:id1}}'
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
-    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id31}}'
+    assert ('\\phantomsection\\label{\\detokenize{index:id31}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
     assert ('First footnote: %\n\\begin{footnote}[2]\\sphinxAtStartFootnote\n'

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -592,12 +592,12 @@ def test_footnote(app, status, warning):
     assert '\\begin{footnote}[3]\\sphinxAtStartFootnote\nnamed\n%\n\\end{footnote}' in result
     assert '{\\hyperref[\\detokenize{footnote:bar}]{\\sphinxcrossref{{[}bar{]}}}}' in result
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\label{\\detokenize{footnote:bar}} ') in result
+            '{\\phantomsection\\relax\\label{\\detokenize{footnote:bar}} ') in result
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
+            '{\\phantomsection\\relax\\label{\\detokenize{footnote:bar}} '
             '\ncite') in result
     assert ('\\bibitem[bar]{\\detokenize{bar}}'
-            '{\\phantomsection\\label{\\detokenize{footnote:bar}} '
+            '{\\phantomsection\\relax\\label{\\detokenize{footnote:bar}} '
             '\ncite\n}') in result
     assert '\\sphinxcaption{Table caption \\sphinxfootnotemark[4]' in result
     assert ('\\hline%\n\\begin{footnotetext}[4]\\sphinxAtStartFootnote\n'
@@ -666,14 +666,14 @@ def test_latex_show_urls_is_inline(app, status, warning):
             'footnote in bar\n%\n\\end{footnote} in bar.rst') in result
     assert ('Auto footnote number %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'footnote in baz\n%\n\\end{footnote} in baz.rst') in result
-    assert ('\\phantomsection\\label{\\detokenize{index:id30}}'
+    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id30}}'
             '{\\hyperref[\\detokenize{index:the-section'
             '-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference to '
-            '\\phantomsection\\label{\\detokenize{index:id1}}'
+            '\\phantomsection\\relax\\label{\\detokenize{index:id1}}'
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
-    assert ('\\phantomsection\\label{\\detokenize{index:id31}}'
+    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id31}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
     assert ('First footnote: %\n\\begin{footnote}[2]\\sphinxAtStartFootnote\n'
@@ -711,13 +711,13 @@ def test_latex_show_urls_is_footnote(app, status, warning):
             'footnote in bar\n%\n\\end{footnote} in bar.rst') in result
     assert ('Auto footnote number %\n\\begin{footnote}[2]\\sphinxAtStartFootnote\n'
             'footnote in baz\n%\n\\end{footnote} in baz.rst') in result
-    assert ('\\phantomsection\\label{\\detokenize{index:id30}}'
+    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id30}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\phantomsection\\label{\\detokenize{index:id1}}'
+            'to \\phantomsection\\relax\\label{\\detokenize{index:id1}}'
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
-    assert ('\\phantomsection\\label{\\detokenize{index:id31}}'
+    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id31}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}') in result
     assert ('First footnote: %\n\\begin{footnote}[3]\\sphinxAtStartFootnote\n'
@@ -764,13 +764,13 @@ def test_latex_show_urls_is_no(app, status, warning):
             'footnote in bar\n%\n\\end{footnote} in bar.rst') in result
     assert ('Auto footnote number %\n\\begin{footnote}[1]\\sphinxAtStartFootnote\n'
             'footnote in baz\n%\n\\end{footnote} in baz.rst') in result
-    assert ('\\phantomsection\\label{\\detokenize{index:id30}}'
+    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id30}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to-authoryear}]'
             '{\\sphinxcrossref{The section with a reference '
-            'to \\phantomsection\\label{\\detokenize{index:id1}}'
+            'to \\phantomsection\\relax\\label{\\detokenize{index:id1}}'
             '{\\hyperref[\\detokenize{index:authoryear}]'
             '{\\sphinxcrossref{{[}AuthorYear{]}}}}}}}') in result
-    assert ('\\phantomsection\\label{\\detokenize{index:id31}}'
+    assert ('\\phantomsection\\relax\\label{\\detokenize{index:id31}}'
             '{\\hyperref[\\detokenize{index:the-section-with-a-reference-to}]'
             '{\\sphinxcrossref{The section with a reference to }}}' in result)
     assert ('First footnote: %\n\\begin{footnote}[2]\\sphinxAtStartFootnote\n'
@@ -1242,3 +1242,25 @@ def test_latex_nested_enumerated_list(app, status, warning):
     assert r'\setcounter{enumiii}{9}' in result
     assert r'\setcounter{enumiv}{23}' in result
     assert r'\setcounter{enumii}{2}' in result
+
+
+@pytest.mark.sphinx('latex', testroot='glossary')
+def test_latex_glossary(app, status, warning):
+    app.builder.build_all()
+
+    result = (app.outdir / 'test.tex').text(encoding='utf8')
+    assert (u'\\item[{änhlich\\index{änhlich|textbf}\\phantomsection\\relax'
+            r'\label{\detokenize{index:term-anhlich}}}] \leavevmode' in result)
+    assert (r'\item[{boson\index{boson|textbf}\phantomsection\relax'
+            r'\label{\detokenize{index:term-boson}}}] \leavevmode' in result)
+    assert (r'\item[{\sphinxstyleemphasis{fermion}\index{fermion|textbf}'
+            r'\phantomsection\relax\label{\detokenize{index:term-fermion}}}] '
+            r'\leavevmode' in result)
+    assert (r'\item[{tauon\index{tauon|textbf}\phantomsection\relax'
+            r'\label{\detokenize{index:term-tauon}}}] \leavevmode'
+            r'\item[{myon\index{myon|textbf}\phantomsection\relax'
+            r'\label{\detokenize{index:term-myon}}}] \leavevmode'
+            r'\item[{electron\index{electron|textbf}\phantomsection\relax'
+            r'\label{\detokenize{index:term-electron}}}] \leavevmode' in result)
+    assert (u'\\item[{über\\index{über|textbf}\\phantomsection\\relax'
+            r'\label{\detokenize{index:term-uber}}}] \leavevmode' in result)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1249,18 +1249,18 @@ def test_latex_glossary(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'test.tex').text(encoding='utf8')
-    assert (u'\\item[{änhlich\\index{änhlich|textbf}\\phantomsection\\relax'
+    assert (u'\\item[{änhlich\\index{änhlich|textbf}\\phantomsection'
             r'\label{\detokenize{index:term-anhlich}}}] \leavevmode' in result)
-    assert (r'\item[{boson\index{boson|textbf}\phantomsection\relax'
+    assert (r'\item[{boson\index{boson|textbf}\phantomsection'
             r'\label{\detokenize{index:term-boson}}}] \leavevmode' in result)
     assert (r'\item[{\sphinxstyleemphasis{fermion}\index{fermion|textbf}'
-            r'\phantomsection\relax\label{\detokenize{index:term-fermion}}}] '
-            r'\leavevmode' in result)
-    assert (r'\item[{tauon\index{tauon|textbf}\phantomsection\relax'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-fermion}}}] \leavevmode' in result)
+    assert (r'\item[{tauon\index{tauon|textbf}\phantomsection'
             r'\label{\detokenize{index:term-tauon}}}] \leavevmode'
-            r'\item[{myon\index{myon|textbf}\phantomsection\relax'
+            r'\item[{myon\index{myon|textbf}\phantomsection'
             r'\label{\detokenize{index:term-myon}}}] \leavevmode'
-            r'\item[{electron\index{electron|textbf}\phantomsection\relax'
+            r'\item[{electron\index{electron|textbf}\phantomsection'
             r'\label{\detokenize{index:term-electron}}}] \leavevmode' in result)
-    assert (u'\\item[{über\\index{über|textbf}\\phantomsection\\relax'
+    assert (u'\\item[{über\\index{über|textbf}\\phantomsection'
             r'\label{\detokenize{index:term-uber}}}] \leavevmode' in result)


### PR DESCRIPTION

### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4973 
