### PR TITLE
Fix invalid escape sequence in test_directive_code.py

### DIFF
--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -356,7 +356,7 @@ def test_code_block_emphasize_latex(app, status, warning):
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8').replace('\r\n', '\n')
     includes = '\\fvset{hllines={, 5, 6, 13, 14, 15, 24, 25, 26, 27,}}%\n'
     assert includes in latex
-    includes = '\\end{sphinxVerbatim}\n\sphinxresetverbatimhllines\n'
+    includes = '\\end{sphinxVerbatim}\n\\sphinxresetverbatimhllines\n'
     assert includes in latex
 
 


### PR DESCRIPTION
Fixes error when running tests:

```
tests/test_directive_code.py:359
  sphinx/tests/test_directive_code.py:359: DeprecationWarning: invalid escape sequence \s
    includes = '\\end{sphinxVerbatim}\n\sphinxresetverbatimhllines\n'
```