### PR TITLE
Fix i18n: warnings for translation catalogs have wrong line numbers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.io.SphinxI18nReader.set_lineno_for_reporter()`` is deprecated
+* ``sphinx.io.SphinxI18nReader.line`` is deprecated
+
 Features added
 --------------
 
@@ -17,6 +20,7 @@ Bugs fixed
 ----------
 
 * html: search box overrides to other elements if scrolled
+* i18n: warnings for translation catalogs have wrong line numbers (refs: #5321)
 
 Testing
 --------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -136,6 +136,16 @@ The following is a list of deprecated interface.
      - 4.0
      - :confval:`autodoc_default_options`
 
+   * - ``sphinx.io.SphinxI18nReader.set_lineno_for_reporter()``
+     - 1.8
+     - 3.0
+     - N/A
+
+   * - ``sphinx.io.SphinxI18nReader.line``
+     - 1.8
+     - 3.0
+     - N/A
+
    * - ``sphinx.directives.other.VersionChanges``
      - 1.8
      - 3.0

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -10,6 +10,7 @@
 """
 import codecs
 import re
+import warnings
 
 from docutils.core import Publisher
 from docutils.io import FileInput, NullOutput
@@ -20,6 +21,7 @@ from docutils.writers import UnfilteredWriter
 from six import text_type, iteritems
 from typing import Any, Union  # NOQA
 
+from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.locale import __
 from sphinx.transforms import (
     ApplySourceWorkaround, ExtraTranslatableNodes, CitationReferences,
@@ -116,7 +118,6 @@ class SphinxI18nReader(SphinxBaseReader):
     Because the translated texts are partial and they don't have correct line numbers.
     """
 
-    lineno = None  # type: int
     transforms = [ApplySourceWorkaround, ExtraTranslatableNodes, CitationReferences,
                   DefaultSubstitutions, MoveModuleTargets, HandleCodeBlocks,
                   AutoNumbering, SortIds, RemoveTranslatableInline,
@@ -127,22 +128,15 @@ class SphinxI18nReader(SphinxBaseReader):
     def set_lineno_for_reporter(self, lineno):
         # type: (int) -> None
         """Stores the source line number of original text."""
-        self.lineno = lineno
+        warnings.warn('SphinxI18nReader.set_lineno_for_reporter() is deprecated.',
+                      RemovedInSphinx30Warning)
 
-    def new_document(self):
-        # type: () -> nodes.document
-        """Creates a new document object which having a special reporter object for
-        translation.
-        """
-        document = SphinxBaseReader.new_document(self)
-        reporter = document.reporter
-
-        def get_source_and_line(lineno=None):
-            # type: (int) -> Tuple[unicode, int]
-            return reporter.source, self.lineno
-
-        reporter.get_source_and_line = get_source_and_line
-        return document
+    @property
+    def line(self):
+        # type: () -> int
+        warnings.warn('SphinxI18nReader.line is deprecated.',
+                      RemovedInSphinx30Warning)
+        return 0
 
 
 class SphinxDummyWriter(UnfilteredWriter):

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -51,10 +51,10 @@ def publish_msgstr(app, source, source_path, source_line, config, settings):
     """
     from sphinx.io import SphinxI18nReader
     reader = SphinxI18nReader(app)
-    reader.set_lineno_for_reporter(source_line)
     parser = app.registry.create_source_parser(app, 'restructuredtext')
     doc = reader.read(
-        source=StringInput(source=source, source_path=source_path),
+        source=StringInput(source=source,
+                           source_path="%s:%s:<translated>" % (source_path, source_line)),
         parser=parser,
         settings=settings,
     )

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -131,8 +131,8 @@ def test_text_emit_warnings(app, warning):
     app.build()
     # test warnings in translation
     warnings = getwarning(warning)
-    warning_expr = u'.*/warnings.txt:4: ' \
-                   u'WARNING: Inline literal start-string without end-string.\n'
+    warning_expr = ('.*/warnings.txt:4:<translated>:1: '
+                   'WARNING: Inline literal start-string without end-string.\n')
     assert_re_search(warning_expr, warnings)
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- warnings for translation catalogs have wrong line numbers
- For #5321 case, `index.rst:3` was wrong. The 3rd line of *translated text* is correct.
   ```
   /private/tmp/work/test/sample/source/index.rst:3: WARNING: Unexpected indentation.
   /private/tmp/work/test/sample/source/index.rst:11: WARNING: Block quote ends without a blank line; unexpected unindent.
   /private/tmp/work/test/sample/source/index.rst:13: WARNING: Definition list ends without a blank line; unexpected unindent.
   ```
- With this patch, it will be warned as following:
   ```
   /Users/tkomiya/work/tmp/doc/zzz/sample/source/index.rst:11:<translated>:3: WARNING: Unexpected indentation.
   /Users/tkomiya/work/tmp/doc/zzz/sample/source/index.rst:11:<translated>:4: WARNING: Block quote ends without a blank line; unexpected unindent.
   /Users/tkomiya/work/tmp/doc/zzz/sample/source/index.rst:13:<translated>:3: WARNING: Definition list ends without a blank line; unexpected unindent.
   ```
- As a side effect, `SphinxI18nReader.set_lineno_for_reporter` lost its meaning. So I marked it as deprecated.
