### PR TITLE
Fix typo in error message

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -365,7 +365,7 @@ def eval_config_file(filename, tags):
                      "called sys.exit()")
             raise ConfigError(msg)
         except Exception:
-            msg = __("There is a programable error in your configuration file:\n\n%s")
+            msg = __("There is a programmable error in your configuration file:\n\n%s")
             raise ConfigError(msg % traceback.format_exc())
 
     return namespace


### PR DESCRIPTION
Subject: This PR fixes a typo in an error message.

### Feature or Bugfix
- Bugfix

### Purpose
- "Programable" is a misspelling of "programmable"
- No dependent environment

### Detail
- No details

### Relates
- None

