### PR TITLE
Fix #5362: apidoc: Add ``--toc`` option to change the filename of ToC

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Features added
 --------------
 
 * #5388: Ensure frozen object descriptions are reproducible
+* #5362: apidoc: Add ``--tocfile`` option to change the filename of ToC
 
 Bugs fixed
 ----------

--- a/doc/man/sphinx-apidoc.rst
+++ b/doc/man/sphinx-apidoc.rst
@@ -58,6 +58,10 @@ Options
 
    Maximum depth for the generated table of contents file.
 
+.. option:: --tocfile
+
+   Filename for a table of contents file. Defaults to ``modules``.
+
 .. option:: -T, --no-toc
 
    Do not create a table of contents file. Ignored when :option:`--full` is

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -340,7 +340,9 @@ Note: By default this script will not overwrite already created files."""))
     parser.add_argument('-P', '--private', action='store_true',
                         dest='includeprivate',
                         help=__('include "_private" modules'))
-    parser.add_argument('-T', '--no-toc', action='store_true', dest='notoc',
+    parser.add_argument('--tocfile', action='store', dest='tocfile', default='modules',
+                        help=__("don't create a table of contents file"))
+    parser.add_argument('-T', '--no-toc', action='store_false', dest='tocfile',
                         help=__("don't create a table of contents file"))
     parser.add_argument('-E', '--no-headings', action='store_true',
                         dest='noheadings',
@@ -453,8 +455,8 @@ def main(argv=sys.argv[1:]):
 
         if not args.dryrun:
             qs.generate(d, silent=True, overwrite=args.force)
-    elif not args.notoc:
-        create_modules_toc_file(modules, args)
+    elif args.tocfile:
+        create_modules_toc_file(modules, args, args.tocfile)
 
     return 0
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Purpose
- refs: #5362 
- I know this is a new command line option. But it is also bug fix.
- I think this is enough stable.