### PR TITLE
Update Python 2 doc links to Python 3

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -103,7 +103,7 @@ texinfo_documents = [
 
 # We're not using intersphinx right now, but if we did, this would be part of
 # the mapping:
-intersphinx_mapping = {'python': ('https://docs.python.org/2/', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}
 
 # Sphinx document translation with sphinx gettext feature uses these settings:
 locale_dirs = ['locale/']

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -864,7 +864,7 @@ Including content based on tags
 
    All tags must follow the standard Python identifier syntax as set out in
    the `Identifiers and keywords
-   <https://docs.python.org/2/reference/lexical_analysis.html#identifiers>`_
+   <https://docs.python.org/3/reference/lexical_analysis.html#identifiers>`_
    documentation.  That is, a tag expression may only consist of tags that
    conform to the syntax of Python variables.  In ASCII, this consists of the
    uppercase and lowercase letters ``A`` through ``Z``, the underscore ``_``

--- a/sphinx/ext/napoleon/iterators.py
+++ b/sphinx/ext/napoleon/iterators.py
@@ -41,7 +41,7 @@ class peek_iter(object):
     See Also
     --------
     `peek_iter` can operate as a drop in replacement for the built-in
-    `iter <https://docs.python.org/2/library/functions.html#iter>`_ function.
+    `iter <https://docs.python.org/3/library/functions.html#iter>`_ function.
 
     Attributes
     ----------


### PR DESCRIPTION
Python 3 docs are more actively maintained and are the future.