### PR TITLE
LaTeX: do not use `-I xelatex` option with xindy (Fix: #5561)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * #5419: incompatible math_block node has been generated
 * #5548: Fix ensuredir() in case of pre-existing file
 * #5549: graphviz Correctly deal with non-existing static dir
+* #5561: make all-pdf fails with old xindy version
 
 Testing
 --------

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -33,8 +33,6 @@ XINDYOPTS += -M LICRcyr2utf8.xdy
 {% if xindy_cyrillic -%}
 XINDYOPTS += -M LatinRules.xdy
 {% endif -%}
-# also with pdflatex as LICRlatin2utf8.xdy replaces xindy's /tex/inputenc/utf8.xdy
-XINDYOPTS += -I xelatex
 {% endif -%}
 # format: pdf or dvi (used only by archive targets)
 FMT = pdf


### PR DESCRIPTION
It is not supported by old xindy (TeXLive 2013 or earlier), and probably
irrelevant anyhow as the .idx file should not have ^^ab or ^^^^abcd
entries.

### Relates
- #5561, #5134

