### PR TITLE
Fix AttributeError in ExtensionError

### DIFF
--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -55,6 +55,7 @@ class ExtensionError(SphinxError):
     def __init__(self, message, orig_exc=None):
         # type: (unicode, Exception) -> None
         SphinxError.__init__(self, message)
+        self.message = message
         self.orig_exc = orig_exc
 
     def __repr__(self):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,17 @@
+import sys
+
+from sphinx.errors import ExtensionError
+
+
+def test_extension_error_repr():
+    exc = ExtensionError("foo")
+    assert repr(exc) == "ExtensionError('foo')"
+
+
+def test_extension_error_with_orig_exc_repr():
+    exc = ExtensionError("foo", Exception("bar"))
+    if sys.version_info < (3, 7):
+        expected = "ExtensionError('foo', Exception('bar',))"
+    else:
+        expected = "ExtensionError('foo', Exception('bar'))"
+    assert repr(exc) == expected


### PR DESCRIPTION
Subject: Fix AttributeError in ExtensionError

### Feature or Bugfix
- Bugfix

### Purpose

In Python 3, the attribute BaseException.message doesn't exist.

```
$ python3
>>> from sphinx.errors import ExtensionError
>>> e = ExtensionError('foo')
>>> repr(e)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sphinx/sphinx/errors.py", line 65, in __repr__
    return '%s(%r)' % (self.__class__.__name__, self.message)
AttributeError: 'ExtensionError' object has no attribute 'message'
```