### PR TITLE
Update napoleon docs with features from #4613

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Other contributors, listed alphabetically, are:
 * Chris Lamb -- reproducibility fixes
 * Thomas Lamb -- linkcheck builder
 * Łukasz Langa -- partial support for autodoc
+* Martin Larralde -- additional napoleon admonitions
 * Ian Lee -- quickstart improvements
 * Robert Lehmann -- gettext builder (GSOC project)
 * Dan MacKinlay -- metadata fixes

--- a/CHANGES
+++ b/CHANGES
@@ -164,6 +164,7 @@ Documentation
 -------------
 
 * #5083: Fix wrong make.bat option for internationalization.
+* #5115: napoleon: add admonitions added by #4613 to the docs.
 
 Release 1.7.6 (in development)
 ==============================

--- a/doc/ext/napoleon.rst
+++ b/doc/ext/napoleon.rst
@@ -97,9 +97,15 @@ All of the following section headers are supported:
 
     * ``Args`` *(alias of Parameters)*
     * ``Arguments`` *(alias of Parameters)*
+    * ``Attention``
     * ``Attributes``
+    * ``Caution``
+    * ``Danger``
+    * ``Error``
     * ``Example``
     * ``Examples``
+    * ``Hint``
+    * ``Important``
     * ``Keyword Args`` *(alias of Keyword Arguments)*
     * ``Keyword Arguments``
     * ``Methods``
@@ -112,6 +118,7 @@ All of the following section headers are supported:
     * ``Raises``
     * ``References``
     * ``See Also``
+    * ``Tip``
     * ``Todo``
     * ``Warning``
     * ``Warnings`` *(alias of Warning)*


### PR DESCRIPTION
Subject: Update napoleon docs with features from #4613

### Feature or Bugfix
- Bugfix

### Purpose
This is a patch for #4613, since I only realised now that I should have updated the documentation as well. I also forgot to add myself to the `AUTHORS`, so I took the occasion now.

### Detail
- Add additional docstring section headers to the napoleon documentation
- Add myself to the contributors

### Relates
- #4613 

