### PR TITLE
LaTeX: compatibility with caption package

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-Release 1.8.2 (in development)
+Release 1.8.3 (in development)
 ==============================
 
 Dependencies
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #5460: html search does not work with some 3rd party themes
+* #5520: LaTeX, caption package incompatibility since Sphinx 1.6
 
 Testing
 --------

--- a/sphinx/templates/latex/longtable.tex_t
+++ b/sphinx/templates/latex/longtable.tex_t
@@ -8,6 +8,7 @@
 <%- endif -%>
 <%= table.get_colspec() %>
 <%- if table.caption -%>
+\sphinxthelongtablecaptionisattop
 \caption{<%= ''.join(table.caption) %>\strut}<%= labels %>\\*[\sphinxlongtablecapskipadjust]
 \hline
 <% elif labels -%>

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -12,6 +12,7 @@
 <%- endif %>
 <% if table.caption -%>
 \sphinxcapstartof{table}
+\sphinxthecaptionisattop
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftertopcaption
 <% elif labels -%>

--- a/sphinx/templates/latex/tabular.tex_t
+++ b/sphinx/templates/latex/tabular.tex_t
@@ -13,7 +13,7 @@
 <% if table.caption -%>
 \sphinxcapstartof{table}
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
-\sphinxaftercaption
+\sphinxaftertopcaption
 <% elif labels -%>
 \phantomsection<%= labels %>\nobreak
 <% endif -%>

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -12,6 +12,7 @@
 <%- endif %>
 <% if table.caption -%>
 \sphinxcapstartof{table}
+\sphinxthecaptionisattop
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
 \sphinxaftertopcaption
 <% elif labels -%>

--- a/sphinx/templates/latex/tabulary.tex_t
+++ b/sphinx/templates/latex/tabulary.tex_t
@@ -13,7 +13,7 @@
 <% if table.caption -%>
 \sphinxcapstartof{table}
 \sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
-\sphinxaftercaption
+\sphinxaftertopcaption
 <% elif labels -%>
 \phantomsection<%= labels %>\nobreak
 <% endif -%>

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -82,11 +82,13 @@
 % User interface to set-up whitespace before and after tables:
 \newcommand*\sphinxtablepre {0pt}%
 \newcommand*\sphinxtablepost{\medskipamount}%
+% Space from caption baseline to top of table or frame of literal-block
 \newcommand*\sphinxbelowcaptionspace{.5\sphinxbaselineskip}%
 % as one can not use \baselineskip from inside longtable (it is zero there)
 % we need \sphinxbaselineskip, which defaults to \baselineskip
 \def\sphinxbaselineskip{\baselineskip}%
 % These commands are inserted by the table templates
+% A. Table with longtable
 \def\sphinxatlongtablestart
    {\par
     \vskip\parskip
@@ -95,35 +97,51 @@
     \LTpre\z@skip\LTpost\z@skip % set to zero longtable's own skips
     \edef\sphinxbaselineskip{\dimexpr\the\dimexpr\baselineskip\relax\relax}%
    }%
-\def\sphinxatlongtableend{\prevdepth\z@\vskip\sphinxtablepost\relax}%
+% Compatibility with caption package
+\def\sphinxthelongtablecaptionisattop{%
+    \spx@ifcaptionpackage{\noalign{\vskip-\belowcaptionskip}}{}%
+}%
+% Achieves exactly \sphinxbelowcaptionspace below longtable caption
 \def\sphinxlongtablecapskipadjust
-   {\dimexpr-\dp\strutbox-\sphinxbaselineskip+\sphinxbelowcaptionspace\relax}%
-% Now for tables not using longtable
-\def\sphinxattablestart
-   {\par
-    \vskip\dimexpr\sphinxtablepre\relax
-   }%
+   {\dimexpr-\dp\strutbox
+            -\spx@ifcaptionpackage{\abovecaptionskip}{\sphinxbaselineskip}%
+            +\sphinxbelowcaptionspace\relax}%
+\def\sphinxatlongtableend{\prevdepth\z@\vskip\sphinxtablepost\relax}%
+% B. Table with tabular or tabulary
+\def\sphinxattablestart{\par\vskip\dimexpr\sphinxtablepre\relax}%
 \let\sphinxattableend\sphinxatlongtableend
+% This is used by tabular and tabulary templates
 \newcommand*\sphinxcapstartof[1]{%
    \vskip\parskip
    \vbox{}% force baselineskip for good positioning by capstart of hyperanchor
+   % hyperref puts the anchor 6pt above this baseline; in case of caption
+   % this baseline will be \ht\strutbox above first baseline of caption
    \def\@captype{#1}%
    \capstart
-% move back vertically to compensate space inserted by next paragraph
+% move back vertically, as tabular (or its caption) will compensate
    \vskip-\baselineskip\vskip-\parskip
 }%
-% longtable wraps captions to a maximal width of \LTcapwidth
-% so we do the same for tabular(y) tables (see their templates)
-\def\sphinxtablecapwidth{\LTcapwidth}% (default is 4in: max width of caption)
-% TODO: add alignment options? but user can employ caption package instead.
+\def\sphinxthecaptionisattop{% locate it after \sphinxcapstartof
+    \spx@ifcaptionpackage
+      {\caption@setposition{t}%
+       \vskip\baselineskip\vskip\parskip
+       \vskip-\belowcaptionskip\vskip-\dp\strutbox
+      }%
+      {}%
+}%
+\def\sphinxthecaptionisatbottom{% (not finalized)
+    \spx@ifcaptionpackage{\caption@setposition{b}}{}%
+}%
+% The aim of \sphinxcaption is to apply to tabular(y) the maximal width
+% of caption as done by longtable
+\def\sphinxtablecapwidth{\LTcapwidth}%
 \newcommand\sphinxcaption{\@dblarg\spx@caption}%
 \long\def\spx@caption[#1]#2{%
    \noindent\hb@xt@\linewidth{\hss
       \vtop{\@tempdima\dimexpr\sphinxtablecapwidth\relax
 % don't exceed linewidth for the caption width
             \ifdim\@tempdima>\linewidth\hsize\linewidth\else\hsize\@tempdima\fi
-% longtable ignores \abovecaptionskip/\belowcaptionskip, so add hooks here
-% to uniformize control of caption distance to tables
+% longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
             \abovecaptionskip\sphinxabovecaptionskip
             \belowcaptionskip\sphinxbelowcaptionskip
             \caption[{#1}]%
@@ -131,14 +149,19 @@
            }\hss}%
    \par\prevdepth\dp\strutbox
 }%
-\def\spx@abovecaptionskip{\abovecaptionskip}% for literal blocks captions
-\newcommand*\sphinxabovecaptionskip{\z@skip}
-\newcommand*\sphinxbelowcaptionskip{\z@skip}
-%
+\def\sphinxabovecaptionskip{\z@skip}% Do not use! Flagged for removal
+\def\sphinxbelowcaptionskip{\z@skip}% Do not use! Flagged for removal
+% This wrapper of \abovecaptionskip is to allow modified setting
+% in case of a literal block inside a table cell.
+% TODO: unify spacing above captions of tables with the one for code-blocks,
+%       this means \abovecaptionskip must be without any effect
+\def\spx@abovecaptionskip{\abovecaptionskip}%
+% Achieve \sphinxbelowcaptionspace below a caption located above a tabular
+% or a tabulary
 \newcommand\sphinxaftertopcaption
-{% this default definition serves with a caption *above* a table, to make sure
- % its last baseline is \sphinxbelowcaptionspace above table top
- \nobreak
+{%
+   \spx@ifcaptionpackage
+     {\par\prevdepth\dp\strutbox\nobreak\vskip-\abovecaptionskip}{\nobreak}%
    \vskip\dimexpr\sphinxbelowcaptionspace\relax
    \vskip-\baselineskip\vskip-\parskip
 }%
@@ -697,13 +720,6 @@
 % ensure same width of caption to all kinds of tables (tabular(y), longtable),
 % because caption package has its own width (or margin) option
        \def\sphinxcaption{\caption}%
-% vertical spacing from last baseline of a top caption to top rule of
-% table will still be \sphinxbelowcaptionspace for tabular/tabulary,
-% (i.e. \sphinxaftertopcaption needs no modification) but we now need
-% this definition for the corrective skip inserted by longtable template:
-       \def\sphinxlongtablecapskipadjust
-          {\dimexpr-\dp\strutbox-\abovecaptionskip+
-                   \sphinxbelowcaptionspace\relax}% this is the vspace we want
       }%
       {\let\spx@ifcaptionpackage\@secondoftwo}%
 }

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -95,6 +95,7 @@
 %      caption is exactly \parskip+\baselineskip+ height of a strut.
 %   c) the caption text will wrap at width \LTcapwidth (4in)
 % - make sure this works also if "caption" package is loaded by user
+%   (with its width or margin option taking place of \LTcapwidth role)
 % TODO: obtain same for caption of literal block: a) & c) DONE, b) TO BE DONE
 %
 % To modify space below such top caption, adjust \sphinxbelowcaptionspace

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -87,7 +87,19 @@
 % as one can not use \baselineskip from inside longtable (it is zero there)
 % we need \sphinxbaselineskip, which defaults to \baselineskip
 \def\sphinxbaselineskip{\baselineskip}%
-% These commands are inserted by the table templates
+% The following is to ensure that, whether tabular(y) or longtable:
+% - if a caption is on top of table:
+%   a) the space between its last baseline and the top rule of table is
+%      exactly \sphinxbelowcaptionspace
+%   b) the space from last baseline of previous text to first baseline of
+%      caption is exactly \parskip+\baselineskip+ height of a strut.
+%   c) the caption text will wrap at width \LTcapwidth (4in)
+% - make sure this works also if "caption" package is loaded by user
+% TODO: obtain same for caption of literal block: a) & c) DONE, b) TO BE DONE
+%
+% To modify space below such top caption, adjust \sphinxbelowcaptionspace
+% To add or remove space above such top caption, adjust \sphinxtablepre:
+%   notice that \abovecaptionskip, \belowcaptionskip, \LTpre are **ignored**
 % A. Table with longtable
 \def\sphinxatlongtablestart
    {\par
@@ -124,12 +136,15 @@
 \def\sphinxthecaptionisattop{% locate it after \sphinxcapstartof
     \spx@ifcaptionpackage
       {\caption@setposition{t}%
-       \vskip\baselineskip\vskip\parskip
-       \vskip-\belowcaptionskip\vskip-\dp\strutbox
+       \vskip\baselineskip\vskip\parskip % undo those from \sphinxcapstartof
+       \vskip-\belowcaptionskip          % anticipate caption package skip
+       % caption package uses a \vbox, not a \vtop, so "single line" case
+       % gives different result from "multi-line" without this:
+       \nointerlineskip
       }%
       {}%
 }%
-\def\sphinxthecaptionisatbottom{% (not finalized)
+\def\sphinxthecaptionisatbottom{% (not finalized; for template usage)
     \spx@ifcaptionpackage{\caption@setposition{b}}{}%
 }%
 % The aim of \sphinxcaption is to apply to tabular(y) the maximal width
@@ -142,8 +157,8 @@
 % don't exceed linewidth for the caption width
             \ifdim\@tempdima>\linewidth\hsize\linewidth\else\hsize\@tempdima\fi
 % longtable ignores \abovecaptionskip/\belowcaptionskip, so do the same here
-            \abovecaptionskip\sphinxabovecaptionskip
-            \belowcaptionskip\sphinxbelowcaptionskip
+            \abovecaptionskip\sphinxabovecaptionskip % \z@skip
+            \belowcaptionskip\sphinxbelowcaptionskip % \z@skip
             \caption[{#1}]%
                {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
            }\hss}%
@@ -151,10 +166,12 @@
 }%
 \def\sphinxabovecaptionskip{\z@skip}% Do not use! Flagged for removal
 \def\sphinxbelowcaptionskip{\z@skip}% Do not use! Flagged for removal
-% This wrapper of \abovecaptionskip is to allow modified setting
-% in case of a literal block inside a table cell.
-% TODO: unify spacing above captions of tables with the one for code-blocks,
-%       this means \abovecaptionskip must be without any effect
+% This wrapper of \abovecaptionskip is used in sphinxVerbatim for top
+% caption, and with another value in sphinxVerbatimintable
+% TODO: To unify space above caption of a code-block with the one above
+%       caption of a table/longtable, \abovecaptionskip must not be used
+%       This auxiliary will get renamed and receive a different meaning
+%       in future.
 \def\spx@abovecaptionskip{\abovecaptionskip}%
 % Achieve \sphinxbelowcaptionspace below a caption located above a tabular
 % or a tabulary

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -104,8 +104,6 @@
     \vskip\dimexpr\sphinxtablepre\relax
    }%
 \let\sphinxattableend\sphinxatlongtableend
-% longtable's wraps captions to a maximal width of \LTcapwidth
-% so we do the same for all tables
 \newcommand*\sphinxcapstartof[1]{%
    \vskip\parskip
    \vbox{}% force baselineskip for good positioning by capstart of hyperanchor
@@ -114,26 +112,30 @@
 % move back vertically to compensate space inserted by next paragraph
    \vskip-\baselineskip\vskip-\parskip
 }%
-% use \LTcapwidth (default is 4in) to wrap caption (if line width is bigger)
-\newcommand\sphinxcaption[2][\LTcapwidth]{%
+% longtable wraps captions to a maximal width of \LTcapwidth
+% so we do the same for tabular(y) tables (see their templates)
+\def\sphinxtablecapwidth{\LTcapwidth}% (default is 4in: max width of caption)
+% TODO: add alignment options? but user can employ caption package instead.
+\newcommand\sphinxcaption{\@dblarg\spx@caption}%
+\long\def\spx@caption[#1]#2{%
    \noindent\hb@xt@\linewidth{\hss
-      \vtop{\@tempdima\dimexpr#1\relax
+      \vtop{\@tempdima\dimexpr\sphinxtablecapwidth\relax
 % don't exceed linewidth for the caption width
             \ifdim\@tempdima>\linewidth\hsize\linewidth\else\hsize\@tempdima\fi
 % longtable ignores \abovecaptionskip/\belowcaptionskip, so add hooks here
 % to uniformize control of caption distance to tables
             \abovecaptionskip\sphinxabovecaptionskip
             \belowcaptionskip\sphinxbelowcaptionskip
-            \caption[{#2}]%
+            \caption[{#1}]%
                {\strut\ignorespaces#2\ifhmode\unskip\@finalstrut\strutbox\fi}%
            }\hss}%
    \par\prevdepth\dp\strutbox
 }%
-\def\spx@abovecaptionskip{\abovecaptionskip}
+\def\spx@abovecaptionskip{\abovecaptionskip}% for literal blocks captions
 \newcommand*\sphinxabovecaptionskip{\z@skip}
 \newcommand*\sphinxbelowcaptionskip{\z@skip}
-
-\newcommand\sphinxaftercaption
+%
+\newcommand\sphinxaftertopcaption
 {% this default definition serves with a caption *above* a table, to make sure
  % its last baseline is \sphinxbelowcaptionspace above table top
  \nobreak
@@ -683,8 +685,29 @@
   \sphinxsetvskipsforfigintablecaption
   \begin{minipage}{#1}%
 }{\end{minipage}}
-% store original \caption macro for use with figures in longtable and tabulary
-\AtBeginDocument{\let\spx@originalcaption\caption}
+% store the original \caption macro for usage with figures inside longtable
+% and tabulary cells. Make sure we get the final \caption in presence of
+% caption package, whether the latter was loaded before or after sphinx.
+\AtBeginDocument{%
+    \let\spx@originalcaption\caption
+    \@ifpackageloaded{caption}
+      {\let\spx@ifcaptionpackage\@firstoftwo
+       \caption@AtBeginDocument*{\let\spx@originalcaption\caption}%
+% in presence of caption package, drop our own \sphinxcaption whose aim was to
+% ensure same width of caption to all kinds of tables (tabular(y), longtable),
+% because caption package has its own width (or margin) option
+       \def\sphinxcaption{\caption}%
+% vertical spacing from last baseline of a top caption to top rule of
+% table will still be \sphinxbelowcaptionspace for tabular/tabulary,
+% (i.e. \sphinxaftertopcaption needs no modification) but we now need
+% this definition for the corrective skip inserted by longtable template:
+       \def\sphinxlongtablecapskipadjust
+          {\dimexpr-\dp\strutbox-\abovecaptionskip+
+                   \sphinxbelowcaptionspace\relax}% this is the vspace we want
+      }%
+      {\let\spx@ifcaptionpackage\@secondoftwo}%
+}
+% tabulary expands twice contents, we need to prevent double counter stepping
 \newcommand*\sphinxfigcaption
   {\ifx\equation$%$% this is trick to identify tabulary first pass
        \firstchoice@false\else\firstchoice@true\fi
@@ -1049,17 +1072,28 @@
        \vskip\spx@abovecaptionskip
        \def\sphinxVerbatim@Before
            {\sphinxVerbatim@Title\nointerlineskip
-            \kern\dimexpr-\dp\strutbox+\sphinxbelowcaptionspace\relax}%
+            \kern\dimexpr-\dp\strutbox+\sphinxbelowcaptionspace
+                 % if no frame (code-blocks inside table cells), remove
+                 % the "verbatimsep" whitespace from the top (better visually)
+                 \ifspx@opt@verbatimwithframe\else-\sphinxverbatimsep\fi
+                 % caption package adds \abovecaptionskip vspace, remove it
+                 \spx@ifcaptionpackage{-\abovecaptionskip}{}\relax}%
      \else
        \vskip\sphinxverbatimsmallskipamount
        \def\sphinxVerbatim@After
-          {\nointerlineskip\kern\dp\strutbox\sphinxVerbatim@Title}%
+          {\nointerlineskip\kern\dimexpr\dp\strutbox
+            \ifspx@opt@verbatimwithframe\else-\sphinxverbatimsep\fi
+            \spx@ifcaptionpackage{-\abovecaptionskip}{}\relax
+           \sphinxVerbatim@Title}%
      \fi
      \def\@captype{literalblock}%
      \capstart
      % \sphinxVerbatimTitle must reset color
      \setbox\sphinxVerbatim@TitleBox
             \hbox{\begin{minipage}{\linewidth}%
+     % caption package may detect wrongly if top or bottom, so we help it
+                    \spx@ifcaptionpackage
+                      {\caption@setposition{\spx@opt@literalblockcappos}}{}%
                     \sphinxVerbatimTitle
                   \end{minipage}}%
   \fi

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -1,6 +1,7 @@
 \label{\detokenize{longtable:longtable-having-caption}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
+\sphinxthelongtablecaptionisattop
 \caption{caption for longtable\strut}\label{\detokenize{longtable:id1}}\\*[\sphinxlongtablecapskipadjust]
 \hline
 \sphinxstyletheadfamily 

--- a/tests/roots/test-latex-table/expects/table_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/table_having_caption.tex
@@ -4,7 +4,7 @@
 \centering
 \sphinxcapstartof{table}
 \sphinxcaption{caption for table}\label{\detokenize{tabular:id1}}
-\sphinxaftercaption
+\sphinxaftertopcaption
 \begin{tabulary}{\linewidth}[t]{|T|T|}
 \hline
 \sphinxstyletheadfamily 

--- a/tests/roots/test-latex-table/expects/table_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/table_having_caption.tex
@@ -3,6 +3,7 @@
 \begin{savenotes}\sphinxattablestart
 \centering
 \sphinxcapstartof{table}
+\sphinxthecaptionisattop
 \sphinxcaption{caption for table}\label{\detokenize{tabular:id1}}
 \sphinxaftertopcaption
 \begin{tabulary}{\linewidth}[t]{|T|T|}


### PR DESCRIPTION
This compatibility is mainly re-instored for convenience of user to
style the fonts used for the caption, and also possibly influence the
horizontal position via "width" or "margin" option of caption package
(attention that caption package obeys the document class tacit "twoside"
option, so if left and right margins are not set-up to be the same,
positioning of caption will depend on parity of the page number).

Regarding vertical skips, for captions placed on top (which is the table
templates default and also the literalblockcappos default), this commit
ensures that the vertical spacing separating the caption last baseline
to the top of framing is governed by \sphinxbelowcaptionspace in all
these three cases: tabular(y), longtable, literal blocks; the "skip"
option of caption package is ignored for them.

The "skip" is obeyed for the spacing between an image and its caption,
which currently in Sphinx is always below the image (no customization of
the figure caption vertical placement is currently available).

If literalblockcappos is "b" (captions follow code-blocks), this commit
removes the caption-package added \abovecaptionskip, so that "skip" is
also ignored for code-blocks in this case. This looks better due to the
extra space already added by the framing of the code-block and achieves
same spacing as without caption package (presumably loaded mainly to
style the fonts used for the caption). However in future maybe caption's
package "skip" should be obeyed for "literalblock" caption type.

For testing with caption package I mainly used this:

```
   'preamble': r'''
\usepackage{caption}
\captionsetup{justification=RaggedRight,
              margin={20pt,20pt},
              labelfont=bf, textfont=it,
              format=hang,
              singlelinecheck=false}
'''
```

I checked in particular behaviour of captions of code-blocks inside table cells whether 

```
    'sphinxsetup': 'literalblockcappos=b',
```

is made use of or if the default of top positioning of captions for code-blokcs is obeyed.

I made very quick check that hyperlinks to captions still work with `caption` package loaded as above.

### Feature or Bugfix

- mainly Bugfix

Fixes #5520