### PR TITLE
Fix #344: autosummary does not understand docstring of module level attributes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -174,6 +174,7 @@ Bugs fixed
 * #5132: (lualatex) PDF build fails if indexed word starts with Unicode character
 * #5133: latex: index headings "Symbols" and "Numbers" not internationalized
 * #5114: sphinx-build: Handle errors on scanning documents
+* #344: autosummary does not understand docstring of module level attributes
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1265,6 +1265,11 @@ class DataDocumenter(ModuleLevelDocumenter):
         # type: (bool) -> None
         pass
 
+    def get_real_modname(self):
+        # type: () -> str
+        return self.get_attr(self.parent or self.object, '__module__', None) \
+            or self.modname
+
 
 class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: ignore
     """


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #344
