### PR TITLE
Fix #5139: autodoc: Enum argument missing if it shares value with another

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
 * autosummary: warnings of autosummary indicates wrong location (refs: #5146)
 * #5143: autodoc: crashed on inspecting dict like object which does not support
   sorting
+* #5139: autodoc: Enum argument missing if it shares value with another
 
 Testing
 --------

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -219,12 +219,21 @@ def get_object_members(subject, objpath, attrgetter, analyzer=None):
         for name, value in subject.__members__.items():
             obj_dict[name] = value
 
-    members = {}
+    members = {}  # type: Dict[str, Attribute]
+
+    # enum members
+    if isenumclass(subject):
+        for name, value in subject.__members__.items():
+            if name not in members:
+                members[name] = Attribute(name, True, value)
+
+    # other members
     for name in dir(subject):
         try:
             value = attrgetter(subject, name)
             directly_defined = name in obj_dict
-            members[name] = Attribute(name, directly_defined, value)
+            if name not in members:
+                members[name] = Attribute(name, directly_defined, value)
         except AttributeError:
             continue
 

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -233,3 +233,4 @@ class EnumCls(enum.Enum):
     val2 = 23  #: doc for val2
     val3 = 34
     """doc for val3"""
+    val4 = 34

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -873,13 +873,14 @@ def test_generate():
     # test members with enum attributes
     directive.env.ref_context['py:module'] = 'target'
     options.inherited_members = False
-    options.undoc_members = False
+    options.undoc_members = True
     options.members = ALL
     assert_processes([
         ('class', 'target.EnumCls'),
         ('attribute', 'target.EnumCls.val1'),
         ('attribute', 'target.EnumCls.val2'),
         ('attribute', 'target.EnumCls.val3'),
+        ('attribute', 'target.EnumCls.val4'),
     ], 'class', 'EnumCls')
     assert_result_contains(
         '   :annotation: = 12', 'attribute', 'EnumCls.val1')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5139 
