### PR TITLE
Remove Python 2 monkey patch for Unicode ugettext

### DIFF
--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -190,8 +190,6 @@ def init(locale_dirs, language, catalog='sphinx', namespace='general'):
         translator = NullTranslations()
         has_translation = False
     translators[(namespace, catalog)] = translator
-    if hasattr(translator, 'ugettext'):
-        translator.gettext = translator.ugettext  # type: ignore
     return translator, has_translation
 
 


### PR DESCRIPTION
In Python 3, gettext always returns a Unicode text string.