### PR TITLE
Fix #5659: linkcheck: crashes for a hyperlink containing multibyte character

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #5520: LaTeX, caption package incompatibility since Sphinx 1.6
 * #5614: autodoc: incremental build is broken when builtin modules are imported
 * #5627: qthelp: index.html missing in QtHelp
+* #5659: linkcheck: crashes for a hyperlink containing multibyte character
 
 Testing
 --------

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -598,12 +598,11 @@ def import_object(objname, source=None):
 
 def encode_uri(uri):
     # type: (unicode) -> unicode
-    split = list(urlsplit(uri))  # type: Any
+    split = list(urlsplit(uri))  # type: List[unicode]
     split[1] = split[1].encode('idna').decode('ascii')
-    split[2] = quote_plus(split[2].encode('utf-8'), '/').decode('ascii')
-    query = list((q, quote_plus(v.encode('utf-8')))
-                 for (q, v) in parse_qsl(split[3]))
-    split[3] = urlencode(query).decode('ascii')
+    split[2] = quote_plus(split[2].encode('utf-8'), '/')
+    query = list((q, v.encode('utf-8')) for (q, v) in parse_qsl(split[3]))
+    split[3] = urlencode(query)
     return urlunsplit(split)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,13 +30,13 @@ def test_encode_uri():
                 u'%D0%B1%D0%B0%D0%B7%D0%B0%D0%BC%D0%B8_%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D1%85')
     uri = (u'https://ru.wikipedia.org/wiki'
            u'/Система_управления_базами_данных')
-    assert expected, encode_uri(uri)
+    assert expected == encode_uri(uri)
 
     expected = (u'https://github.com/search?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+is%3A'
                 u'sprint-friendly+user%3Ajupyter&type=Issues&ref=searchresults')
     uri = (u'https://github.com/search?utf8=✓&q=is%3Aissue+is%3Aopen+is%3A'
            u'sprint-friendly+user%3Ajupyter&type=Issues&ref=searchresults')
-    assert expected, encode_uri(uri)
+    assert expected == encode_uri(uri)
 
 
 def test_display_chunk():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5659 
