### PR TITLE
autosummary: expose inherited_members to template

### DIFF
--- a/doc/ext/autosummary.rst
+++ b/doc/ext/autosummary.rst
@@ -205,6 +205,11 @@ The following variables available in the templates:
    List containing names of all members of the module or class.  Only available
    for modules and classes.
 
+.. data:: inherited_members
+
+   List containing names of all inherited members of class.  Only available for
+   classes.
+
 .. data:: functions
 
    List containing names of "public" functions in the module.  Here, "public"

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -203,6 +203,8 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                     get_members(obj, 'exception', imported=imported_members)
             elif doc.objtype == 'class':
                 ns['members'] = dir(obj)
+                ns['inherited_members'] = \
+                    set(dir(obj)) - set(obj.__dict__.keys())
                 ns['methods'], ns['all_methods'] = \
                     get_members(obj, 'method', ['__init__'])
                 ns['attributes'], ns['all_attributes'] = \


### PR DESCRIPTION
I want to expose this variable to separately list inherited methods/attributes in class documents.