### PR TITLE
Fix #5213: i18n: sphinx-build crashes if node having tupled-attributed

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -56,7 +56,10 @@ def repr_domxml(node, length=80):
        returns full of DOM XML representation.
     :return: DOM XML representation
     """
-    text = node.asdom().toxml()
+    try:
+        text = node.asdom().toxml()
+    except Exception:
+        text = text_type(node)
     if length and len(text) > length:
         text = text[:length] + '...'
     return text


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5213 
