### PR TITLE
Fix #5841: Add --extensions option to sphinx-apidoc.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -127,6 +127,7 @@ Features added
 * LaTeX: support rendering (not in math, yet) of Greek and Cyrillic Unicode
   letters in non-Cyrillic document even with ``'pdflatex'`` as
   :confval:`latex_engine` (refs: #5645)
+* #5841: apidoc: Add --extensions option to sphinx-apidoc
 
 Bugs fixed
 ----------

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -371,6 +371,8 @@ Note: By default this script will not overwrite already created files."""))
                                 'defaults to --doc-version'))
 
     group = parser.add_argument_group(__('extension options'))
+    group.add_argument('--extensions', metavar='EXTENSIONS', dest='extensions',
+                       action='append', help=__('enable arbitrary extensions'))
     for ext in EXTENSIONS:
         group.add_argument('--ext-%s' % ext, action='append_const',
                            const='sphinx.ext.%s' % ext, dest='extensions',
@@ -438,6 +440,11 @@ def main(argv=sys.argv[1:]):
         }
         if args.extensions:
             d['extensions'].extend(args.extensions)
+
+        for ext in d['extensions'][:]:
+            if ',' in ext:
+                d['extensions'].remove(ext)
+                d['extensions'].extend(ext.split(','))
 
         if not args.dryrun:
             qs.generate(d, silent=True, overwrite=args.force)


### PR DESCRIPTION
### Feature
Add  --extensions option to sphinx-apidoc.

### Detail
Example: `sphinx-apidoc -F -a -o doc sphinx --extensions sphinx.ext.napoleon,sphinx.ext.extlinks --ext-coverage`

Result(conf.py):
```
...
extensions = [
    'sphinx.ext.autodoc',
    'sphinx.ext.viewcode',
    'sphinx.ext.todo',
    'sphinx.ext.coverage',
    'sphinx.ext.napoleon',
    'sphinx.ext.extlinks',
]
...
```


### Relates
https://github.com/sphinx-doc/sphinx/issues/5841


