### PR TITLE
Fix formatting type annotations for tuples with more than two arguments

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -521,6 +521,13 @@ class Signature(object):
 
         if annotation.__module__ == 'builtins':
             return annotation.__qualname__  # type: ignore
+        elif (hasattr(typing, 'TupleMeta') and
+              isinstance(annotation, typing.TupleMeta) and  # type: ignore
+              not hasattr(annotation, '__tuple_params__')):
+            # This is for Python 3.6+, 3.5 case is handled below
+            params = annotation.__args__
+            param_str = ', '.join(self.format_annotation(p) for p in params)
+            return '%s[%s]' % (qualified_name, param_str)
         elif (hasattr(typing, 'GenericMeta') and  # for py36 or below
               isinstance(annotation, typing.GenericMeta)):
             # In Python 3.5.2+, all arguments are stored in __args__,

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -231,7 +231,7 @@ def test_Signature_partialmethod():
 @pytest.mark.skipif(sys.version_info < (3, 5),
                     reason='type annotation test is available on py35 or above')
 def test_Signature_annotations():
-    from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11
+    from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -283,6 +283,10 @@ def test_Signature_annotations():
     # has_retval=False
     sig = inspect.Signature(f11, has_retval=False).format_args()
     assert sig == '(x: CustomAnnotation, y: 123)'
+
+    # tuple with more than two items
+    sig = inspect.Signature(f12).format_args()
+    assert sig == '() -> Tuple[int, str, int]'
 
 
 def test_safe_getattr_with_default():

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -62,3 +62,7 @@ class CustomAnnotation:
 
 def f11(x: CustomAnnotation(), y: 123) -> None:
     pass
+
+
+def f12() -> Tuple[int, str, int]:
+    pass


### PR DESCRIPTION
Currently in Python 3.6, Sphinx formats this function:
```python3
def foo() -> Tuple[int, str, int]:
    pass
```
in the following way (which can be seen in the [Travis log for the first commit in this PR][1]):

    () -> Tuple[[int, str], int]

This is because the tuple gets treated as a function, and the last `int` is treated like a return value.
This affects only `format_annotation_old` function. `format_annotation_new` which is used for Python 3.7 is not affected.

This pull request fixes this bug, and adds a test.

There is a `hasattr(annotation, '__tuple_params__')` clause below in that function. I am not sure for which Python version it is because all versions I tested (2.7, 3.5, 3.6, 3.7) do not have this attribute. Maybe it is for 3.4? Anyway I added an opposite condition (`not hasattr`) to be on the safe side.

[1]: https://travis-ci.com/mitya57/sphinx/jobs/134445530