### PR TITLE
Fix #5016: ``character_level_inline_markup`` setting is not initialized

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,10 @@ Features added
 Bugs fixed
 ----------
 
+* #5016: ``character_level_inline_markup`` setting is not initialized for
+  combination of non reST source parsers (ex. recommonmark) and docutils-0.13
+
+
 Testing
 --------
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -66,6 +66,7 @@ default_settings = {
     'halt_level': 5,
     'file_insertion_enabled': True,
     'smartquotes_locales': [],
+    'character_level_inline_markup': False,  # for docutils-0.13.1 or older
 }
 
 # This is increased every time an environment attribute is added


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5016 
