### PR TITLE
latex: add defaults for enumerated list prefix/suffix

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1469,13 +1469,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
         enum = "enum%s" % toRoman(get_nested_level(node)).lower()
         enumnext = "enum%s" % toRoman(get_nested_level(node) + 1).lower()
         style = ENUMERATE_LIST_STYLE.get(get_enumtype(node))
+        prefix = node.get('prefix', '')
+        suffix = node.get('suffix', '.')
 
         self.body.append('\\begin{enumerate}\n')
         self.body.append('\\def\\the%s{%s{%s}}\n' % (enum, style, enum))
         self.body.append('\\def\\label%s{%s\\the%s %s}\n' %
-                         (enum, node['prefix'], enum, node['suffix']))
+                         (enum, prefix, enum, suffix))
         self.body.append('\\makeatletter\\def\\p@%s{\\p@%s %s\\the%s %s}\\makeatother\n' %
-                         (enumnext, enum, node['prefix'], enum, node['suffix']))
+                         (enumnext, enum, prefix, enum, suffix))
         if 'start' in node:
             self.body.append('\\setcounter{%s}{%d}\n' % (enum, node['start'] - 1))
         if self.table:


### PR DESCRIPTION
Subject: enumerated lists can fail to build latex if they lack the optional prefix/suffix attributes, (e.g. if they come from recommonmark parser).

### Feature or Bugfix

- Bugfix

### Purpose

Adds handling for when `prefix`/`suffix` are undefined. If I understand correctly, it should not be assumed that these are always defined, since they are not part of the docutils enumerated_list object. Fixes error in `make latex`:

```
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/minrk-jupyterhub/conda/latest/lib/python3.6/site-packages/docutils/nodes.py", line 567, in __getitem__
    return self.attributes[key]
KeyError: 'prefix'
```

when building with enumerated lists coming from recommonmark, e.g. with `index.md`:

```markdown
# test

1. an
2. enumerated
3. list
```

and `conf.py`:

```python
from recommonmark.parser import CommonMarkParser
source_parsers = {'.md': CommonMarkParser}
source_suffix = ['.rst', '.md']
```

Build fails with the above error in 1.8.1, succeeds with 1.7.9.

### Relates

- #5001 introduced use of these values in 1.8, causing latex/pdf builds to fail for any doc with enumerated lists in markdown

