### PR TITLE
Remove unnecessary object from class definitions

### DIFF
--- a/doc/usage/extensions/example_google.py
+++ b/doc/usage/extensions/example_google.py
@@ -178,7 +178,7 @@ class ExampleError(Exception):
         self.code = code
 
 
-class ExampleClass(object):
+class ExampleClass:
     """The summary line for a class docstring should fit on one line.
 
     If the class has public attributes, they may be documented here

--- a/doc/usage/extensions/example_numpy.py
+++ b/doc/usage/extensions/example_numpy.py
@@ -223,7 +223,7 @@ class ExampleError(Exception):
         self.code = code
 
 
-class ExampleClass(object):
+class ExampleClass:
     """The summary line for a class docstring should fit on one line.
 
     If the class has public attributes, they may be documented here

--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -54,7 +54,7 @@ It adds this directive:
            E   D   F
         """
 
-        class A(object):
+        class A:
             pass
 
         class B(A):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ extras_require = {
 cmdclass = {}
 
 
-class Tee(object):
+class Tee:
     def __init__(self, stream):
         self.stream = stream
         self.buffer = StringIO()

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -20,7 +20,7 @@ if False:
     from typing import List, Sequence  # NOQA
 
 
-class translatable(object):
+class translatable:
     """Node which supports translation.
 
     The translation goes forward with following steps:
@@ -53,7 +53,7 @@ class translatable(object):
         raise NotImplementedError
 
 
-class not_smartquotable(object):
+class not_smartquotable:
     """A node which does not support smart-quotes."""
     support_smartquotes = False
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -118,7 +118,7 @@ ENV_PICKLE_FILENAME = 'environment.pickle'
 logger = logging.getLogger(__name__)
 
 
-class Sphinx(object):
+class Sphinx:
     """The main application class and extensibility interface.
 
     :ivar srcdir: Directory containing source.
@@ -1208,7 +1208,7 @@ class Sphinx(object):
         return True
 
 
-class TemplateBridge(object):
+class TemplateBridge:
     """
     This class defines the interface for a "template bridge", that is, a class
     that renders templates given a template name and a context.

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -52,7 +52,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-class Builder(object):
+class Builder:
     """
     Builds target formats from the reST sources.
     """

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -62,7 +62,7 @@ msgstr ""
 """[1:]
 
 
-class Catalog(object):
+class Catalog:
     """Catalog of translatable messages."""
 
     def __init__(self):
@@ -84,7 +84,7 @@ class Catalog(object):
         self.metadata[msg].append((origin.source, origin.line, origin.uid))
 
 
-class MsgOrigin(object):
+class MsgOrigin:
     """
     Origin holder for Catalog message origin.
     """

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -169,7 +169,7 @@ class JavaScript(text_type):
         return self
 
 
-class BuildInfo(object):
+class BuildInfo:
     """buildinfo file manipulator.
 
     HTMLBuilder and its family are storing their own envdata to ``.buildinfo``.

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -59,7 +59,7 @@ BUILDERS = [
 ]
 
 
-class Make(object):
+class Make:
 
     def __init__(self, srcdir, builddir, opts):
         # type: (unicode, unicode, List[unicode]) -> None

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -49,7 +49,7 @@ ConfigValue = NamedTuple('ConfigValue', [('name', str),
                                          ('rebuild', Union[bool, unicode])])
 
 
-class ENUM(object):
+class ENUM:
     """represents the config value should be a one of candidates.
 
     Example:
@@ -72,7 +72,7 @@ if PY2:
     string_classes.append(binary_type)  # => [str, unicode]
 
 
-class Config(object):
+class Config:
     """Configuration file abstraction.
 
     The config object makes the values of all config values available as

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -177,7 +177,7 @@ class CodeBlock(SphinxDirective):
         return [literal]
 
 
-class LiteralIncludeReader(object):
+class LiteralIncludeReader:
     INVALID_OPTIONS_PAIR = [
         ('lineno-match', 'lineno-start'),
         ('lineno-match', 'append'),

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -28,7 +28,7 @@ if False:
     from sphinx.util.typing import RoleFunction  # NOQA
 
 
-class ObjType(object):
+class ObjType:
     """
     An ObjType is the description for a type of object that a domain can
     document.  In the object_types attribute of Domain subclasses, object type
@@ -55,7 +55,7 @@ class ObjType(object):
         self.attrs.update(attrs)
 
 
-class Index(object):
+class Index:
     """
     An Index is the description for a domain-specific index.  To add an index to
     a domain, subclass Index, overriding the three name attributes:
@@ -113,7 +113,7 @@ class Index(object):
         raise NotImplementedError
 
 
-class Domain(object):
+class Domain:
     """
     A Domain is meant to be a group of "object" description directives for
     objects of a similar nature, and corresponding roles to create references to

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3592,7 +3592,7 @@ class ASTNamespace(ASTBase):
         self.templatePrefix = templatePrefix
 
 
-class SymbolLookupResult(object):
+class SymbolLookupResult:
     def __init__(self, symbols, parentSymbol, identOrOp, templateParams, templateArgs):
         # type: (Iterator[Symbol], Symbol, Union[ASTIdentifier, ASTOperator], Any, ASTTemplateArgs) -> None  # NOQA
         self.symbols = symbols
@@ -3602,7 +3602,7 @@ class SymbolLookupResult(object):
         self.templateArgs = templateArgs
 
 
-class Symbol(object):
+class Symbol:
     debug_lookup = False
 
     def _assert_invariants(self):
@@ -4293,7 +4293,7 @@ class Symbol(object):
         return ''.join(res)
 
 
-class DefinitionParser(object):
+class DefinitionParser:
     # those without signedness and size modifiers
     # see http://en.cppreference.com/w/cpp/language/types
     _simple_fundemental_types = (
@@ -6585,7 +6585,7 @@ class CPPXRefRole(XRefRole):
         return title, target
 
 
-class CPPExprRole(object):
+class CPPExprRole:
     def __init__(self, asCode):
         if asCode:
             # render the expression as inline code
@@ -6597,7 +6597,7 @@ class CPPExprRole(object):
             self.node_type = nodes.inline
 
     def __call__(self, typ, rawtext, text, lineno, inliner, options={}, content=[]):
-        class Warner(object):
+        class Warner:
             def warn(self, msg):
                 inliner.reporter.warning(msg, line=lineno)
         text = utils.unescape(text).replace('\n', ' ')
@@ -6716,7 +6716,7 @@ class CPPDomain(Domain):
                             target, node, contnode, emitWarnings=True):
         # type: (BuildEnvironment, unicode, Builder, unicode, unicode, nodes.Node, nodes.Node, bool) -> nodes.Node  # NOQA
 
-        class Warner(object):
+        class Warner:
             def warn(self, msg):
                 if emitWarnings:
                     logger.warning(msg, location=node)

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -114,7 +114,7 @@ def _pseudo_parse_arglist(signode, arglist):
 
 # This override allows our inline type specifiers to behave like :class: link
 # when it comes to handling "." and "~" prefixes.
-class PyXrefMixin(object):
+class PyXrefMixin:
     def make_xref(self,
                   rolename,                  # type: unicode
                   domain,                    # type: unicode
@@ -536,7 +536,7 @@ class PyClassmember(PyObject):
             return ''
 
 
-class PyDecoratorMixin(object):
+class PyDecoratorMixin:
     """
     Mixin for decorator directives.
     """

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -91,7 +91,7 @@ class NoUri(Exception):
     pass
 
 
-class BuildEnvironment(object):
+class BuildEnvironment:
     """
     The environment in which the ReST files are translated.
     Stores an inventory of cross-file targets and provides doctree

--- a/sphinx/environment/adapters/asset.py
+++ b/sphinx/environment/adapters/asset.py
@@ -14,7 +14,7 @@ if False:
     from sphinx.environment import BuildEnvironment  # NOQA
 
 
-class ImageAdapter(object):
+class ImageAdapter:
     def __init__(self, env):
         # type: (BuildEnvironment) -> None
         self.env = env

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -27,7 +27,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-class IndexEntries(object):
+class IndexEntries:
     def __init__(self, env):
         # type: (BuildEnvironment) -> None
         self.env = env

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -27,7 +27,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-class TocTree(object):
+class TocTree:
     def __init__(self, env):
         # type: (BuildEnvironment) -> None
         self.env = env

--- a/sphinx/environment/collectors/__init__.py
+++ b/sphinx/environment/collectors/__init__.py
@@ -19,7 +19,7 @@ if False:
     from sphinx.environment import BuildEnvironment  # NOQA
 
 
-class EnvironmentCollector(object):
+class EnvironmentCollector:
     """An EnvironmentCollector is a specific data collector from each document.
 
     It gathers data and stores :py:class:`BuildEnvironment

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -45,7 +45,7 @@ core_events = {
 }  # type: Dict[unicode, unicode]
 
 
-class EventManager(object):
+class EventManager:
     def __init__(self):
         # type: () -> None
         self.events = core_events.copy()

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -199,7 +199,7 @@ class Options(dict):
             return None
 
 
-class Documenter(object):
+class Documenter:
     """
     A Documenter knows how to autodocument a single object type.  When
     registered with the AutoDirective, it will be used to document objects
@@ -916,7 +916,7 @@ class ClassLevelDocumenter(Documenter):
         return modname, parents + [base]
 
 
-class DocstringSignatureMixin(object):
+class DocstringSignatureMixin:
     """
     Mixin for FunctionDocumenter and MethodDocumenter to provide the
     feature of reading the signature from the docstring.

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -34,7 +34,7 @@ AUTODOC_DEFAULT_OPTIONS = ['members', 'undoc-members', 'inherited-members',
                            'ignore-module-all', 'exclude-members']
 
 
-class DummyOptionSpec(object):
+class DummyOptionSpec:
     """An option_spec allows any options."""
 
     def __getitem__(self, key):
@@ -42,7 +42,7 @@ class DummyOptionSpec(object):
         return lambda x: x
 
 
-class DocumenterBridge(object):
+class DocumenterBridge:
     """A parameters container for Documenters."""
 
     def __init__(self, env, reporter, options, lineno):

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -28,7 +28,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-class _MockObject(object):
+class _MockObject:
     """Used by autodoc_mock_imports."""
 
     def __new__(cls, *args, **kwargs):
@@ -93,7 +93,7 @@ class _MockModule(ModuleType):
         return o
 
 
-class _MockImporter(object):
+class _MockImporter:
     def __init__(self, names):
         # type: (List[str]) -> None
         self.names = names

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -51,7 +51,7 @@ if False:
     from sphinx.ext.autodoc import Documenter  # NOQA
 
 
-class DummyApplication(object):
+class DummyApplication:
     """Dummy Application class for sphinx-autogen command."""
 
     def __init__(self):

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -203,7 +203,7 @@ parser = doctest.DocTestParser()
 
 # helper classes
 
-class TestGroup(object):
+class TestGroup:
     def __init__(self, name):
         # type: (unicode) -> None
         self.name = name
@@ -236,7 +236,7 @@ class TestGroup(object):
             self.name, self.setup, self.cleanup, self.tests)
 
 
-class TestCode(object):
+class TestCode:
     def __init__(self, code, type, filename, lineno, options=None):
         # type: (unicode, unicode, Optional[str], int, Optional[Dict]) -> None
         self.code = code

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -44,7 +44,7 @@ class GraphvizError(SphinxError):
     category = 'Graphviz error'
 
 
-class ClickableMapDefinition(object):
+class ClickableMapDefinition:
     """A manipulator for clickable map file of graphviz."""
     maptag_re = re.compile('<map id="(.*?)"')
     href_re = re.compile('href=".*?"')

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -129,7 +129,7 @@ class InheritanceException(Exception):
     pass
 
 
-class InheritanceGraph(object):
+class InheritanceGraph:
     """
     Given a list of classes, determines the set of classes that they inherit
     from all the way to the root "object", and then is able to generate a

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -58,7 +58,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-class InventoryAdapter(object):
+class InventoryAdapter:
     """Inventory adapter for environment"""
 
     def __init__(self, env):
@@ -387,11 +387,11 @@ def inspect_main(argv):
               file=sys.stderr)
         sys.exit(1)
 
-    class MockConfig(object):
+    class MockConfig:
         intersphinx_timeout = None  # type: int
         tls_verify = False
 
-    class MockApp(object):
+    class MockApp:
         srcdir = ''
         config = MockConfig()
 

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -22,7 +22,7 @@ if False:
     from typing import Any, Dict, List  # NOQA
 
 
-class Config(object):
+class Config:
     """Sphinx napoleon extension settings in `conf.py`.
 
     Listed below are all the settings used by napoleon and their default

--- a/sphinx/ext/napoleon/iterators.py
+++ b/sphinx/ext/napoleon/iterators.py
@@ -18,7 +18,7 @@ if False:
     from typing import Any, Iterable  # NOQA
 
 
-class peek_iter(object):
+class peek_iter:
     """An iterator object that supports peeking ahead.
 
     Parameters

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -24,7 +24,7 @@ if False:
 logger = logging.getLogger(__name__)
 
 
-class Extension(object):
+class Extension:
     def __init__(self, name, module, **kwargs):
         # type: (unicode, Any, Any) -> None
         self.name = name

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -62,7 +62,7 @@ _LATEX_ADD_STYLES = r'''
 '''
 
 
-class PygmentsBridge(object):
+class PygmentsBridge:
     # Set these attributes if you want to have different Pygments formatters
     # than the default ones.
     html_formatter = HtmlFormatter

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -98,7 +98,7 @@ def accesskey(context, key):
     return ''
 
 
-class idgen(object):
+class idgen:
     def __init__(self):
         # type: () -> None
         self.id = 0

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -25,7 +25,7 @@ if False:
     from typing import Any, Callable, Dict, Iterator, List, Tuple  # NOQA
 
 
-class _TranslationProxy(UserString, object):
+class _TranslationProxy(UserString):
     """
     Class for proxy strings from gettext translations.  This is a helper for the
     lazy_* functions from this module.
@@ -36,7 +36,6 @@ class _TranslationProxy(UserString, object):
     This inherits from UserString because some docutils versions use UserString
     for their Text nodes, which then checks its argument for being either a
     basestring or UserString, otherwise calls str() -- not unicode() -- on it.
-    This also inherits from object to make the __new__ method work.
     """
     __slots__ = ('_func', '_args')
 

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -24,7 +24,7 @@ if False:
     from typing import Any, Dict, IO, List, Tuple  # NOQA
 
 
-class ModuleAnalyzer(object):
+class ModuleAnalyzer:
     # cache for analyzer objects -- caches both by module and file name
     cache = {}  # type: Dict[Tuple[unicode, unicode], Any]
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -107,7 +107,7 @@ def dedent_docstring(s):
     return docstring.lstrip("\r\n").rstrip("\r\n")
 
 
-class Token(object):
+class Token:
     """Better token wrapper for tokenize module."""
 
     def __init__(self, kind, value, start, end, source):
@@ -145,7 +145,7 @@ class Token(object):
                                              self.value.strip())
 
 
-class TokenProcessor(object):
+class TokenProcessor:
     def __init__(self, buffers):
         # type: (List[unicode]) -> None
         lines = iter(buffers)
@@ -464,7 +464,7 @@ class DefinitionFinder(TokenProcessor):
             self.context.pop()
 
 
-class Parser(object):
+class Parser:
     """Python source code parser to pick up variable comments.
 
     This is a better wrapper for ``VariableCommentPicker``.

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -54,7 +54,7 @@ EXTENSION_BLACKLIST = {
 }  # type: Dict[unicode, unicode]
 
 
-class SphinxComponentRegistry(object):
+class SphinxComponentRegistry:
     def __init__(self):
         # type: () -> None
         #: special attrgetter for autodoc; class object -> attrgetter

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -45,7 +45,7 @@ generic_docroles = {
 
 # -- generic cross-reference role ----------------------------------------------
 
-class XRefRole(object):
+class XRefRole:
     """
     A generic cross-referencing role.  To create a callable that can be used as
     a role function, create an instance of this class.

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -28,7 +28,7 @@ if False:
     from sphinx.environment import BuildEnvironment  # NOQA
 
 
-class SearchLanguage(object):
+class SearchLanguage:
     """
     This class is the base class for search natural language preprocessors.  If
     you want to add support for a new language, you should override the methods
@@ -155,7 +155,7 @@ languages = {
 }   # type: Dict[unicode, Any]
 
 
-class _JavaScriptIndex(object):
+class _JavaScriptIndex:
     """
     The search index as javascript file that calls a function
     on the documentation search object to register the index.
@@ -236,7 +236,7 @@ class WordCollector(NodeVisitor):
             self.found_words.extend(keywords)
 
 
-class IndexBuilder(object):
+class IndexBuilder:
     """
     Helper class that creates a searchindex based on the doctrees
     passed to the `feed` method.

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -46,7 +46,7 @@ if False:
     from typing import Any, Dict, List  # NOQA
 
 
-class BaseSplitter(object):
+class BaseSplitter:
 
     def __init__(self, options):
         # type: (Dict) -> None

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -173,7 +173,7 @@ def make_app(test_params, monkeypatch):
         app_.cleanup()
 
 
-class SharedResult(object):
+class SharedResult:
     cache = {}  # type: Dict[str, Dict[str, str]]
 
     def store(self, key, app_):

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -92,7 +92,7 @@ def etree_parse(path):
         return ElementTree.parse(path)  # type: ignore
 
 
-class Struct(object):
+class Struct:
     def __init__(self, **kwds):
         # type: (Any) -> None
         self.__dict__.update(kwds)
@@ -163,7 +163,7 @@ class SphinxTestApp(application.Sphinx):
         return '<%s buildername=%r>' % (self.__class__.__name__, self.builder.name)
 
 
-class SphinxTestAppWrapperForSkipBuilding(object):
+class SphinxTestAppWrapperForSkipBuilding:
     """
     This class is a wrapper for SphinxTestApp to speed up the test by skipping
     `app.build` process if it is already built and there is even one output

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -51,7 +51,7 @@ def extract_zip(filename, targetdir):
                 fp.write(archive.read(name))
 
 
-class Theme(object):
+class Theme:
     """A Theme is a set of HTML templates and configurations.
 
     This class supports both theme directory and theme archive (zipped theme)."""
@@ -159,7 +159,7 @@ def is_archived_theme(filename):
         return False
 
 
-class HTMLThemeFactory(object):
+class HTMLThemeFactory:
     """A factory class for HTML Themes."""
 
     def __init__(self, app):

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -403,7 +403,7 @@ def detect_encoding(readline):
 
 # Low-level utility functions and classes.
 
-class Tee(object):
+class Tee:
     """
     File-like object writing to two streams.
     """
@@ -535,7 +535,7 @@ def format_exception_cut_frames(x=1):
     return ''.join(res)
 
 
-class PeekableIterator(object):
+class PeekableIterator:
     """
     An iterator which wraps any iterable and makes it possible to peek to see
     what's the next item.

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -36,7 +36,7 @@ def _is_single_paragraph(node):
     return False
 
 
-class Field(object):
+class Field:
     """A doc field that is never grouped.  It can have an argument or not, the
     argument can be linked using a specified *rolename*.  Field should be used
     for doc fields that usually don't occur more than once.
@@ -235,7 +235,7 @@ class TypedField(GroupedField):
         return nodes.field('', fieldname, fieldbody)
 
 
-class DocFieldTransformer(object):
+class DocFieldTransformer:
     """
     Transforms field lists in "doc field" syntax into better-looking
     equivalents, using the field type definitions given on a domain.

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -148,7 +148,7 @@ class ElementLookupError(Exception):
     pass
 
 
-class sphinx_domains(object):
+class sphinx_domains:
     """Monkey-patch directive and role dispatch, so that domain-specific
     markup takes precedence.
     """
@@ -223,7 +223,7 @@ class sphinx_domains(object):
             return self.role_func(name, lang_module, lineno, reporter)
 
 
-class WarningStream(object):
+class WarningStream:
     def write(self, text):
         # type: (unicode) -> None
         matched = report_re.search(text)  # type: ignore

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -317,7 +317,7 @@ def is_builtin_class_method(obj, attr_name):
     return getattr(builtins, safe_getattr(cls, '__name__', '')) is cls  # type: ignore
 
 
-class Parameter(object):
+class Parameter:
     """Fake parameter class for python2."""
     POSITIONAL_ONLY = 0
     POSITIONAL_OR_KEYWORD = 1
@@ -334,7 +334,7 @@ class Parameter(object):
         self.annotation = self.empty
 
 
-class Signature(object):
+class Signature:
     """The Signature object represents the call signature of a callable object and
     its return annotation.
     """

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -32,7 +32,7 @@ BUFSIZE = 16 * 1024
 logger = logging.getLogger(__name__)
 
 
-class InventoryFileReader(object):
+class InventoryFileReader:
     """A file reader for inventory file.
 
     This reader supports mixture of texts and compressed texts.
@@ -94,7 +94,7 @@ class InventoryFileReader(object):
                 pos = buf.find(b'\n')
 
 
-class InventoryFile(object):
+class InventoryFile:
     @classmethod
     def load(cls, stream, uri, joinfunc):
         # type: (IO, unicode, Callable) -> Inventory

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -315,7 +315,7 @@ def skip_warningiserror(skip=True):
                 handler.removeFilter(disabler)
 
 
-class LogCollector(object):
+class LogCollector:
     def __init__(self):
         # type: () -> None
         self.logs = []  # type: List[logging.LogRecord]
@@ -495,7 +495,7 @@ class ColorizeFormatter(logging.Formatter):
             return message
 
 
-class SafeEncodingWriter(object):
+class SafeEncodingWriter:
     """Stream writer which ignores UnicodeEncodeError silently"""
     def __init__(self, stream):
         # type: (IO) -> None
@@ -517,7 +517,7 @@ class SafeEncodingWriter(object):
             self.stream.flush()
 
 
-class LastMessagesWriter(object):
+class LastMessagesWriter:
     """Stream writer which memories last 10 messages to save trackback"""
     def __init__(self, app, stream):
         # type: (Sphinx, IO) -> None

--- a/sphinx/util/matching.py
+++ b/sphinx/util/matching.py
@@ -68,7 +68,7 @@ def compile_matchers(patterns):
     return [re.compile(_translate_pattern(pat)).match for pat in patterns]
 
 
-class Matcher(object):
+class Matcher:
     """A pattern matcher for Multiple shell-style glob patterns.
 
     Note: this modifies the patterns to work with copy_asset().

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -34,7 +34,7 @@ explicit_title_re = re.compile(r'^(.+?)\s*(?<!\x00)<(.*?)>$', re.DOTALL)
 caption_ref_re = explicit_title_re  # b/w compat alias
 
 
-class NodeMatcher(object):
+class NodeMatcher:
     """A helper class for Node.traverse().
 
     It checks that given node is an instance of specified node-classes and it has

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -260,7 +260,7 @@ def cd(target_dir):
         os.chdir(cwd)
 
 
-class FileAvoidWrite(object):
+class FileAvoidWrite:
     """File-like object that buffers output and only writes if content changed.
 
     Use this class like when writing to a file to avoid touching the original

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 parallel_available = multiprocessing and (os.name == 'posix')
 
 
-class SerialTasks(object):
+class SerialTasks:
     """Has the same interface as ParallelTasks, but executes tasks directly."""
 
     def __init__(self, nproc=1):
@@ -57,7 +57,7 @@ class SerialTasks(object):
         pass
 
 
-class ParallelTasks(object):
+class ParallelTasks:
     """Executes *nproc* tasks in parallel after forking."""
 
     def __init__(self, nproc):

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -91,14 +91,14 @@ else:
 
 # UnicodeMixin
 if PY3:
-    class UnicodeMixin(object):
+    class UnicodeMixin:
         """Mixin class to handle defining the proper __str__/__unicode__
         methods in Python 2 or 3."""
 
         def __str__(self):
             return self.__unicode__()
 else:
-    class UnicodeMixin(object):
+    class UnicodeMixin:
         """Mixin class to handle defining the proper __str__/__unicode__
         methods in Python 2 or 3."""
 

--- a/sphinx/util/stemmer/__init__.py
+++ b/sphinx/util/stemmer/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     PYSTEMMER = False
 
 
-class BaseStemmer(object):
+class BaseStemmer:
     def stem(self, word):
         # type: (unicode) -> unicode
         raise NotImplementedError()

--- a/sphinx/util/stemmer/porter.py
+++ b/sphinx/util/stemmer/porter.py
@@ -29,7 +29,7 @@
 """
 
 
-class PorterStemmer(object):
+class PorterStemmer:
 
     def __init__(self):
         # type: () -> None

--- a/sphinx/util/tags.py
+++ b/sphinx/util/tags.py
@@ -46,7 +46,7 @@ class BooleanParser(Parser):
         return node
 
 
-class Tags(object):
+class Tags:
     def __init__(self, tags=None):
         # type: (List[unicode]) -> None
         self.tags = dict.fromkeys(tags or [], True)

--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -23,7 +23,7 @@ if False:
     from jinja2.loaders import BaseLoader  # NOQA
 
 
-class BaseRenderer(object):
+class BaseRenderer:
     def __init__(self, loader=None):
         # type: (BaseLoader) -> None
         self.env = SandboxedEnvironment(loader=loader, extensions=['jinja2.ext.i18n'])

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -265,7 +265,7 @@ class ExtBabel(Babel):
             return None
 
 
-class Table(object):
+class Table:
     """A table data"""
 
     def __init__(self, node):
@@ -386,7 +386,7 @@ class Table(object):
             return None
 
 
-class TableCell(object):
+class TableCell:
     """A cell data of tables."""
 
     def __init__(self, table, row, col):

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -45,7 +45,7 @@ class ManualPageWriter(Writer):
         self.output = visitor.astext()
 
 
-class NestedInlineTransform(object):
+class NestedInlineTransform:
     """
     Flatten nested inline nodes:
 

--- a/tests/py35/test_autodoc_py35.py
+++ b/tests/py35/test_autodoc_py35.py
@@ -247,7 +247,7 @@ class CustomEx(Exception):
         """Exception method."""
 
 
-class CustomDataDescriptor(object):
+class CustomDataDescriptor:
     """Descriptor class docstring."""
 
     def __init__(self, doc):
@@ -275,7 +275,7 @@ def _funky_classmethod(name, b, c, d, docstring=None):
     return classmethod(function)
 
 
-class Base(object):
+class Base:
     def inheritedmeth(self):
         """Inherited function."""
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -216,7 +216,7 @@ def test_format_signature():
     class D:
         pass
 
-    class E(object):
+    class E:
         pass
     # no signature for classes without __init__
     for C in (D, E):
@@ -226,7 +226,7 @@ def test_format_signature():
         def __init__(self, a, b=None):
             pass
 
-    class G(F, object):
+    class G(F):
         pass
     for C in (F, G):
         assert formatsig('class', 'C', C, None, None) == '(a, b=None)'
@@ -243,7 +243,7 @@ def test_format_signature():
 
             some docstring for __init__.
             '''
-    class G2(F2, object):
+    class G2(F2):
         pass
 
     assert formatsig('class', 'F2', F2, None, None) == \
@@ -399,7 +399,7 @@ def test_get_doc():
     assert getdocl('class', E) == ['Class docstring', '', 'Init docstring']
 
     # class does not have __init__ method
-    class F(object):
+    class F:
         """Class docstring"""
 
     # docstring in the __init__ method of base class will be discard
@@ -413,7 +413,7 @@ def test_get_doc():
         assert getdocl('class', F) == ['Class docstring']
 
     # class has __init__ method with no docstring
-    class G(object):
+    class G:
         """Class docstring"""
         def __init__(self):
             pass

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -28,7 +28,7 @@ def runnable(command):
         return p.returncode == 0
 
 
-class EPUBElementTree(object):
+class EPUBElementTree:
     """Test helper for content.opf and toc.ncx"""
     namespaces = {
         'idpf': 'http://www.idpf.org/2007/opf',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,7 +218,7 @@ def test_builtin_conf(app, status, warning):
 
 
 # example classes for type checking
-class A(object):
+class A:
     pass
 
 

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -22,7 +22,7 @@ from sphinx.domains.cpp import Symbol, _max_id, _id_prefix
 
 
 def parse(name, string):
-    class Config(object):
+    class Config:
         cpp_id_attributes = ["id_attr"]
         cpp_paren_attributes = ["paren_attr"]
     parser = DefinitionParser(string, None, Config())
@@ -804,7 +804,7 @@ not found in `{test}`
         assert result, expect
         return set(result.group('classes').split())
 
-    class RoleClasses(object):
+    class RoleClasses:
         """Collect the classes from the layout that was generated for a given role."""
 
         def __init__(self, role, root, contents):

--- a/tests/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon.py
@@ -37,7 +37,7 @@ def __special_undoc__():
     pass
 
 
-class SampleClass(object):
+class SampleClass:
     def _private_doc(self):
         """SampleClass._private_doc.DOCSTRING"""
         pass

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,7 +22,7 @@ from sphinx.util import jsdump
 DummyEnvironment = namedtuple('DummyEnvironment', ['version', 'domains'])
 
 
-class DummyDomain(object):
+class DummyDomain:
     def __init__(self, data):
         self.data = data
         self.object_types = {}

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -206,7 +206,7 @@ def test_Signature_methods():
 def test_Signature_partialmethod():
     from functools import partialmethod
 
-    class Foo(object):
+    class Foo:
         def meth1(self, arg1, arg2, arg3=None, arg4=None):
             pass
 
@@ -309,7 +309,7 @@ def test_Signature_annotations():
 
 
 def test_safe_getattr_with_default():
-    class Foo(object):
+    class Foo:
         def __getattr__(self, item):
             raise Exception
 
@@ -321,7 +321,7 @@ def test_safe_getattr_with_default():
 
 
 def test_safe_getattr_with_exception():
-    class Foo(object):
+    class Foo:
         def __getattr__(self, item):
             raise Exception
 
@@ -336,7 +336,7 @@ def test_safe_getattr_with_exception():
 
 
 def test_safe_getattr_with_property_exception():
-    class Foo(object):
+    class Foo:
         @property
         def bar(self):
             raise Exception
@@ -352,7 +352,7 @@ def test_safe_getattr_with_property_exception():
 
 
 def test_safe_getattr_with___dict___override():
-    class Foo(object):
+    class Foo:
         @property
         def __dict__(self):
             raise Exception
@@ -410,7 +410,7 @@ def test_frozenset_sorting_fallback():
 
 
 def test_dict_customtype():
-    class CustomType(object):
+    class CustomType:
         def __init__(self, value):
             self._value = value
 

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -84,7 +84,7 @@ def processing(message):
         print('done')
 
 
-class Changes(object):
+class Changes:
     def __init__(self, path):
         self.path = path
         self.fetch_version()


### PR DESCRIPTION
In Python 3, all classes are new-style classes. The object in the definition is redundant and unnecessary.