### PR TITLE
[tests] LaTeX: use latex engines with ``--halt-on-error`` option

### DIFF
--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -71,6 +71,7 @@ def compile_latex_document(app):
             copyfile('SphinxTests.tex',
                      app.config.latex_engine + '/SphinxTests.tex')
             p = Popen([app.config.latex_engine,
+                       '--halt-on-error',
                        '--interaction=nonstopmode',
                        '-output-directory=%s' % app.config.latex_engine,
                        'SphinxTests.tex'],


### PR DESCRIPTION
Subject: avoid very lengthy console output when LaTeX compilation fails during testing

as example of such lengthy output see #5823. Running the `tests/test_build_latex.py` with an `\setmainfont{COUCOU}` added to preamble for xelatex runs I get this (which I hardwrapped at each `\n`)

```
----------------------------- Captured stdout call -----------------------------
b'This is XeTeX, Version 3.14159265-2.6-0.99999 (TeX Live 2018) (preloaded format=xelatex)\n
 restricted \\write18 enabled.\n
entering extended mode\n
(xelatex/SphinxTests.tex\n
LaTeX2e <2018-12-01>\n
(./sphinxmanual.cls\n
Document Class: sphinxmanual 2018/09/18 v1.8.1 Document class (Sphinx manual)\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/report.cls\n
Document Class: report 2018/09/03 v1.4i Standard LaTeX document class\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/size10.clo)))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/cmap/cmap.sty\n
\n
Package cmap Warning: pdftex not detected - exiting.\n
\n
) (/usr/local/texlive/2018/texmf-dist/tex/latex/fontspec/fontspec.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3packages/xparse/xparse.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3kernel/expl3.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3kernel/expl3-code.tex)\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/l3kernel/l3xdvipdfmx.def)))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/fontspec/fontspec-xetex.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/fontenc.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/base/tuenc.def))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/fontspec/fontspec.cfg)))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsmath/amsmath.sty\n
For additional information on amsmath, use the `?\' option.\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsmath/amstext.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsmath/amsgen.sty))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsmath/amsbsy.sty)\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsmath/amsopn.sty))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsfonts/amssymb.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/amsfonts/amsfonts.sty))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/polyglossia/polyglossia.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/etoolbox/etoolbox.sty)\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/makecmds/makecmds.sty)\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/xkeyval/xkeyval.sty\n
(/usr/local/texlive/2018/texmf-dist/tex/generic/xkeyval/xkeyval.tex\n
(/usr/local/texlive/2018/texmf-dist/tex/generic/xkeyval/xkvutils.tex\n
(/usr/local/texlive/2018/texmf-dist/tex/generic/xkeyval/keyval.tex))))\n
(/usr/local/texlive/2018/texmf-dist/tex/generic/oberdiek/ifluatex.sty)\n
(/usr/local/texlive/2018/texmf-dist/tex/generic/ifxetex/ifxetex.sty))\n
(/usr/local/texlive/2018/texmf-dist/tex/latex/polyglossia/gloss-english.ldf)\n
\n
! Package fontspec Error: The font "COUCOU" cannot be found.\n
\n
For immediate help type H <return>.\n
 ...                                              \n
                                                  \n
l.20 \\usepackage\n
                [Bjarne]{fncychap}\n
No pages of output.\n
Transcript written on xelatex/SphinxTests.log.\n
'
b"\n
kpathsea: Running mktextfm COUCOU\n
/usr/local/texlive/2018/texmf-dist/web2c/mktexnam: Could not map source abbreviation C for COUCOU.\n
/usr/local/texlive/2018/texmf-dist/web2c/mktexnam: Need to update /usr/local/texlive/2018/texmf-dist/fonts/map/fontname/special.map?\n
mktextfm: Running mf-nowin -progname=mf \\mode:=ljfour; mag:=1; nonstopmode; input COUCOU\n
This is METAFONT, Version 2.7182818 (TeX Live 2018) (preloaded base=mf)\n
\n
kpathsea: Running mktexmf COUCOU\n
\n
! I can't find file `COUCOU'.\n
<*> ...:=ljfour; mag:=1; nonstopmode; input COUCOU\n
                                                  \n
Please type another input file name\n
! Emergency stop.\n
<*> ...:=ljfour; mag:=1; nonstopmode; input COUCOU\n
                                                  \n
Transcript written on mfput.log.\n
grep: COUCOU.log: No such file or directory\n
mktextfm: `mf-nowin -progname=mf \\mode:=ljfour; mag:=1; nonstopmode; input COUCOU' failed to make COUCOU.tfm.\n
kpathsea: Appending font creation commands to missfont.log.\n
"
```

which is still a bit lengthy, but does provide the only relevant information which is that an attempt was made to use a non-existing font.


