### PR TITLE
Reorder the arguments for translators

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,8 @@ Incompatible changes
   (refs: #5772)
 * #5770: doctest: Follow :confval:`highlight_language` on highlighting doctest
   block.  As a result, they are highlighted as python3 by default.
+* The order of argument for ``HTMLTranslator``, ``HTML5Translator`` and
+  ``ManualPageTranslator`` are changed
 
 Deprecated
 ----------

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -392,8 +392,8 @@ class SphinxTranslator(nodes.NodeVisitor):
               This class is strongly coupled with Sphinx.
     """
 
-    def __init__(self, builder, document):
-        # type: (Builder, nodes.document) -> None
+    def __init__(self, document, builder):
+        # type: (nodes.document, Builder) -> None
         super().__init__(document)
         self.builder = builder
         self.config = builder.config

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -18,7 +18,8 @@ from docutils import nodes
 from docutils.writers.html5_polyglot import HTMLTranslator as BaseTranslator
 
 from sphinx import addnodes
-from sphinx.deprecation import RemovedInSphinx30Warning
+from sphinx.builders import Builder
+from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
 from sphinx.locale import admonitionlabels, _, __
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxTranslator
@@ -43,9 +44,17 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     builder = None  # type: StandaloneHTMLBuilder
 
-    def __init__(self, builder, document):
-        # type: (StandaloneHTMLBuilder, nodes.document) -> None
-        super().__init__(builder, document)
+    def __init__(self, *args):
+        # type: (Any) -> None
+        if isinstance(args[0], nodes.document) and isinstance(args[1], Builder):
+            document, builder = args
+        else:
+            warnings.warn('The order of arguments for HTML5Translator has been changed. '
+                          'Please give "document" as 1st and "builder" as 2nd.',
+                          RemovedInSphinx40Warning, stacklevel=2)
+            builder, document = args
+        super().__init__(document, builder)
+
         self.highlighter = self.builder.highlighter
         self.docnames = [self.builder.current_docname]  # for singlehtml builder
         self.manpages_url = self.config.manpages_url

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -508,7 +508,7 @@ class LaTeXTranslator(SphinxTranslator):
 
     def __init__(self, document, builder):
         # type: (nodes.document, LaTeXBuilder) -> None
-        super().__init__(builder, document)
+        super().__init__(document, builder)
         self.body = []  # type: List[str]
 
         # flags

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -168,7 +168,7 @@ class TexinfoTranslator(SphinxTranslator):
 
     def __init__(self, document, builder):
         # type: (nodes.document, TexinfoBuilder) -> None
-        super().__init__(builder, document)
+        super().__init__(document, builder)
         self.init_settings()
 
         self.written_ids = set()        # type: Set[str]

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -396,7 +396,7 @@ class TextTranslator(SphinxTranslator):
 
     def __init__(self, document, builder):
         # type: (nodes.document, TextBuilder) -> None
-        super().__init__(builder, document)
+        super().__init__(document, builder)
 
         newlines = self.config.text_newlines
         if newlines == 'windows':


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The order for constructor of Translator is not standadized.
- This tries to standardize the order of them.
