### PR TITLE
Fix: #5133 via ``\sphinxsymbolsname``, ``\sphinxnumbersname``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -152,6 +152,7 @@ Bugs fixed
 * #4945: i18n: fix lang_COUNTRY not fallback correctly for IndexBuilder. Thanks
   to Shengjing Zhu.
 * #4983: productionlist directive generates invalid IDs for the tokens
+* #5133: latex: index headings "Symbols" and "Numbers" not internationalized
 
 Testing
 --------

--- a/sphinx/texinputs/python.ist
+++ b/sphinx/texinputs/python.ist
@@ -3,11 +3,11 @@ headings_flag 1
 heading_prefix "  \\bigletter "
 
 preamble "\\begin{sphinxtheindex}
-\\def\\bigletter#1{{\\Large\\sffamily#1}\\nopagebreak\\vspace{1mm}}
+\\let\\bigletter\\sphinxstyleindexletterhead
 
 "
 
 postamble "\n\n\\end{sphinxtheindex}\n"
 
-symhead_positive "{Symbols}"
-numhead_positive "{Numbers}"
+symhead_positive "{\\sphinxsymbolsname}"
+numhead_positive "{\\sphinxnumbersname}"

--- a/sphinx/texinputs/python.ist
+++ b/sphinx/texinputs/python.ist
@@ -3,7 +3,7 @@ headings_flag 1
 heading_prefix "  \\bigletter "
 
 preamble "\\begin{sphinxtheindex}
-\\let\\bigletter\\sphinxstyleindexletterhead
+\\let\\bigletter\\sphinxstyleindexlettergroup
 
 "
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -471,8 +471,8 @@
  {}% else clause of \ltx@ifundefined
 
 % redefined in preamble, headings for makeindex produced index
-\newcommand*{\sphinxsymbolsname}{Symbols}
-\newcommand*{\sphinxnumbersname}{Numbers}
+\newcommand*{\sphinxsymbolsname}{}
+\newcommand*{\sphinxnumbersname}{}
 
 %% COLOR (general)
 %
@@ -1598,7 +1598,7 @@
 \def\sphinxstyleindexentry   #1{\texttt{#1}}
 \def\sphinxstyleindexextra   #1{ \emph{(#1)}}
 \def\sphinxstyleindexpageref #1{, \pageref{#1}}
-\def\sphinxstyleindexletterhead #1{{\Large\sffamily#1}\nopagebreak\vspace{1mm}}
+\def\sphinxstyleindexlettergroup #1{{\Large\sffamily#1}\nopagebreak\vspace{1mm}}
 \protected\def\sphinxstyletopictitle   #1{\textbf{#1}\par\medskip}
 \let\sphinxstylesidebartitle\sphinxstyletopictitle
 \protected\def\sphinxstyleothertitle   #1{\textbf{#1}}

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -470,6 +470,9 @@
  {\newenvironment{sphinxtheindex}{\begin{theindex}}{\end{theindex}}}%
  {}% else clause of \ltx@ifundefined
 
+% redefined in preamble, headings for makeindex produced index
+\newcommand*{\sphinxsymbolsname}{Symbols}
+\newcommand*{\sphinxnumbersname}{Numbers}
 
 %% COLOR (general)
 %
@@ -1592,9 +1595,10 @@
 
 % additional customizable styling
 % FIXME: convert this to package options ?
-\protected\def\sphinxstyleindexentry   #1{\texttt{#1}}
-\protected\def\sphinxstyleindexextra   #1{ \emph{(#1)}}
-\protected\def\sphinxstyleindexpageref #1{, \pageref{#1}}
+\def\sphinxstyleindexentry   #1{\texttt{#1}}
+\def\sphinxstyleindexextra   #1{ \emph{(#1)}}
+\def\sphinxstyleindexpageref #1{, \pageref{#1}}
+\def\sphinxstyleindexletterhead #1{{\Large\sffamily#1}\nopagebreak\vspace{1mm}}
 \protected\def\sphinxstyletopictitle   #1{\textbf{#1}\par\medskip}
 \let\sphinxstylesidebartitle\sphinxstyletopictitle
 \protected\def\sphinxstyleothertitle   #1{\textbf{#1}}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -862,8 +862,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         def generate(content, collapsed):
             # type: (List[Tuple[unicode, List[Tuple[unicode, unicode, unicode, unicode, unicode]]]], bool) -> None  # NOQA
             ret.append('\\begin{sphinxtheindex}\n')
-            ret.append('\\def\\bigletter#1{{\\Large\\sffamily#1}'
-                       '\\nopagebreak\\vspace{1mm}}\n')
+            ret.append('\\let\\bigletter\\sphinxstyleindexletterhead\n')
             for i, (letter, entries) in enumerate(content):
                 if i > 0:
                     ret.append('\\indexspace\n')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -862,7 +862,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         def generate(content, collapsed):
             # type: (List[Tuple[unicode, List[Tuple[unicode, unicode, unicode, unicode, unicode]]]], bool) -> None  # NOQA
             ret.append('\\begin{sphinxtheindex}\n')
-            ret.append('\\let\\bigletter\\sphinxstyleindexletterhead\n')
+            ret.append('\\let\\bigletter\\sphinxstyleindexlettergroup\n')
             for i, (letter, entries) in enumerate(content):
                 if i > 0:
                     ret.append('\\indexspace\n')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -673,6 +673,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
             ) +
             self.babel_renewcommand(
                 '\\literalblockcontinuesname', self.encode(_('continues on next page'))
+            ) +
+            self.babel_renewcommand(
+                '\\sphinxsymbolsname', self.encode(_('Symbols'))
+            ) +
+            self.babel_renewcommand(
+                '\\sphinxnumbersname', self.encode(_('Numbers'))
             )
         )
         self.elements['pageautorefname'] = \


### PR DESCRIPTION
These new macros replace previously hard-coded `Symbols` and `Numbers` in `python.ist` (style file for `makeindex` binary used to prepare general index in PDF builds).

Further, this  adds new ``\sphinxstyleindexletterhead`` as customizable alias to previously hard-coded ``\bigletter`` for usage in the indices.

Both bugfix (#5133) and feature (customizability of rendering of Letter headings in indices of documents using makeindex, i.e. non-Japanese documents).

**edit** I changed the macro name to ``\sphinxstyleindexlettergroup`` for reasons related to other PR #5134
