### PR TITLE
Fix py domain: rtype field could not handle "None" as a type (refs: #4946)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
 * autosummary: warnings of autosummary indicates wrong location (refs: #5146)
 * #5143: autodoc: crashed on inspecting dict like object which does not support
   sorting
+* #4946: py domain: rtype field could not handle "None" as a type
 
 Testing
 --------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -148,7 +148,15 @@ class PyXrefMixin(object):
 
 
 class PyField(PyXrefMixin, Field):
-    pass
+    def make_xref(self, rolename, domain, target,
+                  innernode=nodes.emphasis, contnode=None, env=None):
+        # type: (unicode, unicode, unicode, nodes.Node, nodes.Node, BuildEnvironment) ->  nodes.Node  # NOQA
+        if rolename == 'class' and target == 'None':
+            # None is not a type, so use obj role instead.
+            rolename = 'obj'
+
+        return super(PyField, self).make_xref(rolename, domain, target,
+                                              innernode, contnode, env)
 
 
 class PyGroupedField(PyXrefMixin, GroupedField):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4946 
