### PR TITLE
Remove unnecessary bytes/str type check from doctree_read()

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -13,7 +13,6 @@ import traceback
 import warnings
 
 from docutils import nodes
-from six import text_type
 
 import sphinx
 from sphinx import addnodes
@@ -75,12 +74,8 @@ def doctree_read(app, doctree):
                 env._viewcode_modules[modname] = False  # type: ignore
                 return
 
-            if not isinstance(analyzer.code, text_type):
-                code = analyzer.code.decode(analyzer.encoding)
-            else:
-                code = analyzer.code
-
             analyzer.find_tags()
+            code = analyzer.code
             tags = analyzer.tags
         else:
             code, tags = code_tags


### PR DESCRIPTION
ModuleAnalyzer.code is always type str. Decoding is unnecessary.