### PR TITLE
sphinx.ext.extlinks: support callable URL & prefix (resolves #1622)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Other contributors, listed alphabetically, are:
 * Kevin Dunn -- MathJax extension
 * Josip Dzolonga -- coverage builder
 * Buck Evan -- dummy builder
+* Travis A. Everett -- extlinks improvements
 * Matthew Fernandez -- todo extension fix
 * Hernan Grecco -- search improvements
 * Horst Gutmann -- internationalization support

--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,7 @@ __ https://github.com/sphinx-contrib/sphinx-pretty-searchresults
 * #5533: autodoc: :confval:`autodoc_default_options` supports ``member-order``
 * #4018: htmlhelp: Add :confval:`htmlhelp_file_suffix` and
   :confval:`htmlhelp_link_suffix`
+* #1622: extlinks: :confval:`extlinks` supports callable URL and prefix
 
 Bugs fixed
 ----------

--- a/doc/usage/extensions/extlinks.rst
+++ b/doc/usage/extensions/extlinks.rst
@@ -47,6 +47,20 @@ The extension adds one new config value:
    that generate links, i.e. ``:issue:`this issue <123>```.  In this case, the
    *prefix* is not relevant.
 
+   One or either of the base URL and prefix can also be callables. In this
+   case, they are called with the role as the lone argument and are fully
+   responsible for turning the role target into the final URL and/or title,
+   respectively. Using the following example, ``:pydoc:`about.html``` would
+   produce a link titled ``About`` to ``about.html`` in the docsset for the
+   same major version of Python that builds the documentation::
+
+       one, two = sys.version_info[0:2]
+
+       extlinks = {'pydoc': (
+           lambda pg: "https://docs.python.org/{}.{}/{}".format(one, two, pg),
+           lambda pg: pg.split(".")[0].title()
+       )}
+
 .. note::
 
    Since links are generated from the role in the reading stage, they appear as

--- a/tests/roots/test-ext-extlinks/conf.py
+++ b/tests/roots/test-ext-extlinks/conf.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import sys
+
+extensions = ["sphinx.ext.extlinks"]
+
+one, two = sys.version_info[0:2]
+extlinks = {
+    "issue": ("http://bugs.python.org/issue%s", "issue "),
+    "pyurl": ("http://python.org/%s", None),
+    "pydoc": (
+        lambda pg: "https://docs.python.org/{}.{}/{}".format(one, two, pg),
+        lambda pg: pg.split(".")[0].title(),
+    ),
+}

--- a/tests/roots/test-ext-extlinks/index.rst
+++ b/tests/roots/test-ext-extlinks/index.rst
@@ -1,0 +1,5 @@
+extlinks
+--------
+
+Test diverse links: :issue:`1000` and :pyurl:`dev/`, also with
+:issue:`explicit caption <1042>` and :pydoc:`about.html`.

--- a/tests/test_ext_extlinks.py
+++ b/tests/test_ext_extlinks.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+    test_ext_extlinks
+    ~~~~~~~~~~~
+
+    Test the sphinx.ext.extlinks module.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+import sys
+
+
+@pytest.mark.sphinx("html", testroot="ext-extlinks")
+def test_extlinks(app, status, warning):
+    app.builder.build_all()
+    assert (app.outdir / "index.html").isfile()
+    with open(app.outdir / "index.html") as f:
+        rst = f.read()
+
+        # simple usage
+        assert (
+            '<a class="reference external" href="http://bugs.python.org/issue1042">explicit caption</a>'
+            in rst
+        )
+        assert (
+            '<a class="reference external" href="http://python.org/dev/">http://python.org/dev/</a>'
+            in rst
+        )
+        assert (
+            '<a class="reference external" href="http://bugs.python.org/issue1000">issue 1000</a>'
+            in rst
+        )
+
+        # callable/advanced usage
+        one, two = sys.version_info[0:2]
+        assert (
+            '<a class="reference external" href="https://docs.python.org/{}.{}/about.html">About</a>'.format(
+                one, two
+            )
+            in rst
+        )


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Support more complex extlinks use cases by providing a callable in the place of the URL and/or the prefix.

### Relates
- #1622
