### PR TITLE
Fix #5007: sphinx-build crashes when error log contains a "%" character

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,7 @@ Bugs fixed
 * #4980: latex: Explicit labels on code blocks are duplicated
 * #4919: node.asdom() crashes if toctree has :numbered: option
 * #4914: autodoc: Parsing error when using dataclasses without default values
+* #5007: sphinx-build crashes when error log contains a "%" character
 
 Testing
 --------

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -373,7 +373,7 @@ class WarningIsErrorFilter(logging.Filter):
             location = getattr(record, 'location', '')
             try:
                 message = record.msg % record.args
-            except TypeError:
+            except (TypeError, ValueError):
                 message = record.msg  # use record.msg itself
 
             if location:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5007 
