### PR TITLE
Use StringList for params to docutils because of expected

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -13,7 +13,7 @@ from difflib import unified_diff
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.statemachine import ViewList
+from docutils.statemachine import StringList
 from six import text_type
 
 from sphinx import addnodes
@@ -89,7 +89,7 @@ def container_wrapper(directive, literal_node, caption):
     container_node = nodes.container('', literal_block=True,
                                      classes=['literal-block-wrapper'])
     parsed = nodes.Element()
-    directive.state.nested_parse(ViewList([caption], source=''),
+    directive.state.nested_parse(StringList([caption], source=''),
                                  directive.content_offset, parsed)
     if isinstance(parsed[0], nodes.system_message):
         msg = __('Invalid caption: %s' % parsed[0].astext())

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -17,7 +17,7 @@ import sys
 import warnings
 from typing import Any
 
-from docutils.statemachine import ViewList
+from docutils.statemachine import StringList
 from six import text_type
 
 import sphinx
@@ -1177,8 +1177,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
                 parentmodule = safe_getattr(self.parent, '__module__', None)
                 if module and module != parentmodule:
                     classname = str(module) + u'.' + str(classname)
-                content = ViewList(
-                    [_('alias of :class:`%s`') % classname], source='')
+                content = StringList([_('alias of :class:`%s`') % classname], source='')
                 super(ClassDocumenter, self).add_content(content, no_docstring=True)
         else:
             super(ClassDocumenter, self).add_content(more_content)

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -64,7 +64,7 @@ from typing import List, cast
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.states import RSTStateMachine, state_classes
-from docutils.statemachine import ViewList
+from docutils.statemachine import StringList
 from six import text_type
 
 import sphinx
@@ -243,7 +243,7 @@ class Autosummary(SphinxDirective):
         # type: () -> List[nodes.Node]
         self.genopt = Options()
         self.warnings = []  # type: List[nodes.Node]
-        self.result = ViewList()
+        self.result = StringList()
 
         names = [x.strip().split()[0] for x in self.content
                  if x.strip() and re.search(r'^[~a-zA-Z_]', x.strip()[0])]
@@ -302,7 +302,7 @@ class Autosummary(SphinxDirective):
                 items.append((name, '', '', name))
                 continue
 
-            self.result = ViewList()  # initialize for each documenter
+            self.result = StringList()  # initialize for each documenter
             full_name = real_name
             if not isinstance(obj, ModuleType):
                 # give explicitly separated module name, so that members
@@ -377,7 +377,7 @@ class Autosummary(SphinxDirective):
             source, line = self.state_machine.get_source_and_line()
             for text in column_texts:
                 node = nodes.paragraph('')
-                vl = ViewList()
+                vl = StringList()
                 vl.append(text, '%s:%d:<autosummary>' % (source, line))
                 with switch_source_input(self.state, vl):
                     self.state.nested_parse(vl, 0, node)

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -38,7 +38,7 @@ if False:
     # For type annotation
     from types import ModuleType  # NOQA
     from typing import Any, Callable, Generator, List, Set, Tuple, Type  # NOQA
-    from docutils.statemachine import State, ViewList  # NOQA
+    from docutils.statemachine import State, StringList  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.io import SphinxFileInput  # NOQA
@@ -324,7 +324,7 @@ def directive_helper(obj, has_content=None, argument_spec=None, **option_spec):
 
 @contextmanager
 def switch_source_input(state, content):
-    # type: (State, ViewList) -> Generator[None, None, None]
+    # type: (State, StringList) -> Generator[None, None, None]
     """Switch current source input of state temporarily."""
     try:
         # remember the original ``get_source_and_line()`` method


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
- Bugfix

### Purpose
- Use `StringList` object as a parameter to docutils APIs.
- `ViewList` is an abstract class. So `StringList` is much better to use in our application.
