### PR TITLE
Pass exceptions directly to docutils reporter

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -14,7 +14,6 @@ from difflib import unified_diff
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
-from six import text_type
 
 from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx40Warning
@@ -143,7 +142,7 @@ class CodeBlock(SphinxDirective):
 
                 hl_lines = [x + 1 for x in hl_lines if x < nlines]
             except ValueError as err:
-                return [document.reporter.warning(str(err), line=self.lineno)]
+                return [document.reporter.warning(err, line=self.lineno)]
         else:
             hl_lines = None
 
@@ -170,7 +169,7 @@ class CodeBlock(SphinxDirective):
             try:
                 literal = container_wrapper(self, literal, caption)
             except ValueError as exc:
-                return [document.reporter.warning(text_type(exc), line=self.lineno)]
+                return [document.reporter.warning(exc, line=self.lineno)]
 
         # literal will be note_implicit_target that is linked from caption and numref.
         # when options['name'] is provided, it should be primary ID.
@@ -465,7 +464,7 @@ class LiteralInclude(SphinxDirective):
 
             return [retnode]
         except Exception as exc:
-            return [document.reporter.warning(text_type(exc), line=self.lineno)]
+            return [document.reporter.warning(exc, line=self.lineno)]
 
 
 def setup(app):

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -162,7 +162,7 @@ class MathDirective(SphinxDirective):
             self.state.document.note_explicit_target(target)
             ret.insert(0, target)
         except UserWarning as exc:
-            self.state_machine.reporter.warning(exc.args[0], line=self.lineno)
+            self.state_machine.reporter.warning(exc, line=self.lineno)
 
 
 def setup(app):

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6288,7 +6288,7 @@ class CPPObject(ObjectDescription):
     option_spec['tparam-line-spec'] = directives.flag
 
     def warn(self, msg):
-        # type: (str) -> None
+        # type: (Union[str, Exception]) -> None
         self.state_machine.reporter.warning(msg, line=self.lineno)
 
     def _add_enumerator_to_parent(self, ast):
@@ -6443,7 +6443,7 @@ class CPPObject(ObjectDescription):
             ast = self.parse_definition(parser)
             parser.assert_end()
         except DefinitionError as e:
-            self.warn(e.description)
+            self.warn(e)
             # It is easier to assume some phony name than handling the error in
             # the possibly inner declarations.
             name = _make_phony_error_name()
@@ -6588,7 +6588,7 @@ class CPPNamespaceObject(SphinxDirective):
     option_spec = {}  # type: Dict
 
     def warn(self, msg):
-        # type: (str) -> None
+        # type: (Union[str, Exception]) -> None
         self.state_machine.reporter.warning(msg, line=self.lineno)
 
     def run(self):
@@ -6603,7 +6603,7 @@ class CPPNamespaceObject(SphinxDirective):
                 ast = parser.parse_namespace_object()
                 parser.assert_end()
             except DefinitionError as e:
-                self.warn(e.description)
+                self.warn(e)
                 name = _make_phony_error_name()
                 ast = ASTNamespace(name, None)
             symbol = rootSymbol.add_name(ast.nestedName, ast.templatePrefix)
@@ -6622,7 +6622,7 @@ class CPPNamespacePushObject(SphinxDirective):
     option_spec = {}  # type: Dict
 
     def warn(self, msg):
-        # type: (str) -> None
+        # type: (Union[str, Exception]) -> None
         self.state_machine.reporter.warning(msg, line=self.lineno)
 
     def run(self):
@@ -6634,7 +6634,7 @@ class CPPNamespacePushObject(SphinxDirective):
             ast = parser.parse_namespace_object()
             parser.assert_end()
         except DefinitionError as e:
-            self.warn(e.description)
+            self.warn(e)
             name = _make_phony_error_name()
             ast = ASTNamespace(name, None)
         oldParent = self.env.temp_data.get('cpp:parent_symbol', None)
@@ -6657,7 +6657,7 @@ class CPPNamespacePopObject(SphinxDirective):
     option_spec = {}  # type: Dict
 
     def warn(self, msg):
-        # type: (str) -> None
+        # type: (Union[str, Exception]) -> None
         self.state_machine.reporter.warning(msg, line=self.lineno)
 
     def run(self):

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -363,8 +363,7 @@ class InheritanceDiagram(SphinxDirective):
                 aliases=self.config.inheritance_alias,
                 top_classes=node['top-classes'])
         except InheritanceException as err:
-            return [node.document.reporter.warning(err.args[0],
-                                                   line=self.lineno)]
+            return [node.document.reporter.warning(err, line=self.lineno)]
 
         # Create xref nodes for each target of the graph's image map and
         # add them to the doc tree so that Sphinx can resolve the


### PR DESCRIPTION
The docutils reporter supports an exception as an argument. It is converted to a string internally.