### PR TITLE
Use mathjax CDN "latest" URL by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Features added
 Bugs fixed
 ----------
 
+* #5725: mathjax: Use CDN URL for "latest" version by default
 * #5460: html search does not work with some 3rd party themes
 * #5520: LaTeX, caption package incompatibility since Sphinx 1.6
 * #5614: autodoc: incremental build is broken when builtin modules are imported

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -98,7 +98,7 @@ def setup(app):
     # more information for mathjax secure url is here:
     # https://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn
     app.add_config_value('mathjax_path',
-                         'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?'
+                         'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?'
                          'config=TeX-AMS-MML_HTMLorMML', 'html')
     app.add_config_value('mathjax_options', {}, 'html')
     app.add_config_value('mathjax_inline', [r'\(', r'\)'], 'html')

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -97,7 +97,7 @@ def test_mathjax_options(app, status, warning):
 
     content = (app.outdir / 'index.html').text()
     assert ('<script async="async" integrity="sha384-0123456789" type="text/javascript" '
-            'src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?'
+            'src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?'
             'config=TeX-AMS-MML_HTMLorMML"></script>' in content)
 
 


### PR DESCRIPTION
Closes #5725

