### PR TITLE
Latex turnoff lualatex ligatures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -108,6 +108,8 @@ Bugs fixed
 * #5248: LaTeX: Greek letters in section titles disappear from PDF bookmarks
 * #5772: LaTeX: should the Bjarne style of fncychap be used for English also
   if passed as language option?
+* #5179: LaTex: (lualatex only) escaping of ``>`` by ``\textgreater{}`` is not
+  enough, ``\textgreater{}\textgreater{}`` applies TeX-ligature
 
 Testing
 --------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2199,7 +2199,11 @@ information.
            Defaults to ``'\\usepackage{fontspec}'`` when
            :confval:`latex_engine` is ``'xelatex'``.
         .. versionchanged:: 1.6
-           ``'lualatex'`` also uses ``fontspec`` per default.
+           ``'lualatex'`` uses ``fontspec`` per default like ``'xelatex'``.
+        .. versionchanged:: 2.0
+           ``'lualatex'`` executes
+           ``\defaultfontfeatures[\rmfamily,\sffamily]{}`` to disable TeX
+           ligatures.
         .. versionchanged:: 2.0
            Detection of ``LGR``, ``T2A``, ``X2`` to trigger support of
            occasional Greek or Cyrillic (``'pdflatex'`` only, as this support

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -208,7 +208,7 @@ ADDITIONAL_SETTINGS = {
         'polyglossia':  '\\usepackage{polyglossia}',
         'babel':        '',
         'fontenc':     ('\\usepackage{fontspec}\n'
-                        '\\defaultfontfeatures[\rmfamily,\sffamily]{}'),
+                        '\\defaultfontfeatures[\\rmfamily,\\sffamily]{}'),
         'fontpkg':      LUALATEX_DEFAULT_FONTPKG,
         'textgreek':    '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -207,7 +207,8 @@ ADDITIONAL_SETTINGS = {
         'latex_engine': 'lualatex',
         'polyglossia':  '\\usepackage{polyglossia}',
         'babel':        '',
-        'fontenc':      '\\usepackage{fontspec}',
+        'fontenc':     ('\\usepackage{fontspec}\n'
+                        '\\defaultfontfeatures[\rmfamily,\sffamily]{}'),
         'fontpkg':      LUALATEX_DEFAULT_FONTPKG,
         'textgreek':    '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'


### PR DESCRIPTION
Closes: #5179. Notice that also `-{}-` mark-up (cf. https://github.com/sphinx-doc/sphinx/blob/415ebc15c59e8b2e7fd2eb1df76017a331f8b131/sphinx/util/texescape.py#L45-L46
where the invisible escaped character is a U+FEFF ZERO WIDTH NO-BREAK SPACE)
which prevents ligatures with pdflatex and xelatex does not prevent it with lualatex. This PR fixes that, too.

This is a bugfix but not applied to 1.8 branch because due to the fact LuaLaTeX is configured on 1.8 branch to not modify the default fonts (Latin Modern) chosen by `fontspec`, it would need different approach to turn off the automatic TeX ligatures, this PR works by disabling TeX ligatures for any font configured *after* loading of fontspec.

(besides the `fontspec` manual is obscure about exact syntax, it mentions ``..Off`` or ``No..`` variants which do not work at all, so it is quite a mess).

The method here is to not complicate our TeX escaping, keep it the same, but make sure fonts are loaded without the automatic ``Ligatures = TeX`` done by fontspec by default (LuaLaTeX contrarily to XeLaTeX applies ligature even if mark-up is like ``\textgreater{}\textgreater{}`` or ``-{}-``).

But this requires 2.0, because workaround needs that `\setmainfont`, `\setsansfont` are explicitly used at least once after loading `fontspec`, thus either by user custom choice of fonts, or Sphinx default font choice as done in ``LUALATEX_DEFAULT_FONTPKG``.