### PR TITLE
refactor: Replace six.add_metaclass by __metaclass_ attribute

### DIFF
--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -2,7 +2,7 @@
 
 import enum
 
-from six import StringIO, add_metaclass
+from six import StringIO
 
 from sphinx.util import save_traceback  # NOQA
 
@@ -45,9 +45,9 @@ class CustomDataDescriptorMeta(type):
     """Descriptor metaclass docstring."""
 
 
-@add_metaclass(CustomDataDescriptorMeta)
 class CustomDataDescriptor2(CustomDataDescriptor):
     """Descriptor class with custom metaclass docstring."""
+    __metaclass__ = CustomDataDescriptorMeta
 
 
 def _funky_classmethod(name, b, c, d, docstring=None):

--- a/tests/roots/test-root/autodoc_target.py
+++ b/tests/roots/test-root/autodoc_target.py
@@ -2,7 +2,7 @@
 
 import enum
 
-from six import StringIO, add_metaclass
+from six import StringIO
 
 
 __all__ = ['Class']
@@ -43,9 +43,9 @@ class CustomDataDescriptorMeta(type):
     """Descriptor metaclass docstring."""
 
 
-@add_metaclass(CustomDataDescriptorMeta)
 class CustomDataDescriptor2(CustomDataDescriptor):
     """Descriptor class with custom metaclass docstring."""
+    __metaclass__ = CustomDataDescriptorMeta
 
 
 def _funky_classmethod(name, b, c, d, docstring=None):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To stop to use six module
