### PR TITLE
Deprecate whole of sphinx.ext.mathbase

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -107,6 +107,7 @@ Deprecated
 * ``sphinx.writers.html5.HTMLTranslator.highlightlang_base`` is deprecated
 * ``sphinx.writers.html5.HTMLTranslator.highlightlangopts`` is deprecated
 * ``sphinx.writers.html5.HTMLTranslator.highlightlinenothreshold`` is deprecated
+* ``sphinx.ext.mathbase`` extension is deprecated
 * ``sphinx.ext.mathbase.math`` node is deprecated
 * ``sphinx.ext.mathbase.displaymath`` node is deprecated
 * ``sphinx.ext.mathbase.eqref`` node is deprecated
@@ -114,6 +115,8 @@ Deprecated
 * ``sphinx.ext.mathbase.MathDomain`` is deprecated
 * ``sphinx.ext.mathbase.setup_math()`` is deprecated
 * ``sphinx.highlighting.PygmentsBridge.unhighlight()`` is deprecated
+* ``sphinx.ext.mathbase.get_node_equation_number()`` is deprecated
+* ``sphinx.ext.mathbase.wrap_displaymath()`` is deprecated
 * The ``trim_doctest_flags`` argument of ``sphinx.highlighting.PygmentsBridge``
   is deprecated
 

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -142,6 +142,11 @@ The following is a list of deprecated interface.
      - 3.0
      - N/A
 
+   * - ``sphinx.ext.mathbase``
+     - 1.8
+     - 3.0
+     - N/A
+
    * - ``sphinx.ext.mathbase.MathDomain``
      - 1.8
      - 3.0
@@ -156,6 +161,16 @@ The following is a list of deprecated interface.
      - 1.8
      - 3.0
      - N/A
+
+   * - ``sphinx.ext.mathbase.get_node_equation_number()``
+     - 1.8
+     - 3.0
+     - ``sphinx.util.math.get_node_equation_number()``
+
+   * - ``sphinx.ext.mathbase.wrap_displaymath()``
+     - 1.8
+     - 3.0
+     - ``sphinx.util.math.wrap_displaymath()``
 
    * - ``sphinx.ext.mathbase.math`` (node)
      - 1.8

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -23,10 +23,9 @@ from six import text_type
 
 import sphinx
 from sphinx.errors import SphinxError
-from sphinx.ext.mathbase import get_node_equation_number
-from sphinx.ext.mathbase import wrap_displaymath
 from sphinx.locale import _, __
 from sphinx.util import logging
+from sphinx.util.math import get_node_equation_number, wrap_displaymath
 from sphinx.util.osutil import ensuredir, ENOENT, cd
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.pycompat import sys_encoding
@@ -34,10 +33,10 @@ from sphinx.util.pycompat import sys_encoding
 if False:
     # For type annotation
     from typing import Any, Dict, List, Tuple  # NOQA
+    from sphinx.addnodes import displaymath  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.config import Config  # NOQA
-    from sphinx.ext.mathbase import displaymath  # NOQA
 
 logger = logging.getLogger(__name__)
 
@@ -315,7 +314,7 @@ def html_visit_math(self, node):
 
 
 def html_visit_displaymath(self, node):
-    # type: (nodes.NodeVisitor, displaymath) -> None
+    # type: (nodes.NodeVisitor, nodes.math_block) -> None
     if node['nowrap']:
         latex = node.astext()
     else:

--- a/sphinx/ext/jsmath.py
+++ b/sphinx/ext/jsmath.py
@@ -14,8 +14,8 @@ from docutils import nodes
 
 import sphinx
 from sphinx.errors import ExtensionError
-from sphinx.ext.mathbase import get_node_equation_number
 from sphinx.locale import _
+from sphinx.util.math import get_node_equation_number
 
 if False:
     # For type annotation

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -28,57 +28,20 @@ if False:
 
 def get_node_equation_number(writer, node):
     # type: (Writer, nodes.Node) -> unicode
-    if writer.builder.config.math_numfig and writer.builder.config.numfig:
-        figtype = 'displaymath'
-        if writer.builder.name == 'singlehtml':
-            key = u"%s/%s" % (writer.docnames[-1], figtype)
-        else:
-            key = figtype
-
-        id = node['ids'][0]
-        number = writer.builder.fignumbers.get(key, {}).get(id, ())
-        number = '.'.join(map(str, number))
-    else:
-        number = node['number']
-
-    return number
+    warnings.warn('sphinx.ext.mathbase.get_node_equation_number() is moved to '
+                  'sphinx.util.math package.',
+                  RemovedInSphinx30Warning)
+    from sphinx.util.math import get_node_equation_number
+    return get_node_equation_number(writer, node)
 
 
 def wrap_displaymath(text, label, numbering):
     # type: (unicode, unicode, bool) -> unicode
-    def is_equation(part):
-        # type: (unicode) -> unicode
-        return part.strip()
-
-    if label is None:
-        labeldef = ''
-    else:
-        labeldef = r'\label{%s}' % label
-        numbering = True
-
-    parts = list(filter(is_equation, text.split('\n\n')))
-    equations = []
-    if len(parts) == 0:
-        return ''
-    elif len(parts) == 1:
-        if numbering:
-            begin = r'\begin{equation}' + labeldef
-            end = r'\end{equation}'
-        else:
-            begin = r'\begin{equation*}' + labeldef
-            end = r'\end{equation*}'
-        equations.append('\\begin{split}%s\\end{split}\n' % parts[0])
-    else:
-        if numbering:
-            begin = r'\begin{align}%s\!\begin{aligned}' % labeldef
-            end = r'\end{aligned}\end{align}'
-        else:
-            begin = r'\begin{align*}%s\!\begin{aligned}' % labeldef
-            end = r'\end{aligned}\end{align*}'
-        for part in parts:
-            equations.append('%s\\\\\n' % part.strip())
-
-    return '%s\n%s%s' % (begin, ''.join(equations), end)
+    warnings.warn('sphinx.ext.mathbase.wrap_displaymath() is moved to '
+                  'sphinx.util.math package.',
+                  RemovedInSphinx30Warning)
+    from sphinx.util.math import wrap_displaymath
+    return wrap_displaymath(text, label, numbering)
 
 
 def is_in_section_title(node):

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -15,8 +15,8 @@ from docutils import nodes
 
 import sphinx
 from sphinx.errors import ExtensionError
-from sphinx.ext.mathbase import get_node_equation_number
 from sphinx.locale import _
+from sphinx.util.math import get_node_equation_number
 
 if False:
     # For type annotation

--- a/sphinx/util/math.py
+++ b/sphinx/util/math.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.util.math
+    ~~~~~~~~~~~~~~~~
+
+    Utility functions for math.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+
+if False:
+    # For type annotation
+    from docutils import nodes  # NOQA
+    from docutils.writers.html4css1 import Writer  # NOQA
+
+
+def get_node_equation_number(writer, node):
+    # type: (Writer, nodes.Node) -> unicode
+    if writer.builder.config.math_numfig and writer.builder.config.numfig:
+        figtype = 'displaymath'
+        if writer.builder.name == 'singlehtml':
+            key = u"%s/%s" % (writer.docnames[-1], figtype)
+        else:
+            key = figtype
+
+        id = node['ids'][0]
+        number = writer.builder.fignumbers.get(key, {}).get(id, ())
+        number = '.'.join(map(str, number))
+    else:
+        number = node['number']
+
+    return number
+
+
+def wrap_displaymath(text, label, numbering):
+    # type: (unicode, unicode, bool) -> unicode
+    def is_equation(part):
+        # type: (unicode) -> unicode
+        return part.strip()
+
+    if label is None:
+        labeldef = ''
+    else:
+        labeldef = r'\label{%s}' % label
+        numbering = True
+
+    parts = list(filter(is_equation, text.split('\n\n')))
+    equations = []
+    if len(parts) == 0:
+        return ''
+    elif len(parts) == 1:
+        if numbering:
+            begin = r'\begin{equation}' + labeldef
+            end = r'\end{equation}'
+        else:
+            begin = r'\begin{equation*}' + labeldef
+            end = r'\end{equation*}'
+        equations.append('\\begin{split}%s\\end{split}\n' % parts[0])
+    else:
+        if numbering:
+            begin = r'\begin{align}%s\!\begin{aligned}' % labeldef
+            end = r'\end{aligned}\end{align}'
+        else:
+            begin = r'\begin{align*}%s\!\begin{aligned}' % labeldef
+            end = r'\end{aligned}\end{align*}'
+        for part in parts:
+            equations.append('%s\\\\\n' % part.strip())
+
+    return '%s\n%s%s' % (begin, ''.join(equations), end)

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -8,6 +8,7 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import absolute_import
 
 import os
 import time

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2544,11 +2544,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 self.body.append(r'\label{%s}' % label)
             self.body.append(node.astext())
         else:
-            def is_equation(part):
-                # type: (unicode) -> unicode
-                return part.strip()
-
-            from sphinx.ext.mathbase import wrap_displaymath
+            from sphinx.util.math import wrap_displaymath
             self.body.append(wrap_displaymath(node.astext(), label,
                                               self.builder.config.math_number_all))
         raise nodes.SkipNode


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- mathbase module is no longer needed.
