### PR TITLE
LaTeX: use ``\small`` fontsize in code-blocks with xelatex and lualatex

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2301,20 +2301,16 @@ information.
         index is full of long entries.
 
      ``'fvset'``
-        Customization of ``fancyvrb`` LaTeX package.  Currently, Sphinx uses
-        this key to set the fontsize in code-blocks according to the
-        :confval:`latex_engine`.
-
-        - ``'pdflatex'`` uses ``'fvset': '\\fvset{fontsize=\\small}'``,
-          to mitigate the size difference between the default monospaced font
-          (Courier) and the default text font (Times).  You may need to modify
-          this if you use custom fonts.
-
-        - ``'xelatex'`` and ``'lualatex'`` use ``'\\fvset{fontsize=auto}'``,
-          as there is no size difference between the regular and the
-          monospaced fonts used by default by Sphinx with these engines.
+        Customization of ``fancyvrb`` LaTeX package.  Sphinx does by default
+        ``'fvset': '\\fvset{fontsize=\\small}'``, to adjust for the large
+        character width of the monospace font, used in code-blocks.
+        You may need to modify this if you use custom fonts.
 
         .. versionadded:: 1.8
+        .. versionchanged:: 2.0
+           Due to new default font choice for ``'xelatex'`` and ``'lualatex'``
+           (FreeFont), Sphinx does ``\\fvset{fontsize=\\small}`` also with these
+           engines (and not ``\\fvset{fontsize=auto}``).
 
    * Keys that are set by other options and therefore should not be overridden
      are:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -202,7 +202,6 @@ ADDITIONAL_SETTINGS = {
         'textgreek':    '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'
                         '{\\leavevmode\\nobreak\\ }'),
-        'fvset':        '\\fvset{fontsize=auto}',
     },
     'lualatex': {
         'latex_engine': 'lualatex',
@@ -213,7 +212,6 @@ ADDITIONAL_SETTINGS = {
         'textgreek':    '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'
                         '{\\leavevmode\\nobreak\\ }'),
-        'fvset':        '\\fvset{fontsize=auto}',
     },
     'platex': {
         'latex_engine': 'platex',


### PR DESCRIPTION
Amusingly the character width of FreeFont Mono (now used by `xelatex/lualatex`) is quite large, a bit like Courier compared to Times, which is used by `pdflatex`. Thus in my testing it gives better looking result to use ``\small`` with these Unicode engines too. Of course if user changes the font setting, it may be needed that he/she uses also ``'fvset'`` key of ``latex_elements`` to adjust.


### Relates
- #5645
- #4793

