### PR TITLE
Fix #4946: py domain: type field could not handle "None" as a type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
   LaTeX engine crashed
 * #4978: latex: shorthandoff is not set up for Brazil locale
 * #4928: i18n: Ignore dot-directories like .git/ in LC_MESSAGES/
+* #4946: py domain: type field could not handle "None" as a type
 
 Testing
 --------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -156,7 +156,15 @@ class PyGroupedField(PyXrefMixin, GroupedField):
 
 
 class PyTypedField(PyXrefMixin, TypedField):
-    pass
+    def make_xref(self, rolename, domain, target,
+                  innernode=nodes.emphasis, contnode=None, env=None):
+        # type: (unicode, unicode, unicode, nodes.Node, nodes.Node, BuildEnvironment) ->  nodes.Node  # NOQA
+        if rolename == 'class' and target == 'None':
+            # None is not a type, so use obj role instead.
+            rolename = 'obj'
+
+        return super(PyTypedField, self).make_xref(rolename, domain, target,
+                                                   innernode, contnode, env)
 
 
 class PyObject(ObjectDescription):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4946 
