### PR TITLE
refactor: Replace six.UserString by collections.UserString

### DIFF
--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -12,11 +12,10 @@
 import gettext
 import locale
 import warnings
-from collections import defaultdict
+from collections import UserString, defaultdict
 from gettext import NullTranslations
 
 from six import text_type
-from six.moves import UserString
 
 from sphinx.deprecation import RemovedInSphinx30Warning
 

--- a/sphinx/util/jsonimpl.py
+++ b/sphinx/util/jsonimpl.py
@@ -10,9 +10,9 @@
 """
 
 import json
+from collections import UserString
 
 from six import text_type
-from six.moves import UserString
 
 if False:
     # For type annotation


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To stop to use six module
