### PR TITLE
Move immediate append operation to list literal

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -696,15 +696,12 @@ def rfc1123_to_epoch(rfc1123):
 def xmlname_checker():
     # type: () -> Pattern
     # https://www.w3.org/TR/REC-xml/#NT-Name
-    # Only Python 3.3 or newer support character code in regular expression
     name_start_chars = [
         ':', ['A', 'Z'], '_', ['a', 'z'], ['\u00C0', '\u00D6'],
         ['\u00D8', '\u00F6'], ['\u00F8', '\u02FF'], ['\u0370', '\u037D'],
         ['\u037F', '\u1FFF'], ['\u200C', '\u200D'], ['\u2070', '\u218F'],
         ['\u2C00', '\u2FEF'], ['\u3001', '\uD7FF'], ['\uF900', '\uFDCF'],
-        ['\uFDF0', '\uFFFD']]
-
-    name_start_chars.append(['\U00010000', '\U000EFFFF'])
+        ['\uFDF0', '\uFFFD'], ['\U00010000', '\U000EFFFF']]
 
     name_chars = [
         "\\-", "\\.", ['0', '9'], '\u00B7', ['\u0300', '\u036F'],


### PR DESCRIPTION
Was previously separate for Python 2 support, but this is no longer
necessary. Can simply include the item in the literal.

https://github.com/sphinx-doc/sphinx/blob/v1.8.2/sphinx/util/__init__.py#L680-L681
