### PR TITLE
Correct installation docs about supported Python versions

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -12,8 +12,7 @@ Installing Sphinx
 Overview
 --------
 
-Sphinx is written in `Python`__ and supports both Python 2.7 and Python 3.3+.
-We recommend the latter.
+Sphinx is written in `Python`__ and supports Python 3.5+.
 
 __ http://docs.python-guide.org/en/latest/
 


### PR DESCRIPTION
Since commit 9412bd76b7f5fdf0adc231ef8130e45bda130164, older Python versions have been dropped.