### PR TITLE
Fix #3329: i18n: crashed by auto-symbol footnote references

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
 * autosummary: warnings of autosummary indicates wrong location (refs: #5146)
 * #5143: autodoc: crashed on inspecting dict like object which does not support
   sorting
+* #3329: i18n: crashed by auto-symbol footnote references
 
 Testing
 --------

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -275,10 +275,9 @@ class Locale(SphinxTransform):
                 continue  # skip
 
             # auto-numbered foot note reference should use original 'ids'.
-            def is_autonumber_footnote_ref(node):
+            def is_autofootnote_ref(node):
                 # type: (nodes.Node) -> bool
-                return isinstance(node, nodes.footnote_reference) and \
-                    node.get('auto') == 1
+                return isinstance(node, nodes.footnote_reference) and node.get('auto')
 
             def list_replace_or_append(lst, old, new):
                 # type: (List, Any, Any) -> None
@@ -286,8 +285,8 @@ class Locale(SphinxTransform):
                     lst[lst.index(old)] = new
                 else:
                     lst.append(new)
-            old_foot_refs = node.traverse(is_autonumber_footnote_ref)
-            new_foot_refs = patch.traverse(is_autonumber_footnote_ref)
+            old_foot_refs = node.traverse(is_autofootnote_ref)
+            new_foot_refs = patch.traverse(is_autofootnote_ref)
             if len(old_foot_refs) != len(new_foot_refs):
                 old_foot_ref_rawsources = [ref.rawsource for ref in old_foot_refs]
                 new_foot_ref_rawsources = [ref.rawsource for ref in new_foot_refs]
@@ -308,8 +307,14 @@ class Locale(SphinxTransform):
                 new['ids'] = old['ids']
                 for id in new['ids']:
                     self.document.ids[id] = new
-                list_replace_or_append(
-                    self.document.autofootnote_refs, old, new)
+
+                if new['auto'] == 1:
+                    # autofootnote_refs
+                    list_replace_or_append(self.document.autofootnote_refs, old, new)
+                else:
+                    # symbol_footnote_refs
+                    list_replace_or_append(self.document.symbol_footnote_refs, old, new)
+
                 if refname:
                     list_replace_or_append(
                         self.document.footnote_refs.setdefault(refname, []),

--- a/tests/roots/test-intl/footnote.po
+++ b/tests/roots/test-intl/footnote.po
@@ -19,8 +19,8 @@ msgstr ""
 msgid "i18n with Footnote"
 msgstr "I18N WITH FOOTNOTE"
 
-msgid "[100]_ Contents [#]_ for `i18n with Footnote`_ [ref]_ [#named]_."
-msgstr "`I18N WITH FOOTNOTE`_ INCLUDE THIS CONTENTS [#named]_ [ref]_ [#]_ [100]_."
+msgid "[100]_ Contents [#]_ for `i18n with Footnote`_ [ref]_ [#named]_ [*]_."
+msgstr "`I18N WITH FOOTNOTE`_ INCLUDE THIS CONTENTS [#named]_ [ref]_ [#]_ [100]_ [*]_."
 
 msgid "This is a auto numbered footnote."
 msgstr "THIS IS A AUTO NUMBERED FOOTNOTE."
@@ -34,3 +34,5 @@ msgstr "THIS IS A NUMBERED FOOTNOTE."
 msgid "This is a auto numbered named footnote."
 msgstr "THIS IS A AUTO NUMBERED NAMED FOOTNOTE."
 
+msgid "This is a auto symbol footnote."
+msgstr "THIS IS A AUTO SYMBOL FOOTNOTE."

--- a/tests/roots/test-intl/footnote.txt
+++ b/tests/roots/test-intl/footnote.txt
@@ -4,9 +4,10 @@ i18n with Footnote
 ==================
 .. #955 cant-build-html-with-footnotes-when-using
 
-[100]_ Contents [#]_ for `i18n with Footnote`_ [ref]_ [#named]_.
+[100]_ Contents [#]_ for `i18n with Footnote`_ [ref]_ [#named]_ [*]_.
 
 .. [#] This is a auto numbered footnote.
 .. [ref] This is a named footnote.
 .. [100] This is a numbered footnote.
 .. [#named] This is a auto numbered named footnote.
+.. [*] This is a auto symbol footnote.

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -791,7 +791,7 @@ def test_xml_footnotes(app, warning):
     assert_elem(
         para0[0],
         ['I18N WITH FOOTNOTE', 'INCLUDE THIS CONTENTS',
-         '2', '[ref]', '1', '100', '.'],
+         '2', '[ref]', '1', '100', '*', '.'],
         ['i18n-with-footnote', 'ref'])
 
     footnote0 = secs[0].findall('footnote')
@@ -810,6 +810,11 @@ def test_xml_footnotes(app, warning):
         ['2', 'THIS IS A AUTO NUMBERED NAMED FOOTNOTE.'],
         None,
         ['named'])
+    assert_elem(
+        footnote0[3],
+        ['*', 'THIS IS A AUTO SYMBOL FOOTNOTE.'],
+        None,
+        None)
 
     citation0 = secs[0].findall('citation')
     assert_elem(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #3329 
