### PR TITLE
refactor: Move Makefile for texinfo to templates dir

### DIFF
--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -17,6 +17,7 @@ from docutils.frontend import OptionParser
 from docutils.io import FileOutput
 
 from sphinx import addnodes
+from sphinx import package_dir
 from sphinx.builders import Builder
 from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
@@ -37,59 +38,7 @@ if False:
 
 
 logger = logging.getLogger(__name__)
-
-TEXINFO_MAKEFILE = '''\
-# Makefile for Sphinx Texinfo output
-
-infodir ?= /usr/share/info
-
-MAKEINFO = makeinfo --no-split
-MAKEINFO_html = makeinfo --no-split --html
-MAKEINFO_plaintext = makeinfo --no-split --plaintext
-TEXI2PDF = texi2pdf --batch --expand
-INSTALL_INFO = install-info
-
-ALLDOCS = $(basename $(wildcard *.texi))
-
-all: info
-info: $(addsuffix .info,$(ALLDOCS))
-plaintext: $(addsuffix .txt,$(ALLDOCS))
-html: $(addsuffix .html,$(ALLDOCS))
-pdf: $(addsuffix .pdf,$(ALLDOCS))
-
-install-info: info
-\tfor f in *.info; do \\
-\t  cp -t $(infodir) "$$f" && \\
-\t  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" ; \\
-\tdone
-
-uninstall-info: info
-\tfor f in *.info; do \\
-\t  rm -f "$(infodir)/$$f"  ; \\
-\t  $(INSTALL_INFO) --delete --info-dir=$(infodir) "$$f" ; \\
-\tdone
-
-%.info: %.texi
-\t$(MAKEINFO) -o '$@' '$<'
-
-%.txt: %.texi
-\t$(MAKEINFO_plaintext) -o '$@' '$<'
-
-%.html: %.texi
-\t$(MAKEINFO_html) -o '$@' '$<'
-
-%.pdf: %.texi
-\t-$(TEXI2PDF) '$<'
-\t-$(TEXI2PDF) '$<'
-\t-$(TEXI2PDF) '$<'
-
-clean:
-\trm -f *.info *.pdf *.txt *.html
-\trm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ky *.pg
-\trm -f *.vr *.tp *.fn *.fns *.def *.defs *.cp *.cps *.ge *.ges *.mo
-
-.PHONY: all info plaintext html pdf install-info uninstall-info clean
-'''
+template_dir = os.path.join(package_dir, 'templates', 'texinfo')
 
 
 class TexinfoBuilder(Builder):
@@ -239,8 +188,7 @@ class TexinfoBuilder(Builder):
         fn = path.join(self.outdir, 'Makefile')
         logger.info(fn, nonl=1)
         try:
-            with open(fn, 'w') as mkfile:
-                mkfile.write(TEXINFO_MAKEFILE)
+            copy_asset_file(os.path.join(template_dir, 'Makefile'), fn)
         except (IOError, OSError) as err:
             logger.warning(__("error writing file %s: %s"), fn, err)
         logger.info(__(' done'))

--- a/sphinx/templates/texinfo/Makefile
+++ b/sphinx/templates/texinfo/Makefile
@@ -1,0 +1,50 @@
+# Makefile for Sphinx Texinfo output
+
+infodir ?= /usr/share/info
+
+MAKEINFO = makeinfo --no-split
+MAKEINFO_html = makeinfo --no-split --html
+MAKEINFO_plaintext = makeinfo --no-split --plaintext
+TEXI2PDF = texi2pdf --batch --expand
+INSTALL_INFO = install-info
+
+ALLDOCS = $(basename $(wildcard *.texi))
+
+all: info
+info: $(addsuffix .info,$(ALLDOCS))
+plaintext: $(addsuffix .txt,$(ALLDOCS))
+html: $(addsuffix .html,$(ALLDOCS))
+pdf: $(addsuffix .pdf,$(ALLDOCS))
+
+install-info: info
+	for f in *.info; do \\
+	  cp -t $(infodir) "$$f" && \\
+	  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" ; \\
+	done
+
+uninstall-info: info
+	for f in *.info; do \\
+	  rm -f "$(infodir)/$$f"  ; \\
+	  $(INSTALL_INFO) --delete --info-dir=$(infodir) "$$f" ; \\
+	done
+
+%.info: %.texi
+	$(MAKEINFO) -o '$@' '$<'
+
+%.txt: %.texi
+	$(MAKEINFO_plaintext) -o '$@' '$<'
+
+%.html: %.texi
+	$(MAKEINFO_html) -o '$@' '$<'
+
+%.pdf: %.texi
+	-$(TEXI2PDF) '$<'
+	-$(TEXI2PDF) '$<'
+	-$(TEXI2PDF) '$<'
+
+clean:
+	rm -f *.info *.pdf *.txt *.html
+	rm -f *.log *.ind *.aux *.toc *.syn *.idx *.out *.ilg *.pla *.ky *.pg
+	rm -f *.vr *.tp *.fn *.fns *.def *.defs *.cp *.cps *.ge *.ges *.mo
+
+.PHONY: all info plaintext html pdf install-info uninstall-info clean


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- As a preparation of bug fix, this extracts `Makefile` template as an independent file, not a string.
