### PR TITLE
#5460 Make JS refactoring compatible with old templates

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1597,14 +1597,14 @@ def setup_js_tag_helper(app, pagename, templatexname, context, doctree):
                         attrs.append('%s="%s"' % (key, htmlescape(value, True)))
             if js.filename:
                 attrs.append('src="%s"' % pathto(js.filename, resource=True))
+                # special handling of 'documentation_options.js'
+                if 'documentation_options.js' in js.filename:
+                    attrs.append('id="documentation_options"')
+                    attrs.append('data-url_root="%s"' % pathto('', 1))
         else:
             # str value (old styled)
             attrs.append('type="text/javascript"')
             attrs.append('src="%s"' % pathto(js, resource=True))
-        # special handling of 'documentation_options.js'
-        if 'documentation_options.js' in js.filename:
-            attrs.append('id="documentation_options"')
-            attrs.append('data-url_root="%s"' % pathto('', 1))
         return '<script %s>%s</script>' % (' '.join(attrs), body)
 
     context['js_tag'] = js_tag

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -87,7 +87,6 @@
 {%- endmacro %}
 
 {%- macro script() %}
-    <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for js in script_files %}
     {{ js_tag(js) }}
     {%- endfor %}

--- a/sphinx/themes/basic/static/documentation_options.js_t
+++ b/sphinx/themes/basic/static/documentation_options.js_t
@@ -1,5 +1,7 @@
 var DOCUMENTATION_OPTIONS = {
-    URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
+    URL_ROOT: document.getElementById("documentation_options") ?
+        document.getElementById("documentation_options").getAttribute('data-url_root') :
+        DOCUMENTATION_OPTIONS.URL_ROOT,
     VERSION: '{{ release|e }}',
     LANGUAGE: '{{ language }}',
     COLLAPSE_INDEX: false,


### PR DESCRIPTION
Subject: Make JS refactoring compatible with old templates

### Feature or Bugfix
- Bugfix

### Purpose
- Fixes #5460, prevents old templates from breaking search function

### Detail
This is my attempt of fixing this issue.
Feedback on implementation details are appreciated.
* Inject ``documentation_options.js`` script as part of HTML build
* Set attributes of the script accordingly
* Remove script reference from basic template (would be duplication)
* Add fallback for URL_ROOT variable
* Tested with Read the Docs template and Sphinx template

### Relates
- #5460

