### PR TITLE
Deprecate sphinx.util.pycompat.u

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@ Deprecated
 * ``sphinx.testing.util.remove_unicode_literal()``
 * ``sphinx.util.get_matching_docs()`` is deprecated
 * ``sphinx.util.osutil.walk()``
+* ``sphinx.util.pycompat.u``
 * ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
 * template variables for LaTeX template
 

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -158,6 +158,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``os.walk()``
 
+   * - ``sphinx.util.pycompat.u``
+     - 2.0
+     - 4.0
+     - N/A
+
    * - ``sphinx.application.Sphinx._setting_up_extension``
      - 2.0
      - 3.0

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -14,8 +14,6 @@ import re
 
 from six import integer_types, string_types
 
-from sphinx.util.pycompat import u
-
 if False:
     # For type annotation
     from typing import Any, Dict, IO, List, Match, Union  # NOQA
@@ -62,7 +60,7 @@ def encode_string(s):
 
 def decode_string(s):
     # type: (str) -> str
-    return ESCAPED.sub(lambda m: eval(u + '"' + m.group() + '"'), s)
+    return ESCAPED.sub(lambda m: eval('"' + m.group() + '"'), s)
 
 
 reswords = set("""\

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -27,7 +27,7 @@ NoneType = type(None)
 # Python 2/3 compatibility
 
 # prefix for Unicode strings
-u = ''
+u = ''  # RemovedInSphinx40Warning
 
 
 # sys_encoding: some kind of default system encoding; should be used with


### PR DESCRIPTION
It is now simply a constant equal to the empty string. Provides no further utility.