### PR TITLE
Close #5035: qthelp builder allows dashes in :confval:`qthelp_namespace`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,7 @@ Incompatible changes
 * #4983: html: The URL for the productionlist has been changed
 * Modifying a template variable ``script_files`` in templates is allowed now.
   Please use ``app.add_js_file()`` instead.
+* #5035: qthelp builder allows dashes in :confval:`qthelp_namespace`
 
 Deprecated
 ----------

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -140,7 +140,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         else:
             nspace = 'org.sphinx.%s.%s' % (outname, self.config.version)
 
-        nspace = re.sub('[^a-zA-Z0-9.]', '', nspace)
+        nspace = re.sub('[^a-zA-Z0-9.\-]', '', nspace)
         nspace = re.sub(r'\.+', '.', nspace).strip('.')
         nspace = nspace.lower()
 

--- a/tests/test_build_qthelp.py
+++ b/tests/test_build_qthelp.py
@@ -88,11 +88,11 @@ def test_qthelp_namespace(app, status, warning):
     app.builder.build_all()
 
     qhp = (app.outdir / 'Python.qhp').text()
-    assert '<namespace>org.sphinxdoc.sphinx</namespace>' in qhp
+    assert '<namespace>org.sphinx-doc.sphinx</namespace>' in qhp
 
     qhcp = (app.outdir / 'Python.qhcp').text()
-    assert '<homePage>qthelp://org.sphinxdoc.sphinx/doc/index.html</homePage>' in qhcp
-    assert '<startPage>qthelp://org.sphinxdoc.sphinx/doc/index.html</startPage>' in qhcp
+    assert '<homePage>qthelp://org.sphinx-doc.sphinx/doc/index.html</homePage>' in qhcp
+    assert '<startPage>qthelp://org.sphinx-doc.sphinx/doc/index.html</startPage>' in qhcp
 
 
 @pytest.mark.sphinx('qthelp', testroot='basic')


### PR DESCRIPTION
### Feature or Bugfix
- Feature?
- Bugfix?

### Purpose
- refs: #5035 
