### PR TITLE
doc: Add deprecation info to script_files (template variable)

### DIFF
--- a/doc/templating.rst
+++ b/doc/templating.rst
@@ -200,6 +200,10 @@ Overriding works like this::
 
       {% set script_files = script_files + ["_static/myscript.js"] %}
 
+   .. deprecated:: 1.8.0
+
+      Please use ``.Sphinx.add_js_file()`` instead.
+
 Helper Functions
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- `script_files` should be marked as deprecated.