### PR TITLE
Fix #5648: NodeMatcher matches Text node on attribute match

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -67,6 +67,9 @@ class NodeMatcher:
             if self.classes and not isinstance(node, self.classes):
                 return False
 
+            if self.attrs and isinstance(node, nodes.Text):
+                return False
+
             for key, value in self.attrs.items():
                 if key not in node:
                     return False

--- a/tests/test_util_nodes.py
+++ b/tests/test_util_nodes.py
@@ -82,6 +82,10 @@ def test_NodeMatcher():
     matcher = NodeMatcher(nodes.title)
     assert len(doctree.traverse(matcher)) == 0
 
+    # search with Any does not match to Text node
+    matcher = NodeMatcher(blah=Any)
+    assert len(doctree.traverse(matcher)) == 0
+
 
 @pytest.mark.parametrize(
     'rst,node_cls,count',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5648 
