### PR TITLE
Fix #5125: sphinx-build: Interface of ``sphinx:main()`` has changed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,8 @@ Bugs fixed
 * #5070: epub: Wrong internal href fragment links
 * #5104: apidoc: Interface of ``sphinx.apidoc:main()`` has changed
 * #5125: sphinx-build: Interface of ``sphinx:main()`` has changed
+* sphinx-build: ``sphinx.cmd.build.main()`` refers ``sys.argv`` instead of given
+  argument
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #5091: latex: curly braces in index entries are not handled correctly
 * #5070: epub: Wrong internal href fragment links
 * #5104: apidoc: Interface of ``sphinx.apidoc:main()`` has changed
+* #5125: sphinx-build: Interface of ``sphinx:main()`` has changed
 
 Testing
 --------

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -60,15 +60,15 @@ if __version__.endswith('+'):
         pass
 
 
-def main(*args, **kwargs):
+def main(argv=sys.argv):
     from .cmd import build
     warnings.warn(
         '`sphinx.main()` has moved to `sphinx.cmd.build.main()`.',
         RemovedInSphinx20Warning,
         stacklevel=2,
     )
-    args = args[1:]  # skip first argument to adjust arguments (refs: #4615)
-    return build.main(*args, **kwargs)
+    argv = argv[1:]  # skip first argument to adjust arguments (refs: #4615)
+    return build.main(argv)
 
 
 def build_main(argv=sys.argv):

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -32,7 +32,7 @@ def make_main(argv=sys.argv[1:]):
 
 def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
-    if sys.argv[1:2] == ['-M']:
+    if argv[:1] == ['-M']:
         return make_main(argv)
     else:
         return build_main(argv)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5125 
- And more, `sphinx.cmd.build:main()` does not refer given argument.

