### PR TITLE
intersphinx: Normalize mapping on config-inited

### DIFF
--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -20,7 +20,7 @@ from test_util_inventory import inventory_v2, inventory_v2_not_having_version
 
 from sphinx import addnodes
 from sphinx.ext.intersphinx import (
-    load_mappings, missing_reference, _strip_basic_auth,
+    load_mappings, missing_reference, normalize_intersphinx_mapping, _strip_basic_auth,
     _get_safe_url, fetch_inventory, INVENTORY_FILENAME, inspect_main
 )
 from sphinx.ext.intersphinx import setup as intersphinx_setup
@@ -99,6 +99,7 @@ def test_missing_reference(tempdir, app, status, warning):
     app.config.intersphinx_cache_limit = 0
 
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
     inv = app.env.intersphinx_inventory
 
@@ -174,6 +175,7 @@ def test_missing_reference_pydomain(tempdir, app, status, warning):
     app.config.intersphinx_cache_limit = 0
 
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
 
     # no context data
@@ -198,6 +200,7 @@ def test_missing_reference_stddomain(tempdir, app, status, warning):
     app.config.intersphinx_cache_limit = 0
 
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
 
     # no context data
@@ -229,6 +232,7 @@ def test_missing_reference_cppdomain(tempdir, app, status, warning):
     app.config.intersphinx_cache_limit = 0
 
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
 
     app.build()
@@ -255,6 +259,7 @@ def test_missing_reference_jsdomain(tempdir, app, status, warning):
     app.config.intersphinx_cache_limit = 0
 
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
 
     # no context data
@@ -280,6 +285,7 @@ def test_inventory_not_having_version(tempdir, app, status, warning):
     app.config.intersphinx_cache_limit = 0
 
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
 
     rn = reference_check(app, 'py', 'mod', 'module1', 'foo')
@@ -307,6 +313,7 @@ def test_load_mappings_warnings(tempdir, app, status, warning):
 
     app.config.intersphinx_cache_limit = 0
     # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
     assert warning.getvalue().count('\n') == 1
 
@@ -320,6 +327,7 @@ def test_load_mappings_fallback(tempdir, app, status, warning):
     app.config.intersphinx_mapping = {
         'fallback': ('https://docs.python.org/py3k/', '/invalid/inventory/path'),
     }
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
     assert "failed to reach any of the inventories" in warning.getvalue()
 
@@ -335,6 +343,7 @@ def test_load_mappings_fallback(tempdir, app, status, warning):
         'fallback': ('https://docs.python.org/py3k/', ('/invalid/inventory/path',
                                                        inv_file)),
     }
+    normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
     assert "encountered some issues with some of the inventories" in status.getvalue()
     assert "" == warning.getvalue()


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The main loop of `load_mappings()` is too complicated. To make it simple, this tries to normalize `intersphinx_mapping` on config-inited event.
