### PR TITLE
Add default Accept header to the linkcheck

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -120,11 +120,12 @@ class CheckExternalLinksBuilder(Builder):
 
     def check_thread(self):
         # type: () -> None
-        kwargs = {}
+        kwargs = {
+            'allow_redirects': True,
+            'headers': {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'},
+        }
         if self.app.config.linkcheck_timeout:
             kwargs['timeout'] = self.app.config.linkcheck_timeout
-
-        kwargs['allow_redirects'] = True
 
         def check_uri():
             # type: () -> Tuple[unicode, unicode, int]

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -122,7 +122,10 @@ class CheckExternalLinksBuilder(Builder):
         # type: () -> None
         kwargs = {
             'allow_redirects': True,
-            'headers': {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'},
+            'headers': {
+                'Accept': ('text/html,application/xhtml+xml,'
+                           'application/xml;q=0.9,*/*;q=0.8')
+            },
         }
         if self.app.config.linkcheck_timeout:
             kwargs['timeout'] = self.app.config.linkcheck_timeout


### PR DESCRIPTION
Adds default `Accept` header to the `linkcheck` as some servers have troubles to respond correctly without it. The added `Accept` header resembles what Firefox sets by default.

### Feature or Bugfix
- Feature

### Purpose

There are situations where requested server replies with a different content (in my particular case HTTP 404) when there is no accept header, possibly because it evaluates the content negotiation to an API request instead of a browser request. This change adds a default Accept header, which equals to what my Firefox sets out of the box to its requests.

I stumbled upon this when checking a link to https://crates.io/crates/dredd-hooks. While

```
curl -i https://crates.io/crates/dredd-hooks
```

returns HTTP 404, following results in an expected HTTP 200 response with HTML body:

```
curl -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' -i https://crates.io/crates/dredd-hooks
```
