### PR TITLE
Fix #5322: autodoc: ``Any`` typehint causes formatting error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #5322: autodoc: ``Any`` typehint causes formatting error
+
 Testing
 --------
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -531,8 +531,10 @@ class Signature(object):
                 qualname = annotation.__qualname__
             elif getattr(annotation, '__forward_arg__', None):
                 qualname = annotation.__forward_arg__
-            else:
+            elif getattr(annotation, '__origin__', None):
                 qualname = self.format_annotation(annotation.__origin__)  # ex. Union
+            else:
+                qualname = repr(annotation).replace('typing.', '')
         elif hasattr(annotation, '__qualname__'):
             qualname = '%s.%s' % (module, annotation.__qualname__)
         else:

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -232,7 +232,7 @@ def test_Signature_partialmethod():
                     reason='type annotation test is available on py34 or above')
 def test_Signature_annotations():
     from typing_test_data import (
-        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, Node)
+        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, Node)
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -292,6 +292,10 @@ def test_Signature_annotations():
     # optional
     sig = inspect.Signature(f13).format_args()
     assert sig == '() -> Optional[str]'
+
+    # Any
+    sig = inspect.Signature(f14).format_args()
+    assert sig == '() -> Any'
 
     # type hints by string
     sig = inspect.Signature(Node.children).format_args()

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -1,5 +1,5 @@
 from numbers import Integral
-from typing import List, TypeVar, Union, Callable, Tuple, Optional
+from typing import Any, List, TypeVar, Union, Callable, Tuple, Optional
 
 
 def f0(x: int, y: Integral) -> None:
@@ -69,6 +69,10 @@ def f12() -> Tuple[int, str, int]:
 
 
 def f13() -> Optional[str]:
+    pass
+
+
+def f14() -> Any:
     pass
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5322 
