### PR TITLE
Fix #5176

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,7 @@ Bugs fixed
   sorting
 * #5139: autodoc: Enum argument missing if it shares value with another
 * #4946: py domain: rtype field could not handle "None" as a type
+* #5176: LaTeX: indexing of terms containing ``@``, ``!``, or ``"`` fails
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1955,6 +1955,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             value = self.encode(value)
             value = value.replace(r'\{', r'{\sphinxleftcurlybrace}')
             value = value.replace(r'\}', r'{\sphinxrightcurlybrace}')
+            value = value.replace('@', '"@')
             return value
 
         if not node.get('inline', True):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1956,6 +1956,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             value = value.replace(r'\{', r'{\sphinxleftcurlybrace}')
             value = value.replace(r'\}', r'{\sphinxrightcurlybrace}')
             value = value.replace('@', '"@')
+            value = value.replace('!', '"!')
             return value
 
         if not node.get('inline', True):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1955,6 +1955,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             value = self.encode(value)
             value = value.replace(r'\{', r'{\sphinxleftcurlybrace}')
             value = value.replace(r'\}', r'{\sphinxrightcurlybrace}')
+            value = value.replace('"', '""')
             value = value.replace('@', '"@')
             value = value.replace('!', '"!')
             return value


### PR DESCRIPTION
fix: in LaTeX, characters ``@``, ``!`` and ``"`` needs so-called "quoting". Works both with makeindex and xindy. The ``|`` is anyhow already TeX-escaped.

Documentation is found in chapter on makeindex in LaTeX companion.

