### PR TITLE
latex: Invoke mendex from perl (for Windows)

### DIFF
--- a/sphinx/texinputs/latexmkjarc
+++ b/sphinx/texinputs/latexmkjarc
@@ -1,6 +1,23 @@
 $latex = 'platex ' . $ENV{'LATEXOPTS'} . ' -kanji=utf8 %O %S';
 $dvipdf = 'dvipdfmx %O -o %D %S';
-$makeindex = 'rm -f %D; mendex -U -f -d %B.dic -s python.ist %S || echo "mendex exited with error code $? (ignoring)" && : >> %D';
+$makeindex = 'internal mendex %S %B %D';
+sub mendex {
+  my ($source, $basename, $destination) = @_;
+  my $dictfile = $basename . ".dic";
+  unlink($destination);
+  if (-f $dictfile) {
+    system("mendex", "-U", "-f", "-d", $dictfile, "-s", "python.ist", $source);
+    if ($? > 0) {
+      print("mendex exited with error code $? (ignored)\n");
+    }
+  }
+  if (!-e $destination) {
+    # create an empty .ind file if nothing
+    open(FH, ">" . $destination);
+    close(FH);
+  }
+  return 0;
+}
 add_cus_dep( "glo", "gls", 0, "makeglo" );
 sub makeglo {
  return system( "mendex -J -f -s gglo.ist -o '$_[0].gls' '$_[0].glo'" );


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- To build Japanese PDF on Windows, this refactors `latexmkjarc`.
- It uses perl function to invoke `mendex` command instead of POSIX shell.
- I confirmed this works fine on MacOS side.