### PR TITLE
Fix #5800: todo: crashed if todo is defined in TextElement

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
 * #5724: quickstart: sphinx-quickstart fails when $LC_ALL is empty
 * #1956: Default conf.py is not PEP8-compliant
 * #5834: apidoc: wrong help for ``--tocfile``
+* #5800: todo: crashed if todo is defined in TextElement
 
 Testing
 --------

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -166,7 +166,10 @@ def process_todo_nodes(app, doctree, fromdocname):
             try:
                 newnode['refuri'] = app.builder.get_relative_uri(
                     fromdocname, todo_info['docname'])
-                newnode['refuri'] += '#' + todo_info['target']['refid']
+                if 'refid' in todo_info['target']:
+                    newnode['refuri'] += '#' + todo_info['target']['refid']
+                else:
+                    newnode['refuri'] += '#' + todo_info['target']['ids'][0]
             except NoUri:
                 # ignore if no URI can be determined, e.g. for LaTeX output
                 pass

--- a/tests/roots/test-ext-todo/foo.rst
+++ b/tests/roots/test-ext-todo/foo.rst
@@ -2,3 +2,9 @@ foo
 ===
 
 .. todo:: todo in foo
+
+.. py:function:: hello()
+
+   :param bug: #5800
+
+               .. todo:: todo in param field

--- a/tests/test_ext_todo.py
+++ b/tests/test_ext_todo.py
@@ -41,13 +41,19 @@ def test_todo(app, status, warning):
             '<p class="last">todo in foo</p>')
     assert re.search(html, content, re.S)
 
+    html = ('<p class="first admonition-title">Todo</p>\n'
+            '<p class="last">todo in param field</p>')
+    assert re.search(html, content, re.S)
+
     # check emitted warnings
     assert 'WARNING: TODO entry found: todo in foo' in warning.getvalue()
     assert 'WARNING: TODO entry found: todo in bar' in warning.getvalue()
 
     # check handled event
-    assert len(todos) == 2
-    assert set(todo[1].astext() for todo in todos) == set(['todo in foo', 'todo in bar'])
+    assert len(todos) == 3
+    assert set(todo[1].astext() for todo in todos) == {'todo in foo',
+                                                       'todo in bar',
+                                                       'todo in param field'}
 
 
 @pytest.mark.sphinx('html', testroot='ext-todo', freshenv=True,
@@ -82,8 +88,10 @@ def test_todo_not_included(app, status, warning):
     assert 'WARNING: TODO entry found: todo in bar' in warning.getvalue()
 
     # check handled event
-    assert len(todos) == 2
-    assert set(todo[1].astext() for todo in todos) == set(['todo in foo', 'todo in bar'])
+    assert len(todos) == 3
+    assert set(todo[1].astext() for todo in todos) == {'todo in foo',
+                                                       'todo in bar',
+                                                       'todo in param field'}
 
 
 @pytest.mark.sphinx('latex', testroot='ext-todo', freshenv=True,
@@ -106,7 +114,7 @@ def test_todo_valid_link(app, status, warning):
     link = r'\{\\hyperref\[\\detokenize\{(.*?foo.*?)}]\{\\sphinxcrossref{' \
         r'\\sphinxstyleemphasis{original entry}}}}'
     m = re.findall(link, content)
-    assert len(m) == 2
+    assert len(m) == 4
     target = m[0]
 
     # Look for the targets of this link.


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5800
