### PR TITLE
Deprecate evaluating Python 2 configuration files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,8 @@ Incompatible changes
 Deprecated
 ----------
 
+* Support for evaluating Python 2 syntax is deprecated. This includes
+  configuration files which should be converted to Python 3.
 * The ``encoding`` argument of ``autodoc.Documenter.get_doc()``,
   ``autodoc.DocstringSignatureMixin.get_doc()``,
   ``autodoc.DocstringSignatureMixin._find_signature()``, and

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -361,8 +361,7 @@ def eval_config_file(filename, tags):
         try:
             execfile_(filename, namespace)
         except SyntaxError as err:
-            msg = __("There is a syntax error in your configuration file: %s\n"
-                     "Did you change the syntax from 2.x to 3.x?")
+            msg = __("There is a syntax error in your configuration file: %s\n")
             raise ConfigError(msg % err)
         except SystemExit:
             msg = __("The configuration file (or one of the modules it imports) "

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -16,9 +16,15 @@ from textwrap import indent  # type: ignore # NOQA
 
 from six import text_type
 
+from sphinx.locale import __
+from sphinx.util import logging
+
 if False:
     # For type annotation
     from typing import Any, Callable, Generator  # NOQA
+
+
+logger = logging.getLogger(__name__)
 
 
 NoneType = type(None)
@@ -79,11 +85,14 @@ def execfile_(filepath, _globals, open=open):
     try:
         code = compile(source, filepath_enc, 'exec')
     except SyntaxError:
-        if convert_with_2to3:
-            # maybe the file uses 2.x syntax; try to refactor to
-            # 3.x syntax using 2to3
-            source = convert_with_2to3(filepath)
-            code = compile(source, filepath_enc, 'exec')
-        else:
-            raise
+        # maybe the file uses 2.x syntax; try to refactor to
+        # 3.x syntax using 2to3
+        source = convert_with_2to3(filepath)
+        code = compile(source, filepath_enc, 'exec')
+        # TODO: When support for evaluating Python 2 syntax is removed,
+        # deprecate convert_with_2to3().
+        logger.warning(__('Support for evaluating Python 2 syntax is deprecated '
+                          'and will be removed in Sphinx 4.0. '
+                          'Convert %s to Python 3 syntax.'),
+                       filepath)
     exec(code, _globals)

--- a/tests/test_util_pycompat.py
+++ b/tests/test_util_pycompat.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+    test_util_pycompat
+    ~~~~~~~~~~~~~~~~~~
+
+    Tests sphinx.util.pycompat functions.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import tempfile
+
+from sphinx.testing.util import strip_escseq
+from sphinx.util import logging
+from sphinx.util.pycompat import execfile_
+
+
+def test_execfile_python2(capsys, app, status, warning):
+    logging.setup(app, status, warning)
+
+    ns = {}
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(b'print "hello"\n')
+        tmp.flush()
+        execfile_(tmp.name, ns)
+    msg = (
+        'Support for evaluating Python 2 syntax is deprecated '
+        'and will be removed in Sphinx 4.0. '
+        'Convert %s to Python 3 syntax.\n' % tmp.name)
+    assert msg in strip_escseq(warning.getvalue())
+    captured = capsys.readouterr()
+    assert captured.out == 'hello\n'
+
+
+def test_execfile(capsys):
+    ns = {}
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(b'print("hello")\n')
+        tmp.flush()
+        execfile_(tmp.name, ns)
+    captured = capsys.readouterr()
+    assert captured.out == 'hello\n'


### PR DESCRIPTION
Converting Python 2 configuration files to Python 3 is now deprecated. This is the only internal use of
`sphinx.util.pycompat.convert_with_2to3()`, so that is now also deprecated.