### PR TITLE
Deprecate UnicodeMixin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,7 @@ Deprecated
 * ``sphinx.util.osutil.ENOENT``
 * ``sphinx.util.osutil.walk()``
 * ``sphinx.util.PeekableIterator``
+* ``sphinx.util.pycompat.UnicodeMixin``
 * ``sphinx.util.pycompat.u``
 * ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
 * ``sphinx.writers.latex.TextTranslator._make_visit_admonition()``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -222,6 +222,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``os.walk()``
 
+   * - ``sphinx.util.pycompat.UnicodeMixin``
+     - 2.0
+     - 4.0
+     - N/A
+
    * - ``sphinx.util.pycompat.u``
      - 2.0
      - 4.0

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -26,7 +26,6 @@ from sphinx.util import logging
 from sphinx.util.docfields import Field, GroupedField
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import make_refnode
-from sphinx.util.pycompat import UnicodeMixin
 
 
 if False:
@@ -564,28 +563,28 @@ _id_explicit_cast = {
 }
 
 
-class NoOldIdError(UnicodeMixin, Exception):
+class NoOldIdError(Exception):
     # Used to avoid implementing unneeded id generation for old id schmes.
     def __init__(self, description=""):
         # type: (str) -> None
         self.description = description
 
-    def __unicode__(self):
+    def __str__(self):
         # type: () -> str
         return self.description
 
 
-class DefinitionError(UnicodeMixin, Exception):
+class DefinitionError(Exception):
     def __init__(self, description):
         # type: (str) -> None
         self.description = description
 
-    def __unicode__(self):
+    def __str__(self):
         # type: () -> str
         return self.description
 
 
-class _DuplicateSymbolError(UnicodeMixin, Exception):
+class _DuplicateSymbolError(Exception):
     def __init__(self, symbol, declaration):
         # type: (Symbol, Any) -> None
         assert symbol
@@ -593,12 +592,12 @@ class _DuplicateSymbolError(UnicodeMixin, Exception):
         self.symbol = symbol
         self.declaration = declaration
 
-    def __unicode__(self):
+    def __str__(self):
         # type: () -> str
         return "Internal C++ duplicate symbol error:\n%s" % self.symbol.dump(0)
 
 
-class ASTBase(UnicodeMixin):
+class ASTBase:
     def __eq__(self, other):
         # type: (Any) -> bool
         if type(self) is not type(other):
@@ -622,7 +621,7 @@ class ASTBase(UnicodeMixin):
         # type: (Callable[[Any], str]) -> str
         raise NotImplementedError(repr(self))
 
-    def __unicode__(self):
+    def __str__(self):
         # type: () -> str
         return self._stringify(lambda ast: text_type(ast))
 
@@ -789,7 +788,7 @@ class ASTNumberLiteral(ASTBase):
         signode.append(nodes.Text(txt, txt))
 
 
-class UnsupportedMultiCharacterCharLiteral(UnicodeMixin, Exception):
+class UnsupportedMultiCharacterCharLiteral(Exception):
     def __init__(self, decoded):
         self.decoded = decoded
 
@@ -1497,9 +1496,9 @@ class ASTIdentifier(ASTBase):
             else:
                 return text_type(len(self.identifier)) + self.identifier
 
-    # and this is where we finally make a difference between __unicode__ and the display string
+    # and this is where we finally make a difference between __str__ and the display string
 
-    def __unicode__(self):
+    def __str__(self):
         # type: () -> str
         return self.identifier
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -17,7 +17,6 @@ from functools import partial
 
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.locale import _
-from sphinx.util.pycompat import UnicodeMixin
 
 if False:
     # For type annotation
@@ -39,7 +38,7 @@ _enumerated_list_regex = re.compile(
     r'(?(paren)\)|\.)(\s+\S|\s*$)')
 
 
-class GoogleDocstring(UnicodeMixin):
+class GoogleDocstring:
     """Convert Google style docstrings to reStructuredText.
 
     Parameters
@@ -177,7 +176,7 @@ class GoogleDocstring(UnicodeMixin):
 
         self._parse()
 
-    def __unicode__(self):
+    def __str__(self):
         # type: () -> str
         """Return the parsed docstring in reStructuredText format.
 

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -80,10 +80,6 @@ class _TranslationProxy(UserString):
         # type: () -> str
         return str(self.data)
 
-    def __unicode__(self):
-        # type: () -> str
-        return text_type(self.data)
-
     def __add__(self, other):  # type: ignore
         # type: (str) -> str
         return self.data + other

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -10,12 +10,14 @@
 """
 
 import sys
+import warnings
 from html import escape as htmlescape  # NOQA
 from io import TextIOWrapper  # NOQA
 from textwrap import indent  # NOQA
 
 from six import text_type
 
+from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.locale import __
 from sphinx.util import logging
 
@@ -68,9 +70,13 @@ def convert_with_2to3(filepath):
 
 class UnicodeMixin:
     """Mixin class to handle defining the proper __str__/__unicode__
-    methods in Python 2 or 3."""
+    methods in Python 2 or 3.
 
+    .. deprecated:: 2.0
+    """
     def __str__(self):
+        warnings.warn('UnicodeMixin is deprecated',
+                      RemovedInSphinx40Warning, stacklevel=2)
         return self.__unicode__()
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `UnicodeMixin` is a helper for writing code working in both py2/py3.
- Since Sphinx-2.0, we dropped py2 support. As a result, the helper is not important for us.
