### PR TITLE
Fix #5146: autosummary: warning is emitted when the first line of docstring ends with literal notation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,8 @@ Bugs fixed
 * #5091: latex: curly braces in index entries are not handled correctly
 * #5070: epub: Wrong internal href fragment links
 * #5104: apidoc: Interface of ``sphinx.apidoc:main()`` has changed
+* #5146: autosummary: warning is emitted when the first line of docstring ends
+  with literal notation
 
 Testing
 --------

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -91,6 +91,7 @@ logger = logging.getLogger(__name__)
 
 
 periods_re = re.compile(r'\.(?:\s+)')
+literal_re = re.compile(r'::\s*$')
 
 
 # -- autosummary_toc node ------------------------------------------------------
@@ -483,6 +484,9 @@ def extract_summary(doc, document):
             if not node.traverse(nodes.system_message):
                 # considered as that splitting by period does not break inline markups
                 break
+
+    # strip literal notation mark ``::`` from tail of summary
+    summary = literal_re.sub('.', summary)
 
     return summary
 

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -81,6 +81,10 @@ def test_extract_summary(capsys):
     doc = ['Blabla, i.e. bla.']
     assert extract_summary(doc, document) == 'Blabla, i.e.'
 
+    # literal
+    doc = ['blah blah::']
+    assert extract_summary(doc, document) == 'blah blah.'
+
     _, err = capsys.readouterr()
     assert err == ''
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5146 
