### PR TITLE
napoleon: Use collections.abc

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -11,7 +11,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-import collections
+import collections.abc
 import inspect
 import re
 from functools import partial
@@ -120,7 +120,7 @@ class GoogleDocstring(UnicodeMixin):
                 what = 'class'
             elif inspect.ismodule(obj):
                 what = 'module'
-            elif isinstance(obj, collections.Callable):  # type: ignore
+            elif isinstance(obj, collections.abc.Callable):
                 what = 'function'
             else:
                 what = 'object'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `collections.Callable` was moved to under `collections.abc` package since python 3.3.  And python 3.8 will remove it.  So this imports it from new localtion.
- I saw derepcation warnings for this
   ```
   /home/travis/build/sphinx-doc/sphinx/sphinx/ext/napoleon/docstring.py:123: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
     elif isinstance(obj, collections.Callable):  # type: ignore
   ```
   https://travis-ci.org/sphinx-doc/sphinx/jobs/428170247#L1888