### PR TITLE
Remove unnecessary bytes type check from path.write_text()

### DIFF
--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -152,8 +152,6 @@ class path(text_type):
         """
         Writes the given `text` to the file.
         """
-        if isinstance(text, bytes):
-            text = text.decode(encoding)
         with open(self, 'w', encoding=encoding, **kwargs) as f:
             f.write(text)
 


### PR DESCRIPTION
All code passes type str to the method. Per the type signature, only str is allowed.