### PR TITLE
C++: support for contracts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -101,6 +101,7 @@ Features added
   full production rule
 * #6373: autosectionlabel: Allow suppression of warnings
 * coverage: Support a new ``coverage_ignore_pyobjects`` option
+* C++: add support for contracts
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1275,6 +1275,38 @@ Resulting in the following:
 
 .. cpp:namespace-pop::
 
+Assertions
+^^^^^^^^^^
+
+The :rst:role:`cpp:expr` and :rst:role:`cpp:texpr` roles can accept a contract
+assertion. This can allow you to express program invariants::
+
+    .. cpp:struct:: config
+
+        .. cpp:var:: int height
+                     int width
+
+            Canvas dimensions. These must define a valid resolution, i.e.
+            subject to:
+
+            - :cpp:expr:`[[assert: 0 < height && 0 && width]]`
+            - :cpp:expr:`[[assert: min_pixels <= height * width]]`
+            - :cpp:expr:`[[assert: height * width <= max_pixels]]`
+
+This is rendered as follows:
+
+.. cpp:struct:: config
+
+    .. cpp:var:: int height
+                    int width
+
+        Canvas dimensions. These must define a valid resolution, i.e.
+        subject to:
+
+        - :cpp:expr:`[[assert: 0 < height && 0 && width]]`
+        - :cpp:expr:`[[assert: min_pixels < height * width]]`
+        - :cpp:expr:`[[assert: height * width < max_pixels]]`
+
 Configuration Variables
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -792,6 +792,9 @@ Some directives support options:
 - ``:noindex:``, see :ref:`basic-domain-markup`.
 - ``:tparam-line-spec:``, for templated declarations.
   If specified, each template parameter will be rendered on a separate line.
+- ``:contract-line-spec:``, for :rst:dir:`cpp:function` directives. If
+  specified, each contract assertion will be rendered on a separate line. (See
+  :ref:`cpp-contracts`.)
 
   .. versionadded:: 1.6
 
@@ -1211,6 +1214,66 @@ References to partial specialisations must always include the template
 parameter lists, e.g., ``template\<typename T> Outer\<T*>``
 (:cpp:class:`template\<typename T> Outer\<T*>`).  Currently the lookup only
 succeed if the template parameter identifiers are equal strings.
+
+.. _cpp-contracts:
+
+Contracts
+~~~~~~~~~
+
+Pre- and post-conditions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a function is documented with its pre- and post-condition contracts, these
+will not be displayed in the attribute list but on a separate line below.
+Example::
+
+    .. cpp:function:: double sqrt(double arg)         \
+                          [[expects: 0 <= arg]]       \
+                          __attribute__((deprecated)) \
+                          [[ensures root: is_approx(root * root, arg)]]
+
+        Computes the square root of a nonnegative real number.
+
+This is rendered as follows:
+
+.. cpp:namespace-push:: @no_contract_line_spec
+
+.. cpp:function:: double sqrt(double arg)         \
+                      [[expects: 0 <= arg]]       \
+                      __attribute__((deprecated)) \
+                      [[ensures root: is_approx(root * root, arg)]]
+
+    Computes the square root of a nonnegative real number.
+
+This can be split to span multiple lines with the ``:contract-line-spec:``
+directive option:
+
+.. code-block:: rst
+    :emphasize-lines: 5
+
+    .. cpp:function:: double sqrt(double arg)         \
+                          [[expects: 0 <= arg]]       \
+                          __attribute__((deprecated)) \
+                          [[ensures root: is_approx(root * root, arg)]]
+        :contract-line-spec:
+
+        Computes the square root of a nonnegative real number.
+
+Resulting in the following:
+
+.. cpp:namespace-pop::
+
+.. cpp:namespace-push:: @contract_line_spec
+
+.. cpp:function:: double sqrt(double arg)         \
+                      [[expects: 0 <= arg]]       \
+                      __attribute__((deprecated)) \
+                      [[ensures root: is_approx(root * root, arg)]]
+    :contract-line-spec:
+
+    Computes the square root of a nonnegative real number.
+
+.. cpp:namespace-pop::
 
 Configuration Variables
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3213,9 +3213,8 @@ class ASTParenExprList(ASTBase):
         for e in self.exprs:
             if not first:
                 signode.append(nodes.Text(', '))
-            else:
-                first = False
-                e.describe_signature(signode, mode, env, symbol)
+            first = False
+            e.describe_signature(signode, mode, env, symbol)
         signode.append(nodes.Text(')'))
 
 

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -754,6 +754,11 @@ def test_attributes():
     check('member', 'int &[[attr]] i', {1: 'i__iR', 2: '1i'})
     check('member', 'int *[[attr]] *i', {1: 'i__iPP', 2: '1i'})
 
+    # position: function type
+    check('function', 'int f()  const&  noexcept  [[maybe_unused]]  __attribute__((pure))',
+          {1: 'fCR', 2: 'NKR1fEv'},
+          output='int f() const & noexcept [[maybe_unused]] __attribute__((pure))')
+
 
 def test_xref_parsing():
     def check(target):


### PR DESCRIPTION
Implement support for C++2a contracts, allowing for things of the style:

```rST
.. cpp::function:: double sqrt(double arg)  \
                       [[expects: 0 <= arg]] \
                       [[ensures root: is_approx(root * root, arg)]]

    A user can document program invariants as if they were assertions, too,
    via the expression roles:

    | :cpp:expr:`[[assert: rounding_mode == FE_TOWARDZERO]]`
```

In the rendered output the contract attributes are moved to their separate line, in the spirit of the separate line that is afforted to template parameters. There is a `:contract-line-spec:` directive option to put one pre- or post-condition per line as well.

[Take a look at the proof-of-concept here.](https://mickk-on-cpp.github.io/sphinx-demo/2019-05/default/pr/)

Some reservations / possible concerns:

- I changed the order of description of function qualifiers and attributes to match that of C++ ([here](https://github.com/sphinx-doc/sphinx/pull/5144#pullrequestreview-239165472))
- I would like for the function pre- and post-conditions to be indented or somehow set apart at least through user styles, but none of the output has e.g. classes set (the same could be said of template parameters etc.)
- parsing is not strict, producing warnings rather than rejecting constructs which would not otherwise be valid C++ such as attaching contracts to any function type; this can be noisy when the parser backtracks