### PR TITLE
Fix regression regarding LaTeX table of contents name (refs: #5683)

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -683,8 +683,9 @@ class LaTeXTranslator(SphinxTranslator):
                                            minsecnumdepth
 
         contentsname = self.settings.contentsname
-        self.elements['contentsname'] = self.babel_renewcommand('\\contentsname',
-                                                                contentsname)
+        if contentsname:
+            self.elements['contentsname'] = self.babel_renewcommand('\\contentsname',
+                                                                    contentsname)
 
         if self.elements['maxlistdepth']:
             self.elements['sphinxpkgoptions'] += (',maxlistdepth=%s' %


### PR DESCRIPTION
Our [documentation in PDF format](https://media.readthedocs.org/pdf/sphinx/master/sphinx.pdf) at www.sphinx-doc.org on master branch has "None" in place of "Contents" as title of the table of contents.

### Relates
- #5683

