### PR TITLE
Remove dead code `or '.'`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ collect_ignore = ['roots']
 
 @pytest.fixture(scope='session')
 def rootdir():
-    return path(os.path.dirname(__file__) or '.').abspath() / 'roots'
+    return path(os.path.dirname(__file__)).abspath() / 'roots'
 
 
 def pytest_report_header(config):


### PR DESCRIPTION
The expression `os.path.dirname(__file__)` always evaluates as a truthy value. The `or '.'` is never evaluated.