### PR TITLE
quickstart: set conf.py pygments_style value to None

### DIFF
--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -78,7 +78,7 @@ language = {{ language | repr }}
 exclude_patterns = [{{ exclude_patterns }}]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = None
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION

### Feature or Bugfix

- Bugfix

### Purpose

Currently quickstart sets a value for `pygments_style`,
this is not desirable because it overrides the theme's default `pygments_style`.
It should be `None` so theme`s value is used by default.

