### PR TITLE
Display meaningful names in type annotations for mocked objects

### DIFF
--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -84,11 +84,11 @@ class _MockObject(object):
 
 
 def _make_subclass(name, module, superclass=_MockObject, attributes=None):
-    # type: (str, str, Any, dict) -> _MockObject
+    # type: (str, str, Any, dict) -> Any
     attrs = {'__module__': module, '__display_name__': module + '.' + name}
     attrs.update(attributes or {})
 
-    return type(name, (superclass,), attrs)
+    return type(name, (superclass,), attrs)  # type: ignore
 
 
 class _MockModule(ModuleType):

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -80,6 +80,7 @@ class _MockObject(object):
         return self
 
     def __repr__(self):
+        # type: () -> str
         return self.__display_name__
 
 
@@ -88,7 +89,7 @@ def _make_subclass(name, module, superclass=_MockObject, attributes=None):
     attrs = {'__module__': module, '__display_name__': module + '.' + name}
     attrs.update(attributes or {})
 
-    return type(name, (superclass,), attrs)  # type: ignore
+    return type(name, (superclass,), attrs)
 
 
 class _MockModule(ModuleType):
@@ -107,6 +108,7 @@ class _MockModule(ModuleType):
         return _make_subclass(name, self.__name__)()
 
     def __repr__(self):
+        # type: () -> str
         return self.__name__
 
 

--- a/tests/test_ext_autodoc_importer.py
+++ b/tests/test_ext_autodoc_importer.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from sphinx.ext.autodoc.importer import _MockObject
+from sphinx.ext.autodoc.importer import _MockObject, _MockModule
 
 
 def test_MockObject():
@@ -21,6 +21,7 @@ def test_MockObject():
 
     class SubClass(mock.SomeClass):
         """docstring of SubClass"""
+
         def method(self):
             return "string"
 
@@ -29,3 +30,18 @@ def test_MockObject():
     assert isinstance(obj, SubClass)
     assert obj.method() == "string"
     assert isinstance(obj.other_method(), SubClass)
+
+
+def test_MockModule():
+    mock = _MockModule('mocked_module', None)
+    assert isinstance(mock.some_attr, _MockObject)
+    assert isinstance(mock.some_method, _MockObject)
+    assert isinstance(mock.attr1.attr2, _MockObject)
+    assert isinstance(mock.attr1.attr2.meth(), _MockObject)
+
+    assert repr(mock.some_attr) == 'mocked_module.some_attr'
+    assert repr(mock.some_method) == 'mocked_module.some_method'
+    assert repr(mock.attr1.attr2) == 'mocked_module.attr1.attr2'
+    assert repr(mock.attr1.attr2.meth) == 'mocked_module.attr1.attr2.meth'
+
+    assert repr(mock) == 'mocked_module'


### PR DESCRIPTION
Consider this snippet:
```python
from mocked_module import x

def f(arg: x.y):
    pass
```

The resulting documentation will be something like
```
f(arg: <sphinx.ext.autodoc.importer._MockObject at 0x54313513513>)
```
This patch fixes this:
```
f(arg: mocked_module.x.y)
```

Same goes for mocked superclass names in classes documentation.

### Feature or Bugfix
- Feature