### PR TITLE
Give install_command to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps =
     du12: docutils==0.12
     du13: docutils==0.13.1
     du14: docutils==0.14
+# This entry should be also removed after moving 'extras' option
+install_command = pip install {opts} {packages}
 setenv =
     PYTHONWARNINGS = all,ignore::ImportWarning:pkgutil,ignore::ImportWarning:importlib._bootstrap,ignore::ImportWarning:importlib._bootstrap_external,ignore::ImportWarning:pytest_cov.plugin,ignore::DeprecationWarning:site,ignore::DeprecationWarning:_pytest.assertion.rewrite,ignore::DeprecationWarning:_pytest.fixtures,ignore::DeprecationWarning:distutils
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
Since tox-3.2.0, 'usedevelop' option and 'deps=.[test,websupport]'
option have been conflicted.  As a workaround, this adds
'install_command' option to avoid the situation.
