### PR TITLE
Fix #3606: MathJax should be loaded with async attribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,7 @@ Deprecated
 * ``env._nitpick_ignore`` is deprecated
 * ``app.override_domain()`` is deprecated
 * ``app.add_stylesheet()`` is deprecated
+* ``app.add_javascript()`` is deprecated
 * ``sphinx.versioning.prepare()`` is deprecated
 * ``Config.__init__()`` has changed;  the *dirname*, *filename* and *tags*
   argument has been deprecated

--- a/CHANGES
+++ b/CHANGES
@@ -117,6 +117,7 @@ Features added
 * #4785: napoleon: Add strings to translation file for localisation
 * #4927: Display a warning when invalid values are passed to linenothreshold
   option of highlight directive
+* #3606: MathJax should be loaded with async attribute
 
 Bugs fixed
 ----------

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -71,7 +71,7 @@ package.
 
 .. automethod:: Sphinx.add_post_transform(transform)
 
-.. automethod:: Sphinx.add_javascript(filename, **kwargs)
+.. automethod:: Sphinx.add_js_file(filename, **kwargs)
 
 .. automethod:: Sphinx.add_stylesheet(filename, alternate=None, title=None)
 

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -71,7 +71,7 @@ package.
 
 .. automethod:: Sphinx.add_post_transform(transform)
 
-.. automethod:: Sphinx.add_javascript(filename)
+.. automethod:: Sphinx.add_javascript(filename, **kwargs)
 
 .. automethod:: Sphinx.add_stylesheet(filename, alternate=None, title=None)
 

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -126,6 +126,11 @@ The following is a list of deprecated interface.
      - 4.0
      - :meth:`~sphinx.application.Sphinx.add_css_file()`
 
+   * - :meth:`~sphinx.application.Sphinx.add_javascript()`
+     - 1.8
+     - 4.0
+     - :meth:`~sphinx.application.Sphinx.add_js_file()`
+
    * - ``sphinx.ext.mathbase.MathDomain``
      - 1.8
      - 3.0

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -998,25 +998,36 @@ class Sphinx(object):
         """
         self.registry.add_post_transform(transform)
 
-    def add_javascript(self, filename):
-        # type: (unicode) -> None
+    def add_javascript(self, filename, **kwargs):
+        # type: (unicode, **unicode) -> None
         """Register a JavaScript file to include in the HTML output.
 
         Add *filename* to the list of JavaScript files that the default HTML
         template will include.  The filename must be relative to the HTML
-        static path, see :confval:`the docs for the config value
-        <html_static_path>`.  A full URI with scheme, like
-        ``http://example.org/foo.js``, is also supported.
+        static path , or a full URI with scheme.  The keyword arguments are
+        also accepted for attributes of ``<script>`` tag.
+
+        Example::
+
+            app.add_javascript('example.js')
+            # => <scrtipt src="_static/example.js"></script>
+
+            app.add_javascript('example.js', async="async")
+            # => <scrtipt src="_static/example.js" async="async"></script>
 
         .. versionadded:: 0.5
+
+        .. versionchanged:: 1.8
+           Allows keyword arguments as attributes of script tag.
         """
         logger.debug('[app] adding javascript: %r', filename)
-        from sphinx.builders.html import StandaloneHTMLBuilder
+        from sphinx.builders.html import StandaloneHTMLBuilder, JavaScript
         if '://' in filename:
-            StandaloneHTMLBuilder.script_files.append(filename)
+            js = JavaScript(filename, **kwargs)  # type: ignore
         else:
-            StandaloneHTMLBuilder.script_files.append(
-                posixpath.join('_static', filename))
+            js = JavaScript(posixpath.join('_static', filename), **kwargs)
+
+        StandaloneHTMLBuilder.script_files.append(js)
 
     def add_css_file(self, filename, **kwargs):
         # type: (unicode, **unicode) -> None

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1000,6 +1000,14 @@ class Sphinx(object):
 
     def add_javascript(self, filename, **kwargs):
         # type: (unicode, **unicode) -> None
+        """An alias of :meth:`add_js_file`."""
+        warnings.warn('The app.add_javascript() is deprecated. '
+                      'Please use app.add_js_file() instead.',
+                      RemovedInSphinx40Warning)
+        self.add_js_file(filename, **kwargs)
+
+    def add_js_file(self, filename, **kwargs):
+        # type: (unicode, **unicode) -> None
         """Register a JavaScript file to include in the HTML output.
 
         Add *filename* to the list of JavaScript files that the default HTML
@@ -1009,16 +1017,17 @@ class Sphinx(object):
 
         Example::
 
-            app.add_javascript('example.js')
+            app.add_js_file('example.js')
             # => <scrtipt src="_static/example.js"></script>
 
-            app.add_javascript('example.js', async="async")
+            app.add_js_file('example.js', async="async")
             # => <scrtipt src="_static/example.js" async="async"></script>
 
         .. versionadded:: 0.5
 
         .. versionchanged:: 1.8
-           Allows keyword arguments as attributes of script tag.
+           Renamed from ``app.add_javascript()``.
+           And it allows keyword arguments as attributes of script tag.
         """
         logger.debug('[app] adding javascript: %r', filename)
         from sphinx.builders.html import StandaloneHTMLBuilder, JavaScript

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -139,7 +139,7 @@ class CSSContainer(list):
 
 
 class Stylesheet(text_type):
-    """The metadata of stylesheet.
+    """A metadata of stylesheet.
 
     To keep compatibility with old themes, an instance of stylesheet behaves as
     its filename (str).
@@ -158,6 +158,26 @@ class Stylesheet(text_type):
         if args:  # old style arguments (rel, title)
             self.attributes['rel'] = args[0]
             self.attributes['title'] = args[1]
+
+        return self
+
+
+class JavaScript(text_type):
+    """A metadata of javascript file.
+
+    To keep compatibility with old themes, an instance of javascript behaves as
+    its filename (str).
+    """
+
+    attributes = None   # type: Dict[unicode, unicode]
+    filename = None     # type: unicode
+
+    def __new__(cls, filename, **attributes):
+        # type: (unicode, **unicode) -> None
+        self = text_type.__new__(cls, filename)  # type: ignore
+        self.filename = filename
+        self.attributes = attributes
+        self.attributes.setdefault('type', 'text/javascript')
 
         return self
 
@@ -1479,6 +1499,31 @@ def convert_html_css_files(app, config):
     config.html_css_files = html_css_files  # type: ignore
 
 
+def setup_js_tag_helper(app, pagename, templatexname, context, doctree):
+    # type: (Sphinx, unicode, unicode, Dict, nodes.Node) -> None
+    """Set up js_tag() template helper.
+
+    .. note:: This set up function is added to keep compatibility with webhelper.
+    """
+    pathto = context.get('pathto')
+
+    def js_tag(js):
+        # type: (JavaScript) -> unicode
+        attrs = []
+        if isinstance(js, JavaScript):
+            for key in sorted(js.attributes):
+                value = js.attributes[key]
+                if value is not None:
+                    attrs.append('%s="%s"' % (key, htmlescape(value, True)))
+            attrs.append('src="%s"' % pathto(js.filename, resource=True))
+        else:
+            # str value (old styled)
+            attrs.append('src="%s"' % pathto(js, resource=True))
+        return '<script %s></script>' % ' '.join(attrs)
+
+    context['js_tag'] = js_tag
+
+
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     # builders
@@ -1529,6 +1574,7 @@ def setup(app):
 
     # event handlers
     app.connect('config-inited', convert_html_css_files)
+    app.connect('html-page-context', setup_js_tag_helper)
 
     return {
         'version': 'builtin',

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -266,7 +266,7 @@ class StandaloneHTMLBuilder(Builder):
     # use html5 translator by default
     default_html5_translator = False
 
-    # This is a class attribute because it is mutated by Sphinx.add_javascript.
+    # This is a class attribute because it is mutated by Sphinx.add_js_file().
     script_files = ['_static/jquery.js', '_static/underscore.js',
                     '_static/doctools.js']  # type: List[unicode]
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -13,6 +13,7 @@ import codecs
 import posixpath
 import re
 import sys
+import types
 import warnings
 from hashlib import md5
 from os import path
@@ -1409,6 +1410,11 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         # we're not taking the return value here, since no template is
         # actually rendered
         self.app.emit('html-page-context', pagename, templatename, ctx, event_arg)
+
+        # make context object serializable
+        for key in list(ctx):
+            if isinstance(ctx[key], types.FunctionType):
+                del ctx[key]
 
         ensuredir(path.dirname(outfilename))
         self.dump_context(ctx, outfilename)

--- a/sphinx/ext/jsmath.py
+++ b/sphinx/ext/jsmath.py
@@ -64,7 +64,7 @@ def builder_inited(app):
     if not app.config.jsmath_path:
         raise ExtensionError('jsmath_path config value must be set for the '
                              'jsmath extension to work')
-    app.add_javascript(app.config.jsmath_path)
+    app.add_js_file(app.config.jsmath_path)
 
 
 def setup(app):

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -72,7 +72,8 @@ def builder_inited(app):
     if not app.config.mathjax_path:
         raise ExtensionError('mathjax_path config value must be set for the '
                              'mathjax extension to work')
-    app.add_js_file(app.config.mathjax_path)
+    options = {'async': 'async'}
+    app.add_js_file(app.config.mathjax_path, **options)
 
 
 def setup(app):

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -72,7 +72,7 @@ def builder_inited(app):
     if not app.config.mathjax_path:
         raise ExtensionError('mathjax_path config value must be set for the '
                              'mathjax extension to work')
-    app.add_javascript(app.config.mathjax_path)
+    app.add_js_file(app.config.mathjax_path)
 
 
 def setup(app):

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -88,8 +88,8 @@
 
 {%- macro script() %}
     <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
-    {%- for scriptfile in script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+    {%- for js in script_files %}
+    {{ js_tag(js) }}
     {%- endfor %}
 {%- endmacro %}
 

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -105,6 +105,6 @@ def setup(app):
     app.add_directive('clsdir', ClassDirective)
     app.add_object_type('userdesc', 'userdescrole', '%s (userdesc)',
                         userdesc_parse, objname='user desc')
-    app.add_javascript('file://moo.js')
+    app.add_js_file('file://moo.js')
     app.add_source_suffix('.foo', 'foo')
     app.add_source_parser(parsermod.Parser)


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Refactoring

### Purpose
- refs: #3606
- As discussed in #4595, I renamed `app.add_javascript()` to `add.add_js_file()`
    -  I give long deprecation period to the API because it has been used longly.
