### PR TITLE
change format_args to prefer annotations from typing.get_type_hints

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -433,8 +433,7 @@ class Signature(object):
         if PY2 or self.return_annotation is inspect.Parameter.empty:
             return '(%s)' % ', '.join(args)
         else:
-            if isinstance(self.return_annotation, string_types) and \
-                    'return' in self.annotations:
+            if 'return' in self.annotations:
                 annotation = self.format_annotation(self.annotations['return'])
             else:
                 annotation = self.format_annotation(self.return_annotation)

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -20,6 +20,7 @@ from six import PY2, PY3, StringIO, binary_type, string_types, itervalues
 from six.moves import builtins
 
 from sphinx.util import force_decode
+from sphinx.util.pycompat import NoneType
 
 if False:
     # For type annotation
@@ -464,6 +465,8 @@ class Signature(object):
             return annotation.__name__
         elif not annotation:
             return repr(annotation)
+        elif annotation is NoneType:  # type: ignore
+            return 'None'
         elif module == 'builtins':
             return annotation.__qualname__
         elif annotation is Ellipsis:
@@ -517,6 +520,9 @@ class Signature(object):
             qualified_name = annotation.__qualname__  # type: ignore
         else:
             qualified_name = (annotation.__module__ + '.' + annotation.__qualname__)  # type: ignore  # NOQA
+
+        if annotation is NoneType:  # type: ignore
+            return 'None'
 
         if annotation.__module__ == 'builtins':
             return annotation.__qualname__  # type: ignore

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -231,7 +231,8 @@ def test_Signature_partialmethod():
 @pytest.mark.skipif(sys.version_info < (3, 5),
                     reason='type annotation test is available on py35 or above')
 def test_Signature_annotations():
-    from typing_test_data import f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12
+    from typing_test_data import (
+        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, Node)
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -287,6 +288,9 @@ def test_Signature_annotations():
     # tuple with more than two items
     sig = inspect.Signature(f12).format_args()
     assert sig == '() -> Tuple[int, str, int]'
+
+    sig = inspect.Signature(Node.children).format_args()
+    assert sig == '(self) -> List[typing_test_data.Node]'
 
 
 def test_safe_getattr_with_default():

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -66,3 +66,8 @@ def f11(x: CustomAnnotation(), y: 123) -> None:
 
 def f12() -> Tuple[int, str, int]:
     pass
+
+
+class Node:
+    def children(self) -> List['Node']:
+        pass


### PR DESCRIPTION
Subject: change format_args to prefer annotations from typing.get_type_hints

### Feature or Bugfix
- Bugfix

### Purpose

The current code looks for the pattern:

```python
class Node:
    def parent(self) -> 'Node': pass
```

This change allows more complex forward references:

```python
class Node:
    def children(self) -> Set['Node']: pass
```