### PR TITLE
Make generated texinfo files reproducible by sorting the anchors

### DIFF
--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -612,7 +612,7 @@ class TexinfoTranslator(nodes.NodeVisitor):
         node_name = node['node_name']
         pointers = tuple([node_name] + self.rellinks[node_name])
         self.body.append('\n@node %s,%s,%s,%s\n' % pointers)  # type: ignore
-        for id in self.next_section_ids:
+        for id in sorted(self.next_section_ids):
             self.add_anchor(id, node)
 
         self.next_section_ids.clear()

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -50,6 +50,10 @@ def test_texinfo_warnings(app, status, warning):
 def test_texinfo(app, status, warning):
     TexinfoTranslator.ignore_missing_images = True
     app.builder.build_all()
+    result = (app.outdir / 'SphinxTests.texi').text(encoding='utf8')
+    assert ('@anchor{markup doc}@anchor{12}'
+            '@anchor{markup id1}@anchor{13}'
+            '@anchor{markup testing-various-markup}@anchor{14}' in result)
     # now, try to run makeinfo over it
     cwd = os.getcwd()
     os.chdir(app.outdir)


### PR DESCRIPTION
This fixes the problem with reproducible builds originally reported in Debian: https://bugs.debian.org/907352.