### PR TITLE
Allow setting audodoc default options in conf

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -341,7 +341,8 @@ There are also new config values that you can set:
    This value is a list of autodoc directive flags that should be automatically
    applied to all autodoc directives.  The supported flags are ``'members'``,
    ``'undoc-members'``, ``'private-members'``, ``'special-members'``,
-   ``'inherited-members'``, ``'show-inheritance'`` and ``'ignore-module-all'``.
+   ``'inherited-members'``, ``'show-inheritance'``, ``'ignore-module-all'``
+   and ``'exclude-members'``.
 
    If you set one of these flags in this config value, you can use a negated
    form, :samp:`'no-{flag}'`, in an autodoc directive, to disable it once.
@@ -361,6 +362,7 @@ There are also new config values that you can set:
         'member-order': 'bysource',
         'special-members': '__init__',
         'undoc-members': None,
+        'exclude-members': '__weakref__'
     }
 
     Setting ``None`` is equivalent to giving the option name in the list format

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -353,7 +353,24 @@ There are also new config values that you can set:
 
    the directive will be interpreted as if only ``:members:`` was given.
 
+   You can also set `autodoc_default_flags` to a dictionary, mapping option
+   names to the values which can used in .rst files. For example::
+
+     autodoc_default_flags = {
+        'members': 'var1, var2',
+        'member-order': 'bysource',
+        'special-members': '__init__',
+        'undoc-members': None,
+    }
+
+    Setting ``None`` is equivalent to giving the option name in the list format
+    (i.e. it means "yes/true/on").
+
    .. versionadded:: 1.0
+
+   .. versionchanged:: 1.8
+
+      Specifying in dictionary format added.
 
 .. confval:: autodoc_docstring_signature
 

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -68,7 +68,7 @@ def process_documenter_options(documenter, config, options):
         else:
             negated = options.pop('no-' + name, True) is None
             if name in config.autodoc_default_flags and not negated:
-                options[name] = None
+                options[name] = config.autodoc_default_flags[name]
 
     return Options(assemble_option_dict(options.items(), documenter.option_spec))
 

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # common option names for autodoc directives
 AUTODOC_DEFAULT_OPTIONS = ['members', 'undoc-members', 'inherited-members',
                            'show-inheritance', 'private-members', 'special-members',
-                           'ignore-module-all']
+                           'ignore-module-all', 'exclude-members']
 
 
 class DummyOptionSpec(object):

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -234,3 +234,18 @@ class EnumCls(enum.Enum):
     val3 = 34
     """doc for val3"""
     val4 = 34
+
+
+class CustomIter(object):
+    def __init__(self):
+        """Create a new `CustomIter`."""
+        self.values = range(10)
+
+    def __iter__(self):
+        """Iterate squares of each value."""
+        for i in self.values:
+            yield i ** 2
+
+    def snafucate(self):
+        """Makes this snafucated."""
+        print("snafucated")

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -11,6 +11,7 @@
 """
 
 import re
+import platform
 import sys
 from warnings import catch_warnings
 
@@ -19,7 +20,8 @@ from docutils.statemachine import ViewList
 from six import PY3
 
 from sphinx.ext.autodoc import (
-    AutoDirective, ModuleLevelDocumenter, cut_lines, between, ALL
+    AutoDirective, ModuleLevelDocumenter, cut_lines, between, ALL,
+    convert_autodoc_default_flags
 )
 from sphinx.ext.autodoc.directive import DocumenterBridge, process_documenter_options
 from sphinx.testing.util import SphinxTestApp, Struct  # NOQA
@@ -32,6 +34,8 @@ if PY3:
     ROGER_METHOD = '   .. py:classmethod:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)'
 else:
     ROGER_METHOD = '   .. py:classmethod:: Class.roger(a, e=5, f=6)'
+
+IS_PYPY = platform.python_implementation() == 'PyPy'
 
 
 def do_autodoc(app, objtype, name, options=None):
@@ -1414,21 +1418,94 @@ def test_partialmethod(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_default_flags(app):
+def test_autodoc_default_flags__as_list__converted(app):
+    orig = [
+        'members',
+        'undoc-members',
+        ('skipped', 1, 2),
+        {'also': 'skipped'},
+    ]
+    expected = {
+        'members': None,
+        'undoc-members': None,
+    }
+    app.config.autodoc_default_flags = orig
+    convert_autodoc_default_flags(app, app.config)
+    assert app.config.autodoc_default_flags == expected
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_default_flags__as_dict__no_conversion(app):
+    orig = {
+        'members': 'this,that,other',
+        'undoc-members': None,
+    }
+    app.config.autodoc_default_flags = orig
+    convert_autodoc_default_flags(app, app.config)
+    assert app.config.autodoc_default_flags == orig
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_default_flags__with_flags(app):
     # no settings
     actual = do_autodoc(app, 'class', 'target.EnumCls')
     assert '   .. py:attribute:: EnumCls.val1' not in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
+    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    assert '   .. py:method:: target.CustomIter' not in actual
 
     # with :members:
-    app.config.autodoc_default_flags = ['members']
+    app.config.autodoc_default_flags = {'members': None}
     actual = do_autodoc(app, 'class', 'target.EnumCls')
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
 
     # with :members: and :undoc-members:
-    app.config.autodoc_default_flags = ['members',
-                                        'undoc-members']
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'undoc-members': None,
+    }
     actual = do_autodoc(app, 'class', 'target.EnumCls')
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val4' in actual
+
+    # with :special-members:
+    # Note that :members: must be *on* for :special-members: to work.
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'special-members': None
+    }
+    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    assert '   .. py:method:: CustomIter.__init__()' in actual
+    assert '      Create a new `CustomIter`.' in actual
+    assert '   .. py:method:: CustomIter.__iter__()' in actual
+    assert '      Iterate squares of each value.' in actual
+    if not IS_PYPY:
+        assert '   .. py:attribute:: CustomIter.__weakref__' in actual
+        assert '      list of weak references to the object (if defined)' in actual
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_default_flags__with_values(app):
+    # with :members:
+    app.config.autodoc_default_flags = {'members': 'val1,val2'}
+    actual = do_autodoc(app, 'class', 'target.EnumCls')
+    assert '   .. py:attribute:: EnumCls.val1' in actual
+    assert '   .. py:attribute:: EnumCls.val2' in actual
+    assert '   .. py:attribute:: EnumCls.val3' not in actual
+    assert '   .. py:attribute:: EnumCls.val4' not in actual
+
+    # with :special-members:
+    # Note that :members: must be *on* for :special-members: to work.
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'special-members': '__init__,__iter__',
+    }
+    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    assert '   .. py:method:: CustomIter.__init__()' in actual
+    assert '      Create a new `CustomIter`.' in actual
+    assert '   .. py:method:: CustomIter.__iter__()' in actual
+    assert '      Iterate squares of each value.' in actual
+    if not IS_PYPY:
+        assert '   .. py:attribute:: CustomIter.__weakref__' not in actual
+        assert '      list of weak references to the object (if defined)' not in actual

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -34,7 +34,9 @@ else:
     ROGER_METHOD = '   .. py:classmethod:: Class.roger(a, e=5, f=6)'
 
 
-def do_autodoc(app, objtype, name, options={}):
+def do_autodoc(app, objtype, name, options=None):
+    if options is None:
+        options = {}
     doccls = app.registry.documenters[objtype]
     docoptions = process_documenter_options(doccls, app.config, options)
     bridge = DocumenterBridge(app.env, LoggingReporter(''), docoptions, 1)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1484,6 +1484,32 @@ def test_autodoc_default_flags__with_flags(app):
         assert '   .. py:attribute:: CustomIter.__weakref__' in actual
         assert '      list of weak references to the object (if defined)' in actual
 
+    # :exclude-members: None - has no effect. Unlike :members:,
+    # :special-members:, etc. where None == "include all", here None means
+    # "no/false/off".
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'exclude-members': None,
+    }
+    actual = do_autodoc(app, 'class', 'target.EnumCls')
+    assert '   .. py:attribute:: EnumCls.val1' in actual
+    assert '   .. py:attribute:: EnumCls.val4' not in actual
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'special-members': None,
+        'exclude-members': None,
+    }
+    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    assert '   .. py:method:: CustomIter.__init__()' in actual
+    assert '      Create a new `CustomIter`.' in actual
+    assert '   .. py:method:: CustomIter.__iter__()' in actual
+    assert '      Iterate squares of each value.' in actual
+    if not IS_PYPY:
+        assert '   .. py:attribute:: CustomIter.__weakref__' in actual
+        assert '      list of weak references to the object (if defined)' in actual
+    assert '   .. py:method:: CustomIter.snafucate()' in actual
+    assert '      Makes this snafucated.' in actual
+
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_flags__with_values(app):
@@ -1509,3 +1535,29 @@ def test_autodoc_default_flags__with_values(app):
     if not IS_PYPY:
         assert '   .. py:attribute:: CustomIter.__weakref__' not in actual
         assert '      list of weak references to the object (if defined)' not in actual
+
+    # with :exclude-members:
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'exclude-members': 'val1'
+    }
+    actual = do_autodoc(app, 'class', 'target.EnumCls')
+    assert '   .. py:attribute:: EnumCls.val1' not in actual
+    assert '   .. py:attribute:: EnumCls.val2' in actual
+    assert '   .. py:attribute:: EnumCls.val3' in actual
+    assert '   .. py:attribute:: EnumCls.val4' not in actual
+    app.config.autodoc_default_flags = {
+        'members': None,
+        'special-members': None,
+        'exclude-members': '__weakref__,snafucate',
+    }
+    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    assert '   .. py:method:: CustomIter.__init__()' in actual
+    assert '      Create a new `CustomIter`.' in actual
+    assert '   .. py:method:: CustomIter.__iter__()' in actual
+    assert '      Iterate squares of each value.' in actual
+    if not IS_PYPY:
+        assert '   .. py:attribute:: CustomIter.__weakref__' not in actual
+        assert '      list of weak references to the object (if defined)' not in actual
+    assert '   .. py:method:: CustomIter.snafucate()' not in actual
+    assert '      Makes this snafucated.' not in actual


### PR DESCRIPTION
Subject: Set global default values for directives in config

### Feature or Bugfix
- Feature

### Purpose
- In RST files, you can set, for example: `:special-members: __init__, __iter__`. In config, you can set this flag, but only to include *all* special members, by including it in a list `autodoc_default_flags`. This PR make it so you can set the same values in global config as you can individually in RST files.

### Detail
- I wanted to write a test for this but I couldn't get the existing setup in `test_autodoc` to work for me, because `autodoc.directives.process_documenter_options` wants a `options` object which in the unit tests is mocked to a `Struct`, which doesn't work with `process_documenter_options`.
- I have managed to use this code to produce the docs for my own project, and it worked as expected using
```python
autodoc_default_values = {
    'members': None,
    'undoc-members': None,
    'special-members': None,
    'show-inheritance': None,
    'member-order': 'bysource',
    'exclude-members': '__dict__,__weakref__,__module__',
}
```
in conf.py

### Relates
- Issue: https://github.com/sphinx-doc/sphinx/issues/4075 (see final comment)
- Overlaps/replaces https://github.com/sphinx-doc/sphinx/pull/4076