### PR TITLE
Fix #5326: manpage: crashed when invalid docname is specified as ``man_pages``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #5326: manpage: crashed when invalid docname is specified as ``man_pages``
+
+
 Testing
 --------
 

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -18,6 +18,7 @@ from six import string_types
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
+from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.util.nodes import inline_all_toctrees
@@ -72,6 +73,10 @@ class ManualPageBuilder(Builder):
 
         for info in self.config.man_pages:
             docname, name, description, authors, section = info
+            if docname not in self.env.all_docs:
+                logger.warning(__('"man_pages" config value references unknown '
+                                  'document %s'), docname)
+                continue
             if isinstance(authors, string_types):
                 if authors:
                     authors = [authors]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5326 
