### PR TITLE
latex: Move \pageautorefname to sphinxmessage.sty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,7 +26,11 @@ Deprecated
 * ``sphinx.testing.util.remove_unicode_literal()``
 * ``sphinx.util.get_matching_docs()`` is deprecated
 * ``sphinx.util.osutil.walk()``
-* ``translatablestrings`` variable for LaTeX template
+* ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
+* template variables for LaTeX template
+
+  - ``pageautorefname``
+  - ``translatablestrings``
 
 For more details, see `deprecation APIs list
 <http://www.sphinx-doc.org/en/master/extdev/index.html#deprecated-apis>`_

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -158,6 +158,11 @@ The following is a list of deprecated interfaces.
      - 3.0
      - N/A
 
+   * - ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
+     - 2.0
+     - 4.0
+     - N/A
+
    * - :rst:dir:`highlightlang`
      - 1.8
      - 4.0

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -37,7 +37,6 @@
 <%= contentsname %>
 <%= numfig_format %>
 \input{sphinxmessages.sty}
-<%= pageautorefname %>
 <%= tocdepth %>
 <%= secnumdepth %>
 <%= preamble %>

--- a/sphinx/templates/latex/sphinxmessages.sty_t
+++ b/sphinx/templates/latex/sphinxmessages.sty_t
@@ -8,3 +8,4 @@
 \renewcommand{\sphinxnonalphabeticalgroupname}{<%= _('Non-alphabetical') | e %>}
 \renewcommand{\sphinxsymbolsname}{<%= _('Symbols') | e %>}
 \renewcommand{\sphinxnumbersname}{<%= _('Numbers') | e %>}
+\def\pageautorefname{<%= _('page') | e %>}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -24,7 +24,7 @@ from six import text_type
 
 from sphinx import addnodes
 from sphinx import highlighting
-from sphinx.deprecation import RemovedInSphinx30Warning
+from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
 from sphinx.errors import SphinxError
 from sphinx.locale import admonitionlabels, _, __
 from sphinx.util import split_into, logging
@@ -114,7 +114,6 @@ DEFAULT_SETTINGS = {
     'figure_align':    'htbp',
     'tocdepth':        '',
     'secnumdepth':     '',
-    'pageautorefname': '',
 }  # type: Dict[unicode, unicode]
 
 ADDITIONAL_SETTINGS = {
@@ -627,8 +626,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.elements['extraclassoptions']:
             self.elements['classoptions'] += ',' + \
                                              self.elements['extraclassoptions']
-        self.elements['pageautorefname'] = \
-            self.babel_defmacro('\\pageautorefname', self.encode(_('page')))
         self.elements['numfig_format'] = self.generate_numfig_format(builder)
 
         self.highlighter = highlighting.PygmentsBridge('latex', builder.config.pygments_style)
@@ -729,17 +726,6 @@ class LaTeXTranslator(nodes.NodeVisitor):
             suffix = ''
 
         return ('%s\\renewcommand{%s}{%s}%s\n' % (prefix, command, definition, suffix))
-
-    def babel_defmacro(self, name, definition):
-        # type: (unicode, unicode) -> unicode
-        if self.elements['babel']:
-            prefix = '\\addto\\extras%s{' % self.babel.get_language()
-            suffix = '}'
-        else:  # babel is disabled (mainly for Japanese environment)
-            prefix = ''
-            suffix = ''
-
-        return ('%s\\def%s{%s}%s\n' % (prefix, name, definition, suffix))
 
     def generate_numfig_format(self, builder):
         # type: (Builder) -> unicode
@@ -2564,6 +2550,19 @@ class LaTeXTranslator(nodes.NodeVisitor):
                 msg = __("Unknown configure key: latex_elements[%r] is ignored.")
                 logger.warning(msg % key)
 
+    def babel_defmacro(self, name, definition):
+        # type: (unicode, unicode) -> unicode
+        warnings.warn('babel_defmacro() is deprecated.',
+                      RemovedInSphinx40Warning)
+
+        if self.elements['babel']:
+            prefix = '\\addto\\extras%s{' % self.babel.get_language()
+            suffix = '}'
+        else:  # babel is disabled (mainly for Japanese environment)
+            prefix = ''
+            suffix = ''
+
+        return ('%s\\def%s{%s}%s\n' % (prefix, name, definition, suffix))
 
 # Import old modules here for compatibility
 # They should be imported after `LaTeXTranslator` to avoid recursive import.

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -420,8 +420,12 @@ def test_babel_with_no_language_settings(app, status, warning):
             in result)
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
     assert '\\shorthandoff' not in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{page}' in result
 
 
 @pytest.mark.sphinx(
@@ -441,8 +445,12 @@ def test_babel_with_language_de(app, status, warning):
             in result)
     assert '\\addto\\captionsngerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert '\\addto\\extrasngerman{\\def\\pageautorefname{Seite}}\n' in result
     assert '\\shorthandoff{"}' in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{Seite}' in result
 
 
 @pytest.mark.sphinx(
@@ -462,9 +470,12 @@ def test_babel_with_language_ru(app, status, warning):
             in result)
     assert '\\addto\\captionsrussian{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert (u'\\addto\\extrasrussian{\\def\\pageautorefname'
-            u'{\u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430}}\n' in result)
     assert '\\shorthandoff{"}' in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{страница}' in result
 
 
 @pytest.mark.sphinx(
@@ -484,8 +495,12 @@ def test_babel_with_language_tr(app, status, warning):
             in result)
     assert '\\addto\\captionsturkish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert '\\addto\\extrasturkish{\\def\\pageautorefname{sayfa}}\n' in result
     assert '\\shorthandoff{=}' in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{sayfa}' in result
 
 
 @pytest.mark.sphinx(
@@ -504,8 +519,12 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\renewcommand{\\contentsname}{Table of content}\n' in result
     assert '\\renewcommand{\\figurename}{Fig.}\n' in result
     assert '\\renewcommand{\\tablename}{Table.}\n' in result
-    assert u'\\def\\pageautorefname{ページ}\n' in result
     assert '\\shorthandoff' not in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{ページ}' in result
 
 
 @pytest.mark.sphinx(
@@ -525,10 +544,14 @@ def test_babel_with_unknown_language(app, status, warning):
             in result)
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
     assert '\\shorthandoff' in result
 
     assert "WARNING: no Babel option known for language 'unknown'" in warning.getvalue()
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{page}' in result
 
 
 @pytest.mark.sphinx(
@@ -549,8 +572,12 @@ def test_polyglossia_with_language_de(app, status, warning):
             in result)
     assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert '\\def\\pageautorefname{Seite}\n' in result
     assert '\\shorthandoff' not in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{Seite}' in result
 
 
 @pytest.mark.sphinx(
@@ -571,8 +598,12 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
             in result)
     assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
-    assert '\\def\\pageautorefname{page}\n' in result
     assert '\\shorthandoff' not in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\def\pageautorefname{page}' in result
 
 
 @pytest.mark.sphinx('latex')


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- As a second step of #5512, this moves `\pageautorefname` to sphinxmessage.sty
