### PR TITLE
Fix #5437: autodoc: crashed on modules importing eggs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #5421: autodoc emits deprecation warning for :confval:`autodoc_default_flags`
 * #5422: lambda object causes PicklingError on storing environment
 * #5417: Sphinx fails to build with syntax error in Python 2.7.5
+* #5437: autodoc: crashed on modules importing eggs
 
 Testing
 --------

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -314,8 +314,9 @@ def get_module_source(modname):
             filename += 'w'
     elif not (lfilename.endswith('.py') or lfilename.endswith('.pyw')):
         raise PycodeError('source is not a .py file: %r' % filename)
-    elif '.egg' in filename:
-        eggpath, _ = re.split('(?<=\\.egg)/', filename)
+    elif ('.egg' + os.path.sep) in filename:
+        pat = '(?<=\\.egg)' + re.escape(os.path.sep)
+        eggpath, _ = re.split(pat, filename, 1)
         if path.isfile(eggpath):
             return 'file', filename
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5437 
