### PR TITLE
Search: make a difference between fullname and dispname

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -331,13 +331,13 @@ class IndexBuilder(object):
         for domainname, domain in sorted(iteritems(self.env.domains)):
             for fullname, dispname, type, docname, anchor, prio in \
                     sorted(domain.get_objects()):
-                # XXX use dispname?
                 if docname not in fn2index:
                     continue
                 if prio < 0:
                     continue
                 fullname = htmlescape(fullname)
-                prefix, name = rpartition(fullname, '.')
+                dispname = htmlescape(dispname)
+                prefix, name = rpartition(dispname, '.')
                 pdict = rv.setdefault(prefix, {})
                 try:
                     typeindex = otypes[domainname, type]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -161,7 +161,7 @@ def test_IndexBuilder():
         'docnames': ('docname', 'docname2'),
         'envversion': '1.0',
         'filenames': ['filename', 'filename2'],
-        'objects': {'': {'objname': (0, 0, 1, '#anchor')}},
+        'objects': {'': {'objdispname': (0, 0, 1, '#anchor')}},
         'objnames': {0: ('dummy', 'objtype', 'objtype')},
         'objtypes': {0: 'dummy:objtype'},
         'terms': {'comment': [0, 1],


### PR DESCRIPTION
Subject: search should use ``dispname`` instead of ``fullname`` from ``Domain.get_objects()``

### Feature or Bugfix
- Bugfix

### Purpose
Often there is no difference between the full name and the display name of objects, but when there is the search is still based on the full name instead of the display name.

### Relates
Needed for PR #5062 to use/display anonymous names as ``[anonymous]`` in search, instead of ``@someName``.

