### PR TITLE
Fix #5627: index.html missing in QtHelp

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #5460: html search does not work with some 3rd party themes
 * #5614: autodoc: incremental build is broken when builtin modules are imported
+* #5627: qthelp: index.html missing in QtHelp
 
 Testing
 --------

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -269,7 +269,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
             resourcedir = root.startswith((staticdir, imagesdir))
             for fn in sorted(files):
                 if (resourcedir and not fn.endswith('.js')) or fn.endswith('.html'):
-                    filename = posixpath.join(root, fn)[olen:]
+                    filename = path.join(root, fn)[olen:]
                     project_files.append(filename)
 
         return project_files


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5627 
