### PR TITLE
Fix #5432: py domain: :type: field can't process :term: references

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #5453: PDF builds of 'howto' documents have no page numbers
 * #5463: mathbase: math_role and MathDirective was disappeared in 1.8.0
 * #5454: latex: Index has disappeared from PDF for Japanese documents
+* #5432: py domain: ``:type:`` field can't process ``:term:`` references
 
 Testing
 --------

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -305,7 +305,8 @@ class DocFieldTransformer(object):
                 entries.append(field)
 
                 # but if this has a type then we can at least link it
-                if typedesc and is_typefield and content:
+                if (typedesc and is_typefield and content and
+                        len(content) == 1 and isinstance(content[0], nodes.Text)):
                     target = content[0].astext()
                     xrefs = typedesc.make_xrefs(
                         typedesc.typerolename,

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -38,3 +38,10 @@ module
    :type  y: tuple(str, float)
    :rtype:   list
 
+.. py:attribute:: attr1
+
+   :type: ModTopLevel
+
+.. py:attribute:: attr2
+
+   :type: :doc:`index`

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -113,7 +113,10 @@ def test_domain_py_xrefs(app, status, warning):
     assert_refnode(refnodes[9], False, False, 'str', 'class')
     assert_refnode(refnodes[10], False, False, 'float', 'class')
     assert_refnode(refnodes[11], False, False, 'list', 'class')
-    assert len(refnodes) == 12
+    assert_refnode(refnodes[11], False, False, 'list', 'class')
+    assert_refnode(refnodes[12], False, False, 'ModTopLevel', 'class')
+    assert_refnode(refnodes[13], False, False, 'index', 'doc', domain='std')
+    assert len(refnodes) == 14
 
     doctree = app.env.get_doctree('module_option')
     refnodes = list(doctree.traverse(addnodes.pending_xref))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5432 