### PR TITLE
Replace mock dependency with stdlib unitest.mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ extras_require = {
         'whoosh>=2.0',
     ],
     'test': [
-        'mock',
         'pytest',
         'pytest-cov',
         'html5lib',

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -12,8 +12,8 @@
 import pickle
 import sys
 from textwrap import dedent
+from unittest import mock
 
-import mock
 import pytest
 from docutils import nodes
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,9 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import mock
+
+from unittest import mock
+
 import pytest
 
 import sphinx

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -9,9 +9,10 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import Mock
+
 import pytest
 from docutils import nodes
-from mock import Mock
 
 from sphinx import addnodes
 from sphinx.domains.javascript import JavaScriptDomain

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -9,9 +9,10 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import Mock
+
 import pytest
 from docutils import nodes
-from mock import Mock
 from six import text_type
 
 from sphinx import addnodes

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -9,7 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import mock
+from unittest import mock
+
 from docutils import nodes
 
 from sphinx.domains.std import StandardDomain

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -10,8 +10,7 @@
 """
 
 from collections import namedtuple
-
-import mock
+from unittest import mock
 
 from sphinx import locale
 from sphinx.environment.adapters.indexentries import IndexEntries

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -57,7 +57,7 @@ def test_mangle_signature():
 
 def test_extract_summary(capsys):
     from sphinx.util.docutils import new_document
-    from mock import Mock
+    from unittest.mock import Mock
     settings = Mock(language_code='',
                     id_prefix='',
                     auto_id_prefix='',

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -12,8 +12,8 @@
 import os
 import unittest
 from io import BytesIO
+from unittest import mock
 
-import mock
 import pytest
 import requests
 from docutils import nodes

--- a/tests/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon.py
@@ -13,7 +13,7 @@
 from collections import namedtuple
 from unittest import TestCase
 
-import mock
+from unittest import mock
 
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon import _process_docstring, _skip_member, Config, setup

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -13,9 +13,7 @@
 from collections import namedtuple
 from inspect import cleandoc
 from textwrap import dedent
-from unittest import TestCase
-
-import mock
+from unittest import mock, TestCase
 
 from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -9,7 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import mock
+from unittest import mock
+
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexer import RegexLexer
 from pygments.token import Text, Name

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -9,8 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import Mock
+
 from docutils import nodes
-from mock import Mock
 
 from sphinx.roles import emph_literal_role
 from sphinx.testing.util import assert_node

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,8 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import patch
+
 import pytest
-from mock import patch
 
 from sphinx.testing.util import strip_escseq
 from sphinx.util import (

--- a/tests/test_util_fileutil.py
+++ b/tests/test_util_fileutil.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-import mock
+from unittest import mock
 
 from sphinx.jinja2glue import BuiltinTemplateLoader
 from sphinx.util.fileutil import copy_asset, copy_asset_file


### PR DESCRIPTION
Mock was added to the stdlib in Python 3.3. Can drop the dependency.

https://docs.python.org/3/library/unittest.mock.html