### PR TITLE
Latex reduce hyperref warnings

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1607,6 +1607,23 @@
 \newcommand*\sphinxstylecodecontinues[1]{\footnotesize(#1)}%
 % figure legend comes after caption and may contain arbitrary body elements
 \newenvironment{sphinxlegend}{\par\small}{\par}
+% reduce hyperref "Token not allowed in a PDF string" warnings on PDF builds
+\AtBeginDocument{\pdfstringdefDisableCommands{%
+% all "protected" macros possibly ending up in section titles should be here
+    \let\sphinxstyleemphasis        \@firstofone
+    \let\sphinxstyleliteralemphasis \@firstofone
+    \let\sphinxstylestrong          \@firstofone
+    \let\sphinxstyleliteralstrong   \@firstofone
+    \let\sphinxstyleabbreviation    \@firstofone
+    \let\sphinxstyleliteralintitle  \@firstofone
+    \let\sphinxupquote  \@firstofone
+    \let\sphinxstrong   \@firstofone
+    \let\sphinxcode     \@firstofone
+    \let\sphinxbfcode   \@firstofone
+    \let\sphinxemail    \@firstofone
+    \let\sphinxcrossref \@firstofone
+    \let\sphinxtermref  \@firstofone
+}}
 
 % For curly braces inside \index macro
 \def\sphinxleftcurlybrace{\{}

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2018/03/11 v1.7.2 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2018/07/18 v1.7.7 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but


### PR DESCRIPTION
Subject: the aim is to reduce some warnings in the latex compilation log, related to creation of PDF bookmarks by hyperref.

I propose this PR for 1.7.7 release, although not really bugfix. but it should not break anything.


