### PR TITLE
Fix html: search box overrides to other elements if scrolled

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* html: search box overrides to other elements if scrolled
+
 Testing
 --------
 

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -81,6 +81,10 @@ div.sphinxsidebar input {
     font-size: 1em;
 }
 
+div.sphinxsidebar #searchbox form.search {
+    overflow: hidden;
+}
+
 div.sphinxsidebar #searchbox input[type="text"] {
     float: left;
     width: 80%;


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- search box has overflow styles. As a result, it sometimes overrides to other elements.
- For example, the form on sphinx-doc.org overrides on footer if window height is narrow.

   ![2018-08-22 14 36 20](https://user-images.githubusercontent.com/748828/44445246-364ace00-a61b-11e8-9154-33b92ef2f7ea.png)
