### PR TITLE
Capitalization: "Table Of Contents" -> "Table of Contents".

### DIFF
--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -43,7 +43,7 @@
         </div>
         <div class="sidebar">
           {%- block sidebartoc %}
-          <h3>{{ _('Table Of Contents') }}</h3>
+          <h3>{{ _('Table of Contents') }}</h3>
           {{ toctree() }}
           {%- endblock %}
           {%- block sidebarsearch %}

--- a/sphinx/themes/basic/globaltoc.html
+++ b/sphinx/themes/basic/globaltoc.html
@@ -7,5 +7,5 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-<h3><a href="{{ pathto(master_doc) }}">{{ _('Table Of Contents') }}</a></h3>
+<h3><a href="{{ pathto(master_doc) }}">{{ _('Table of Contents') }}</a></h3>
 {{ toctree() }}

--- a/sphinx/themes/basic/localtoc.html
+++ b/sphinx/themes/basic/localtoc.html
@@ -8,6 +8,6 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if display_toc %}
-  <h3><a href="{{ pathto(master_doc) }}">{{ _('Table Of Contents') }}</a></h3>
+  <h3><a href="{{ pathto(master_doc) }}">{{ _('Table of Contents') }}</a></h3>
   {{ toc }}
 {%- endif %}

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -54,7 +54,7 @@
       <div class="content">
         {#{%- if display_toc %}
         <div id="toc">
-          <h3>{{ _('Table Of Contents') }}</h3>
+          <h3>{{ _('Table of Contents') }}</h3>
           {{ toc }}
         </div>
         {%- endif %}#}

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -38,7 +38,7 @@
       <div id="contentwrapper">
         {%- if display_toc %}
         <div id="toc" role="navigation" aria-label="table of contents navigation">
-          <h3>{{ _('Table Of Contents') }}</h3>
+          <h3>{{ _('Table of Contents') }}</h3>
           {{ toc }}
         </div>
         {%- endif %}

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -124,7 +124,7 @@ def test_theme_sidebars(app, status, warning):
 
     # test-theme specifies globaltoc and searchbox as default sidebars
     result = (app.outdir / 'index.html').text(encoding='utf8')
-    assert '<h3><a href="#">Table Of Contents</a></h3>' in result
+    assert '<h3><a href="#">Table of Contents</a></h3>' in result
     assert '<h3>Related Topics</h3>' not in result
     assert '<h3>This Page</h3>' not in result
     assert '<h3>Quick search</h3>' in result


### PR DESCRIPTION
Subject: Capitalization: "Table Of Contents" -> "Table of Contents".

### Feature or Bugfix
- Bugfix

### Purpose
This is consistent with "Complete Table of Contents" (which is already
in the database), as well as e.g. "Indices and Tables" where "and" is
not capitalized.

This is also fairly standard title-case practice.

### Detail
Ran `sed -i 's/Table Of Contents/Table of Contents/' $(git ls-files)`.

### Relates
N/A