### PR TITLE
Remove redundant coerce to str in string formatting

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3138,8 +3138,7 @@ class ASTDeclaratorNameParamQual(ASTBase):
         # cv-qualifiers
         if self.paramQual:
             return self.paramQual.get_modifiers_id(version)
-        raise Exception(
-            "This should only be called on a function: %s" % text_type(self))
+        raise Exception("This should only be called on a function: %s" % self)
 
     def get_param_id(self, version):  # only the parameters (if any)
         # type: (int) -> str
@@ -6132,7 +6131,7 @@ class DefinitionParser:
                     % (numArgs, numParams, numExtra)
                 msg += " Declaration:\n\t"
                 if templatePrefix:
-                    msg += "%s\n\t" % text_type(templatePrefix)
+                    msg += "%s\n\t" % templatePrefix
                 msg += text_type(nestedName)
                 self.warn(msg)
 
@@ -6349,7 +6348,7 @@ class CPPObject(ObjectDescription):
         assert newestId  # shouldn't be None
         if not re.compile(r'^[a-zA-Z0-9_]*$').match(newestId):
             self.warn('Index id generation for C++ object "%s" failed, please '
-                      'report as bug (id=%s).' % (text_type(ast), newestId))
+                      'report as bug (id=%s).' % (ast, newestId))
 
         name = ast.symbol.get_full_nested_name().get_display_string().lstrip(':')
         # Add index entry, but not if it's a declaration inside a concept

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -18,7 +18,6 @@ from subprocess import Popen, PIPE
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from six import text_type
 
 import sphinx
 from sphinx.errors import SphinxError
@@ -284,7 +283,7 @@ def render_dot_html(self, node, code, options, prefix='graphviz',
                                    "'svg', but is %r") % format)
         fname, outfn = render_dot(self, code, options, format, prefix)
     except GraphvizError as exc:
-        logger.warning(__('dot code %r: %s'), code, text_type(exc))
+        logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode
 
     if imgcls:
@@ -338,7 +337,7 @@ def render_dot_latex(self, node, code, options, prefix='graphviz'):
     try:
         fname, outfn = render_dot(self, code, options, 'pdf', prefix)
     except GraphvizError as exc:
-        logger.warning(__('dot code %r: %s'), code, text_type(exc))
+        logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode
 
     is_inline = self.is_inline(node)
@@ -376,7 +375,7 @@ def render_dot_texinfo(self, node, code, options, prefix='graphviz'):
     try:
         fname, outfn = render_dot(self, code, options, 'png', prefix)
     except GraphvizError as exc:
-        logger.warning(__('dot code %r: %s'), code, text_type(exc))
+        logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode
     if fname is not None:
         self.body.append('@image{%s,,,[graphviz],png}\n' % fname[:-4])

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -92,7 +92,7 @@ class Table:
        table.add_row()
        table.add_cell(Cell("FOO"))
        table.add_cell(Cell("BAR"))
-       print(str(table))
+       print(table)
        +--------+--------+
        | foo    | bar    |
        |========|========|

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -43,7 +43,7 @@ def check(name, input, idDict, output=None):
     res = text_type(ast)
     if res != output:
         print("")
-        print("Input:    ", text_type(input))
+        print("Input:    ", input)
         print("Result:   ", res)
         print("Expected: ", output)
         raise DefinitionError("")
@@ -74,13 +74,13 @@ def check(name, input, idDict, output=None):
         res.append(idExpected[i] == idActual[i])
 
     if not all(res):
-        print("input:    %s" % text_type(input).rjust(20))
+        print("input:    %s" % input.rjust(20))
         for i in range(1, _max_id + 1):
             if res[i]:
                 continue
             print("Error in id version %d." % i)
-            print("result:   %s" % str(idActual[i]))
-            print("expected: %s" % str(idExpected[i]))
+            print("result:   %s" % idActual[i])
+            print("expected: %s" % idExpected[i])
         print(rootSymbol.dump(0))
         raise DefinitionError("")
 


### PR DESCRIPTION
When an object is passed to a string format placeholder `'%s'`, Python will implicitly call `str()` on the object. This applies to `print()` and logging as well.