### PR TITLE
Remove absolute_import

### DIFF
--- a/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
+++ b/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
@@ -1,4 +1,1 @@
-# TODO(stephenfin): Removing this breaks tests. Why?
-from __future__ import absolute_import
-
 from .submodule import func1, Class1  # NOQA

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -67,10 +67,10 @@ def test_local_source_files(app, status, warning):
         if modname == 'not_a_package':
             source = (app.srcdir / 'not_a_package/__init__.py').text()
             tags = {
-                'func1': ('def', 3, 3),
-                'Class1': ('class', 3, 3),
-                'not_a_package.submodule.func1': ('def', 3, 3),
-                'not_a_package.submodule.Class1': ('class', 3, 3),
+                'func1': ('def', 1, 1),
+                'Class1': ('class', 1, 1),
+                'not_a_package.submodule.func1': ('def', 1, 1),
+                'not_a_package.submodule.Class1': ('class', 1, 1),
             }
         else:
             source = (app.srcdir / 'not_a_package/submodule.py').text()


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- This is not necessary for py3
