### PR TITLE
setup.py: Move configuration to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,90 @@
 [metadata]
+name = Sphinx
+version = attr: sphinx.__version__
+author = 'Georg Brandl
+author_email = 'georg@python.org
+description = 'Python documentation generator
+long_description = file: README.rst
+license = BSD
 license_file = LICENSE
+url = http://sphinx-doc.org/
+download_url = https://pypi.org/project/Sphinx/
+platforms = any
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Environment :: Web Environment
+    Intended Audience :: Developers
+    Intended Audience :: Education
+    Intended Audience :: End Users/Desktop
+    Intended Audience :: Science/Research
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Framework :: Setuptools Plugin
+    Framework :: Sphinx
+    Framework :: Sphinx :: Extension
+    Framework :: Sphinx :: Theme
+    Topic :: Documentation
+    Topic :: Documentation :: Sphinx
+    Topic :: Internet :: WWW/HTTP :: Site Management
+    Topic :: Printing
+    Topic :: Software Development
+    Topic :: Software Development :: Documentation
+    Topic :: Text Processing
+    Topic :: Text Processing :: General
+    Topic :: Text Processing :: Indexing
+    Topic :: Text Processing :: Markup
+    Topic :: Text Processing :: Markup :: HTML
+    Topic :: Text Processing :: Markup :: LaTeX
+    Topic :: Utilities
+
+[options]
+zip_safe = False
+packages = find:
+include_package_data = True
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+install_requires =
+    six>=1.5
+    Jinja2>=2.3
+    Pygments>=2.0
+    docutils>=0.11
+    snowballstemmer>=1.1
+    babel>=1.3,!=2.0
+    alabaster>=0.7,<0.8
+    imagesize
+    requests>=2.0.0
+    setuptools>=30.3.0
+    sphinxcontrib-websupport
+    colorama>=0.3.5; sys_platform=="win32"
+    typing; python_version<"3.5"
+
+[options.extras_require]
+test =
+    pytest
+    pytest-cov
+    html5lib
+    enum34; python_version<"3"
+    mock; python_version<"3"
+    mypy; python_version>="3"
+    typed_ast; python_version>="3"
+websupport =
+    sqlalchemy>=0.9
+    whoosh>=2.0
+
+[options.packages.find]
+exclude =
+    tests
+    utils
 
 [egg_info]
 tag_build = .dev

--- a/setup.py
+++ b/setup.py
@@ -4,60 +4,7 @@ import sys
 from distutils import log
 from io import StringIO
 
-from setuptools import find_packages, setup
-
-import sphinx
-
-with open('README.rst') as f:
-    long_desc = f.read()
-
-if sys.version_info < (2, 7) or (3, 0) <= sys.version_info < (3, 4):
-    print('ERROR: Sphinx requires at least Python 2.7 or 3.4 to run.')
-    sys.exit(1)
-
-install_requires = [
-    'six>=1.5',
-    'Jinja2>=2.3',
-    'Pygments>=2.0',
-    'docutils>=0.11',
-    'snowballstemmer>=1.1',
-    'babel>=1.3,!=2.0',
-    'alabaster>=0.7,<0.8',
-    'imagesize',
-    'requests>=2.0.0',
-    'setuptools',
-    'packaging',
-    'sphinxcontrib-websupport',
-]
-
-extras_require = {
-    # Environment Marker works for wheel 0.24 or later
-    ':sys_platform=="win32"': [
-        'colorama>=0.3.5',
-    ],
-    ':python_version<"3.5"': [
-        'typing'
-    ],
-    'websupport': [
-        'sqlalchemy>=0.9',
-        'whoosh>=2.0',
-    ],
-    'test': [
-        'mock',
-        'pytest',
-        'pytest-cov',
-        'html5lib',
-        'flake8>=3.5.0',
-        'flake8-import-order',
-    ],
-    'test:python_version<"3"': [
-        'enum34',
-    ],
-    'test:python_version>="3"': [
-        'mypy',
-        'typed_ast',
-    ],
-}
+from setuptools import setup
 
 # Provide a "compile_catalog" command that also creates the translated
 # JavaScript files if Babel is available.
@@ -173,57 +120,6 @@ else:
 
 
 setup(
-    name='Sphinx',
-    version=sphinx.__version__,
-    url='http://sphinx-doc.org/',
-    download_url='https://pypi.org/project/Sphinx/',
-    license='BSD',
-    author='Georg Brandl',
-    author_email='georg@python.org',
-    description='Python documentation generator',
-    long_description=long_desc,
-    zip_safe=False,
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: End Users/Desktop',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Framework :: Setuptools Plugin',
-        'Framework :: Sphinx',
-        'Framework :: Sphinx :: Extension',
-        'Framework :: Sphinx :: Theme',
-        'Topic :: Documentation',
-        'Topic :: Documentation :: Sphinx',
-        'Topic :: Internet :: WWW/HTTP :: Site Management',
-        'Topic :: Printing',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: Documentation',
-        'Topic :: Text Processing',
-        'Topic :: Text Processing :: General',
-        'Topic :: Text Processing :: Indexing',
-        'Topic :: Text Processing :: Markup',
-        'Topic :: Text Processing :: Markup :: HTML',
-        'Topic :: Text Processing :: Markup :: LaTeX',
-        'Topic :: Utilities',
-    ],
-    platforms='any',
-    packages=find_packages(exclude=['tests', 'utils']),
-    include_package_data=True,
     entry_points={
         'console_scripts': [
             'sphinx-build = sphinx.cmd.build:main',
@@ -235,8 +131,5 @@ setup(
             'build_sphinx = sphinx.setup_command:BuildDoc',
         ],
     },
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    install_requires=install_requires,
-    extras_require=extras_require,
     cmdclass=cmdclass,
 )


### PR DESCRIPTION
Recent versions of Setuptools allows most configuration to be kept in
'setup.cfg' instead of 'setup.py' [1]. This allows for some automation
scenarios and results in less duplication than we might otherwise see.

There is one functional change included: the requirement for setuptools
30.3.0 (8 December 2016). This is required to support the 'setup.cfg'
format.

[1] https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files