### PR TITLE
Drop explicit dependency: typed_ast

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ extras_require = {
         'html5lib',
         'flake8>=3.5.0',
         'flake8-import-order',
-        'mypy',
-        'typed_ast',
+        'mypy>=0.470',
     ],
 }
 


### PR DESCRIPTION
typed-ast has been a required dependency of mypy since v0.470. Can rely on it being installed as a transient dependency and not list it explicitly. For the change in mypy, see:

https://github.com/python/mypy/commit/a207754a7e426359812c7ae490ea13c979762b51