### PR TITLE
latex: Separate message catalogs to sphinxmessage.sty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Incompatible changes
 * Drop docutils 0.11 support
 * The default setting for :confval:`master_doc` is changed to ``'index'`` which
   has been longly used as default of sphinx-quickstart.
+* LaTeX: Move message resources to ``sphinxmessage.sty``
+* LaTeX: Stop using ``\captions<lang>`` macro for some labels
 
 Deprecated
 ----------
@@ -22,6 +24,7 @@ Deprecated
 * ``sphinx.ext.doctest.doctest_encode()``
 * ``sphinx.testing.util.remove_unicode_literal()``
 * ``sphinx.util.osutil.walk()``
+* ``translatablestrings`` variable for LaTeX template
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -34,6 +34,7 @@ from sphinx.util.docutils import SphinxFileOutput, new_document
 from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import SEP, make_filename
+from sphinx.util.template import LaTeXRenderer
 from sphinx.writers.latex import (
     ADDITIONAL_SETTINGS, DEFAULT_SETTINGS, LaTeXWriter, LaTeXTranslator
 )
@@ -327,6 +328,7 @@ class LaTeXBuilder(Builder):
     def finish(self):
         # type: () -> None
         self.copy_image_files()
+        self.write_message_catalog()
 
         # copy TeX support files from texinputs
         # configure usage of xindy (impacts Makefile and latexmkrc)
@@ -389,6 +391,11 @@ class LaTeXBuilder(Builder):
                 except Exception as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
+
+    def write_message_catalog(self):
+        # type: () -> None
+        filename = path.join(package_dir, 'templates', 'latex', 'sphinxmessage.sty_t')
+        copy_asset_file(filename, self.outdir, context={}, renderer=LaTeXRenderer())
 
 
 def validate_config_values(app, config):

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -29,6 +29,7 @@
 <%= fontpkg %>
 <%= fncychap %>
 \usepackage<%= sphinxpkgoptions %>{sphinx}
+\input{sphinxmessage.sty}
 <%= sphinxsetup %>
 <%= fvset %>
 <%= geometry %>
@@ -36,7 +37,6 @@
 <%= hyperref %>
 <%= contentsname %>
 <%= numfig_format %>
-<%= translatablestrings %>
 <%= pageautorefname %>
 <%= tocdepth %>
 <%= secnumdepth %>

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -29,7 +29,6 @@
 <%= fontpkg %>
 <%= fncychap %>
 \usepackage<%= sphinxpkgoptions %>{sphinx}
-\input{sphinxmessage.sty}
 <%= sphinxsetup %>
 <%= fvset %>
 <%= geometry %>
@@ -37,6 +36,7 @@
 <%= hyperref %>
 <%= contentsname %>
 <%= numfig_format %>
+\input{sphinxmessage.sty}
 <%= pageautorefname %>
 <%= tocdepth %>
 <%= secnumdepth %>

--- a/sphinx/templates/latex/sphinxmessage.sty_t
+++ b/sphinx/templates/latex/sphinxmessage.sty_t
@@ -1,0 +1,5 @@
+\renewcommand{\literalblockcontinuedname}{<%= _('continued from previous page') | e %>}
+\renewcommand{\literalblockcontinuesname}{<%= _('continues on next page') | e %>}
+\renewcommand{\sphinxnonalphabeticalgroupname}{<%= _('Non-alphabetical') | e %>}
+\renewcommand{\sphinxsymbolsname}{<%= _('Symbols') | e %>}
+\renewcommand{\sphinxnumbersname}{<%= _('Numbers') | e %>}

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -43,7 +43,7 @@ def copy_asset_file(source, destination, context=None, renderer=None):
         # Use source filename if destination points a directory
         destination = os.path.join(destination, os.path.basename(source))
 
-    if source.lower().endswith('_t') and context:
+    if source.lower().endswith('_t') and context is not None:
         if renderer is None:
             from sphinx.util.template import SphinxRenderer
             renderer = SphinxRenderer()

--- a/sphinx/util/texescape.py
+++ b/sphinx/util/texescape.py
@@ -128,6 +128,7 @@ tex_hl_escape_map_new = {}
 
 def escape(s):
     # type: (unicode) -> unicode
+    """Escape text for LaTeX output."""
     return s.translate(tex_escape_map)
 
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -115,7 +115,6 @@ DEFAULT_SETTINGS = {
     'tocdepth':        '',
     'secnumdepth':     '',
     'pageautorefname': '',
-    'translatablestrings': '',
 }  # type: Dict[unicode, unicode]
 
 ADDITIONAL_SETTINGS = {
@@ -628,23 +627,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.elements['extraclassoptions']:
             self.elements['classoptions'] += ',' + \
                                              self.elements['extraclassoptions']
-        self.elements['translatablestrings'] = (
-            self.babel_renewcommand(
-                '\\literalblockcontinuedname', self.encode(_('continued from previous page'))
-            ) +
-            self.babel_renewcommand(
-                '\\literalblockcontinuesname', self.encode(_('continues on next page'))
-            ) +
-            self.babel_renewcommand(
-                '\\sphinxnonalphabeticalgroupname', self.encode(_('Non-alphabetical'))
-            ) +
-            self.babel_renewcommand(
-                '\\sphinxsymbolsname', self.encode(_('Symbols'))
-            ) +
-            self.babel_renewcommand(
-                '\\sphinxnumbersname', self.encode(_('Numbers'))
-            )
-        )
         self.elements['pageautorefname'] = \
             self.babel_defmacro('\\pageautorefname', self.encode(_('page')))
         self.elements['numfig_format'] = self.generate_numfig_format(builder)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To make main latex output simple, I'd like to move message resources to separated file.
- This is first step of separation. I will work for other messages in other work if agreed.
