### PR TITLE
Simplify tox configuration with 'extras' option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.0
+minversion = 2.4.0
 envlist = docs,flake8,mypy,coverage,py{35,36,37,38},du{12,13,14}
 
 [testenv]
@@ -9,18 +9,13 @@ passenv =
 description =
     py{35,36,37,38}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.
-
-# TODO(stephenfin) Replace this with the 'extras' config option when tox 2.4 is
-# widely available, likely some time after the Ubuntu 18.04 release
-#
-# https://tox.readthedocs.io/en/latest/config.html#confval-extras=MULTI-LINE-LIST
 deps =
-    .[test,websupport]
     du12: docutils==0.12
     du13: docutils==0.13.1
     du14: docutils==0.14
-# This entry should be also removed after moving 'extras' option
-install_command = pip install {opts} {packages}
+extras =
+    test
+    websupport
 setenv =
     PYTHONWARNINGS = all,ignore::ImportWarning:pkgutil,ignore::ImportWarning:importlib._bootstrap,ignore::ImportWarning:importlib._bootstrap_external,ignore::ImportWarning:pytest_cov.plugin,ignore::DeprecationWarning:site,ignore::DeprecationWarning:_pytest.assertion.rewrite,ignore::DeprecationWarning:_pytest.fixtures,ignore::DeprecationWarning:distutils
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/config.html#conf-extras

> extras(MULTI-LINE-LIST)
>
> New in version 2.4.
>
> A list of “extras” to be installed with the sdist or develop install.
> For example, extras = testing is equivalent to [testing] in a pip
> install command.