### PR TITLE
Deprecate quickstart.term_decode() and remove internal uses

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,8 @@ Deprecated
   ``IndexBuilder.feed()`` method is deprecated.
 * ``sphinx.addnodes.abbreviation``
 * ``sphinx.application.Sphinx._setting_up_extension``
+* ``sphinx.cmd.quickstart.term_decode()``
+* ``sphinx.cmd.quickstart.TERM_ENCODING``
 * ``sphinx.config.check_unicode()``
 * ``sphinx.config.string_classes``
 * ``sphinx.ext.autodoc.importer._MockImporter``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -152,6 +152,16 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``docutils.nodes.abbreviation``
 
+   * - ``sphinx.cmd.quickstart.term_decode()``
+     - 2.0
+     - 4.0
+     - N/A
+
+   * - ``sphinx.cmd.quickstart.TERM_ENCODING``
+     - 2.0
+     - 4.0
+     - ``sys.stdin.encoding``
+
    * - ``sphinx.config.check_unicode()``
      - 2.0
      - 4.0

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -49,7 +49,7 @@ if False:
     # For type annotation
     from typing import Any, Callable, Dict, List, Pattern, Union  # NOQA
 
-TERM_ENCODING = getattr(sys.stdin, 'encoding', None)
+TERM_ENCODING = getattr(sys.stdin, 'encoding', None)  # RemovedInSphinx40Warning
 
 EXTENSIONS = OrderedDict([
     ('autodoc', __('automatically insert docstrings from modules')),
@@ -155,6 +155,9 @@ def ok(x):
 
 def term_decode(text):
     # type: (Union[bytes,str]) -> str
+    warnings.warn('term_decode() is deprecated.',
+                  RemovedInSphinx40Warning, stacklevel=2)
+
     if isinstance(text, text_type):
         return text
 
@@ -192,7 +195,6 @@ def do_prompt(text, default=None, validator=nonempty):
         x = term_input(prompt).strip()
         if default and not x:
             x = default
-        x = term_decode(x)
         try:
             x = validator(x)
         except ValidationError as err:

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -8,7 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-import sys
 import time
 from io import StringIO
 
@@ -51,7 +50,6 @@ real_input = input
 
 def teardown_module():
     qs.term_input = real_input
-    qs.TERM_ENCODING = getattr(sys.stdin, 'encoding', None)
     coloron()
 
 
@@ -94,12 +92,7 @@ def test_do_prompt_with_nonascii():
         'Q1': '\u30c9\u30a4\u30c4',
     }
     qs.term_input = mock_input(answers)
-    try:
-        result = qs.do_prompt('Q1', default='\u65e5\u672c')
-    except UnicodeEncodeError:
-        raise pytest.skip.Exception(
-            'non-ASCII console input not supported on this encoding: %s',
-            qs.TERM_ENCODING)
+    result = qs.do_prompt('Q1', default='\u65e5\u672c')
     assert result == '\u30c9\u30a4\u30c4'
 
 
@@ -144,8 +137,8 @@ def test_quickstart_all_answers(tempdir):
         'Root path': tempdir,
         'Separate source and build': 'y',
         'Name prefix for templates': '.',
-        'Project name': 'STASI™'.encode(),
-        'Author name': 'Wolfgang Schäuble & G\'Beckstein'.encode(),
+        'Project name': 'STASI™',
+        'Author name': 'Wolfgang Schäuble & G\'Beckstein',
         'Project version': '2.0',
         'Project release': '2.0.1',
         'Project language': 'de',
@@ -166,7 +159,6 @@ def test_quickstart_all_answers(tempdir):
         'Do you want to use the epub builder': 'yes',
     }
     qs.term_input = mock_input(answers, needanswer=True)
-    qs.TERM_ENCODING = 'utf-8'
     d = {}
     qs.ask_user(d)
     qs.generate(d)


### PR DESCRIPTION
Per the Python 3 docs, `input()` always returns a string:

https://docs.python.org/3/library/functions.html#input

> The function then reads a line from input, converts it to a string (stripping a trailing newline), and returns that.

The stubs from typeshed say the same:

https://github.com/python/typeshed/blob/5c69373890dfaf4f07f0638766fb0a4903352892/stdlib/3/builtins.pyi#L835

Here is the implementation from CPython with also shows a call to `PyUnicode_Decode` on the result:

https://github.com/python/cpython/blob/3.7/Python/bltinmodule.c#L1960-L2143

As the value is always a string, there is nothing to decode. Therefore the call to `term_decode()` unnecessary and can safely be removed.

With this in mind, must adjust quickstart tests to be more representative.