### PR TITLE
Remove 'usedevelop = True' from default tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ minversion = 2.4.0
 envlist = docs,flake8,mypy,coverage,py{35,36,37,38},du{12,13,14}
 
 [testenv]
-usedevelop = True
 passenv =
     https_proxy http_proxy no_proxy PERL PERL5LIB PYTEST_ADDOPTS EPUBCHECK_PATH
 description =


### PR DESCRIPTION
To ensure that the Sphinx package passes tests, test against the sdist, not a development environment. Helps to provide confidence that `MANIFEST.in` is correct as well as any other sdist edge cases.
