### PR TITLE
refactor: Replace six.integer_types by int

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 from os import path, getenv
 from typing import Any, NamedTuple, Union
 
-from six import text_type, integer_types
+from six import text_type
 
 from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
 from sphinx.errors import ConfigError, ExtensionError
@@ -224,7 +224,7 @@ class Config:
                                  (name, name + '.key=value'))
             elif isinstance(defvalue, list):
                 return value.split(',')
-            elif isinstance(defvalue, integer_types):
+            elif isinstance(defvalue, int):
                 try:
                     return int(value)
                 except ValueError:

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -12,8 +12,6 @@
 
 import re
 
-from six import integer_types
-
 if False:
     # For type annotation
     from typing import Any, Dict, IO, List, Match, Union  # NOQA
@@ -95,7 +93,7 @@ def dumps(obj, key=False):
         return 'null'
     elif obj is True or obj is False:
         return obj and 'true' or 'false'
-    elif isinstance(obj, integer_types + (float,)):  # type: ignore
+    elif isinstance(obj, (int, float)):
         return str(obj)
     elif isinstance(obj, dict):
         return '{%s}' % ','.join(sorted('%s:%s' % (


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To stop to use six module
