### PR TITLE
Remove pypy from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 minversion = 2.0
-envlist = docs,flake8,mypy,coverage,py{35,36,37,38,py},du{12,13,14}
+envlist = docs,flake8,mypy,coverage,py{35,36,37,38},du{12,13,14}
 
 [testenv]
 usedevelop = True
 passenv =
     https_proxy http_proxy no_proxy PERL PERL5LIB PYTEST_ADDOPTS EPUBCHECK_PATH
 description =
-    py{35,36,37,38,py}: Run unit tests against {envname}.
+    py{35,36,37,38}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.
 
 # TODO(stephenfin) Replace this with the 'extras' config option when tox 2.4 is


### PR DESCRIPTION
The pypy executable is Python 2 and Python 2 support was dropped in commit 9412bd76b7f5fdf0adc231ef8130e45bda130164.
