### PR TITLE
Update deps: requests-2.5.0 or above

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Dependencies
 * LaTeX builder with :confval:`latex_engine` set to ``'xelatex'`` or to
   ``'lualatex'`` requires (by default) the ``FreeFont`` fonts,
   which in Ubuntu xenial are provided by package ``fonts-freefont-otf``.
+* requests 2.5.0 or above
 
 Incompatible changes
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'babel>=1.3,!=2.0',
     'alabaster>=0.7,<0.8',
     'imagesize',
-    'requests>=2.0.0',
+    'requests>=2.5.0',
     'setuptools',
     'packaging',
 ]

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -56,13 +56,6 @@ else:
     except (pkg_resources.DistributionNotFound,
             pkg_resources.VersionConflict):
         pass  # ignored
-    except pkg_resources.UnknownExtra:
-        warnings.warn(
-            'Some links may return broken results due to being unable to '
-            'check the Server Name Indication (SNI) in the returned SSL cert '
-            'against the hostname in the url requested. Recommended to '
-            'install requests-2.4.1+.'
-        )
 
 if False:
     # For type annotation


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Update deps: requests-2.5.0 or above
- 2.5.0 was released at Dec 2, 2014.
- At present, sphinx depends on requests-2.4.0 (mentioned in CHANGES)

  https://github.com/sphinx-doc/sphinx/blob/a1e845d964d3c6a4bc60c1676d97c7d24e434919/CHANGES#L1546-L1552

- Ubuntu-16.04 LTS provides 2.9.1
  - refs: https://packages.ubuntu.com/xenial/python-requests
