### PR TITLE
Fix: #5037

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -200,42 +200,10 @@ class ExtBabel(Babel):
 
     def get_shorthandoff(self):
         # type: () -> unicode
-        shortlang = self.language.split('_')[0]
-        if shortlang in ('br', 'breton',
-                         'bg', 'bulgarian',
-                         'ca', 'catalan',
-                         'cs', 'czech',
-                         'da', 'danish',
-                         'de', 'ngerman',
-                         'de-1901', 'german',
-                         'de-AT', 'naustrian',
-                         'de-AT-1901', 'austrian',
-                         'es', 'spanish',
-                         'et', 'estonian',
-                         'eu', 'basque',
-                         'hsb', 'uppersorbian',
-                         'gl', 'galician',
-                         'is', 'icelandic',
-                         'it', 'italian',
-                         'fi', 'finnish',
-                         'nn', 'nynorsk',
-                         'no', 'norsk',
-                         'nl', 'dutch',
-                         'pl', 'polish',
-                         'pt', 'pt-PT', 'portuges',
-                         'pt-BR', 'brazil',
-                         'ru', 'russian',
-                         'sh-Latn', 'serbian',
-                         'sk', 'slovak',
-                         'sl', 'slovene',
-                         'sq', 'albanian',
-                         'sv', 'swedish',
-                         'uk', 'ukrainian'):
-            return '\\ifnum\\catcode`\\"=\\active\\shorthandoff{"}\\fi'
-        elif shortlang in ('tr', 'turkish'):
-            # memo: if ever Sphinx starts supporting 'Latin', do as for Turkish
-            return '\\ifnum\\catcode`\\=\\string=\\active\\shorthandoff{=}\\fi'
-        return ''
+        return ('\\ifdefined\\shorthandoff\n'
+                '  \\ifnum\\catcode`\\=\\string=\\active\\shorthandoff{=}\\fi\n'
+                '  \\ifnum\\catcode`\\"=\\active\\shorthandoff{"}\\fi\n'
+                '\\fi')
 
     def uses_cyrillic(self):
         # type: () -> bool
@@ -595,6 +563,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.elements['classoptions'] = ',dvipdfmx'
                     # disable babel which has not publishing quality in Japanese
                     self.elements['babel'] = ''
+                    self.elements['shorthandoff'] = ''
                     self.elements['multilingual'] = ''
                     # disable fncychap in Japanese documents
                     self.elements['fncychap'] = ''

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -201,9 +201,36 @@ class ExtBabel(Babel):
     def get_shorthandoff(self):
         # type: () -> unicode
         shortlang = self.language.split('_')[0]
-        if shortlang in ('de', 'ngerman', 'sl', 'slovene', 'pt', 'portuges',
-                         'es', 'spanish', 'nl', 'dutch', 'pl', 'polish', 'it',
-                         'italian', 'pt-BR', 'brazil'):
+        if shortlang in ('br', 'breton',
+                         'bg', 'bulgarian',
+                         'ca', 'catalan',
+                         'cs', 'czech',
+                         'da', 'danish',
+                         'de', 'ngerman',
+                         'de-1901', 'german',
+                         'de-AT', 'naustrian',
+                         'de-AT-1901', 'austrian',
+                         'es', 'spanish',
+                         'et', 'estonian',
+                         'eu', 'basque',
+                         'hsb', 'uppersorbian',
+                         'gl', 'galician',
+                         'is', 'icelandic',
+                         'it', 'italian',
+                         'fi', 'finnish',
+                         'nn', 'nynorsk',
+                         'no', 'norsk',
+                         'nl', 'dutch',
+                         'pl', 'polish',
+                         'pt', 'pt-PT', 'portuges',
+                         'pt-BR', 'brazil',
+                         'ru', 'russian',
+                         'sh-Latn', 'serbian',
+                         'sk', 'slovak',
+                         'sl', 'slovene',
+                         'sq', 'albanian',
+                         'sv', 'swedish',
+                         'uk', 'ukrainian'):
             return '\\ifnum\\catcode`\\"=\\active\\shorthandoff{"}\\fi'
         elif shortlang in ('tr', 'turkish'):
             # memo: if ever Sphinx starts supporting 'Latin', do as for Turkish

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -467,7 +467,7 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert (u'\\addto\\extrasrussian{\\def\\pageautorefname'
             u'{\u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430}}\n' in result)
-    assert '\\shorthandoff' not in result
+    assert '\\shorthandoff' in result
 
 
 @pytest.mark.sphinx(
@@ -529,7 +529,7 @@ def test_babel_with_unknown_language(app, status, warning):
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
-    assert '\\shorthandoff' not in result
+    assert '\\shorthandoff' in result
 
     assert "WARNING: no Babel option known for language 'unknown'" in warning.getvalue()
 


### PR DESCRIPTION
Subject: fix #5037

- Bugfix

The first commit tries to update the list of languages. Only the " and the = needs special treatments for not causing problems with `\sphinxupquote` and similar contexts. Info picked from LaTeX-babel documentation and docutils.writers.latex2e.

The second commit replaces this by generic TeX code, so that there is no need to maintain the language list in future.

