### PR TITLE
Define _MockImporter as a MetaPathFinder

### DIFF
--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -98,7 +98,7 @@ class _MockModule(ModuleType):
         return o
 
 
-class _MockImporter:
+class _MockImporter(MetaPathFinder):
     def __init__(self, names):
         # type: (List[str]) -> None
         self.names = names
@@ -120,7 +120,7 @@ class _MockImporter:
                 del sys.modules[m]
 
     def find_module(self, name, path=None):
-        # type: (str, str) -> Any
+        # type: (str, Sequence[Union[bytes, str]]) -> Any
         # check if name is (or is a descendant of) one of our base_packages
         for n in self.names:
             if n == name or name.startswith(n + '.'):


### PR DESCRIPTION
The instance is added to sys.meta_path. Per the documentation, this should be a `MetaPathFinder`:

https://docs.python.org/3/library/sys.html#sys.meta_path

Correct the `_MockImporter.find_module()` type signature per typeshed.

https://github.com/python/typeshed/blob/0b49ce75b478fdf283dda5dd1368759ac342dfe2/stdlib/3/importlib/abc.pyi#L56-L57