### PR TITLE
LaTeX, follow-up to PR #5012, avoid label separated by pagebreak

### DIFF
--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -15,7 +15,7 @@
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
 <% elif labels -%>
-\phantomsection<%= labels %>
+\phantomsection<%= labels %>\nobreak
 <% endif -%>
 \begin{tabular}[t]<%= table.get_colspec() -%>
 \hline

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -15,7 +15,7 @@
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftercaption
 <% elif labels -%>
-\phantomsection<%= labels %>
+\phantomsection<%= labels %>\nobreak
 <% endif -%>
 \begin{tabulary}{\linewidth}[t]<%= table.get_colspec() -%>
 \hline

--- a/tests/roots/test-latex-table/expects/table_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths.tex
@@ -2,7 +2,7 @@
 
 \begin{savenotes}\sphinxattablestart
 \centering
-\phantomsection\label{\detokenize{tabular:namedtabular}}\label{\detokenize{tabular:mytabular}}
+\phantomsection\label{\detokenize{tabular:namedtabular}}\label{\detokenize{tabular:mytabular}}\nobreak
 \begin{tabular}[t]{|\X{30}{100}|\X{70}{100}|}
 \hline
 \sphinxstyletheadfamily 


### PR DESCRIPTION
PR #5012 took care of this by anticipation for longtable, but the problem can also arise
with tabular/tabulary and is much easier to fix.


### Relates
- #5012 

