### PR TITLE
[1.8] Revert "Builder.build: save env also with only new documents"

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -369,14 +369,14 @@ class Builder(object):
         else:
             logger.info(__('none found'))
 
-        # save the environment
-        from sphinx.application import ENV_PICKLE_FILENAME
-        logger.info(bold(__('pickling environment... ')), nonl=True)
-        with open(path.join(self.doctreedir, ENV_PICKLE_FILENAME), 'wb') as f:
-            pickle.dump(self.env, f, pickle.HIGHEST_PROTOCOL)
-        logger.info(__('done'))
-
         if updated_docnames:
+            # save the environment
+            from sphinx.application import ENV_PICKLE_FILENAME
+            logger.info(bold(__('pickling environment... ')), nonl=True)
+            with open(path.join(self.doctreedir, ENV_PICKLE_FILENAME), 'wb') as f:
+                pickle.dump(self.env, f, pickle.HIGHEST_PROTOCOL)
+            logger.info(__('done'))
+
             # global actions
             self.app.phase = BuildPhase.CONSISTENCY_CHECK
             logger.info(bold(__('checking consistency... ')), nonl=True)


### PR DESCRIPTION
* [x] bugfix
* [x] 1.8 backport of #5524

This reverts commit 20f625b4d39d0e981b4922f629212acc74271665, which
introduced a regression in dependency tracking for build systems
invoking sphinx-build (described in issue #5501.)

The correct solution is to properly track when the pickle file needs to
be written;  unfortunately I don't know enough about sphinx to implement
this.  Also, I'm not sure the intersphinx cache belongs into this at
all.