### PR TITLE
Fix #4931: autodoc: crashed when handler for autodoc-skip-member raises an error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,7 @@ Bugs fixed
 * #4980: latex: Explicit labels on code blocks are duplicated
 * #4919: node.asdom() crashes if toctree has :numbered: option
 * #4914: autodoc: Parsing error when using dataclasses without default values
+* #4931: autodoc: crashed when handler for autodoc-skip-member raises an error
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,8 @@ Bugs fixed
 * #4919: node.asdom() crashes if toctree has :numbered: option
 * #4914: autodoc: Parsing error when using dataclasses without default values
 * #4931: autodoc: crashed when handler for autodoc-skip-member raises an error
+* #4931: autodoc: crashed when subclass of mocked class are processed by
+  napoleon module
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -25,7 +25,7 @@ from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.ext.autodoc.importer import mock, import_object, get_object_members
 from sphinx.ext.autodoc.importer import _MockImporter  # to keep compatibility  # NOQA
 from sphinx.ext.autodoc.inspector import format_annotation, formatargspec  # to keep compatibility  # NOQA
-from sphinx.locale import _
+from sphinx.locale import _, __
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.util import logging
 from sphinx.util import rpartition, force_decode
@@ -643,11 +643,17 @@ class Documenter(object):
             # should be skipped
             if self.env.app:
                 # let extensions preprocess docstrings
-                skip_user = self.env.app.emit_firstresult(
-                    'autodoc-skip-member', self.objtype, membername, member,
-                    not keep, self.options)
-                if skip_user is not None:
-                    keep = not skip_user
+                try:
+                    skip_user = self.env.app.emit_firstresult(
+                        'autodoc-skip-member', self.objtype, membername, member,
+                        not keep, self.options)
+                    if skip_user is not None:
+                        keep = not skip_user
+                except Exception as exc:
+                    logger.warning(__('autodoc: failed to determine %r to be documented.'
+                                      'the following exception was raised:\n%s'),
+                                   member, exc)
+                    keep = False
 
             if keep:
                 ret.append((membername, member, isattr))

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -23,7 +23,7 @@ from sphinx.util.inspect import isenumclass, safe_getattr
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Generator, List, Optional, Tuple  # NOQA
+    from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Tuple  # NOQA
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class _MockObject(object):
 
     def __init__(self, *args, **kwargs):
         # type: (Any, Any) -> None
-        pass
+        self.__qualname__ = ''
 
     def __len__(self):
         # type: () -> int
@@ -52,8 +52,8 @@ class _MockObject(object):
         return False
 
     def __iter__(self):
-        # type: () -> None
-        pass
+        # type: () -> Iterator
+        return iter([])
 
     def __mro_entries__(self, bases):
         # type: (Tuple) -> Tuple


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4931
