### PR TITLE
Let Latexmk check if idx file is empty before xindy call

### DIFF
--- a/sphinx/texinputs/latexmkrc_t
+++ b/sphinx/texinputs/latexmkrc_t
@@ -11,7 +11,7 @@ $pdflatex = 'xelatex ' . $ENV{'LATEXOPTS'} . ' %O %S';
 $lualatex = 'lualatex ' . $ENV{'LATEXOPTS'} . ' %O %S';
 $xelatex = 'xelatex --no-pdf ' . $ENV{'LATEXOPTS'} . ' %O %S';
 {% if xindy_use -%}
-$makeindex = 'xindy ' . $ENV{'XINDYOPTS'} . ' %O -o %D %S';
+$makeindex = '[ ! -s %S ] && : > %D || xindy ' . $ENV{'XINDYOPTS'} . ' %O -o %D %S';
 {% else -%}
 $makeindex = 'makeindex -s python.ist %O -o %D %S';
 {% endif -%}


### PR DESCRIPTION
Fix: #5240

This is alternative to #5241. It works at my locale (MacOS X, bash shell, but I think `-s` is already Bourne shell `sh` syntax). This way, `xindy` remains default for `xelatex/lualatex` contrarily to #5241.

The point is that if FOO.idx file is empty (no `\index` in LaTeX document), then an empty FOO.ind file is created, and `xindy` is not used. This avoids empty Index section at end of PDF.

Either this or #5241 should be merged but *not* both.