### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-dist: trusty
+dist: xenial
 cache: pip
 
 env:
@@ -20,12 +20,8 @@ matrix:
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
     - python: '3.7'
       env: TOXENV=py37
-      dist: xenial
-      sudo: true
     - python: 'nightly'
       env: TOXENV=py38
-      dist: xenial
-      sudo: true
     - python: '3.6'
       env: TOXENV=docs
     - python: '3.6'


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release