### PR TITLE
Replace pycompat.htmlescape() by html.escape()

### DIFF
--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
 import pipes
 import plistlib
 import shlex
@@ -24,7 +25,6 @@ from sphinx.util.console import bold  # type: ignore
 from sphinx.util.fileutil import copy_asset
 from sphinx.util.matching import Matcher
 from sphinx.util.osutil import copyfile, ensuredir, make_filename
-from sphinx.util.pycompat import htmlescape
 
 if False:
     # For type annotation
@@ -186,8 +186,8 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
         logger.info(bold(__('building access page...')), nonl=True)
         with open(path.join(language_dir, '_access.html'), 'w') as ft:
             ft.write(access_page_template % {
-                'toc': htmlescape(toc, quote=True),
-                'title': htmlescape(self.config.applehelp_title)
+                'toc': html.escape(toc, quote=True),
+                'title': html.escape(self.config.applehelp_title)
             })
         logger.info(__('done'))
 

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
 from os import path
 from typing import cast
 
@@ -21,7 +22,6 @@ from sphinx.util import logging
 from sphinx.util.console import bold  # type: ignore
 from sphinx.util.fileutil import copy_asset_file
 from sphinx.util.osutil import ensuredir, os_path
-from sphinx.util.pycompat import htmlescape
 
 if False:
     # For type annotation
@@ -123,7 +123,7 @@ class ChangesBuilder(Builder):
 
         def hl(no, line):
             # type: (int, str) -> str
-            line = '<a name="L%s"> </a>' % no + htmlescape(line)
+            line = '<a name="L%s"> </a>' % no + html.escape(line)
             for x in hltext:
                 if x in line:
                     line = '<span class="hl">%s</span>' % line
@@ -157,7 +157,7 @@ class ChangesBuilder(Builder):
 
     def hl(self, text, version):
         # type: (str, str) -> str
-        text = htmlescape(text)
+        text = html.escape(text)
         for directive in ['versionchanged', 'versionadded', 'deprecated']:
             text = text.replace('.. %s:: %s' % (directive, version),
                                 '<b>.. %s:: %s</b>' % (directive, version))

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
 import pickle
 import posixpath
 import re
@@ -50,7 +51,6 @@ from sphinx.util.matching import patmatch, Matcher, DOTFILES
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.osutil import SEP, os_path, relative_uri, ensuredir, \
     movefile, copyfile
-from sphinx.util.pycompat import htmlescape
 from sphinx.writers.html import HTMLWriter, HTMLTranslator
 
 if False:
@@ -1083,7 +1083,7 @@ class StandaloneHTMLBuilder(Builder):
             for key in sorted(css.attributes):
                 value = css.attributes[key]
                 if value is not None:
-                    attrs.append('%s="%s"' % (key, htmlescape(value, True)))
+                    attrs.append('%s="%s"' % (key, html.escape(value, True)))
             attrs.append('href="%s"' % pathto(css.filename, resource=True))
             return '<link %s />' % ' '.join(attrs)
         ctx['css_tag'] = css_tag
@@ -1578,7 +1578,7 @@ def setup_js_tag_helper(app, pagename, templatexname, context, doctree):
                     if key == 'body':
                         body = value
                     else:
-                        attrs.append('%s="%s"' % (key, htmlescape(value, True)))
+                        attrs.append('%s="%s"' % (key, html.escape(value, True)))
             if js.filename:
                 attrs.append('src="%s"' % pathto(js.filename, resource=True))
         else:

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -10,6 +10,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
 import os
 from os import path
 
@@ -23,7 +24,6 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.nodes import NodeMatcher
 from sphinx.util.osutil import make_filename_from_project
-from sphinx.util.pycompat import htmlescape
 
 if False:
     # For type annotation
@@ -280,7 +280,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                         write_toc(subnode, ullevel)
                 elif isinstance(node, nodes.reference):
                     link = node['refuri']
-                    title = htmlescape(node.astext()).replace('"', '&quot;')
+                    title = html.escape(node.astext()).replace('"', '&quot;')
                     f.write(object_sitemap % (title, link))
                 elif isinstance(node, nodes.bullet_list):
                     if ullevel != 0:
@@ -310,7 +310,7 @@ class HTMLHelpBuilder(StandaloneHTMLBuilder):
                     item = '    <param name="%s" value="%s">\n' % \
                         (name, value)
                     f.write(item)
-                title = htmlescape(title)
+                title = html.escape(title)
                 f.write('<LI> <OBJECT type="text/sitemap">\n')
                 write_param('Keyword', title)
                 if len(refs) == 0:

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
 import os
 import posixpath
 import re
@@ -26,7 +27,6 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.nodes import NodeMatcher
 from sphinx.util.osutil import make_filename
-from sphinx.util.pycompat import htmlescape
 from sphinx.util.template import SphinxRenderer
 
 if False:
@@ -175,7 +175,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
             compact_paragraph = cast(addnodes.compact_paragraph, node[0])
             reference = cast(nodes.reference, compact_paragraph[0])
             link = reference['refuri']
-            title = htmlescape(reference.astext()).replace('"', '&quot;')
+            title = html.escape(reference.astext()).replace('"', '&quot;')
             item = '<section title="%(title)s" ref="%(ref)s">' % \
                 {'title': title, 'ref': link}
             parts.append(' ' * 4 * indentlevel + item)
@@ -190,7 +190,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
                 parts.extend(self.write_toc(subnode, indentlevel))
         elif isinstance(node, nodes.reference):
             link = node['refuri']
-            title = htmlescape(node.astext()).replace('"', '&quot;')
+            title = html.escape(node.astext()).replace('"', '&quot;')
             item = section_template % {'title': title, 'ref': link}
             item = u' ' * 4 * indentlevel + item
             parts.append(item.encode('ascii', 'xmlcharrefreplace').decode())
@@ -217,8 +217,8 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         else:
             id = None
 
-        nameattr = htmlescape(name, quote=True)
-        refattr = htmlescape(ref[1], quote=True)
+        nameattr = html.escape(name, quote=True)
+        refattr = html.escape(ref[1], quote=True)
         if id:
             item = ' ' * 12 + '<keyword name="%s" id="%s" ref="%s"/>' % (nameattr, id, refattr)
         else:

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
 import warnings
 
 from pygments import highlight
@@ -27,7 +28,6 @@ from sphinx.ext import doctest
 from sphinx.locale import __
 from sphinx.pygments_styles import SphinxStyle, NoneStyle
 from sphinx.util import logging
-from sphinx.util.pycompat import htmlescape
 from sphinx.util.texescape import tex_hl_escape_map_new
 
 if False:
@@ -103,7 +103,7 @@ class PygmentsBridge:
         warnings.warn('PygmentsBridge.unhighlighted() is now deprecated.',
                       RemovedInSphinx30Warning, stacklevel=2)
         if self.dest == 'html':
-            return '<pre>' + htmlescape(source) + '</pre>\n'
+            return '<pre>' + html.escape(source) + '</pre>\n'
         else:
             # first, escape highlighting characters like Pygments does
             source = source.translate(escape_hl_chars)

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -8,6 +8,7 @@
     :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import html
 import pickle
 import re
 import warnings
@@ -21,7 +22,6 @@ from sphinx import addnodes
 from sphinx import package_dir
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.util import jsdump, rpartition
-from sphinx.util.pycompat import htmlescape
 from sphinx.search.jssplitter import splitter_code
 
 if False:
@@ -341,8 +341,8 @@ class IndexBuilder:
                     continue
                 if prio < 0:
                     continue
-                fullname = htmlescape(fullname)
-                dispname = htmlescape(dispname)
+                fullname = html.escape(fullname)
+                dispname = html.escape(dispname)
                 prefix, name = rpartition(dispname, '.')
                 pdict = rv.setdefault(prefix, {})
                 try:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Replace `pycompat.htmlescape()` by `html.escape()`
