### PR TITLE
[WIP] Delete from __future__ import ...

### DIFF
--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -12,8 +12,6 @@
 # Keep this file executable as-is in Python 3!
 # (Otherwise getting the version out of it from setup.py is impossible.)
 
-from __future__ import absolute_import
-
 import os
 import warnings
 from os import path

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -10,7 +10,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import pickle

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import pipes
 import plistlib

--- a/sphinx/builders/devhelp.py
+++ b/sphinx/builders/devhelp.py
@@ -10,7 +10,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import gzip
 import re

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
 
 from codecs import open
 from collections import defaultdict, OrderedDict

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -9,7 +9,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 from os import path

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import argparse
 import locale

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -14,7 +14,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import subprocess

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -8,8 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
-from __future__ import print_function
 
 import argparse
 import locale

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -8,8 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 import warnings

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -10,7 +10,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 from collections import OrderedDict, defaultdict
 

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -15,8 +15,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import print_function
-
 import argparse
 import glob
 import locale

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -17,7 +17,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import argparse
 import locale

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -9,7 +9,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import doctest
 import re

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -24,8 +24,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import print_function
-
 import functools
 import posixpath
 import sys

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import re
 from io import BytesIO

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import traceback
 import warnings

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -11,7 +11,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import sys

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import subprocess

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import fnmatch
 import os

--- a/sphinx/util/compat.py
+++ b/sphinx/util/compat.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import absolute_import
-
 import sys
 import warnings
 

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -9,8 +9,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
-
 from typing import List, Tuple, cast
 
 from docutils import nodes

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import os
 import re

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import os
 import posixpath

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import base64
 import imghdr

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import builtins
 import enum

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import logging
 import logging.handlers

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import re
 from typing import Any, cast

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import contextlib
 import errno

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import os
 import time

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import absolute_import
 
 import warnings
 from contextlib import contextmanager

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import absolute_import
 
 import re
 from contextlib import contextmanager

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -25,7 +25,6 @@
     See the LICENSE file and the original docutils code for details.
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import re
 

--- a/sphinx/util/texescape.py
+++ b/sphinx/util/texescape.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
-
 if False:
     # For type annotation
     from typing import Dict  # NOQA

--- a/tests/roots/test-ext-autodoc/target/enum.py
+++ b/tests/roots/test-ext-autodoc/target/enum.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import enum
 
 

--- a/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
+++ b/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import
-
 from .submodule import func1, Class1  # NOQA

--- a/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
+++ b/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import
+
 from .submodule import func1, Class1  # NOQA

--- a/tests/roots/test-ext-viewcode/spam/__init__.py
+++ b/tests/roots/test-ext-viewcode/spam/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import
-
 from .mod1 import func1, Class1  # NOQA
 from .mod2 import func2, Class2  # NOQA

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import gettext
 import os

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import re

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import pytest
 

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import pytest
 

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import re

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import print_function
-
 from collections import namedtuple
 
 import pytest

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -9,7 +9,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import os
 import pickle

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import datetime
 import os

--- a/tests/test_util_images.py
+++ b/tests/test_util_images.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import pytest
 

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import codecs
 import os

--- a/tests/test_writer_latex.py
+++ b/tests/test_writer_latex.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from __future__ import print_function
 
 import pytest
 

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import os
 import re


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Remove `import future import ...` in order to drop python2.x support.

### Relates
- #5342
