### PR TITLE
quickstart: Simplify generated conf.py (for htmlhelp)

### DIFF
--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -22,13 +22,14 @@ from sphinx.config import string_classes
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import __
 from sphinx.util import logging
-from sphinx.util.osutil import make_filename
+from sphinx.util.osutil import make_filename_from_project
 from sphinx.util.pycompat import htmlescape
 
 if False:
     # For type annotation
     from typing import Any, Dict, IO, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
+    from sphinx.config import Config  # NOQA
     from sphinx.util.typing import unicode  # NOQA
 
 
@@ -337,12 +338,18 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
             f.write('</UL>\n')
 
 
+def default_htmlhelp_basename(config):
+    # type: (Config) -> unicode
+    """Better default htmlhelp_basename setting."""
+    return make_filename_from_project(config.project) + 'doc'
+
+
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.setup_extension('sphinx.builders.html')
     app.add_builder(HTMLHelpBuilder)
 
-    app.add_config_value('htmlhelp_basename', lambda self: make_filename(self.project), None)
+    app.add_config_value('htmlhelp_basename', default_htmlhelp_basename, None)
     app.add_config_value('htmlhelp_file_suffix', None, 'html', string_classes)
     app.add_config_value('htmlhelp_link_suffix', None, 'html', string_classes)
 

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -112,12 +112,6 @@ html_static_path = ['{{ dot }}static']
 # html_sidebars = {}
 
 
-# -- Options for HTMLHelp output ---------------------------------------------
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = '{{ project_fn }}doc'
-
-
 # -- Options for LaTeX output ------------------------------------------------
 
 latex_elements = {

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -41,8 +41,6 @@ html_style = 'default.css'
 html_last_updated_fmt = '%b %d, %Y'
 html_context = {'hckey': 'hcval', 'hckey_co': 'wrong_hcval_co'}
 
-htmlhelp_basename = 'SphinxTestsdoc'
-
 applehelp_bundle_id = 'org.sphinx-doc.Sphinx.help'
 applehelp_disable_external_tools = True
 

--- a/tests/test_build_htmlhelp.py
+++ b/tests/test_build_htmlhelp.py
@@ -11,6 +11,9 @@
 
 import pytest
 
+from sphinx.builders.htmlhelp import default_htmlhelp_basename
+from sphinx.config import Config
+
 
 @pytest.mark.sphinx('htmlhelp', testroot='basic')
 def test_default_htmlhelp_file_suffix(app, warning):
@@ -21,3 +24,9 @@ def test_default_htmlhelp_file_suffix(app, warning):
                     confoverrides={'htmlhelp_file_suffix': '.htm'})
 def test_htmlhelp_file_suffix(app, warning):
     assert app.builder.out_suffix == '.htm'
+
+
+def test_default_htmlhelp_basename():
+    config = Config({'project': u'Sphinx Documentation'})
+    config.init_values()
+    assert default_htmlhelp_basename(config) == 'sphinxdoc'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #4256
- This removes `htmlhelp_basename`
