### PR TITLE
Fix #5127: quickstart: ``Makefile`` and ``make.bat`` are not overwritten if exists

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Incompatible changes
 
 * #5282: html theme: refer ``pygments_style`` settings of HTML themes
   preferentially
+* #5127: quickstart: ``Makefile`` and ``make.bat`` are not overwritten if exists
 
 Deprecated
 ----------

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -678,7 +678,7 @@ def main(argv=sys.argv[1:]):
         except ValueError:
             print(__('Invalid template variable: %s') % variable)
 
-    generate(d, templatedir=args.templatedir)
+    generate(d, overwrite=False, templatedir=args.templatedir)
     return 0
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5127 
