### PR TITLE
MathJax config: Allow single $ delimiters, only apply to CSS "math" class

### DIFF
--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -181,7 +181,8 @@ Sphinx.
            'jax': ['input/TeX', 'output/HTML-CSS'],
        }
 
-   The default is empty (not configured).
+   The default is to enable single ``$`` signs as delimiters (which are disabled
+   in the MathJax default settings).
 
 .. _Using in-line configuration options: https://docs.mathjax.org/en/latest/configuration.html#using-in-line-configuration-options
 

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -182,7 +182,7 @@ Sphinx.
        }
 
    The default is to enable single ``$`` signs as delimiters (which are disabled
-   in the MathJax default settings).
+   in the MathJax default settings) and to only operate on the "math" CSS class.
 
 .. _Using in-line configuration options: https://docs.mathjax.org/en/latest/configuration.html#using-in-line-configuration-options
 

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -115,7 +115,7 @@ def setup(app):
                              'tex2jax': {
                                  'inlineMath': [['$', '$'], ['\\(', '\\)']],
                                  'processEscapes': True,
-                                 'ignoreClass': '.*',
+                                 'ignoreClass': 'document',
                                  'processClass': 'math',
                              },
                          }, 'html')

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -115,6 +115,8 @@ def setup(app):
                              'tex2jax': {
                                  'inlineMath': [['$', '$'], ['\\(', '\\)']],
                                  'processEscapes': True,
+                                 'ignoreClass': '.*',
+                                 'processClass': 'math',
                              },
                          }, 'html')
     app.connect('env-check-consistency', install_mathjax)

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -110,7 +110,13 @@ def setup(app):
     app.add_config_value('mathjax_options', {}, 'html')
     app.add_config_value('mathjax_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('mathjax_display', [r'\[', r'\]'], 'html')
-    app.add_config_value('mathjax_config', None, 'html')
+    app.add_config_value('mathjax_config',
+                         {
+                             'tex2jax': {
+                                 'inlineMath': [['$', '$'], ['\\(', '\\)']],
+                                 'processEscapes': True,
+                             },
+                         }, 'html')
     app.connect('env-check-consistency', install_mathjax)
 
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}


### PR DESCRIPTION
I'm not quite sure if that's the right thing to do. This should be understood as a question, but I made this PR so that it's easy to test the suggested behavior.

### Feature or Bugfix

Something inbetween.

### Purpose

* Support single `$` as math delimiters (probably only relevant in `:nowrap:` math directives).
* Reduce MathJax processing to CSS `math` class.

### Detail

This is some example reST code to check this out:

```rst
Dollars in normal text: $a^2$.
A single dollar sign: $.
An escaped dollar sign: \$.

Inline math: :math:`a^2`.

Normal math directive:

.. math::

    a^2

"nowrap" math with ``$``:

.. math::
    :nowrap:

    $a^2$

"nowrap" with normal text:

.. math::
    :nowrap:

    This is a \LaTeX{} equation: $a^2 + b^2 = c^2$

    This is a dollar sign: \$.
```

Note that this PR mainly fixes the `:nowrap:` cases above. This might not be important for most "normal" users. But when auto-generating reST files which have arbitrary math markup (out of my control), this is the only way I found to make it work.