### PR TITLE
Fix #5009: latex: a label for table is vanished if table does not have a caption

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #5016: ``character_level_inline_markup`` setting is not initialized for
   combination of non reST source parsers (ex. recommonmark) and docutils-0.13
 * #5022: latex: crashed with docutils package provided by Debian/Ubuntu
+* #5009: latex: a label for table is vanished if table does not have a caption
 
 Testing
 --------

--- a/sphinx/templates/latex/longtable.tex_t
+++ b/sphinx/templates/latex/longtable.tex_t
@@ -9,8 +9,12 @@
 <%= table.get_colspec() %>
 <%- if table.caption -%>
 \caption{<%= ''.join(table.caption) %>\strut}<%= labels %>\\*[\sphinxlongtablecapskipadjust]
-<% endif -%>
 \hline
+<% elif labels -%>
+\hline\noalign{\phantomsection<%= labels %>}%
+<% else -%>
+\hline
+<% endif -%>
 <%= ''.join(table.header) %>
 \endfirsthead
 

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -14,6 +14,8 @@
 \sphinxcapstartof{table}
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
+<% elif labels -%>
+\phantomsection<%= labels %>
 <% endif -%>
 \begin{tabular}[t]<%= table.get_colspec() -%>
 \hline

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -14,6 +14,8 @@
 \sphinxcapstartof{table}
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
+<% elif labels -%>
+\phantomsection<%= labels %>
 <% endif -%>
 \begin{tabulary}{\linewidth}[t]<%= table.get_colspec() -%>
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -1,7 +1,7 @@
 \label{\detokenize{longtable:longtable-having-widths-option}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
-\hline
+\hline\noalign{\phantomsection\label{\detokenize{longtable:namedlongtable}}\label{\detokenize{longtable:mylongtable}}}%
 \sphinxstyletheadfamily 
 header1
 &\sphinxstyletheadfamily 
@@ -43,3 +43,5 @@ cell3-2
 \\
 \hline
 \end{longtable}\sphinxatlongtableend\end{savenotes}
+
+See {\hyperref[\detokenize{longtable:mylongtable}]{\sphinxcrossref{mylongtable}}}, same as {\hyperref[\detokenize{longtable:namedlongtable}]{\sphinxcrossref{\DUrole{std,std-ref}{this one}}}}.

--- a/tests/roots/test-latex-table/expects/table_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths.tex
@@ -2,6 +2,7 @@
 
 \begin{savenotes}\sphinxattablestart
 \centering
+\phantomsection\label{\detokenize{tabular:namedtabular}}\label{\detokenize{tabular:mytabular}}
 \begin{tabular}[t]{|\X{30}{100}|\X{70}{100}|}
 \hline
 \sphinxstyletheadfamily 
@@ -28,3 +29,5 @@ cell3-2
 \end{tabular}
 \par
 \sphinxattableend\end{savenotes}
+
+See {\hyperref[\detokenize{tabular:mytabular}]{\sphinxcrossref{\DUrole{std,std-ref}{this}}}}, same as {\hyperref[\detokenize{tabular:namedtabular}]{\sphinxcrossref{namedtabular}}}.

--- a/tests/roots/test-latex-table/longtable.rst
+++ b/tests/roots/test-latex-table/longtable.rst
@@ -18,9 +18,12 @@ longtable
 longtable having :widths: option
 --------------------------------
 
+.. _mylongtable:
+
 .. table::
    :class: longtable
    :widths: 30,70
+   :name: namedlongtable
 
    ======= =======
    header1 header2
@@ -29,6 +32,8 @@ longtable having :widths: option
    cell2-1 cell2-2
    cell3-1 cell3-2
    ======= =======
+
+See mylongtable_, same as :ref:`this one <namedlongtable>`.
 
 longtable having :align: option
 -------------------------------

--- a/tests/roots/test-latex-table/tabular.rst
+++ b/tests/roots/test-latex-table/tabular.rst
@@ -1,4 +1,4 @@
-taburar and taburary
+tabular and tabulary
 ====================
 
 simple table
@@ -15,8 +15,11 @@ cell3-1 cell3-2
 table having :widths: option
 ----------------------------
 
+.. _mytabular:
+
 .. table::
    :widths: 30,70
+   :name: namedtabular
 
    ======= =======
    header1 header2
@@ -25,6 +28,8 @@ table having :widths: option
    cell2-1 cell2-2
    cell3-1 cell3-2
    ======= =======
+
+See :ref:`this <mytabular>`, same as namedtabular_.
 
 table having :align: option (tabulary)
 --------------------------------------


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5009 