### PR TITLE
Make it possible to construct Sphinx twice with warningiserror=True

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1152,7 +1152,7 @@ class Sphinx(object):
         logger.debug('[app] adding autodocumenter: %r', cls)
         from sphinx.ext.autodoc.directive import AutodocDirective
         self.registry.add_documenter(cls.objtype, cls)
-        self.add_directive('auto' + cls.objtype, AutodocDirective)
+        self.add_directive('auto' + cls.objtype, AutodocDirective, override=True)
 
     def add_autodoc_attrgetter(self, typ, getter):
         # type: (Type, Callable[[Any, unicode, Any], Any]) -> None

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -147,9 +147,9 @@ class ChangeSetDomain(Domain):
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_domain(ChangeSetDomain)
-    app.add_directive('deprecated', VersionChange)
-    app.add_directive('versionadded', VersionChange)
-    app.add_directive('versionchanged', VersionChange)
+    app.add_directive('deprecated', VersionChange, override=True)
+    app.add_directive('versionadded', VersionChange, override=True)
+    app.add_directive('versionchanged', VersionChange, override=True)
 
     return {
         'version': 'builtin',

--- a/sphinx/domains/math.py
+++ b/sphinx/domains/math.py
@@ -143,7 +143,7 @@ class MathDomain(Domain):
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_domain(MathDomain)
-    app.add_role('eq', MathReferenceRole(warn_dangling=True))
+    app.add_role('eq', MathReferenceRole(warn_dangling=True), override=True)
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
Subject: Make it possible to construct Sphinx application twice with `warningiserror=True`

### Feature or Bugfix
Bugfix

### Purpose
Currently you can only construct the Sphinx application object once, if the `warningiserror=True` argument is used. When you try to construct it again, you get error about directives already registered. However it may be useful to construct it multiple times for testing.

For example, many projects are using [sphinx-testing](https://github.com/sphinx/sphinx-testing) framework. And their tests fail with the current Sphinx, see e.g. mcmtroffaes/sphinxcontrib-bibtex#149.

This pull request makes it possible to construct the application twice if only the standard extensions are available. If `conf.py` enables more extensions it may fail because of similar constructs in other extensions.

An alternative approach would be for register functions to raise warnings only when the directive/role object being registered differs from the already registered one. This works fine for VersionChange or AutodocDirective classes, but does not work for MathReferenceRole because it is constructed dynamically and differs from time to time.

### Relates
Fixes sphinx-doc/sphinx-testing#9.