### PR TITLE
test: Give filterwarnings=all by ini file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ strict_optional = False
 
 [tool:pytest]
 filterwarnings =
+    all
     ignore::DeprecationWarning:docutils.io
 
 [coverage:run]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     PYTHONWARNINGS = all,ignore::ImportWarning:pkgutil,ignore::ImportWarning:importlib._bootstrap,ignore::ImportWarning:importlib._bootstrap_external,ignore::ImportWarning:pytest_cov.plugin,ignore::DeprecationWarning:site,ignore::DeprecationWarning:_pytest.assertion.rewrite,ignore::DeprecationWarning:_pytest.fixtures,ignore::DeprecationWarning:distutils
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
 commands=
-    pytest -Wall --durations 25 {posargs}
+    pytest --durations 25 {posargs}
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION

### Feature or Bugfix
- Refactoring

### Purpose
Since pytest-3.9, precedence order of warning options had been
changed.  This moves ``-W all`` option into setup.cfg.

In detail, see https://github.com/pytest-dev/pytest/issues/3946

