### PR TITLE
directive-code: do not force linenos value on run

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -154,8 +154,8 @@ class CodeBlock(SphinxDirective):
             code = '\n'.join(lines)
 
         literal = nodes.literal_block(code, code)  # type: nodes.Element
-        literal['linenos'] = 'linenos' in self.options or \
-                             'lineno-start' in self.options
+        if 'linenos' in self.options or 'lineno-start' in self.options:
+            literal['linenos'] = True
         literal['classes'] += self.options.get('class', [])
         if self.arguments:
             # highlight language specified
@@ -451,9 +451,9 @@ class LiteralInclude(SphinxDirective):
                 retnode['language'] = 'udiff'
             elif 'language' in self.options:
                 retnode['language'] = self.options['language']
-            retnode['linenos'] = ('linenos' in self.options or
-                                  'lineno-start' in self.options or
-                                  'lineno-match' in self.options)
+            if ('linenos' in self.options or 'lineno-start' in self.options or
+                    'lineno-match' in self.options):
+                retnode['linenos'] = True
             retnode['classes'] += self.options.get('class', [])
             extra_args = retnode['highlight_args'] = {}
             if 'emphasize-lines' in self.options:

--- a/tests/roots/test-directive-code/linenothreshold.rst
+++ b/tests/roots/test-directive-code/linenothreshold.rst
@@ -1,0 +1,23 @@
+Code Blocks and Literal Includes with Line Numbers via linenothreshold
+======================================================================
+
+.. highlight:: python
+   :linenothreshold: 5
+
+.. code-block::
+
+   class Foo:
+       pass
+
+   class Bar:
+       def baz():
+       pass
+
+.. code-block::
+
+   # comment
+   value = True
+
+.. literalinclude:: literal.inc
+
+.. literalinclude:: literal-short.inc

--- a/tests/roots/test-directive-code/literal-short.inc
+++ b/tests/roots/test-directive-code/literal-short.inc
@@ -1,0 +1,3 @@
+# Very small literal include (linenothreshold check)
+
+value = True

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -565,3 +565,52 @@ def test_code_block_highlighted(app, status, warning):
     assert codeblocks[1]['language'] == 'python2'
     assert codeblocks[2]['language'] == 'python3'
     assert codeblocks[3]['language'] == 'python2'
+
+
+@pytest.mark.sphinx('html', testroot='directive-code')
+def test_linenothreshold(app, status, warning):
+    app.builder.build(['linenothreshold'])
+    html = (app.outdir / 'linenothreshold.html').text()
+
+    lineos_head = '<td class="linenos"><div class="linenodiv"><pre>'
+    lineos_tail = '</pre></div></td>'
+
+    # code-block using linenothreshold
+    _, matched, html = html.partition(lineos_head +
+                                      '1\n'
+                                      '2\n'
+                                      '3\n'
+                                      '4\n'
+                                      '5\n'
+                                      '6' + lineos_tail)
+    assert matched
+
+    # code-block not using linenothreshold
+    html, matched, _ = html.partition(lineos_head +
+                                      '1\n'
+                                      '2' + lineos_tail)
+    assert not matched
+
+    # literal include using linenothreshold
+    _, matched, html = html.partition(lineos_head +
+                                      ' 1\n'
+                                      ' 2\n'
+                                      ' 3\n'
+                                      ' 4\n'
+                                      ' 5\n'
+                                      ' 6\n'
+                                      ' 7\n'
+                                      ' 8\n'
+                                      ' 9\n'
+                                      '10\n'
+                                      '11\n'
+                                      '12\n'
+                                      '13' + lineos_tail)
+    assert matched
+
+    # literal include not using linenothreshold
+    html, matched, _ = html.partition(lineos_head +
+                                      '1\n'
+                                      '2\n' 
+                                      '3' + lineos_tail)
+    assert not matched


### PR DESCRIPTION
Now that `highlightlang` directive is deprecated \[1\], the `linenothreshold` option is to be used via the `highlight` directive. The `highlight` directive will walk-through literal blocks to apply a `linenos` value if:

1) The literal block has not been explicitly configured with the `linenos` option.
2) If there is enough content (when comparing literal block's line count to `linenothreshold`) that `linenos` should be explicitly enabled or disabled \[2\].

While the `hightlight` directive should be able to explicitly define if a literal block needs to enable line numbers, the logic is always ignored since the code block directive already configures `linenos` when checking for the `linenos` and `lineno-start` options on the node \[3\]. This effectively prevents `linenothreshold` from being used.

To allow `linenothreshold` to be used in literal blocks, this commit disables the explicit configuration `linenos` on a literal block instance when the `CodeBlock` directive is processed.

\[1\]: b35198d8475fe89aaf9a5224a9832fb394e73cca
\[2\]: https://github.com/sphinx-doc/sphinx/blob/v1.8.1/sphinx/transforms/post_transforms/code.py#L95-L97
\[3\]: https://github.com/sphinx-doc/sphinx/blob/v1.8.1/sphinx/directives/code.py#L156-L157