### PR TITLE
Replace escape sequence '\u00B6' with literal '¶'

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1633,7 +1633,7 @@ def setup(app):
     app.add_config_value('html_sidebars', {}, 'html')
     app.add_config_value('html_additional_pages', {}, 'html')
     app.add_config_value('html_domain_indices', True, 'html', [list])
-    app.add_config_value('html_add_permalinks', '\u00B6', 'html')
+    app.add_config_value('html_add_permalinks', '¶', 'html')
     app.add_config_value('html_use_index', True, 'html')
     app.add_config_value('html_split_index', False, 'html')
     app.add_config_value('html_copy_source', True, 'html')

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -92,7 +92,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.permalink_text = self.config.html_add_permalinks
         # support backwards-compatible setting to a bool
         if not isinstance(self.permalink_text, str):
-            self.permalink_text = self.permalink_text and '\u00B6' or ''
+            self.permalink_text = self.permalink_text and '¶' or ''
         self.permalink_text = self.encode(self.permalink_text)
         self.secnumber_suffix = self.config.html_secnumber_suffix
         self.param_separator = ''

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -62,7 +62,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.permalink_text = self.config.html_add_permalinks
         # support backwards-compatible setting to a bool
         if not isinstance(self.permalink_text, str):
-            self.permalink_text = self.permalink_text and '\u00B6' or ''
+            self.permalink_text = self.permalink_text and '¶' or ''
         self.permalink_text = self.encode(self.permalink_text)
         self.secnumber_suffix = self.config.html_secnumber_suffix
         self.param_separator = ''


### PR DESCRIPTION
More obvious to the reader.