### PR TITLE
Fix #5418: Incorrect default path for sphinx-build -d/doctrees files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #5418: Incorrect default path for sphinx-build -d/doctrees files
+
 Testing
 --------
 

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -219,7 +219,7 @@ def build_main(argv=sys.argv[1:]):  # type: ignore
         args.confdir = args.sourcedir
 
     if not args.doctreedir:
-        args.doctreedir = os.path.join(args.sourcedir, '.doctrees')
+        args.doctreedir = os.path.join(args.outputdir, '.doctrees')
 
     # handle remaining filename arguments
     filenames = args.filenames


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5418 
