### PR TITLE
refactor: Replace six.StringIO by io.StringIO

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -14,11 +14,10 @@ from __future__ import unicode_literals
 from codecs import open
 from collections import defaultdict, OrderedDict
 from datetime import datetime, tzinfo, timedelta
+from io import StringIO
 from os import path, walk, getenv
 from time import time
 from uuid import uuid4
-
-from six import StringIO
 
 from sphinx.builders import Builder
 from sphinx.domains.python import pairindextypes

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -16,13 +16,13 @@ import re
 import sys
 import time
 import warnings
+from io import StringIO
 from os import path
 
 from docutils import nodes
 from docutils.parsers.rst import directives
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 from packaging.version import Version
-from six import StringIO
 
 import sphinx
 from sphinx.builders import Builder

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -11,10 +11,8 @@
 from __future__ import print_function
 
 import re
-from io import BytesIO
+from io import BytesIO, StringIO
 from zipfile import ZipFile
-
-from six import StringIO
 
 from sphinx.errors import PycodeError
 from sphinx.pycode.parser import Parser

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -17,8 +17,7 @@ import os
 import sys
 from distutils.cmd import Command
 from distutils.errors import DistutilsOptionError, DistutilsExecError
-
-from six import StringIO
+from io import StringIO
 
 from sphinx.application import Sphinx
 from sphinx.cmd.build import handle_exception

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -14,10 +14,10 @@ import os
 import subprocess
 import sys
 from collections import namedtuple
+from io import StringIO
 from tempfile import gettempdir
 
 import pytest
-from six import StringIO
 
 from . import util
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -17,8 +17,7 @@ import re
 import sys
 import typing
 from functools import partial
-
-from six import StringIO
+from io import StringIO
 
 from sphinx.util import logging
 from sphinx.util.pycompat import NoneType

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import enum
-
-from six import StringIO
+from io import StringIO
 
 from sphinx.util import save_traceback  # NOQA
 

--- a/tests/roots/test-root/autodoc_target.py
+++ b/tests/roots/test-root/autodoc_target.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import enum
-
-from six import StringIO
+from io import StringIO
 
 
 __all__ = ['Class']

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -9,8 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+from io import StringIO
+
 import pytest
-from six import StringIO
 
 from sphinx.ext.autosummary import mangle_signature, import_by_name, extract_summary
 from sphinx.testing.util import etree_parse

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,8 +9,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+from io import StringIO
+
 import pytest
-from six import StringIO
 
 from sphinx.io import SphinxRSTFileInput
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -11,9 +11,10 @@
 
 import sys
 import time
+from io import StringIO
 
 import pytest
-from six import text_type, StringIO
+from six import text_type
 
 from sphinx import application
 from sphinx.cmd import quickstart as qs


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To remove six module
