### PR TITLE
Remove unnecessary bytes type check in ModuleAnalyzer.for_string()

### DIFF
--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -10,7 +10,7 @@
 """
 
 import re
-from io import BytesIO, StringIO
+from io import StringIO
 from zipfile import ZipFile
 
 from sphinx.errors import PycodeError
@@ -29,8 +29,6 @@ class ModuleAnalyzer:
     @classmethod
     def for_string(cls, string, modname, srcname='<string>'):
         # type: (str, str, str) -> ModuleAnalyzer
-        if isinstance(string, bytes):
-            return cls(BytesIO(string), modname, srcname)
         return cls(StringIO(string), modname, srcname, decoded=True)
 
     @classmethod


### PR DESCRIPTION
All uses always pass a str, never a bytes. Per the type signature, only str types are allowed.