### PR TITLE
[WIP] include doc-less data objects with undoc-members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ TAGS
 .tox/
 .tx/
 .venv/
+.vscode/
 .coverage
 htmlcov
 .DS_Store

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1254,7 +1254,7 @@ class DataDocumenter(ModuleLevelDocumenter):
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
         # type: (Any, unicode, bool, Any) -> bool
-        return isinstance(parent, ModuleDocumenter) and isattr
+        return isinstance(parent, ModuleDocumenter)
 
     def add_directive_header(self, sig):
         # type: (unicode) -> None
@@ -1281,6 +1281,15 @@ class DataDocumenter(ModuleLevelDocumenter):
         # type: () -> str
         return self.get_attr(self.parent or self.object, '__module__', None) \
             or self.modname
+
+    def get_doc(self, encoding=None, ignore=1):
+        # type: (unicode, int) -> List[List[unicode]]
+        # data objects wont be processed with DataDocumenter when documented
+        # hence, docs should be empty unless autodoc_inherit_docstrings is True
+        if not self.env.config.autodoc_inherit_docstrings:
+            return [prepare_docstring('', ignore)]
+
+        return super(DataDocumenter, self).get_doc(encoding=None, ignore=1)
 
 
 class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: ignore

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -9,6 +9,9 @@ from sphinx.ext.autodoc import add_documenter  # NOQA
 
 __all__ = ['Class']
 
+# this should be documented when :undoc-members:
+UNDOC_DATA = []
+
 #: documentation for the integer
 integer = 1
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -571,14 +571,13 @@ def test_data_documenter():
         return ret
 
     app.env.config.autodoc_inherit_docstrings = False
-    result = get_result('module', 'target')
-    assert '.. py:data:: UNDOC_DATA' in result
-    assert '   list() -> new empty list' not in result
+    inherit_false = get_result('module', 'target')
+    assert '.. py:data:: UNDOC_DATA' in inherit_false
 
     app.env.config.autodoc_inherit_docstrings = True
-    result = get_result('module', 'target')
-    assert '.. py:data:: UNDOC_DATA' in result
-    assert '   list() -> new empty list' in result
+    inherit_true = get_result('module', 'target')
+    assert '.. py:data:: UNDOC_DATA' in inherit_true
+    assert len(inherit_true) > len(inherit_false)
 
     options.undoc_members = False
     assert '.. py:data:: UNDOC_DATA' not in get_result('module', 'target')

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -20,7 +20,7 @@ from docutils.statemachine import ViewList
 from six import PY3
 
 from sphinx.ext.autodoc import (
-    AutoDirective, ModuleLevelDocumenter, cut_lines, between, ALL,
+    AutoDirective, DataDocumenter, ModuleLevelDocumenter, cut_lines, between, ALL,
     merge_autodoc_default_flags
 )
 from sphinx.ext.autodoc.directive import DocumenterBridge, process_documenter_options
@@ -552,6 +552,26 @@ def test_new_documenter():
 
     options.members = ['integer']
     assert_result_contains('.. py:data:: integer', 'module', 'target')
+
+
+@pytest.mark.usefixtures('setup_test')
+def test_data_documenter():
+    logging.setup(app, app._status, app._warning)
+    app.add_autodocumenter(DataDocumenter)
+
+    def assert_result(item, objtype, name, isin=True):
+        app._warning.truncate(0)
+        inst = app.registry.documenters[objtype](directive, name)
+        inst.generate()
+        assert app._warning.getvalue() == ''
+        assert item in directive.result if isin else item not in directive.result
+        del directive.result[:]
+
+    options.members = ['UNDOC_DATA']
+    options.undoc_members = True
+    assert_result('.. py:data:: UNDOC_DATA', 'module', 'target')
+    options.undoc_members = False
+    assert_result('.. py:data:: UNDOC_DATA', 'module', 'target', False)
 
 
 @pytest.mark.usefixtures('setup_test')


### PR DESCRIPTION
Make sure undocumented module level constants (or data objects) are included  when `undoc_members=True`, see #1063.

