### PR TITLE
Fix #5724: quickstart: sphinx-quickstart fails when $LC_ALL is empty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
   (refs: #1238)
 * #5636: C++, fix parsing of floating point literals.
 * #5496 (again): C++, fix assertion in partial builds with duplicates.
+* #5724: quickstart: sphinx-quickstart fails when $LC_ALL is empty
 
 Testing
 --------

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -310,7 +310,7 @@ def build_main(argv=sys.argv[1:]):  # type: ignore
 
 def main(argv=sys.argv[1:]):  # type: ignore
     # type: (List[unicode]) -> int
-    locale.setlocale(locale.LC_ALL, '')
+    sphinx.locale.setlocale(locale.LC_ALL, '')
     sphinx.locale.init_console(os.path.join(package_dir, 'locale'), 'sphinx')
 
     if argv[:1] == ['-M']:

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -613,7 +613,7 @@ Makefile to be used with sphinx-build.
 
 def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
-    locale.setlocale(locale.LC_ALL, '')
+    sphinx.locale.setlocale(locale.LC_ALL, '')
     sphinx.locale.init_console(os.path.join(package_dir, 'locale'), 'sphinx')
 
     if not color_terminal():

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -387,7 +387,7 @@ Note: By default this script will not overwrite already created files."""))
 def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     """Parse and check the command line arguments."""
-    locale.setlocale(locale.LC_ALL, '')
+    sphinx.locale.setlocale(locale.LC_ALL, '')
     sphinx.locale.init_console(os.path.join(package_dir, 'locale'), 'sphinx')
 
     parser = get_parser()

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -408,7 +408,7 @@ The format of the autosummary directive is documented in the
 
 def main(argv=sys.argv[1:]):
     # type: (List[str]) -> None
-    locale.setlocale(locale.LC_ALL, '')
+    sphinx.locale.setlocale(locale.LC_ALL, '')
     sphinx.locale.init_console(os.path.join(package_dir, 'locale'), 'sphinx')
 
     app = DummyApplication()

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -22,7 +22,7 @@ from sphinx.deprecation import RemovedInSphinx30Warning
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterator, List, Tuple  # NOQA
+    from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple, Union  # NOQA
 
 
 class _TranslationProxy(UserString, object):
@@ -245,6 +245,27 @@ def init(locale_dirs, language, catalog='sphinx', namespace='general'):
     if hasattr(translator, 'ugettext'):
         translator.gettext = translator.ugettext  # type: ignore
     return translator, has_translation
+
+
+def setlocale(category, value=None):
+    # type: (int, Union[str, Iterable[str]]) -> None
+    """Update locale settings.
+
+    This does not throw any exception even if update fails.
+    This is workaround for Python's bug.
+
+    For more details:
+
+    * https://github.com/sphinx-doc/sphinx/issues/5724
+    * https://bugs.python.org/issue18378#msg215215
+
+    .. note:: Only for internal use.  Please don't call this method from extensions.
+              This will be removed in future.
+    """
+    try:
+        locale.setlocale(category, value)
+    except locale.Error:
+        pass
 
 
 def init_console(locale_dir, catalog):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5724 
