### PR TITLE
Fix TypeError in error message when override is prohibited

### DIFF
--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -199,7 +199,7 @@ class SphinxComponentRegistry(object):
 
         directives = self.domain_directives.setdefault(domain, {})
         if name in directives and not override:
-            raise ExtensionError(__('The %r directive is already registered to %d domain') %
+            raise ExtensionError(__('The %r directive is already registered to domain %s') %
                                  (name, domain))
         if not isclass(obj) or not issubclass(obj, Directive):
             directives[name] = directive_helper(obj, has_content, argument_spec, **option_spec)
@@ -213,7 +213,7 @@ class SphinxComponentRegistry(object):
             raise ExtensionError(__('domain %s not yet registered') % domain)
         roles = self.domain_roles.setdefault(domain, {})
         if name in roles and not override:
-            raise ExtensionError(__('The %r role is already registered to %d domain') %
+            raise ExtensionError(__('The %r role is already registered to domain %s') %
                                  (name, domain))
         roles[name] = role
 
@@ -224,7 +224,7 @@ class SphinxComponentRegistry(object):
             raise ExtensionError(__('domain %s not yet registered') % domain)
         indices = self.domain_indices.setdefault(domain, [])
         if index in indices and not override:
-            raise ExtensionError(__('The %r index is already registered to %d domain') %
+            raise ExtensionError(__('The %r index is already registered to domain %s') %
                                  (index.name, domain))
         indices.append(index)
 


### PR DESCRIPTION
Fix following `TypeError` when we are attempting to override while override is `False`:

```
Exception occurred:
  File "/usr/lib/python3.7/site-packages/sphinx/registry.py", line 203, in add_directive_to_domain
    (name, domain))
TypeError: %d format: a number is required, not str
```

This happened when I am trying to build user guides for ghc:

```
# Sphinx version: 1.8.0
# Python version: 3.7.0 (CPython)
# Docutils version: 0.14 
# Jinja2 version: 2.10
# Last messages:

# Loaded extensions:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/sphinx/cmd/build.py", line 303, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/usr/lib/python3.7/site-packages/sphinx/application.py", line 228, in __init__
    self.setup_extension(extension)
  File "/usr/lib/python3.7/site-packages/sphinx/application.py", line 449, in setup_extension
    self.registry.load_extension(self, extname)
  File "/usr/lib/python3.7/site-packages/sphinx/registry.py", line 483, in load_extension
    metadata = mod.setup(app)
  File "/home/watashi/gao/ghc/docs/users_guide/flags.py", line 605, in setup
    app.add_directive_to_domain('std', 'ghc-flag', Flag)
  File "/usr/lib/python3.7/site-packages/sphinx/application.py", line 821, in add_directive_to_domain
    **option_spec)
  File "/usr/lib/python3.7/site-packages/sphinx/registry.py", line 203, in add_directive_to_domain
    (name, domain))
TypeError: %d format: a number is required, not str
```

After the fix, we get correct error message like:

```
Extension error:
The 'ghc-flag' directive is already registered to domain std
```