### PR TITLE
quickstart: check default path for validity

### DIFF
--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -265,12 +265,7 @@ Selected root path: %s''') % d['path']))
 Enter the root path for documentation.'''))
         d['path'] = do_prompt(__('Root path for the documentation'), '.', is_path)
 
-    while path.isfile(path.join(d['path'], 'conf.py')) or \
-            path.isfile(path.join(d['path'], 'source', 'conf.py')):
-        print()
-        print(bold(__('Error: an existing conf.py has been found in the '
-                      'selected root path.')))
-        print(__('sphinx-quickstart will not overwrite existing Sphinx projects.'))
+    while not check_valid_dir(d):
         print()
         d['path'] = do_prompt(__('Please enter a new root path (or just Enter '
                                  'to exit)'), '', is_path)
@@ -523,6 +518,18 @@ def valid_dir(d):
     return True
 
 
+def check_valid_dir(d):
+    # type: (Dict) -> bool
+    if valid_dir(d):
+        return True
+
+    print()
+    print(bold(__('Error: specified path is not a directory, or Sphinx'
+                  ' files already exist.')))
+    print(__('sphinx-quickstart will not overwrite existing Sphinx projects.'))
+    return False
+
+
 def get_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(
@@ -639,12 +646,7 @@ def main(argv=sys.argv[1:]):
             d2.update(d)
             d = d2
 
-            if not valid_dir(d):
-                print()
-                print(bold(__('Error: specified path is not a directory, or sphinx'
-                              ' files already exist.')))
-                print(__('sphinx-quickstart only generate into a empty directory.'
-                         ' Please specify a new root path.'))
+            if not check_valid_dir(d):
                 return 1
         else:
             ask_user(d)

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -265,13 +265,6 @@ Selected root path: %s''') % d['path']))
 Enter the root path for documentation.'''))
         d['path'] = do_prompt(__('Root path for the documentation'), '.', is_path)
 
-    while not check_valid_dir(d):
-        print()
-        d['path'] = do_prompt(__('Please enter a new root path (or just Enter '
-                                 'to exit)'), '', is_path)
-        if not d['path']:
-            sys.exit(1)
-
     if 'sep' not in d:
         print(__('''
 You have two options for placing the build directory for Sphinx output.
@@ -341,6 +334,13 @@ document is a custom template, you can also set this to another filename.'''))
         print()
         d['master'] = do_prompt(__('Please enter a new file name, or rename the '
                                    'existing file and press Enter'), d['master'])
+
+    while not check_valid_dir(d):
+        print()
+        d['path'] = do_prompt(__('Please enter a new root path (or just Enter '
+                                 'to exit)'), '', is_path)
+        if not d['path']:
+            sys.exit(1)
 
     if 'epub' not in d:
         print(__('''


### PR DESCRIPTION
`sphinx-quickstart` without arguments will currently overwrite e.g. a
project's `Makefile`, since it only checks for `conf.py` explicitly in
`ask_user`.

This change uses the same check for both a provided path via arguments
and in `ask_user` now.