### PR TITLE
graphviz: run dot in the document directory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #5156: the :py:mod:`sphinx.ext.graphviz: extension runs `dot` in the
+  directory of the document being built instead of in the root directory of
+  the documentation.
 * #4460: extensions which stores any data to environment should return the
   version of its env data structure as metadata.  In detail, please see
   :ref:`ext-metadata`.

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -238,7 +238,8 @@ def render_dot(self, code, options, format, prefix='graphviz'):
     if format == 'png':
         dot_args.extend(['-Tcmapx', '-o%s.map' % outfn])
     try:
-        p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+        p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE, cwd=path.dirname(
+            path.join(self.builder.srcdir, self.builder.current_docname)))
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory
             raise

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -235,11 +235,14 @@ def render_dot(self, code, options, format, prefix='graphviz'):
     dot_args = [graphviz_dot]
     dot_args.extend(self.builder.config.graphviz_dot_args)
     dot_args.extend(['-T' + format, '-o' + outfn])
+
+    cwd = path.dirname(
+        path.join(self.builder.srcdir, self.builder.env.docname))
+
     if format == 'png':
         dot_args.extend(['-Tcmapx', '-o%s.map' % outfn])
     try:
-        p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE, cwd=path.dirname(
-            path.join(self.builder.srcdir, self.builder.current_docname)))
+        p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE, cwd=cwd)
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory
             raise

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -155,7 +155,10 @@ class Graphviz(SphinxDirective):
                     line=self.lineno)]
         node = graphviz()
         node['code'] = dotcode
-        node['options'] = {}
+        node['options'] = {
+            'docpath': path.splitext(self.state.document.current_source)[0],
+        }
+
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']
         if 'alt' in self.options:
@@ -192,7 +195,9 @@ class GraphvizSimple(SphinxDirective):
         node = graphviz()
         node['code'] = '%s %s {\n%s\n}\n' % \
                        (self.name, self.arguments[0], '\n'.join(self.content))
-        node['options'] = {}
+        node['options'] = {
+            'docpath': path.splitext(self.state.document.current_source)[0],
+        }
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']
         if 'alt' in self.options:
@@ -236,8 +241,7 @@ def render_dot(self, code, options, format, prefix='graphviz'):
     dot_args.extend(self.builder.config.graphviz_dot_args)
     dot_args.extend(['-T' + format, '-o' + outfn])
 
-    cwd = path.dirname(
-        path.join(self.builder.srcdir, self.builder.env.docname))
+    cwd = path.dirname(options.get('docpath', self.builder.srcdir))
 
     if format == 'png':
         dot_args.extend(['-Tcmapx', '-o%s.map' % outfn])

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -156,7 +156,7 @@ class Graphviz(SphinxDirective):
         node = graphviz()
         node['code'] = dotcode
         node['options'] = {
-            'docpath': path.splitext(self.state.document.current_source)[0],
+            'docname': path.splitext(self.state.document.current_source)[0],
         }
 
         if 'graphviz_dot' in self.options:
@@ -196,7 +196,7 @@ class GraphvizSimple(SphinxDirective):
         node['code'] = '%s %s {\n%s\n}\n' % \
                        (self.name, self.arguments[0], '\n'.join(self.content))
         node['options'] = {
-            'docpath': path.splitext(self.state.document.current_source)[0],
+            'docname': path.splitext(self.state.document.current_source)[0],
         }
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']
@@ -241,7 +241,8 @@ def render_dot(self, code, options, format, prefix='graphviz'):
     dot_args.extend(self.builder.config.graphviz_dot_args)
     dot_args.extend(['-T' + format, '-o' + outfn])
 
-    cwd = path.dirname(options.get('docpath', self.builder.srcdir))
+    docname = options.get('docname', 'index')
+    cwd = path.dirname(path.join(self.builder.srcdir, docname))
 
     if format == 'png':
         dot_args.extend(['-Tcmapx', '-o%s.map' % outfn])


### PR DESCRIPTION
Subject: use the current document's directory as the build directory for the `dot` subprocess. 

### Feature or Bugfix
- Bugfix

### Purpose
- Allow the use of relative file paths for files included as a part of `dot` graphviz code

### Detail
- The current implementation runs `dot` wherever the sphinx command is run. This means that if images are used for nodes and specified as relative paths, they will not be found either during the build or while the built docs are viewed.
- Debugging this behavior was made more difficult by the lack of any logging from the `dot` subprocess. The change in the PR includes sending the contents of `stderr` to the logs. 

### Relates
- #4033

