### PR TITLE
Fix #5306: autodoc: ``getargspec()`` raises NameError for invalid typehints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
 * autodoc: Optional types are wrongly rendered
 * #5291: autodoc crashed by ForwardRef types
 * #5211: autodoc: No docs generated for functools.partial functions
+* #5306: autodoc: ``getargspec()`` raises NameError for invalid typehints
 * #5298: imgmath: math_number_all causes equations to have two numbers in html
 
 Testing

--- a/sphinx/ext/autodoc/inspector.py
+++ b/sphinx/ext/autodoc/inspector.py
@@ -130,8 +130,11 @@ def formatargspec(function, args, varargs=None, varkw=None, defaults=None,
         else:
             return value
 
-    introspected_hints = (typing.get_type_hints(function)  # type: ignore
-                          if typing and hasattr(function, '__code__') else {})
+    try:
+        introspected_hints = (typing.get_type_hints(function)  # type: ignore
+                              if typing and hasattr(function, '__code__') else {})
+    except Exception:
+        introspected_hints = {}
 
     fd = StringIO()
     fd.write('(')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5306 
