### PR TITLE
Remove use of Python 2 os.getcwdu()

### DIFF
--- a/sphinx/environment/collectors/dependencies.py
+++ b/sphinx/environment/collectors/dependencies.py
@@ -9,12 +9,13 @@
     :license: BSD, see LICENSE for details.
 """
 
+import os
 from os import path
 
 from docutils.utils import relative_path
 
 from sphinx.environment.collectors import EnvironmentCollector
-from sphinx.util.osutil import getcwd, fs_encoding
+from sphinx.util.osutil import fs_encoding
 
 if False:
     # For type annotation
@@ -40,7 +41,7 @@ class DependenciesCollector(EnvironmentCollector):
     def process_doc(self, app, doctree):
         # type: (Sphinx, nodes.Node) -> None
         """Process docutils-generated dependency info."""
-        cwd = getcwd()
+        cwd = os.getcwd()
         frompath = path.join(path.normpath(app.srcdir), 'dummy')
         deps = doctree.settings.record_dependencies
         if not deps:

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -25,7 +25,7 @@ from os import path
 
 from six import PY2, PY3, text_type
 
-from sphinx.deprecation import RemovedInSphinx30Warning
+from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
 
 if False:
     # For type annotation
@@ -243,15 +243,16 @@ def abspath(pathdir):
 
 def getcwd():
     # type: () -> unicode
-    if hasattr(os, 'getcwdu'):
-        return os.getcwdu()
+    warnings.warn('sphinx.util.osutil.getcwd() is deprecated. '
+                  'Please use os.getcwd() instead.',
+                  RemovedInSphinx40Warning)
     return os.getcwd()
 
 
 @contextlib.contextmanager
 def cd(target_dir):
     # type: (unicode) -> Iterator[None]
-    cwd = getcwd()
+    cwd = os.getcwd()
     try:
         os.chdir(target_dir)
         yield


### PR DESCRIPTION
os.getcwdu() is Python 2 only. It was removed from Python 3. As Sphinx
is now Python 3 only, can remove the workaround.

```
$ python2 -c 'import os; print(os.getcwdu)'
<built-in function getcwdu>
$ python3 -c 'import os; print(os.getcwdu)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AttributeError: module 'os' has no attribute 'getcwdu'
```