### PR TITLE
Fix classic theme: collapsiblesidebar is always enabled

### DIFF
--- a/sphinx/themes/classic/layout.html
+++ b/sphinx/themes/classic/layout.html
@@ -9,9 +9,9 @@
 #}
 {%- extends "basic/layout.html" %}
 
-{% if theme_collapsiblesidebar|tobool %}
 {%- block scripts %}
     {{ super() }}
+    {% if theme_collapsiblesidebar|tobool %}
     <script type="text/javascript" src="{{ pathto('_static/sidebar.js', 1) }}"></script>
+    {% endif %}
 {%- endblock %}
-{% endif %}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix `collapsiblesidebar` option is always enabled.
- This is only happened in master branch.
