### PR TITLE
Fix #5421: autodoc emits deprecation warning for :confval:`autodoc_default_flags`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #5421: autodoc emits deprecation warning for :confval:`autodoc_default_flags`
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -21,7 +21,7 @@ from docutils.statemachine import ViewList
 from six import iteritems, itervalues, text_type, class_types, string_types
 
 import sphinx
-from sphinx.deprecation import RemovedInSphinx20Warning
+from sphinx.deprecation import RemovedInSphinx20Warning, RemovedInSphinx30Warning
 from sphinx.errors import ExtensionError
 from sphinx.ext.autodoc.importer import mock, import_object, get_object_members
 from sphinx.ext.autodoc.importer import _MockImporter  # to keep compatibility  # NOQA
@@ -1562,8 +1562,13 @@ def merge_autodoc_default_flags(app, config):
     if not config.autodoc_default_flags:
         return
 
-    logger.warning(__('autodoc_default_flags is now deprecated. '
-                      'Please use autodoc_default_options instead.'))
+    # Note: this option will be removed in Sphinx-4.0.  But I marked this as
+    # RemovedInSphinx *30* Warning because we have to emit warnings for users
+    # who will be still in use with Sphinx-3.x.  So we should replace this by
+    # logger.warning() on 3.0.0 release.
+    warnings.warn('autodoc_default_flags is now deprecated. '
+                  'Please use autodoc_default_options instead.',
+                  RemovedInSphinx30Warning)
 
     for option in config.autodoc_default_flags:
         if isinstance(option, string_types):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5421 
