### PR TITLE
Qualify attribute names for generated ivar

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -43,6 +43,18 @@ _enumerated_list_regex = re.compile(
     r'(?(paren)\)|\.)(\s+\S|\s*$)')
 
 
+def _qualify_name(attr_name, klass):
+    if klass and not '.' in attr_name:
+        if attr_name.startswith('~'):
+            attr_name = attr_name[1:]
+        try:
+            q = klass.__qualname__
+        except AttributeError:
+            q = klass.__name__
+        return '~%s.%s' % (q, attr_name)
+    return attr_name
+
+
 class GoogleDocstring(UnicodeMixin):
     """Convert Google style docstrings to reStructuredText.
 
@@ -597,8 +609,7 @@ class GoogleDocstring(UnicodeMixin):
         lines = []
         for _name, _type, _desc in self._consume_fields():
             if self._config.napoleon_use_ivar:
-                if not _name.startswith('~') and self._obj:
-                    _name = '~%s.%s' % (self._obj.__qualname__, _name)
+                _name = _qualify_name(_name, self._obj)
                 field = ':ivar %s: ' % _name  # type: unicode
                 lines.extend(self._format_block(field, _desc))
                 if _type:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -44,7 +44,7 @@ _enumerated_list_regex = re.compile(
 
 
 def _qualify_name(attr_name, klass):
-    if klass and not '.' in attr_name:
+    if klass and '.' not in attr_name:
         if attr_name.startswith('~'):
             attr_name = attr_name[1:]
         try:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -597,6 +597,8 @@ class GoogleDocstring(UnicodeMixin):
         lines = []
         for _name, _type, _desc in self._consume_fields():
             if self._config.napoleon_use_ivar:
+                if not _name.startswith('~') and self._obj:
+                    _name = '~%s.%s' % (self._obj.__qualname__, _name)
                 field = ':ivar %s: ' % _name  # type: unicode
                 lines.extend(self._format_block(field, _desc))
                 if _type:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -43,18 +43,6 @@ _enumerated_list_regex = re.compile(
     r'(?(paren)\)|\.)(\s+\S|\s*$)')
 
 
-def _qualify_name(attr_name, klass):
-    if klass and '.' not in attr_name:
-        if attr_name.startswith('~'):
-            attr_name = attr_name[1:]
-        try:
-            q = klass.__qualname__
-        except AttributeError:
-            q = klass.__name__
-        return '~%s.%s' % (q, attr_name)
-    return attr_name
-
-
 class GoogleDocstring(UnicodeMixin):
     """Convert Google style docstrings to reStructuredText.
 
@@ -609,7 +597,7 @@ class GoogleDocstring(UnicodeMixin):
         lines = []
         for _name, _type, _desc in self._consume_fields():
             if self._config.napoleon_use_ivar:
-                _name = _qualify_name(_name, self._obj)
+                _name = self._qualify_name(_name, self._obj)
                 field = ':ivar %s: ' % _name  # type: unicode
                 lines.extend(self._format_block(field, _desc))
                 if _type:
@@ -808,6 +796,18 @@ class GoogleDocstring(UnicodeMixin):
         return ("".join(before_colon).strip(),
                 colon,
                 "".join(after_colon).strip())
+
+    def _qualify_name(self, attr_name, klass):
+        # type: (unicode, type) -> unicode
+        if klass and '.' not in attr_name:
+            if attr_name.startswith('~'):
+                attr_name = attr_name[1:]
+            try:
+                q = klass.__qualname__
+            except AttributeError:
+                q = klass.__name__
+            return '~%s.%s' % (q, attr_name)
+        return attr_name
 
     def _strip_empty(self, lines):
         # type: (List[unicode]) -> List[unicode]


### PR DESCRIPTION
Subject: Make Napoleon qualify attribute names for generated ivar

### Feature or Bugfix
- Feature

### Purpose
This PR gives a partial fix of #4074.  I hope this works in the most cases (an exception is the same attribute name in different classes with the same name, in python<3.3).

### Detail
- Make Napoleon apply a workaround that my team has manually done.
For example, the `Attributes` items in
```python
class A(object):
    """
    An A.

    Attributes:
        foo (int): Blah blah.
    """
```
will be treated as
```
    Attributes:
        ~module_name.A.foo (int): Blah blah.
```
which is converted to
```
    :ivar ~module_name.A.foo: Blah blah.
    :vartype ~module_name.A.foo: int
```
in order to avoid unintended links.

- This PR does not break "manually fixed" lines.

### Relates
- #4676

