### PR TITLE
Fix #5022: latex: crashed with docutils package provided by Debian/Ubuntu

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * sphinx.testing uses deprecated pytest API; ``Node.get_marker(name)``
 * #5016: ``character_level_inline_markup`` setting is not initialized for
   combination of non reST source parsers (ex. recommonmark) and docutils-0.13
+* #5022: latex: crashed with docutils package provided by Debian/Ubuntu
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -18,7 +18,6 @@ from collections import defaultdict
 from os import path
 
 from docutils import nodes, writers
-from docutils.utils.roman import toRoman
 from docutils.writers.latex2e import Babel
 from six import itervalues, text_type
 
@@ -31,6 +30,12 @@ from sphinx.util.i18n import format_date
 from sphinx.util.nodes import clean_astext
 from sphinx.util.template import LaTeXRenderer
 from sphinx.util.texescape import tex_escape_map, tex_replace_map
+
+try:
+    from docutils.utils.roman import toRoman
+except ImportError:
+    # In Debain/Ubuntu, roman package is provided as roman, not as docutils.utils.roman
+    from roman import toRoman
 
 if False:
     # For type annotation


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix ?

### Purpose
- refs: #5022 
