### PR TITLE
LaTeX: allow sphinxVerbatim usage without explicit "hllines" extra setup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Bugs fixed
 * #5627: qthelp: index.html missing in QtHelp
 * #5659: linkcheck: crashes for a hyperlink containing multibyte character
 * #5754: DOC: Fix some mistakes in :doc:`/latex`
+* #5810: LaTeX: sphinxVerbatim requires explicit "hllines" set-up since 1.6.6
+  (refs: #1238)
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2018/11/18 v1.8.3 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2018/12/16 v1.8.3 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -208,6 +208,9 @@
 % For highlighted code.
 \RequirePackage{fancyvrb}
 \define@key{FV}{hllines}{\def\sphinx@verbatim@checkifhl##1{\in@{, ##1,}{#1}}}
+% sphinxVerbatim must be usable by third party without requiring hllines set-up
+\def\sphinxresetverbatimhllines{\def\sphinx@verbatim@checkifhl##1{\in@false}}
+\sphinxresetverbatimhllines
 % For hyperlinked footnotes in tables; also for gathering footnotes from
 % topic and warning blocks. Also to allow code-blocks in footnotes.
 \RequirePackage{footnotehyper-sphinx}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2260,9 +2260,12 @@ class LaTeXTranslator(nodes.NodeVisitor):
             else:
                 hlcode += '\\end{sphinxVerbatim}'
 
-            hllines = '\\fvset{hllines={, %s,}}%%' %\
-                      str(highlight_args.get('hl_lines', []))[1:-1]
-            self.body.append('\n' + hllines + '\n' + hlcode + '\n')
+            hllines = str(highlight_args.get('hl_lines', []))[1:-1]
+            if hllines:
+                self.body.append('\n\\fvset{hllines={, %s,}}%%' % hllines)
+            self.body.append('\n' + hlcode + '\n')
+            if hllines:
+                self.body.append('\\sphinxresetverbatimhllines\n')
             raise nodes.SkipNode
 
     def depart_literal_block(self, node):

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -27,7 +27,6 @@ header2
 
 \endlastfoot
 
-\fvset{hllines={, ,}}%
 \begin{sphinxVerbatimintable}[commandchars=\\\{\}]
 \PYG{n}{hello} \PYG{n}{world}
 \end{sphinxVerbatimintable}

--- a/tests/roots/test-latex-table/expects/table_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/table_having_verbatim.tex
@@ -10,7 +10,6 @@ header1
 header2
 \\
 \hline
-\fvset{hllines={, ,}}%
 \begin{sphinxVerbatimintable}[commandchars=\\\{\}]
 \PYG{n}{hello} \PYG{n}{world}
 \end{sphinxVerbatimintable}

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -356,6 +356,8 @@ def test_code_block_emphasize_latex(app, status, warning):
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8').replace('\r\n', '\n')
     includes = '\\fvset{hllines={, 5, 6, 13, 14, 15, 24, 25, 26, 27,}}%\n'
     assert includes in latex
+    includes = '\\end{sphinxVerbatim}\n\sphinxresetverbatimhllines\n'
+    assert includes in latex
 
 
 @pytest.mark.sphinx('xml', testroot='directive-code')

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -219,8 +219,7 @@ def get_verifier(verify, verify_re):
         'verify',
         u'::\n\n @Γ\\∞${}',
         None,
-        (u'\\fvset{hllines={, ,}}%\n'
-         u'\\begin{sphinxVerbatim}[commandchars=\\\\\\{\\}]\n'
+        (u'\\begin{sphinxVerbatim}[commandchars=\\\\\\{\\}]\n'
          u'@\\(\\Gamma\\)\\PYGZbs{}\\(\\infty\\)\\PYGZdl{}\\PYGZob{}\\PYGZcb{}\n'
          u'\\end{sphinxVerbatim}'),
     ),


### PR DESCRIPTION
Fixes: #5810

### Relates
- #1238, 8de0abd1b669b7ccf70a54187937d34dcfd69c56 (1.6.6)

