### PR TITLE
Deprecate unused Exception attributes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -63,6 +63,9 @@ Deprecated
 * ``sphinx.cmd.quickstart.TERM_ENCODING``
 * ``sphinx.config.check_unicode()``
 * ``sphinx.config.string_classes``
+* ``sphinx.domains.cpp.DefinitionError.description``
+* ``sphinx.domains.cpp.NoOldIdError.description``
+* ``sphinx.domains.cpp.UnsupportedMultiCharacterCharLiteral.decoded``
 * ``sphinx.ext.autodoc.importer._MockImporter``
 * ``sphinx.ext.autosummary.Autosummary.warn()``
 * ``sphinx.ext.autosummary.Autosummary.genopt``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -172,6 +172,21 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``[str]``
 
+   * - ``sphinx.domains.cpp.DefinitionError.description``
+     - 2.0
+     - 4.0
+     - ``str(exc)``
+
+   * - ``sphinx.domains.cpp.NoOldIdError.description``
+     - 2.0
+     - 4.0
+     - ``str(exc)``
+
+   * - ``sphinx.domains.cpp.UnsupportedMultiCharacterCharLiteral.decoded``
+     - 2.0
+     - 4.0
+     - ``str(exc)``
+
    * - ``sphinx.ext.autosummary.Autosummary.warn()``
      - 2.0
      - 4.0


### PR DESCRIPTION
The attributes were used only for the string representation, but that is also the default behavior of the `Exception` class. Observe:

```
>>> str(Exception('foo'))
'foo'
>>> print(Exception('foo'))
foo
```