### PR TITLE
Fix ensuredir() in case of pre-existing file

### DIFF
--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -89,8 +89,9 @@ def ensuredir(path):
     try:
         os.makedirs(path)
     except OSError as err:
-        # 0 for Jython/Win32
-        if err.errno not in [0, EEXIST]:
+        # If the path is already an existing directory (not a file!),
+        # that is OK.
+        if not os.path.isdir(path):
             raise
 
 


### PR DESCRIPTION
Subject: `sphinx.util.osutil.ensuredir()` should give an error when an ordinary file (not directory) exists with the given name.

### Feature or Bugfix
- Bugfix

### Purpose
I'm currently in the process of debugging an issue with SageMath when upgrading from Sphinx 1.7 to Sphinx 1.8. I get a warning `[Errno 20] Not a directory` while copying static files due to #5541 which causes the static "directory" to be an ordinary file. This should be detected earlier by `ensuredir()`.

The current pull request also changes the philosophy of the test: we don't care about the process (why did it fail?) but we care about the result (we want a directory with the given name). By not using `errno`, it is very likely also more portable, which is an additional advantage.