### PR TITLE
Move labels related with numfig_format to sphinxmessage.sty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -104,11 +104,13 @@ Deprecated
 * ``sphinx.writers.latex.LaTeXTranslator._make_visit_admonition()``
 * ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
 * ``sphinx.writers.latex.LaTeXTranslator.collect_footnotes()``
+* ``sphinx.writers.latex.LaTeXTranslator.generate_numfig_format()``
 * ``sphinx.writers.texinfo.TexinfoTranslator._make_visit_admonition()``
 * ``sphinx.writers.text.TextTranslator._make_depart_admonition()``
 * template variables for LaTeX template
 
   - ``logo``
+  - ``numfig_format``
   - ``pageautorefname``
   - ``translatablestrings``
 

--- a/CHANGES
+++ b/CHANGES
@@ -100,6 +100,7 @@ Deprecated
 * ``sphinx.util.PeekableIterator``
 * ``sphinx.util.pycompat.UnicodeMixin``
 * ``sphinx.util.pycompat.u``
+* ``sphinx.writers.latex.ExtBabel``
 * ``sphinx.writers.latex.LaTeXTranslator._make_visit_admonition()``
 * ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
 * ``sphinx.writers.latex.LaTeXTranslator.collect_footnotes()``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -459,6 +459,11 @@ The following is a list of deprecated interfaces.
      - 3.0
      - N/A
 
+   * - ``sphinx.writers.latex.LaTeXTranslator.generate_numfig_format()``
+     - 2.0
+     - 4.0
+     - N/A
+
    * - :rst:dir:`highlightlang`
      - 1.8
      - 4.0

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -394,6 +394,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``IndexBuilder.feed(docname, filename, title, doctree)``
 
+   * - ``sphinx.writers.latex.ExtBabel``
+     - 2.0
+     - 4.0
+     - ``sphinx.builders.latex.util.ExtBabel``
+
    * - ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
      - 2.0
      - 4.0

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -419,10 +419,12 @@ class LaTeXBuilder(Builder):
 
     def write_message_catalog(self):
         # type: () -> None
+        formats = self.config.numfig_format
         context = {
             'addtocaptions': '',
-            'figurename': self.config.numfig_format.get('figure', '').split('%s', 1),
-            'tablename': self.config.numfig_format.get('table', '').split('%s', 1)
+            'figurename': formats.get('figure', '').split('%s', 1),
+            'tablename': formats.get('table', '').split('%s', 1),
+            'literalblockname': formats.get('code-block', '').split('%s', 1)
         }
 
         if self.context['babel'] or self.context['polyglossia']:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -422,6 +422,7 @@ class LaTeXBuilder(Builder):
         context = {
             'addtocaptions': '',
             'figurename': self.config.numfig_format.get('figure', '').split('%s', 1),
+            'tablename': self.config.numfig_format.get('table', '').split('%s', 1)
         }
 
         if self.context['babel'] or self.context['polyglossia']:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -21,6 +21,7 @@ from sphinx.builders.latex.transforms import (
     FootnoteDocnameUpdater, LaTeXFootnoteTransform, LiteralBlockTransform,
     ShowUrlsTransform, DocumentTargetTransform,
 )
+from sphinx.builders.latex.util import ExtBabel
 from sphinx.config import ENUM
 from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
@@ -129,6 +130,7 @@ class LaTeXBuilder(Builder):
 
     def init(self):
         # type: () -> None
+        self.babel = None           # type: ExtBabel
         self.context = {}           # type: Dict[str, Any]
         self.docnames = []          # type: Iterable[str]
         self.document_data = []     # type: List[Tuple[str, str, str, str, str, bool]]
@@ -136,6 +138,7 @@ class LaTeXBuilder(Builder):
         texescape.init()
 
         self.init_context()
+        self.init_babel()
 
     def get_outdated_docs(self):
         # type: () -> Union[str, List[str]]
@@ -209,6 +212,15 @@ class LaTeXBuilder(Builder):
         if self.config.release:
             # Show the release label only if release value exists
             self.context['releasename'] = _('Release')
+
+    def init_babel(self):
+        # type: () -> None
+        self.babel = ExtBabel(self.config.language, not self.context['babel'])
+        if self.config.language and not self.babel.is_supported_language():
+            # emit warning if specified language is invalid
+            # (only emitting, nothing changed to processing)
+            logger.warning(__('no Babel option known for language %r'),
+                           self.config.language)
 
     def write_stylesheet(self):
         # type: () -> None
@@ -407,8 +419,16 @@ class LaTeXBuilder(Builder):
 
     def write_message_catalog(self):
         # type: () -> None
+        context = {
+            'addtocaptions': '',
+            'figurename': self.config.numfig_format.get('figure', '').split('%s', 1),
+        }
+
+        if self.context['babel'] or self.context['polyglossia']:
+            context['addtocaptions'] = r'\addto\captions%s' % self.babel.get_language()
+
         filename = path.join(package_dir, 'templates', 'latex', 'sphinxmessages.sty_t')
-        copy_asset_file(filename, self.outdir, context={}, renderer=LaTeXRenderer())
+        copy_asset_file(filename, self.outdir, context=context, renderer=LaTeXRenderer())
 
 
 def validate_config_values(app, config):

--- a/sphinx/builders/latex/compat.py
+++ b/sphinx/builders/latex/compat.py
@@ -11,7 +11,10 @@
 """
 
 from sphinx.builders.latex.transforms import URI_SCHEMES, ShowUrlsTransform
-from sphinx.deprecation import RemovedInSphinx30Warning, deprecated_alias
+from sphinx.builders.latex.util import ExtBabel
+from sphinx.deprecation import (
+    RemovedInSphinx30Warning, RemovedInSphinx40Warning, deprecated_alias
+)
 
 
 deprecated_alias('sphinx.writers.latex',
@@ -20,3 +23,9 @@ deprecated_alias('sphinx.writers.latex',
                      'URI_SCHEMES': URI_SCHEMES,
                  },
                  RemovedInSphinx30Warning)
+
+deprecated_alias('sphinx.writers.latex',
+                 {
+                     'ExtBabel': ExtBabel,
+                 },
+                 RemovedInSphinx40Warning)

--- a/sphinx/builders/latex/util.py
+++ b/sphinx/builders/latex/util.py
@@ -1,0 +1,68 @@
+"""
+    sphinx.builders.latex.util
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Utilities for LaTeX builder.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import warnings
+
+from docutils.writers.latex2e import Babel
+
+from sphinx.deprecation import RemovedInSphinx30Warning
+
+
+class ExtBabel(Babel):
+    cyrillic_languages = ('bulgarian', 'kazakh', 'mongolian', 'russian', 'ukrainian')
+
+    def __init__(self, language_code, use_polyglossia=False):
+        # type: (str, bool) -> None
+        self.language_code = language_code
+        self.use_polyglossia = use_polyglossia
+        self.supported = True
+        super().__init__(language_code or '')
+
+    def get_shorthandoff(self):
+        # type: () -> str
+        warnings.warn('ExtBabel.get_shorthandoff() is deprecated.',
+                      RemovedInSphinx30Warning, stacklevel=2)
+        from sphinx.writers.latex import SHORTHANDOFF
+        return SHORTHANDOFF
+
+    def uses_cyrillic(self):
+        # type: () -> bool
+        return self.language in self.cyrillic_languages
+
+    def is_supported_language(self):
+        # type: () -> bool
+        return self.supported
+
+    def language_name(self, language_code):
+        # type: (str) -> str
+        language = super().language_name(language_code)
+        if language == 'ngerman' and self.use_polyglossia:
+            # polyglossia calls new orthography (Neue Rechtschreibung) as
+            # german (with new spelling option).
+            return 'german'
+        elif not language:
+            self.supported = False
+            return 'english'  # fallback to english
+        else:
+            return language
+
+    def get_mainlanguage_options(self):
+        # type: () -> str
+        """Return options for polyglossia's ``\\setmainlanguage``."""
+        if self.use_polyglossia is False:
+            return None
+        elif self.language == 'german':
+            language = super().language_name(self.language_code)
+            if language == 'ngerman':
+                return 'spelling=new'
+            else:
+                return 'spelling=old'
+        else:
+            return None

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -46,7 +46,6 @@
 
 <%= hyperref %>
 <%= contentsname %>
-<%= numfig_format %>
 \usepackage{sphinxmessages}
 <%= tocdepth %>
 <%= secnumdepth %>

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -47,7 +47,7 @@
 <%= hyperref %>
 <%= contentsname %>
 <%= numfig_format %>
-\input{sphinxmessages.sty}
+\usepackage{sphinxmessages}
 <%= tocdepth %>
 <%= secnumdepth %>
 <%= preamble %>

--- a/sphinx/templates/latex/sphinxmessages.sty_t
+++ b/sphinx/templates/latex/sphinxmessages.sty_t
@@ -11,3 +11,8 @@
 \renewcommand{\sphinxsymbolsname}{<%= _('Symbols') | e %>}
 \renewcommand{\sphinxnumbersname}{<%= _('Numbers') | e %>}
 \def\pageautorefname{<%= _('page') | e %>}
+
+<%= addtocaptions %>{\renewcommand{\figurename}{<%= figurename[0].strip() | e %>}}
+<%- if figurename[1] %>
+\def\fnum@figure{\figurename\thefigure\relax{}<%= figurename[1].strip() | e %>}
+<%- endif %>

--- a/sphinx/templates/latex/sphinxmessages.sty_t
+++ b/sphinx/templates/latex/sphinxmessages.sty_t
@@ -21,3 +21,5 @@
 <%- if tablename[1] %>
 \def\fnum@table{\tablename\thetable\relax{}<%= tablename[1].strip() | e %>}
 <%- endif %>
+
+<%= addtocaptions %>{\renewcommand{\literalblockname}{<%= literalblockname[0].strip() %>}}

--- a/sphinx/templates/latex/sphinxmessages.sty_t
+++ b/sphinx/templates/latex/sphinxmessages.sty_t
@@ -16,3 +16,8 @@
 <%- if figurename[1] %>
 \def\fnum@figure{\figurename\thefigure\relax{}<%= figurename[1].strip() | e %>}
 <%- endif %>
+
+<%= addtocaptions %>{\renewcommand{\tablename}{<%= tablename[0].strip() %>}}
+<%- if tablename[1] %>
+\def\fnum@table{\tablename\thetable\relax{}<%= tablename[1].strip() | e %>}
+<%- endif %>

--- a/sphinx/templates/latex/sphinxmessages.sty_t
+++ b/sphinx/templates/latex/sphinxmessages.sty_t
@@ -3,6 +3,8 @@
 %
 % message resources for Sphinx
 %
+\ProvidesPackage{sphinxmessages}[2019/01/04 v2.0 Localized LaTeX macros (Sphinx team)]
+
 \renewcommand{\literalblockcontinuedname}{<%= _('continued from previous page') | e %>}
 \renewcommand{\literalblockcontinuesname}{<%= _('continues on next page') | e %>}
 \renewcommand{\sphinxnonalphabeticalgroupname}{<%= _('Non-alphabetical') | e %>}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -19,7 +19,6 @@ from os import path
 from typing import Iterable, cast
 
 from docutils import nodes, writers
-from docutils.writers.latex2e import Babel
 
 from sphinx import addnodes
 from sphinx import highlighting
@@ -258,58 +257,6 @@ class LaTeXWriter(writers.Writer):
 
 
 # Helper classes
-
-class ExtBabel(Babel):
-    cyrillic_languages = ('bulgarian', 'kazakh', 'mongolian', 'russian', 'ukrainian')
-
-    def __init__(self, language_code, use_polyglossia=False):
-        # type: (str, bool) -> None
-        self.language_code = language_code
-        self.use_polyglossia = use_polyglossia
-        self.supported = True
-        super().__init__(language_code or '')
-
-    def get_shorthandoff(self):
-        # type: () -> str
-        warnings.warn('ExtBabel.get_shorthandoff() is deprecated.',
-                      RemovedInSphinx30Warning, stacklevel=2)
-        return SHORTHANDOFF
-
-    def uses_cyrillic(self):
-        # type: () -> bool
-        return self.language in self.cyrillic_languages
-
-    def is_supported_language(self):
-        # type: () -> bool
-        return self.supported
-
-    def language_name(self, language_code):
-        # type: (str) -> str
-        language = super().language_name(language_code)
-        if language == 'ngerman' and self.use_polyglossia:
-            # polyglossia calls new orthography (Neue Rechtschreibung) as
-            # german (with new spelling option).
-            return 'german'
-        elif not language:
-            self.supported = False
-            return 'english'  # fallback to english
-        else:
-            return language
-
-    def get_mainlanguage_options(self):
-        # type: () -> str
-        """Return options for polyglossia's ``\\setmainlanguage``."""
-        if self.use_polyglossia is False:
-            return None
-        elif self.language == 'german':
-            language = super().language_name(self.language_code)
-            if language == 'ngerman':
-                return 'spelling=new'
-            else:
-                return 'spelling=old'
-        else:
-            return None
-
 
 class Table:
     """A table data"""
@@ -586,8 +533,7 @@ class LaTeXTranslator(SphinxTranslator):
                                          '\\sffamily}\n\\ChTitleVar{\\Large'
                                          '\\normalfont\\sffamily}')
 
-        self.babel = ExtBabel(self.config.language,
-                              not self.elements['babel'])
+        self.babel = self.builder.babel
         if self.config.language and not self.babel.is_supported_language():
             # emit warning if specified language is invalid
             # (only emitting, nothing changed to processing)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -151,7 +151,6 @@ DEFAULT_SETTINGS = {
                         '\\usepackage{hypcap}% it must be loaded after hyperref.\n'
                         '% Set up styles of URL: it should be placed after hyperref.\n'
                         '\\urlstyle{same}'),
-    'numfig_format':   '',
     'contentsname':    '',
     'preamble':        '',
     'title':           '',
@@ -621,7 +620,6 @@ class LaTeXTranslator(SphinxTranslator):
         if self.elements['extraclassoptions']:
             self.elements['classoptions'] += ',' + \
                                              self.elements['extraclassoptions']
-        self.elements['numfig_format'] = self.generate_numfig_format(self.builder)
 
         self.highlighter = highlighting.PygmentsBridge('latex', self.config.pygments_style)
         self.context = []                   # type: List[Any]
@@ -721,46 +719,6 @@ class LaTeXTranslator(SphinxTranslator):
             suffix = ''
 
         return ('%s\\renewcommand{%s}{%s}%s\n' % (prefix, command, definition, suffix))
-
-    def generate_numfig_format(self, builder):
-        # type: (LaTeXBuilder) -> str
-        ret = []  # type: List[str]
-        figure = self.builder.config.numfig_format['figure'].split('%s', 1)
-        if len(figure) == 1:
-            ret.append('\\def\\fnum@figure{%s}\n' %
-                       str(figure[0]).strip().translate(tex_escape_map))
-        else:
-            definition = str(figure[0]).strip().translate(tex_escape_map)
-            ret.append(self.babel_renewcommand('\\figurename', definition))
-            if figure[1]:
-                ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@figure{\\figurename\\thefigure%s}\n' %
-                           str(figure[1]).strip().translate(tex_escape_map))
-                ret.append('\\makeatother\n')
-
-        table = self.builder.config.numfig_format['table'].split('%s', 1)
-        if len(table) == 1:
-            ret.append('\\def\\fnum@table{%s}\n' %
-                       str(table[0]).strip().translate(tex_escape_map))
-        else:
-            definition = str(table[0]).strip().translate(tex_escape_map)
-            ret.append(self.babel_renewcommand('\\tablename', definition))
-            if table[1]:
-                ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@table{\\tablename\\thetable%s}\n' %
-                           str(table[1]).strip().translate(tex_escape_map))
-                ret.append('\\makeatother\n')
-
-        codeblock = self.builder.config.numfig_format['code-block'].split('%s', 1)
-        if len(codeblock) == 1:
-            pass  # FIXME
-        else:
-            definition = str(codeblock[0]).strip().translate(tex_escape_map)
-            ret.append(self.babel_renewcommand('\\literalblockname', definition))
-            if codeblock[1]:
-                pass  # FIXME
-
-        return ''.join(ret)
 
     def generate_indices(self):
         # type: () -> str
@@ -2602,6 +2560,49 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append('\n\\begin{sphinxadmonition}{%s}{%s:}' %
                              (name, admonitionlabels[name]))
         return visit_admonition
+
+    def generate_numfig_format(self, builder):
+        # type: (LaTeXBuilder) -> str
+        warnings.warn('generate_numfig_format() is deprecated.',
+                      RemovedInSphinx40Warning)
+        ret = []  # type: List[str]
+        figure = self.builder.config.numfig_format['figure'].split('%s', 1)
+        if len(figure) == 1:
+            ret.append('\\def\\fnum@figure{%s}\n' %
+                       str(figure[0]).strip().translate(tex_escape_map))
+        else:
+            definition = str(figure[0]).strip().translate(tex_escape_map)
+            ret.append(self.babel_renewcommand('\\figurename', definition))
+            if figure[1]:
+                ret.append('\\makeatletter\n')
+                ret.append('\\def\\fnum@figure{\\figurename\\thefigure%s}\n' %
+                           str(figure[1]).strip().translate(tex_escape_map))
+                ret.append('\\makeatother\n')
+
+        table = self.builder.config.numfig_format['table'].split('%s', 1)
+        if len(table) == 1:
+            ret.append('\\def\\fnum@table{%s}\n' %
+                       str(table[0]).strip().translate(tex_escape_map))
+        else:
+            definition = str(table[0]).strip().translate(tex_escape_map)
+            ret.append(self.babel_renewcommand('\\tablename', definition))
+            if table[1]:
+                ret.append('\\makeatletter\n')
+                ret.append('\\def\\fnum@table{\\tablename\\thetable%s}\n' %
+                           str(table[1]).strip().translate(tex_escape_map))
+                ret.append('\\makeatother\n')
+
+        codeblock = self.builder.config.numfig_format['code-block'].split('%s', 1)
+        if len(codeblock) == 1:
+            pass  # FIXME
+        else:
+            definition = str(codeblock[0]).strip().translate(tex_escape_map)
+            ret.append(self.babel_renewcommand('\\literalblockname', definition))
+            if codeblock[1]:
+                pass  # FIXME
+
+        return ''.join(ret)
+
 
 # Import old modules here for compatibility
 import sphinx.builders.latex.compat  # NOQA

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -203,7 +203,6 @@ def test_numref(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table}}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Listing}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Fig.\\@ \\ref{\\detokenize{index:fig1}}}') in result
@@ -230,6 +229,7 @@ def test_numref(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\tablename}{Table}}' in result
 
 
 @pytest.mark.sphinx(
@@ -245,7 +245,6 @@ def test_numref_with_prefix1(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert '\\ref{\\detokenize{index:fig1}}' in result
     assert '\\ref{\\detokenize{baz:fig22}}' in result
@@ -278,6 +277,7 @@ def test_numref_with_prefix1(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\tablename}{Tab_}}' in result
 
 
 @pytest.mark.sphinx(
@@ -293,8 +293,6 @@ def test_numref_with_prefix2(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
-    assert '\\def\\fnum@table{\\tablename\\thetable:}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Figure:\\ref{\\detokenize{index:fig1}}.\\@}') in result
@@ -322,6 +320,8 @@ def test_numref_with_prefix2(app, status, warning):
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
     assert r'\def\fnum@figure{\figurename\thefigure\relax{}.}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\tablename}{Tab_}}' in result
+    assert r'\def\fnum@table{\tablename\thetable\relax{}:}' in result
 
 
 @pytest.mark.sphinx(
@@ -333,7 +333,6 @@ def test_numref_with_language_ja(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\renewcommand{\\tablename}{\u8868}' in result  # 表
     assert '\\renewcommand{\\literalblockname}{\u30ea\u30b9\u30c8}' in result  # リスト
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{\u56f3 \\ref{\\detokenize{index:fig1}}}') in result
@@ -360,6 +359,7 @@ def test_numref_with_language_ja(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert '\n{\\renewcommand{\\figurename}{図}}' in result
+    assert '\n{\\renewcommand{\\tablename}{表}}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-numfig')
@@ -435,7 +435,6 @@ def test_babel_with_no_language_settings(app, status, warning):
     assert '\\usepackage[Bjarne]{fncychap}' in result
     assert ('\\addto\\captionsenglish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
@@ -443,6 +442,7 @@ def test_babel_with_no_language_settings(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{page}' in result
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -460,7 +460,6 @@ def test_babel_with_language_de(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsngerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff{"}' in result
 
     # sphinxmessages.sty
@@ -468,6 +467,7 @@ def test_babel_with_language_de(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{Seite}' in result
     assert r'\addto\captionsngerman{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsngerman{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -485,7 +485,6 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsrussian{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff{"}' in result
 
     # sphinxmessages.sty
@@ -493,6 +492,7 @@ def test_babel_with_language_ru(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{страница}' in result
     assert r'\addto\captionsrussian{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsrussian{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -510,7 +510,6 @@ def test_babel_with_language_tr(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsturkish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff{=}' in result
 
     # sphinxmessages.sty
@@ -518,6 +517,7 @@ def test_babel_with_language_tr(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{sayfa}' in result
     assert r'\addto\captionsturkish{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsturkish{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -534,7 +534,6 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\usepackage{times}' in result
     assert '\\usepackage[Sonny]{fncychap}' not in result
     assert '\\renewcommand{\\contentsname}{Table of content}\n' in result
-    assert '\\renewcommand{\\tablename}{Table.}\n' in result
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
@@ -542,6 +541,7 @@ def test_babel_with_language_ja(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{ページ}' in result
     assert '\n{\\renewcommand{\\figurename}{Fig.}}' in result
+    assert '\n{\\renewcommand{\\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -559,7 +559,6 @@ def test_babel_with_unknown_language(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsenglish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' in result
 
     assert "WARNING: no Babel option known for language 'unknown'" in warning.getvalue()
@@ -569,6 +568,7 @@ def test_babel_with_unknown_language(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{page}' in result
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -587,7 +587,6 @@ def test_polyglossia_with_language_de(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsgerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
@@ -595,6 +594,7 @@ def test_polyglossia_with_language_de(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{Seite}' in result
     assert r'\addto\captionsgerman{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsgerman{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -613,7 +613,6 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsgerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
@@ -621,6 +620,7 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     print(result)
     assert r'\def\pageautorefname{page}' in result
     assert r'\addto\captionsgerman{\renewcommand{\figurename}{Fig.}}' in result
+    assert r'\addto\captionsgerman{\renewcommand{\tablename}{Table.}}' in result
 
 
 @pytest.mark.sphinx('latex')

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -203,7 +203,6 @@ def test_numref(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table}}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Listing}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
@@ -227,6 +226,11 @@ def test_numref(app, status, warning):
     assert ('\\hyperref[\\detokenize{foo:foo}]{Sect.\\ref{\\detokenize{foo:foo}} '
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
+
 
 @pytest.mark.sphinx(
     'latex', testroot='numfig',
@@ -241,7 +245,6 @@ def test_numref_with_prefix1(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Figure:}}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert '\\ref{\\detokenize{index:fig1}}' in result
@@ -271,6 +274,11 @@ def test_numref_with_prefix1(app, status, warning):
     assert ('\\hyperref[\\detokenize{foo:foo}]{Sect.\\ref{\\detokenize{foo:foo}} '
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
+
 
 @pytest.mark.sphinx(
     'latex', testroot='numfig',
@@ -285,8 +293,6 @@ def test_numref_with_prefix2(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Figure:}}' in result
-    assert '\\def\\fnum@figure{\\figurename\\thefigure.}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
     assert '\\def\\fnum@table{\\tablename\\thetable:}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
@@ -311,6 +317,12 @@ def test_numref_with_prefix2(app, status, warning):
     assert ('\\hyperref[\\detokenize{foo:foo}]{Sect.\\ref{\\detokenize{foo:foo}} '
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
+    assert r'\def\fnum@figure{\figurename\thefigure\relax{}.}' in result
+
 
 @pytest.mark.sphinx(
     'latex', testroot='numfig',
@@ -321,7 +333,6 @@ def test_numref_with_language_ja(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\renewcommand{\\figurename}{\u56f3}' in result  # 図
     assert '\\renewcommand{\\tablename}{\u8868}' in result  # 表
     assert '\\renewcommand{\\literalblockname}{\u30ea\u30b9\u30c8}' in result  # リスト
     assert ('\\hyperref[\\detokenize{index:fig1}]'
@@ -344,6 +355,11 @@ def test_numref_with_language_ja(app, status, warning):
             '\\nameref{\\detokenize{index:fig1}}}') in result
     assert ('\\hyperref[\\detokenize{foo:foo}]{Sect.\\ref{\\detokenize{foo:foo}} '
             '\\nameref{\\detokenize{foo:foo}}}') in result
+
+    # sphinxmessages.sty
+    result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
+    print(result)
+    assert '\n{\\renewcommand{\\figurename}{図}}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-numfig')
@@ -419,7 +435,6 @@ def test_babel_with_no_language_settings(app, status, warning):
     assert '\\usepackage[Bjarne]{fncychap}' in result
     assert ('\\addto\\captionsenglish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -427,6 +442,7 @@ def test_babel_with_no_language_settings(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{page}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -444,7 +460,6 @@ def test_babel_with_language_de(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsngerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsngerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff{"}' in result
 
@@ -452,6 +467,7 @@ def test_babel_with_language_de(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{Seite}' in result
+    assert r'\addto\captionsngerman{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -469,7 +485,6 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsrussian{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsrussian{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff{"}' in result
 
@@ -477,6 +492,7 @@ def test_babel_with_language_ru(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{страница}' in result
+    assert r'\addto\captionsrussian{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -494,7 +510,6 @@ def test_babel_with_language_tr(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsturkish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsturkish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff{=}' in result
 
@@ -502,6 +517,7 @@ def test_babel_with_language_tr(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{sayfa}' in result
+    assert r'\addto\captionsturkish{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -518,7 +534,6 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\usepackage{times}' in result
     assert '\\usepackage[Sonny]{fncychap}' not in result
     assert '\\renewcommand{\\contentsname}{Table of content}\n' in result
-    assert '\\renewcommand{\\figurename}{Fig.}\n' in result
     assert '\\renewcommand{\\tablename}{Table.}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -526,6 +541,7 @@ def test_babel_with_language_ja(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{ページ}' in result
+    assert '\n{\\renewcommand{\\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -543,7 +559,6 @@ def test_babel_with_unknown_language(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsenglish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' in result
 
@@ -553,6 +568,7 @@ def test_babel_with_unknown_language(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{page}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -571,7 +587,6 @@ def test_polyglossia_with_language_de(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsgerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -579,6 +594,7 @@ def test_polyglossia_with_language_de(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{Seite}' in result
+    assert r'\addto\captionsgerman{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx(
@@ -597,7 +613,6 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsgerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
     assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -605,6 +620,7 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{page}' in result
+    assert r'\addto\captionsgerman{\renewcommand{\figurename}{Fig.}}' in result
 
 
 @pytest.mark.sphinx('latex')

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -203,7 +203,6 @@ def test_numref(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Listing}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Fig.\\@ \\ref{\\detokenize{index:fig1}}}') in result
     assert ('\\hyperref[\\detokenize{baz:fig22}]'
@@ -230,6 +229,7 @@ def test_numref(app, status, warning):
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.}}' in result
     assert r'\addto\captionsenglish{\renewcommand{\tablename}{Table}}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\literalblockname}{Listing}}' in result
 
 
 @pytest.mark.sphinx(
@@ -245,7 +245,6 @@ def test_numref_with_prefix1(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert '\\ref{\\detokenize{index:fig1}}' in result
     assert '\\ref{\\detokenize{baz:fig22}}' in result
     assert '\\ref{\\detokenize{index:table-1}}' in result
@@ -278,6 +277,7 @@ def test_numref_with_prefix1(app, status, warning):
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
     assert r'\addto\captionsenglish{\renewcommand{\tablename}{Tab_}}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\literalblockname}{Code-}}' in result
 
 
 @pytest.mark.sphinx(
@@ -293,7 +293,6 @@ def test_numref_with_prefix2(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Figure:\\ref{\\detokenize{index:fig1}}.\\@}') in result
     assert ('\\hyperref[\\detokenize{baz:fig22}]'
@@ -322,6 +321,7 @@ def test_numref_with_prefix2(app, status, warning):
     assert r'\def\fnum@figure{\figurename\thefigure\relax{}.}' in result
     assert r'\addto\captionsenglish{\renewcommand{\tablename}{Tab_}}' in result
     assert r'\def\fnum@table{\tablename\thetable\relax{}:}' in result
+    assert r'\addto\captionsenglish{\renewcommand{\literalblockname}{Code-}}' in result
 
 
 @pytest.mark.sphinx(
@@ -333,7 +333,6 @@ def test_numref_with_language_ja(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\renewcommand{\\literalblockname}{\u30ea\u30b9\u30c8}' in result  # リスト
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{\u56f3 \\ref{\\detokenize{index:fig1}}}') in result
     assert ('\\hyperref[\\detokenize{baz:fig22}]'
@@ -360,6 +359,7 @@ def test_numref_with_language_ja(app, status, warning):
     print(result)
     assert '\n{\\renewcommand{\\figurename}{図}}' in result
     assert '\n{\\renewcommand{\\tablename}{表}}' in result
+    assert '\n{\\renewcommand{\\literalblockname}{リスト}}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-numfig')

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -91,6 +91,7 @@ def verify_re_latex(app, parse):
         app.builder = LaTeXBuilder(app)
         app.builder.set_environment(app.env)
         app.builder.init_context()
+        app.builder.init_babel()
         latex_translator = ForgivingLaTeXTranslator(document, app.builder)
         latex_translator.first_document = -1  # don't write \begin{document}
         document.walkabout(latex_translator)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Move labels for `numfig_format` to `sphinxmessage.sty`
- ~Still WIP. This contains #5515.~