### PR TITLE
Fix #5498: autodoc: unable to find type hints for a ``functools.partial``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #3704: latex: wrong ``\label`` positioning for figures with a legend
 * #5496: C++, fix assertion when a symbol is declared more than twice.
 * #5493: gettext: crashed with broken template
+* #5498: autodoc: unable to find type hints for a ``functools.partial``
 
 Testing
 --------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -358,10 +358,14 @@ class Signature(object):
             self.argspec = getargspec(subject)
 
         try:
-            self.annotations = typing.get_type_hints(subject)  # type: ignore
+            if ispartial(subject):
+                # get_type_hints() does not support partial objects
+                self.annotations = {}  # type: Dict[str, Any]
+            else:
+                self.annotations = typing.get_type_hints(subject)  # type: ignore
         except Exception as exc:
             if (3, 5, 0) <= sys.version_info < (3, 5, 3) and isinstance(exc, AttributeError):
-                # python 3.5.2 raises ValueError for partial objects.
+                # python 3.5.2 raises ValueError for classmethod-ized partial objects.
                 self.annotations = {}
             else:
                 logger.warning('Invalid type annotation found on %r. Ignored: %r',

--- a/tests/py35/test_autodoc_py35.py
+++ b/tests/py35/test_autodoc_py35.py
@@ -112,6 +112,7 @@ def test_generate():
         assert len(directive.result) == 0, directive.result
         assert warn_str in app._warning.getvalue()
         app._warning.truncate(0)
+        app._warning.seek(0)
 
     def assert_works(objtype, name, **kw):
         inst = app.registry.documenters[objtype](directive, name)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5498 
