### PR TITLE
Enable epub by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,7 @@ Deprecated
 ----------
 
 * :confval:`source_parsers` is deprecated
+* quickstart: ``--epub`` option becomes default, so it is deprecated
 * Drop function based directive support.  For now, Sphinx only supports class
   based directives.
 * ``sphinx.util.docutils.directive_helper()`` is deprecated
@@ -186,6 +187,7 @@ Features added
 * #5140: linkcheck: Add better Accept header to HTTP client
 * #4614: sphinx-build: Add ``--keep-going`` option to show all warnings
 * Add :rst:role:`math:numref` role to refer equations (Same as :rst:role:`eq`)
+* quickstart: epub builder is enabled by default
 
 Bugs fixed
 ----------

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -74,7 +74,6 @@ DEFAULTS = {
     'language': None,
     'suffix': '.rst',
     'master': 'index',
-    'epub': False,
     'makefile': True,
     'batchfile': True,
 }
@@ -246,7 +245,6 @@ def ask_user(d):
     * language:  document language
     * suffix:    source file suffix
     * master:    master document name
-    * epub:      use epub (bool)
     * extensions:  extensions to use (list)
     * makefile:  make Makefile
     * batchfile: make command file
@@ -346,12 +344,6 @@ document is a custom template, you can also set this to another filename.'''))
         print()
         d['master'] = do_prompt(__('Please enter a new file name, or rename the '
                                    'existing file and press Enter'), d['master'])
-
-    if 'epub' not in d:
-        print(__('''
-Sphinx can also add configuration for epub output:'''))
-        d['epub'] = do_prompt(__('Do you want to use the epub builder (y/n)'),
-                              'n', boolean)
 
     if 'extensions' not in d:
         print(__('Indicate which of the following Sphinx extensions should be '

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -171,9 +171,6 @@ texinfo_documents = [
 
 # Bibliographic Dublin Core info.
 epub_title = project
-epub_author = author
-epub_publisher = author
-epub_copyright = copyright
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -165,7 +165,6 @@ texinfo_documents = [
      author, '{{ project_fn }}', 'One line description of project.',
      'Miscellaneous'),
 ]
-{%- if epub %}
 
 
 # -- Options for Epub output -------------------------------------------------
@@ -187,7 +186,6 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
-{%- endif %}
 {%- if extensions %}
 
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -197,7 +197,6 @@ def test_quickstart_all_answers(tempdir):
     assert ns['latex_documents'] == [
         ('contents', 'STASI.tex', u'STASI™ Documentation',
          u'Wolfgang Schäuble \\& G\'Beckstein', 'manual')]
-    assert ns['epub_author'] == u'Wolfgang Schäuble & G\'Beckstein'
     assert ns['man_pages'] == [
         ('contents', 'stasi', u'STASI™ Documentation',
          [u'Wolfgang Schäuble & G\'Beckstein'], 1)]


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Enable settings for EPUB builder by default (in quickstart)
- I think EPUB is one of largest destination target of Sphinx
- Note: all builders are available by default. so this only effects to the default generated conf.py.
- In addition, remove meaningless entry from conf.py