### PR TITLE
Fix #5091: latex: curly braces in index entries are not handled correctly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #5019: autodoc: crashed by Form Feed Character
 * #5032: autodoc: loses the first staticmethod parameter for old styled classes
 * #5036: quickstart: Typing Ctrl-U clears the whole of line
+* #5091: latex: curly braces in index entries are not handled correctly
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1953,8 +1953,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (nodes.Node, Pattern) -> None
         def escape(value):
             value = self.encode(value)
-            value = value.replace(r'\{', r'\sphinxleftcurlybrace')
-            value = value.replace(r'\}', r'\sphinxrightcurlybrace')
+            value = value.replace(r'\{', r'{\sphinxleftcurlybrace}')
+            value = value.replace(r'\}', r'{\sphinxrightcurlybrace}')
             return value
 
         if not node.get('inline', True):

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1209,7 +1209,7 @@ def test_latex_index(app, status, warning):
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
     assert 'A \\index{famous}famous \\index{equation}equation:\n' in result
     assert '\n\\index{Einstein}\\index{relativity}\\ignorespaces \nand' in result
-    assert '\n\\index{main \\sphinxleftcurlybrace}\\ignorespaces ' in result
+    assert '\n\\index{main {\\sphinxleftcurlybrace}}\\ignorespaces ' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-equations')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5091 
