### PR TITLE
Closes #5076: [ext/napoleon] explicitly catch StopIteration

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -527,7 +527,14 @@ class GoogleDocstring(UnicodeMixin):
         self._parsed_lines = self._consume_empty()
 
         if self._name and (self._what == 'attribute' or self._what == 'data'):
-            self._parsed_lines.extend(self._parse_attribute_docstring())
+            # Implicit stop using StopIteration no longer allowed in
+            # Python 3.7; see PEP 479
+            res = []
+            try:
+                res = self._parse_attribute_docstring()
+            except StopIteration as e:
+                pass
+            self._parsed_lines.extend(res)
             return
 
         while self._line_iter.has_next():

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -529,10 +529,10 @@ class GoogleDocstring(UnicodeMixin):
         if self._name and (self._what == 'attribute' or self._what == 'data'):
             # Implicit stop using StopIteration no longer allowed in
             # Python 3.7; see PEP 479
-            res = []
+            res = []  # type: List[unicode]
             try:
                 res = self._parse_attribute_docstring()
-            except StopIteration as e:
+            except StopIteration:
                 pass
             self._parsed_lines.extend(res)
             return


### PR DESCRIPTION
Subject: fix error in Python 3.7 due to changed handling of StopIteration

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Building docs (e.g. for fedmsg) fails due to the changed handling of StopIteration in PEP 479
that is fully enforced in Python 3.7.

### Detail
Per PEP 479, Python 3.7 no longer allows bubbling up StopIteration
outside of a generator. Instead, wrap attribute parsing in a try
block and provide a sane default in case it raises an exception
([]).

### Relates
https://github.com/sphinx-doc/sphinx/issues/5076#issuecomment-396271461

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sphinx-doc/sphinx/5119)
<!-- Reviewable:end -->
