### PR TITLE
LaTeX: fix usage of PAPER envvar, which got broken at Sphinx 1.5

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -273,7 +273,16 @@ variables to customize behavior:
 
 .. describe:: PAPER
 
-   The value for '"papersize"` key of :confval:`latex_elements`.
+   This sets the ``'papersize'`` key of :confval:`latex_elements`:
+   i.e. ``PAPER=a4`` sets it to ``'a4paper'`` and ``PAPER=letter`` to
+   ``'letterpaper'``.
+
+   .. note::
+
+      Usage of this environment variable got broken at Sphinx 1.5 as
+      ``a4`` or ``letter`` ended up as option to LaTeX document in
+      place of the needed ``a4paper``, resp. ``letterpaper``.  Fixed at
+      1.7.7.
 
 .. describe:: SPHINXBUILD
 

--- a/sphinx/make_mode.py
+++ b/sphinx/make_mode.py
@@ -143,7 +143,7 @@ class Make(object):
         papersize = os.getenv('PAPER', '')
         opts = self.opts
         if papersize in ('a4', 'letter'):
-            opts.extend(['-D', 'latex_elements.papersize=' + papersize])
+            opts.extend(['-D', 'latex_elements.papersize=' + papersize + 'paper'])
         if doctreedir is None:
             doctreedir = self.builddir_join('doctrees')
 

--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -9,8 +9,8 @@ SOURCEDIR     = {{ rsrcdir }}
 BUILDDIR      = {{ rbuilddir }}
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_elements.papersize=a4
-PAPEROPT_letter = -D latex_elements.papersize=letter
+PAPEROPT_a4     = -D latex_elements.papersize=a4paper
+PAPEROPT_letter = -D latex_elements.papersize=letterpaper
 # $(O) is meant as a shortcut for $(SPHINXOPTS)
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(O) $(SOURCEDIR)
 # the i18n builder cannot share the environment and doctrees with the others

--- a/sphinx/templates/quickstart/make.bat_t
+++ b/sphinx/templates/quickstart/make.bat_t
@@ -12,8 +12,8 @@ set SOURCEDIR={{ rsrcdir }}
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% %SOURCEDIR%
 set I18NSPHINXOPTS=%SPHINXOPTS% %SOURCEDIR%
 if NOT "%PAPER%" == "" (
-	set ALLSPHINXOPTS=-D latex_elements.papersize=%PAPER% %ALLSPHINXOPTS%
-	set I18NSPHINXOPTS=-D latex_elements.papersize=%PAPER% %I18NSPHINXOPTS%
+	set ALLSPHINXOPTS=-D latex_elements.papersize=%PAPER%paper %ALLSPHINXOPTS%
+	set I18NSPHINXOPTS=-D latex_elements.papersize=%PAPER%paper %I18NSPHINXOPTS%
 )
 
 if "%1" == "" goto help


### PR DESCRIPTION
Fix: #5234

@tk0miya I can not test the Windows make.bat, I hope my commit is ok for it.