### PR TITLE
autodoc: fix indentation errors for inherited methods

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -476,6 +476,9 @@ class Documenter(object):
         docstring = self.get_attr(self.object, '__doc__', None)
         if docstring is None and self.env.config.autodoc_inherit_docstrings:
             docstring = getdoc(self.object)
+            # getdoc already strips leading indentation (ignoring the first
+            # line). Make sure that prepare_docstring will not do it again.
+            ignore = 0
         # make sure we have Unicode docstrings, then sanitize and split
         # into lines
         if isinstance(docstring, text_type):


### PR DESCRIPTION
When using the autoclass directive on a class that looks like this:

```python
# module.py
class A:
    def method(self):
        """
        :returns:
            Foo(self) if self.bar is True, else None.
        """
        return Foo(self) if self.bar else None

class B(A):
    pass
```

With `autodoc_inherit_docstrings=True`, `.. autoclass:: B` will trigger a warning like this:

```
module.py:docstring of module.B.method:2:Field list ends without a blank line; unexpected unindent.
```

Although, the docstring is correct. Running with `sphinx-build -vvv` gives more info:

```
 [autodoc] => <class 'module.B'>
 [autodoc] getattr(_, u'method')
 [autodoc] => <unbound method B.method>
 [autodoc] output:

 .. py:class:: B()

    .. py:method:: B.method()
       :module: module

       :returns:
       Foo(self) if self.bar is True, else None.
```

Here we can see that the indentation was corrupted by autodoc. The problem only appears when documenting inherited methods and attributes.

When the documented object (in that case, method) has no `__doc__` attribute (which is the case when the method is inherited, we fallback on `inspect.getdoc` (or a sphinx copy of the function on python < 3.5).

`inspect.getdoc` already strips the indentation (ignoring the first line), we must not do it again to avoid corrupting the overall indentation of the docstring.

