### PR TITLE
LaTeX: make xindy usage opt-in also for xelatex/lualatex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,10 +4,9 @@ Release 1.8.0 (in development)
 Dependencies
 ------------
 
-* LaTeX: :confval:`latex_use_xindy`, if ``True`` (default for
-  ``xelatex/lualatex``), instructs ``make latexpdf`` to use :program:`xindy`
-  for general index.  Make sure your LaTeX distribution includes it.
-  (refs: #5134)
+* LaTeX: :confval:`latex_use_xindy`, if ``True`` instructs ``make latexpdf``
+  to use :program:`xindy` for general index.  Make sure your LaTeX
+  distribution includes it.  (refs: #5134)
 
 Incompatible changes
 --------------------
@@ -44,10 +43,6 @@ Incompatible changes
   Please use ``app.add_js_file()`` instead.
 * #5072: Save environment object also with only new documents
 * #5035: qthelp builder allows dashes in :confval:`qthelp_namespace`
-* LaTeX: with lualatex or xelatex use by default :program:`xindy` as
-  UTF-8 able replacement of :program:`makeindex` (refs: #5134).  After
-  upgrading Sphinx, please clean latex build repertory of existing project
-  before new build.
 * #5163: html: hlist items are now aligned to top
 * ``highlightlang`` directive is processed on resolving phase
 
@@ -177,8 +172,7 @@ Features added
   ``pdflatex`` runs for index to show up in PDF bookmarks (refs: #3742)
 
   __ https://github.com/rtfd/readthedocs.org/issues/2857
-* Add :confval:`latex_use_xindy` for UTF-8 savvy indexing, defaults to ``True``
-  if :confval:`latex_engine` is ``'xelatex'`` or ``'lualatex'``.
+* Add :confval:`latex_use_xindy` for UTF-8 savvy indexing.
 * #4976: ``SphinxLoggerAdapter.info()`` now supports ``location`` parameter
 * #5122: setuptools: support nitpicky option
 * #2820: autoclass directive supports nested class

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1917,7 +1917,8 @@ macros and environments, see also :doc:`/latex`.
 
 .. confval:: latex_use_xindy
 
-   If ``True``, the PDF build from the LaTeX files created by Sphinx
+   If ``True`` (the default is ``False``),
+   the PDF build from the LaTeX files created by Sphinx
    will use :program:`xindy` (doc__) rather than :program:`makeindex`
    for preparing the index of general terms (from :rst:dir:`index`
    usage).  This means that words with UTF-8 characters will get
@@ -1929,13 +1930,15 @@ macros and environments, see also :doc:`/latex`.
      (Japanese documents; :program:`mendex` replaces :program:`makeindex`
      then).
 
-   - The default is ``True`` for ``'xelatex'`` or ``'lualatex'`` as
-     :program:`makeindex`, if any indexed term starts with a non-ascii
-     character, creates ``.ind`` files containing invalid bytes for
-     UTF-8 encoding. With ``'lualatex'`` this then breaks the PDF
-     build.
+   - With``'xelatex'`` or ``'lualatex'``, :program:`makeindex` creates
+     ``.ind`` files containing invalid bytes for UTF-8 encoding, if any
+     indexed term starts with a non-ascii letter.  With ``'lualatex'``
+     this then breaks the PDF build.  It is thus highly recommended to
+     set the variable to ``True``.  This is not done by default because
+     :program:`xindy` creates empty Index section in PDF if no indexed
+     terms exist.
 
-   - The default is ``False`` for ``'pdflatex'`` but ``True`` is
+   - For ``'pdflatex'``, setting the option to ``True`` is
      recommended for non-English documents as soon as some indexed
      terms use non-ascii characters from the language script.
 
@@ -1943,6 +1946,9 @@ macros and environments, see also :doc:`/latex`.
    for using ``'pdflatex'`` engine with Cyrillic scripts.  And whether with
    ``'pdflatex'`` or Unicode engines, Cyrillic documents handle correctly the
    indexing of Latin names, even with diacritics.
+
+   After setting this option to ``True`` on existing project, issue ``make
+   clean`` inside the LaTeX build repertory before next ``make latex``.
 
    .. versionadded:: 1.8
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -399,12 +399,6 @@ def default_latex_docclass(config):
         return {}
 
 
-def default_latex_use_xindy(config):
-    # type: (Config) -> bool
-    """ Better default latex_use_xindy settings for specific engines. """
-    return config.latex_engine in {'xelatex', 'lualatex'}
-
-
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_builder(LaTeXBuilder)
@@ -422,7 +416,7 @@ def setup(app):
     app.add_config_value('latex_logo', None, None, string_classes)
     app.add_config_value('latex_appendices', [], None)
     app.add_config_value('latex_use_latex_multicolumn', False, None)
-    app.add_config_value('latex_use_xindy', default_latex_use_xindy, None)
+    app.add_config_value('latex_use_xindy', False, None)
     app.add_config_value('latex_toplevel_sectioning', None, None,
                          ENUM(None, 'part', 'chapter', 'section'))
     app.add_config_value('latex_domain_indices', True, None, [list])


### PR DESCRIPTION
This is option to fix #5240.

Either this or #5242 should be merged but *not* both.