### PR TITLE
Fix "invalid escape sequence" warnings emitted during tests

### DIFF
--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -224,7 +224,7 @@ def test_generated_files_eol(tempdir):
     qs.generate(d)
 
     def assert_eol(filename, eol):
-        content = filename.bytes().decode('unicode-escape')
+        content = filename.bytes().decode()
         assert all([l[-len(eol):] == eol for l in content.splitlines(True)])
 
     assert_eol(tempdir / 'make.bat', '\r\n')


### PR DESCRIPTION
```
  sphinx/tests/test_quickstart.py:221: DeprecationWarning: invalid escape sequence '\*'
    content = filename.bytes().decode('unicode-escape')
  sphinx/tests/test_quickstart.py:221: DeprecationWarning: invalid escape sequence '\`'
    content = filename.bytes().decode('unicode-escape')
```