### PR TITLE
Fix #5453 and move LaTeX ``\pagestyle`` to template

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Dependencies
 Incompatible changes
 --------------------
 
+* LaTeX ``\pagestyle`` commands have been moved to the LaTeX template. No
+  changes in PDF, except possibly if ``\sphinxtableofcontents``, which
+  contained them, had been customized in :file:`conf.py`. (refs: #5455)
+
 Deprecated
 ----------
 
@@ -26,6 +30,7 @@ Bugs fixed
 * #5433: latex: ImportError: cannot import name 'DEFAULT_SETTINGS'
 * #5431: autodoc: ``autofunction`` emits a warning for callable objects
 * #5457: Fix TypeError in error message when override is prohibited
+* #5453: PDF builds of 'howto' documents have no page numbers
 
 Testing
 --------

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -51,8 +51,11 @@
 <%= makeindex %>
 \begin{document}
 <%= shorthandoff %>
+\pagestyle{empty}
 <%= maketitle %>
+\pagestyle{plain}
 <%= tableofcontents %>
+\pagestyle{normal}
 <%= body %>
 <%= atendofbody %>
 <%= indices %>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2018/07/18 v1.8 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2018/09/18 v1.8.1 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -499,15 +499,31 @@
 \sloppy
 \hbadness = 5000                % don't print trivial gripes
 
-\pagestyle{empty}               % start this way
-
+% Use \pagestyle{normal} as the primary pagestyle for text.
 % Redefine the 'normal' header/footer style when using "fancyhdr" package:
-% Note: this presupposes "twoside". If "oneside" class option, there will be warnings.
-\ltx@ifundefined{fancyhf}{}{
-  % Use \pagestyle{normal} as the primary pagestyle for text.
-  \fancypagestyle{normal}{
+\@ifpackageloaded{fancyhdr}{%
+  \ltx@ifundefined{c@chapter}
+  {% no \chapter, "howto" (non-Japanese) docclass
+   \fancypagestyle{plain}{
     \fancyhf{}
-% (for \py@HeaderFamily cf "TITLES")
+    \fancyfoot[C]{{\py@HeaderFamily\thepage}}
+    \renewcommand{\headrulewidth}{0pt}
+    \renewcommand{\footrulewidth}{0pt}
+   }
+   % Same as 'plain', this way we can use it in template
+   % FIXME: shouldn't this have a running header with Name and Release like 'manual'?
+   \fancypagestyle{normal}{
+    \fancyhf{}
+    \fancyfoot[C]{{\py@HeaderFamily\thepage}}
+    \renewcommand{\headrulewidth}{0pt}
+    \renewcommand{\footrulewidth}{0pt}
+   }
+  }%
+  {% classes with \chapter command
+   \fancypagestyle{normal}{
+    \fancyhf{}
+   % FIXME: this presupposes "twoside".
+   % If "oneside" class option, there are warnings in LaTeX log.
     \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}
     \fancyfoot[LO]{{\py@HeaderFamily\nouppercase{\rightmark}}}
     \fancyfoot[RE]{{\py@HeaderFamily\nouppercase{\leftmark}}}
@@ -517,17 +533,24 @@
     % define chaptermark with \@chappos when \@chappos is available for Japanese
     \ltx@ifundefined{@chappos}{}
       {\def\chaptermark##1{\markboth{\@chapapp\space\thechapter\space\@chappos\space ##1}{}}}
-  }
+    }
   % Update the plain style so we get the page number & footer line,
   % but not a chapter or section title.  This is to keep the first
   % page of a chapter and the blank page between chapters `clean.'
-  \fancypagestyle{plain}{
+   \fancypagestyle{plain}{
     \fancyhf{}
     \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}
     \renewcommand{\headrulewidth}{0pt}
     \renewcommand{\footrulewidth}{0.4pt}
+    }
+   }
   }
-}
+  {% no fancyhdr: memoir class
+   % Provide default for 'normal' style simply as an alias of 'plain' style
+   % This way we can use \pagestyle{normal} in LaTeX template
+   \def\ps@normal{\ps@plain}
+   % Users of memoir class are invited to redefine 'normal' style in preamble
+  }
 
 % geometry
 \ifx\kanjiskip\@undefined

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -536,7 +536,7 @@
     }
   % Update the plain style so we get the page number & footer line,
   % but not a chapter or section title.  This is to keep the first
-  % page of a chapter and the blank page between chapters `clean.'
+  % page of a chapter `clean.'
    \fancypagestyle{plain}{
     \fancyhf{}
     \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -3,7 +3,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesClass{sphinxhowto}[2017/03/26 v1.6 Document class (Sphinx HOWTO)]
+\ProvidesClass{sphinxhowto}[2018/09/18 v1.8.1 Document class (Sphinx HOWTO)]
 
 % 'oneside' option overriding the 'twoside' default
 \newif\if@oneside
@@ -66,12 +66,7 @@
   \vspace{12pt}
 }  
 
-\@ifundefined{fancyhf}{
-  \pagestyle{plain}}{
-  \pagestyle{normal}}		% start this way; change for
-\pagenumbering{arabic}		% ToC & chapters
-
-\thispagestyle{empty}
+\pagenumbering{arabic}
 
 % Fix the bibliography environment to add an entry to the Table of
 % Contents.

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -3,7 +3,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesClass{sphinxmanual}[2017/03/26 v1.6 Document class (Sphinx manual)]
+\ProvidesClass{sphinxmanual}[2018/09/18 v1.8.1 Document class (Sphinx manual)]
 
 % chapters starting at odd pages (overridden by 'openany' document option)
 \PassOptionsToClass{openright}{\sphinxdocclass}
@@ -75,7 +75,6 @@
 
 \newcommand{\sphinxtableofcontents}{%
   \pagenumbering{roman}%
-  \pagestyle{plain}%
   \begingroup
     \parskip \z@skip
     \tableofcontents
@@ -83,7 +82,6 @@
   % before resetting page counter, let's do the right thing.
   \if@openright\cleardoublepage\else\clearpage\fi
   \pagenumbering{arabic}%
-  \ifdefined\fancyhf\pagestyle{normal}\fi
 }
 
 % This is needed to get the width of the section # area wide enough in the


### PR DESCRIPTION
Bugfix: #5453 

No change for 'manual' class (or Japanese documents), but the `\sphinxtableofcontents` for 'manual' has been modified: the `\pagestyle` commands therein have been moved to LaTeX template.

Overall this changes nothing to 'manual' documents except for those users who have customized `\sphinxtableofcontents` in their own way and perhaps don't want the `\pagestyle` now in LaTeX templates: I expect very few if any project have done that, and in that case the user only needs to use custom LaTeX template to suppress the `\pagestyle` inserted from it.



