### PR TITLE
Remove usage of internal shorthandoff variable from LaTeX writer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -74,6 +74,7 @@ Deprecated
 * ``sphinx.writers.latex.LaTeXWriter.push_hyperlink_ids()`` is deprecated
 * ``sphinx.writers.latex.LaTeXWriter.pop_hyperlink_ids()`` is deprecated
 * ``sphinx.writers.latex.LaTeXWriter.bibitems`` is deprecated
+* ``sphinx.writers.latex.ExtBabel.get_shorthandoff()`` is deprecated
 * ``BuildEnvironment.load()`` is deprecated
 * ``BuildEnvironment.loads()`` is deprecated
 * ``BuildEnvironment.frompickle()`` is deprecated

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -216,6 +216,11 @@ The following is a list of deprecated interface.
      - 3.0
      - N/A
 
+   * - ``sphinx.writers.latex.ExtBabel.get_shorthandoff()``
+     - 1.8
+     - 2.0
+     - N/A
+
    * - ``sphinx.application.CONFIG_FILENAME``
      - 1.8
      - 3.0

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -218,7 +218,7 @@ The following is a list of deprecated interface.
 
    * - ``sphinx.writers.latex.ExtBabel.get_shorthandoff()``
      - 1.8
-     - 2.0
+     - 3.0
      - N/A
 
    * - ``sphinx.application.CONFIG_FILENAME``

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2114,6 +2114,7 @@ information.
      ``'author'``
      ``'logo'``
      ``'makeindex'``
+     ``'shorthandoff'``
 
 .. confval:: latex_docclass
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2114,7 +2114,6 @@ information.
      ``'author'``
      ``'logo'``
      ``'makeindex'``
-     ``'shorthandoff'``
 
 .. confval:: latex_docclass
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -26,7 +26,7 @@ from six import itervalues, text_type
 from sphinx import addnodes
 from sphinx import highlighting
 from sphinx.builders.latex.nodes import captioned_literal_block, footnotetext
-from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx20Warning
+from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.errors import SphinxError
 from sphinx.locale import admonitionlabels, _, __
 from sphinx.util import split_into, logging
@@ -216,7 +216,7 @@ class ExtBabel(Babel):
     def get_shorthandoff(self):
         # type: () -> unicode
         warnings.warn('ExtBabel.get_shorthandoff() is deprecated.',
-                      RemovedInSphinx20Warning)
+                      RemovedInSphinx30Warning)
         return SHORTHANDOFF
 
     def uses_cyrillic(self):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -44,7 +44,10 @@ logger = logging.getLogger(__name__)
 
 BEGIN_DOC = r'''
 \begin{document}
-%(shorthandoff)s
+\ifdefined\shorthandoff
+  \ifnum\catcode`\=\string=\active\shorthandoff{=}\fi
+  \ifnum\catcode`\"=\active\shorthandoff{"}\fi
+\fi
 %(maketitle)s
 %(tableofcontents)s
 '''
@@ -101,7 +104,6 @@ DEFAULT_SETTINGS = {
     'logo':            '\\vbox{}',
     'releasename':     '',
     'makeindex':       '\\makeindex',
-    'shorthandoff':    '',
     'maketitle':       '\\maketitle',
     'tableofcontents': '\\sphinxtableofcontents',
     'atendofbody':     '',
@@ -216,13 +218,6 @@ class ExtBabel(Babel):
         self.use_polyglossia = use_polyglossia
         self.supported = True
         super(ExtBabel, self).__init__(language_code or '')
-
-    def get_shorthandoff(self):
-        # type: () -> unicode
-        return ('\\ifdefined\\shorthandoff\n'
-                '  \\ifnum\\catcode`\\=\\string=\\active\\shorthandoff{=}\\fi\n'
-                '  \\ifnum\\catcode`\\"=\\active\\shorthandoff{"}\\fi\n'
-                '\\fi')
 
     def uses_cyrillic(self):
         # type: () -> bool
@@ -579,7 +574,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
             # this branch is not taken for xelatex/lualatex if default settings
             self.elements['multilingual'] = self.elements['babel']
             if builder.config.language:
-                self.elements['shorthandoff'] = self.babel.get_shorthandoff()
 
                 # Times fonts don't work with Cyrillic languages
                 if self.babel.uses_cyrillic() \
@@ -592,7 +586,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     self.elements['classoptions'] = ',dvipdfmx'
                     # disable babel which has not publishing quality in Japanese
                     self.elements['babel'] = ''
-                    self.elements['shorthandoff'] = ''
                     self.elements['multilingual'] = ''
                     # disable fncychap in Japanese documents
                     self.elements['fncychap'] = ''

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -26,7 +26,7 @@ from six import itervalues, text_type
 from sphinx import addnodes
 from sphinx import highlighting
 from sphinx.builders.latex.nodes import captioned_literal_block, footnotetext
-from sphinx.deprecation import RemovedInSphinx30Warning
+from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx20Warning
 from sphinx.errors import SphinxError
 from sphinx.locale import admonitionlabels, _, __
 from sphinx.util import split_into, logging

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -424,7 +424,6 @@ def test_babel_with_no_language_settings(app, status, warning):
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
-    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx(
@@ -445,7 +444,6 @@ def test_babel_with_language_de(app, status, warning):
     assert '\\addto\\captionsngerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasngerman{\\def\\pageautorefname{Seite}}\n' in result
-    assert '\\shorthandoff{"}' in result
 
 
 @pytest.mark.sphinx(
@@ -467,7 +465,6 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert (u'\\addto\\extrasrussian{\\def\\pageautorefname'
             u'{\u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430}}\n' in result)
-    assert '\\shorthandoff' in result
 
 
 @pytest.mark.sphinx(
@@ -488,7 +485,6 @@ def test_babel_with_language_tr(app, status, warning):
     assert '\\addto\\captionsturkish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasturkish{\\def\\pageautorefname{sayfa}}\n' in result
-    assert '\\shorthandoff{=}' in result
 
 
 @pytest.mark.sphinx(
@@ -508,7 +504,6 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\renewcommand{\\figurename}{Fig.}\n' in result
     assert '\\renewcommand{\\tablename}{Table.}\n' in result
     assert u'\\def\\pageautorefname{ページ}\n' in result
-    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx(
@@ -529,7 +524,6 @@ def test_babel_with_unknown_language(app, status, warning):
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
-    assert '\\shorthandoff' in result
 
     assert "WARNING: no Babel option known for language 'unknown'" in warning.getvalue()
 
@@ -553,7 +547,6 @@ def test_polyglossia_with_language_de(app, status, warning):
     assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\def\\pageautorefname{Seite}\n' in result
-    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx(
@@ -575,7 +568,6 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\def\\pageautorefname{page}\n' in result
-    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx('latex')

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -424,6 +424,7 @@ def test_babel_with_no_language_settings(app, status, warning):
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
+    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx(
@@ -444,6 +445,7 @@ def test_babel_with_language_de(app, status, warning):
     assert '\\addto\\captionsngerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasngerman{\\def\\pageautorefname{Seite}}\n' in result
+    assert '\\shorthandoff{"}' in result
 
 
 @pytest.mark.sphinx(
@@ -465,6 +467,7 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert (u'\\addto\\extrasrussian{\\def\\pageautorefname'
             u'{\u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430}}\n' in result)
+    assert '\\shorthandoff{"}' in result
 
 
 @pytest.mark.sphinx(
@@ -485,6 +488,7 @@ def test_babel_with_language_tr(app, status, warning):
     assert '\\addto\\captionsturkish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasturkish{\\def\\pageautorefname{sayfa}}\n' in result
+    assert '\\shorthandoff{=}' in result
 
 
 @pytest.mark.sphinx(
@@ -504,6 +508,7 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\renewcommand{\\figurename}{Fig.}\n' in result
     assert '\\renewcommand{\\tablename}{Table.}\n' in result
     assert u'\\def\\pageautorefname{ページ}\n' in result
+    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx(
@@ -524,6 +529,7 @@ def test_babel_with_unknown_language(app, status, warning):
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
+    assert '\\shorthandoff' in result
 
     assert "WARNING: no Babel option known for language 'unknown'" in warning.getvalue()
 
@@ -547,6 +553,7 @@ def test_polyglossia_with_language_de(app, status, warning):
     assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\def\\pageautorefname{Seite}\n' in result
+    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx(
@@ -568,6 +575,7 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\def\\pageautorefname{page}\n' in result
+    assert '\\shorthandoff' not in result
 
 
 @pytest.mark.sphinx('latex')


### PR DESCRIPTION
Subject: brings simplicity by removing shorthandoff internal variable from LaTeX writer

Neither bugfix nor feature, but refactoring.

Pros: simplified code

Cons: now, some LaTeX code gets exported to all Sphinx produced LaTeX documents ; in the past it was incorporated only language conf val was set to certain languages. Code was not included for Japanese, or when latex_engine was lualatex xelatex and document used polyglossia, or when engine was pdflatex but certain languages were used.

But the TeX code is crafted to be usable in all circumstances (platex incorporates e-TeX extensions, hence `\ifdefined` can be used).

added in edit: sphinx.sty has had for some time already numerous usages of `\numexpr`, `\dimexpr` and a few `\ifdefined`, so e-TeX has been mandatory for all engines. I have been told on TeXLive list (I don't know for MikTeX but expect it to be same) that platex includes e-TeX since 2011. For pdflatex it is since 2004. For xelatex and lualatex they always incorporated e-TeX.

### Relates
- #5040 

see https://github.com/sphinx-doc/sphinx/pull/5040#discussion_r193122150

**attention** this PR includes no deprecation and simply removes the internal variable. Maybe this is bad...
