### PR TITLE
Fix #4379: toctree shows confusible warning when document is excluded

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
 * #5348: download reference to remote file is not displayed
 * #5282: html theme: ``pygments_style`` of theme was overrided by ``conf.py``
   by default
+* #4379: toctree shows confusible warning when document is excluded
 
 Testing
 --------

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -22,7 +22,7 @@ from sphinx.domains.changeset import VersionChange  # NOQA  # for compatibility
 from sphinx.locale import _
 from sphinx.util import url_re, docname_join
 from sphinx.util.docutils import SphinxDirective
-from sphinx.util.matching import patfilter
+from sphinx.util.matching import Matcher, patfilter
 from sphinx.util.nodes import explicit_title_re, set_source_info, \
     process_index_entry
 
@@ -96,6 +96,7 @@ class TocTree(SphinxDirective):
         all_docnames.remove(self.env.docname)  # remove current document
 
         ret = []
+        excluded = Matcher(self.config.exclude_patterns)
         for entry in self.content:
             if not entry:
                 continue
@@ -131,9 +132,13 @@ class TocTree(SphinxDirective):
                 if url_re.match(ref) or ref == 'self':
                     toctree['entries'].append((title, ref))
                 elif docname not in self.env.found_docs:
-                    ret.append(self.state.document.reporter.warning(
-                        'toctree contains reference to nonexisting '
-                        'document %r' % docname, line=self.lineno))
+                    if excluded(self.env.doc2path(docname, None)):
+                        message = 'toctree contains reference to excluded document %r'
+                    else:
+                        message = 'toctree contains reference to nonexisting document %r'
+
+                    ret.append(self.state.document.reporter.warning(message % docname,
+                                                                    line=self.lineno))
                     self.env.note_reread()
                 else:
                     all_docnames.discard(docname)

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -15,6 +15,7 @@ from six import iteritems
 from sphinx import addnodes
 from sphinx.locale import __
 from sphinx.util import url_re, logging
+from sphinx.util.matching import Matcher
 from sphinx.util.nodes import clean_astext, process_only_nodes
 
 if False:
@@ -83,6 +84,7 @@ class TocTree(object):
         # interactions between marking and pruning the tree (see bug #1046).
 
         toctree_ancestors = self.get_toctree_ancestors(docname)
+        excluded = Matcher(self.env.config.exclude_patterns)
 
         def _toctree_add_classes(node, depth):
             # type: (nodes.Node, int) -> None
@@ -172,8 +174,12 @@ class TocTree(object):
                                        ref, location=toctreenode)
                 except KeyError:
                     # this is raised if the included file does not exist
-                    logger.warning(__('toctree contains reference to nonexisting document %r'),
-                                   ref, location=toctreenode)
+                    if excluded(self.env.doc2path(ref, None)):
+                        message = __('toctree contains reference to excluded document %r')
+                    else:
+                        message = __('toctree contains reference to nonexisting document %r')
+
+                    logger.warning(message, ref, location=toctreenode)
                 else:
                     # if titles_only is given, only keep the main title and
                     # sub-toctrees

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -81,6 +81,7 @@ from sphinx.util import import_object, rst, logging
 from sphinx.util.docutils import (
     NullReporter, SphinxDirective, new_document, switch_source_input
 )
+from sphinx.util.matching import Matcher
 
 if False:
     # For type annotation
@@ -261,12 +262,17 @@ class Autosummary(SphinxDirective):
 
             tree_prefix = self.options['toctree'].strip()
             docnames = []
+            excluded = Matcher(self.config.exclude_patterns)
             for name, sig, summary, real_name in items:
                 docname = posixpath.join(tree_prefix, real_name)
                 docname = posixpath.normpath(posixpath.join(dirname, docname))
                 if docname not in self.env.found_docs:
-                    self.warn('toctree references unknown document %r'
-                              % docname)
+                    if excluded(self.env.doc2path(docname, None)):
+                        self.warn('toctree references excluded document %r'
+                                  % docname)
+                    else:
+                        self.warn('toctree references unknown document %r'
+                                  % docname)
                 docnames.append(docname)
 
             tocnode = addnodes.toctree()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #4379 (give more appropriate warning message)