### PR TITLE
Fixed internationalization quick guide

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -123,14 +123,14 @@ This section describe an easy way to translate with sphinx-intl.
 
    .. code-block:: console
 
-      > set SPHINXOPTS=-D language='de'
+      > set SPHINXOPTS=-D language=de
       > .\make.bat html
 
    command line (for PowerShell):
 
    .. code-block:: console
 
-      > Set-Item env:SPHINXOPTS "-D language='de'"
+      > Set-Item env:SPHINXOPTS "-D language=de"
       > .\make.bat html
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix in the documentation

### Purpose
The internationalization quick guide didn't work for me on a Windows 10 machine.

### Detail
There were additional apostrophs in the commands I had to remove. The commands now work in cmd.exe and powershell on my Windows 10 machine.

Can someone else double check, if this is the right fix? Or is it a system issue/difference on my site?

I have also verified the GNU make example, and this works as expected on my linux system.

### Relates
- #5081

