### PR TITLE
Remove instructions to install Python 2 on Windows

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -113,8 +113,7 @@ Prompt* (:kbd:`⊞Win-r` and type :command:`cmd`).  Once the command prompt is
 open, type :command:`python --version` and press Enter.  If Python is
 available, you will see the version of Python printed to the screen.  If you do
 not have Python installed, refer to the `Hitchhikers Guide to Python's`__
-Python on Windows installation guides. You can install either `Python 3`__ or
-`Python 2.7`__. Python 3 is recommended.
+Python on Windows installation guides. You must install `Python 3`__.
 
 Once Python is installed, you can install Sphinx using :command:`pip`.  Refer
 to the :ref:`pip installation instructions <install-pypi>` below for more
@@ -122,7 +121,6 @@ information.
 
 __ https://docs.python-guide.org/
 __ https://docs.python-guide.org/starting/install3/win/
-__ https://docs.python-guide.org/starting/install/win/
 
 
 .. _install-pypi:


### PR DESCRIPTION
As only Python 3 is supported, should not advise users to install Python 2.