### PR TITLE
Fix #5417: Sphinx fails to build with syntax error in Python 2.7.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #5418: Incorrect default path for sphinx-build -d/doctrees files
 * #5421: autodoc emits deprecation warning for :confval:`autodoc_default_flags`
 * #5422: lambda object causes PicklingError on storing environment
+* #5417: Sphinx fails to build with syntax error in Python 2.7.5
 
 Testing
 --------

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -153,7 +153,7 @@ class TestDirective(SphinxDirective):
         if self.name == 'doctest' and 'pyversion' in self.options:
             try:
                 spec = self.options['pyversion']
-                python_version = '.'.join(str(v) for v in sys.version_info[:3])
+                python_version = '.'.join([str(v) for v in sys.version_info[:3]])
                 if not is_allowed_version(spec, python_version):
                     flag = doctest.OPTIONFLAGS_BY_NAME['SKIP']
                     node['options'][flag] = True  # Skip the test


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5417 
