### PR TITLE
Move make mode to sphinx.cmd

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,7 @@ Deprecated
   based directives.
 * ``sphinx.util.docutils.directive_helper()`` is deprecated
 * ``sphinx.cmdline`` is deprecated
+* ``sphinx.make_mode`` is deprecated
 * ``sphinx.locale.l_()`` is deprecated
 * #2157: helper function ``warn()`` for HTML themes is deprecated
 * ``app.override_domain()`` is deprecated

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -410,6 +410,11 @@ The following is a list of deprecated interface.
      - 3.0
      - ``sphinx.cmd.build``
 
+   * - ``sphinx.make_mode``
+     - 1.8
+     - 3.0
+     - ``sphinx.cmd.make_mode``
+
    * - ``sphinx.locale.l_()``
      - 1.8
      - 3.0

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -200,7 +200,7 @@ files can be built by specifying individual filenames.
 def make_main(argv=sys.argv[1:]):  # type: ignore
     # type: (List[unicode]) -> int
     """Sphinx build "make mode" entry."""
-    from sphinx import make_mode
+    from sphinx.cmd import make_mode
     return make_mode.run_make_mode(argv[1:])
 
 

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    sphinx.make_mode
-    ~~~~~~~~~~~~~~~~
+    sphinx.cmd.make_mode
+    ~~~~~~~~~~~~~~~~~~~~
 
     sphinx-build -M command-line handling.
 

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.make_mode
+    ~~~~~~~~~~~~~~~~
+
+    sphinx-build -M command-line handling.
+
+    This replaces the old, platform-dependent and once-generated content
+    of Makefile / make.bat.
+
+    This is in its own module so that importing it is fast.  It should not
+    import the main Sphinx modules (like sphinx.applications, sphinx.builders).
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import warnings
+
+from sphinx.cmd import make_mode
+from sphinx.deprecation import RemovedInSphinx30Warning
+
+
+BUILDERS = make_mode.BUILDERS
+
+
+class Make(make_mode.Make):
+    def __init__(self, *args):
+        warnings.warn('sphinx.make_mode.Make is deprecated. '
+                      'Please use sphinx.cmd.make_mode.Make instead.',
+                      RemovedInSphinx30Warning)
+        super(Make, self).__init__(*args)
+
+
+def run_make_mode(args):
+    warnings.warn('sphinx.make_mode.run_make_mode() is deprecated. '
+                  'Please use sphinx.cmd.make_mode.run_make_mode() instead.',
+                  RemovedInSphinx30Warning)
+    return make_mode.run_make_mode(args)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since 1.7, we've started to use `sphinx.cmd` package for CLI implementations. So `sphinx.make_mode` should be moved into the package.
