### PR TITLE
`numfig_format` can be defined using a `numfig_format()` node method.

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -746,8 +746,12 @@ class StandardDomain(Domain):
         try:
             if node['refexplicit']:
                 title = contnode.astext()
+            elif figtype in env.config.numfig_format:
+                title = env.config.numfig_format[figtype]
+            elif hasattr(target_node, "numfig_format"):
+                title = target_node.numfig_format(builder, figtype, ref=True)
             else:
-                title = env.config.numfig_format.get(figtype, '')
+                title = ''
 
             if figname is None and '{name}' in title:
                 logger.warning(__('the link has no caption: %s'), title, location=node)

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -332,13 +332,15 @@ class HTMLTranslator(BaseTranslator):
             if figure_id in self.builder.fignumbers.get(key, {}):
                 self.body.append('<span class="caption-number">')
                 prefix = self.builder.config.numfig_format.get(figtype)
+                if prefix is None and hasattr(node, "numfig_format"):
+                    prefix = node.numfig_format(self.builder, figtype, ref=False)
                 if prefix is None:
                     msg = __('numfig_format is not defined for %s') % figtype
                     logger.warning(msg)
                 else:
                     numbers = self.builder.fignumbers[key][figure_id]
                     self.body.append(prefix % '.'.join(map(str, numbers)) + ' ')
-                    self.body.append('</span>')
+                self.body.append('</span>')
 
         figtype = self.builder.env.domains['std'].get_enumerable_node_type(node)
         if figtype:

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -300,13 +300,15 @@ class HTML5Translator(BaseTranslator):
             if figure_id in self.builder.fignumbers.get(key, {}):
                 self.body.append('<span class="caption-number">')
                 prefix = self.builder.config.numfig_format.get(figtype)
+                if prefix is None and hasattr(node, "numfig_format"):
+                    prefix = node.numfig_format(self.builder, figtype, ref=False)
                 if prefix is None:
                     msg = __('numfig_format is not defined for %s') % figtype
                     logger.warning(msg)
                 else:
                     numbers = self.builder.fignumbers[key][figure_id]
                     self.body.append(prefix % '.'.join(map(str, numbers)) + ' ')
-                    self.body.append('</span>')
+                self.body.append('</span>')
 
         figtype = self.builder.env.domains['std'].get_enumerable_node_type(node)
         if figtype:


### PR DESCRIPTION
⚠️ This is a proof-of-concept. It does not include tests or documentation; I will write it if you accept this idea.

Subject: Allow more complex formatting for `numfig_format`.

# Feature description

Caption and references of an enumerable node are defined using:

1. Configuration variable [numfig_format](http://www.sphinx-doc.org/en/stable/usage/configuration.html#confval-numfig_format).
2. If conf variable `numfig_format` is not defined: method `numfig_format()` of the node (this is the feature implemented by this pull request).
3. If method `numfig_format()` is not defined: the empty string.

Being able to define `numfig_format` by a method is much more powerful than a string.

# Writers affected

This feature only works with html and html5 writers.

* LaTeX writer: the way `numfig_format` is managed right now is [kind of a hack](https://github.com/sphinx-doc/sphinx/blob/c97441e2afaa01eebde01716ebbee8b0d40c715d/sphinx/writers/latex.py#L744-L782), and would not work easily with this new feature. So, it is up to the extension writer to handle LaTeX on her own.
* Other writers: I do not use/know them.

# Problems solved by this feature

- In my sphinx extension [sphinxcontrib-proof](https://sphinxcontrib-proof.readthedocs.io), I define definitions, theorems, etc, which share the same counter. I cannot name them differently (*Theorem 1*, *Definition 2*, etc.) using the string `numfig_format`. With this pull request, I achieve this by defining the method `Node.numfig_format()`:

  ~~~python
    class NumberedStatementNode(_StatementNode):
        """Statement with a number."""

        def numfig_format(self, builder, figtype, ref):
            """Give each theorem type its own name."""
            # `self["name"]` is "Theorem" or "Definition" or etc.
            return self["name"] + " %s "
  ~~~

- Issue sphinx-doc/sphinx#3209 can be solved by implementing such a `numfig_format()` method.
- Issue sphinx-doc/sphinx#4086 can be also solved by implementing such a method, for a boolean `ref` argument is provided to this `numfig_format()` (which make it possible to return different names whether the returned string is used  to name a node or to reference it).

# Next

If you agree with this idea, I can write test and documentation.