### PR TITLE
Use 3.8-dev for testing instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       sudo: true
     - python: 'nightly'
       env: TOXENV=py38
+      dist: xenial
+      sudo: true
     - python: '3.6'
       env: TOXENV=docs
     - python: '3.6'


### PR DESCRIPTION
At present, it seems nightly build points 3.7.0a4+.  So use 3.8-dev
for our testing instead.  This change will be reverted after Travis
fixes nightly build.
