### PR TITLE
Deprecate the old IndexBuilder.feed() method signature

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,8 @@ Deprecated
   is_meta_keywords()``
 * The ``suffix`` argument of ``env.doc2path()`` is deprecated.
 * The string style ``base`` argument of ``env.doc2path()`` is deprecated.
+* The fallback to allow omitting the ``filename`` argument from an overridden
+  ``IndexBuilder.feed()`` method is deprecated.
 * ``sphinx.addnodes.abbreviation``
 * ``sphinx.application.Sphinx._setting_up_extension``
 * ``sphinx.config.check_unicode()``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -237,6 +237,12 @@ The following is a list of deprecated interfaces.
      - 4.0
      - N/A
 
+   * - Omitting the ``filename`` argument in an overriddent
+       ``IndexBuilder.feed()`` method.
+     - 2.0
+     - 4.0
+     - ``IndexBuilder.feed(docname, filename, title, doctree)``
+
    * - ``sphinx.writers.latex.LaTeXTranslator.babel_defmacro()``
      - 2.0
      - 4.0

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -32,7 +32,7 @@ from sphinx import package_dir, __display_version__
 from sphinx.application import ENV_PICKLE_FILENAME
 from sphinx.builders import Builder
 from sphinx.config import string_classes
-from sphinx.deprecation import RemovedInSphinx30Warning
+from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
 from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.environment.adapters.toctree import TocTree
@@ -977,6 +977,12 @@ class StandaloneHTMLBuilder(Builder):
             except TypeError:
                 # fallback for old search-adapters
                 self.indexer.feed(pagename, title, doctree)  # type: ignore
+                indexer_name = self.indexer.__class__.__name__
+                warnings.warn(
+                    'The %s.feed() method signature is deprecated. Update to '
+                    '%s.feed(docname, filename, title, doctree).' % (
+                        indexer_name, indexer_name),
+                    RemovedInSphinx40Warning)
 
     def _get_local_toctree(self, docname, collapse=True, **kwds):
         # type: (str, bool, Any) -> str


### PR DESCRIPTION
The method signature changed in commit d27386cc95772a7e7cc47941a0c08b27e0272f67 (Jun 8, 2016).