### PR TITLE
Check latex_elements at config-inited event

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -96,6 +96,7 @@ Deprecated
 * ``sphinx.writers.latex.LaTeXTranslator.unrestrict_footnote()`` is deprecated
 * ``sphinx.writers.latex.LaTeXTranslator.push_hyperlink_ids()`` is deprecated
 * ``sphinx.writers.latex.LaTeXTranslator.pop_hyperlink_ids()`` is deprecated
+* ``sphinx.writers.latex.LaTeXTranslator.check_latex_elements()`` is deprecated
 * ``sphinx.writers.latex.LaTeXTranslator.bibitems`` is deprecated
 * ``sphinx.writers.latex.LaTeXTranslator.hlsettingstack`` is deprecated
 * ``sphinx.writers.latex.ExtBabel.get_shorthandoff()`` is deprecated

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -282,6 +282,11 @@ The following is a list of deprecated interface.
      - 3.0
      - N/A
 
+   * - ``sphinx.writers.latex.LaTeXTranslator.check_latex_elements()``
+     - 1.8
+     - 3.0
+     - Nothing
+
    * - ``sphinx.application.CONFIG_FILENAME``
      - 1.8
      - 3.0

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -34,7 +34,7 @@ from sphinx.util.docutils import SphinxFileOutput, new_document
 from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import SEP, make_filename
-from sphinx.writers.latex import LaTeXWriter, LaTeXTranslator
+from sphinx.writers.latex import DEFAULT_SETTINGS, LaTeXWriter, LaTeXTranslator
 
 if False:
     # For type annotation
@@ -372,6 +372,12 @@ def validate_config_values(app, config):
                 __('Invalid latex_documents.author found (might contain non-ASCII chars. '
                    'Please use u"..." notation instead): %r') % (document,)
             )
+
+    for key in list(config.latex_elements):
+        if key not in DEFAULT_SETTINGS:
+            msg = __("Unknown configure key: latex_elements[%r]. ignored.")
+            logger.warning(msg % key)
+            config.latex_elements.pop(key)
 
 
 def default_latex_engine(config):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -494,7 +494,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
                         'babel':       '\\usepackage{babel}',
                     })
         # allow the user to override them all
-        self.check_latex_elements()
         self.elements.update(builder.config.latex_elements)
 
         # but some have other interface in config file
@@ -718,13 +717,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         body = self.body
         self.body = self.bodystack.pop()
         return body
-
-    def check_latex_elements(self):
-        # type: () -> None
-        for key in self.builder.config.latex_elements:
-            if key not in self.elements:
-                msg = __("Unknown configure key: latex_elements[%r] is ignored.")
-                logger.warning(msg % key)
 
     def restrict_footnote(self, node):
         # type: (nodes.Node) -> None
@@ -2624,6 +2616,16 @@ class LaTeXTranslator(nodes.NodeVisitor):
         warnings.warn('LaTeXTranslator.hlsettingstack is deprecated.',
                       RemovedInSphinx30Warning)
         return [[self.builder.config.highlight_language, sys.maxsize]]
+
+    def check_latex_elements(self):
+        # type: () -> None
+        warnings.warn('check_latex_elements() is deprecated.',
+                      RemovedInSphinx30Warning)
+
+        for key in self.builder.config.latex_elements:
+            if key not in self.elements:
+                msg = __("Unknown configure key: latex_elements[%r] is ignored.")
+                logger.warning(msg % key)
 
 
 # Import old modules here for compatibility

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ from sphinx.testing.path import path
 @pytest.mark.sphinx(testroot='config', confoverrides={
     'master_doc': 'master',
     'nonexisting_value': 'True',
-    'latex_elements.docclass': 'scrartcl',
+    'latex_elements.maketitle': 'blah blah blah',
     'modindex_common_prefix': 'path1,path2'})
 def test_core_config(app, status, warning):
     cfg = app.config
@@ -34,7 +34,7 @@ def test_core_config(app, status, warning):
 
     # overrides
     assert cfg.master_doc == 'master'
-    assert cfg.latex_elements['docclass'] == 'scrartcl'
+    assert cfg.latex_elements['maketitle'] == 'blah blah blah'
     assert cfg.modindex_common_prefix == ['path1', 'path2']
 
     # simple default values


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To make LaTeX writer simple, move `check_latex_elements()` to config-inited handler.
