### PR TITLE
refactor figure_wrapper() using state.inline_text()

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -18,7 +18,6 @@ from subprocess import Popen, PIPE
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.statemachine import ViewList
 from six import text_type
 
 import sphinx
@@ -28,6 +27,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.fileutil import copy_asset
 from sphinx.util.i18n import search_image_for_language
+from sphinx.util.nodes import set_source_info
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
 if False:
@@ -104,12 +104,10 @@ def figure_wrapper(directive, node, caption):
     if 'align' in node:
         figure_node['align'] = node.attributes.pop('align')
 
-    parsed = nodes.Element()
-    directive.state.nested_parse(ViewList([caption], source=''),
-                                 directive.content_offset, parsed)
-    caption_node = nodes.caption(parsed[0].rawsource, '', *parsed[0].children)
-    caption_node.source = parsed[0].source
-    caption_node.line = parsed[0].line
+    inodes, messages = directive.state.inline_text(caption, directive.lineno)
+    caption_node = nodes.caption(caption, '', *inodes)
+    caption_node.extend(messages)
+    set_source_info(directive, caption_node)
     figure_node += caption_node
     return figure_node
 

--- a/tests/roots/test-ext-graphviz/index.rst
+++ b/tests/roots/test-ext-graphviz/index.rst
@@ -22,7 +22,7 @@ Hello |graph| graphviz world
 
 .. digraph:: bar
    :align: right
-   :caption: on right
+   :caption: on *right*
 
    foo -> bar
 

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -35,7 +35,7 @@ def test_graphviz_png_html(app, status, warning):
 
     html = (r'<div class="figure align-right" .*?>\s*'
             r'<div class="graphviz"><img .*?/></div>\s*<p class="caption">'
-            r'<span class="caption-text">on right</span>.*</p>\s*</div>')
+            r'<span class="caption-text">on <em>right</em></span>.*</p>\s*</div>')
     assert re.search(html, content, re.S)
 
     html = (r'<div align=\"center\" class=\"align-center\">'
@@ -73,7 +73,7 @@ def test_graphviz_svg_html(app, status, warning):
             r'foo -&gt; bar\n'
             r'}</p></object></div>\n'
             r'<p class=\"caption\"><span class=\"caption-text\">'
-            r'on right</span>.*</p>\n'
+            r'on <em>right</em></span>.*</p>\n'
             r'</div>')
     assert re.search(html, content, re.S)
 
@@ -102,7 +102,8 @@ def test_graphviz_latex(app, status, warning):
 
     macro = ('\\\\begin{wrapfigure}{r}{0pt}\n\\\\centering\n'
              '\\\\sphinxincludegraphics\\[\\]{graphviz-\\w+.pdf}\n'
-             '\\\\caption{on right}\\\\label{.*}\\\\end{wrapfigure}')
+             '\\\\caption{on \\\\sphinxstyleemphasis{right}}'
+             '\\\\label{.*}\\\\end{wrapfigure}')
     assert re.search(macro, content, re.S)
 
     macro = (r'\{\\hfill'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `:caption:` option should be interpreted as "inline" text. So `inline_text()` is much better than `nested_parse()`.
