### PR TITLE
Fix #5158: autosummary: module summary has been broken when it starts with heading

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ Bugs fixed
 * #5167: autodoc: Fix formatting type annotations for tuples with more than two
   arguments
 * #3329: i18n: crashed by auto-symbol footnote references
+* #5158: autosummary: module summary has been broken when it starts with heading
 
 Testing
 --------

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -85,6 +85,11 @@ def test_extract_summary(capsys):
     doc = ['blah blah::']
     assert extract_summary(doc, document) == 'blah blah.'
 
+    # heading
+    doc = ['blah blah',
+           '=========']
+    assert extract_summary(doc, document) == 'blah blah'
+
     _, err = capsys.readouterr()
     assert err == ''
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5158 
