### PR TITLE
Fix #3080: multiline rubrics and citations are broken in texinfo builder

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,7 @@ Bugs fixed
 * #5561: make all-pdf fails with old xindy version
 * #5557: quickstart: --no-batchfile isn't honored
 * #3080: texinfo: multiline rubrics are broken
+* #3080: texinfo: multiline citations are broken
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,7 @@ Bugs fixed
   crashed
 * #5561: make all-pdf fails with old xindy version
 * #5557: quickstart: --no-batchfile isn't honored
+* #3080: texinfo: multiline rubrics are broken
 
 Testing
 --------

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -673,9 +673,11 @@ class TexinfoTranslator(nodes.NodeVisitor):
         except IndexError:
             rubric = self.rubrics[-1]
         self.body.append('\n%s ' % rubric)
+        self.escape_newlines += 1
 
     def depart_rubric(self, node):
         # type: (nodes.Node) -> None
+        self.escape_newlines -= 1
         self.body.append('\n\n')
 
     def visit_subtitle(self, node):

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -922,12 +922,14 @@ class TexinfoTranslator(nodes.NodeVisitor):
 
     def visit_citation(self, node):
         # type: (nodes.Node) -> None
+        self.body.append('\n')
         for id in node.get('ids'):
             self.add_anchor(id, node)
+        self.escape_newlines += 1
 
     def depart_citation(self, node):
         # type: (nodes.Node) -> None
-        pass
+        self.escape_newlines -= 1
 
     def visit_citation_reference(self, node):
         # type: (nodes.Node) -> None

--- a/tests/roots/test-markup-citation/conf.py
+++ b/tests/roots/test-markup-citation/conf.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'test.tex', 'The basic Sphinx documentation for testing', 'Sphinx', 'report')
+]

--- a/tests/roots/test-markup-citation/index.rst
+++ b/tests/roots/test-markup-citation/index.rst
@@ -1,0 +1,9 @@
+test-markup-citation
+=====================
+
+This is a citation ref; [CITE1]_ and [CITE2]_.
+
+.. [CITE1] This is a citation
+
+.. [CITE2] This is
+   a multiline citation

--- a/tests/roots/test-markup-rubric/conf.py
+++ b/tests/roots/test-markup-rubric/conf.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+master_doc = 'index'
+
+latex_documents = [
+    (master_doc, 'test.tex', 'The basic Sphinx documentation for testing', 'Sphinx', 'report')
+]

--- a/tests/roots/test-markup-rubric/index.rst
+++ b/tests/roots/test-markup-rubric/index.rst
@@ -1,0 +1,7 @@
+test-markup-rubric
+===================
+
+.. rubric:: This is a rubric
+
+.. rubric:: This is
+   a multiline rubric

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -81,3 +81,15 @@ def test_texinfo_rubric(app, status, warning):
     output = (app.outdir / 'python.texi').text()
     assert '@heading This is a rubric' in output
     assert '@heading This is a multiline rubric' in output
+
+
+@pytest.mark.sphinx('texinfo', testroot='markup-citation')
+def test_texinfo_citation(app, status, warning):
+    app.builder.build_all()
+
+    output = (app.outdir / 'python.texi').text()
+    assert 'This is a citation ref; @ref{1,,[CITE1]} and @ref{2,,[CITE2]}.' in output
+    assert ('@anchor{index cite1}@anchor{1}@w{(CITE1)} \n'
+            'This is a citation\n') in output
+    assert ('@anchor{index cite2}@anchor{2}@w{(CITE2)} \n'
+            'This is a multiline citation\n') in output

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -72,3 +72,12 @@ def test_texinfo(app, status, warning):
                 assert False, 'makeinfo exited with return code %s' % retcode
     finally:
         os.chdir(cwd)
+
+
+@pytest.mark.sphinx('texinfo', testroot='markup-rubric')
+def test_texinfo_rubric(app, status, warning):
+    app.build()
+
+    output = (app.outdir / 'python.texi').text()
+    assert '@heading This is a rubric' in output
+    assert '@heading This is a multiline rubric' in output


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #3080 
