### PR TITLE
Remove use six.move module

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -18,10 +18,10 @@ import sys
 import warnings
 from collections import deque
 from inspect import isclass
+from io import StringIO
 from os import path
 
 from docutils.parsers.rst import Directive, directives, roles
-from six.moves import cStringIO
 
 import sphinx
 from sphinx import package_dir, locale
@@ -164,14 +164,14 @@ class Sphinx:
         self.parallel = parallel
 
         if status is None:
-            self._status = cStringIO()      # type: IO
+            self._status = StringIO()      # type: IO
             self.quiet = True
         else:
             self._status = status
             self.quiet = False
 
         if warning is None:
-            self._warning = cStringIO()     # type: IO
+            self._warning = StringIO()     # type: IO
         else:
             self._warning = warning
         self._warncount = 0

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -20,6 +20,7 @@ import time
 import warnings
 from collections import OrderedDict
 from os import path
+from urllib.parse import quote
 
 # try to import readline, unix specific enhancement
 try:
@@ -35,7 +36,6 @@ except ImportError:
 
 from docutils.utils import column_width
 from six import text_type, binary_type
-from six.moves.urllib.parse import quote as urlquote
 
 import sphinx.locale
 from sphinx import __display_version__, package_dir
@@ -386,7 +386,7 @@ def generate(d, overwrite=True, silent=False, templatedir=None):
 
     d['PY3'] = True
     d['project_fn'] = make_filename(d['project'])
-    d['project_url'] = urlquote(d['project'].encode('idna'))
+    d['project_url'] = quote(d['project'].encode('idna'))
     d['project_manpage'] = d['project_fn'].lower()
     d['now'] = time.asctime()
     d['project_underline'] = column_width(d['project']) * '='

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -31,11 +31,11 @@ import posixpath
 import sys
 import time
 from os import path
+from urllib.parse import urlsplit, urlunsplit
 
 from docutils import nodes
 from docutils.utils import relative_path
 from six import string_types, text_type
-from six.moves.urllib.parse import urlsplit, urlunsplit
 
 import sphinx
 from sphinx.builders.html import INVENTORY_FILENAME

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -25,10 +25,10 @@ from datetime import datetime
 from hashlib import md5
 from os import path
 from time import mktime, strptime
+from urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 
 from docutils.utils import relative_path
 from six import text_type, binary_type
-from six.moves.urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 
 from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
 from sphinx.errors import PycodeError, SphinxParallelError, ExtensionError

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -13,11 +13,11 @@ from __future__ import absolute_import
 
 import warnings
 from contextlib import contextmanager
+from urllib.parse import urlsplit
 
 import pkg_resources
 import requests
 from six import string_types
-from six.moves.urllib.parse import urlsplit
 
 try:
     from requests.packages.urllib3.exceptions import SSLError

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -16,7 +16,7 @@ from operator import itemgetter
 from os import path
 from uuid import uuid4
 
-from six.moves import range, zip_longest
+from six.moves import zip_longest
 
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.transforms import SphinxTransform
@@ -151,7 +151,7 @@ def levenshtein_distance(a, b):
             deletions = current_row[j] + 1
             substitutions = previous_row[j] + (column1 != column2)
             current_row.append(min(insertions, deletions, substitutions))
-        previous_row = current_row  # type: ignore
+        previous_row = current_row
     return previous_row[-1]
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Remove use of `six.move.*`
