### PR TITLE
Fix #5431: autodoc: ``autofunction`` emits a warning for callable objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #5421: autodoc emits deprecation warning for :confval:`autodoc_default_flags`
 * #5422: lambda object causes PicklingError on storing environment
 * #5417: Sphinx fails to build with syntax error in Python 2.7.5
+* #5431: autodoc: ``autofunction`` emits a warning for callable objects
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1055,7 +1055,13 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             # cannot introspect arguments of a C function or method
             return None
         try:
-            args = Signature(self.object).format_args()
+            if (not isfunction(self.object) and
+                    not isbuiltin(self.object) and
+                    not inspect.isclass(self.object) and
+                    hasattr(self.object, '__call__')):
+                args = Signature(self.object.__call__).format_args()
+            else:
+                args = Signature(self.object).format_args()
         except TypeError:
             if (is_builtin_class_method(self.object, '__new__') and
                is_builtin_class_method(self.object, '__init__')):

--- a/tests/roots/test-ext-autodoc/target/callable.py
+++ b/tests/roots/test-ext-autodoc/target/callable.py
@@ -1,0 +1,8 @@
+class Callable():
+    """A callable object that behaves like a function."""
+
+    def __call__(self, arg1, arg2, **kwargs):
+        pass
+
+
+function = Callable()

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1341,6 +1341,19 @@ def test_descriptor_class(app):
     ]
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autofunction_for_callable(app):
+    actual = do_autodoc(app, 'function', 'target.callable.function')
+    assert list(actual) == [
+        '',
+        '.. py:function:: function(arg1, arg2, **kwargs)',
+        '   :module: target.callable',
+        '',
+        '   A callable object that behaves like a function.',
+        '   '
+    ]
+
+
 @pytest.mark.sphinx('html', testroot='root')
 def test_mocked_module_imports(app):
     options = {"members": 'TestAutodoc,decoratedFunction'}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5431 
