### PR TITLE
Improve pytest header

### DIFF
--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -61,8 +61,7 @@ if __version__.endswith('+'):
     __version__ = __version__[:-1]  # remove '+' for PEP-440 version spec.
     try:
         import subprocess
-        p = subprocess.Popen(['git', 'show', '-s', '--pretty=format:%h',
-                              path.join(package_dir, '..')],
+        p = subprocess.Popen(['git', 'show', '-s', '--pretty=format:%h'],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if out:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,10 @@ import os
 import shutil
 import sys
 
+import docutils
 import pytest
 
+import sphinx
 from sphinx.testing.path import path
 
 pytest_plugins = 'sphinx.testing.fixtures'
@@ -34,8 +36,8 @@ def rootdir():
 
 
 def pytest_report_header(config):
-    return 'Running Sphinx test suite (with Python %s)...' % (
-        sys.version.split()[0])
+    return ("libraries: Sphinx-%s, docutils-%s" %
+            (sphinx.__display_version__, docutils.__version__))
 
 
 def _initialize_test_directory(session):


### PR DESCRIPTION
### Feature or Bugfix
- Testing

### Purpose
- Show the version of sphinx and docutils as a pytest header.

Before:
```
platform darwin -- Python 2.7.15, pytest-3.7.2, py-1.5.4, pluggy-0.7.1
Running Sphinx test suite (with Python 2.7.15)...
rootdir: /Users/tkomiya/work/sphinx, inifile: setup.cfg
plugins: cov-2.5.1
collected 1323 items
```

After:
```
platform darwin -- Python 2.7.15, pytest-3.7.2, py-1.5.4, pluggy-0.7.1
libraries: Sphinx-1.8.0+/48427ae57, docutils-0.14
rootdir: /Users/tkomiya/work/sphinx, inifile: setup.cfg
plugins: cov-2.5.1
collected 1323 items
```