### PR TITLE
Run everything but unit tests under Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       env: TOXENV=docs
     - python: '3.6'
       env: TOXENV=mypy
-    - python: '2.7'
+    - python: '3.6'
       env: TOXENV=flake8
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON ?= python
+PYTHON ?= python3
 
 .PHONY: all
 all: clean-pyc clean-backupfiles style-check type-check test

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Sphinx documentation
 #
-PYTHON ?= python
+PYTHON ?= python3
 
 # You can set these variables from the command line.
 SPHINXOPTS   =

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -140,7 +140,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         else:
             nspace = 'org.sphinx.%s.%s' % (outname, self.config.version)
 
-        nspace = re.sub('[^a-zA-Z0-9.\-]', '', nspace)
+        nspace = re.sub(r'[^a-zA-Z0-9.\-]', '', nspace)
         nspace = re.sub(r'\.+', '.', nspace).strip('.')
         nspace = nspace.lower()
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -45,7 +45,7 @@ locale.versionlabels = DeprecatedDict(
     RemovedInSphinx30Warning
 )
 
-glob_re = re.compile('.*[*?\[].*')
+glob_re = re.compile(r'.*[*?\[].*')
 
 
 def int_or_nothing(argument):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -247,7 +247,7 @@ class ExtBabel(Babel):
 
     def get_mainlanguage_options(self):
         # type: () -> unicode
-        """Return options for polyglossia's ``\setmainlanguage``."""
+        """Return options for polyglossia's ``\\setmainlanguage``."""
         if self.use_polyglossia is False:
             return None
         elif self.language == 'german':

--- a/tox.ini
+++ b/tox.ini
@@ -27,12 +27,14 @@ commands=
     pytest -Wall --durations 25 {posargs}
 
 [testenv:flake8]
+basepython = python3
 description =
     Run style checks.
 commands =
     flake8
 
 [testenv:pylint]
+basepython = python3
 description =
     Run source code analyzer.
 deps =
@@ -42,6 +44,7 @@ commands =
     pylint --rcfile utils/pylintrc sphinx
 
 [testenv:coverage]
+basepython = python3
 description =
     Run code coverage checks.
 setenv =
@@ -51,6 +54,7 @@ commands =
     coverage report
 
 [testenv:mypy]
+basepython = python3
 description =
     Run type checks.
 deps =
@@ -59,6 +63,7 @@ commands=
     mypy sphinx/
 
 [testenv:docs]
+basepython = python3
 description =
     Build documentation.
 commands =


### PR DESCRIPTION
The demise of Python 2.7 is not far off and we intend to drop support for it in Sphinx 2.0. As a result, there probably isn't a better time than now to start testing with Python 3 by default. There are a couple of advantages to this:
    
- flake8 is stricter under Python 3 and we don't need to ignore files with Python 3 syntax
- We get to dogfood Sphinx against its own documentation using Python 3
- pylint gains support for Python 3 syntax
