### PR TITLE
Remove uses of six.moves that did not cause any type errors

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -13,6 +13,7 @@
 from __future__ import print_function
 
 import os
+import pickle
 import sys
 import warnings
 from collections import deque
@@ -21,7 +22,6 @@ from os import path
 
 from docutils.parsers.rst import Directive, directives, roles
 from six import itervalues
-from six.moves import cPickle as pickle
 from six.moves import cStringIO
 
 import sphinx

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -9,11 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 
+import pickle
 import time
 from os import path
 
 from docutils import nodes
-from six.moves import cPickle as pickle
 
 from sphinx.environment import CONFIG_OK, CONFIG_CHANGED_REASON
 from sphinx.environment.adapters.asset import ImageAdapter

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import pickle
 import posixpath
 import re
 import sys
@@ -25,7 +26,6 @@ from docutils.io import DocTreeInput, StringOutput
 from docutils.readers.doctree import Reader as DoctreeReader
 from docutils.utils import relative_path
 from six import text_type, string_types
-from six.moves import cPickle as pickle
 
 from sphinx import package_dir, __display_version__
 from sphinx.application import ENV_PICKLE_FILENAME

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -35,7 +35,6 @@ except ImportError:
 
 from docutils.utils import column_width
 from six import text_type, binary_type
-from six.moves import input
 from six.moves.urllib.parse import quote as urlquote
 
 import sphinx.locale

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -15,7 +15,6 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 from docutils.parsers.rst.directives.misc import Class
 from docutils.parsers.rst.directives.misc import Include as BaseInclude
-from six.moves import range
 
 from sphinx import addnodes
 from sphinx.domains.changeset import VersionChange  # NOQA  # for compatibility

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -10,6 +10,7 @@
 """
 
 import os
+import pickle
 import sys
 import warnings
 from collections import defaultdict
@@ -17,7 +18,6 @@ from copy import copy
 from os import path
 
 from six import BytesIO, next
-from six.moves import cPickle as pickle
 
 from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx30Warning

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -12,10 +12,9 @@
 
 import glob
 import inspect
+import pickle
 import re
 from os import path
-
-from six.moves import cPickle as pickle
 
 import sphinx
 from sphinx.builders import Builder

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -36,6 +36,7 @@ r"""
     :license: BSD, see LICENSE for details.
 """
 
+import builtins
 import inspect
 import re
 import sys
@@ -44,7 +45,6 @@ from hashlib import md5
 from docutils import nodes
 from docutils.parsers.rst import directives
 from six import text_type
-from six.moves import builtins
 
 import sphinx
 from sphinx.ext.graphviz import render_dot_html, render_dot_latex, \

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -17,7 +17,6 @@ from collections.abc import Callable
 from functools import partial
 
 from six import string_types, u
-from six.moves import range
 
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.locale import _

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -8,11 +8,11 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import pickle
 import re
 from os import path
 
 from six import itervalues, text_type, string_types
-from six.moves import cPickle as pickle
 
 from docutils.nodes import raw, comment, title, Text, NodeVisitor, SkipNode
 

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import configparser
 import os
 import shutil
 import tempfile
@@ -16,7 +17,6 @@ from os import path
 from zipfile import ZipFile
 
 import pkg_resources
-from six.moves import configparser
 
 from sphinx import package_dir
 from sphinx.errors import ThemeError
@@ -72,7 +72,7 @@ class Theme:
             extract_zip(theme_path, self.themedir)
 
         self.config = configparser.RawConfigParser()
-        self.config.read(path.join(self.themedir, THEMECONF))  # type: ignore
+        self.config.read(path.join(self.themedir, THEMECONF))
 
         try:
             inherit = self.config.get('theme', 'inherit')
@@ -104,7 +104,7 @@ class Theme:
         base theme chain.
         """
         try:
-            return self.config.get(section, name)  # type: ignore
+            return self.config.get(section, name)
         except (configparser.NoOptionError, configparser.NoSectionError):
             if self.base:
                 return self.base.get_config(section, name, default)

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -28,7 +28,6 @@ from time import mktime, strptime
 
 from docutils.utils import relative_path
 from six import text_type, binary_type, itervalues
-from six.moves import range
 from six.moves.urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 
 from sphinx.deprecation import RemovedInSphinx30Warning

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -10,6 +10,7 @@
 """
 from __future__ import absolute_import
 
+import builtins
 import enum
 import inspect
 import re
@@ -18,7 +19,6 @@ import typing
 from functools import partial
 
 from six import StringIO, binary_type, string_types, itervalues
-from six.moves import builtins
 
 from sphinx.util import force_decode
 from sphinx.util import logging

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -9,12 +9,12 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import pickle
 import warnings
 from itertools import product
 from operator import itemgetter
 from uuid import uuid4
 
-from six.moves import cPickle as pickle
 from six.moves import range, zip_longest
 
 from sphinx.deprecation import RemovedInSphinx30Warning

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -15,7 +15,6 @@ from os import path
 
 from docutils import nodes, writers
 from six import itervalues
-from six.moves import range
 
 from sphinx import addnodes, __display_version__
 from sphinx.errors import ExtensionError

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -14,7 +14,6 @@ import time
 
 import pytest
 from six import text_type, StringIO
-from six.moves import input
 
 from sphinx import application
 from sphinx.cmd import quickstart as qs


### PR DESCRIPTION
Removal of the remaining imports may require passing `--python-version 3.5` to the mypy command.