### PR TITLE
Add super method; CPPObject.get_index_text()

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6395,6 +6395,10 @@ class CPPObject(ObjectDescription):
             signode['first'] = (not self.names)  # hmm, what is this about?
             self.state.document.note_explicit_target(signode)
 
+    def get_index_text(self, name):
+        # type: (unicode) -> unicode
+        raise NotImplementedError()
+
     def parse_definition(self, parser):
         # type: (Any) -> Any
         raise NotImplementedError()


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `CPPObject.add_target_and_index()` calls `self.get_index_text()`. But it is not defined at `CPPObject` class. Only subclasses have it.
- This PR adds it as a super method.