### PR TITLE
Fix #5495: csv-table directive with file option in included file is broken

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
 * #3704: latex: wrong ``\label`` positioning for figures with a legend
 * #5496: C++, fix assertion when a symbol is declared more than twice.
 * #5493: gettext: crashed with broken template
+* #5495: csv-table directive with file option in included file is broken (refs:
+  #4821)
 
 Testing
 --------

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -8,7 +8,6 @@
 """
 
 import re
-from contextlib import contextmanager
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -381,7 +380,6 @@ class Include(BaseInclude, SphinxDirective):
 
     def run(self):
         # type: () -> List[nodes.Node]
-        current_filename = self.env.doc2path(self.env.docname)
         if self.arguments[0].startswith('<') and \
            self.arguments[0].endswith('>'):
             # docutils "standard" includes, do not do path processing
@@ -389,27 +387,7 @@ class Include(BaseInclude, SphinxDirective):
         rel_filename, filename = self.env.relfn2path(self.arguments[0])
         self.arguments[0] = filename
         self.env.note_included(filename)
-        with patched_warnings(self, current_filename):
-            return BaseInclude.run(self)
-
-
-@contextmanager
-def patched_warnings(directive, parent_filename):
-    # type: (BaseInclude, unicode) -> Generator[None, None, None]
-    """Add includee filename to the warnings during inclusion."""
-    try:
-        original = directive.state_machine.insert_input
-
-        def insert_input(input_lines, source):
-            # type: (Any, unicode) -> None
-            source += ' <included from %s>' % parent_filename
-            original(input_lines, source)
-
-        # patch insert_input() temporarily
-        directive.state_machine.insert_input = insert_input
-        yield
-    finally:
-        directive.state_machine.insert_input = original
+        return BaseInclude.run(self)
 
 
 def setup(app):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5495 
- I reverted #4821 to fix this.
- I'll try #4821 again if I'll get another idea.
