### PR TITLE
Fix #5143: autodoc: crashed on inspecting dict like object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,8 @@ Bugs fixed
 * #5146: autosummary: warning is emitted when the first line of docstring ends
   with literal notation
 * autosummary: warnings of autosummary indicates wrong location (refs: #5146)
+* #5143: autodoc: crashed on inspecting dict like object which does not support
+  sorting
 
 Testing
 --------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -241,7 +241,7 @@ def object_description(object):
     if isinstance(object, dict):
         try:
             sorted_keys = sorted(object)
-        except TypeError:
+        except Exception:
             pass  # Cannot sort dict keys, fall back to generic repr
         else:
             items = ("%r: %r" % (key, object[key]) for key in sorted_keys)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5143 
