### PR TITLE
Fix ensuredir() in case of pre-existing file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 * #5495: csv-table directive with file option in included file is broken (refs:
   #4821)
 * #5498: autodoc: unable to find type hints for a ``functools.partial``
+* #5480: autodoc: unable to find type hints for unresolvable Forward references
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -150,7 +150,7 @@ Deprecated
 * :confval:`autodoc_default_flags` is deprecated
 * quickstart: ``--epub`` option becomes default, so it is deprecated
 * Drop function based directive support.  For now, Sphinx only supports class
-  based directives.
+  based directives (see :class:`~Directive`)
 * ``sphinx.util.docutils.directive_helper()`` is deprecated
 * ``sphinx.cmdline`` is deprecated
 * ``sphinx.make_mode`` is deprecated

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -89,8 +89,9 @@ def ensuredir(path):
     try:
         os.makedirs(path)
     except OSError as err:
-        # 0 for Jython/Win32
-        if err.errno not in [0, EEXIST]:
+        # If the path is already an existing directory (not a file!),
+        # that is OK.
+        if not os.path.isdir(path):
             raise
 
 

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -232,7 +232,7 @@ def test_Signature_partialmethod():
                     reason='type annotation test is available on py34 or above')
 def test_Signature_annotations():
     from typing_test_data import (
-        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, Node)
+        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, Node)
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -296,6 +296,10 @@ def test_Signature_annotations():
     # Any
     sig = inspect.Signature(f14).format_args()
     assert sig == '() -> Any'
+
+    # ForwardRef
+    sig = inspect.Signature(f15).format_args()
+    assert sig == '(x: Unknown, y: int) -> Any'
 
     # type hints by string
     sig = inspect.Signature(Node.children).format_args()

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -76,6 +76,10 @@ def f14() -> Any:
     pass
 
 
+def f15(x: "Unknown", y: "int") -> Any:
+    pass
+
+
 class Node:
     def __init__(self, parent: Optional['Node']) -> None:
         pass


### PR DESCRIPTION
Subject: `sphinx.util.osutil.ensuredir()` should give an error when an ordinary file (not directory) exists with the given name.

### Feature or Bugfix
- Bugfix

### Purpose
I'm currently in the process of debugging an issue with SageMath when upgrading from Sphinx 1.7 to Sphinx 1.8. I get a warning `[Errno 20] Not a directory` while copying static files due to #5541 which causes the static "directory" to be an ordinary file. This should be detected earlier by `ensuredir()`.

The current pull request also changes the philosophy of the test: we don't care about the process (why did it fail?) but we care about the result (we want a directory with the given name). By not using `errno`, it is very likely also more portable, which is an additional advantage.