### PR TITLE
Simplify open() call by removing default mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ else:
                                                  domain + '.js'))
 
             for js_file, (locale, po_file) in zip(js_files, po_files):
-                with open(po_file, 'r') as infile:
+                with open(po_file) as infile:
                     catalog = read_po(infile, locale)
 
                 if catalog.fuzzy and not self.use_fuzzy:

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -135,7 +135,7 @@ class ChangesBuilder(Builder):
 
         logger.info(bold(__('copying source files...')))
         for docname in self.env.all_docs:
-            with open(self.env.doc2path(docname), 'r',  # type: ignore
+            with open(self.env.doc2path(docname),  # type: ignore
                       encoding=self.env.config.source_encoding) as f:
                 try:
                     lines = f.readlines()

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -198,7 +198,7 @@ def should_write(filepath, new_content):
     if not path.exists(filepath):
         return True
     try:
-        with open(filepath, 'r', encoding='utf-8') as oldpot:  # type: ignore
+        with open(filepath, encoding='utf-8') as oldpot:  # type: ignore
             old_content = oldpot.read()
             old_header_index = old_content.index('"POT-Creation-Date:')
             new_header_index = new_content.index('"POT-Creation-Date:')
@@ -249,7 +249,7 @@ class MessageCatalogBuilder(I18nBuilder):
         for template in status_iterator(files, __('reading templates... '), "purple",  # type: ignore  # NOQA
                                         len(files), self.app.verbosity):
             try:
-                with open(template, 'r', encoding='utf-8') as f:  # type: ignore
+                with open(template, encoding='utf-8') as f:  # type: ignore
                     context = f.read()
                 for line, meth, msg in extract_translations(context):
                     origin = MsgOrigin(template, line)

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -956,7 +956,7 @@ class StandaloneHTMLBuilder(Builder):
         try:
             searchindexfn = path.join(self.outdir, self.searchindex_filename)
             if self.indexer_dumps_unicode:
-                with open(searchindexfn, 'r', encoding='utf-8') as ft:  # type: ignore
+                with open(searchindexfn, encoding='utf-8') as ft:  # type: ignore
                     self.indexer.load(ft, self.indexer_format)
             else:
                 with open(searchindexfn, 'rb') as fb:

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -216,7 +216,7 @@ class LiteralIncludeReader:
     def read_file(self, filename, location=None):
         # type: (unicode, Any) -> List[unicode]
         try:
-            with open(filename, 'r',  # type: ignore
+            with open(filename,  # type: ignore
                       encoding=self.encoding, errors='strict') as f:
                 text = f.read()  # type: unicode
                 if 'tab-width' in self.options:

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -248,7 +248,7 @@ def find_autosummary_in_files(filenames):
     """
     documented = []  # type: List[Tuple[unicode, unicode, unicode]]
     for filename in filenames:
-        with open(filename, 'r', encoding='utf-8',  # type: ignore
+        with open(filename, encoding='utf-8',  # type: ignore
                   errors='ignore') as f:
             lines = f.read().splitlines()
             documented.extend(find_autosummary_in_lines(lines, filename=filename))

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -102,7 +102,7 @@ class CoverageBuilder(Builder):
         c_objects = self.env.domaindata['c']['objects']
         for filename in self.c_sourcefiles:
             undoc = set()  # type: Set[Tuple[unicode, unicode]]
-            with open(filename, 'r') as f:
+            with open(filename) as f:
                 for line in f:
                     for key, regex in self.c_regexes:
                         match = regex.match(line)

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -145,7 +145,7 @@ class Graphviz(SphinxDirective):
             rel_filename, filename = self.env.relfn2path(argument)
             self.env.note_dependency(rel_filename)
             try:
-                with open(filename, 'r', encoding='utf-8') as fp:  # type: ignore
+                with open(filename, encoding='utf-8') as fp:  # type: ignore
                     dotcode = fp.read()
             except (IOError, OSError):
                 return [document.reporter.warning(
@@ -310,7 +310,7 @@ def render_dot_html(self, node, code, options, prefix='graphviz',
             self.body.append('<p class="warning">%s</p>' % alt)
             self.body.append('</object></div>\n')
         else:
-            with open(outfn + '.map', 'r', encoding='utf-8') as mapfile:  # type: ignore
+            with open(outfn + '.map', encoding='utf-8') as mapfile:  # type: ignore
                 imgmap = ClickableMapDefinition(outfn + '.map', mapfile.read(), dot=code)
                 if imgmap.clickable:
                     # has a map

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -163,7 +163,7 @@ class path(text_type):
         """
         Returns the text in the file.
         """
-        with open(self, mode='r', encoding=encoding, **kwargs) as f:  # type: ignore
+        with open(self, encoding=encoding, **kwargs) as f:  # type: ignore
             return f.read()
 
     def bytes(self):

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -49,7 +49,7 @@ def copy_asset_file(source, destination, context=None, renderer=None):
             from sphinx.util.template import SphinxRenderer
             renderer = SphinxRenderer()
 
-        with open(source, 'r', encoding='utf-8') as fsrc:  # type: ignore
+        with open(source, encoding='utf-8') as fsrc:  # type: ignore
             if destination.lower().endswith('_t'):
                 destination = destination[:-2]
             with open(destination, 'w', encoding='utf-8') as fdst:  # type: ignore

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -69,7 +69,7 @@ class CatalogInfo(LocaleFileInfoBase):
 
     def write_mo(self, locale):
         # type: (unicode) -> None
-        with open(self.po_path, 'rt', encoding=self.charset) as file_po:  # type: ignore
+        with open(self.po_path, encoding=self.charset) as file_po:  # type: ignore
             try:
                 po = read_po(file_po, locale)
             except Exception as exc:


### PR DESCRIPTION
The open() function opens files in read-only text mode by default. Drop the mode argument to be slightly simpler and more idiomatic.

https://docs.python.org/3/library/functions.html#open

> The default mode is 'r' (open for reading text, synonym of 'rt').