### PR TITLE
Update requirements and dependencies for Sphinx-2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,8 +5,6 @@ environment:
     PYTHONWARNINGS: all
 
   matrix:
-    - PYTHON: 27
-      TEST_IGNORE: --ignore py35
     - PYTHON: 37
     - PYTHON: 37-x64
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,9 @@ env:
 
 matrix:
   include:
-    - python: 'pypy'
-      env: TOXENV=pypy
-    - python: '2.7'
+    - python: '3.5'
       env:
         - TOXENV=du13
-        - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
-    - python: '3.4'
-      env: TOXENV=py34
-    - python: '3.5'
-      env: TOXENV=py35
     - python: '3.6'
       env:
         - TOXENV=py36

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Release 2.0.0 (in development)
 Dependencies
 ------------
 
+* LaTeX builder now depends on TeX Live 2015 or above
+
 Incompatible changes
 --------------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Incompatible changes
 --------------------
 
 * Drop python 2.7 and 3.4 support
+* Drop docutils 0.11 support
 
 Deprecated
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* Drop python 2.7 and 3.4 support
+
 Deprecated
 ----------
 

--- a/doc/usage/builders/index.rst
+++ b/doc/usage/builders/index.rst
@@ -165,15 +165,16 @@ The builder's "name" must be given to the **-b** command-line option of
    * ``texlive-fonts-recommended``
    * ``texlive-latex-extra``
    * ``latexmk`` (for ``make latexpdf`` on GNU/Linux and MacOS X)
-   * ``latex-xcolor`` (old Ubuntu)
    * ``texlive-luatex``, ``texlive-xetex`` (see :confval:`latex_engine`)
 
-   The testing of Sphinx LaTeX is done on Ubuntu trusty with the above
-   mentioned packages, which are from a TeXLive 2013 snapshot dated
-   February 2014.
+   The testing of Sphinx LaTeX is done on Ubuntu xenial with the above mentioned
+   packages, which are from a TeXLive 2015 snapshot dated March 2016.
 
    .. versionchanged:: 1.6
       Formerly, testing had been done on Ubuntu precise (TeXLive 2009).
+
+   .. versionchanged:: 2.0
+      Formerly, testing had been done on Ubuntu trusty (TeXLive 2013).
 
    .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
     'six>=1.5',
     'Jinja2>=2.3',
     'Pygments>=2.0',
-    'docutils>=0.11',
+    'docutils>=0.12',
     'snowballstemmer>=1.1',
     'babel>=1.3,!=2.0',
     'alabaster>=0.7,<0.8',

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import sphinx
 with open('README.rst') as f:
     long_desc = f.read()
 
-if sys.version_info < (2, 7) or (3, 0) <= sys.version_info < (3, 4):
-    print('ERROR: Sphinx requires at least Python 2.7 or 3.4 to run.')
+if sys.version_info < (3, 5):
+    print('ERROR: Sphinx requires at least Python 3.5 to run.')
     sys.exit(1)
 
 install_requires = [
@@ -35,9 +35,6 @@ extras_require = {
     ':sys_platform=="win32"': [
         'colorama>=0.3.5',
     ],
-    ':python_version<"3.5"': [
-        'typing'
-    ],
     'websupport': [
         'sqlalchemy>=0.9',
         'whoosh>=2.0',
@@ -49,11 +46,6 @@ extras_require = {
         'html5lib',
         'flake8>=3.5.0',
         'flake8-import-order',
-    ],
-    'test:python_version<"3"': [
-        'enum34',
-    ],
-    'test:python_version>="3"': [
         'mypy',
         'typed_ast',
     ],
@@ -195,12 +187,11 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Setuptools Plugin',
@@ -235,7 +226,7 @@ setup(
             'build_sphinx = sphinx.setup_command:BuildDoc',
         ],
     },
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.5",
     install_requires=install_requires,
     extras_require=extras_require,
     cmdclass=cmdclass,

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -11,12 +11,10 @@
 
 from docutils import nodes
 from docutils.writers.manpage import (
-    MACRO_DEF,
     Writer,
     Translator as BaseTranslator
 )
 
-import sphinx.util.docutils
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
@@ -112,10 +110,6 @@ class ManualPageTranslator(BaseTranslator):
         self._docinfo['copyright'] = builder.config.copyright
         self._docinfo['version'] = builder.config.version
         self._docinfo['manual_group'] = builder.config.project
-
-        # In docutils < 0.11 self.append_header() was never called
-        if sphinx.util.docutils.__version_info__ < (0, 11):
-            self.body.append(MACRO_DEF)
 
         # Overwrite admonition label translations with our own
         for label, translation in admonitionlabels.items():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = docs,flake8,mypy,coverage,py{35,36,37,38,py},du{11,12,13,14}
+envlist = docs,flake8,mypy,coverage,py{35,36,37,38,py},du{12,13,14}
 
 [testenv]
 usedevelop = True
@@ -8,7 +8,7 @@ passenv =
     https_proxy http_proxy no_proxy PERL PERL5LIB PYTEST_ADDOPTS EPUBCHECK_PATH
 description =
     py{35,36,37,38,py}: Run unit tests against {envname}.
-    du{11,12,13,14}: Run unit tests with the given version of docutils.
+    du{12,13,14}: Run unit tests with the given version of docutils.
 
 # TODO(stephenfin) Replace this with the 'extras' config option when tox 2.4 is
 # widely available, likely some time after the Ubuntu 18.04 release
@@ -16,7 +16,6 @@ description =
 # https://tox.readthedocs.io/en/latest/config.html#confval-extras=MULTI-LINE-LIST
 deps =
     .[test,websupport]
-    du11: docutils==0.11
     du12: docutils==0.12
     du13: docutils==0.13.1
     du14: docutils==0.14

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 minversion = 2.0
-envlist = docs,flake8,mypy,coverage,py{27,34,35,36,37,38,py},du{11,12,13,14}
+envlist = docs,flake8,mypy,coverage,py{35,36,37,38,py},du{11,12,13,14}
 
 [testenv]
 usedevelop = True
 passenv =
     https_proxy http_proxy no_proxy PERL PERL5LIB PYTEST_ADDOPTS EPUBCHECK_PATH
 description =
-    py{27,34,35,36,37,38,py}: Run unit tests against {envname}.
+    py{35,36,37,38,py}: Run unit tests against {envname}.
     du{11,12,13,14}: Run unit tests with the given version of docutils.
 
 # TODO(stephenfin) Replace this with the 'extras' config option when tox 2.4 is


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- As discussed in #4484, we will leave Ubuntu 14.04 and start to use 16.04 as a standard environment (in other word, testing environment).
- So it's time to drop old interpreters and libraries!
    - Drop old pythons (2.7 and 3.4)
    - Drop docutils-0.11 support
    - Drop TeXLive 2013 support

