### PR TITLE
Customizable Python interpreter in doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,9 +1,10 @@
 # Makefile for Sphinx documentation
 #
+PYTHON ?= python
 
 # You can set these variables from the command line.
 SPHINXOPTS   =
-SPHINXBUILD  = python3 ../sphinx/cmd/build.py
+SPHINXBUILD  = $(PYTHON) ../sphinx/cmd/build.py
 SPHINXPROJ   = sphinx
 SOURCEDIR    = .
 BUILDDIR     = _build


### PR DESCRIPTION
Let the environment variable ``PYTHON`` be used for specifying interpreter.

Fix after previous stray edit of hard-coded interpreter in 6d52b63eeee5dcea7f9b8f0358ca85c67c19925e.