### PR TITLE
#5660 add classes for different version modications

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -132,6 +132,11 @@ Features added
 * LaTeX: support rendering (not in math, yet) of Greek and Cyrillic Unicode
   letters in non-Cyrillic document even with ``'pdflatex'`` as
   :confval:`latex_engine` (refs: #5645)
+* #5660: The ``versionadded``, ``versionchanged`` and ``deprecated`` directives
+  are now generated with their own specific CSS classes
+  (``added``, ``changed`` and ``deprecated``, respectively) in addition to the
+  generic ``versionmodified`` class.
+
 
 Bugs fixed
 ----------

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -27,11 +27,16 @@ if False:
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 
-
 versionlabels = {
     'versionadded':   _('New in version %s'),
     'versionchanged': _('Changed in version %s'),
     'deprecated':     _('Deprecated since version %s'),
+}
+
+versionlabel_classes = {
+    'versionadded':     'added',
+    'versionchanged':   'changed',
+    'deprecated':       'deprecated',
 }
 
 locale.versionlabels = DeprecatedDict(
@@ -78,6 +83,7 @@ class VersionChange(SphinxDirective):
             messages = []
         if self.content:
             self.state.nested_parse(self.content, self.content_offset, node)
+        classes = ['versionmodified', versionlabel_classes[self.name]]
         if len(node):
             if isinstance(node[0], nodes.paragraph) and node[0].rawsource:
                 content = nodes.inline(node[0].rawsource, translatable=True)
@@ -87,11 +93,11 @@ class VersionChange(SphinxDirective):
                 node[0].replace_self(nodes.paragraph('', '', content, translatable=False))
 
             para = cast(nodes.paragraph, node[0])
-            para.insert(0, nodes.inline('', '%s: ' % text, classes=['versionmodified']))
+            para.insert(0, nodes.inline('', '%s: ' % text, classes=classes))
         else:
             para = nodes.paragraph('', '',
                                    nodes.inline('', '%s.' % text,
-                                                classes=['versionmodified']),
+                                                classes=classes),
                                    translatable=False)
             node.append(para)
 

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -27,6 +27,7 @@ if False:
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 
+
 versionlabels = {
     'versionadded':   _('New in version %s'),
     'versionchanged': _('Changed in version %s'),

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -705,20 +705,20 @@ def test_html_versionchanges(app):
             return ''
 
     expect1 = (
-        """<p><span class="versionmodified">Deprecated since version 1.0: </span>"""
+        """<p><span class="versionmodified deprecated">Deprecated since version 1.0: </span>"""
         """THIS IS THE <em>FIRST</em> PARAGRAPH OF DEPRECATED.</p>\n"""
         """<p>THIS IS THE <em>SECOND</em> PARAGRAPH OF DEPRECATED.</p>\n""")
     matched_content = get_content(result, "deprecated")
     assert expect1 == matched_content
 
     expect2 = (
-        """<p><span class="versionmodified">New in version 1.0: </span>"""
+        """<p><span class="versionmodified added">New in version 1.0: </span>"""
         """THIS IS THE <em>FIRST</em> PARAGRAPH OF VERSIONADDED.</p>\n""")
     matched_content = get_content(result, "versionadded")
     assert expect2 == matched_content
 
     expect3 = (
-        """<p><span class="versionmodified">Changed in version 1.0: </span>"""
+        """<p><span class="versionmodified changed">Changed in version 1.0: </span>"""
         """THIS IS THE <em>FIRST</em> PARAGRAPH OF VERSIONCHANGED.</p>\n""")
     matched_content = get_content(result, "versionchanged")
     assert expect3 == matched_content


### PR DESCRIPTION
Subject: Add classes for different version modifications

### Feature or Bugfix
- Feature

### Purpose
- To allow users to use different styles for different modification types.
### Detail
* Generic class: ``versionmodified``
* *Changed* class: ``changed``
* *Added* class: ``added``
* *Deprecated* class: ``deprecated``

### Relates
- Closes #5660

