### PR TITLE
Replace ENOENT errno checks with Python 3 FileNotFoundError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -66,6 +66,8 @@ Deprecated
 * ``sphinx.util.force_decode()``
 * ``sphinx.util.get_matching_docs()``
 * ``sphinx.util.inspect.Parameter``
+* ``sphinx.util.osutil.EEXIST``
+* ``sphinx.util.osutil.ENOENT``
 * ``sphinx.util.osutil.walk()``
 * ``sphinx.util.PeekableIterator``
 * ``sphinx.util.pycompat.u``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -207,6 +207,16 @@ The following is a list of deprecated interfaces.
      - 3.0
      - N/A
 
+   * - ``sphinx.util.osutil.EEXIST``
+     - 2.0
+     - 4.0
+     - ``errno.EEXIST`` or ``FileExistsError``
+
+   * - ``sphinx.util.osutil.ENOENT``
+     - 2.0
+     - 4.0
+     - ``errno.ENOENT`` or ``FileNotFoundError``
+
    * - ``sphinx.util.osutil.walk()``
      - 2.0
      - 4.0

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -28,7 +28,7 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.fileutil import copy_asset
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.nodes import set_source_info
-from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
+from sphinx.util.osutil import ensuredir, EPIPE, EINVAL
 
 if False:
     # For type annotation
@@ -247,9 +247,7 @@ def render_dot(self, code, options, format, prefix='graphviz'):
         dot_args.extend(['-Tcmapx', '-o%s.map' % outfn])
     try:
         p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE, cwd=cwd)
-    except OSError as err:
-        if err.errno != ENOENT:   # No such file or directory
-            raise
+    except FileNotFoundError:
         logger.warning(__('dot command %r cannot be run (needed for graphviz '
                           'output), check the graphviz_dot setting'), graphviz_dot)
         if not hasattr(self.builder, '_graphviz_warned_dot'):

--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -15,7 +15,7 @@ from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.transforms.post_transforms.images import ImageConverter
 from sphinx.util import logging
-from sphinx.util.osutil import ENOENT, EPIPE, EINVAL
+from sphinx.util.osutil import EPIPE, EINVAL
 
 if False:
     # For type annotation
@@ -75,9 +75,7 @@ class ImagemagickConverter(ImageConverter):
                     [_from, _to])
             logger.debug('Invoking %r ...', args)
             p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        except OSError as err:
-            if err.errno != ENOENT:  # No such file or directory
-                raise
+        except FileNotFoundError:
             logger.warning(__('convert command %r cannot be run.'
                               'check the image_converter setting'),
                            self.config.image_converter)

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -25,7 +25,7 @@ from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.math import get_node_equation_number, wrap_displaymath
-from sphinx.util.osutil import ensuredir, ENOENT, cd
+from sphinx.util.osutil import ensuredir, cd
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.pycompat import sys_encoding
 
@@ -137,9 +137,7 @@ def compile_math(latex, builder):
     with cd(tempdir):
         try:
             p = Popen(command, stdout=PIPE, stderr=PIPE)
-        except OSError as err:
-            if err.errno != ENOENT:   # No such file or directory
-                raise
+        except FileNotFoundError:
             logger.warning(__('LaTeX command %r cannot be run (needed for math '
                               'display), check the imgmath_latex setting'),
                            builder.config.imgmath_latex)
@@ -157,9 +155,7 @@ def convert_dvi_to_image(command, name):
     """Convert DVI file to specific image format."""
     try:
         p = Popen(command, stdout=PIPE, stderr=PIPE)
-    except OSError as err:
-        if err.errno != ENOENT:   # No such file or directory
-            raise
+    except FileNotFoundError:
         logger.warning(__('%s command %r cannot be run (needed for math '
                           'display), check the imgmath_%s setting'),
                        name, command[0], name)

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -30,8 +30,8 @@ if False:
     from typing import Any, Iterator, List, Tuple, Union  # NOQA
 
 # Errnos that we need.
-EEXIST = getattr(errno, 'EEXIST', 0)
-ENOENT = getattr(errno, 'ENOENT', 0)
+EEXIST = getattr(errno, 'EEXIST', 0)  # RemovedInSphinx40Warning
+ENOENT = getattr(errno, 'ENOENT', 0)  # RemovedInSphinx40Warning
 EPIPE = getattr(errno, 'EPIPE', 0)
 EINVAL = getattr(errno, 'EINVAL', 0)
 

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -23,12 +23,10 @@ from sphinx.testing.util import assert_node
 def has_binary(binary):
     try:
         subprocess.check_output([binary])
-    except OSError as e:
-        if e.errno == errno.ENOENT:
-            # handle file not found error.
-            return False
-        else:
-            return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        pass
     return True
 
 


### PR DESCRIPTION
The error is more specific and self documenting.

This removes the last use of `sphinx.util.osutil.ENOENT`, so it is now deprecated for removal. `sphinx.util.osutil.EEXIST` was already unused so that is deprecated as well.