### PR TITLE
Remove SphinxTranslator.get_settings()

### DIFF
--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -398,16 +398,7 @@ class SphinxTranslator(nodes.NodeVisitor):
         super(SphinxTranslator, self).__init__(document)
         self.builder = builder
         self.config = builder.config
-
-    def get_settings(self):
-        # type: () -> Any
-        """Get settings object with type safe.
-
-        .. note:: It is hard to check types for settings object because it's attributes
-                  are added dynamically.  This method avoids the type errors through
-                  imitating it's type as Any.
-        """
-        return self.document.settings
+        self.settings = document.settings
 
 
 # cache a vanilla instance of nodes.document

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -252,8 +252,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             atts['class'] += ' external'
         if 'refuri' in node:
             atts['href'] = node['refuri'] or '#'
-            if (self.get_settings().cloak_email_addresses and
-                    atts['href'].startswith('mailto:')):
+            if self.settings.cloak_email_addresses and atts['href'].startswith('mailto:'):
                 atts['href'] = self.cloak_mailto(atts['href'])
                 self.in_mailto = True
         else:
@@ -710,7 +709,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
                     # protect runs of multiple spaces; the last one can wrap
                     self.body.append('&#160;' * (len(token) - 1) + ' ')
         else:
-            if self.in_mailto and self.get_settings().cloak_email_addresses:
+            if self.in_mailto and self.settings.cloak_email_addresses:
                 encoded = self.cloak_email(encoded)
             self.body.append(encoded)
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -221,8 +221,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             atts['class'] += ' external'
         if 'refuri' in node:
             atts['href'] = node['refuri'] or '#'
-            if (self.get_settings().cloak_email_addresses and
-                    atts['href'].startswith('mailto:')):
+            if self.settings.cloak_email_addresses and atts['href'].startswith('mailto:'):
                 atts['href'] = self.cloak_mailto(atts['href'])
                 self.in_mailto = True
         else:
@@ -639,7 +638,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
                     # protect runs of multiple spaces; the last one can wrap
                     self.body.append('&#160;' * (len(token) - 1) + ' ')
         else:
-            if self.in_mailto and self.get_settings().cloak_email_addresses:
+            if self.in_mailto and self.settings.cloak_email_addresses:
                 encoded = self.cloak_email(encoded)
             self.body.append(encoded)
 
@@ -777,8 +776,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
         self._table_row_index = 0
 
-        classes = [cls.strip(u' \t\n')
-                   for cls in self.get_settings().table_style.split(',')]
+        classes = [cls.strip(u' \t\n') for cls in self.settings.table_style.split(',')]
         classes.insert(0, "docutils")  # compat
         if 'align' in node:
             classes.append('align-%s' % node['align'])

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -534,12 +534,12 @@ class LaTeXTranslator(SphinxTranslator):
         self.elements = self.builder.context.copy()
 
         # but some have other interface in config file
-        self.elements['wrapperclass'] = self.format_docclass(self.get_settings().docclass)
+        self.elements['wrapperclass'] = self.format_docclass(self.settings.docclass)
 
         # we assume LaTeX class provides \chapter command except in case
         # of non-Japanese 'howto' case
         self.sectionnames = LATEXSECTIONNAMES[:]
-        if self.get_settings().docclass == 'howto':
+        if self.settings.docclass == 'howto':
             docclass = self.config.latex_docclass.get('howto', 'article')
             if docclass[0] == 'j':  # Japanese class...
                 pass
@@ -684,7 +684,7 @@ class LaTeXTranslator(SphinxTranslator):
             self.elements['secnumdepth'] = '\\setcounter{secnumdepth}{%d}' %\
                                            minsecnumdepth
 
-        contentsname = self.get_settings().contentsname
+        contentsname = self.settings.contentsname
         self.elements['contentsname'] = self.babel_renewcommand('\\contentsname',
                                                                 contentsname)
 

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -96,13 +96,12 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         self.section_level = -1
 
         # docinfo set by man_pages config value
-        settings = self.get_settings()
-        self._docinfo['title'] = settings.title
-        self._docinfo['subtitle'] = settings.subtitle
-        if settings.authors:
+        self._docinfo['title'] = self.settings.title
+        self._docinfo['subtitle'] = self.settings.subtitle
+        if self.settings.authors:
             # don't set it if no author given
-            self._docinfo['author'] = settings.authors
-        self._docinfo['manual_section'] = settings.section
+            self._docinfo['author'] = self.settings.authors
+        self._docinfo['manual_section'] = self.settings.section
 
         # docinfo set by other config values
         self._docinfo['title_upper'] = self._docinfo['title'].upper()

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -231,14 +231,13 @@ class TexinfoTranslator(SphinxTranslator):
 
     def init_settings(self):
         # type: () -> None
-        self.settings = settings = self.get_settings()
         elements = self.elements = self.default_elements.copy()
         elements.update({
             # if empty, the title is set to the first section title
-            'title': settings.title,
-            'author': settings.author,
+            'title': self.settings.title,
+            'author': self.settings.author,
             # if empty, use basename of input file
-            'filename': settings.texinfo_filename,
+            'filename': self.settings.texinfo_filename,
             'release': self.escape(self.builder.config.release),
             'project': self.escape(self.builder.config.project),
             'copyright': self.escape(self.builder.config.copyright),
@@ -247,7 +246,7 @@ class TexinfoTranslator(SphinxTranslator):
                                             language=self.builder.config.language))
         })
         # title
-        title = settings.title  # type: unicode
+        title = self.settings.title  # type: unicode
         if not title:
             title_node = self.document.next_node(nodes.title)
             title = (title and title_node.astext()) or '<untitled>'
@@ -259,19 +258,19 @@ class TexinfoTranslator(SphinxTranslator):
                 elements['filename'] = elements['filename'][:-4]  # type: ignore
             elements['filename'] += '.info'  # type: ignore
         # direntry
-        if settings.texinfo_dir_entry:
+        if self.settings.texinfo_dir_entry:
             entry = self.format_menu_entry(
-                self.escape_menu(settings.texinfo_dir_entry),
+                self.escape_menu(self.settings.texinfo_dir_entry),
                 '(%s)' % elements['filename'],
-                self.escape_arg(settings.texinfo_dir_description))
+                self.escape_arg(self.settings.texinfo_dir_description))
             elements['direntry'] = ('@dircategory %s\n'
                                     '@direntry\n'
                                     '%s'
                                     '@end direntry\n') % (
-                self.escape_id(settings.texinfo_dir_category), entry)
+                self.escape_id(self.settings.texinfo_dir_category), entry)
         elements['copying'] = COPYING % elements
         # allow the user to override them all
-        elements.update(settings.texinfo_elements)
+        elements.update(self.settings.texinfo_elements)
 
     def collect_node_names(self):
         # type: () -> None


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
It was introduced to fake its type information and make mypy silent.
But the warnings had came from wrong typing of docutils-stubs.
(see https://github.com/tk0miya/docutils-stubs/pull/28)

After the fix, the helper method is not needed for us. So this
removes it right away.

