### PR TITLE
Fix #5454: latex: Index has disappeared from PDF for Japanese documents

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * #5457: Fix TypeError in error message when override is prohibited
 * #5453: PDF builds of 'howto' documents have no page numbers
 * #5463: mathbase: math_role and MathDirective was disappeared in 1.8.0
+* #5454: latex: Index has disappeared from PDF for Japanese documents
 
 Testing
 --------

--- a/sphinx/texinputs/latexmkjarc
+++ b/sphinx/texinputs/latexmkjarc
@@ -5,11 +5,9 @@ sub mendex {
   my ($source, $basename, $destination) = @_;
   my $dictfile = $basename . ".dic";
   unlink($destination);
-  if (-f $dictfile) {
-    system("mendex", "-U", "-f", "-d", $dictfile, "-s", "python.ist", $source);
-    if ($? > 0) {
-      print("mendex exited with error code $? (ignored)\n");
-    }
+  system("mendex", "-U", "-f", "-d", $dictfile, "-s", "python.ist", $source);
+  if ($? > 0) {
+    print("mendex exited with error code $? (ignored)\n");
   }
   if (!-e $destination) {
     # create an empty .ind file if nothing


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5454 
