### PR TITLE
LaTeX: use lookbehind regex to not match semicolon at start

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1884,7 +1884,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         self.body.append('\n\\end{flushright}\n')
 
-    def visit_index(self, node, scre=re.compile(r';\s*')):
+    def visit_index(self, node, scre=re.compile(r'(?<!^);\s*')):
         # type: (nodes.Node, Pattern) -> None
         def escape(value):
             value = self.encode(value)


### PR DESCRIPTION
Closes: #5576

Here is screen shot of a portion of the index in library.pdf from CPython 3.7 documentation, showing indexing of `;` now works:

![capture d ecran 2018-10-30 a 23 27 42](https://user-images.githubusercontent.com/2589111/47754679-fbf55100-dc9b-11e8-9acf-fcee1f4b6514.png)


I used a look-behind regex as advocated at this [stackoverflow answer](https://stackoverflow.com/a/15669590/4184837)

### Relates

- #5561 

