### PR TITLE
Fix #5480: autodoc: unable to find type hints for unresolvable Forward references

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 * #5495: csv-table directive with file option in included file is broken (refs:
   #4821)
 * #5498: autodoc: unable to find type hints for a ``functools.partial``
+* #5480: autodoc: unable to find type hints for unresolvable Forward references
 
 Testing
 --------

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -232,7 +232,7 @@ def test_Signature_partialmethod():
                     reason='type annotation test is available on py34 or above')
 def test_Signature_annotations():
     from typing_test_data import (
-        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, Node)
+        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, Node)
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -296,6 +296,10 @@ def test_Signature_annotations():
     # Any
     sig = inspect.Signature(f14).format_args()
     assert sig == '() -> Any'
+
+    # ForwardRef
+    sig = inspect.Signature(f15).format_args()
+    assert sig == '(x: Unknown, y: int) -> Any'
 
     # type hints by string
     sig = inspect.Signature(Node.children).format_args()

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -76,6 +76,10 @@ def f14() -> Any:
     pass
 
 
+def f15(x: "Unknown", y: "int") -> Any:
+    pass
+
+
 class Node:
     def __init__(self, parent: Optional['Node']) -> None:
         pass


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5480
