### PR TITLE
C++, fix assertion on multiple duplicate symbols

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #5490: latex: enumerated list causes a crash with recommonmark
 * #5492: sphinx-build fails to build docs w/ Python < 3.5.2
 * #3704: latex: wrong ``\label`` positioning for figures with a legend
+* #5496: C++, fix assertion when a symbol is declared more than twice.
 
 Testing
 --------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4014,14 +4014,20 @@ class Symbol(object):
 
         noDecl = []
         withDecl = []
+        dupDecl = []
         for s in symbols:
             if s.declaration is None:
                 noDecl.append(s)
+            elif s.isRedeclaration:
+                dupDecl.append(s)
             else:
                 withDecl.append(s)
         if Symbol.debug_lookup:
             print("      #noDecl:  ", len(noDecl))
             print("      #withDecl:", len(withDecl))
+            print("      #dupDecl: ", len(dupDecl))
+        if len(dupDecl) > 0:
+            assert len(withDecl) > 0
         # assert len(noDecl) <= 1  # we should fill in symbols when they are there
         # TODO: enable assertion when we at some point find out how to do cleanup
         # With partial builds we may start with a large symbol tree stripped of declarations.


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

If a symbol was declared more than 2 times, it would trigger an assertion.

Fixes #5496.
