### PR TITLE
Fix #4927: Display a warning when invalid values are passed to linenothreshold option of highlight directive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -113,6 +113,8 @@ Features added
 * #4866: Wrap graphviz diagrams in ``<div>`` tag
 * Add :event:`viewcode-find-source` event to viewcode extension.
 * #4785: napoleon: Add strings to translation file for localisation
+* #4927: Display a warning when invalid values are passed to linenothreshold
+  option of highlight directive
 
 Bugs fixed
 ----------

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -45,18 +45,12 @@ class Highlight(SphinxDirective):
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec = {
-        'linenothreshold': directives.unchanged,
+        'linenothreshold': directives.positive_int,
     }
 
     def run(self):
         # type: () -> List[nodes.Node]
-        if 'linenothreshold' in self.options:
-            try:
-                linenothreshold = int(self.options['linenothreshold'])
-            except Exception:
-                linenothreshold = 10
-        else:
-            linenothreshold = sys.maxsize
+        linenothreshold = self.options.get('linenothreshold', sys.maxsize)
         return [addnodes.highlightlang(lang=self.arguments[0].strip(),
                                        linenothreshold=linenothreshold)]
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #4927  (yet another version)