### PR TITLE
C++: parse pack expansions in function calls.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -122,6 +122,7 @@ Bugs fixed
 * #4850: latex: footnote inside footnote was not rendered
 * #4945: i18n: fix lang_COUNTRY not fallback correctly for IndexBuilder. Thanks
   to Shengjing Zhu.
+* C++, parse pack expansions in function calls
 
 Testing
 --------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -1221,6 +1221,22 @@ class ASTPostfixExpr(ASTBase):
             p.describe_signature(signode, mode, env, symbol)
 
 
+class ASTPackExpansionExpr(ASTBase):
+    def __init__(self, expr):
+        self.expr = expr
+
+    def __unicode__(self):
+        return text_type(self.expr) + '...'
+
+    def get_id(self, version):
+        id = self.expr.get_id(version)
+        return 'sp' + id
+
+    def describe_signature(self, signode, mode, env, symbol):
+        self.expr.describe_signature(signode, mode, env, symbol)
+        signode += nodes.Text('...')
+
+
 class ASTFallbackExpr(ASTBase):
     def __init__(self, expr):
         self.expr = expr
@@ -4275,6 +4291,9 @@ class DefinitionParser(object):
                     if self.skip_string('*'):
                         # don't steal the dot
                         self.pos -= 2
+                    elif self.skip_string('..'):
+                        # don't steal the dot
+                        self.pos -= 3
                     else:
                         name = self._parse_nested_name()
                         postFixes.append(ASTPostfixMember(name))  # type: ignore
@@ -4301,7 +4320,11 @@ class DefinitionParser(object):
                     while True:
                         self.skip_ws()
                         expr = self._parse_expression(inTemplate=False)
-                        exprs.append(expr)
+                        self.skip_ws()
+                        if self.skip_string('...'):
+                            exprs.append(ASTPackExpansionExpr(expr))
+                        else:
+                            exprs.append(expr)
                         self.skip_ws()
                         if self.skip_string(')'):
                             break

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -214,6 +214,9 @@ def test_expressions():
     exprCheck('operator()()', 'clclE')
     exprCheck('operator()<int>()', 'clclIiEE')
 
+    # pack expansion
+    exprCheck('a(b(c, 1 + d...)..., e(f..., g))', 'cl1aspcl1b1cspplL1E1dEcl1esp1f1gEE')
+
 
 def test_type_definitions():
     check("type", "public bool b", {1: "b", 2: "1b"}, "bool b")


### PR DESCRIPTION
Currently the parser has support for pack expansions in e.g. angle bracket lists:

```rST
.. cpp:var:: template<typename... Args> int angled = foo<args...>
```

This adds support for parsing pack expansions in function calls:

```rST
.. cpp:function:: template<typename... Args> void foo(Args... args)

.. cpp:function:: template<typename... Args> decltype( foo(args...) ) bar(Args... args)

    N.b. not valid C++ (args is not in scope before the declaration of the parameter pack),
    but Sphinx links correctly.
```

ping @jakobandersen 