### PR TITLE
LaTeX: for French and xelatex, use babel not polyglossia (fix: #4272, #5130)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #5091: latex: curly braces in index entries are not handled correctly
 * #5070: epub: Wrong internal href fragment links
 * #5104: apidoc: Interface of ``sphinx.apidoc:main()`` has changed
+* #4272: PDF builds of French projects have issues with XeTeX
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -453,6 +453,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # sort out some elements
         self.elements = DEFAULT_SETTINGS.copy()
         self.elements.update(ADDITIONAL_SETTINGS.get(builder.config.latex_engine, {}))
+        # for xelatex+French, don't use polyglossia
+        if self.elements['latex_engine'] == 'xelatex':
+            if builder.config.language:
+                if builder.config.language[:2] == 'fr':
+                    self.elements.update({
+                        'polyglossia': '',
+                        'babel':       '\\usepackage{babel}',
+                    })
         # allow the user to override them all
         self.check_latex_elements()
         self.elements.update(builder.config.latex_elements)


### PR DESCRIPTION
Unfortunately, xelatex currently has problems with polyglossia+French. Nowadays, LateX/babel+French is more actively maintained than polyglossia+French.

Some aspects were raised as #4272, and more recently at #5130, it showed as failure to build the PDF Docs for CPython in French translation.

This PR would solve #5130, although only with also #5134, for 1.8 release, for correct indices of terms containing French characters like ``é``, will #5130 be completely solved.

