### PR TITLE
Use nodes.Element for visitor/departure methods

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -95,25 +95,25 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.required_params_left = 0
 
     def visit_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         # only occurs in the single-file builder
         self.docnames.append(node['docname'])
         self.body.append('<span id="document-%s"></span>' % node['docname'])
 
     def depart_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         self.docnames.pop()
 
     def visit_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'dl', CLASS=node['objtype']))
 
     def depart_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</dl>\n\n')
 
     def visit_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         # the id is set automatically
         self.body.append(self.starttag(node, 'dt'))
         # anchor for per-desc interactive data
@@ -122,56 +122,56 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.body.append('<!--[%s]-->' % node['ids'][0])
 
     def depart_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         if not node.get('is_multiline'):
             self.add_permalink_ref(node, _('Permalink to this definition'))
         self.body.append('</dt>\n')
 
     def visit_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         if node.get('add_permalink'):
             # the permalink info is on the parent desc_signature node
             self.add_permalink_ref(node.parent, _('Permalink to this definition'))
         self.body.append('<br />')
 
     def visit_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'code', '', CLASS='descclassname'))
 
     def depart_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</code>')
 
     def visit_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         self.body.append(' &#x2192; ')
 
     def depart_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'code', '', CLASS='descname'))
 
     def depart_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</code>')
 
     def visit_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<span class="sig-paren">(</span>')
         self.first_param = 1
         self.optional_param_level = 0
@@ -181,7 +181,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.param_separator = node.child_text_separator
 
     def depart_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<span class="sig-paren">)</span>')
 
     # If required parameters are still to come, then put the comma after
@@ -191,7 +191,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
     #     foo([a, ]b, c[, d])
     #
     def visit_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if self.first_param:
             self.first_param = 0
         elif not self.required_params_left:
@@ -202,49 +202,49 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.body.append('<em>')
 
     def depart_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if not node.hasattr('noemph'):
             self.body.append('</em>')
         if self.required_params_left:
             self.body.append(self.param_separator)
 
     def visit_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.optional_param_level += 1
         self.body.append('<span class="optional">[</span>')
 
     def depart_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.optional_param_level -= 1
         self.body.append('<span class="optional">]</span>')
 
     def visit_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'em', '', CLASS='property'))
 
     def depart_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</em>')
 
     def visit_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'dd', ''))
 
     def depart_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</dd>')
 
     def visit_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'div', CLASS=node['type']))
 
     def depart_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</div>\n')
 
     # overwritten
     def visit_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         atts = {'class': 'reference'}
         if node.get('internal') or 'refuri' not in node:
             atts['class'] += ' internal'
@@ -273,16 +273,16 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
                              '.'.join(map(str, node['secnumber'])))
 
     def visit_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         self.visit_reference(node)
 
     def depart_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         self.depart_reference(node)
 
     # overwritten -- we don't want source comments to show up in the HTML
     def visit_comment(self, node):
-        # type: (nodes.comment) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     # overwritten
@@ -295,11 +295,11 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.set_first_last(node)
 
     def visit_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'seealso')
 
     def depart_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def add_secnumber(self, node):
@@ -373,7 +373,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def visit_bullet_list(self, node):
-        # type: (nodes.bullet_list) -> None
+        # type: (nodes.Element) -> None
         if len(node) == 1 and isinstance(node[0], addnodes.toctree):
             # avoid emitting empty <ul></ul>
             raise nodes.SkipNode
@@ -382,13 +382,13 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def visit_enumerated_list(self, node):
-        # type: (nodes.enumerated_list) -> None
+        # type: (nodes.Element) -> None
         self.generate_targets_for_listing(node)
         super(HTMLTranslator, self).visit_enumerated_list(node)
 
     # overwritten
     def visit_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         super(HTMLTranslator, self).visit_title(node)
         self.add_secnumber(node)
         self.add_fignumber(node.parent)
@@ -396,7 +396,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.body.append('<span class="caption-text">')
 
     def depart_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         close_tag = self.context[-1]
         if (self.permalink_text and self.builder.add_permalinks and
            node.parent.hasattr('ids') and node.parent['ids']):
@@ -419,7 +419,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def visit_literal_block(self, node):
-        # type: (nodes.literal_block) -> None
+        # type: (nodes.Element) -> None
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight
             return super(HTMLTranslator, self).visit_literal_block(node)
@@ -444,7 +444,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def visit_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, nodes.container) and node.parent.get('literal_block'):
             self.body.append('<div class="code-block-caption">')
         else:
@@ -453,7 +453,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.body.append(self.starttag(node, 'span', '', CLASS='caption-text'))
 
     def depart_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</span>')
 
         # append permalink if available
@@ -472,21 +472,21 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             super(HTMLTranslator, self).depart_caption(node)
 
     def visit_doctest_block(self, node):
-        # type: (nodes.doctest_block) -> None
+        # type: (nodes.Element) -> None
         self.visit_literal_block(node)
 
     # overwritten to add the <div> (for XHTML compliance)
     def visit_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'blockquote') + '<div>')
 
     def depart_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</div></blockquote>\n')
 
     # overwritten
     def visit_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         if 'kbd' in node['classes']:
             self.body.append(self.starttag(node, 'kbd', '',
                                            CLASS='docutils literal notranslate'))
@@ -496,7 +496,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.protect_literal_text += 1
 
     def depart_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         if 'kbd' in node['classes']:
             self.body.append('</kbd>')
         else:
@@ -504,7 +504,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.body.append('</code>')
 
     def visit_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'pre'))
         names = []
         productionlist = cast(Iterable[addnodes.production], node)
@@ -525,24 +525,24 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def depart_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'p', CLASS="centered") +
                          '<strong>')
 
     def depart_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</strong></p>')
 
     # overwritten
@@ -558,15 +558,15 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         return super(HTMLTranslator, self).should_be_compact_paragraph(node)
 
     def visit_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         atts = {'class': 'reference download',
                 'download': ''}
 
@@ -586,12 +586,12 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.context.append('')
 
     def depart_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     # overwritten
     def visit_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         olduri = node['uri']
         # rewrite the URI if the environment knows about it
         if olduri in self.builder.images:
@@ -633,60 +633,60 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def depart_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         if node['uri'].lower().endswith(('svg', 'svgz')):
             self.body.append(self.context.pop())
         else:
             super(HTMLTranslator, self).depart_image(node)
 
     def visit_toctree(self, node):
-        # type: (addnodes.toctree) -> None
+        # type: (nodes.Element) -> None
         # this only happens when formatting a toc from env.tocs -- in this
         # case we don't want to include the subtree
         raise nodes.SkipNode
 
     def visit_index(self, node):
-        # type: (addnodes.index) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_tabular_col_spec(self, node):
-        # type: (addnodes.tabular_col_spec) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<table class="hlist"><tr>')
 
     def depart_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</tr></table>\n')
 
     def visit_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<td>')
 
     def depart_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</td>')
 
     def visit_option_group(self, node):
-        # type: (nodes.option_group) -> None
+        # type: (nodes.Element) -> None
         super(HTMLTranslator, self).visit_option_group(node)
         self.context[-2] = self.context[-2].replace('&nbsp;', '&#160;')
 
@@ -714,113 +714,113 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.body.append(encoded)
 
     def visit_note(self, node):
-        # type: (nodes.note) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'note')
 
     def depart_note(self, node):
-        # type: (nodes.note) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_warning(self, node):
-        # type: (nodes.warning) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'warning')
 
     def depart_warning(self, node):
-        # type: (nodes.warning) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_attention(self, node):
-        # type: (nodes.attention) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'attention')
 
     def depart_attention(self, node):
-        # type: (nodes.attention) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_caution(self, node):
-        # type: (nodes.caution) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'caution')
 
     def depart_caution(self, node):
-        # type: (nodes.caution) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_danger(self, node):
-        # type: (nodes.danger) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'danger')
 
     def depart_danger(self, node):
-        # type: (nodes.danger) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_error(self, node):
-        # type: (nodes.error) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'error')
 
     def depart_error(self, node):
-        # type: (nodes.error) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_hint(self, node):
-        # type: (nodes.hint) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'hint')
 
     def depart_hint(self, node):
-        # type: (nodes.hint) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_important(self, node):
-        # type: (nodes.important) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'important')
 
     def depart_important(self, node):
-        # type: (nodes.important) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_tip(self, node):
-        # type: (nodes.tip) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'tip')
 
     def depart_tip(self, node):
-        # type: (nodes.tip) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         return self.visit_emphasis(node)
 
     def depart_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         return self.depart_emphasis(node)
 
     def visit_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         return self.visit_strong(node)
 
     def depart_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         return self.depart_strong(node)
 
     def visit_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         attrs = {}
         if node.hasattr('explanation'):
             attrs['title'] = node['explanation']
         self.body.append(self.starttag(node, 'abbr', '', **attrs))
 
     def depart_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</abbr>')
 
     def visit_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         self.visit_literal_emphasis(node)
         if self.manpages_url:
             node['refuri'] = self.manpages_url.format(**node.attributes)
             self.visit_reference(node)
 
     def depart_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         if self.manpages_url:
             self.depart_reference(node)
         self.depart_literal_emphasis(node)
@@ -828,12 +828,12 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
     # overwritten to add even/odd classes
 
     def visit_table(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         self._table_row_index = 0
         return super(HTMLTranslator, self).visit_table(node)
 
     def visit_row(self, node):
-        # type: (nodes.row) -> None
+        # type: (nodes.Element) -> None
         self._table_row_index += 1
         if self._table_row_index % 2 == 0:
             node['classes'].append('row-even')
@@ -843,18 +843,18 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         node.column = 0
 
     def visit_entry(self, node):
-        # type: (nodes.entry) -> None
+        # type: (nodes.Element) -> None
         super(HTMLTranslator, self).visit_entry(node)
         if self.body[-1] == '&nbsp;':
             self.body[-1] = '&#160;'
 
     def visit_field_list(self, node):
-        # type: (nodes.field_list) -> None
+        # type: (nodes.Element) -> None
         self._fieldlist_row_index = 0
         return super(HTMLTranslator, self).visit_field_list(node)
 
     def visit_field(self, node):
-        # type: (nodes.field) -> None
+        # type: (nodes.Element) -> None
         self._fieldlist_row_index += 1
         if self._fieldlist_row_index % 2 == 0:
             node['classes'].append('field-even')
@@ -863,33 +863,33 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.body.append(self.starttag(node, 'tr', '', CLASS='field'))
 
     def visit_field_name(self, node):
-        # type: (nodes.field_name) -> None
+        # type: (nodes.Element) -> None
         context_count = len(self.context)
         super(HTMLTranslator, self).visit_field_name(node)
         if context_count != len(self.context):
             self.context[-1] = self.context[-1].replace('&nbsp;', '&#160;')
 
     def visit_math(self, node, math_env=''):
-        # type: (nodes.math, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         visit, _ = self.builder.app.registry.html_inline_math_renderers[name]
         visit(self, node)
 
     def depart_math(self, node, math_env=''):
-        # type: (nodes.math, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         _, depart = self.builder.app.registry.html_inline_math_renderers[name]
         if depart:
             depart(self, node)
 
     def visit_math_block(self, node, math_env=''):
-        # type: (nodes.math_block, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         visit, _ = self.builder.app.registry.html_block_math_renderers[name]
         visit(self, node)
 
     def depart_math_block(self, node, math_env=''):
-        # type: (nodes.math_block, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         _, depart = self.builder.app.registry.html_block_math_renderers[name]
         if depart:

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -64,25 +64,25 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.required_params_left = 0
 
     def visit_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         # only occurs in the single-file builder
         self.docnames.append(node['docname'])
         self.body.append('<span id="document-%s"></span>' % node['docname'])
 
     def depart_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         self.docnames.pop()
 
     def visit_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'dl', CLASS=node['objtype']))
 
     def depart_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</dl>\n\n')
 
     def visit_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         # the id is set automatically
         self.body.append(self.starttag(node, 'dt'))
         # anchor for per-desc interactive data
@@ -91,56 +91,56 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.body.append('<!--[%s]-->' % node['ids'][0])
 
     def depart_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         if not node.get('is_multiline'):
             self.add_permalink_ref(node, _('Permalink to this definition'))
         self.body.append('</dt>\n')
 
     def visit_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         if node.get('add_permalink'):
             # the permalink info is on the parent desc_signature node
             self.add_permalink_ref(node.parent, _('Permalink to this definition'))
         self.body.append('<br />')
 
     def visit_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'code', '', CLASS='descclassname'))
 
     def depart_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</code>')
 
     def visit_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         self.body.append(' &#x2192; ')
 
     def depart_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'code', '', CLASS='descname'))
 
     def depart_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</code>')
 
     def visit_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<span class="sig-paren">(</span>')
         self.first_param = 1
         self.optional_param_level = 0
@@ -150,7 +150,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.param_separator = node.child_text_separator
 
     def depart_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<span class="sig-paren">)</span>')
 
     # If required parameters are still to come, then put the comma after
@@ -160,7 +160,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     #     foo([a, ]b, c[, d])
     #
     def visit_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if self.first_param:
             self.first_param = 0
         elif not self.required_params_left:
@@ -171,49 +171,49 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.body.append('<em>')
 
     def depart_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if not node.hasattr('noemph'):
             self.body.append('</em>')
         if self.required_params_left:
             self.body.append(self.param_separator)
 
     def visit_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.optional_param_level += 1
         self.body.append('<span class="optional">[</span>')
 
     def depart_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.optional_param_level -= 1
         self.body.append('<span class="optional">]</span>')
 
     def visit_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'em', '', CLASS='property'))
 
     def depart_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</em>')
 
     def visit_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'dd', ''))
 
     def depart_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</dd>')
 
     def visit_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'div', CLASS=node['type']))
 
     def depart_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</div>\n')
 
     # overwritten
     def visit_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         atts = {'class': 'reference'}
         if node.get('internal') or 'refuri' not in node:
             atts['class'] += ' internal'
@@ -242,16 +242,16 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
                              '.'.join(map(str, node['secnumber'])))
 
     def visit_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         self.visit_reference(node)
 
     def depart_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         self.depart_reference(node)
 
     # overwritten -- we don't want source comments to show up in the HTML
     def visit_comment(self, node):
-        # type: (nodes.comment) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     # overwritten
@@ -263,11 +263,11 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             node.insert(0, nodes.title(name, admonitionlabels[name]))
 
     def visit_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'seealso')
 
     def depart_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def add_secnumber(self, node):
@@ -326,7 +326,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def visit_bullet_list(self, node):
-        # type: (nodes.bullet_list) -> None
+        # type: (nodes.Element) -> None
         if len(node) == 1 and isinstance(node[0], addnodes.toctree):
             # avoid emitting empty <ul></ul>
             raise nodes.SkipNode
@@ -334,7 +334,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def visit_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         super(HTML5Translator, self).visit_title(node)
         self.add_secnumber(node)
         self.add_fignumber(node.parent)
@@ -342,7 +342,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.body.append('<span class="caption-text">')
 
     def depart_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         close_tag = self.context[-1]
         if (self.permalink_text and self.builder.add_permalinks and
            node.parent.hasattr('ids') and node.parent['ids']):
@@ -365,7 +365,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def visit_literal_block(self, node):
-        # type: (nodes.literal_block) -> None
+        # type: (nodes.Element) -> None
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight
             return super(HTML5Translator, self).visit_literal_block(node)
@@ -390,7 +390,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def visit_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, nodes.container) and node.parent.get('literal_block'):
             self.body.append('<div class="code-block-caption">')
         else:
@@ -399,7 +399,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.body.append(self.starttag(node, 'span', '', CLASS='caption-text'))
 
     def depart_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</span>')
 
         # append permalink if available
@@ -418,21 +418,21 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             super(HTML5Translator, self).depart_caption(node)
 
     def visit_doctest_block(self, node):
-        # type: (nodes.doctest_block) -> None
+        # type: (nodes.Element) -> None
         self.visit_literal_block(node)
 
     # overwritten to add the <div> (for XHTML compliance)
     def visit_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'blockquote') + '<div>')
 
     def depart_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</div></blockquote>\n')
 
     # overwritten
     def visit_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         if 'kbd' in node['classes']:
             self.body.append(self.starttag(node, 'kbd', '',
                                            CLASS='docutils literal notranslate'))
@@ -442,7 +442,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.protect_literal_text += 1
 
     def depart_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         if 'kbd' in node['classes']:
             self.body.append('</kbd>')
         else:
@@ -450,7 +450,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.body.append('</code>')
 
     def visit_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'pre'))
         names = []
         productionlist = cast(Iterable[addnodes.production], node)
@@ -471,36 +471,36 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def depart_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.starttag(node, 'p', CLASS="centered") +
                          '<strong>')
 
     def depart_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</strong></p>')
 
     def visit_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         atts = {'class': 'reference download',
                 'download': ''}
 
@@ -520,12 +520,12 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.context.append('')
 
     def depart_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     # overwritten
     def visit_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         olduri = node['uri']
         # rewrite the URI if the environment knows about it
         if olduri in self.builder.images:
@@ -567,56 +567,56 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     # overwritten
     def depart_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         if node['uri'].lower().endswith(('svg', 'svgz')):
             self.body.append(self.context.pop())
         else:
             super(HTML5Translator, self).depart_image(node)
 
     def visit_toctree(self, node):
-        # type: (addnodes.toctree) -> None
+        # type: (nodes.Element) -> None
         # this only happens when formatting a toc from env.tocs -- in this
         # case we don't want to include the subtree
         raise nodes.SkipNode
 
     def visit_index(self, node):
-        # type: (addnodes.index) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_tabular_col_spec(self, node):
-        # type: (addnodes.tabular_col_spec) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<table class="hlist"><tr>')
 
     def depart_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</tr></table>\n')
 
     def visit_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         self.body.append('<td>')
 
     def depart_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</td>')
 
     # overwritten
@@ -643,113 +643,113 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.body.append(encoded)
 
     def visit_note(self, node):
-        # type: (nodes.note) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'note')
 
     def depart_note(self, node):
-        # type: (nodes.note) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_warning(self, node):
-        # type: (nodes.warning) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'warning')
 
     def depart_warning(self, node):
-        # type: (nodes.warning) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_attention(self, node):
-        # type: (nodes.attention) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'attention')
 
     def depart_attention(self, node):
-        # type: (nodes.attention) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_caution(self, node):
-        # type: (nodes.caution) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'caution')
 
     def depart_caution(self, node):
-        # type: (nodes.caution) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_danger(self, node):
-        # type: (nodes.danger) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'danger')
 
     def depart_danger(self, node):
-        # type: (nodes.danger) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_error(self, node):
-        # type: (nodes.error) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'error')
 
     def depart_error(self, node):
-        # type: (nodes.error) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_hint(self, node):
-        # type: (nodes.hint) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'hint')
 
     def depart_hint(self, node):
-        # type: (nodes.hint) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_important(self, node):
-        # type: (nodes.important) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'important')
 
     def depart_important(self, node):
-        # type: (nodes.important) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_tip(self, node):
-        # type: (nodes.tip) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'tip')
 
     def depart_tip(self, node):
-        # type: (nodes.tip) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         return self.visit_emphasis(node)
 
     def depart_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         return self.depart_emphasis(node)
 
     def visit_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         return self.visit_strong(node)
 
     def depart_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         return self.depart_strong(node)
 
     def visit_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         attrs = {}
         if node.hasattr('explanation'):
             attrs['title'] = node['explanation']
         self.body.append(self.starttag(node, 'abbr', '', **attrs))
 
     def depart_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         self.body.append('</abbr>')
 
     def visit_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         self.visit_literal_emphasis(node)
         if self.manpages_url:
             node['refuri'] = self.manpages_url.format(**node.attributes)
             self.visit_reference(node)
 
     def depart_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         if self.manpages_url:
             self.depart_reference(node)
         self.depart_literal_emphasis(node)
@@ -771,7 +771,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             node['ids'].remove(id)
 
     def visit_table(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         self.generate_targets_for_table(node)
 
         self._table_row_index = 0
@@ -784,7 +784,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.body.append(tag)
 
     def visit_row(self, node):
-        # type: (nodes.row) -> None
+        # type: (nodes.Element) -> None
         self._table_row_index += 1
         if self._table_row_index % 2 == 0:
             node['classes'].append('row-even')
@@ -794,12 +794,12 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         node.column = 0
 
     def visit_field_list(self, node):
-        # type: (nodes.field_list) -> None
+        # type: (nodes.Element) -> None
         self._fieldlist_row_index = 0
         return super(HTML5Translator, self).visit_field_list(node)
 
     def visit_field(self, node):
-        # type: (nodes.field) -> None
+        # type: (nodes.Element) -> None
         self._fieldlist_row_index += 1
         if self._fieldlist_row_index % 2 == 0:
             node['classes'].append('field-even')
@@ -807,26 +807,26 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             node['classes'].append('field-odd')
 
     def visit_math(self, node, math_env=''):
-        # type: (nodes.math, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         visit, _ = self.builder.app.registry.html_inline_math_renderers[name]
         visit(self, node)
 
     def depart_math(self, node, math_env=''):
-        # type: (nodes.math, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         _, depart = self.builder.app.registry.html_inline_math_renderers[name]
         if depart:
             depart(self, node)
 
     def visit_math_block(self, node, math_env=''):
-        # type: (nodes.math_block, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         visit, _ = self.builder.app.registry.html_block_math_renderers[name]
         visit(self, node)
 
     def depart_math_block(self, node, math_env=''):
-        # type: (nodes.math_block, unicode) -> None
+        # type: (nodes.Element, unicode) -> None
         name = self.builder.math_renderer_name
         _, depart = self.builder.app.registry.html_block_math_renderers[name]
         if depart:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -320,7 +320,7 @@ class Table:
     """A table data"""
 
     def __init__(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         self.header = []                        # type: List[unicode]
         self.body = []                          # type: List[unicode]
         self.align = node.get('align')
@@ -895,7 +895,7 @@ class LaTeXTranslator(SphinxTranslator):
         return LaTeXRenderer().render(template_name, variables)
 
     def visit_document(self, node):
-        # type: (nodes.document) -> None
+        # type: (nodes.Element) -> None
         self.curfilestack.append(node.get('docname', ''))
         if self.first_document == 1:
             # the first document is all the regular content ...
@@ -910,11 +910,11 @@ class LaTeXTranslator(SphinxTranslator):
         self.sectionlevel = self.top_sectionlevel - 1
 
     def depart_document(self, node):
-        # type: (nodes.document) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         self.curfilestack.append(node['docname'])
 
     def collect_footnotes(self, node):
@@ -940,60 +940,60 @@ class LaTeXTranslator(SphinxTranslator):
         return fnotes
 
     def depart_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         self.curfilestack.pop()
 
     def visit_section(self, node):
-        # type: (nodes.section) -> None
+        # type: (nodes.Element) -> None
         if not self.this_is_the_title:
             self.sectionlevel += 1
         self.body.append('\n\n')
 
     def depart_section(self, node):
-        # type: (nodes.section) -> None
+        # type: (nodes.Element) -> None
         self.sectionlevel = max(self.sectionlevel - 1,
                                 self.top_sectionlevel - 1)
 
     def visit_problematic(self, node):
-        # type: (nodes.problematic) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'{\color{red}\bfseries{}')
 
     def depart_problematic(self, node):
-        # type: (nodes.problematic) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
 
     def visit_topic(self, node):
-        # type: (nodes.topic) -> None
+        # type: (nodes.Element) -> None
         self.in_minipage = 1
         self.body.append('\n\\begin{sphinxShadowBox}\n')
 
     def depart_topic(self, node):
-        # type: (nodes.topic) -> None
+        # type: (nodes.Element) -> None
         self.in_minipage = 0
         self.body.append('\\end{sphinxShadowBox}\n')
     visit_sidebar = visit_topic
     depart_sidebar = depart_topic
 
     def visit_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\n\\begin{productionlist}\n')
         self.in_production_list = 1
 
     def depart_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{productionlist}\n\n')
         self.in_production_list = 0
 
     def visit_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         if node['tokenname']:
             tn = node['tokenname']
             self.body.append(self.hypertarget('grammar-token-' + tn))
@@ -1002,19 +1002,19 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append('\\productioncont{')
 
     def depart_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}\n')
 
     def visit_transition(self, node):
-        # type: (nodes.transition) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.elements['transition'])
 
     def depart_transition(self, node):
-        # type: (nodes.transition) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         parent = node.parent
         if isinstance(parent, addnodes.seealso):
             # the environment already handles this
@@ -1064,7 +1064,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_title = 1
 
     def depart_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         self.in_title = 0
         if isinstance(node.parent, nodes.table):
             self.table.caption = self.popbody()
@@ -1072,7 +1072,7 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(self.context.pop())
 
     def visit_subtitle(self, node):
-        # type: (nodes.subtitle) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, nodes.sidebar):
             self.body.append('\\sphinxstylesidebarsubtitle{')
             self.context.append('}\n')
@@ -1080,17 +1080,17 @@ class LaTeXTranslator(SphinxTranslator):
             self.context.append('')
 
     def depart_subtitle(self, node):
-        # type: (nodes.subtitle) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     def visit_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\n\\begin{fulllineitems}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\end{fulllineitems}\n\n')
 
     def _visit_signature_line(self, node):
@@ -1103,11 +1103,11 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(r'\pysigline{')
 
     def _depart_signature_line(self, node):
-        # type: (nodes.Node) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
 
     def visit_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         if node.parent['objtype'] != 'describe' and node['ids']:
             hyper = self.hypertarget(node['ids'][0])
         else:
@@ -1119,71 +1119,71 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append('%\n\\pysigstartmultiline\n')
 
     def depart_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         if not node.get('is_multiline'):
             self._depart_signature_line(node)
         else:
             self.body.append('%\n\\pysigstopmultiline')
 
     def visit_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         self._visit_signature_line(node)
 
     def depart_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         self._depart_signature_line(node)
 
     def visit_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxcode{\sphinxupquote{')
         self.literal_whitespace += 1
 
     def depart_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}')
         self.literal_whitespace -= 1
 
     def visit_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'{ $\rightarrow$ ')
 
     def depart_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'}')
 
     def visit_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxbfcode{\sphinxupquote{')
         self.no_contractions += 1
         self.literal_whitespace += 1
 
     def depart_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}')
         self.literal_whitespace -= 1
         self.no_contractions -= 1
 
     def visit_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         # close name, open parameterlist
         self.body.append('}{')
         self.first_param = 1
 
     def depart_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         # close parameterlist, open return annotation
         self.body.append('}{')
 
     def visit_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if not self.first_param:
             self.body.append(', ')
         else:
@@ -1192,46 +1192,46 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(r'\emph{')
 
     def depart_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if not node.hasattr('noemph'):
             self.body.append('}')
 
     def visit_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxoptional{')
 
     def depart_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
 
     def visit_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxbfcode{\sphinxupquote{')
 
     def depart_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}')
 
     def visit_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         if node.children and not isinstance(node.children[0], nodes.paragraph):
             # avoid empty desc environment which causes a formatting bug
             self.body.append('~')
 
     def depart_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.body.append(u'\n\n\\sphinxstrong{%s:}\n\n' % admonitionlabels['seealso'])
 
     def depart_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.body.append("\n\n")
 
     def visit_rubric(self, node):
-        # type: (nodes.rubric) -> None
+        # type: (nodes.Element) -> None
         if len(node) == 1 and node.astext() in ('Footnotes', _('Footnotes')):
             raise nodes.SkipNode
         self.body.append('\\subsubsection*{')
@@ -1239,12 +1239,12 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_title = 1
 
     def depart_rubric(self, node):
-        # type: (nodes.rubric) -> None
+        # type: (nodes.Element) -> None
         self.in_title = 0
         self.body.append(self.context.pop())
 
     def visit_footnote(self, node):
-        # type: (nodes.footnote) -> None
+        # type: (nodes.Element) -> None
         self.in_footnote += 1
         label = cast(nodes.label, node[0])
         if self.in_parsed_literal:
@@ -1254,7 +1254,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.append('\\sphinxAtStartFootnote\n')
 
     def depart_footnote(self, node):
-        # type: (nodes.footnote) -> None
+        # type: (nodes.Element) -> None
         if self.in_parsed_literal:
             self.body.append('\\end{footnote}')
         else:
@@ -1262,16 +1262,16 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_footnote -= 1
 
     def visit_label(self, node):
-        # type: (nodes.label) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_tabular_col_spec(self, node):
-        # type: (addnodes.tabular_col_spec) -> None
+        # type: (nodes.Element) -> None
         self.next_table_colspec = node['spec']
         raise nodes.SkipNode
 
     def visit_table(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         if self.table:
             raise UnsupportedError(
                 '%s:%s: nested tables are not yet implemented.' %
@@ -1285,7 +1285,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.next_table_colspec = None
 
     def depart_table(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         labels = self.hypertarget_to(node)
         table_type = self.table.get_table_type()
         table = self.render(table_type + '.tex_t',
@@ -1297,7 +1297,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.table = None
 
     def visit_colspec(self, node):
-        # type: (nodes.colspec) -> None
+        # type: (nodes.Element) -> None
         self.table.colcount += 1
         if 'colwidth' in node:
             self.table.colwidths.append(node['colwidth'])
@@ -1305,37 +1305,37 @@ class LaTeXTranslator(SphinxTranslator):
             self.table.stubs.append(self.table.colcount - 1)
 
     def depart_colspec(self, node):
-        # type: (nodes.colspec) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_tgroup(self, node):
-        # type: (nodes.tgroup) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_tgroup(self, node):
-        # type: (nodes.tgroup) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_thead(self, node):
-        # type: (nodes.thead) -> None
+        # type: (nodes.Element) -> None
         # Redirect head output until header is finished.
         self.pushbody(self.table.header)
 
     def depart_thead(self, node):
-        # type: (nodes.thead) -> None
+        # type: (nodes.Element) -> None
         self.popbody()
 
     def visit_tbody(self, node):
-        # type: (nodes.tbody) -> None
+        # type: (nodes.Element) -> None
         # Redirect body output until table is finished.
         self.pushbody(self.table.body)
 
     def depart_tbody(self, node):
-        # type: (nodes.tbody) -> None
+        # type: (nodes.Element) -> None
         self.popbody()
 
     def visit_row(self, node):
-        # type: (nodes.row) -> None
+        # type: (nodes.Element) -> None
         self.table.col = 0
 
         # fill columns if the row starts with the bottom of multirow cell
@@ -1356,7 +1356,7 @@ class LaTeXTranslator(SphinxTranslator):
                                      (cell.width, cell.cell_id))
 
     def depart_row(self, node):
-        # type: (nodes.row) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\\\\n')
         cells = [self.table.cell(self.table.row, i) for i in range(self.table.colcount)]
         underlined = [cell.row + cell.height == self.table.row + 1 for cell in cells]
@@ -1374,7 +1374,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.table.row += 1
 
     def visit_entry(self, node):
-        # type: (nodes.entry) -> None
+        # type: (nodes.Element) -> None
         if self.table.col > 0:
             self.body.append('&')
         self.table.add_cell(node.get('morerows', 0) + 1, node.get('morecols', 0) + 1)
@@ -1412,7 +1412,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.context.append(context)
 
     def depart_entry(self, node):
-        # type: (nodes.entry) -> None
+        # type: (nodes.Element) -> None
         if self.needs_linetrimming:
             self.needs_linetrimming = 0
             body = self.popbody()
@@ -1446,7 +1446,7 @@ class LaTeXTranslator(SphinxTranslator):
                                      (nextcell.width, nextcell.cell_id))
 
     def visit_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         # this is a list in the source, but should be rendered as a
         # comma-separated list here
         bullet_list = cast(nodes.bullet_list, node[0])
@@ -1457,21 +1457,21 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_bullet_list(self, node):
-        # type: (nodes.bullet_list) -> None
+        # type: (nodes.Element) -> None
         if not self.compact_list:
             self.body.append('\\begin{itemize}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_bullet_list(self, node):
-        # type: (nodes.bullet_list) -> None
+        # type: (nodes.Element) -> None
         if not self.compact_list:
             self.body.append('\\end{itemize}\n')
 
     def visit_enumerated_list(self, node):
-        # type: (nodes.enumerated_list) -> None
+        # type: (nodes.Element) -> None
         def get_enumtype(node):
-            # type: (nodes.enumerated_list) -> unicode
+            # type: (nodes.Element) -> unicode
             enumtype = node.get('enumtype', 'arabic')
             if 'alpha' in enumtype and 26 < node.get('start', 0) + len(node):
                 # fallback to arabic if alphabet counter overflows
@@ -1480,7 +1480,7 @@ class LaTeXTranslator(SphinxTranslator):
             return enumtype
 
         def get_nested_level(node):
-            # type: (nodes.Node) -> int
+            # type: (nodes.Element) -> int
             if node is None:
                 return 0
             elif isinstance(node, nodes.enumerated_list):
@@ -1506,39 +1506,39 @@ class LaTeXTranslator(SphinxTranslator):
             self.table.has_problematic = True
 
     def depart_enumerated_list(self, node):
-        # type: (nodes.enumerated_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{enumerate}\n')
 
     def visit_list_item(self, node):
-        # type: (nodes.list_item) -> None
+        # type: (nodes.Element) -> None
         # Append "{}" in case the next character is "[", which would break
         # LaTeX's list environment (no numbering and the "[" is not printed).
         self.body.append(r'\item {} ')
 
     def depart_list_item(self, node):
-        # type: (nodes.list_item) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n')
 
     def visit_definition_list(self, node):
-        # type: (nodes.definition_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\begin{description}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_definition_list(self, node):
-        # type: (nodes.definition_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{description}\n')
 
     def visit_definition_list_item(self, node):
-        # type: (nodes.definition_list_item) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_definition_list_item(self, node):
-        # type: (nodes.definition_list_item) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_term(self, node):
-        # type: (nodes.term) -> None
+        # type: (nodes.Element) -> None
         self.in_term += 1
         ctx = ''  # type: unicode
         if node.get('ids'):
@@ -1550,42 +1550,42 @@ class LaTeXTranslator(SphinxTranslator):
         self.context.append(ctx)
 
     def depart_term(self, node):
-        # type: (nodes.term) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
         self.in_term -= 1
 
     def visit_classifier(self, node):
-        # type: (nodes.classifier) -> None
+        # type: (nodes.Element) -> None
         self.body.append('{[}')
 
     def depart_classifier(self, node):
-        # type: (nodes.classifier) -> None
+        # type: (nodes.Element) -> None
         self.body.append('{]}')
 
     def visit_definition(self, node):
-        # type: (nodes.definition) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_definition(self, node):
-        # type: (nodes.definition) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n')
 
     def visit_field_list(self, node):
-        # type: (nodes.field_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\begin{quote}\\begin{description}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_field_list(self, node):
-        # type: (nodes.field_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{description}\\end{quote}\n')
 
     def visit_field(self, node):
-        # type: (nodes.field) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_field(self, node):
-        # type: (nodes.field) -> None
+        # type: (nodes.Element) -> None
         pass
 
     visit_field_name = visit_term
@@ -1595,7 +1595,7 @@ class LaTeXTranslator(SphinxTranslator):
     depart_field_body = depart_definition
 
     def visit_paragraph(self, node):
-        # type: (nodes.paragraph) -> None
+        # type: (nodes.Element) -> None
         index = node.parent.index(node)
         if (index > 0 and isinstance(node.parent, nodes.compound) and
                 not isinstance(node.parent[index - 1], nodes.paragraph) and
@@ -1610,21 +1610,21 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append('\n')
 
     def depart_paragraph(self, node):
-        # type: (nodes.paragraph) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n')
 
     def visit_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\begin{center}')
         if self.table:
             self.table.has_problematic = True
 
     def depart_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\end{center}')
 
     def visit_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         # for now, we don't support a more compact list format
         # don't add individual itemize environments, but one for all columns
         self.compact_list += 1
@@ -1634,16 +1634,16 @@ class LaTeXTranslator(SphinxTranslator):
             self.table.has_problematic = True
 
     def depart_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.compact_list -= 1
         self.body.append('\\end{itemize}\n')
 
     def visit_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def latex_image_length(self, width_str):
@@ -1655,12 +1655,12 @@ class LaTeXTranslator(SphinxTranslator):
             return None
 
     def is_inline(self, node):
-        # type: (nodes.Node) -> bool
+        # type: (nodes.Element) -> bool
         """Check whether a node represents an inline element."""
         return isinstance(node.parent, nodes.TextElement)
 
     def visit_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         attrs = node.attributes
         pre = []    # type: List[unicode]
                     # in reverse order
@@ -1737,11 +1737,11 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.extend(post)
 
     def depart_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_figure(self, node):
-        # type: (nodes.figure) -> None
+        # type: (nodes.Element) -> None
         if self.table:
             # TODO: support align option
             if 'width' in node:
@@ -1774,11 +1774,11 @@ class LaTeXTranslator(SphinxTranslator):
             self.context.append('\\end{figure}\n')
 
     def depart_figure(self, node):
-        # type: (nodes.figure) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     def visit_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         self.in_caption += 1
         if isinstance(node.parent, captioned_literal_block):
             self.body.append('\\sphinxSetupCaptionForVerbatim{')
@@ -1790,7 +1790,7 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append('\\caption{')
 
     def depart_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
         if isinstance(node.parent, nodes.figure):
             labels = self.hypertarget_to(node.parent)
@@ -1798,19 +1798,19 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_caption -= 1
 
     def visit_legend(self, node):
-        # type: (nodes.legend) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\begin{sphinxlegend}')
 
     def depart_legend(self, node):
-        # type: (nodes.legend) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{sphinxlegend}\n')
 
     def visit_admonition(self, node):
-        # type: (nodes.admonition) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\begin{sphinxadmonition}{note}')
 
     def depart_admonition(self, node):
-        # type: (nodes.admonition) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{sphinxadmonition}\n')
 
     def _visit_named_admonition(self, node):
@@ -1843,15 +1843,15 @@ class LaTeXTranslator(SphinxTranslator):
     depart_warning = _depart_named_admonition
 
     def visit_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_target(self, node):
-        # type: (nodes.target) -> None
+        # type: (nodes.Element) -> None
         def add_target(id):
             # type: (unicode) -> None
             # indexing uses standard LaTeX index markup, so the targets
@@ -1892,20 +1892,20 @@ class LaTeXTranslator(SphinxTranslator):
             add_target(id)
 
     def depart_target(self, node):
-        # type: (nodes.target) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_attribution(self, node):
-        # type: (nodes.attribution) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\begin{flushright}\n')
         self.body.append('---')
 
     def depart_attribution(self, node):
-        # type: (nodes.attribution) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\end{flushright}\n')
 
     def visit_index(self, node, scre = None):
-        # type: (addnodes.index, Pattern) -> None
+        # type: (nodes.Element, Pattern) -> None
         def escape(value):
             value = self.encode(value)
             value = value.replace(r'\{', r'\sphinxleftcurlybrace{}')
@@ -1975,7 +1975,7 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_raw(self, node):
-        # type: (nodes.raw) -> None
+        # type: (nodes.Element) -> None
         if not self.is_inline(node):
             self.body.append('\n')
         if 'latex' in node.get('format', '').split():
@@ -1985,7 +1985,7 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         if not self.in_title:
             for id in node.get('ids'):
                 anchor = not self.in_caption
@@ -2041,11 +2041,11 @@ class LaTeXTranslator(SphinxTranslator):
                 self.context.append('}')
 
     def depart_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     def visit_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         if node.get('refid'):
             id = self.curfilestack[-1] + ':' + node['refid']
         else:
@@ -2067,59 +2067,59 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_pending_xref(self, node):
-        # type: (addnodes.pending_xref) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_pending_xref(self, node):
-        # type: (addnodes.pending_xref) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_emphasis(self, node):
-        # type: (nodes.emphasis) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxstyleemphasis{')
 
     def depart_emphasis(self, node):
-        # type: (nodes.emphasis) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
 
     def visit_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxstyleliteralemphasis{\sphinxupquote{')
         self.no_contractions += 1
 
     def depart_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}')
         self.no_contractions -= 1
 
     def visit_strong(self, node):
-        # type: (nodes.strong) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxstylestrong{')
 
     def depart_strong(self, node):
-        # type: (nodes.strong) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
 
     def visit_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxstyleliteralstrong{\sphinxupquote{')
         self.no_contractions += 1
 
     def depart_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}')
         self.no_contractions -= 1
 
     def visit_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         abbr = node.astext()
         self.body.append(r'\sphinxstyleabbreviation{')
         # spell out the explanation once
@@ -2130,23 +2130,23 @@ class LaTeXTranslator(SphinxTranslator):
             self.context.append('}')
 
     def depart_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     def visit_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         return self.visit_literal_emphasis(node)
 
     def depart_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         return self.depart_literal_emphasis(node)
 
     def visit_title_reference(self, node):
-        # type: (nodes.title_reference) -> None
+        # type: (nodes.Element) -> None
         self.body.append(r'\sphinxtitleref{')
 
     def depart_title_reference(self, node):
-        # type: (nodes.title_reference) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}')
 
     def visit_thebibliography(self, node):
@@ -2166,17 +2166,17 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.append(u'\\end{sphinxthebibliography}\n')
 
     def visit_citation(self, node):
-        # type: (nodes.citation) -> None
+        # type: (nodes.Element) -> None
         label = cast(nodes.label, node[0])
         self.body.append(u'\\bibitem[%s]{%s:%s}' % (self.encode(label.astext()),
                                                     node['docname'], node['ids'][0]))
 
     def depart_citation(self, node):
-        # type: (nodes.citation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_citation_reference(self, node):
-        # type: (nodes.citation_reference) -> None
+        # type: (nodes.Element) -> None
         if self.in_title:
             pass
         else:
@@ -2184,11 +2184,11 @@ class LaTeXTranslator(SphinxTranslator):
             raise nodes.SkipNode
 
     def depart_citation_reference(self, node):
-        # type: (nodes.citation_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         self.no_contractions += 1
         if self.in_title:
             self.body.append(r'\sphinxstyleliteralintitle{\sphinxupquote{')
@@ -2196,12 +2196,12 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(r'\sphinxcode{\sphinxupquote{')
 
     def depart_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         self.no_contractions -= 1
         self.body.append('}}')
 
     def visit_footnote_reference(self, node):
-        # type: (nodes.footnote_reference) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_footnotemark(self, node):
@@ -2232,7 +2232,7 @@ class LaTeXTranslator(SphinxTranslator):
         pass
 
     def visit_literal_block(self, node):
-        # type: (nodes.literal_block) -> None
+        # type: (nodes.Element) -> None
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight
             self.in_parsed_literal += 1
@@ -2287,22 +2287,22 @@ class LaTeXTranslator(SphinxTranslator):
             raise nodes.SkipNode
 
     def depart_literal_block(self, node):
-        # type: (nodes.literal_block) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n\\end{sphinxalltt}\n')
         self.in_parsed_literal -= 1
     visit_doctest_block = visit_literal_block
     depart_doctest_block = depart_literal_block
 
     def visit_line(self, node):
-        # type: (nodes.line) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\item[] ')
 
     def depart_line(self, node):
-        # type: (nodes.line) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n')
 
     def visit_line_block(self, node):
-        # type: (nodes.line_block) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, nodes.line_block):
             self.body.append('\\item[]\n'
                              '\\begin{DUlineblock}{\\DUlineblockindent}\n')
@@ -2312,11 +2312,11 @@ class LaTeXTranslator(SphinxTranslator):
             self.table.has_problematic = True
 
     def depart_line_block(self, node):
-        # type: (nodes.line_block) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{DUlineblock}\n')
 
     def visit_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         # If the block quote contains a single object and that object
         # is a list, then generate a list not a block quote.
         # This lets us indent lists.
@@ -2332,7 +2332,7 @@ class LaTeXTranslator(SphinxTranslator):
                 self.table.has_problematic = True
 
     def depart_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         done = 0
         if len(node.children) == 1:
             child = node.children[0]
@@ -2345,56 +2345,56 @@ class LaTeXTranslator(SphinxTranslator):
     # option node handling copied from docutils' latex writer
 
     def visit_option(self, node):
-        # type: (nodes.option) -> None
+        # type: (nodes.Element) -> None
         if self.context[-1]:
             # this is not the first option
             self.body.append(', ')
 
     def depart_option(self, node):
-        # type: (nodes.option) -> None
+        # type: (nodes.Element) -> None
         # flag that the first option is done.
         self.context[-1] += 1
 
     def visit_option_argument(self, node):
-        # type: (nodes.option_argument) -> None
+        # type: (nodes.Element) -> None
         """The delimiter betweeen an option and its argument."""
         self.body.append(node.get('delimiter', ' '))
 
     def depart_option_argument(self, node):
-        # type: (nodes.option_argument) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_option_group(self, node):
-        # type: (nodes.option_group) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\item [')
         # flag for first option
         self.context.append(0)
 
     def depart_option_group(self, node):
-        # type: (nodes.option_group) -> None
+        # type: (nodes.Element) -> None
         self.context.pop()  # the flag
         self.body.append('] ')
 
     def visit_option_list(self, node):
-        # type: (nodes.option_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\begin{optionlist}{3cm}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_option_list(self, node):
-        # type: (nodes.option_list) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\\end{optionlist}\n')
 
     def visit_option_list_item(self, node):
-        # type: (nodes.option_list_item) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_option_list_item(self, node):
-        # type: (nodes.option_list_item) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_option_string(self, node):
-        # type: (nodes.option_string) -> None
+        # type: (nodes.Element) -> None
         ostring = node.astext()
         self.no_contractions += 1
         self.body.append(self.encode(ostring))
@@ -2402,31 +2402,31 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_description(self, node):
-        # type: (nodes.description) -> None
+        # type: (nodes.Element) -> None
         self.body.append(' ')
 
     def depart_description(self, node):
-        # type: (nodes.description) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_superscript(self, node):
-        # type: (nodes.superscript) -> None
+        # type: (nodes.Element) -> None
         self.body.append('$^{\\text{')
 
     def depart_superscript(self, node):
-        # type: (nodes.superscript) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}$')
 
     def visit_subscript(self, node):
-        # type: (nodes.subscript) -> None
+        # type: (nodes.Element) -> None
         self.body.append('$_{\\text{')
 
     def depart_subscript(self, node):
-        # type: (nodes.subscript) -> None
+        # type: (nodes.Element) -> None
         self.body.append('}}$')
 
     def visit_inline(self, node):
-        # type: (nodes.inline) -> None
+        # type: (nodes.Element) -> None
         classes = node.get('classes', [])
         if classes in [['menuselection']]:
             self.body.append(r'\sphinxmenuselection{')
@@ -2444,53 +2444,53 @@ class LaTeXTranslator(SphinxTranslator):
             self.context.append('')
 
     def depart_inline(self, node):
-        # type: (nodes.inline) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.context.pop())
 
     def visit_generated(self, node):
-        # type: (nodes.generated) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_generated(self, node):
-        # type: (nodes.generated) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_compound(self, node):
-        # type: (nodes.compound) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_compound(self, node):
-        # type: (nodes.compound) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_container(self, node):
-        # type: (nodes.container) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_container(self, node):
-        # type: (nodes.container) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_decoration(self, node):
-        # type: (nodes.decoration) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_decoration(self, node):
-        # type: (nodes.decoration) -> None
+        # type: (nodes.Element) -> None
         pass
 
     # docutils-generated elements that we don't support
 
     def visit_header(self, node):
-        # type: (nodes.header) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_footer(self, node):
-        # type: (nodes.footer) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_docinfo(self, node):
-        # type: (nodes.docinfo) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     # text handling
@@ -2522,24 +2522,24 @@ class LaTeXTranslator(SphinxTranslator):
         pass
 
     def visit_comment(self, node):
-        # type: (nodes.comment) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_meta(self, node):
-        # type: (addnodes.meta) -> None
+        # type: (nodes.Element) -> None
         # only valid for HTML
         raise nodes.SkipNode
 
     def visit_system_message(self, node):
-        # type: (nodes.system_message) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_system_message(self, node):
-        # type: (nodes.system_message) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n')
 
     def visit_math(self, node):
-        # type: (nodes.math) -> None
+        # type: (nodes.Element) -> None
         if self.in_title:
             self.body.append(r'\protect\(%s\protect\)' % node.astext())
         else:
@@ -2547,7 +2547,7 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_math_block(self, node):
-        # type: (nodes.math_block) -> None
+        # type: (nodes.Element) -> None
         if node.get('label'):
             label = "equation:%s:%s" % (node['docname'], node['label'])
         else:

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -128,125 +128,125 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         return tmpl % self._docinfo
 
     def visit_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_start_of_file(self, node):
-        # type: (addnodes.start_of_file) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.visit_definition_list(node)
 
     def depart_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         self.depart_definition_list(node)
 
     def visit_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         self.visit_definition_list_item(node)
         self.visit_term(node)
 
     def depart_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         self.depart_term(node)
 
     def visit_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         self.body.append(' ')
 
     def visit_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         self.body.append(' -> ')
 
     def depart_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append('(')
         self.first_param = 1
 
     def depart_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.body.append(')')
 
     def visit_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if not self.first_param:
             self.body.append(', ')
         else:
             self.first_param = 0
 
     def depart_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.body.append('[')
 
     def depart_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.body.append(']')
 
     def visit_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.visit_definition(node)
 
     def depart_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.depart_definition(node)
 
     def visit_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.visit_paragraph(node)
 
     def depart_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.depart_paragraph(node)
 
     # overwritten -- don't make whole of term bold if it includes strong node
     def visit_term(self, node):
-        # type: (nodes.term) -> None
+        # type: (nodes.Element) -> None
         if node.traverse(nodes.strong):
             self.body.append('\n')
         else:
@@ -254,18 +254,18 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten -- we don't want source comments to show up
     def visit_comment(self, node):
-        # type: (nodes.comment) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     # overwritten -- added ensure_eol()
     def visit_footnote(self, node):
-        # type: (nodes.footnote) -> None
+        # type: (nodes.Element) -> None
         self.ensure_eol()
         super(ManualPageTranslator, self).visit_footnote(node)
 
     # overwritten -- handle footnotes rubric
     def visit_rubric(self, node):
-        # type: (nodes.rubric) -> None
+        # type: (nodes.Element) -> None
         self.ensure_eol()
         if len(node) == 1 and node.astext() in ('Footnotes', _('Footnotes')):
             self.body.append('.SH ' + self.deunicode(node.astext()).upper() + '\n')
@@ -274,19 +274,19 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
             self.body.append('.sp\n')
 
     def depart_rubric(self, node):
-        # type: (nodes.rubric) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.visit_admonition(node, 'seealso')
 
     def depart_seealso(self, node):
-        # type: (addnodes.seealso) -> None
+        # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
     def visit_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         self.ensure_eol()
         names = []
         self.in_productionlist += 1
@@ -312,16 +312,16 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def visit_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_production(self, node):
-        # type: (addnodes.production) -> None
+        # type: (nodes.Element) -> None
         pass
 
     # overwritten -- don't emit a warning for images
     def visit_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         if 'alt' in node.attributes:
             self.body.append(_('[image: %s]') % node['alt'] + '\n')
         self.body.append(_('[image]') + '\n')
@@ -329,7 +329,7 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten -- don't visit inner marked up nodes
     def visit_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         self.body.append(self.defs['reference'][0])
         # avoid repeating escaping code... fine since
         # visit_Text calls astext() and only works on that afterwards
@@ -351,58 +351,58 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def visit_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         text = nodes.Text(node.get('title', '#'))
         self.visit_Text(text)
         raise nodes.SkipNode
 
     def visit_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.ensure_eol()
         self.body.append('.sp\n.ce\n')
 
     def depart_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         self.body.append('\n.ce 0\n')
 
     def visit_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_toctree(self, node):
-        # type: (addnodes.toctree) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_index(self, node):
-        # type: (addnodes.index) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_tabular_col_spec(self, node):
-        # type: (addnodes.tabular_col_spec) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         bullet_list = cast(nodes.bullet_list, node[0])
         list_items = cast(Iterable[nodes.list_item], bullet_list)
         self.ensure_eol()
@@ -413,56 +413,56 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         raise nodes.SkipNode
 
     def visit_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.visit_bullet_list(node)
 
     def depart_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         self.depart_bullet_list(node)
 
     def visit_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         return self.visit_emphasis(node)
 
     def depart_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         return self.depart_emphasis(node)
 
     def visit_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         return self.visit_strong(node)
 
     def depart_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         return self.depart_strong(node)
 
     def visit_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         return self.visit_strong(node)
 
     def depart_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         return self.depart_strong(node)
 
     # overwritten: handle section titles better than in 0.6 release
     def visit_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, addnodes.seealso):
             self.body.append('.IP "')
             return
@@ -477,44 +477,44 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         return super(ManualPageTranslator, self).visit_title(node)
 
     def depart_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, addnodes.seealso):
             self.body.append('"\n')
             return
         return super(ManualPageTranslator, self).depart_title(node)
 
     def visit_raw(self, node):
-        # type: (nodes.raw) -> None
+        # type: (nodes.Element) -> None
         if 'manpage' in node.get('format', '').split():
             self.body.append(node.astext())
         raise nodes.SkipNode
 
     def visit_meta(self, node):
-        # type: (addnodes.meta) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_inline(self, node):
-        # type: (nodes.inline) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_inline(self, node):
-        # type: (nodes.inline) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_math(self, node):
-        # type: (nodes.math) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_math(self, node):
-        # type: (nodes.math) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_math_block(self, node):
-        # type: (nodes.math_block) -> None
+        # type: (nodes.Element) -> None
         self.visit_centered(node)
 
     def depart_math_block(self, node):
-        # type: (nodes.math_block) -> None
+        # type: (nodes.Element) -> None
         self.depart_centered(node)
 
     def unknown_visit(self, node):

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -467,11 +467,11 @@ class TextTranslator(SphinxTranslator):
         self.states[-1].extend(result)
 
     def visit_document(self, node):
-        # type: (nodes.document) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_document(self, node):
-        # type: (nodes.document) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
         self.body = self.nl.join(line and (' ' * indent + line)
                                  for indent, lines in self.states[0]
@@ -479,60 +479,60 @@ class TextTranslator(SphinxTranslator):
         # XXX header/footer?
 
     def visit_section(self, node):
-        # type: (nodes.section) -> None
+        # type: (nodes.Element) -> None
         self._title_char = self.sectionchars[self.sectionlevel]
         self.sectionlevel += 1
 
     def depart_section(self, node):
-        # type: (nodes.section) -> None
+        # type: (nodes.Element) -> None
         self.sectionlevel -= 1
 
     def visit_topic(self, node):
-        # type: (nodes.topic) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_topic(self, node):
-        # type: (nodes.topic) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     visit_sidebar = visit_topic
     depart_sidebar = depart_topic
 
     def visit_rubric(self, node):
-        # type: (nodes.rubric) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
         self.add_text('-[ ')
 
     def depart_rubric(self, node):
-        # type: (nodes.rubric) -> None
+        # type: (nodes.Element) -> None
         self.add_text(' ]-')
         self.end_state()
 
     def visit_compound(self, node):
-        # type: (nodes.compound) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_compound(self, node):
-        # type: (nodes.compound) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_glossary(self, node):
-        # type: (addnodes.glossary) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, nodes.Admonition):
             self.add_text(node.astext() + ': ')
             raise nodes.SkipNode
         self.new_state(0)
 
     def get_section_number_string(self, node):
-        # type: (nodes.Node) -> unicode
+        # type: (nodes.Element) -> unicode
         if isinstance(node.parent, nodes.section):
             anchorname = '#' + node.parent['ids'][0]
             numbers = self.builder.secnumbers.get(anchorname)
@@ -543,7 +543,7 @@ class TextTranslator(SphinxTranslator):
         return ''
 
     def depart_title(self, node):
-        # type: (nodes.title) -> None
+        # type: (nodes.Element) -> None
         if isinstance(node.parent, nodes.section):
             char = self._title_char
         else:
@@ -560,89 +560,89 @@ class TextTranslator(SphinxTranslator):
         self.states[-1].append((0, title))
 
     def visit_subtitle(self, node):
-        # type: (nodes.subtitle) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_subtitle(self, node):
-        # type: (nodes.subtitle) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_attribution(self, node):
-        # type: (nodes.attribution) -> None
+        # type: (nodes.Element) -> None
         self.add_text('-- ')
 
     def depart_attribution(self, node):
-        # type: (nodes.attribution) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc(self, node):
-        # type: (addnodes.desc) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_desc_signature(self, node):
-        # type: (addnodes.desc_signature) -> None
+        # type: (nodes.Element) -> None
         # XXX: wrap signatures in a way that makes sense
         self.end_state(wrap=False, end=None)
 
     def visit_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_signature_line(self, node):
-        # type: (addnodes.desc_signature_line) -> None
+        # type: (nodes.Element) -> None
         self.add_text('\n')
 
     def visit_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_name(self, node):
-        # type: (addnodes.desc_name) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_addname(self, node):
-        # type: (addnodes.desc_addname) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_type(self, node):
-        # type: (addnodes.desc_type) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         self.add_text(' -> ')
 
     def depart_desc_returns(self, node):
-        # type: (addnodes.desc_returns) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.add_text('(')
         self.first_param = 1
 
     def depart_desc_parameterlist(self, node):
-        # type: (addnodes.desc_parameterlist) -> None
+        # type: (nodes.Element) -> None
         self.add_text(')')
 
     def visit_desc_parameter(self, node):
-        # type: (addnodes.desc_parameter) -> None
+        # type: (nodes.Element) -> None
         if not self.first_param:
             self.add_text(', ')
         else:
@@ -651,48 +651,48 @@ class TextTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.add_text('[')
 
     def depart_desc_optional(self, node):
-        # type: (addnodes.desc_optional) -> None
+        # type: (nodes.Element) -> None
         self.add_text(']')
 
     def visit_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_desc_annotation(self, node):
-        # type: (addnodes.desc_annotation) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
         self.add_text(self.nl)
 
     def depart_desc_content(self, node):
-        # type: (addnodes.desc_content) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_figure(self, node):
-        # type: (nodes.figure) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
 
     def depart_figure(self, node):
-        # type: (nodes.figure) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_caption(self, node):
-        # type: (nodes.caption) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_productionlist(self, node):
-        # type: (addnodes.productionlist) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
         names = []
         productionlist = cast(Iterable[addnodes.production], node)
@@ -711,17 +711,17 @@ class TextTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_footnote(self, node):
-        # type: (nodes.footnote) -> None
+        # type: (nodes.Element) -> None
         label = cast(nodes.label, node[0])
         self._footnote = label.astext().strip()
         self.new_state(len(self._footnote) + 3)
 
     def depart_footnote(self, node):
-        # type: (nodes.footnote) -> None
+        # type: (nodes.Element) -> None
         self.end_state(first='[%s] ' % self._footnote)
 
     def visit_citation(self, node):
-        # type: (nodes.citation) -> None
+        # type: (nodes.Element) -> None
         if len(node) and isinstance(node[0], nodes.label):
             self._citlabel = node[0].astext()
         else:
@@ -729,133 +729,133 @@ class TextTranslator(SphinxTranslator):
         self.new_state(len(self._citlabel) + 3)
 
     def depart_citation(self, node):
-        # type: (nodes.citation) -> None
+        # type: (nodes.Element) -> None
         self.end_state(first='[%s] ' % self._citlabel)
 
     def visit_label(self, node):
-        # type: (nodes.label) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_legend(self, node):
-        # type: (nodes.legend) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_legend(self, node):
-        # type: (nodes.legend) -> None
+        # type: (nodes.Element) -> None
         pass
 
     # XXX: option list could use some better styling
 
     def visit_option_list(self, node):
-        # type: (nodes.option_list) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_option_list(self, node):
-        # type: (nodes.option_list) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_option_list_item(self, node):
-        # type: (nodes.option_list_item) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_option_list_item(self, node):
-        # type: (nodes.option_list_item) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_option_group(self, node):
-        # type: (nodes.option_group) -> None
+        # type: (nodes.Element) -> None
         self._firstoption = True
 
     def depart_option_group(self, node):
-        # type: (nodes.option_group) -> None
+        # type: (nodes.Element) -> None
         self.add_text('     ')
 
     def visit_option(self, node):
-        # type: (nodes.option) -> None
+        # type: (nodes.Element) -> None
         if self._firstoption:
             self._firstoption = False
         else:
             self.add_text(', ')
 
     def depart_option(self, node):
-        # type: (nodes.option) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_option_string(self, node):
-        # type: (nodes.option_string) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_option_string(self, node):
-        # type: (nodes.option_string) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_option_argument(self, node):
-        # type: (nodes.option_argument) -> None
+        # type: (nodes.Element) -> None
         self.add_text(node['delimiter'])
 
     def depart_option_argument(self, node):
-        # type: (nodes.option_argument) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_description(self, node):
-        # type: (nodes.description) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_description(self, node):
-        # type: (nodes.description) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_tabular_col_spec(self, node):
-        # type: (addnodes.tabular_col_spec) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_colspec(self, node):
-        # type: (nodes.colspec) -> None
+        # type: (nodes.Element) -> None
         self.table.colwidth.append(node["colwidth"])
         raise nodes.SkipNode
 
     def visit_tgroup(self, node):
-        # type: (nodes.tgroup) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_tgroup(self, node):
-        # type: (nodes.tgroup) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_thead(self, node):
-        # type: (nodes.thead) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_thead(self, node):
-        # type: (nodes.thead) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_tbody(self, node):
-        # type: (nodes.tbody) -> None
+        # type: (nodes.Element) -> None
         self.table.set_separator()
 
     def depart_tbody(self, node):
-        # type: (nodes.tbody) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_row(self, node):
-        # type: (nodes.row) -> None
+        # type: (nodes.Element) -> None
         if self.table.lines:
             self.table.add_row()
 
     def depart_row(self, node):
-        # type: (nodes.row) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_entry(self, node):
-        # type: (nodes.entry) -> None
+        # type: (nodes.Element) -> None
         self.entry = Cell(
             rowspan=node.get("morerows", 0) + 1, colspan=node.get("morecols", 0) + 1
         )
         self.new_state(0)
 
     def depart_entry(self, node):
-        # type: (nodes.entry) -> None
+        # type: (nodes.Element) -> None
         text = self.nl.join(self.nl.join(x[1]) for x in self.states.pop())
         self.stateindent.pop()
         self.entry.text = text
@@ -863,20 +863,20 @@ class TextTranslator(SphinxTranslator):
         self.entry = None
 
     def visit_table(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         if self.table:
             raise NotImplementedError('Nested tables are not supported.')
         self.new_state(0)
         self.table = Table()
 
     def depart_table(self, node):
-        # type: (nodes.table) -> None
+        # type: (nodes.Element) -> None
         self.add_text(str(self.table))
         self.table = None
         self.end_state(wrap=False)
 
     def visit_acks(self, node):
-        # type: (addnodes.acks) -> None
+        # type: (nodes.Element) -> None
         bullet_list = cast(nodes.bullet_list, node[0])
         list_items = cast(Iterable[nodes.list_item], bullet_list)
         self.new_state(0)
@@ -885,14 +885,14 @@ class TextTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_image(self, node):
-        # type: (nodes.image) -> None
+        # type: (nodes.Element) -> None
         if 'alt' in node.attributes:
             self.add_text(_('[image: %s]') % node['alt'])
         self.add_text(_('[image]'))
         raise nodes.SkipNode
 
     def visit_transition(self, node):
-        # type: (nodes.transition) -> None
+        # type: (nodes.Element) -> None
         indent = sum(self.stateindent)
         self.new_state(0)
         self.add_text('=' * (MAXWIDTH - indent))
@@ -900,31 +900,31 @@ class TextTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_bullet_list(self, node):
-        # type: (nodes.bullet_list) -> None
+        # type: (nodes.Element) -> None
         self.list_counter.append(-1)
 
     def depart_bullet_list(self, node):
-        # type: (nodes.bullet_list) -> None
+        # type: (nodes.Element) -> None
         self.list_counter.pop()
 
     def visit_enumerated_list(self, node):
-        # type: (nodes.enumerated_list) -> None
+        # type: (nodes.Element) -> None
         self.list_counter.append(node.get('start', 1) - 1)
 
     def depart_enumerated_list(self, node):
-        # type: (nodes.enumerated_list) -> None
+        # type: (nodes.Element) -> None
         self.list_counter.pop()
 
     def visit_definition_list(self, node):
-        # type: (nodes.definition_list) -> None
+        # type: (nodes.Element) -> None
         self.list_counter.append(-2)
 
     def depart_definition_list(self, node):
-        # type: (nodes.definition_list) -> None
+        # type: (nodes.Element) -> None
         self.list_counter.pop()
 
     def visit_list_item(self, node):
-        # type: (nodes.list_item) -> None
+        # type: (nodes.Element) -> None
         if self.list_counter[-1] == -1:
             # bullet list
             self.new_state(2)
@@ -937,7 +937,7 @@ class TextTranslator(SphinxTranslator):
             self.new_state(len(str(self.list_counter[-1])) + 2)
 
     def depart_list_item(self, node):
-        # type: (nodes.list_item) -> None
+        # type: (nodes.Element) -> None
         if self.list_counter[-1] == -1:
             self.end_state(first='* ')
         elif self.list_counter[-1] == -2:
@@ -946,103 +946,103 @@ class TextTranslator(SphinxTranslator):
             self.end_state(first='%s. ' % self.list_counter[-1])
 
     def visit_definition_list_item(self, node):
-        # type: (nodes.definition_list_item) -> None
+        # type: (nodes.Element) -> None
         self._classifier_count_in_li = len(node.traverse(nodes.classifier))
 
     def depart_definition_list_item(self, node):
-        # type: (nodes.definition_list_item) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_term(self, node):
-        # type: (nodes.term) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_term(self, node):
-        # type: (nodes.term) -> None
+        # type: (nodes.Element) -> None
         if not self._classifier_count_in_li:
             self.end_state(end=None)
 
     def visit_classifier(self, node):
-        # type: (nodes.classifier) -> None
+        # type: (nodes.Element) -> None
         self.add_text(' : ')
 
     def depart_classifier(self, node):
-        # type: (nodes.classifier) -> None
+        # type: (nodes.Element) -> None
         self._classifier_count_in_li -= 1
         if not self._classifier_count_in_li:
             self.end_state(end=None)
 
     def visit_definition(self, node):
-        # type: (nodes.definition) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
 
     def depart_definition(self, node):
-        # type: (nodes.definition) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_field_list(self, node):
-        # type: (nodes.field_list) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_field_list(self, node):
-        # type: (nodes.field_list) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_field(self, node):
-        # type: (nodes.field) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_field(self, node):
-        # type: (nodes.field) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_field_name(self, node):
-        # type: (nodes.field_name) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_field_name(self, node):
-        # type: (nodes.field_name) -> None
+        # type: (nodes.Element) -> None
         self.add_text(':')
         self.end_state(end=None)
 
     def visit_field_body(self, node):
-        # type: (nodes.field_body) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
 
     def depart_field_body(self, node):
-        # type: (nodes.field_body) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_centered(self, node):
-        # type: (addnodes.centered) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_hlist(self, node):
-        # type: (addnodes.hlist) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_hlistcol(self, node):
-        # type: (addnodes.hlistcol) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_admonition(self, node):
-        # type: (nodes.admonition) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_admonition(self, node):
-        # type: (nodes.admonition) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def _visit_admonition(self, node):
@@ -1079,210 +1079,210 @@ class TextTranslator(SphinxTranslator):
     depart_seealso = _depart_admonition
 
     def visit_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_versionmodified(self, node):
-        # type: (addnodes.versionmodified) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_literal_block(self, node):
-        # type: (nodes.literal_block) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
 
     def depart_literal_block(self, node):
-        # type: (nodes.literal_block) -> None
+        # type: (nodes.Element) -> None
         self.end_state(wrap=False)
 
     def visit_doctest_block(self, node):
-        # type: (nodes.doctest_block) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
 
     def depart_doctest_block(self, node):
-        # type: (nodes.doctest_block) -> None
+        # type: (nodes.Element) -> None
         self.end_state(wrap=False)
 
     def visit_line_block(self, node):
-        # type: (nodes.line_block) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
         self.lineblocklevel += 1
 
     def depart_line_block(self, node):
-        # type: (nodes.line_block) -> None
+        # type: (nodes.Element) -> None
         self.lineblocklevel -= 1
         self.end_state(wrap=False, end=None)
         if not self.lineblocklevel:
             self.add_text('\n')
 
     def visit_line(self, node):
-        # type: (nodes.line) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_line(self, node):
-        # type: (nodes.line) -> None
+        # type: (nodes.Element) -> None
         self.add_text('\n')
 
     def visit_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
 
     def depart_block_quote(self, node):
-        # type: (nodes.block_quote) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def visit_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_compact_paragraph(self, node):
-        # type: (addnodes.compact_paragraph) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_paragraph(self, node):
-        # type: (nodes.paragraph) -> None
+        # type: (nodes.Element) -> None
         if not isinstance(node.parent, nodes.Admonition) or \
            isinstance(node.parent, addnodes.seealso):
             self.new_state(0)
 
     def depart_paragraph(self, node):
-        # type: (nodes.paragraph) -> None
+        # type: (nodes.Element) -> None
         if not isinstance(node.parent, nodes.Admonition) or \
            isinstance(node.parent, addnodes.seealso):
             self.end_state()
 
     def visit_target(self, node):
-        # type: (nodes.target) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_index(self, node):
-        # type: (addnodes.index) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_toctree(self, node):
-        # type: (addnodes.toctree) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_pending_xref(self, node):
-        # type: (addnodes.pending_xref) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_pending_xref(self, node):
-        # type: (addnodes.pending_xref) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         if self.add_secnumbers:
             numbers = node.get("secnumber")
             if numbers is not None:
                 self.add_text('.'.join(map(str, numbers)) + self.secnumber_suffix)
 
     def depart_reference(self, node):
-        # type: (nodes.reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_number_reference(self, node):
-        # type: (addnodes.number_reference) -> None
+        # type: (nodes.Element) -> None
         text = nodes.Text(node.get('title', '#'))
         self.visit_Text(text)
         raise nodes.SkipNode
 
     def visit_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_download_reference(self, node):
-        # type: (addnodes.download_reference) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_emphasis(self, node):
-        # type: (nodes.emphasis) -> None
+        # type: (nodes.Element) -> None
         self.add_text('*')
 
     def depart_emphasis(self, node):
-        # type: (nodes.emphasis) -> None
+        # type: (nodes.Element) -> None
         self.add_text('*')
 
     def visit_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         self.add_text('*')
 
     def depart_literal_emphasis(self, node):
-        # type: (addnodes.literal_emphasis) -> None
+        # type: (nodes.Element) -> None
         self.add_text('*')
 
     def visit_strong(self, node):
-        # type: (nodes.strong) -> None
+        # type: (nodes.Element) -> None
         self.add_text('**')
 
     def depart_strong(self, node):
-        # type: (nodes.strong) -> None
+        # type: (nodes.Element) -> None
         self.add_text('**')
 
     def visit_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         self.add_text('**')
 
     def depart_literal_strong(self, node):
-        # type: (addnodes.literal_strong) -> None
+        # type: (nodes.Element) -> None
         self.add_text('**')
 
     def visit_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         self.add_text('')
 
     def depart_abbreviation(self, node):
-        # type: (nodes.abbreviation) -> None
+        # type: (nodes.Element) -> None
         if node.hasattr('explanation'):
             self.add_text(' (%s)' % node['explanation'])
 
     def visit_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         return self.visit_literal_emphasis(node)
 
     def depart_manpage(self, node):
-        # type: (addnodes.manpage) -> None
+        # type: (nodes.Element) -> None
         return self.depart_literal_emphasis(node)
 
     def visit_title_reference(self, node):
-        # type: (nodes.title_reference) -> None
+        # type: (nodes.Element) -> None
         self.add_text('*')
 
     def depart_title_reference(self, node):
-        # type: (nodes.title_reference) -> None
+        # type: (nodes.Element) -> None
         self.add_text('*')
 
     def visit_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         self.add_text('"')
 
     def depart_literal(self, node):
-        # type: (nodes.literal) -> None
+        # type: (nodes.Element) -> None
         self.add_text('"')
 
     def visit_subscript(self, node):
-        # type: (nodes.subscript) -> None
+        # type: (nodes.Element) -> None
         self.add_text('_')
 
     def depart_subscript(self, node):
-        # type: (nodes.subscript) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_superscript(self, node):
-        # type: (nodes.superscript) -> None
+        # type: (nodes.Element) -> None
         self.add_text('^')
 
     def depart_superscript(self, node):
-        # type: (nodes.superscript) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_footnote_reference(self, node):
-        # type: (nodes.footnote_reference) -> None
+        # type: (nodes.Element) -> None
         self.add_text('[%s]' % node.astext())
         raise nodes.SkipNode
 
     def visit_citation_reference(self, node):
-        # type: (nodes.citation_reference) -> None
+        # type: (nodes.Element) -> None
         self.add_text('[%s]' % node.astext())
         raise nodes.SkipNode
 
@@ -1295,57 +1295,57 @@ class TextTranslator(SphinxTranslator):
         pass
 
     def visit_generated(self, node):
-        # type: (nodes.generated) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_generated(self, node):
-        # type: (nodes.generated) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_inline(self, node):
-        # type: (nodes.inline) -> None
+        # type: (nodes.Element) -> None
         if 'xref' in node['classes'] or 'term' in node['classes']:
             self.add_text('*')
 
     def depart_inline(self, node):
-        # type: (nodes.inline) -> None
+        # type: (nodes.Element) -> None
         if 'xref' in node['classes'] or 'term' in node['classes']:
             self.add_text('*')
 
     def visit_container(self, node):
-        # type: (nodes.container) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_container(self, node):
-        # type: (nodes.container) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_problematic(self, node):
-        # type: (nodes.problematic) -> None
+        # type: (nodes.Element) -> None
         self.add_text('>>')
 
     def depart_problematic(self, node):
-        # type: (nodes.problematic) -> None
+        # type: (nodes.Element) -> None
         self.add_text('<<')
 
     def visit_system_message(self, node):
-        # type: (nodes.system_message) -> None
+        # type: (nodes.Element) -> None
         self.new_state(0)
         self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
         self.end_state()
         raise nodes.SkipNode
 
     def visit_comment(self, node):
-        # type: (nodes.comment) -> None
+        # type: (nodes.Element) -> None
         raise nodes.SkipNode
 
     def visit_meta(self, node):
-        # type: (addnodes.meta) -> None
+        # type: (nodes.Element) -> None
         # only valid for HTML
         raise nodes.SkipNode
 
     def visit_raw(self, node):
-        # type: (nodes.raw) -> None
+        # type: (nodes.Element) -> None
         if 'text' in node.get('format', '').split():
             self.new_state(0)
             self.add_text(node.astext())
@@ -1353,19 +1353,19 @@ class TextTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_math(self, node):
-        # type: (nodes.math) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def depart_math(self, node):
-        # type: (nodes.math) -> None
+        # type: (nodes.Element) -> None
         pass
 
     def visit_math_block(self, node):
-        # type: (nodes.math_block) -> None
+        # type: (nodes.Element) -> None
         self.new_state()
 
     def depart_math_block(self, node):
-        # type: (nodes.math_block) -> None
+        # type: (nodes.Element) -> None
         self.end_state()
 
     def unknown_visit(self, node):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
To follow docutils-stubs rule, we use nodes.Element for
visitor/departure methods.
