### PR TITLE
Deprecate unused and untested sphinx.util functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,9 +50,11 @@ Deprecated
 * ``sphinx.ext.doctest.doctest_encode()``
 * ``sphinx.io.SphinxRSTFileInput``
 * ``sphinx.testing.util.remove_unicode_literal()``
+* ``sphinx.util.attrdict``
 * ``sphinx.util.force_decode()``
 * ``sphinx.util.get_matching_docs()`` is deprecated
 * ``sphinx.util.osutil.walk()``
+* ``sphinx.util.PeekableIterator``
 * ``sphinx.util.pycompat.u``
 * ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
 * ``sphinx.writers.latex.TextTranslator._make_visit_admonition()``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -162,6 +162,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - N/A
 
+   * - ``sphinx.util.attrdict``
+     - 2.0
+     - 4.0
+     - N/A
+
    * - ``sphinx.util.force_decode()``
      - 2.0
      - 4.0
@@ -178,6 +183,11 @@ The following is a list of deprecated interfaces.
      - ``os.walk()``
 
    * - ``sphinx.util.pycompat.u``
+     - 2.0
+     - 4.0
+     - N/A
+
+   * - ``sphinx.util.PeekableIterator``
      - 2.0
      - 4.0
      - N/A

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -499,6 +499,11 @@ def force_decode(string, encoding):
 
 
 class attrdict(dict):
+    def __init__(self, *args, **kwargs):
+        super(attrdict, self).__init__(*args, **kwargs)
+        warnings.warn('The attrdict class is deprecated.',
+                      RemovedInSphinx40Warning, stacklevel=2)
+
     def __getattr__(self, key):
         # type: (unicode) -> unicode
         return self[key]
@@ -573,6 +578,8 @@ class PeekableIterator:
         # type: (Iterable) -> None
         self.remaining = deque()  # type: deque
         self._iterator = iter(iterable)
+        warnings.warn('PeekableIterator is deprecated.',
+                      RemovedInSphinx40Warning, stacklevel=2)
 
     def __iter__(self):
         # type: () -> PeekableIterator


### PR DESCRIPTION
sphinx.util.attrdict: Last use removed in b09e628b0f33614e81521ad60e94472a0db09a4d.

sphinx.util.PeekableIterator: Last use removed in 85b8a451a696c13d4644d4da900c2bcb31de4010.
