### PR TITLE
Fix #4648: latex: Now "rubric" elements are rendered as unnumbered section title

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Incompatible changes
   :confval:`viewcode_follow_imported_members` (refs: #4035)
 * #1857: latex: :confval:`latex_show_pagerefs` does not add pagerefs for
   citations
+* #4648: latex: Now "rubric" elements are rendered as unnumbered section title
 
 Deprecated
 ----------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1252,7 +1252,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if len(node.children) == 1 and node.children[0].astext() in \
            ('Footnotes', _('Footnotes')):
             raise nodes.SkipNode
-        self.body.append('\\paragraph{')
+        self.body.append('\\subsubsection*{')
         self.context.append('}\n')
         self.in_title = 1
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -617,7 +617,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
     assert ('\\sphinxcaption{The table title with a reference'
             ' to {[}AuthorYear{]}}' in result)
-    assert '\\paragraph{The rubric title with a reference to {[}AuthorYear{]}}' in result
+    assert '\\subsubsection*{The rubric title with a reference to {[}AuthorYear{]}}' in result
     assert ('\\chapter{The section with a reference to \\sphinxfootnotemark[5]}\n'
             '\\label{\\detokenize{index:the-section-with-a-reference-to}}'
             '%\n\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4648 
