### PR TITLE
Correctly deal with non-existing static dir in graphviz extension

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 * #5495: csv-table directive with file option in included file is broken (refs:
   #4821)
 * #5498: autodoc: unable to find type hints for a ``functools.partial``
+* #5480: autodoc: unable to find type hints for unresolvable Forward references
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -150,7 +150,7 @@ Deprecated
 * :confval:`autodoc_default_flags` is deprecated
 * quickstart: ``--epub`` option becomes default, so it is deprecated
 * Drop function based directive support.  For now, Sphinx only supports class
-  based directives.
+  based directives (see :class:`~Directive`)
 * ``sphinx.util.docutils.directive_helper()`` is deprecated
 * ``sphinx.cmdline`` is deprecated
 * ``sphinx.make_mode`` is deprecated

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -27,7 +27,7 @@ from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
-from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.fileutil import copy_asset
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
@@ -413,7 +413,7 @@ def on_build_finished(app, exc):
     if exc is None:
         src = path.join(sphinx.package_dir, 'templates', 'graphviz', 'graphviz.css')
         dst = path.join(app.outdir, '_static')
-        copy_asset_file(src, dst)
+        copy_asset(src, dst)
 
 
 def setup(app):

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -232,7 +232,7 @@ def test_Signature_partialmethod():
                     reason='type annotation test is available on py34 or above')
 def test_Signature_annotations():
     from typing_test_data import (
-        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, Node)
+        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, Node)
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -296,6 +296,10 @@ def test_Signature_annotations():
     # Any
     sig = inspect.Signature(f14).format_args()
     assert sig == '() -> Any'
+
+    # ForwardRef
+    sig = inspect.Signature(f15).format_args()
+    assert sig == '(x: Unknown, y: int) -> Any'
 
     # type hints by string
     sig = inspect.Signature(Node.children).format_args()

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -76,6 +76,10 @@ def f14() -> Any:
     pass
 
 
+def f15(x: "Unknown", y: "int") -> Any:
+    pass
+
+
 class Node:
     def __init__(self, parent: Optional['Node']) -> None:
         pass


### PR DESCRIPTION
Subject: if the `_static` destination directory does not exist, the file `graphviz.css` is copied to a *file* called `_static` instead of a file in the directory `_static`.

### Feature or Bugfix
- Bugfix