### PR TITLE
Fix #5198: document not in toctree warning when including files only for parallel builds

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #5198: document not in toctree warning when including files only for parallel
+  builds
+
 Testing
 --------
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -310,6 +310,7 @@ class BuildEnvironment(object):
         if docname in self.all_docs:
             self.all_docs.pop(docname, None)
             self.reread_always.discard(docname)
+            self.included.discard(docname)
 
             for version, changes in self.versionchanges.items():
                 new = [change for change in changes if change[1] != docname]
@@ -330,6 +331,8 @@ class BuildEnvironment(object):
             self.all_docs[docname] = other.all_docs[docname]
             if docname in other.reread_always:
                 self.reread_always.add(docname)
+            if docname in other.included:
+                self.included.add(docname)
 
         for version, changes in other.versionchanges.items():
             self.versionchanges.setdefault(version, []).extend(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5198 
