### PR TITLE
Fix #5032: autodoc loses the first staticmethod parameter for old styled classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@ Bugs fixed
 * #4667: C++, fix assertion on missing references in global scope when using
   intersphinx. Thanks to Alan M. Carroll.
 * #5019: autodoc: crashed by Form Feed Character
+* #5032: autodoc: loses the first staticmethod parameter for old styled classes
 
 Testing
 --------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -176,8 +176,8 @@ def isstaticmethod(obj, cls=None, name=None):
     elif cls and name:
         # trace __mro__ if the method is defined in parent class
         #
-        # .. note:: This only works with new style classes.
-        for basecls in getattr(cls, '__mro__', []):
+        # .. note:: This only works well with new style classes.
+        for basecls in getattr(cls, '__mro__', [cls]):
             meth = basecls.__dict__.get(name)
             if meth:
                 if isinstance(meth, staticmethod):

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -362,3 +362,26 @@ def test_dict_customtype():
     description = inspect.object_description(dictionary)
     # Type is unsortable, just check that it does not crash
     assert "<CustomType(2)>: 2" in description
+
+
+def test_isstaticmethod():
+    class Foo():
+        @staticmethod
+        def method1():
+            pass
+
+        def method2(self):
+            pass
+
+    class Bar(Foo):
+        pass
+
+    assert inspect.isstaticmethod(Foo.method1, Foo, 'method1') is True
+    assert inspect.isstaticmethod(Foo.method2, Foo, 'method2') is False
+
+    if sys.version_info < (3, 0):
+        assert inspect.isstaticmethod(Bar.method1, Bar, 'method1') is False
+        assert inspect.isstaticmethod(Bar.method2, Bar, 'method2') is False
+    else:
+        assert inspect.isstaticmethod(Bar.method1, Bar, 'method1') is True
+        assert inspect.isstaticmethod(Bar.method2, Bar, 'method2') is False


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5032 
