### PR TITLE
Fix links to sphinx-build man page

### DIFF
--- a/doc/usage/quickstart.rst
+++ b/doc/usage/quickstart.rst
@@ -127,7 +127,7 @@ directory in which you want to place the built documentation.
 The :option:`-b <sphinx-build -b>` option selects a builder; in this example
 Sphinx will build HTML files.
 
-|more| Refer to the :program:`sphinx-build man page <sphinx-build>` for all
+|more| Refer to the :doc:`sphinx-build man page </man/sphinx-build>` for all
 options that :program:`sphinx-build` supports.
 
 However, :program:`sphinx-quickstart` script creates a :file:`Makefile` and a
@@ -331,7 +331,7 @@ More topics to be covered
 
 .. [#] This is the usual layout.  However, :file:`conf.py` can also live in
        another directory, the :term:`configuration directory`.  Refer to the
-       :program:`sphinx-build man page <sphinx-build>` for more information.
+       :doc:`sphinx-build man page </man/sphinx-build>` for more information.
 
 .. |more| image:: /_static/more.png
           :align: middle


### PR DESCRIPTION
Subject: Fix links to sphinx-build man page

- Bugfix

### Purpose
- Swap``program`` for ``doc`` links to sphinx-build man page.

### Detail
- Old links were broken because the man page is a document not a program.
