### PR TITLE
 C++, add missing isPack for some template params

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -172,6 +172,8 @@ Features added
 * C++, add support for anonymous entities using names staring with ``@``.
   Fixes #3593 and #2683.
 * #5147: C++, add support for (most) character literals.
+* C++, cross-referencing entities inside primary templates is supported,
+  and now properly documented.
 * #3606: MathJax should be loaded with async attribute
 * html: Output ``canonical_url`` metadata if :confval:`html_baseurl` set (refs:
   #4193)

--- a/CHANGES
+++ b/CHANGES
@@ -207,6 +207,7 @@ Bugs fixed
 * epub: spine has been broken when "self" is listed on toctree (refs: #4611)
 * #344: autosummary does not understand docstring of module level attributes
 * #5191: C++, prevent nested declarations in functions to avoid lookup problems.
+* #5126: C++, add missing isPack method for certain template parameter types.
 * #5002: graphviz: SVGs do not adapt to the column width
 
 Testing

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1033,19 +1033,25 @@ Assume the following declarations.
                      Inner
 
 In general the reference must include the template parameter declarations,
-e.g., ``template\<typename TOuter> Wrapper::Outer``
-(:cpp:class:`template\<typename TOuter> Wrapper::Outer`).  Currently the lookup
-only succeed if the template parameter identifiers are equal strings. That is,
-``template\<typename UOuter> Wrapper::Outer`` will not work.
+and template arguments for the prefix of qualified names. For example:
 
-The inner class template cannot be directly referenced, unless the current
-namespace is changed or the following shorthand is used.  If a template
-parameter list is omitted, then the lookup will assume either a template or a
-non-template, but not a partial template specialisation.  This means the
-following references work.
+- ``template\<typename TOuter> Wrapper::Outer``
+  (:cpp:class:`template\<typename TOuter> Wrapper::Outer`)
+- ``template\<typename TOuter> template\<typename TInner> Wrapper::Outer<TOuter>::Inner``
+  (:cpp:class:`template\<typename TOuter> template\<typename TInner> Wrapper::Outer<TOuter>::Inner`)
 
-- ``Wrapper::Outer`` (:cpp:class:`Wrapper::Outer`)
-- ``Wrapper::Outer::Inner`` (:cpp:class:`Wrapper::Outer::Inner`)
+Currently the lookup only succeed if the template parameter identifiers are equal strings.
+That is, ``template\<typename UOuter> Wrapper::Outer`` will not work.
+
+As a shorthand notation, if a template parameter list is omitted,
+then the lookup will assume either a primary template or a non-template,
+but not a partial template specialisation.
+This means the following references work as well:
+
+- ``Wrapper::Outer``
+  (:cpp:class:`Wrapper::Outer`)
+- ``Wrapper::Outer::Inner``
+  (:cpp:class:`Wrapper::Outer::Inner`)
 - ``template\<typename TInner> Wrapper::Outer::Inner``
   (:cpp:class:`template\<typename TInner> Wrapper::Outer::Inner`)
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -1492,6 +1492,10 @@ class ASTTemplateParamConstrainedTypeWithInit(ASTBase):
         # type: () -> ASTNestedName
         return self.type.name
 
+    @property
+    def isPack(self):
+        return self.type.isPack
+
     def get_id(self, version, objectType=None, symbol=None):
         # type: (int, unicode, Symbol) -> unicode
         # this is not part of the normal name mangling in C++
@@ -1531,6 +1535,10 @@ class ASTTemplateParamTemplateType(ASTBase):
         id = self.get_identifier()
         return ASTNestedName([ASTNestedNameElement(id, None)], [False], rooted=False)
 
+    @property
+    def isPack(self):
+        return self.data.parameterPack
+
     def get_identifier(self):
         # type: () -> unicode
         return self.data.get_identifier()
@@ -1566,6 +1574,10 @@ class ASTTemplateParamNonType(ASTBase):
         # type: () -> ASTNestedName
         id = self.get_identifier()
         return ASTNestedName([ASTNestedNameElement(id, None)], [False], rooted=False)
+
+    @property
+    def isPack(self):
+        return self.param.isPack
 
     def get_identifier(self):
         # type: () -> unicode
@@ -2636,6 +2648,10 @@ class ASTDeclaratorRef(ASTBase):
         return self.next.name
 
     @property
+    def isPack(self):
+        return True
+
+    @property
     def function_params(self):
         # type: () -> Any
         return self.next.function_params
@@ -2917,6 +2933,10 @@ class ASTDeclaratorNameParamQual(ASTBase):
         return self.declId
 
     @property
+    def isPack(self):
+        return False
+
+    @property
     def function_params(self):
         # type: () -> Any
         return self.paramQual.function_params
@@ -3015,6 +3035,10 @@ class ASTType(ASTBase):
         return self.decl.name
 
     @property
+    def isPack(self):
+        return self.decl.isPack
+
+    @property
     def function_params(self):
         # type: () -> Any
         return self.decl.function_params
@@ -3104,6 +3128,10 @@ class ASTTypeWithInit(ASTBase):
     def name(self):
         # type: () -> ASTNestedName
         return self.type.name
+
+    @property
+    def isPack(self):
+        return self.type.isPack
 
     def get_id(self, version, objectType=None, symbol=None):
         # type: (int, unicode, Symbol) -> unicode


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
A crash was fixed (missing ``isPack``), which uncovered a lookup bug. Its fix allows for more types of cross-references.

### Relates
- Fixes #5126 
- See also #2057

