### PR TITLE
WIP: Fix #4890: support devhelp v2

### DIFF
--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -12,7 +12,7 @@
 """
 from __future__ import absolute_import
 
-import gzip
+import codecs
 import re
 from os import path
 from typing import Any
@@ -75,11 +75,18 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
         logger.info(__('dumping devhelp index...'))
 
         # Basic info
+        # TODO: Add language attribute
+        # TODO: Add online attribute
+        # TODO: Add author attribute
         root = etree.Element('book',
+                             xmlns='http://www.devhelp.net/book',
                              title=self.config.html_title,
                              name=self.config.project,
                              link="index.html",
-                             version=self.config.version)
+                             version=self.config.version,
+                             language='',
+                             online='',
+                             author='')
         tree = etree.ElementTree(root)
 
         # TOC
@@ -112,16 +119,17 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
 
         def write_index(title, refs, subitems):
             # type: (unicode, List[Any], Any) -> None
+            # TODO: Add attribute type
             if len(refs) == 0:
                 pass
             elif len(refs) == 1:
-                etree.SubElement(functions, 'function',
-                                 name=title, link=refs[0][1])
+                etree.SubElement(functions, 'keyword',
+                                 name=title, link=refs[0][1], type='')
             else:
                 for i, ref in enumerate(refs):
-                    etree.SubElement(functions, 'function',
+                    etree.SubElement(functions, 'keyword',
                                      name="[%d] %s" % (i, title),
-                                     link=ref[1])
+                                     link=ref[1], type='None')
 
             if subitems:
                 parent_title = re.sub(r'\s*\(.*\)\s*$', '', title)
@@ -134,9 +142,12 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
                 write_index(title, refs, subitems)
 
         # Dump the XML file
-        xmlfile = path.join(outdir, outname + '.devhelp.gz')
-        with gzip.open(xmlfile, 'w') as f:  # type: ignore
-            tree.write(f, 'utf-8')
+        xmlfile = path.join(outdir, outname + '.devhelp2')
+        with codecs.open(xmlfile, 'a', 'utf-8') as f:
+            xmlheader = '<?xml version="1.0" encoding="utf-8" standalone="no"?>'
+            xmltree = (etree.tostring(tree.getroot(), method='xml')).decode('utf-8')
+            xmlbody = xmlheader + xmltree
+            f.write(xmlbody)
 
 
 def setup(app):

--- a/tests/test_build_devhelp.py
+++ b/tests/test_build_devhelp.py
@@ -1,0 +1,46 @@
+import xml.etree.cElementTree as ElementTree
+
+import pytest
+
+
+@pytest.mark.sphinx('devhelp', testroot='basic')
+def test_devhelp_basic(app):
+    app.builder.build_all()
+    result = (app.outdir / 'Python.devhelp2').text(encoding='utf-8')
+
+    assert '<?xml version="1.0" encoding="utf-8" standalone="no"?>' in result
+    assert '<book' in result
+    assert '<chapters' in result
+    assert '<functions' in result
+
+@pytest.mark.sphinx('devhelp', testroot='root')
+def test_devhelp_check_info(app):
+    app.builder.build_all()
+    result = (app.outdir / 'SphinxTests.devhelp2').text(encoding='utf-8')
+
+    index = ElementTree.fromstring(result)
+
+    assert index.tag == '{http://www.devhelp.net/book}book'
+
+    # Attributes required book root tag
+    assert 'title' in index.keys()
+    assert 'link' in index.keys()
+    assert 'name' in index.keys()
+    assert 'version' in index.keys()
+    assert 'language' in index.keys()
+    assert 'online' in index.keys()
+    assert 'author' in index.keys()
+
+    # Chapters-sub Attributes
+    sub_element = index.findall('./')[0].findall('./')[0]
+    assert sub_element.tag == '{http://www.devhelp.net/book}sub'
+    assert 'name' in sub_element.keys()
+    assert 'link' in sub_element.keys()
+
+    # Functions-keyword Attributes
+    keyword_element = index.findall('./')[1].find('./')
+    assert keyword_element.tag == '{http://www.devhelp.net/book}keyword'
+    assert 'name' in keyword_element.keys()
+    assert 'link' in keyword_element.keys()
+    assert 'type' in keyword_element.keys()
+


### PR DESCRIPTION
Subject: Support for devhelp version 2

### Feature or Bugfix
- Bugfix

### Purpose
- Add full support for devhelp version 2 and remove the deprecated version (devehelp.tar.gz)

### WIP
The patch is like WIP because it needs more work in some parts for extracting information, if possible, otherwise we need to set a default value.

#### TODO
Extract values from the settings:
- [ ] Language
https://github.com/sphinx-doc/sphinx/blob/d788c0118bf96b6b1d0733cf9b47c741430efa30/sphinx/builders/devhelp.py#L87

- [ ] URL from documentation online 
https://github.com/sphinx-doc/sphinx/blob/d788c0118bf96b6b1d0733cf9b47c741430efa30/sphinx/builders/devhelp.py#L88

- [ ] Author
https://github.com/sphinx-doc/sphinx/blob/d788c0118bf96b6b1d0733cf9b47c741430efa30/sphinx/builders/devhelp.py#L89

- [ ] Types¹² 
https://github.com/sphinx-doc/sphinx/blob/d788c0118bf96b6b1d0733cf9b47c741430efa30/sphinx/builders/devhelp.py#L127 https://github.com/sphinx-doc/sphinx/blob/d788c0118bf96b6b1d0733cf9b47c741430efa30/sphinx/builders/devhelp.py#L132

[1] XML Scheme Reference [Attribute Type](https://www.gtk.org/gtk-doc/devhelp2.xsd.html#attribute_type)
[2] [Example](https://gist.github.com/gutierri/bb5c34fc4b2df3188301e15e394914e0#file-totem-devhelp2-L24-L30) of functions and keywords with type attribute