### PR TITLE
Allow periods in texinfo node names

### DIFF
--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -387,7 +387,7 @@ class TexinfoTranslator(SphinxTranslator):
     def escape_id(self, s):
         # type: (str) -> str
         """Return an escaped string suitable for node names and anchors."""
-        bad_chars = ',:.()'
+        bad_chars = ',:()'
         for bc in bad_chars:
             s = s.replace(bc, ' ')
         s = ' '.join(s.split()).strip()


### PR DESCRIPTION
Subject: Allow periods in texinfo node names

### Feature or Bugfix
- Bugfix

### Purpose
- Allow `.` in texinfo node names

### Relates
- #5871

