### PR TITLE
BuildDoc: add and pass through nitpicky option

### DIFF
--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -87,9 +87,10 @@ class BuildDoc(Command):
         ('link-index', 'i', 'Link index.html to the master doc'),
         ('copyright', None, 'The copyright string'),
         ('pdb', None, 'Start pdb on exception'),
+        ('nitpicky', 'n', 'nit-picky mode, warn about all missing references'),
     ]
     boolean_options = ['fresh-env', 'all-files', 'warning-is-error',
-                       'link-index']
+                       'link-index', 'nitpicky']
 
     def initialize_options(self):
         # type: () -> None
@@ -107,6 +108,7 @@ class BuildDoc(Command):
         self.copyright = ''
         self.verbosity = 0
         self.traceback = False
+        self.nitpicky = False
 
     def _guess_source_dir(self):
         # type: () -> unicode
@@ -174,6 +176,8 @@ class BuildDoc(Command):
             confoverrides['today'] = self.today
         if self.copyright:
             confoverrides['copyright'] = self.copyright
+        if self.nitpicky:
+            confoverrides['nitpicky'] = self.nitpicky
 
         for builder, builder_target_dir in self.builder_target_dirs:
             app = None


### PR DESCRIPTION
This allows for using e.g. `tox -e docs -- -n` with Sphinx's own
`build_sphinx` distutils command.

Related: #5121 (since Sphinx uses `build_sphinx.warning-is-error = 1` in `setup.cfg` and therefore it will stop at the first warning)