### PR TITLE
TODOs inside a :param: have a uri, but not a refid.

### DIFF
--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -174,7 +174,15 @@ def process_todo_nodes(app, doctree, fromdocname):
             try:
                 newnode['refuri'] = app.builder.get_relative_uri(
                     fromdocname, todo_info['docname'])
-                newnode['refuri'] += '#' + todo_info['target']['refid']
+                try:
+                    newnode['refuri'] += '#' + todo_info['target']['refid']
+                except KeyError:
+                    # presently, there's no refid for a todo that appears
+                    # inside a param, possibly other places.  avoid crashing
+                    # and leave a warning so we can track it down.
+                    logger.warning(__("TODO target missing refid: %s"),
+                                   todo_info['source'],
+                                   location=node)
             except NoUri:
                 # ignore if no URI can be determined, e.g. for LaTeX output
                 pass


### PR DESCRIPTION
Subject: This avoids a KeyError when generating a link to a TODO that crashes sphinx, and gives a warning so the offending TODO can be tracked down.

### Feature or Bugfix
- Bugfix

### Purpose
- avoid a specific crash when building todolists

### Detail
- a todo inside a :param: will have a relative uri, but not a refid.  instead of crashing, just skip adding the target to the link, and emit a warning that tells the user where the todo is so they can move it or ignore it.  besides that, a missing refid in other cases will be easier to debug with this warning message rather than just a stack trace and a crash.

