### PR TITLE
Improve JS handling in test_search.py

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -44,8 +44,9 @@ def setup_module():
 def jsload(path):
     searchindex = path.text()
     assert searchindex.startswith('Search.setIndex(')
+    assert searchindex.endswith(')')
 
-    return jsdump.loads(searchindex[16:-2])
+    return jsdump.loads(searchindex[16:-1])
 
 
 def is_registered_term(index, keyword):
@@ -65,10 +66,7 @@ test that non-comments are indexed: fermion
 @pytest.mark.sphinx(testroot='ext-viewcode')
 def test_objects_are_escaped(app, status, warning):
     app.builder.build_all()
-    searchindex = (app.outdir / 'searchindex.js').text()
-    assert searchindex.startswith('Search.setIndex(')
-
-    index = jsdump.loads(searchindex[16:-2])
+    index = jsload(app.outdir / 'searchindex.js')
     assert 'n::Array&lt;T, d&gt;' in index.get('objects').get('')  # n::Array<T,d> is escaped
 
 


### PR DESCRIPTION
- Reuse jsload() in all tests to reduce duplication.
- Fix -2 index to -1, to include the entire JSON string. Was previously chopping off the final '}'.
- Assert the serialized string ends with a closing parenthesis