### PR TITLE
[Proposal] Add a helper class for Node.traverse()

### DIFF
--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import gzip
 import re
 from os import path
+from typing import Any
 
 from docutils import nodes
 
@@ -23,6 +24,7 @@ from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import __
 from sphinx.util import logging
+from sphinx.util.nodes import NodeMatcher
 from sphinx.util.osutil import make_filename
 
 try:
@@ -32,7 +34,7 @@ except ImportError:
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List  # NOQA
+    from typing import Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
 
@@ -100,12 +102,8 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
                 parent.attrib['link'] = node['refuri']
                 parent.attrib['name'] = node.astext()
 
-        def istoctree(node):
-            # type: (nodes.Node) -> bool
-            return isinstance(node, addnodes.compact_paragraph) and \
-                'toctree' in node
-
-        for node in tocdoc.traverse(istoctree):
+        matcher = NodeMatcher(addnodes.compact_paragraph, toctree=Any)
+        for node in tocdoc.traverse(matcher):
             write_toc(node, chapters)
 
         # Index

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -293,11 +293,7 @@ def traverse_parent(node, cls=None):
 def traverse_translatable_index(doctree):
     # type: (nodes.Node) -> Iterable[Tuple[nodes.Node, List[unicode]]]
     """Traverse translatable index node from a document tree."""
-    def is_block_index(node):
-        # type: (nodes.Node) -> bool
-        return isinstance(node, addnodes.index) and  \
-            node.get('inline') is False
-    for node in doctree.traverse(is_block_index):
+    for node in doctree.traverse(NodeMatcher(addnodes.index, inline=False)):
         if 'raw_entries' in node:
             entries = node['raw_entries']
         else:

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -21,6 +21,7 @@ from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.util import logging
 from sphinx.util.i18n import format_date
+from sphinx.util.nodes import NodeMatcher
 
 if False:
     # For type annotation
@@ -63,16 +64,13 @@ class NestedInlineTransform(object):
 
     def apply(self):
         # type: () -> None
-        def is_inline(node):
-            # type: (nodes.Node) -> bool
-            return isinstance(node, (nodes.literal, nodes.emphasis, nodes.strong))
-
-        for node in self.document.traverse(is_inline):
-            if any(is_inline(subnode) for subnode in node):
+        matcher = NodeMatcher(nodes.literal, nodes.emphasis, nodes.strong)
+        for node in self.document.traverse(matcher):
+            if any(matcher(subnode) for subnode in node):
                 pos = node.parent.index(node)
                 for subnode in reversed(node[1:]):
                     node.remove(subnode)
-                    if is_inline(subnode):
+                    if matcher(subnode):
                         node.parent.insert(pos + 1, subnode)
                     else:
                         newnode = node.__class__('', subnode, **node.attributes)

--- a/tests/test_util_nodes.py
+++ b/tests/test_util_nodes.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 from textwrap import dedent
+from typing import Any
 
 import pytest
 from docutils import frontend
@@ -17,7 +18,7 @@ from docutils.parsers import rst
 from docutils.utils import new_document
 
 from sphinx.transforms import ApplySourceWorkaround
-from sphinx.util.nodes import extract_messages, clean_astext
+from sphinx.util.nodes import NodeMatcher, extract_messages, clean_astext
 
 
 def _transform(doctree):
@@ -48,6 +49,38 @@ def assert_node_count(messages, node_type, expect_count):
     assert count == expect_count, (
         "Count of %r in the %r is %d instead of %d"
         % (node_type, node_list, count, expect_count))
+
+
+def test_NodeMatcher():
+    doctree = nodes.document(None, None)
+    doctree += nodes.paragraph('', 'Hello')
+    doctree += nodes.paragraph('', 'Sphinx', block=1)
+    doctree += nodes.paragraph('', 'World', block=2)
+    doctree += nodes.literal_block('', 'blah blah blah', block=3)
+
+    # search by node class
+    matcher = NodeMatcher(nodes.paragraph)
+    assert len(doctree.traverse(matcher)) == 3
+
+    # search by multiple node classes
+    matcher = NodeMatcher(nodes.paragraph, nodes.literal_block)
+    assert len(doctree.traverse(matcher)) == 4
+
+    # search by node attribute
+    matcher = NodeMatcher(block=1)
+    assert len(doctree.traverse(matcher)) == 1
+
+    # search by node attribute (Any)
+    matcher = NodeMatcher(block=Any)
+    assert len(doctree.traverse(matcher)) == 3
+
+    # search by both class and attribute
+    matcher = NodeMatcher(nodes.paragraph, block=Any)
+    assert len(doctree.traverse(matcher)) == 2
+
+    # mismatched
+    matcher = NodeMatcher(nodes.title)
+    assert len(doctree.traverse(matcher)) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- In sphinx, there are many small inline functions to pick up nodes conditionally.
- I'd like to add a helper class named `NodeMatcher`.
- It can search nodes simply.
