### PR TITLE
LaTeX: add styling to general index, similar to domain indices

### DIFF
--- a/sphinx/texinputs/python.ist
+++ b/sphinx/texinputs/python.ist
@@ -4,6 +4,9 @@ heading_prefix "  \\bigletter "
 
 preamble "\\begin{sphinxtheindex}
 \\let\\bigletter\\sphinxstyleindexlettergroup
+\\let\\spxpagem \\sphinxstyleindexpagemain
+\\let\\spxentry \\sphinxstyleindexentry
+\\let\\spxextra \\sphinxstyleindexextra
 
 "
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1623,8 +1623,11 @@
 
 % additional customizable styling
 \def\sphinxstyleindexentry   #1{\texttt{#1}}
-\def\sphinxstyleindexextra   #1{ \emph{(#1)}}
+\def\sphinxstyleindexextra   #1{ (\emph{#1})}
 \def\sphinxstyleindexpageref #1{, \pageref{#1}}
+\def\sphinxstyleindexpagemain#1{\textbf{#1}}
+\protected\def\spxentry#1{#1}% will get \let to \sphinxstyleindexentry in index
+\protected\def\spxextra#1{#1}% will get \let to \sphinxstyleindexextra in index
 \def\sphinxstyleindexlettergroup #1%
     {{\Large\sffamily#1}\nopagebreak\vspace{1mm}}
 \def\sphinxstyleindexlettergroupDefault #1%

--- a/sphinx/texinputs/sphinx.xdy
+++ b/sphinx/texinputs/sphinx.xdy
@@ -3,11 +3,12 @@
 ;; Unfortunately xindy is out-of-the-box hyperref-incompatible.  This
 ;; configuration is a workaround, which requires to pass option
 ;; hyperindex=false to hyperref.
-;; textit and emph not currently used by Sphinx LaTeX writer.
-(define-attributes (("textbf" "textit" "emph" "default")))
+;; textit and emph not currently used, spxpagem replaces former textbf
+(define-attributes (("textbf" "textit" "emph" "spxpagem" "default")))
 (markup-locref :open "\textbf{\hyperpage{" :close "}}" :attr "textbf")
 (markup-locref :open "\textit{\hyperpage{" :close "}}" :attr "textit")
 (markup-locref :open "\emph{\hyperpage{" :close "}}" :attr "emph")
+(markup-locref :open "\spxpagem{\hyperpage{" :close "}}" :attr "spxpagem")
 (markup-locref :open "\hyperpage{" :close "}" :attr "default")
 
 (require "numeric-sort.xdy")
@@ -193,6 +194,9 @@
 (markup-index :open  "\begin{sphinxtheindex}
 \let\lettergroup\sphinxstyleindexlettergroup
 \let\lettergroupDefault\sphinxstyleindexlettergroupDefault
+\let\spxpagem\sphinxstyleindexpagemain
+\let\spxentry\sphinxstyleindexentry
+\let\spxextra\sphinxstyleindexextra
 
 "
 	      :close "

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1926,12 +1926,14 @@ class LaTeXTranslator(nodes.NodeVisitor):
                                      (p1, P1, p2, P2, m, p2, P2, p1, P1, m))
                 elif type == 'triple':
                     p1, p2, p3 = [escape(x) for x in split_into(3, 'triple', string)]
+                    P1, P2, P3 = style(p1), style(p2), style(p3)
                     self.body.append(
-                        r'\index{%s@\spxentry{%s}!%s %s@\spxentry{%s %s}%s}'
-                        r'\index{%s@\spxentry{%s}!%s, %s@\spxentry{%s, %s}%s}'
-                        r'\index{%s@\spxentry{%s}!%s %s@\spxentry{%s %s}%s}' %
-                        (p1, p1, p2, p3, p2, p3, m, p2, p2, p3, p1, p3, p1, m,
-                         p3, p3, p1, p2, p1, p2, m))
+                        r'\index{%s@%s!%s %s@%s %s%s}'
+                        r'\index{%s@%s!%s, %s@%s, %s%s}'
+                        r'\index{%s@%s!%s %s@%s %s%s}' %
+                        (p1, P1, p2, p3, P2, P3, m,
+                         p2, P2, p3, p1, P3, P1, m,
+                         p3, P3, p1, p2, P1, P2, m))
                 elif type == 'see':
                     p1, p2 = [escape(x) for x in split_into(2, 'see', string)]
                     P1 = style(p1)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -169,6 +169,8 @@ ADDITIONAL_SETTINGS = {
     },
 }  # type: Dict[unicode, Dict[unicode, unicode]]
 
+EXTRA_RE = re.compile(r'^(.*\S)\s+\(([^()]*)\)\s*$')
+
 
 class collected_footnote(nodes.footnote):
     """Footnotes that are collected are assigned this class."""
@@ -1884,8 +1886,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
         # type: (nodes.Node) -> None
         self.body.append('\n\\end{flushright}\n')
 
-    def visit_index(self, node, extrare=re.compile(r'^(.*\S)\s+\(([^()]*)\)\s*$')):
-        # type: (nodes.Node, Pattern) -> None
+    def visit_index(self, node, scre = None):
+        # type: (nodes.Node, None) -> None
         def escape(value):
             value = self.encode(value)
             value = value.replace(r'\{', r'\sphinxleftcurlybrace{}')
@@ -1896,12 +1898,16 @@ class LaTeXTranslator(nodes.NodeVisitor):
             return value
 
         def style(string):
-            match = extrare.match(string)
+            match = EXTRA_RE.match(string)
             if match:
                 return match.expand(r'\\spxentry{\1}\\spxextra{\2}')
             else:
                 return '\\spxentry{%s}' % string
 
+        if scre:
+            warnings.warn(('LaTeXTranslator.visit_index() optional argument '
+                           '"scre" is deprecated. It is ignored.'),
+                          RemovedInSphinx30Warning, stacklevel=2)
         if not node.get('inline', True):
             self.body.append('\n')
         entries = node['entries']

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1199,9 +1199,13 @@ def test_latex_index(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
-    assert 'A \\index{famous}famous \\index{equation}equation:\n' in result
-    assert '\n\\index{Einstein}\\index{relativity}\\ignorespaces \nand' in result
-    assert '\n\\index{main \\sphinxleftcurlybrace{}}\\ignorespaces ' in result
+    assert ('A \\index{famous@\\spxentry{famous}}famous '
+            '\\index{equation@\\spxentry{equation}}equation:\n' in result)
+    assert ('\n\\index{Einstein@\\spxentry{Einstein}}'
+            '\\index{relativity@\\spxentry{relativity}}'
+            '\\ignorespaces \nand') in result
+    assert ('\n\\index{main \\sphinxleftcurlybrace{}@\\spxentry{'
+            'main \\sphinxleftcurlybrace{}}}\\ignorespaces ' in result)
 
 
 @pytest.mark.sphinx('latex', testroot='latex-equations')
@@ -1269,20 +1273,22 @@ def test_latex_glossary(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'test.tex').text(encoding='utf8')
-    assert (u'\\item[{änhlich\\index{änhlich|textbf}\\phantomsection'
+    assert (u'\\item[{änhlich\\index{änhlich@\\spxentry{änhlich}|spxpagem}'
+            r'\phantomsection'
             r'\label{\detokenize{index:term-anhlich}}}] \leavevmode' in result)
-    assert (r'\item[{boson\index{boson|textbf}\phantomsection'
+    assert (r'\item[{boson\index{boson@\spxentry{boson}|spxpagem}\phantomsection'
             r'\label{\detokenize{index:term-boson}}}] \leavevmode' in result)
-    assert (r'\item[{\sphinxstyleemphasis{fermion}\index{fermion|textbf}'
+    assert (r'\item[{\sphinxstyleemphasis{fermion}'
+            r'\index{fermion@\spxentry{fermion}|spxpagem}'
             r'\phantomsection'
             r'\label{\detokenize{index:term-fermion}}}] \leavevmode' in result)
-    assert (r'\item[{tauon\index{tauon|textbf}\phantomsection'
+    assert (r'\item[{tauon\index{tauon@\spxentry{tauon}|spxpagem}\phantomsection'
             r'\label{\detokenize{index:term-tauon}}}] \leavevmode'
-            r'\item[{myon\index{myon|textbf}\phantomsection'
+            r'\item[{myon\index{myon@\spxentry{myon}|spxpagem}\phantomsection'
             r'\label{\detokenize{index:term-myon}}}] \leavevmode'
-            r'\item[{electron\index{electron|textbf}\phantomsection'
+            r'\item[{electron\index{electron@\spxentry{electron}|spxpagem}\phantomsection'
             r'\label{\detokenize{index:term-electron}}}] \leavevmode' in result)
-    assert (u'\\item[{über\\index{über|textbf}\\phantomsection'
+    assert (u'\\item[{über\\index{über@\\spxentry{über}|spxpagem}\\phantomsection'
             r'\label{\detokenize{index:term-uber}}}] \leavevmode' in result)
 
 


### PR DESCRIPTION
Closes: #5579. Also closes #5576.

With this here is for example how CPython 3.7 library.pdf renders:

![capture d ecran 2018-10-31 a 19 16 38](https://user-images.githubusercontent.com/2589111/47810377-72995980-dd43-11e8-97fe-09f67a404015.png)

and 

![capture d ecran 2018-10-31 a 19 16 52](https://user-images.githubusercontent.com/2589111/47810389-7c22c180-dd43-11e8-827a-010c1f6e380c.png)

Compare to the images posted at #5579.

About the underscore character, it shows fine because CPython uses xelatex for pdf builds and this means another font is used than the Sphinx default `Courier`. Unfortunately the Courier font used by default for monospace font by Sphinx has an underscore glyph which creates continuous lines... one can see that in Sphinx own pdf doc, see top left.

![capture d ecran 2018-10-31 a 19 09 22](https://user-images.githubusercontent.com/2589111/47810592-f81d0980-dd43-11e8-860a-ca2dd007ecee.png)

Sphinx own doc uses `\footnotesize\raggedright` which explains smaller size.

It fixes #5576 in a way different from #5577: the regex argument of `visit_index()` in latex.py is used for something completely different: separate from the index a parenthesized comment ("extra") and style it especially as in Python Module Index.

Another slightly breaking change is in `\sphinxstyleindexextra`, the parentheses stay upright. I feel it looks better. (I will do more detailed review some time later)