### PR TITLE
Correctly deal with non-existing static dir in graphviz extension

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -27,7 +27,7 @@ from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
-from sphinx.util.fileutil import copy_asset_file
+from sphinx.util.fileutil import copy_asset
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
@@ -413,7 +413,7 @@ def on_build_finished(app, exc):
     if exc is None:
         src = path.join(sphinx.package_dir, 'templates', 'graphviz', 'graphviz.css')
         dst = path.join(app.outdir, '_static')
-        copy_asset_file(src, dst)
+        copy_asset(src, dst)
 
 
 def setup(app):


### PR DESCRIPTION
Subject: if the `_static` destination directory does not exist, the file `graphviz.css` is copied to a *file* called `_static` instead of a file in the directory `_static`.

### Feature or Bugfix
- Bugfix