### PR TITLE
autodoc: Respect `member-order` in `autodoc_default_options` as documented

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ Other contributors, listed alphabetically, are:
 * Antonio Valentino -- qthelp builder, docstring inheritance
 * Filip Vavera -- napoleon todo directive
 * Pauli Virtanen -- autodoc improvements, autosummary extension
+* Eric N. Vander Weele -- autodoc improvements
 * Stefan van der Walt -- autosummary extension
 * Thomas Waldmann -- apidoc module fixes
 * John Waltman -- Texinfo builder

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -383,9 +383,10 @@ There are also new config values that you can set:
    Setting ``None`` is equivalent to giving the option name in the list format
    (i.e. it means "yes/true/on").
 
-   The supported options are ``'members'``, ``'undoc-members'``,
-   ``'private-members'``, ``'special-members'``, ``'inherited-members'``,
-   ``'show-inheritance'``, ``'ignore-module-all'`` and ``'exclude-members'``.
+   The supported options are ``'members'``, ``'member-order'``,
+   ``'undoc-members'``, ``'private-members'``, ``'special-members'``,
+   ``'inherited-members'``, ``'show-inheritance'``, ``'ignore-module-all'`` and
+   ``'exclude-members'``.
 
    .. versionadded:: 1.8
 

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # common option names for autodoc directives
 AUTODOC_DEFAULT_OPTIONS = ['members', 'undoc-members', 'inherited-members',
                            'show-inheritance', 'private-members', 'special-members',
-                           'ignore-module-all', 'exclude-members']
+                           'ignore-module-all', 'exclude-members', 'member-order']
 
 
 class DummyOptionSpec:

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1569,6 +1569,29 @@ def test_autodoc_default_options_with_values(app):
     assert '   .. py:attribute:: EnumCls.val3' not in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
 
+    # with :member-order:
+    app.config.autodoc_default_options = {
+        'members': None,
+        'member-order': 'bysource',
+    }
+    actual = do_autodoc(app, 'class', 'target.Class')
+    assert list(filter(lambda l: '::' in l, actual)) == [
+        '.. py:class:: Class(arg)',
+        '   .. py:attribute:: Class.descr',
+        '   .. py:method:: Class.meth()',
+        '   .. py:method:: Class.skipmeth()',
+        '   .. py:method:: Class.excludemeth()',
+        '   .. py:attribute:: Class.attr',
+        '   .. py:attribute:: Class.prop',
+        '   .. py:attribute:: Class.docattr',
+        '   .. py:attribute:: Class.udocattr',
+        '   .. py:attribute:: Class.mdocattr',
+        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:attribute:: Class.inst_attr_inline',
+        '   .. py:attribute:: Class.inst_attr_comment',
+        '   .. py:attribute:: Class.inst_attr_string',
+    ]
+
     # with :special-members:
     app.config.autodoc_default_options = {
         'special-members': '__init__,__iter__',


### PR DESCRIPTION
Subject: autodoc: Respect `member-order` in `autodoc_default_options` as documented

### Feature or Bugfix
- Bugfix

### Purpose & Detail
- In the `autodoc_default_options` documentation, it mentions that `member-order` is respected; however, when setting the key-value pair in `conf.py`, it is not.  Thus, add `member-order` as one of the default options respected in `conf.py`.
