### PR TITLE
Fix #5834: apidoc: wrong help for --tocfile

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Bugs fixed
 * #5636: C++, fix parsing of floating point literals.
 * #5496 (again): C++, fix assertion in partial builds with duplicates.
 * #5724: quickstart: sphinx-quickstart fails when $LC_ALL is empty
+* #5834: apidoc: wrong help for ``--tocfile``
 
 Testing
 --------

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -341,7 +341,7 @@ Note: By default this script will not overwrite already created files."""))
                         dest='includeprivate',
                         help=__('include "_private" modules'))
     parser.add_argument('--tocfile', action='store', dest='tocfile', default='modules',
-                        help=__("don't create a table of contents file"))
+                        help=__("filename of table of contents (default: modules)"))
     parser.add_argument('-T', '--no-toc', action='store_false', dest='tocfile',
                         help=__("don't create a table of contents file"))
     parser.add_argument('-E', '--no-headings', action='store_true',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5834 
