### PR TITLE
WIP: #5605 fix Chinese search index

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #5460: html search does not work with some 3rd party themes
+* #5605 If the documentation language is set to Chinese, English words could not
+  be searched.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Features added
 
 Bugs fixed
 ----------
+* #5605 If the documentation language is set to Chinese, English words could not
+  be searched.
 
 Testing
 --------
@@ -51,8 +53,6 @@ Bugs fixed
 * #5800: todo: crashed if todo is defined in TextElement
 * #5846: htmlhelp: convert hex escaping to decimal escaping in .hhc/.hhk files
 * htmlhelp: broken .hhk file generated when title contains a double quote
-* #5605 If the documentation language is set to Chinese, English words could not
-  be searched.
 
 Release 1.8.2 (released Nov 11, 2018)
 =====================================

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -234,7 +234,7 @@ class SearchChinese(SearchLanguage):
     js_stemmer_code = js_porter_stemmer
     stopwords = english_stopwords
     latin1_letters = re.compile(u'(?:(?![\\s.,])[\x00-\xFF])+')
-    latin1 = []  # type: List[unicode]
+    latin_terms = []  # type: List[unicode]
 
     def init(self, options):
         # type: (Dict) -> None
@@ -251,9 +251,10 @@ class SearchChinese(SearchLanguage):
         if JIEBA:
             chinese = list(jieba.cut_for_search(input))
 
-        self.latin1 =\
+        latin1 = \
             [term.strip() for term in self.latin1_letters.findall(input)]
-        return chinese + self.latin1
+        self.latin_terms.extend(latin1)
+        return chinese + latin1
 
     def word_filter(self, stemmed_word):
         # type: (unicode) -> bool
@@ -266,7 +267,7 @@ class SearchChinese(SearchLanguage):
         # if not stemmed, but would be too short after being stemmed
         # avoids some issues with acronyms
         should_not_be_stemmed = (
-            word in self.latin1 and
+            word in self.latin_terms and
             len(word) >= 3 and
             len(self.stemmer.stem(word.lower())) < 3
         )

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -250,7 +250,7 @@ class SearchChinese(SearchLanguage):
         if JIEBA:
             chinese = list(jieba.cut_for_search(input))
 
-        latin1 = self.latin1_letters.findall(input)
+        latin1 = [term.strip() for term in self.latin1_letters.findall(input)]
         return chinese + latin1
 
     def word_filter(self, stemmed_word):

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -234,7 +234,7 @@ class SearchChinese(SearchLanguage):
     js_stemmer_code = js_porter_stemmer
     stopwords = english_stopwords
     latin1_letters = re.compile(u'(?u)\\w+[\u0000-\u00ff]')
-    latin1 = []
+    latin1 = []  # type: List[unicode]
 
     def init(self, options):
         # type: (Dict) -> None

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -233,7 +233,7 @@ class SearchChinese(SearchLanguage):
     language_name = 'Chinese'
     js_stemmer_code = js_porter_stemmer
     stopwords = english_stopwords
-    latin1_letters = re.compile(u'(?u)\\w+[\u0000-\u00ff]')
+    latin1_letters = re.compile(u'(?:(?![\\s.,])[\x00-\xFF])+')
     latin1 = []  # type: List[unicode]
 
     def init(self, options):

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -265,10 +265,11 @@ class SearchChinese(SearchLanguage):
         # Don't stem Latin words that are long enough to be relevant for search
         # if not stemmed, but would be too short after being stemmed
         # avoids some issues with acronyms
-        should_not_be_stemmed =\
-            word in self.latin1 and\
-            len(word) >= 3 and\
+        should_not_be_stemmed = (
+            word in self.latin1 and
+            len(word) >= 3 and
             len(self.stemmer.stem(word.lower())) < 3
+        )
         if should_not_be_stemmed:
             return word.lower()
         return self.stemmer.stem(word.lower())

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -233,7 +233,7 @@ class SearchChinese(SearchLanguage):
     language_name = 'Chinese'
     js_stemmer_code = js_porter_stemmer
     stopwords = english_stopwords
-    latin1_letters = re.compile(u'(?:(?![\\s.,])[\x00-\xFF])+')
+    latin1_letters = re.compile(r'[a-zA-Z0-9_]+')
     latin_terms = []  # type: List[unicode]
 
     def init(self, options):

--- a/tests/roots/test-search/tocitem.rst
+++ b/tests/roots/test-search/tocitem.rst
@@ -10,3 +10,6 @@ textinheading
 lorem ipsum
 
 可以查看 FAQ 模块中 Chinesetest 部分
+
+模块中 CAS service部分
+

--- a/tests/roots/test-search/tocitem.rst
+++ b/tests/roots/test-search/tocitem.rst
@@ -13,3 +13,4 @@ lorem ipsum
 
 模块中 CAS service部分
 
+可以Chinesetesttwo查看

--- a/tests/roots/test-search/tocitem.rst
+++ b/tests/roots/test-search/tocitem.rst
@@ -8,3 +8,5 @@ textinheading
 =============
 
 lorem ipsum
+
+可以查看 FAQ 模块中 Chinesetest 部分

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -253,4 +253,5 @@ def test_search_index_gen_zh(app, status, warning):
     searchindex = (app.outdir / 'searchindex.js').text()
     assert 'chinesetest ' not in searchindex
     assert 'chinesetest' in searchindex
+    assert 'chinesetesttwo' in searchindex
     assert 'cas' in searchindex

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -240,3 +240,15 @@ def test_IndexBuilder_lookup():
     # zh_CN
     index = IndexBuilder(env, 'zh_CN', {}, None)
     assert index.lang.lang == 'zh'
+
+
+@pytest.mark.sphinx(
+    testroot='search',
+    confoverrides={'html_search_language': 'zh'}
+)
+def test_search_index_gen_zh(app, status, warning):
+    app.builder.build_all()
+    # jsdump fails if search language is 'zh'; hence we just get the text:
+    searchindex = (app.outdir / 'searchindex.js').text()
+    assert 'chinesetest ' not in searchindex
+    assert 'chinesetest' in searchindex

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -244,7 +244,8 @@ def test_IndexBuilder_lookup():
 
 @pytest.mark.sphinx(
     testroot='search',
-    confoverrides={'html_search_language': 'zh'}
+    confoverrides={'html_search_language': 'zh'},
+    srcdir='search_zh'
 )
 def test_search_index_gen_zh(app, status, warning):
     app.builder.build_all()
@@ -252,3 +253,4 @@ def test_search_index_gen_zh(app, status, warning):
     searchindex = (app.outdir / 'searchindex.js').text()
     assert 'chinesetest ' not in searchindex
     assert 'chinesetest' in searchindex
+    assert 'cas' in searchindex


### PR DESCRIPTION
Subject: generate search index for Latin words correctly if search language is Chinese

### Feature or Bugfix
- Bugfix

### Purpose
- As described at #5605
- Conf: ``html_search_language = 'zh'``

### Detail
- Removes trailing (and preceding) spaces from Latin search index terms
- WIP, because a Chinese-speaking person needs to confirm the correctness

### Relates
- Fixes #5605

