### PR TITLE
Fix #5016: crashed when recommonmark.AutoStrictify is enabled

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,8 +18,7 @@ Bugs fixed
 
 * #5037: LaTeX ``\sphinxupquote{}`` breaks in Russian
 * sphinx.testing uses deprecated pytest API; ``Node.get_marker(name)``
-* #5016: ``character_level_inline_markup`` setting is not initialized for
-  combination of non reST source parsers (ex. recommonmark) and docutils-0.13
+* #5016: crashed when recommonmark.AutoStrictify is enabled
 
 Testing
 --------

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -66,7 +66,6 @@ default_settings = {
     'halt_level': 5,
     'file_insertion_enabled': True,
     'smartquotes_locales': [],
-    'character_level_inline_markup': False,  # for docutils-0.13.1 or older
 }
 
 # This is increased every time an environment attribute is added

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -13,6 +13,7 @@ import re
 
 from docutils.core import Publisher
 from docutils.io import FileInput, NullOutput
+from docutils.parsers.rst import Parser as RSTParser
 from docutils.readers import standalone
 from docutils.statemachine import StringList, string2lines
 from docutils.writers import UnfilteredWriter
@@ -282,6 +283,13 @@ def read_doc(app, env, filename):
     source = input_class(app, env, source=None, source_path=filename,
                          encoding=env.config.source_encoding)
     parser = app.registry.create_source_parser(app, filename)
+    if parser.__class__.__name__ == 'CommonMarkParser' and parser.settings_spec == ():
+        # a workaround for recommonmark
+        #   If recommonmark.AutoStrictify is enabled, the parser invokes reST parser
+        #   internally.  But recommonmark-0.4.0 does not provide settings_spec for reST
+        #   parser.  As a workaround, this copies settings_spec for RSTParser to the
+        #   CommonMarkParser.
+        parser.settings_spec = RSTParser.settings_spec
 
     pub = Publisher(reader=reader,
                     parser=parser,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5016 
