### PR TITLE
Plugins can resolve imported members for viewcode

### DIFF
--- a/doc/usage/extensions/viewcode.rst
+++ b/doc/usage/extensions/viewcode.rst
@@ -25,7 +25,11 @@ from the source to the description will also be inserted.
 
    In addition, if you don't want to import the modules by ``viewcode``,
    you can tell the location of the location of source code to ``viewcode``
-   using :event:`viewcode-find-source` event.
+   using the :event:`viewcode-find-source` event.
+
+   If :confval:`viewcode_follow_imported_members` is enabled,
+   you will also need to resolve imported attributes
+   using the :event:`viewcode-follow-imported` event.
 
 This extension works only on HTML related builders like ``html``,
 ``applehelp``, ``devhelp``, ``htmlhelp``, ``qthelp`` and so on except
@@ -83,3 +87,13 @@ Configuration
 
    :param app: The Sphinx application object.
    :param modname: The name of the module to find source code for.
+
+.. event:: viewcode-follow-imported (app, modname, attribute)
+
+   .. versionadded:: 1.8
+
+   Find the name of the original module for an attribute.
+
+   :param app: The Sphinx application object.
+   :param modname: The name of the module that the attribute belongs to.
+   :param attribute: The name of the member to follow.

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -104,7 +104,12 @@ def doctree_read(app, doctree):
             fullname = signode.get('fullname')
             refname = modname
             if env.config.viewcode_follow_imported_members:
-                modname = _get_full_modname(app, modname, fullname)
+                new_modname = app.emit_firstresult(
+                    'viewcode-follow-imported', modname, fullname,
+                )
+                if not new_modname:
+                    new_modname = _get_full_modname(app, modname, fullname)
+                modname = new_modname
             if not modname:
                 continue
             fullname = signode.get('fullname')
@@ -262,6 +267,7 @@ def setup(app):
     # app.add_config_value('viewcode_include_modules', [], 'env')
     # app.add_config_value('viewcode_exclude_modules', [], 'env')
     app.add_event('viewcode-find-source')
+    app.add_event('viewcode-follow-imported')
     return {
         'version': sphinx.__display_version__,
         'env_version': 1,


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
Currently there is no way of finding the original module of an attribute in viewcode without importing the attribute. Just as the `viewcode-find-source` event allows plugins to find source code without needing to import modules, the new `viewcode-follow-imported` event allows plugins to resolve imported members without needing to import modules.

### Detail
- Added the `viewcode-follow-imported` event.
