### PR TITLE
quickstart: Simplify generated conf.py (for manpage)

### DIFF
--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -21,13 +21,14 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.console import bold, darkgreen  # type: ignore
 from sphinx.util.nodes import inline_all_toctrees
-from sphinx.util.osutil import make_filename
+from sphinx.util.osutil import make_filename_from_project
 from sphinx.writers.manpage import ManualPageWriter, ManualPageTranslator
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Set, Union  # NOQA
+    from typing import Any, Dict, List, Set, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
+    from sphinx.config import Config  # NOQA
     from sphinx.util.typing import unicode  # NOQA
 
 
@@ -113,14 +114,19 @@ class ManualPageBuilder(Builder):
         pass
 
 
+def default_man_pages(config):
+    # type: (Config) -> List[Tuple[unicode, unicode, unicode, List[unicode], int]]
+    """ Better default man_pages settings. """
+    filename = make_filename_from_project(config.project)
+    return [(config.master_doc, filename, '%s %s' % (config.project, config.release),
+             [config.author], 1)]
+
+
 def setup(app):
     # type: (Sphinx) -> Dict[unicode, Any]
     app.add_builder(ManualPageBuilder)
 
-    app.add_config_value('man_pages',
-                         lambda self: [(self.master_doc, make_filename(self.project).lower(),
-                                        '%s %s' % (self.project, self.release), [], 1)],
-                         None)
+    app.add_config_value('man_pages', default_man_pages, None)
     app.add_config_value('man_show_urls', False, None)
 
     return {

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -147,16 +147,6 @@ latex_documents = [
 ]
 
 
-# -- Options for manual page output ------------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, '{{ project_manpage }}', u'{{ project_doc_str }}',
-     [author], 1)
-]
-
-
 # -- Options for Epub output -------------------------------------------------
 
 # Bibliographic Dublin Core info.

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -53,11 +53,6 @@ latex_documents = [
 
 latex_additional_files = ['svgimg.svg']
 
-man_pages = [
-    ('index', 'SphinxTests', 'Sphinx Tests Documentation',
-     'Georg Brandl and someone else', 1),
-]
-
 coverage_c_path = ['special/*.h']
 coverage_c_regexes = {'function': r'^PyAPI_FUNC\(.*\)\s+([^_][\w_]+)'}
 

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -12,16 +12,30 @@ from __future__ import print_function
 
 import pytest
 
+from sphinx.builders.manpage import default_man_pages
+from sphinx.config import Config
+
 
 @pytest.mark.sphinx('man')
 def test_all(app, status, warning):
     app.builder.build_all()
-    assert (app.outdir / 'SphinxTests.1').exists()
+    assert (app.outdir / 'sphinxtests.1').exists()
 
-    content = (app.outdir / 'SphinxTests.1').text()
+    content = (app.outdir / 'sphinxtests.1').text()
     assert r'\fBprint \fP\fIi\fP\fB\en\fP' in content
     assert r'\fBmanpage\en\fP' in content
 
     # term of definition list including nodes.strong
     assert '\n.B term1\n' in content
     assert '\nterm2 (\\fBstronged partially\\fP)\n' in content
+
+
+def test_default_man_pages():
+    config = Config({'master_doc': 'index',
+                     'project': u'STASI™ Documentation',
+                     'author': u"Wolfgang Schäuble & G'Beckstein",
+                     'release': '1.0'})
+    config.init_values()
+    expected = [('index', 'stasi', u'STASI™ Documentation 1.0',
+                 [u"Wolfgang Schäuble & G'Beckstein"], 1)]
+    assert default_man_pages(config) == expected

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -191,9 +191,6 @@ def test_quickstart_all_answers(tempdir):
     assert ns['latex_documents'] == [
         ('contents', 'STASI.tex', u'STASI™ Documentation',
          u'Wolfgang Schäuble \\& G\'Beckstein', 'manual')]
-    assert ns['man_pages'] == [
-        ('contents', 'stasi', u'STASI™ Documentation',
-         [u'Wolfgang Schäuble & G\'Beckstein'], 1)]
 
     assert (tempdir / 'build').isdir()
     assert (tempdir / 'source' / '.static').isdir()
@@ -263,7 +260,6 @@ def test_default_filename(tempdir):
     ns = {}
     execfile_(conffile, ns)
     assert ns['latex_documents'][0][1] == 'sphinx.tex'
-    assert ns['man_pages'][0][1] == 'sphinx'
 
 
 def test_extensions(tempdir):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #4256
- This removes `man_pages`
