### PR TITLE
autodoc: Fix typing.get_type_hints() raises AttributeError for partial objects

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -360,8 +360,13 @@ class Signature(object):
         try:
             self.annotations = typing.get_type_hints(subject)  # type: ignore
         except Exception as exc:
-            logger.warning('Invalid type annotation found on %r. Ingored: %r', subject, exc)
-            self.annotations = {}
+            if (3, 5, 0) <= sys.version_info < (3, 5, 3) and isinstance(exc, AttributeError):
+                # python 3.5.2 raises ValueError for partial objects.
+                self.annotations = {}
+            else:
+                logger.warning('Invalid type annotation found on %r. Ingored: %r',
+                               subject, exc)
+                self.annotations = {}
 
         if bound_method:
             # client gives a hint that the subject is a bound method


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- old `typing.get_type_hints()` raises AttributeError for partial objects
- As a result, our `sphinx.util.inspect:Signature` class emits warning for them forcedly. But nobody stop it.
- This prevents such warnings.
