### PR TITLE
add a new book "SpotBugs manual" to EXAMPLES

### DIFF
--- a/EXAMPLES
+++ b/EXAMPLES
@@ -362,6 +362,7 @@ Documentation using sphinx_rtd_theme
 * `Sphinx AutoAPI`__
 * `sphinx-argparse`__
 * `Sphinx-Gallery`__ (customized)
+* `SpotBugs`__
 * `StarUML`__
 * `Sublime Text Unofficial Documentation`__
 * `SunPy`__
@@ -460,6 +461,7 @@ __ http://docs.python-soco.com/
 __ https://sphinx-autoapi.readthedocs.io/
 __ https://sphinx-argparse.readthedocs.io/
 __ https://sphinx-gallery.readthedocs.io/
+__ https://spotbugs.readthedocs.io/
 __ http://docs.staruml.io/
 __ http://docs.sublimetext.info/
 __ http://docs.sunpy.org/


### PR DESCRIPTION
Subject: Add a new book "SpotBugs manual" to EXAMPLES

### Feature or Bugfix
- Feature

### Purpose
- This PR adds a new book which is managed by [SpotBugs team](https://github.com/spotbugs/)

### Relates
- Document is hosted at [Read The Docs](https://spotbugs.readthedocs.io/)
- Code is hosted at [GitHub](https://github.com/spotbugs/spotbugs/tree/release-3.1/docs)

