### PR TITLE
Fix #5211: autodoc: No docs generated for functools.partial functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #5280: autodoc: Fix wrong type annotations for complex typing
 * autodoc: Optional types are wrongly rendered
 * #5291: autodoc crashed by ForwardRef types
+* #5211: autodoc: No docs generated for functools.partial functions
 * #5298: imgmath: math_number_all causes equations to have two numbers in html
 
 Testing

--- a/tests/roots/test-ext-autodoc/target/partialfunction.py
+++ b/tests/roots/test-ext-autodoc/target/partialfunction.py
@@ -1,0 +1,11 @@
+from functools import partial
+
+
+def func1():
+    """docstring of func1"""
+    pass
+
+
+func2 = partial(func1)
+func3 = partial(func1)
+func3.__doc__ = "docstring of func3"

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -912,6 +912,44 @@ def test_generate():
                            'module', 'autodoc_missing_imports')
 
 
+@pytest.mark.usefixtures('setup_test')
+def test_partialfunction():
+    def call_autodoc(objtype, name):
+        inst = app.registry.documenters[objtype](directive, name)
+        inst.generate()
+        result = list(directive.result)
+        del directive.result[:]
+        return result
+
+    options.members = ALL
+    #options.undoc_members = True
+    expected = [
+        '',
+        '.. py:module:: target.partialfunction',
+        '',
+        '',
+        '.. py:function:: func1()',
+        '   :module: target.partialfunction',
+        '',
+        '   docstring of func1',
+        '   ',
+        '',
+        '.. py:function:: func2()',
+        '   :module: target.partialfunction',
+        '',
+        '   docstring of func1',
+        '   ',
+        '',
+        '.. py:function:: func3()',
+        '   :module: target.partialfunction',
+        '',
+        '   docstring of func3',
+        '   '
+    ]
+
+    assert call_autodoc('module', 'target.partialfunction') == expected
+
+
 @pytest.mark.skipif(sys.version_info < (3, 4),
                     reason='functools.partialmethod is available on py34 or above')
 @pytest.mark.usefixtures('setup_test')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5211 
