### PR TITLE
Replace EnvironmentError and IOError by OSError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -78,7 +78,9 @@ Deprecated
 * ``sphinx.util.get_matching_docs()``
 * ``sphinx.util.inspect.Parameter``
 * ``sphinx.util.osutil.EEXIST``
+* ``sphinx.util.osutil.EINVAL``
 * ``sphinx.util.osutil.ENOENT``
+* ``sphinx.util.osutil.EPIPE``
 * ``sphinx.util.osutil.walk()``
 * ``sphinx.util.PeekableIterator``
 * ``sphinx.util.pycompat.UnicodeMixin``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -227,10 +227,20 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``errno.EEXIST`` or ``FileExistsError``
 
+   * - ``sphinx.util.osutil.EINVAL``
+     - 2.0
+     - 4.0
+     - ``errno.EINVAL``
+
    * - ``sphinx.util.osutil.ENOENT``
      - 2.0
      - 4.0
      - ``errno.ENOENT`` or ``FileNotFoundError``
+
+   * - ``sphinx.util.osutil.EPIPE``
+     - 2.0
+     - 4.0
+     - ``errno.ENOENT`` or ``BrokenPipeError``
 
    * - ``sphinx.util.osutil.walk()``
      - 2.0

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -411,14 +411,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
             dest = self.images[src]
             try:
                 img = Image.open(path.join(self.srcdir, src))
-            except IOError:
+            except OSError:
                 if not self.is_vector_graphics(src):
                     logger.warning(__('cannot read image file %r: copying it instead'),
                                    path.join(self.srcdir, src))
                 try:
                     copyfile(path.join(self.srcdir, src),
                              path.join(self.outdir, self.imagedir, dest))
-                except (IOError, OSError) as err:
+                except OSError as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
                 continue
@@ -434,7 +434,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                     img = img.resize((nw, nh), Image.BICUBIC)
             try:
                 img.save(path.join(self.outdir, self.imagedir, dest))
-            except (IOError, OSError) as err:
+            except OSError as err:
                 logger.warning(__('cannot write image file %r: %s'),
                                path.join(self.srcdir, src), err)
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -419,7 +419,7 @@ class StandaloneHTMLBuilder(Builder):
                 return
         except ValueError as exc:
             logger.warning(__('Failed to read build info file: %r'), exc)
-        except IOError:
+        except OSError:
             # ignore errors on reading
             pass
 
@@ -441,7 +441,7 @@ class StandaloneHTMLBuilder(Builder):
                                template_mtime)
                 if srcmtime > targetmtime:
                     yield docname
-            except EnvironmentError:
+            except OSError:
                 # source doesn't exist anymore
                 pass
 
@@ -817,7 +817,7 @@ class StandaloneHTMLBuilder(Builder):
                     dest = path.join(self.outdir, '_downloads', self.env.dlfiles[src][1])
                     ensuredir(path.dirname(dest))
                     copyfile(path.join(self.srcdir, src), dest)
-                except EnvironmentError as err:
+                except OSError as err:
                     logger.warning(__('cannot copy downloadable file %r: %s'),
                                    path.join(self.srcdir, src), err)
 
@@ -883,9 +883,7 @@ class StandaloneHTMLBuilder(Builder):
                     copyfile(path.join(self.confdir, self.config.html_favicon),
                              icontarget)
             logger.info('done')
-        except EnvironmentError as err:
-            # TODO: In py3, EnvironmentError (and IOError) was merged into OSError.
-            # So it should be replaced by IOError on dropping py2 support
+        except OSError as err:
             logger.warning(__('cannot copy static file %r'), err)
 
     def copy_extra_files(self):
@@ -903,7 +901,7 @@ class StandaloneHTMLBuilder(Builder):
 
                 copy_asset(entry, self.outdir, excluded)
             logger.info(__('done'))
-        except EnvironmentError as err:
+        except OSError as err:
             logger.warning(__('cannot copy extra file %r'), err)
 
     def write_buildinfo(self):
@@ -911,7 +909,7 @@ class StandaloneHTMLBuilder(Builder):
         try:
             with open(path.join(self.outdir, '.buildinfo'), 'w') as fp:
                 self.build_info.dump(fp)
-        except IOError as exc:
+        except OSError as exc:
             logger.warning(__('Failed to write build info file: %r'), exc)
 
     def cleanup(self):
@@ -957,7 +955,7 @@ class StandaloneHTMLBuilder(Builder):
             else:
                 with open(searchindexfn, 'rb') as fb:
                     self.indexer.load(fb, self.indexer_format)
-        except (IOError, OSError, ValueError):
+        except (OSError, ValueError):
             if keep:
                 logger.warning(__('search index couldn\'t be loaded, but not all '
                                   'documents will be built: the index will be '
@@ -1142,7 +1140,7 @@ class StandaloneHTMLBuilder(Builder):
             with open(outfilename, 'w', encoding=ctx['encoding'],
                       errors='xmlcharrefreplace') as f:
                 f.write(output)
-        except (IOError, OSError) as err:
+        except OSError as err:
             logger.warning(__("error writing file %s: %s"), outfilename, err)
         if self.copysource and ctx.get('sourcename'):
             # copy the source file for the "show source" link

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -189,7 +189,7 @@ class TexinfoBuilder(Builder):
         logger.info(fn, nonl=1)
         try:
             copy_asset_file(os.path.join(template_dir, 'Makefile'), fn)
-        except (IOError, OSError) as err:
+        except OSError as err:
             logger.warning(__("error writing file %s: %s"), fn, err)
         logger.info(__(' done'))
 

--- a/sphinx/builders/text.py
+++ b/sphinx/builders/text.py
@@ -58,7 +58,7 @@ class TextBuilder(Builder):
                 srcmtime = path.getmtime(self.env.doc2path(docname))
                 if srcmtime > targetmtime:
                     yield docname
-            except EnvironmentError:
+            except OSError:
                 # source doesn't exist anymore
                 pass
 
@@ -81,7 +81,7 @@ class TextBuilder(Builder):
         try:
             with open(outfilename, 'w', encoding='utf-8') as f:
                 f.write(self.writer.output)
-        except (IOError, OSError) as err:
+        except OSError as err:
             logger.warning(__("error writing file %s: %s"), outfilename, err)
 
     def finish(self):

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -62,7 +62,7 @@ class XMLBuilder(Builder):
                 srcmtime = path.getmtime(self.env.doc2path(docname))
                 if srcmtime > targetmtime:
                     yield docname
-            except EnvironmentError:
+            except OSError:
                 # source doesn't exist anymore
                 pass
 
@@ -95,7 +95,7 @@ class XMLBuilder(Builder):
         try:
             with open(outfilename, 'w', encoding='utf-8') as f:
                 f.write(self.writer.output)
-        except (IOError, OSError) as err:
+        except OSError as err:
             logger.warning(__("error writing file %s: %s"), outfilename, err)
 
     def finish(self):

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -219,8 +219,8 @@ class LiteralIncludeReader:
                     text = text.expandtabs(self.options['tab-width'])
 
                 return text.splitlines(True)
-        except (IOError, OSError):
-            raise IOError(__('Include file %r not found or reading it failed') % filename)
+        except OSError:
+            raise OSError(__('Include file %r not found or reading it failed') % filename)
         except UnicodeError:
             raise UnicodeError(__('Encoding %r used for reading included file %r seems to '
                                   'be wrong, try giving an :encoding: option') %

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -140,7 +140,7 @@ class Domain:
     build process starts, every active domain is instantiated and given the
     environment object; the `domaindata` dict must then either be nonexistent or
     a dictionary whose 'version' key is equal to the domain class'
-    :attr:`data_version` attribute.  Otherwise, `IOError` is raised and the
+    :attr:`data_version` attribute.  Otherwise, `OSError` is raised and the
     pickled environment is discarded.
     """
 
@@ -190,7 +190,7 @@ class Domain:
         else:
             self.data = env.domaindata[self.name]
             if self.data['version'] != self.data_version:
-                raise IOError('data of %r domain out of date' % self.label)
+                raise OSError('data of %r domain out of date' % self.label)
         for name, obj in self.object_types.items():
             for rolename in obj.roles:
                 self._role2type.setdefault(rolename, []).append(name)

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -408,7 +408,7 @@ class BuildEnvironment:
                         self.config.gettext_compact)
                     for filename in catalog_files:
                         self.dependencies[docname].add(filename)
-        except EnvironmentError as exc:
+        except OSError as exc:
             raise DocumentError(__('Failed to scan documents in %s: %r') % (self.srcdir, exc))
 
     def get_outdated_files(self, config_changed):
@@ -455,7 +455,7 @@ class BuildEnvironment:
                         if depmtime > mtime:
                             changed.add(docname)
                             break
-                    except EnvironmentError:
+                    except OSError:
                         # give it another chance
                         changed.add(docname)
                         break
@@ -723,7 +723,7 @@ class BuildEnvironment:
         except Exception as exc:
             # This can happen for example when the pickle is from a
             # different version of Sphinx.
-            raise IOError(exc)
+            raise OSError(exc)
         if app:
             env.app = app
             env.config.values = app.config.values

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -103,7 +103,7 @@ class ImageCollector(EnvironmentCollector):
                 mimetype = guess_mimetype(filename)
                 if mimetype not in candidates:
                     globbed.setdefault(mimetype, []).append(new_imgpath)
-            except (OSError, IOError) as err:
+            except OSError as err:
                 logger.warning(__('image file %s not readable: %s') % (filename, err),
                                location=node, type='image', subtype='not_readable')
         for key, files in globbed.items():

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -26,7 +26,7 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.fileutil import copy_asset
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.nodes import set_source_info
-from sphinx.util.osutil import ensuredir, EPIPE, EINVAL
+from sphinx.util.osutil import ensuredir
 
 if False:
     # For type annotation
@@ -144,7 +144,7 @@ class Graphviz(SphinxDirective):
             try:
                 with open(filename, encoding='utf-8') as fp:
                     dotcode = fp.read()
-            except (IOError, OSError):
+            except OSError:
                 return [document.reporter.warning(
                     __('External Graphviz file %r not found or reading '
                        'it failed') % filename, line=self.lineno)]
@@ -256,9 +256,7 @@ def render_dot(self, code, options, format, prefix='graphviz'):
         # Graphviz may close standard input when an error occurs,
         # resulting in a broken pipe on communicate()
         stdout, stderr = p.communicate(code.encode())
-    except (OSError, IOError) as err:
-        if err.errno not in (EPIPE, EINVAL):
-            raise
+    except BrokenPipeError:
         # in this case, read the standard output and standard error streams
         # directly, to get the error message(s)
         stdout, stderr = p.stdout.read(), p.stderr.read()

--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -14,7 +14,6 @@ from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.transforms.post_transforms.images import ImageConverter
 from sphinx.util import logging
-from sphinx.util.osutil import EPIPE, EINVAL
 
 if False:
     # For type annotation
@@ -39,7 +38,7 @@ class ImagemagickConverter(ImageConverter):
             args = [self.config.image_converter, '-version']
             logger.debug('Invoking %r ...', args)
             p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        except (OSError, IOError):
+        except OSError:
             logger.warning(__('convert command %r cannot be run.'
                               'check the image_converter setting'),
                            self.config.image_converter)
@@ -47,9 +46,7 @@ class ImagemagickConverter(ImageConverter):
 
         try:
             stdout, stderr = p.communicate()
-        except (OSError, IOError) as err:
-            if err.errno not in (EPIPE, EINVAL):
-                raise
+        except BrokenPipeError:
             stdout, stderr = p.stdout.read(), p.stderr.read()
             p.wait()
         if p.returncode != 0:
@@ -82,9 +79,7 @@ class ImagemagickConverter(ImageConverter):
 
         try:
             stdout, stderr = p.communicate()
-        except (OSError, IOError) as err:
-            if err.errno not in (EPIPE, EINVAL):
-                raise
+        except BrokenPipeError:
             stdout, stderr = p.stdout.read(), p.stderr.read()
             p.wait()
         if p.returncode != 0:

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -29,8 +29,8 @@ if False:
 # Errnos that we need.
 EEXIST = getattr(errno, 'EEXIST', 0)  # RemovedInSphinx40Warning
 ENOENT = getattr(errno, 'ENOENT', 0)  # RemovedInSphinx40Warning
-EPIPE = getattr(errno, 'EPIPE', 0)
-EINVAL = getattr(errno, 'EINVAL', 0)
+EPIPE = getattr(errno, 'EPIPE', 0)    # RemovedInSphinx40Warning
+EINVAL = getattr(errno, 'EINVAL', 0)  # RemovedInSphinx40Warning
 
 # SEP separates path elements in the canonical file names
 #
@@ -97,7 +97,7 @@ def mtimes_of_files(dirnames, suffix):
                 if sfile.endswith(suffix):
                     try:
                         yield path.getmtime(path.join(root, sfile))
-                    except EnvironmentError:
+                    except OSError:
                         pass
 
 
@@ -257,7 +257,7 @@ class FileAvoidWrite:
                 old_content = old_f.read()
                 if old_content == buf:
                     return
-        except IOError:
+        except OSError:
             pass
 
         with open(self._path, 'w') as f:

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -169,7 +169,7 @@ class UIDTransform(SphinxTransform):
                 filename = path.join(env.doctreedir, env.docname + '.doctree')
                 with open(filename, 'rb') as f:
                     old_doctree = pickle.load(f)
-            except EnvironmentError:
+            except OSError:
                 pass
 
         # add uids for versioning


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
Since python 3.3, EnvironmentError and IOError were merged into OSError.
refs: https://docs.python.org/3/library/exceptions.html#OSError