### PR TITLE
Fix #5298: imgmath: math_number_all causes equations to have two numbers in html

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Bugs fixed
   font with XeLaTeX/LuaLateX (refs: #5251)
 * #5280: autodoc: Fix wrong type annotations for complex typing
 * autodoc: Optional types are wrongly rendered
+* #5298: imgmath: math_number_all causes equations to have two numbers in html
 
 Testing
 --------

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -319,8 +319,7 @@ def html_visit_displaymath(self, node):
     if node['nowrap']:
         latex = node['latex']
     else:
-        latex = wrap_displaymath(node['latex'], None,
-                                 self.builder.config.math_number_all)
+        latex = wrap_displaymath(node['latex'], None, False)
     try:
         fname, depth = render_math(self, latex)
     except MathExtError as exc:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5298
