### PR TITLE
C++, symbol addition and lookup fixes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Bugs fixed
 * html: search box overrides to other elements if scrolled
 * i18n: warnings for translation catalogs have wrong line numbers (refs: #5321)
 * #5325: latex: cross references has been broken by multiply labeled objects
+* C++, fixes for symbol addition and lookup. Lookup should no longer break
+  in partial builds. See also #5337.
 
 Testing
 --------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6678,6 +6678,7 @@ class CPPDomain(Domain):
                                        matchSelf=True, recurseInAnon=True)
         else:
             decl = ast  # type: ASTDeclaration
+            name = decl.name
             s = parentSymbol.find_declaration(decl, typ,
                                               templateShorthand=True,
                                               matchSelf=True, recurseInAnon=True)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix lookup of overloaded-xrefs that can not be found.
- Fix very old problem with checking against all overloads when adding symbols. E.g., with partial builds, this would create symbols, but later wrongly lookup another.
- When filling in an empty symbol with a declaration, remember to add child symbols for template parameters and function parameters. E.g., with partial builds, this would result missing references to those symbols.

### Relates
- Fixes #5337 

