### PR TITLE
Fix #5463: mathbase: math_role and MathDirective was disappeared in 1.8.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Bugs fixed
 * #5431: autodoc: ``autofunction`` emits a warning for callable objects
 * #5457: Fix TypeError in error message when override is prohibited
 * #5453: PDF builds of 'howto' documents have no page numbers
+* #5463: mathbase: math_role and MathDirective was disappeared in 1.8.0
 
 Testing
 --------
@@ -189,6 +190,8 @@ Deprecated
 * ``sphinx.ext.mathbase.eqref`` node is deprecated
 * ``sphinx.ext.mathbase.is_in_section_title()`` is deprecated
 * ``sphinx.ext.mathbase.MathDomain`` is deprecated
+* ``sphinx.ext.mathbase.MathDirective`` is deprecated
+* ``sphinx.ext.mathbase.math_role`` is deprecated
 * ``sphinx.ext.mathbase.setup_math()`` is deprecated
 * ``sphinx.directives.other.VersionChanges`` is deprecated
 * ``sphinx.highlighting.PygmentsBridge.unhighlight()`` is deprecated

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -183,6 +183,16 @@ The following is a list of deprecated interface.
      - 3.0
      - ``sphinx.domains.math.MathDomain``
 
+   * - ``sphinx.ext.mathbase.MathDirective``
+     - 1.8
+     - 3.0
+     - ``sphinx.directives.patches.MathDirective``
+
+   * - ``sphinx.ext.mathbase.math_role()``
+     - 1.8
+     - 3.0
+     - ``docutils.parsers.rst.roles.math_role()``
+
    * - ``sphinx.ext.mathbase.setup_math()``
      - 1.8
      - 3.0

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -12,10 +12,12 @@
 import warnings
 
 from docutils import nodes
+from docutils.parsers.rst.roles import math_role as math_role_base
 
 from sphinx.addnodes import math, math_block as displaymath  # NOQA  # to keep compatibility
 from sphinx.builders.latex.nodes import math_reference as eqref  # NOQA  # to keep compatibility
 from sphinx.deprecation import RemovedInSphinx30Warning
+from sphinx.directives.patches import MathDirective as MathDirectiveBase
 from sphinx.domains.math import MathDomain  # NOQA  # to keep compatibility
 from sphinx.domains.math import MathReferenceRole as EqXRefRole  # NOQA  # to keep compatibility
 
@@ -24,6 +26,21 @@ if False:
     from typing import Any, Callable, List, Tuple  # NOQA
     from docutils.writers.html4css1 import Writer  # NOQA
     from sphinx.application import Sphinx  # NOQA
+
+
+class MathDirective(MathDirectiveBase):
+    def run(self):
+        warnings.warn('sphinx.ext.mathbase.MathDirective is moved to '
+                      'sphinx.directives.patches package.',
+                      RemovedInSphinx30Warning)
+        return super(MathDirective, self).run()
+
+
+def math_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    warnings.warn('sphinx.ext.mathbase.math_role() is deprecated. '
+                  'Please use docutils.parsers.rst.roles.math_role() instead.',
+                  RemovedInSphinx30Warning)
+    return math_role_base(role, rawtext, text, lineno, inliner, options, content)
 
 
 def get_node_equation_number(writer, node):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5463 
