### PR TITLE
Remove coding magic comments from tests

### DIFF
--- a/tests/roots/test-add_enumerable_node/conf.py
+++ b/tests/roots/test-add_enumerable_node/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-add_enumerable_node/enumerable_node.py
+++ b/tests/roots/test-add_enumerable_node/enumerable_node.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from docutils import nodes
 from docutils.parsers.rst import Directive
 

--- a/tests/roots/test-add_source_parser-conflicts-with-users-setting/conf.py
+++ b/tests/roots/test-add_source_parser-conflicts-with-users-setting/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-add_source_parser-conflicts-with-users-setting/source_parser.py
+++ b/tests/roots/test-add_source_parser-conflicts-with-users-setting/source_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from docutils.parsers import Parser
 
 

--- a/tests/roots/test-add_source_parser/conf.py
+++ b/tests/roots/test-add_source_parser/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-add_source_parser/source_parser.py
+++ b/tests/roots/test-add_source_parser/source_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from docutils.parsers import Parser
 
 

--- a/tests/roots/test-api-set-translator/conf.py
+++ b/tests/roots/test-api-set-translator/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # set this by test
 # import os
 # import sys

--- a/tests/roots/test-api-set-translator/nonext/conf.py
+++ b/tests/roots/test-api-set-translator/nonext/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-api-set-translator/translator.py
+++ b/tests/roots/test-api-set-translator/translator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from sphinx.writers.html import HTMLTranslator
 
 

--- a/tests/roots/test-basic/conf.py
+++ b/tests/roots/test-basic/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-build-html-translator/conf.py
+++ b/tests/roots/test-build-html-translator/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from sphinx.writers.html import HTMLTranslator
 
 project = 'test'

--- a/tests/roots/test-build-htmlhelp/conf.py
+++ b/tests/roots/test-build-htmlhelp/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 project = 'test'
 master_doc = 'index'

--- a/tests/roots/test-builder-gettext-dont-rebuild-mo/conf.py
+++ b/tests/roots/test-builder-gettext-dont-rebuild-mo/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-default_role/conf.py
+++ b/tests/roots/test-default_role/conf.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'

--- a/tests/roots/test-directive-code/conf.py
+++ b/tests/roots/test-directive-code/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 exclude_patterns = ['_build']
 numfig = True

--- a/tests/roots/test-directive-code/literal-diff.inc
+++ b/tests/roots/test-directive-code/literal-diff.inc
@@ -1,5 +1,4 @@
 # Literally included file using Python highlighting
-# -*- coding: utf-8 -*-
 
 foo = "Including Unicode characters: üöä"
 

--- a/tests/roots/test-directive-code/literal.inc
+++ b/tests/roots/test-directive-code/literal.inc
@@ -1,5 +1,4 @@
 # Literally included file using Python highlighting
-# -*- coding: utf-8 -*-
 
 foo = "Including Unicode characters: üöä"
 

--- a/tests/roots/test-directive-code/py-decorators.inc
+++ b/tests/roots/test-directive-code/py-decorators.inc
@@ -1,5 +1,4 @@
 # Literally included file using Python highlighting
-# -*- coding: utf-8 -*-
 
 @class_decorator
 @other_decorator()

--- a/tests/roots/test-directive-code/target.py
+++ b/tests/roots/test-directive-code/target.py
@@ -1,5 +1,4 @@
 # Literally included file using Python highlighting
-# -*- coding: utf-8 -*-
 
 foo = "Including Unicode characters: üöä"
 

--- a/tests/roots/test-directives-raw/conf.py
+++ b/tests/roots/test-directives-raw/conf.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'

--- a/tests/roots/test-docutilsconf/conf.py
+++ b/tests/roots/test-docutilsconf/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 project = 'Sphinx docutils conf <Tests>'
 source_suffix = '.txt'
 keep_warnings = True

--- a/tests/roots/test-domain-cpp/conf.py
+++ b/tests/roots/test-domain-cpp/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-domain-js/conf.py
+++ b/tests/roots/test-domain-js/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-domain-py/conf.py
+++ b/tests/roots/test-domain-py/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-double-inheriting-theme/conf.py
+++ b/tests/roots/test-double-inheriting-theme/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 templates_path = ['_templates']
 master_doc = 'index'
 html_theme = 'base_theme2'

--- a/tests/roots/test-epub-anchor-id/conf.py
+++ b/tests/roots/test-epub-anchor-id/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import enum
 from io import StringIO
 

--- a/tests/roots/test-ext-autosectionlabel-prefix-document/conf.py
+++ b/tests/roots/test-ext-autosectionlabel-prefix-document/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.autosectionlabel']
 master_doc = 'index'
 autosectionlabel_prefix_document = True

--- a/tests/roots/test-ext-autosectionlabel/conf.py
+++ b/tests/roots/test-ext-autosectionlabel/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.autosectionlabel']
 master_doc = 'index'

--- a/tests/roots/test-ext-githubpages/conf.py
+++ b/tests/roots/test-ext-githubpages/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.githubpages']
 master_doc = 'index'

--- a/tests/roots/test-ext-graphviz/conf.py
+++ b/tests/roots/test-ext-graphviz/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.graphviz']
 master_doc = 'index'
 exclude_patterns = ['_build']

--- a/tests/roots/test-ext-ifconfig/conf.py
+++ b/tests/roots/test-ext-ifconfig/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.ifconfig']
 master_doc = 'index'
 exclude_patterns = ['_build']

--- a/tests/roots/test-ext-imgconverter/conf.py
+++ b/tests/roots/test-ext-imgconverter/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 extensions = ['sphinx.ext.imgconverter']

--- a/tests/roots/test-ext-inheritance_diagram/conf.py
+++ b/tests/roots/test-ext-inheritance_diagram/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-ext-inheritance_diagram/test.py
+++ b/tests/roots/test-ext-inheritance_diagram/test.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 class Foo(object):
     pass
 

--- a/tests/roots/test-ext-intersphinx-cppdomain/conf.py
+++ b/tests/roots/test-ext-intersphinx-cppdomain/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.intersphinx']
 master_doc = 'index'

--- a/tests/roots/test-ext-math-compat/conf.py
+++ b/tests/roots/test-ext-math-compat/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from docutils.parsers.rst import Directive
 
 from sphinx.ext.mathbase import math, displaymath

--- a/tests/roots/test-ext-math-simple/conf.py
+++ b/tests/roots/test-ext-math-simple/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-ext-math/conf.py
+++ b/tests/roots/test-ext-math/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-ext-todo/conf.py
+++ b/tests/roots/test-ext-todo/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.todo']
 master_doc = 'index'
 

--- a/tests/roots/test-ext-viewcode-find/conf.py
+++ b/tests/roots/test-ext-viewcode-find/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 extensions = ['sphinx.ext.viewcode']
 master_doc = 'index'
 exclude_patterns = ['_build']

--- a/tests/roots/test-ext-viewcode/conf.py
+++ b/tests/roots/test-ext-viewcode/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-footnotes/conf.py
+++ b/tests/roots/test-footnotes/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-gettext-template/conf.py
+++ b/tests/roots/test-gettext-template/conf.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 templates_path = ['_templates']

--- a/tests/roots/test-glossary/conf.py
+++ b/tests/roots/test-glossary/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-html_assets/conf.py
+++ b/tests/roots/test-html_assets/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 project = 'Sphinx'
 version = '1.4.4'

--- a/tests/roots/test-html_entity/conf.py
+++ b/tests/roots/test-html_entity/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-image-in-parsed-literal/conf.py
+++ b/tests/roots/test-image-in-parsed-literal/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 exclude_patterns = ['_build']
 

--- a/tests/roots/test-image-in-section/conf.py
+++ b/tests/roots/test-image-in-section/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 exclude_patterns = ['_build']
 

--- a/tests/roots/test-images/conf.py
+++ b/tests/roots/test-images/conf.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'

--- a/tests/roots/test-intl/conf.py
+++ b/tests/roots/test-intl/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 project = 'Sphinx intl <Tests>'
 source_suffix = '.txt'
 keep_warnings = True

--- a/tests/roots/test-keep_warnings/conf.py
+++ b/tests/roots/test-keep_warnings/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 keep_warnings = True

--- a/tests/roots/test-latex-babel/conf.py
+++ b/tests/roots/test-latex-babel/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 numfig_format = {
     'figure': 'Fig. %s',

--- a/tests/roots/test-latex-equations/conf.py
+++ b/tests/roots/test-latex-equations/conf.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'equations'
 extensions = ['sphinx.ext.imgmath']

--- a/tests/roots/test-latex-index/conf.py
+++ b/tests/roots/test-latex-index/conf.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'

--- a/tests/roots/test-latex-labels/conf.py
+++ b/tests/roots/test-latex-labels/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-latex-numfig/conf.py
+++ b/tests/roots/test-latex-numfig/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 extensions = ['sphinx.ext.imgmath']  # for math_numfig

--- a/tests/roots/test-latex-table/conf.py
+++ b/tests/roots/test-latex-table/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-latex-title/conf.py
+++ b/tests/roots/test-latex-title/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 # set empty string to the third column to use the first section title to document title

--- a/tests/roots/test-manpage_url/conf.py
+++ b/tests/roots/test-manpage_url/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-markup-citation/conf.py
+++ b/tests/roots/test-markup-citation/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-markup-rubric/conf.py
+++ b/tests/roots/test-markup-rubric/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-maxlistdepth/conf.py
+++ b/tests/roots/test-maxlistdepth/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-metadata/conf.py
+++ b/tests/roots/test-metadata/conf.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'

--- a/tests/roots/test-need-escaped/conf.py
+++ b/tests/roots/test-need-escaped/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 project = 'need <b>"escaped"</b> project'
 smartquotes = False

--- a/tests/roots/test-nested-enumerated-list/conf.py
+++ b/tests/roots/test-nested-enumerated-list/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-numfig/conf.py
+++ b/tests/roots/test-numfig/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-prolog/conf.py
+++ b/tests/roots/test-prolog/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))

--- a/tests/roots/test-prolog/prolog_markdown_parser.py
+++ b/tests/roots/test-prolog/prolog_markdown_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from docutils.parsers import Parser
 
 

--- a/tests/roots/test-pycode-egg/conf.py
+++ b/tests/roots/test-pycode-egg/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-pycode-egg/src/sample.py
+++ b/tests/roots/test-pycode-egg/src/sample.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #: constant on sample.py
 CONSTANT = 1
 

--- a/tests/roots/test-pycode-egg/src/setup.py
+++ b/tests/roots/test-pycode-egg/src/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 

--- a/tests/roots/test-refonly_bullet_list/conf.py
+++ b/tests/roots/test-refonly_bullet_list/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_compact_lists = False
 

--- a/tests/roots/test-roles-download/conf.py
+++ b/tests/roots/test-roles-download/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-root/autodoc_target.py
+++ b/tests/roots/test-root/autodoc_target.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import enum
 from io import StringIO
 

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 

--- a/tests/roots/test-root/literal_orig.inc
+++ b/tests/roots/test-root/literal_orig.inc
@@ -1,5 +1,4 @@
 # Literally included file using Python highlighting
-# -*- coding: utf-8 -*-
 
 foo = "Including Unicode characters: üöä"  # This will be changed
 

--- a/tests/roots/test-setup/doc/conf.py
+++ b/tests/roots/test-setup/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 project = 'Sphinx smallest project'
 source_suffix = '.txt'
 keep_warnings = True

--- a/tests/roots/test-smartquotes/conf.py
+++ b/tests/roots/test-smartquotes/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-stylesheets/conf.py
+++ b/tests/roots/test-stylesheets/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 templates_path = ['_templates']

--- a/tests/roots/test-templating/conf.py
+++ b/tests/roots/test-templating/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 project = 'Sphinx templating <Tests>'
 source_suffix = '.txt'
 keep_warnings = True

--- a/tests/roots/test-theming/conf.py
+++ b/tests/roots/test-theming/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 html_theme = 'test-theme'
 html_theme_path = ['.', 'test_theme']
 master_doc = 'index'

--- a/tests/roots/test-theming/setup.py
+++ b/tests/roots/test-theming/setup.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
 setup(

--- a/tests/roots/test-theming/test_theme/__init__.py
+++ b/tests/roots/test-theming/test_theme/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 

--- a/tests/roots/test-tocdepth/conf.py
+++ b/tests/roots/test-tocdepth/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-toctree-empty/conf.py
+++ b/tests/roots/test-toctree-empty/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-toctree-glob/conf.py
+++ b/tests/roots/test-toctree-glob/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-toctree-maxdepth/conf.py
+++ b/tests/roots/test-toctree-maxdepth/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 html_theme = 'classic'
 exclude_patterns = ['_build']

--- a/tests/roots/test-toctree/conf.py
+++ b/tests/roots/test-toctree/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 latex_documents = [

--- a/tests/roots/test-trim_doctest_flags/conf.py
+++ b/tests/roots/test-trim_doctest_flags/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 master_doc = 'index'
 
 extensions = ['sphinx.ext.doctest']

--- a/tests/roots/test-warnings/conf.py
+++ b/tests/roots/test-warnings/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 sys.path.append(os.path.abspath('.'))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,9 +126,7 @@ def test_errors_warnings(logger, tempdir):
     assert 'conf.py' in str(excinfo.value)
 
     # test the automatic conversion of 2.x only code in configs
-    (tempdir / 'conf.py').write_text(
-        '# -*- coding: utf-8\n\nproject = u"Jägermeister"\n',
-        encoding='utf-8')
+    (tempdir / 'conf.py').write_text('project = u"Jägermeister"\n', encoding='utf-8')
     cfg = Config.read(tempdir, {}, None)
     cfg.init_values()
     assert cfg.project == 'Jägermeister'

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -36,18 +36,18 @@ def test_LiteralIncludeReader(literal_inc_path):
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == literal_inc_path.text()
-    assert lines == 14
+    assert lines == 13
     assert reader.lineno_start == 1
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_lineno_start(literal_inc_path):
-    options = {'lineno-start': 5}
+    options = {'lineno-start': 4}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == literal_inc_path.text()
-    assert lines == 14
-    assert reader.lineno_start == 5
+    assert lines == 13
+    assert reader.lineno_start == 4
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
@@ -57,7 +57,7 @@ def test_LiteralIncludeReader_pyobject1(literal_inc_path):
     content, lines = reader.read()
     assert content == ("class Foo:\n"
                        "    pass\n")
-    assert reader.lineno_start == 6
+    assert reader.lineno_start == 5
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
@@ -91,18 +91,17 @@ def test_LiteralIncludeReader_pyobject_and_lines(literal_inc_path):
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_lines1(literal_inc_path):
-    options = {'lines': '1-4'}
+    options = {'lines': '1-3'}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("# Literally included file using Python highlighting\n"
-                       "# -*- coding: utf-8 -*-\n"
                        "\n"
                        "foo = \"Including Unicode characters: üöä\"\n")
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_lines2(literal_inc_path):
-    options = {'lines': '1,4,6'}
+    options = {'lines': '1,3,5'}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("# Literally included file using Python highlighting\n"
@@ -112,18 +111,18 @@ def test_LiteralIncludeReader_lines2(literal_inc_path):
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_lines_and_lineno_match1(literal_inc_path):
-    options = {'lines': '4-6', 'lineno-match': True}
+    options = {'lines': '3-5', 'lineno-match': True}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("foo = \"Including Unicode characters: üöä\"\n"
                        "\n"
                        "class Foo:\n")
-    assert reader.lineno_start == 4
+    assert reader.lineno_start == 3
 
 
 @pytest.mark.sphinx()  # init locale for errors
 def test_LiteralIncludeReader_lines_and_lineno_match2(literal_inc_path, app, status, warning):
-    options = {'lines': '1,4,6', 'lineno-match': True}
+    options = {'lines': '0,3,5', 'lineno-match': True}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     with pytest.raises(ValueError):
         content, lines = reader.read()
@@ -146,7 +145,7 @@ def test_LiteralIncludeReader_start_at(literal_inc_path):
                        "    pass\n"
                        "\n"
                        "class Bar:\n")
-    assert reader.lineno_start == 6
+    assert reader.lineno_start == 5
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
@@ -156,13 +155,13 @@ def test_LiteralIncludeReader_start_after(literal_inc_path):
     content, lines = reader.read()
     assert content == ("    pass\n"
                        "\n")
-    assert reader.lineno_start == 7
+    assert reader.lineno_start == 6
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_start_after_and_lines(literal_inc_path):
     options = {'lineno-match': True, 'lines': '6-',
-               'start-after': 'coding', 'end-before': 'comment'}
+               'start-after': 'Literally', 'end-before': 'comment'}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("\n"
@@ -170,7 +169,7 @@ def test_LiteralIncludeReader_start_after_and_lines(literal_inc_path):
                        "    def baz():\n"
                        "        pass\n"
                        "\n")
-    assert reader.lineno_start == 8
+    assert reader.lineno_start == 7
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
@@ -219,7 +218,7 @@ def test_LiteralIncludeReader_prepend(literal_inc_path):
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_dedent(literal_inc_path):
     # dedent: 2
-    options = {'lines': '10-12', 'dedent': 2}
+    options = {'lines': '9-11', 'dedent': 2}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("  def baz():\n"
@@ -227,7 +226,7 @@ def test_LiteralIncludeReader_dedent(literal_inc_path):
                        "\n")
 
     # dedent: 4
-    options = {'lines': '10-12', 'dedent': 4}
+    options = {'lines': '9-11', 'dedent': 4}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("def baz():\n"
@@ -235,7 +234,7 @@ def test_LiteralIncludeReader_dedent(literal_inc_path):
                        "\n")
 
     # dedent: 6
-    options = {'lines': '10-12', 'dedent': 6}
+    options = {'lines': '9-11', 'dedent': 6}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
     content, lines = reader.read()
     assert content == ("f baz():\n"
@@ -278,7 +277,7 @@ def test_LiteralIncludeReader_diff(testroot, literal_inc_path):
     content, lines = reader.read()
     assert content == ("--- " + testroot + "/literal-diff.inc\n"
                        "+++ " + testroot + "/literal.inc\n"
-                       "@@ -7,8 +7,8 @@\n"
+                       "@@ -6,8 +6,8 @@\n"
                        "     pass\n"
                        " \n"
                        " class Bar:\n"
@@ -353,7 +352,7 @@ def test_code_block_namedlink_latex(app, status, warning):
 def test_code_block_emphasize_latex(app, status, warning):
     app.builder.build(['emphasize'])
     latex = (app.outdir / 'Python.tex').text(encoding='utf-8').replace('\r\n', '\n')
-    includes = '\\fvset{hllines={, 5, 6, 13, 14, 15, 24, 25, 26, 27,}}%\n'
+    includes = '\\fvset{hllines={, 5, 6, 13, 14, 15, 24, 25, 26,}}%\n'
     assert includes in latex
     includes = '\\end{sphinxVerbatim}\n\\sphinxresetverbatimhllines\n'
     assert includes in latex
@@ -414,8 +413,7 @@ def test_literal_include_linenos(app, status, warning):
             '10\n'
             '11\n'
             '12\n'
-            '13\n'
-            '14</pre></div></td>' in html)
+            '13</pre></div></td>' in html)
 
     # :lineno-start:
     assert ('<td class="linenos"><div class="linenodiv"><pre>'
@@ -431,8 +429,7 @@ def test_literal_include_linenos(app, status, warning):
             '209\n'
             '210\n'
             '211\n'
-            '212\n'
-            '213</pre></div></td>' in html)
+            '212</pre></div></td>' in html)
 
     # :lineno-match:
     assert ('<td class="linenos"><div class="linenodiv"><pre>'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- It is meaningless on py3 now.
