### PR TITLE
Simplify XRefRole constructor

### DIFF
--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -68,19 +68,14 @@ class XRefRole:
     * Subclassing and overwriting `process_link()` and/or `result_nodes()`.
     """
 
-    nodeclass = addnodes.pending_xref  # type: Type[nodes.Node]
-    innernodeclass = nodes.literal
-
     def __init__(self, fix_parens=False, lowercase=False,
                  nodeclass=None, innernodeclass=None, warn_dangling=False):
-        # type: (bool, bool, Type[nodes.Node], Type[nodes.Node], bool) -> None
+        # type: (bool, bool, Type[nodes.reference], Type[nodes.TextElement], bool) -> None
         self.fix_parens = fix_parens
         self.lowercase = lowercase
         self.warn_dangling = warn_dangling
-        if nodeclass is not None:
-            self.nodeclass = nodeclass
-        if innernodeclass is not None:
-            self.innernodeclass = innernodeclass
+        self.nodeclass = nodeclass or addnodes.pending_xref
+        self.innernodeclass = innernodeclass or nodes.literal
 
     def _fix_parens(self, env, has_explicit_title, title, target):
         # type: (BuildEnvironment, bool, unicode, unicode) -> Tuple[unicode, unicode]

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -70,7 +70,7 @@ class XRefRole:
 
     def __init__(self, fix_parens=False, lowercase=False,
                  nodeclass=None, innernodeclass=None, warn_dangling=False):
-        # type: (bool, bool, Type[nodes.reference], Type[nodes.TextElement], bool) -> None
+        # type: (bool, bool, Type[nodes.Element], Type[nodes.TextElement], bool) -> None
         self.fix_parens = fix_parens
         self.lowercase = lowercase
         self.warn_dangling = warn_dangling

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -68,14 +68,19 @@ class XRefRole:
     * Subclassing and overwriting `process_link()` and/or `result_nodes()`.
     """
 
+    nodeclass = addnodes.pending_xref  # type: Type[nodes.Node]
+    innernodeclass = nodes.literal
+
     def __init__(self, fix_parens=False, lowercase=False,
                  nodeclass=None, innernodeclass=None, warn_dangling=False):
         # type: (bool, bool, Type[nodes.Element], Type[nodes.TextElement], bool) -> None
         self.fix_parens = fix_parens
         self.lowercase = lowercase
         self.warn_dangling = warn_dangling
-        self.nodeclass = nodeclass or addnodes.pending_xref
-        self.innernodeclass = innernodeclass or nodes.literal
+        if nodeclass is not None:
+            self.nodeclass = nodeclass
+        if innernodeclass is not None:
+            self.innernodeclass = innernodeclass
 
     def _fix_parens(self, env, has_explicit_title, title, target):
         # type: (BuildEnvironment, bool, unicode, unicode) -> Tuple[unicode, unicode]

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -69,13 +69,14 @@ class XRefRole:
     """
 
     def __init__(self, fix_parens=False, lowercase=False,
-                 nodeclass=None, innernodeclass=None, warn_dangling=False):
+                 nodeclass=addnodes.pending_xref, innernodeclass=nodes.literal,
+                 warn_dangling=False):
         # type: (bool, bool, Type[nodes.reference], Type[nodes.TextElement], bool) -> None
         self.fix_parens = fix_parens
         self.lowercase = lowercase
         self.warn_dangling = warn_dangling
-        self.nodeclass = nodeclass or addnodes.pending_xref
-        self.innernodeclass = innernodeclass or nodes.literal
+        self.nodeclass = nodeclass
+        self.innernodeclass = innernodeclass
 
     def _fix_parens(self, env, has_explicit_title, title, target):
         # type: (BuildEnvironment, bool, unicode, unicode) -> Tuple[unicode, unicode]

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -69,14 +69,13 @@ class XRefRole:
     """
 
     def __init__(self, fix_parens=False, lowercase=False,
-                 nodeclass=addnodes.pending_xref, innernodeclass=nodes.literal,
-                 warn_dangling=False):
+                 nodeclass=None, innernodeclass=None, warn_dangling=False):
         # type: (bool, bool, Type[nodes.reference], Type[nodes.TextElement], bool) -> None
         self.fix_parens = fix_parens
         self.lowercase = lowercase
         self.warn_dangling = warn_dangling
-        self.nodeclass = nodeclass
-        self.innernodeclass = innernodeclass
+        self.nodeclass = nodeclass or addnodes.pending_xref
+        self.innernodeclass = innernodeclass or nodes.literal
 
     def _fix_parens(self, env, has_explicit_title, title, target):
         # type: (BuildEnvironment, bool, unicode, unicode) -> Tuple[unicode, unicode]


### PR DESCRIPTION
Subject: Simplify XRefRole constructor

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Original code setting `nodeclass` and `innernodeclass` is unclear, because default values and custom values assignment statements are separated. So, restructuring and simplifying of constructor is needed.

### Detail
- (Edited) ~Put default values on appropriate place.~
- Setting `nodeclass` and `innernodeclass` property by single statement respectively.
- More concrete type annotation to represent which custom classes are to be passed.

### Relates
N/A

