### PR TITLE
Fix #5036: quickstart: Typing Ctrl-U clears the whole of line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * C++, fix lookup of full template specializations with no template arguments.
 * #4667: C++, fix assertion on missing references in global scope when using
   intersphinx. Thanks to Alan M. Carroll.
+* #5036: quickstart: Typing Ctrl-U clears the whole of line
 
 Testing
 --------

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -38,7 +38,7 @@ from six.moves.urllib.parse import quote as urlquote
 from sphinx import __display_version__, package_dir
 from sphinx.util import texescape
 from sphinx.util.console import (  # type: ignore
-    purple, bold, red, turquoise, nocolor, color_terminal
+    colorize, bold, red, turquoise, nocolor, color_terminal
 )
 from sphinx.util.osutil import ensuredir, make_filename
 from sphinx.util.template import SphinxRenderer
@@ -82,8 +82,14 @@ PROMPT_PREFIX = '> '
 # function to get input from terminal -- overridden by the test suite
 def term_input(prompt):
     # type: (unicode) -> unicode
-    print(prompt, end='')
-    return input('')
+    if sys.platform == 'win32':
+        # Important: On windows, readline is not enabled by default.  In these
+        #            environment, escape sequences have been broken.  To avoid the
+        #            problem, quickstart uses ``print()`` to show prompt.
+        print(prompt, end='')
+        return input('')
+    else:
+        return input(prompt)
 
 
 class ValidationError(Exception):
@@ -183,7 +189,7 @@ def do_prompt(text, default=None, validator=nonempty):
                         prompt = prompt.encode('utf-8')
                     except UnicodeEncodeError:
                         prompt = prompt.encode('latin1')
-        prompt = purple(prompt)
+        prompt = colorize('purple', prompt, input_mode=True)
         x = term_input(prompt).strip()
         if default and not x:
             x = default

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -87,9 +87,21 @@ def coloron():
     codes.update(_orig_codes)
 
 
-def colorize(name, text):
-    # type: (str, unicode) -> unicode
-    return codes.get(name, '') + text + codes.get('reset', '')
+def colorize(name, text, input_mode=False):
+    # type: (str, unicode, bool) -> unicode
+    def escseq(name):
+        # Wrap escape sequence with ``\1`` and ``\2`` to let readline know
+        # it is non-printable characters
+        # ref: https://tiswww.case.edu/php/chet/readline/readline.html
+        #
+        # Note: This hack does not work well in Windows (see #5059)
+        escape = codes.get(name, '')
+        if input_mode and escape and sys.platform != 'win32':
+            return '\1' + escape + '\2'
+        else:
+            return escape
+
+    return escseq(name) + text + escseq('reset')
 
 
 def strip_colors(s):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5036 