### PR TITLE
Fix #5018: wrong signature of env-merge-info and env-check-consistency

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -269,7 +269,7 @@ handlers to the events.  Example:
    Here is the place to replace custom nodes that don't have visitor methods in
    the writers, so that they don't cause errors when the writers encounter them.
 
-.. event:: env-merge-info (env, docnames, other)
+.. event:: env-merge-info (app, env, docnames, other)
 
    This event is only emitted when parallel reading of documents is enabled.  It
    is emitted once for every subprocess that has read some documents.
@@ -303,7 +303,7 @@ handlers to the events.  Example:
    .. versionchanged:: 1.3
       The handlers' return value is now used.
 
-.. event:: env-check-consistency (env)
+.. event:: env-check-consistency (app, env)
 
    Emitted when Consistency checks phase.  You can check consistency of
    metadata for whole of documents.


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5018 
