### PR TITLE
test: Replace call_autodoc() by do_autodoc()

### DIFF
--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1396,16 +1396,9 @@ def test_mocked_module_imports(app, warning):
 
 @pytest.mark.usefixtures('setup_test')
 def test_partialfunction():
-    def call_autodoc(objtype, name):
-        inst = app.registry.documenters[objtype](directive, name)
-        inst.generate()
-        result = list(directive.result)
-        del directive.result[:]
-        return result
-
-    options.members = ALL
-    #options.undoc_members = True
-    expected = [
+    options = {"members": None}
+    actual = do_autodoc(app, 'module', 'target.partialfunction', options)
+    assert list(actual) == [
         '',
         '.. py:module:: target.partialfunction',
         '',
@@ -1428,8 +1421,6 @@ def test_partialfunction():
         '   docstring of func3',
         '   '
     ]
-
-    assert call_autodoc('module', 'target.partialfunction') == expected
 
 
 @pytest.mark.usefixtures('setup_test')


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- clean up test code
