### PR TITLE
C++, add support for (most) character literals.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -167,6 +167,7 @@ Features added
 * C++, add support for unions.
 * C++, add support for anonymous entities using names staring with ``@``.
   Fixes #3593 and #2683.
+* #5147: C++, add support for (most) character literals.
 * #3606: MathJax should be loaded with async attribute
 * html: Output ``canonical_url`` metadata if :confval:`html_baseurl` set (refs:
   #4193)

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -127,7 +127,20 @@ def test_expressions():
         exprCheck(expr, 'L' + expr + 'E')
     exprCheck('"abc\\"cba"', 'LA8_KcE')  # string
     exprCheck('this', 'fpT')
-    # TODO: test the rest
+    # character literals
+    for p, t in [('', 'c'), ('u8', 'c'), ('u', 'Ds'), ('U', 'Di'), ('L', 'w')]:
+        exprCheck(p + "'a'", t + "97")
+        exprCheck(p + "'\\n'", t + "10")
+        exprCheck(p + "'\\012'", t + "10")
+        exprCheck(p + "'\\0'", t + "0")
+        exprCheck(p + "'\\x0a'", t + "10")
+        exprCheck(p + "'\\x0A'", t + "10")
+        exprCheck(p + "'\\u0a42'", t + "2626")
+        exprCheck(p + "'\\u0A42'", t + "2626")
+        exprCheck(p + "'\\U0001f34c'", t + "127820")
+        exprCheck(p + "'\\U0001F34C'", t + "127820")
+
+    # TODO: user-defined lit
     exprCheck('(... + Ns)', '(... + Ns)')
     exprCheck('(5)', 'L5E')
     exprCheck('C', '1C')


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
All character literals resulting in a single character after Pythons "unicode-escape" decoding works, e.g., ordinary narrow characters, bytes (``\x42``), and unicode escape sequences (``\u1337``, ``\U00001337``).
Not all explicit unicode literal characters are supported yet.

### Relates
Fixes sphinx-doc/sphinx#5147

