### PR TITLE
Remove unused argument, content, from guess_mimetype

### DIFF
--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -12,12 +12,15 @@ from __future__ import absolute_import
 
 import base64
 import imghdr
+import warnings
 from collections import OrderedDict
 from os import path
 from typing import NamedTuple
 
 import imagesize
 from six import PY3, BytesIO, iteritems
+
+from sphinx.deprecation import RemovedInSphinx30Warning
 
 try:
     from PIL import Image        # check for the Python Imaging Library
@@ -83,6 +86,8 @@ def guess_mimetype(filename='', content=None, default=None):
     if ext in mime_suffixes:
         return mime_suffixes[ext]
     elif content:
+        warnings.warn('The content argument of guess_mimetype() is deprecated.',
+                      RemovedInSphinx30Warning)
         return guess_mimetype_for_stream(BytesIO(content), default=default)
     elif path.exists(filename):
         with open(filename, 'rb') as f:


### PR DESCRIPTION
Unused since its introduction in be261ed71ec797d32fe88dae1acf73adb2b33c8e.