### PR TITLE
Fix #5291: autodoc crashed by ForwardRef types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,8 @@ Bugs fixed
   font with XeLaTeX/LuaLateX (refs: #5251)
 * #5280: autodoc: Fix wrong type annotations for complex typing
 * autodoc: Optional types are wrongly rendered
+* #5291: autodoc crashed by ForwardRef types
+
 
 Testing
 --------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -477,6 +477,8 @@ class Signature(object):
                 qualname = annotation._name
             elif getattr(annotation, '__qualname__', None):
                 qualname = annotation.__qualname__
+            elif getattr(annotation, '__forward_arg__', None):
+                qualname = annotation.__forward_arg__
             else:
                 qualname = self.format_annotation(annotation.__origin__)  # ex. Union
         elif hasattr(annotation, '__qualname__'):
@@ -510,6 +512,8 @@ class Signature(object):
                 qualname = annotation._name
             elif getattr(annotation, '__qualname__', None):
                 qualname = annotation.__qualname__
+            elif getattr(annotation, '__forward_arg__', None):
+                qualname = annotation.__forward_arg__
             else:
                 qualname = self.format_annotation(annotation.__origin__)  # ex. Union
         elif hasattr(annotation, '__qualname__'):

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -297,6 +297,9 @@ def test_Signature_annotations():
     sig = inspect.Signature(Node.children).format_args()
     assert sig == '(self) -> List[typing_test_data.Node]'
 
+    sig = inspect.Signature(Node.__init__).format_args()
+    assert sig == '(self, parent: Optional[Node]) -> None'
+
 
 def test_safe_getattr_with_default():
     class Foo(object):

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -73,5 +73,8 @@ def f13() -> Optional[str]:
 
 
 class Node:
+    def __init__(self, parent: Optional['Node']) -> None:
+        pass
+
     def children(self) -> List['Node']:
         pass


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5291 