### PR TITLE
Fix sphinx.testing uses deprecated pytest API; Node.get_marker(name)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #5037: LaTeX ``\sphinxupquote{}`` breaks in Russian
+* sphinx.testing uses deprecated pytest API; ``Node.get_marker(name)``
 
 Testing
 --------

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -39,7 +39,10 @@ def app_params(request, test_params, shared_result, sphinx_test_tempdir, rootdir
 
     # ##### process pytest.mark.sphinx
 
-    markers = request.node.get_marker("sphinx")
+    if hasattr(request.node, 'iter_markers'):  # pytest-3.6.0 or newer
+        markers = request.node.iter_markers("sphinx")
+    else:
+        markers = request.node.get_marker("sphinx")
     pargs = {}
     kwargs = {}  # type: Dict[str, str]
 
@@ -86,7 +89,10 @@ def test_params(request):
        have same 'shared_result' value.
        **NOTE**: You can not specify shared_result and srcdir in same time.
     """
-    env = request.node.get_marker('test_params')
+    if hasattr(request.node, 'get_closest_marker'):  # pytest-3.6.0 or newer
+        env = request.node.get_closest_marker('test_params')
+    else:
+        env = request.node.get_marker('test_params')
     kwargs = env.kwargs if env else {}
     result = {
         'shared_result': None,

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -32,7 +32,10 @@ def apidoc(rootdir, tempdir, apidoc_params):
 
 @pytest.fixture
 def apidoc_params(request):
-    markers = request.node.get_marker("apidoc")
+    if hasattr(request.node, 'iter_markers'):  # pytest-3.6.0 or newer
+        markers = request.node.iter_markers("apidoc")
+    else:
+        markers = request.node.get_marker("apidoc")
     pargs = {}
     kwargs = {}
 

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -27,7 +27,10 @@ def setup_command(request, tempdir, rootdir):
     Run `setup.py build_sphinx` with args and kwargs,
     pass it to the test and clean up properly.
     """
-    marker = request.node.get_marker('setup_command')
+    if hasattr(request.node, 'get_closest_marker'):  # pytest-3.6.0 or newer
+        marker = request.node.get_closest_marker('setup_command')
+    else:
+        marker = request.node.get_marker('setup_command')
     args = marker.args if marker else []
 
     pkgrootdir = tempdir / 'test-setup'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since pytest-3.6 `Node.get_marker(name)` was marked as deprecated (see https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration )
- This follows the migration rule
