### PR TITLE
Deprecate sphinx.config.string_classes; remove all internal uses

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -54,6 +54,7 @@ Deprecated
 * ``sphinx.addnodes.abbreviation``
 * ``sphinx.application.Sphinx._setting_up_extension``
 * ``sphinx.config.check_unicode()``
+* ``sphinx.config.string_classes``
 * ``sphinx.ext.autodoc.importer._MockImporter``
 * ``sphinx.ext.autosummary.Autosummary.warn()``
 * ``sphinx.ext.autosummary.Autosummary.genopt``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -157,6 +157,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - N/A
 
+   * - ``sphinx.config.string_classes``
+     - 2.0
+     - 4.0
+     - ``[str]``
+
    * - ``sphinx.ext.autosummary.Autosummary.warn()``
      - 2.0
      - 4.0

--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -17,7 +17,6 @@ import subprocess
 from os import path, environ
 
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.config import string_classes
 from sphinx.errors import SphinxError
 from sphinx.locale import __
 from sphinx.util import logging
@@ -274,17 +273,17 @@ def setup(app):
 
     app.add_config_value('applehelp_bundle_name',
                          lambda self: make_filename(self.project), 'applehelp')
-    app.add_config_value('applehelp_bundle_id', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_bundle_id', None, 'applehelp', [str])
     app.add_config_value('applehelp_dev_region', 'en-us', 'applehelp')
     app.add_config_value('applehelp_bundle_version', '1', 'applehelp')
-    app.add_config_value('applehelp_icon', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_icon', None, 'applehelp', [str])
     app.add_config_value('applehelp_kb_product',
                          lambda self: '%s-%s' % (make_filename(self.project), self.release),
                          'applehelp')
-    app.add_config_value('applehelp_kb_url', None, 'applehelp', string_classes)
-    app.add_config_value('applehelp_remote_url', None, 'applehelp', string_classes)
-    app.add_config_value('applehelp_index_anchors', False, 'applehelp', string_classes)
-    app.add_config_value('applehelp_min_term_length', None, 'applehelp', string_classes)
+    app.add_config_value('applehelp_kb_url', None, 'applehelp', [str])
+    app.add_config_value('applehelp_remote_url', None, 'applehelp', [str])
+    app.add_config_value('applehelp_index_anchors', False, 'applehelp', [str])
+    app.add_config_value('applehelp_min_term_length', None, 'applehelp', [str])
     app.add_config_value('applehelp_stopwords',
                          lambda self: self.language or 'en', 'applehelp')
     app.add_config_value('applehelp_locale', lambda self: self.language or 'en', 'applehelp')

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -15,7 +15,7 @@ from os import path
 
 from sphinx import package_dir
 from sphinx.builders import _epub_base
-from sphinx.config import string_classes, ENUM
+from sphinx.config import ENUM
 from sphinx.locale import __
 from sphinx.util import logging, xmlname_checker
 from sphinx.util.fileutil import copy_asset_file
@@ -275,8 +275,8 @@ def setup(app):
     app.add_config_value('epub_max_image_width', 0, 'env')
     app.add_config_value('epub_show_urls', 'inline', 'epub')
     app.add_config_value('epub_use_index', lambda self: self.html_use_index, 'epub')
-    app.add_config_value('epub_description', 'unknown', 'epub', string_classes)
-    app.add_config_value('epub_contributor', 'unknown', 'epub', string_classes)
+    app.add_config_value('epub_description', 'unknown', 'epub')
+    app.add_config_value('epub_contributor', 'unknown', 'epub')
     app.add_config_value('epub_writing_mode', 'horizontal', 'epub',
                          ENUM('horizontal', 'vertical'))
 

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -31,7 +31,6 @@ from six import text_type
 from sphinx import package_dir, __display_version__
 from sphinx.application import ENV_PICKLE_FILENAME
 from sphinx.builders import Builder
-from sphinx.config import string_classes
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.environment.adapters.indexentries import IndexEntries
@@ -1618,16 +1617,16 @@ def setup(app):
     app.add_config_value('html_theme_options', {}, 'html')
     app.add_config_value('html_title',
                          lambda self: _('%s %s documentation') % (self.project, self.release),
-                         'html', string_classes)
+                         'html', [str])
     app.add_config_value('html_short_title', lambda self: self.html_title, 'html')
-    app.add_config_value('html_style', None, 'html', string_classes)
-    app.add_config_value('html_logo', None, 'html', string_classes)
-    app.add_config_value('html_favicon', None, 'html', string_classes)
+    app.add_config_value('html_style', None, 'html', [str])
+    app.add_config_value('html_logo', None, 'html', [str])
+    app.add_config_value('html_favicon', None, 'html', [str])
     app.add_config_value('html_css_files', [], 'html')
     app.add_config_value('html_js_files', [], 'html')
     app.add_config_value('html_static_path', [], 'html')
     app.add_config_value('html_extra_path', [], 'html')
-    app.add_config_value('html_last_updated_fmt', None, 'html', string_classes)
+    app.add_config_value('html_last_updated_fmt', None, 'html', [str])
     app.add_config_value('html_sidebars', {}, 'html')
     app.add_config_value('html_additional_pages', {}, 'html')
     app.add_config_value('html_domain_indices', True, 'html', [list])
@@ -1638,15 +1637,15 @@ def setup(app):
     app.add_config_value('html_show_sourcelink', True, 'html')
     app.add_config_value('html_sourcelink_suffix', '.txt', 'html')
     app.add_config_value('html_use_opensearch', '', 'html')
-    app.add_config_value('html_file_suffix', None, 'html', string_classes)
-    app.add_config_value('html_link_suffix', None, 'html', string_classes)
+    app.add_config_value('html_file_suffix', None, 'html', [str])
+    app.add_config_value('html_link_suffix', None, 'html', [str])
     app.add_config_value('html_show_copyright', True, 'html')
     app.add_config_value('html_show_sphinx', True, 'html')
     app.add_config_value('html_context', {}, 'html')
     app.add_config_value('html_output_encoding', 'utf-8', 'html')
     app.add_config_value('html_compact_lists', True, 'html')
     app.add_config_value('html_secnumber_suffix', '. ', 'html')
-    app.add_config_value('html_search_language', None, 'html', string_classes)
+    app.add_config_value('html_search_language', None, 'html', [str])
     app.add_config_value('html_search_options', {}, 'html')
     app.add_config_value('html_search_scorer', '', None)
     app.add_config_value('html_scaled_image_link', True, 'html')

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -18,7 +18,6 @@ from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.config import string_classes
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import __
 from sphinx.util import logging
@@ -346,8 +345,8 @@ def setup(app):
     app.add_builder(HTMLHelpBuilder)
 
     app.add_config_value('htmlhelp_basename', default_htmlhelp_basename, None)
-    app.add_config_value('htmlhelp_file_suffix', None, 'html', string_classes)
-    app.add_config_value('htmlhelp_link_suffix', None, 'html', string_classes)
+    app.add_config_value('htmlhelp_file_suffix', None, 'html', [str])
+    app.add_config_value('htmlhelp_link_suffix', None, 'html', [str])
 
     return {
         'version': 'builtin',

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -22,7 +22,7 @@ from sphinx.builders.latex.transforms import (
     FootnoteDocnameUpdater, LaTeXFootnoteTransform, LiteralBlockTransform,
     ShowUrlsTransform, DocumentTargetTransform,
 )
-from sphinx.config import string_classes, ENUM
+from sphinx.config import ENUM
 from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.errors import SphinxError, ConfigError
@@ -464,7 +464,7 @@ def setup(app):
                          lambda self: [(self.master_doc, make_filename(self.project) + '.tex',
                                         self.project, '', 'manual')],
                          None)
-    app.add_config_value('latex_logo', None, None, string_classes)
+    app.add_config_value('latex_logo', None, None, [str])
     app.add_config_value('latex_appendices', [], None)
     app.add_config_value('latex_use_latex_multicolumn', False, None)
     app.add_config_value('latex_use_xindy', default_latex_use_xindy, None)

--- a/sphinx/builders/qthelp.py
+++ b/sphinx/builders/qthelp.py
@@ -21,7 +21,6 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx import package_dir
 from sphinx.builders.html import StandaloneHTMLBuilder
-from sphinx.config import string_classes
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.locale import __
 from sphinx.util import logging
@@ -273,7 +272,7 @@ def setup(app):
     app.add_builder(QtHelpBuilder)
 
     app.add_config_value('qthelp_basename', lambda self: make_filename(self.project), None)
-    app.add_config_value('qthelp_namespace', None, 'html', string_classes)
+    app.add_config_value('qthelp_namespace', None, 'html', [str])
     app.add_config_value('qthelp_theme', 'nonav', 'html')
     app.add_config_value('qthelp_theme_options', {}, 'html')
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -78,6 +78,7 @@ class ENUM:
             return value in self.candidates
 
 
+# RemovedInSphinx40Warning
 string_classes = [text_type]  # type: List
 
 
@@ -107,9 +108,9 @@ class Config:
         'release': ('', 'env', []),
         'today': ('', 'env', []),
         # the real default is locale-dependent
-        'today_fmt': (None, 'env', string_classes),
+        'today_fmt': (None, 'env', [str]),
 
-        'language': (None, 'env', string_classes),
+        'language': (None, 'env', [str]),
         'locale_dirs': (['locales'], 'env', []),
         'figure_language_filename': ('{root}.{language}{ext}', 'env', [str]),
 
@@ -118,24 +119,24 @@ class Config:
         'source_encoding': ('utf-8-sig', 'env', []),
         'source_parsers': ({}, 'env', []),
         'exclude_patterns': ([], 'env', []),
-        'default_role': (None, 'env', string_classes),
+        'default_role': (None, 'env', [str]),
         'add_function_parentheses': (True, 'env', []),
         'add_module_names': (True, 'env', []),
         'trim_footnote_reference_space': (False, 'env', []),
         'show_authors': (False, 'env', []),
-        'pygments_style': (None, 'html', string_classes),
+        'pygments_style': (None, 'html', [str]),
         'highlight_language': ('default', 'env', []),
         'highlight_options': ({}, 'env', []),
         'templates_path': ([], 'html', []),
-        'template_bridge': (None, 'html', string_classes),
+        'template_bridge': (None, 'html', [str]),
         'keep_warnings': (False, 'env', []),
         'suppress_warnings': ([], 'env', []),
         'modindex_common_prefix': ([], 'html', []),
-        'rst_epilog': (None, 'env', string_classes),
-        'rst_prolog': (None, 'env', string_classes),
+        'rst_epilog': (None, 'env', [str]),
+        'rst_prolog': (None, 'env', [str]),
         'trim_doctest_flags': (True, 'env', []),
         'primary_domain': ('py', 'env', [NoneType]),   # type: ignore
-        'needs_sphinx': (None, None, string_classes),
+        'needs_sphinx': (None, None, [str]),
         'needs_extensions': ({}, None, []),
         'manpages_url': (None, 'env', []),
         'nitpicky': (False, None, []),
@@ -145,7 +146,7 @@ class Config:
         'numfig_format': ({}, 'env', []),  # will be initialized in init_numfig_format()
 
         'math_number_all': (False, 'env', []),
-        'math_eqref_format': (None, 'env', string_classes),
+        'math_eqref_format': (None, 'env', [str]),
         'math_numfig': (True, 'env', []),
         'tls_verify': (True, 'env', []),
         'tls_cacerts': (None, 'env', []),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ import mock
 import pytest
 
 import sphinx
-from sphinx.config import Config, ENUM, string_classes, check_confval_types
+from sphinx.config import Config, ENUM, check_confval_types
 from sphinx.errors import ExtensionError, ConfigError, VersionRequirementError
 from sphinx.testing.path import path
 
@@ -228,12 +228,8 @@ TYPECHECK_WARNINGS = [
     ('value8', B(), None, C(), False),                          # sibling type
     ('value9', None, None, 'foo', False),                       # no default or no annotations
     ('value10', None, None, 123, False),                        # no default or no annotations
-    ('value11', None, [str], 'bar', False),                     # str vs unicode
-    ('value12', 'string', None, 'bar', False),                  # str vs unicode
-    ('value13', None, string_classes, 'bar', False),            # string_classes
-    ('value14', None, string_classes, 'bar', False),            # string_classes
-    ('value15', 'unicode', None, 'bar', False),                 # str vs unicode
-    ('value16', 'unicode', None, 'bar', False),                 # str vs unicode
+    ('value11', None, [str], 'bar', False),                     # str
+    ('value12', 'string', None, 'bar', False),                  # str
 ]
 
 


### PR DESCRIPTION
With only a single text type across supported Python versions, the `string_classes` is no longer necessary.

Internally, all uses were converted to the value `[str]`. For `.add_config_value()` uses that also supply a default string, the type is inferred.
