### PR TITLE
Remove reference to deprecated easy_install

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -76,8 +76,7 @@ Quick guide
 `sphinx-intl`_ is a useful tool to work with Sphinx translation flow.
 This section describe an easy way to translate with sphinx-intl.
 
-#. Install `sphinx-intl`_ by :command:`pip install sphinx-intl` or
-   :command:`easy_install sphinx-intl`.
+#. Install `sphinx-intl`_ by :command:`pip install sphinx-intl`.
 
 #. Add configurations to your `conf.py`::
 


### PR DESCRIPTION
easy_install is deprecated and its use is discouraged by PyPA:

https://setuptools.readthedocs.io/en/latest/easy_install.html

> Warning: Easy Install is deprecated. Do not use it. Instead use pip.

Follow upstream advice and only recommended supported tools.

Subject: <short purpose of this pull request>