### PR TITLE
Remove unnecessary __ne__ definitions

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -208,10 +208,6 @@ class BuildInfo:
         return (self.config_hash == other.config_hash and
                 self.tags_hash == other.tags_hash)
 
-    def __ne__(self, other):  # type: ignore
-        # type: (BuildInfo) -> bool
-        return not (self == other)  # for py27
-
     def dump(self, f):
         # type: (IO) -> None
         f.write('# Sphinx build info version 1\n'

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -611,10 +611,6 @@ class ASTBase(UnicodeMixin):
             return False
         return True
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return not self.__eq__(other)
-
     __hash__ = None  # type: Callable[[], int]
 
     def clone(self):

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -138,10 +138,6 @@ class _TranslationProxy(UserString):
         # type: (Any) -> bool
         return self.data == other
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return self.data != other
-
     def __gt__(self, other):
         # type: (unicode) -> bool
         return self.data > other

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -128,10 +128,6 @@ class Token:
         else:
             raise ValueError('Unknown value: %r' % other)
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return not (self == other)
-
     def match(self, *conditions):
         # type: (Any) -> bool
         return any(self == candidate for candidate in conditions)


### PR DESCRIPTION
In Python 3, `__ne__` defaults to the inverse of `__eq__`.

From https://docs.python.org/3/reference/datamodel.html#object.__ne__

> By default, `__ne__()` delegates to `__eq__()` and inverts the result unless it is `NotImplemented`.