### PR TITLE
Make :any: work with unknown object types in intersphinx.

### DIFF
--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -266,10 +266,6 @@ def missing_reference(app, env, node, contnode):
     inventories = InventoryAdapter(env)
     objtypes = None  # type: List[str]
     if node['reftype'] == 'any':
-        # we search anything!
-        objtypes = ['%s:%s' % (domain.name, objtype)
-                    for domain in env.domains.values()
-                    for objtype in domain.object_types]
         domain = None
     else:
         domain = node.get('refdomain')
@@ -280,9 +276,9 @@ def missing_reference(app, env, node, contnode):
         if not objtypes:
             return None
         objtypes = ['%s:%s' % (domain, objtype) for objtype in objtypes]
-    if 'std:cmdoption' in objtypes:
-        # until Sphinx-1.6, cmdoptions are stored as std:option
-        objtypes.append('std:option')
+        if 'std:cmdoption' in objtypes:
+            # until Sphinx-1.6, cmdoptions are stored as std:option
+            objtypes.append('std:option')
     to_try = [(inventories.main_inventory, target)]
     if domain:
         full_qualified_name = env.get_domain(domain).get_full_qualified_name(node)
@@ -301,10 +297,15 @@ def missing_reference(app, env, node, contnode):
                 if full_qualified_name:
                     to_try.append((inventories.named_inventory[setname], full_qualified_name))
     for inventory, target in to_try:
-        for objtype in objtypes:
-            if objtype not in inventory or target not in inventory[objtype]:
+        items = (
+            inventory.items()
+            if objtypes is None else
+            ((t, inventory[t]) for t in objtypes if t in inventory)
+        )
+        for objtype, targets in items:
+            if target not in targets:
                 continue
-            proj, version, uri, dispname = inventory[objtype][target]
+            proj, version, uri, dispname = targets[target]
             if '://' not in uri and node.get('refdoc'):
                 # get correct path in case of subdirectories
                 uri = path.join(relative_path(node['refdoc'], '.'), uri)

--- a/tests/test_util_inventory.py
+++ b/tests/test_util_inventory.py
@@ -46,6 +46,7 @@ foo.bar js:class 1 index.html#foo.bar -
 foo.bar.baz js:method 1 index.html#foo.bar.baz -
 foo.bar.qux js:data 1 index.html#foo.bar.qux -
 a term including:colon std:term -1 glossary.html#term-a-term-including-colon -
+gettext_uuid std:confval 0 usage/configuration.html -
 '''.encode())
 
 inventory_v2_not_having_version = '''\


### PR DESCRIPTION
Subject: Make `:any:` work with unknown object types in intersphinx

### Feature or Bugfix
<!-- please choose -->
Feature

### Purpose
As suggested in https://github.com/sphinx-doc/sphinx/issues/5562#issuecomment-434296574, if you want to refer to some custom object type defined in foreign project you had to define it in your project which is inconvenient. It's needed because intersphinx searches foreign inventory only for registered object types. This PR makes `:any:` role to not limit targets by registered object types.

### Relates
- #5562  

