### PR TITLE
doc: Use badge to show latest release

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -3,19 +3,9 @@
   {%trans%}project{%endtrans%}</p>
 
 <h3>Download</h3>
-{% if version.endswith('+') %}
-<p>{%trans%}This documentation is for version <b><a href="changes.html">{{ version }}</a></b>, which is
-  not released yet.{%endtrans%}</p>
-<p>{%trans%}You can use it from the
-  <a href="https://github.com/sphinx-doc/sphinx/">Git repo</a> or look for
-  released versions in the <a href="https://pypi.python.org/pypi/Sphinx">Python
-    Package Index</a>.{%endtrans%}</p>
-{% else %}
-<p>{%trans%}Current version: <b><a href="changes.html">{{ version }}</a></b>{%endtrans%}</p>
-<p>{%trans%}Get Sphinx from the <a href="https://pypi.python.org/pypi/Sphinx">Python Package
-Index</a>, or install it with:{%endtrans%}</p>
+<p class="download">{%trans%}Current version: <a href="https://pypi.org/project/Sphinx/" alt="PyPI"><img src="https://img.shields.io/pypi/v/sphinx.svg"></a>{%endtrans%}</p>
+<p>{%trans%}Install Sphinx with:{%endtrans%}</p>
 <pre>pip install -U Sphinx</pre>
-{% endif %}
 
 <h3>{%trans%}Questions? Suggestions?{%endtrans%}</h3>
 

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -140,6 +140,10 @@ div.sphinxsidebar .logo img {
     vertical-align: middle;
 }
 
+div.sphinxsidebar .download a img {
+    vertical-align: middle;
+}
+
 div.subscribeformwrapper {
     display: block;
     overflow: auto;


### PR DESCRIPTION
### Feature or Bugfix
- Docs

### Purpose
- Under current branch model, the unreleased version is always shown on document.
- With this change, latest version is always shown as badge!

![2018-06-17 15 27 09](https://user-images.githubusercontent.com/748828/41505374-eea97814-7242-11e8-9684-c36d3d17e116.png)

