### PR TITLE
encoding keyword for path.text() and path.write_text() is no longer needed

### DIFF
--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -30,7 +30,7 @@ def test_build_gettext(app):
     assert (app.outdir / 'subdir.pot').isfile()
 
     # regression test for issue #960
-    catalog = (app.outdir / 'markup.pot').text(encoding='utf-8')
+    catalog = (app.outdir / 'markup.pot').text()
     assert 'msgid "something, something else, something more"' in catalog
 
 
@@ -88,7 +88,7 @@ def test_gettext_index_entries(app):
             return m.groups()[0]
         return None
 
-    pot = (app.outdir / 'index_entries.pot').text(encoding='utf-8')
+    pot = (app.outdir / 'index_entries.pot').text()
     msgids = [_f for _f in map(msgid_getter, pot.splitlines()) if _f]
 
     expected_msgids = [
@@ -137,7 +137,7 @@ def test_gettext_disable_index_entries(app):
             return m.groups()[0]
         return None
 
-    pot = (app.outdir / 'index_entries.pot').text(encoding='utf-8')
+    pot = (app.outdir / 'index_entries.pot').text()
     msgids = [_f for _f in map(msgid_getter, pot.splitlines()) if _f]
 
     expected_msgids = [
@@ -160,7 +160,7 @@ def test_gettext_template(app):
     app.builder.build_all()
     assert (app.outdir / 'sphinx.pot').isfile()
 
-    result = (app.outdir / 'sphinx.pot').text(encoding='utf-8')
+    result = (app.outdir / 'sphinx.pot').text()
     assert "Welcome" in result
     assert "Sphinx %(version)s" in result
 
@@ -170,7 +170,7 @@ def test_gettext_template_msgid_order_in_sphinxpot(app):
     app.builder.build_all()
     assert (app.outdir / 'sphinx.pot').isfile()
 
-    result = (app.outdir / 'sphinx.pot').text(encoding='utf-8')
+    result = (app.outdir / 'sphinx.pot').text()
     assert re.search(
         ('msgid "Template 1".*'
          'msgid "This is Template 1\\.".*'

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -585,7 +585,7 @@ def test_numfig_without_numbered_toctree_warn(app, warning):
     # remove :numbered: option
     index = (app.srcdir / 'index.rst').text()
     index = re.sub(':numbered:.*', '', index)
-    (app.srcdir / 'index.rst').write_text(index, encoding='utf-8')
+    (app.srcdir / 'index.rst').write_text(index)
     app.builder.build_all()
 
     warnings = warning.getvalue()
@@ -683,7 +683,7 @@ def test_numfig_without_numbered_toctree(app, cached_etree_parse, fname, expect)
     # remove :numbered: option
     index = (app.srcdir / 'index.rst').text()
     index = re.sub(':numbered:.*', '', index)
-    (app.srcdir / 'index.rst').write_text(index, encoding='utf-8')
+    (app.srcdir / 'index.rst').write_text(index)
 
     if not app.outdir.listdir():
         app.build()

--- a/tests/test_build_text.py
+++ b/tests/test_build_text.py
@@ -26,7 +26,7 @@ def with_text_app(*args, **kw):
 @with_text_app()
 def test_maxwitdh_with_prefix(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'maxwidth.txt').text(encoding='utf-8')
+    result = (app.outdir / 'maxwidth.txt').text()
 
     lines = result.splitlines()
     line_widths = [column_width(line) for line in lines]
@@ -47,7 +47,7 @@ def test_maxwitdh_with_prefix(app, status, warning):
 def test_lineblock(app, status, warning):
     # regression test for #1109: need empty line after line block
     app.builder.build_update()
-    result = (app.outdir / 'lineblock.txt').text(encoding='utf-8')
+    result = (app.outdir / 'lineblock.txt').text()
     expect = (
         "* one\n"
         "\n"
@@ -62,7 +62,7 @@ def test_lineblock(app, status, warning):
 @with_text_app()
 def test_nonascii_title_line(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'nonascii_title.txt').text(encoding='utf-8')
+    result = (app.outdir / 'nonascii_title.txt').text()
     expect_underline = '*********'
     result_underline = result.splitlines()[1].strip()
     assert expect_underline == result_underline
@@ -71,7 +71,7 @@ def test_nonascii_title_line(app, status, warning):
 @with_text_app()
 def test_nonascii_table(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'nonascii_table.txt').text(encoding='utf-8')
+    result = (app.outdir / 'nonascii_table.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     line_widths = [column_width(line) for line in lines]
     assert len(set(line_widths)) == 1  # same widths
@@ -80,7 +80,7 @@ def test_nonascii_table(app, status, warning):
 @with_text_app()
 def test_nonascii_maxwidth(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'nonascii_maxwidth.txt').text(encoding='utf-8')
+    result = (app.outdir / 'nonascii_maxwidth.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     line_widths = [column_width(line) for line in lines]
     assert max(line_widths) < MAXWIDTH
@@ -124,7 +124,7 @@ def test_table_cell():
 @with_text_app()
 def test_table_with_empty_cell(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'table.txt').text(encoding='utf-8')
+    result = (app.outdir / 'table.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     assert lines[0] == "+-------+-------+"
     assert lines[1] == "| XXX   | XXX   |"
@@ -138,7 +138,7 @@ def test_table_with_empty_cell(app, status, warning):
 @with_text_app()
 def test_table_with_rowspan(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'table_rowspan.txt').text(encoding='utf-8')
+    result = (app.outdir / 'table_rowspan.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     assert lines[0] == "+-------+-------+"
     assert lines[1] == "| XXXXXXXXX     |"
@@ -152,7 +152,7 @@ def test_table_with_rowspan(app, status, warning):
 @with_text_app()
 def test_table_with_colspan(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'table_colspan.txt').text(encoding='utf-8')
+    result = (app.outdir / 'table_colspan.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     assert lines[0] == "+-------+-------+"
     assert lines[1] == "| XXX   | XXX   |"
@@ -166,7 +166,7 @@ def test_table_with_colspan(app, status, warning):
 @with_text_app()
 def test_table_with_colspan_left(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'table_colspan_left.txt').text(encoding='utf-8')
+    result = (app.outdir / 'table_colspan_left.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     assert lines[0] == "+-------+-------+"
     assert lines[1] == "| XXX   | XXX   |"
@@ -180,7 +180,7 @@ def test_table_with_colspan_left(app, status, warning):
 @with_text_app()
 def test_table_with_colspan_and_rowspan(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'table_colspan_and_rowspan.txt').text(encoding='utf-8')
+    result = (app.outdir / 'table_colspan_and_rowspan.txt').text()
     lines = [line.strip() for line in result.splitlines() if line.strip()]
     assert result
     assert lines[0] == "+-------+-------+-------+"
@@ -195,7 +195,7 @@ def test_table_with_colspan_and_rowspan(app, status, warning):
 @with_text_app()
 def test_list_items_in_admonition(app, status, warning):
     app.builder.build_update()
-    result = (app.outdir / 'listitems.txt').text(encoding='utf-8')
+    result = (app.outdir / 'listitems.txt').text()
     lines = [line.rstrip() for line in result.splitlines()]
     assert lines[0] == "See also:"
     assert lines[1] == ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,7 +126,7 @@ def test_errors_warnings(logger, tempdir):
     assert 'conf.py' in str(excinfo.value)
 
     # test the automatic conversion of 2.x only code in configs
-    (tempdir / 'conf.py').write_text('project = u"Jägermeister"\n', encoding='utf-8')
+    (tempdir / 'conf.py').write_text('project = u"Jägermeister"\n')
     cfg = Config.read(tempdir, {}, None)
     cfg.init_values()
     assert cfg.project == 'Jägermeister'

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -309,7 +309,7 @@ def test_code_block(app, status, warning):
 @pytest.mark.sphinx('html', testroot='directive-code')
 def test_code_block_caption_html(app, status, warning):
     app.builder.build(['caption'])
-    html = (app.outdir / 'caption.html').text(encoding='utf-8')
+    html = (app.outdir / 'caption.html').text()
     caption = ('<div class="code-block-caption">'
                '<span class="caption-number">Listing 1 </span>'
                '<span class="caption-text">caption <em>test</em> rb'
@@ -321,7 +321,7 @@ def test_code_block_caption_html(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='directive-code')
 def test_code_block_caption_latex(app, status, warning):
     app.builder.build_all()
-    latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
+    latex = (app.outdir / 'Python.tex').text()
     caption = '\\sphinxSetupCaptionForVerbatim{caption \\sphinxstyleemphasis{test} rb}'
     label = '\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:id1}}}'
     link = '\\hyperref[\\detokenize{caption:name-test-rb}]' \
@@ -334,7 +334,7 @@ def test_code_block_caption_latex(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='directive-code')
 def test_code_block_namedlink_latex(app, status, warning):
     app.builder.build_all()
-    latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
+    latex = (app.outdir / 'Python.tex').text()
     label1 = '\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:name-test-rb}}}'
     link1 = '\\hyperref[\\detokenize{caption:name-test-rb}]'\
             '{\\sphinxcrossref{\\DUrole{std,std-ref}{Ruby}}'
@@ -351,7 +351,7 @@ def test_code_block_namedlink_latex(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='directive-code')
 def test_code_block_emphasize_latex(app, status, warning):
     app.builder.build(['emphasize'])
-    latex = (app.outdir / 'Python.tex').text(encoding='utf-8').replace('\r\n', '\n')
+    latex = (app.outdir / 'Python.tex').text().replace('\r\n', '\n')
     includes = '\\fvset{hllines={, 5, 6, 13, 14, 15, 24, 25, 26,}}%\n'
     assert includes in latex
     includes = '\\end{sphinxVerbatim}\n\\sphinxresetverbatimhllines\n'
@@ -364,7 +364,7 @@ def test_literal_include(app, status, warning):
     et = etree_parse(app.outdir / 'index.xml')
     secs = et.findall('./section/section')
     literal_include = secs[1].findall('literal_block')
-    literal_src = (app.srcdir / 'literal.inc').text(encoding='utf-8')
+    literal_src = (app.srcdir / 'literal.inc').text()
     assert len(literal_include) > 0
     actual = literal_include[0].text
     assert actual == literal_src
@@ -397,7 +397,7 @@ def test_literal_include_block_start_with_comment_or_brank(app, status, warning)
 @pytest.mark.sphinx('html', testroot='directive-code')
 def test_literal_include_linenos(app, status, warning):
     app.builder.build(['linenos'])
-    html = (app.outdir / 'linenos.html').text(encoding='utf-8')
+    html = (app.outdir / 'linenos.html').text()
 
     # :linenos:
     assert ('<td class="linenos"><div class="linenodiv"><pre>'
@@ -443,7 +443,7 @@ def test_literal_include_linenos(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='directive-code')
 def test_literalinclude_file_whole_of_emptyline(app, status, warning):
     app.builder.build_all()
-    latex = (app.outdir / 'Python.tex').text(encoding='utf-8').replace('\r\n', '\n')
+    latex = (app.outdir / 'Python.tex').text().replace('\r\n', '\n')
     includes = (
         '\\begin{sphinxVerbatim}'
         '[commandchars=\\\\\\{\\},numbers=left,firstnumber=1,stepnumber=1]\n'
@@ -457,7 +457,7 @@ def test_literalinclude_file_whole_of_emptyline(app, status, warning):
 @pytest.mark.sphinx('html', testroot='directive-code')
 def test_literalinclude_caption_html(app, status, warning):
     app.builder.build('index')
-    html = (app.outdir / 'caption.html').text(encoding='utf-8')
+    html = (app.outdir / 'caption.html').text()
     caption = ('<div class="code-block-caption">'
                '<span class="caption-number">Listing 2 </span>'
                '<span class="caption-text">caption <strong>test</strong> py'
@@ -469,7 +469,7 @@ def test_literalinclude_caption_html(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='directive-code')
 def test_literalinclude_caption_latex(app, status, warning):
     app.builder.build('index')
-    latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
+    latex = (app.outdir / 'Python.tex').text()
     caption = '\\sphinxSetupCaptionForVerbatim{caption \\sphinxstylestrong{test} py}'
     label = '\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:id2}}}'
     link = '\\hyperref[\\detokenize{caption:name-test-py}]' \
@@ -482,7 +482,7 @@ def test_literalinclude_caption_latex(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='directive-code')
 def test_literalinclude_namedlink_latex(app, status, warning):
     app.builder.build('index')
-    latex = (app.outdir / 'Python.tex').text(encoding='utf-8')
+    latex = (app.outdir / 'Python.tex').text()
     label1 = '\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:name-test-py}}}'
     link1 = '\\hyperref[\\detokenize{caption:name-test-py}]'\
             '{\\sphinxcrossref{\\DUrole{std,std-ref}{Python}}'

--- a/tests/test_docutilsconf.py
+++ b/tests/test_docutilsconf.py
@@ -25,7 +25,7 @@ def test_html_with_default_docutilsconf(app, status, warning):
     with patch_docutils(app.confdir):
         app.builder.build(['contents'])
 
-    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    result = (app.outdir / 'index.html').text()
 
     assert regex_count(r'<th class="field-name">', result) == 1
     assert regex_count(r'<th class="field-name" colspan="2">', result) == 1
@@ -43,7 +43,7 @@ def test_html_with_docutilsconf(app, status, warning):
     with patch_docutils(app.confdir):
         app.builder.build(['contents'])
 
-    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    result = (app.outdir / 'index.html').text()
 
     assert regex_count(r'<th class="field-name">', result) == 0
     assert regex_count(r'<th class="field-name" colspan="2">', result) == 2

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -24,7 +24,7 @@ def test_viewcode(app, status, warning):
         warnings
     )
 
-    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    result = (app.outdir / 'index.html').text()
     assert result.count('href="_modules/spam/mod1.html#func1"') == 2
     assert result.count('href="_modules/spam/mod2.html#func2"') == 2
     assert result.count('href="_modules/spam/mod1.html#Class1"') == 2
@@ -37,7 +37,7 @@ def test_viewcode(app, status, warning):
     # the next assert fails, until the autodoc bug gets fixed
     assert result.count('this is the class attribute class_attr') == 2
 
-    result = (app.outdir / '_modules/spam/mod1.html').text(encoding='utf-8')
+    result = (app.outdir / '_modules/spam/mod1.html').text()
     result = re.sub('<span class=".*?">', '<span>', result)  # filter pygments classes
     assert ('<div class="viewcode-block" id="Class1"><a class="viewcode-back" '
             'href="../../index.html#spam.Class1">[docs]</a>'
@@ -53,7 +53,7 @@ def test_viewcode(app, status, warning):
 def test_linkcode(app, status, warning):
     app.builder.build(['objects'])
 
-    stuff = (app.outdir / 'objects.html').text(encoding='utf-8')
+    stuff = (app.outdir / 'objects.html').text()
 
     assert 'http://foobar/source/foolib.py' in stuff
     assert 'http://foobar/js/' in stuff
@@ -93,7 +93,7 @@ def test_local_source_files(app, status, warning):
         warnings
     )
 
-    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    result = (app.outdir / 'index.html').text()
     assert result.count('href="_modules/not_a_package.html#func1"') == 1
     assert result.count('href="_modules/not_a_package.html#not_a_package.submodule.func1"') == 1
     assert result.count('href="_modules/not_a_package/submodule.html#Class1"') == 1

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -104,7 +104,7 @@ def assert_count(expected_expr, result, count):
 @pytest.mark.test_params(shared_result='test_intl_basic')
 def test_text_toctree(app):
     app.build()
-    result = (app.outdir / 'index.txt').text(encoding='utf-8')
+    result = (app.outdir / 'index.txt').text()
     assert_startswith(result, "CONTENTS\n********\n\nTABLE OF CONTENTS\n")
 
 
@@ -126,7 +126,7 @@ def test_text_emit_warnings(app, warning):
 def test_text_warning_node(app):
     app.build()
     # test warnings in translation
-    result = (app.outdir / 'warnings.txt').text(encoding='utf-8')
+    result = (app.outdir / 'warnings.txt').text()
     expect = ("3. I18N WITH REST WARNINGS"
               "\n**************************\n"
               "\nLINE OF >>``<<BROKEN LITERAL MARKUP.\n")
@@ -140,7 +140,7 @@ def test_text_warning_node(app):
 def test_text_title_underline(app):
     app.build()
     # --- simple translation; check title underlines
-    result = (app.outdir / 'bom.txt').text(encoding='utf-8')
+    result = (app.outdir / 'bom.txt').text()
     expect = ("2. Datei mit UTF-8"
               "\n******************\n"  # underline matches new translation
               "\nThis file has umlauts: äöü.\n")
@@ -153,7 +153,7 @@ def test_text_title_underline(app):
 def test_text_subdirs(app):
     app.build()
     # --- check translation in subdirs
-    result = (app.outdir / 'subdir' / 'index.txt').text(encoding='utf-8')
+    result = (app.outdir / 'subdir' / 'index.txt').text()
     assert_startswith(result, "1. subdir contents\n******************\n")
 
 
@@ -163,7 +163,7 @@ def test_text_subdirs(app):
 def test_text_inconsistency_warnings(app, warning):
     app.build()
     # --- check warnings for inconsistency in number of references
-    result = (app.outdir / 'refs_inconsistency.txt').text(encoding='utf-8')
+    result = (app.outdir / 'refs_inconsistency.txt').text()
     expect = ("8. I18N WITH REFS INCONSISTENCY"
               "\n*******************************\n"
               "\n* FOR CITATION [ref3].\n"
@@ -213,7 +213,7 @@ def test_text_inconsistency_warnings(app, warning):
 def test_text_literalblock_warnings(app, warning):
     app.build()
     # --- check warning for literal block
-    result = (app.outdir / 'literalblock.txt').text(encoding='utf-8')
+    result = (app.outdir / 'literalblock.txt').text()
     expect = ("9. I18N WITH LITERAL BLOCK"
               "\n**************************\n"
               "\nCORRECT LITERAL BLOCK:\n"
@@ -235,7 +235,7 @@ def test_text_literalblock_warnings(app, warning):
 def test_text_definition_terms(app):
     app.build()
     # --- definition terms: regression test for #975, #2198, #2205
-    result = (app.outdir / 'definition_terms.txt').text(encoding='utf-8')
+    result = (app.outdir / 'definition_terms.txt').text()
     expect = ("13. I18N WITH DEFINITION TERMS"
               "\n******************************\n"
               "\nSOME TERM"
@@ -255,7 +255,7 @@ def test_text_definition_terms(app):
 def test_text_glossary_term(app, warning):
     app.build()
     # --- glossary terms: regression test for #1090
-    result = (app.outdir / 'glossary_terms.txt').text(encoding='utf-8')
+    result = (app.outdir / 'glossary_terms.txt').text()
     expect = ("18. I18N WITH GLOSSARY TERMS"
               "\n****************************\n"
               "\nSOME NEW TERM"
@@ -274,7 +274,7 @@ def test_text_glossary_term(app, warning):
 def test_text_glossary_term_inconsistencies(app, warning):
     app.build()
     # --- glossary term inconsistencies: regression test for #1090
-    result = (app.outdir / 'glossary_terms_inconsistency.txt').text(encoding='utf-8')
+    result = (app.outdir / 'glossary_terms_inconsistency.txt').text()
     expect = ("19. I18N WITH GLOSSARY TERMS INCONSISTENCY"
               "\n******************************************\n"
               "\n1. LINK TO *SOME NEW TERM*.\n")
@@ -307,7 +307,7 @@ def test_gettext_section(app):
 def test_text_section(app):
     app.build()
     # --- section
-    result = (app.outdir / 'section.txt').text(encoding='utf-8')
+    result = (app.outdir / 'section.txt').text()
     expect = read_po(app.srcdir / 'section.po')
     for expect_msg in [m for m in expect if m.id]:
         assert expect_msg.string in result
@@ -319,7 +319,7 @@ def test_text_section(app):
 def test_text_seealso(app):
     app.build()
     # --- seealso
-    result = (app.outdir / 'seealso.txt').text(encoding='utf-8')
+    result = (app.outdir / 'seealso.txt').text()
     expect = ("12. I18N WITH SEEALSO"
               "\n*********************\n"
               "\nSee also: SHORT TEXT 1\n"
@@ -335,7 +335,7 @@ def test_text_seealso(app):
 def test_text_figure_captions(app):
     app.build()
     # --- figure captions: regression test for #940
-    result = (app.outdir / 'figure.txt').text(encoding='utf-8')
+    result = (app.outdir / 'figure.txt').text()
     expect = ("14. I18N WITH FIGURE CAPTION"
               "\n****************************\n"
               "\n   [image]MY CAPTION OF THE FIGURE\n"
@@ -377,7 +377,7 @@ def test_text_figure_captions(app):
 def test_text_rubric(app):
     app.build()
     # --- rubric: regression test for pull request #190
-    result = (app.outdir / 'rubric.txt').text(encoding='utf-8')
+    result = (app.outdir / 'rubric.txt').text()
     expect = ("I18N WITH RUBRIC"
               "\n****************\n"
               "\n-[ RUBRIC TITLE ]-\n"
@@ -395,7 +395,7 @@ def test_text_rubric(app):
 def test_text_docfields(app):
     app.build()
     # --- docfields
-    result = (app.outdir / 'docfields.txt').text(encoding='utf-8')
+    result = (app.outdir / 'docfields.txt').text()
     expect = ("21. I18N WITH DOCFIELDS"
               "\n***********************\n"
               "\nclass Cls1\n"
@@ -426,7 +426,7 @@ def test_text_admonitions(app):
     # --- admonitions
     # #1206: gettext did not translate admonition directive's title
     # seealso: http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions
-    result = (app.outdir / 'admonitions.txt').text(encoding='utf-8')
+    result = (app.outdir / 'admonitions.txt').text()
     directives = (
         "attention", "caution", "danger", "error", "hint",
         "important", "note", "tip", "warning", "admonition")
@@ -468,7 +468,7 @@ def test_gettext_table(app):
 def test_text_table(app):
     app.build()
     # --- toctree
-    result = (app.outdir / 'table.txt').text(encoding='utf-8')
+    result = (app.outdir / 'table.txt').text()
     expect = read_po(app.srcdir / 'table.po')
     for expect_msg in [m for m in expect if m.id]:
         assert expect_msg.string in result
@@ -492,7 +492,7 @@ def test_gettext_topic(app):
 def test_text_topic(app):
     app.build()
     # --- topic
-    result = (app.outdir / 'topic.txt').text(encoding='utf-8')
+    result = (app.outdir / 'topic.txt').text()
     expect = read_po(app.srcdir / 'topic.po')
     for expect_msg in [m for m in expect if m.id]:
         assert expect_msg.string in result
@@ -611,7 +611,7 @@ def test_gettext_dont_rebuild_mo(make_app, app_params, build_mo):
 def test_html_meta(app):
     app.build()
     # --- test for meta
-    result = (app.outdir / 'index.html').text(encoding='utf-8')
+    result = (app.outdir / 'index.html').text()
     expected_expr = '<meta content="TESTDATA FOR I18N" name="description" />'
     assert expected_expr in result
     expected_expr = '<meta content="I18N, SPHINX, MARKUP" name="keywords" />'
@@ -625,7 +625,7 @@ def test_html_footnotes(app):
     app.build()
     # --- test for #955 cant-build-html-with-footnotes-when-using
     # expect no error by build
-    (app.outdir / 'footnote.html').text(encoding='utf-8')
+    (app.outdir / 'footnote.html').text()
 
 
 @sphinx_intl
@@ -634,7 +634,7 @@ def test_html_footnotes(app):
 def test_html_undefined_refs(app):
     app.build()
     # --- links to undefined reference
-    result = (app.outdir / 'refs_inconsistency.html').text(encoding='utf-8')
+    result = (app.outdir / 'refs_inconsistency.html').text()
 
     expected_expr = ('<a class="reference external" '
                      'href="http://www.example.com">reference</a>')
@@ -656,7 +656,7 @@ def test_html_undefined_refs(app):
 def test_html_index_entries(app):
     app.build()
     # --- index entries: regression test for #976
-    result = (app.outdir / 'genindex.html').text(encoding='utf-8')
+    result = (app.outdir / 'genindex.html').text()
 
     def wrap(tag, keyword):
         start_tag = "<%s[^>]*>" % tag
@@ -694,7 +694,7 @@ def test_html_index_entries(app):
 def test_html_versionchanges(app):
     app.build()
     # --- versionchanges
-    result = (app.outdir / 'versionchange.html').text(encoding='utf-8')
+    result = (app.outdir / 'versionchange.html').text()
 
     def get_content(result, name):
         matched = re.search(r'<div class="%s">\n*(.*?)</div>' % name,
@@ -731,7 +731,7 @@ def test_html_docfields(app):
     app.build()
     # --- docfields
     # expect no error by build
-    (app.outdir / 'docfields.html').text(encoding='utf-8')
+    (app.outdir / 'docfields.html').text()
 
 
 @sphinx_intl
@@ -740,7 +740,7 @@ def test_html_docfields(app):
 def test_html_template(app):
     app.build()
     # --- gettext template
-    result = (app.outdir / 'contents.html').text(encoding='utf-8')
+    result = (app.outdir / 'contents.html').text()
     assert "WELCOME" in result
     assert "SPHINX 2013.120" in result
 
@@ -1038,7 +1038,7 @@ def test_xml_label_targets(app):
 def test_additional_targets_should_not_be_translated(app):
     app.build()
     # [literalblock.txt]
-    result = (app.outdir / 'literalblock.html').text(encoding='utf-8')
+    result = (app.outdir / 'literalblock.html').text()
 
     # title should be translated
     expected_expr = 'CODE-BLOCKS'
@@ -1074,7 +1074,7 @@ def test_additional_targets_should_not_be_translated(app):
 
     # [raw.txt]
 
-    result = (app.outdir / 'raw.html').text(encoding='utf-8')
+    result = (app.outdir / 'raw.html').text()
 
     # raw block should not be translated
     expected_expr = """<iframe src="http://sphinx-doc.org"></iframe></div>"""
@@ -1082,7 +1082,7 @@ def test_additional_targets_should_not_be_translated(app):
 
     # [figure.txt]
 
-    result = (app.outdir / 'figure.html').text(encoding='utf-8')
+    result = (app.outdir / 'figure.html').text()
 
     # alt and src for image block should not be translated
     expected_expr = """<img alt="i18n" src="_images/i18n.png" />"""
@@ -1112,7 +1112,7 @@ def test_additional_targets_should_not_be_translated(app):
 def test_additional_targets_should_be_translated(app):
     app.build()
     # [literalblock.txt]
-    result = (app.outdir / 'literalblock.html').text(encoding='utf-8')
+    result = (app.outdir / 'literalblock.html').text()
 
     # title should be translated
     expected_expr = 'CODE-BLOCKS'
@@ -1148,7 +1148,7 @@ def test_additional_targets_should_be_translated(app):
 
     # [raw.txt]
 
-    result = (app.outdir / 'raw.html').text(encoding='utf-8')
+    result = (app.outdir / 'raw.html').text()
 
     # raw block should be translated
     expected_expr = """<iframe src="HTTP://SPHINX-DOC.ORG"></iframe></div>"""
@@ -1156,7 +1156,7 @@ def test_additional_targets_should_be_translated(app):
 
     # [figure.txt]
 
-    result = (app.outdir / 'figure.html').text(encoding='utf-8')
+    result = (app.outdir / 'figure.html').text()
 
     # alt and src for image block should be translated
     expected_expr = """<img alt="I18N -&gt; IMG" src="_images/img.png" />"""

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -20,8 +20,7 @@ def test_layout_overloading(make_app, app_params):
     setup_documenters(app)
     app.builder.build_update()
 
-    result = (app.outdir / 'index.html').text(encoding='utf-8')
-
+    result = (app.outdir / 'index.html').text()
     assert '<!-- layout overloading -->' in result
 
 
@@ -32,7 +31,5 @@ def test_autosummary_class_template_overloading(make_app, app_params):
     setup_documenters(app)
     app.builder.build_update()
 
-    result = (app.outdir / 'generated' / 'sphinx.application.TemplateBridge.html').text(
-        encoding='utf-8')
-
+    result = (app.outdir / 'generated' / 'sphinx.application.TemplateBridge.html').text()
     assert 'autosummary/class.rst method block overloading' in result

--- a/tests/test_toctree.py
+++ b/tests/test_toctree.py
@@ -43,5 +43,5 @@ def test_numbered_toctree(app, status, warning):
     # give argument to :numbered: option
     index = (app.srcdir / 'index.rst').text()
     index = re.sub(':numbered:.*', ':numbered: 1', index)
-    (app.srcdir / 'index.rst').write_text(index, encoding='utf-8')
+    (app.srcdir / 'index.rst').write_text(index)
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To keep our testcode simple
