### PR TITLE
Use typing.Any for config type hinting instead

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -49,10 +49,6 @@ ConfigValue = NamedTuple('ConfigValue', [('name', str),
                                          ('rebuild', Union[bool, unicode])])
 
 
-#: represents the config value accepts any type of value.
-Any = object()
-
-
 class ENUM(object):
     """represents the config value should be a one of candidates.
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Now we've provided `sphinx.config:Any` for type hinting of confvals.
- But we already have `typing.Any` to represent ANY object types.
- This allows to use `typing.Any` for confval type hinting.
- `sphinx.config.Any` is also available because we import it on `sphinx.config`. So there is no incompatibility.
