### PR TITLE
Move language-specific data into a new JS file, language_data.js

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,6 +44,7 @@ epub_post_files = [('usage/installation.xhtml', 'Installing Sphinx'),
 epub_exclude_files = ['_static/opensearch.xml', '_static/doctools.js',
                       '_static/jquery.js', '_static/searchtools.js',
                       '_static/underscore.js', '_static/basic.css',
+                      '_static/language_data.js',
                       'search.html', '_static/websupport.js']
 epub_fix_images = False
 epub_max_image_width = 0

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -408,6 +408,7 @@ class StandaloneHTMLBuilder(Builder):
         self.add_js_file('jquery.js')
         self.add_js_file('underscore.js')
         self.add_js_file('doctools.js')
+        self.add_js_file('language_data.js')
 
         for filename, attrs in self.app.registry.js_files:
             self.add_js_file(filename, **attrs)

--- a/sphinx/themes/basic/static/documentation_options.js_t
+++ b/sphinx/themes/basic/static/documentation_options.js_t
@@ -7,18 +7,4 @@ var DOCUMENTATION_OPTIONS = {
     HAS_SOURCE: {{ has_source|lower }},
     SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
     NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}},
-    SEARCH_LANGUAGE_STOP_WORDS: {{ search_language_stop_words }}
 };
-
-
-{% if search_language_stemming_code %}
-/* Non-minified version JS is _stemmer.js if file is provided */ {% endif -%}
-{{ search_language_stemming_code|safe }}
-
-{% if search_scorer_tool %}
-{{ search_scorer_tool|safe }}
-{% endif -%}
-
-{% if search_word_splitter_code %}
-{{ search_word_splitter_code }}
-{% endif -%}

--- a/sphinx/themes/basic/static/language_data.js_t
+++ b/sphinx/themes/basic/static/language_data.js_t
@@ -1,0 +1,25 @@
+/*
+ * language_data.js
+ * ~~~~~~~~~~~~~~~~
+ *
+ * This script contains the language-specific data used by searchtools.js,
+ * namely the list of stopwords, stemmer, scorer and splitter.
+ *
+ * :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+ * :license: BSD, see LICENSE for details.
+ *
+ */
+
+var stopwords = {{ search_language_stop_words }};
+
+{% if search_language_stemming_code %}
+/* Non-minified version JS is _stemmer.js if file is provided */ {% endif -%}
+{{ search_language_stemming_code|safe }}
+
+{% if search_scorer_tool %}
+{{ search_scorer_tool|safe }}
+{% endif -%}
+
+{% if search_word_splitter_code %}
+{{ search_word_splitter_code }}
+{% endif -%}

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -138,7 +138,6 @@ var Search = {
    */
   query : function(query) {
     var i;
-    var stopwords = DOCUMENTATION_OPTIONS.SEARCH_LANGUAGE_STOP_WORDS;
 
     // stem the searchterms and add them to the correct list
     var stemmer = new Stemmer();


### PR DESCRIPTION
Subject: Make search work with old templates

### Feature or Bugfix
Bugfix

### Purpose
Not all templates use `documentation_options.js`. The examples are old versions of sphinx-rtd-theme and many other third-party themes. However currently searchtools.js does not work without some classes, which are defined in `documentation_options.js`. This pull request moves these classes to a separate file `language_data.js` which is always included, even for old templates.

### Relates
Fixes #5460.