### PR TITLE
Fix #5104: apidoc: Interface of ``sphinx.apidoc:main()`` has changed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #5019: autodoc: crashed by Form Feed Character
 * #5032: autodoc: loses the first staticmethod parameter for old styled classes
 * #5036: quickstart: Typing Ctrl-U clears the whole of line
+* #5104: apidoc: Interface of ``sphinx.apidoc:main()`` has changed
 
 Testing
 --------

--- a/sphinx/apidoc.py
+++ b/sphinx/apidoc.py
@@ -9,20 +9,20 @@
     :license: BSD, see LICENSE for details.
 """
 
+import sys
 import warnings
 
 from sphinx.deprecation import RemovedInSphinx20Warning
 from sphinx.ext.apidoc import main as _main
 
 
-def main(*args, **kwargs):
+def main(argv=sys.argv):
     warnings.warn(
         '`sphinx.apidoc.main()` has moved to `sphinx.ext.apidoc.main()`.',
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
-    args = args[1:]  # skip first argument to adjust arguments (refs: #4615)
-    _main(*args, **kwargs)
+    _main(argv[1:])  # skip first argument to adjust arguments (refs: #4615)
 
 
 # So program can be started with "python -m sphinx.apidoc ..."


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5104 
