### PR TITLE
graphviz: Don't use document.current_source

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -156,9 +156,7 @@ class Graphviz(SphinxDirective):
                     line=self.lineno)]
         node = graphviz()
         node['code'] = dotcode
-        node['options'] = {
-            'docname': path.splitext(self.state.document.current_source)[0],
-        }
+        node['options'] = {'docname': self.env.docname}
 
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- We can get current processing docname by `env.docname`. So we should use it instead.
- see https://groups.google.com/forum/#!topic/sphinx-users/vn38QHmkl3U