### PR TITLE
Add missing author

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Other contributors, listed alphabetically, are:
 * Zac Hatfield-Dodds -- doctest reporting improvements
 * Doug Hellmann -- graphviz improvements
 * Tim Hoffmann -- theme improvements
+* Antti Kaihola -- doctest extension (skipif option)
 * Dave Kuhlman -- original LaTeX writer
 * Blaise Laflamme -- pyramid theme
 * Chris Lamb -- reproducibility fixes


### PR DESCRIPTION
Subject: `AUTHORS` update

### Feature or Bugfix
- Documentation

### Purpose
- Include missing author in `AUTHORS`

### Detail
- Added myself into `AUTHORS` since I added a feature to the doctest extension, released in Sphinx 1.8.

### Relates
- #5307