### PR TITLE
LaTeX: avoid "The remreset package is obsolete" warnings in latex log

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -183,7 +183,10 @@
 % control caption around literal-block
 \RequirePackage{capt-of}
 \RequirePackage{needspace}
-\RequirePackage{remreset}% provides \@removefromreset
+% LaTeX 2018-04-01 and later provides \@removefromreset
+\ltx@ifundefined{@removefromreset}
+    {\RequirePackage{remreset}}
+    {}% avoid warning
 % to make pdf with correct encoded bookmarks in Japanese
 % this should precede the hyperref package
 \ifx\kanjiskip\@undefined


### PR DESCRIPTION
With 2018 LaTeX, macro `\@removefromreset` is provided by kernel and loading `remreset` package creates this console output warning:

```
(/usr/local/texlive/2018/texmf-dist/tex/latex/carlisle/remreset.sty

Package remreset Warning: The remreset package is obsolete:
(remreset)                \@removefomresset is defined.

) (./sphinxhighlight.sty)
```

Avoid this warning by loading `remreset` only with older LaTeX.