### PR TITLE
Update Google style guide link (previous link deprecated)

### DIFF
--- a/doc/ext/autodoc.rst
+++ b/doc/ext/autodoc.rst
@@ -41,7 +41,7 @@ you can also enable the :mod:`napoleon <sphinx.ext.napoleon>` extension.
 docstrings to correct reStructuredText before :mod:`autodoc` processes them.
 
 .. _Google:
-   https://google.github.io/styleguide/pyguide.html#Comments
+   https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
 .. _NumPy:
    https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 


### PR DESCRIPTION
Subject: Update link in documentation to Google's style guide for writing docstring comments, since the previous location was deprecated

### Bugfix
- Docs bugfix

### Purpose
It's a short docs fix. I hope it is self-explanatory from the above?

### Relates
- https://google.github.io/styleguide/pyguide.html#Comments
- https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

