### PR TITLE
Fix HTML: Invalid HTML5 file is generated for glossary (refs: #4611)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -155,6 +155,8 @@ Bugs fixed
   if passed as language option?
 * #5179: LaTeX: (lualatex only) escaping of ``>`` by ``\textgreater{}`` is not
   enough as ``\textgreater{}\textgreater{}`` applies TeX-ligature
+* HTML: Invalid HTML5 file is generated for a glossary having multiple terms for
+  one description (refs: #4611)
 
 Testing
 --------

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -394,6 +394,48 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         super().visit_enumerated_list(node)
 
     # overwritten
+    def visit_definition(self, node):
+        # type: (nodes.Element) -> None
+        # don't insert </dt> here.
+        self.body.append(self.starttag(node, 'dd', ''))
+
+    # overwritten
+    def depart_definition(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append('</dd>\n')
+
+    # overwritten
+    def visit_classifier(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append(self.starttag(node, 'span', '', CLASS='classifier'))
+
+    # overwritten
+    def depart_classifier(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append('</span>')
+
+        next_node = node.next_node(descend=False, siblings=True)  # type: nodes.Node
+        if not isinstance(next_node, nodes.classifier):
+            # close `<dt>` tag at the tail of classifiers
+            self.body.append('</dt>')
+
+    # overwritten
+    def visit_term(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append(self.starttag(node, 'dt', ''))
+
+    # overwritten
+    def depart_term(self, node):
+        # type: (nodes.Element) -> None
+        next_node = node.next_node(descend=False, siblings=True)  # type: nodes.Node
+        if isinstance(next_node, nodes.classifier):
+            # Leave the end tag to `self.depart_classifier()`, in case
+            # there's a classifier.
+            pass
+        else:
+            self.body.append('</dt>')
+
+    # overwritten
     def visit_title(self, node):
         # type: (nodes.Element) -> None
         super().visit_title(node)

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -340,6 +340,48 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         super().visit_bullet_list(node)
 
     # overwritten
+    def visit_definition(self, node):
+        # type: (nodes.Element) -> None
+        # don't insert </dt> here.
+        self.body.append(self.starttag(node, 'dd', ''))
+
+    # overwritten
+    def depart_definition(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append('</dd>\n')
+
+    # overwritten
+    def visit_classifier(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append(self.starttag(node, 'span', '', CLASS='classifier'))
+
+    # overwritten
+    def depart_classifier(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append('</span>')
+
+        next_node = node.next_node(descend=False, siblings=True)  # type: nodes.Node
+        if not isinstance(next_node, nodes.classifier):
+            # close `<dt>` tag at the tail of classifiers
+            self.body.append('</dt>')
+
+    # overwritten
+    def visit_term(self, node):
+        # type: (nodes.Element) -> None
+        self.body.append(self.starttag(node, 'dt', ''))
+
+    # overwritten
+    def depart_term(self, node):
+        # type: (nodes.Element) -> None
+        next_node = node.next_node(descend=False, siblings=True)  # type: nodes.Node
+        if isinstance(next_node, nodes.classifier):
+            # Leave the end tag to `self.depart_classifier()`, in case
+            # there's a classifier.
+            pass
+        else:
+            self.body.append('</dt>')
+
+    # overwritten
     def visit_title(self, node):
         # type: (nodes.Element) -> None
         super().visit_title(node)

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -234,6 +234,29 @@ def get_verifier(verify, verify_re):
         None,
         r'\\sphinxhref{http://example.com/~me/}{test}.*',
     ),
+    (
+        # description list: simple
+        'verify',
+        'term\n    description',
+        '<dl class="docutils">\n<dt>term</dt><dd>description</dd>\n</dl>',
+        None,
+    ),
+    (
+        # description list: with classifiers
+        'verify',
+        'term : class1 : class2\n    description',
+        ('<dl class="docutils">\n<dt>term<span class="classifier">class1</span>'
+         '<span class="classifier">class2</span></dt><dd>description</dd>\n</dl>'),
+        None,
+    ),
+    (
+        # glossary (description list): multiple terms
+        'verify',
+        '.. glossary::\n\n   term1\n   term2\n       description',
+        ('<dl class="glossary docutils">\n<dt id="term-term1">term1</dt>'
+         '<dt id="term-term2">term2</dt><dd>description</dd>\n</dl>'),
+        None,
+    ),
 ])
 def test_inline(get_verifier, type, rst, html_expected, latex_expected):
     verifier = get_verifier(type)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It was caused by a glossary having multiple terms for one description.

Input:
```
.. glossary::

   tauon
   myon
   electron
      Examples for fermions.
```
Output:
```
<dt id="term-tauon">tauon<dt id="term-myon">myon<dt id="term-electron">electron</dt>
<dd><p>Examples for fermions.</p>
</dd>
```
`<dt>` tag is not closed. So epubcheck warns about it:
```
build/root/_build/epub/SphinxTests.epub/markup.xhtml(372,45): Error while parsing file 'element "dt" not allowed here; expected the element end-tag, text or element "a", "abbr", "area", "audio", "b", "bdi", "bdo", "br", "button", "canvas", "cite", "code", "command", "datalist", "del", "dfn", "em", "embed", "epub:switch", "i", "iframe", "img", "input", "ins", "kbd", "keygen", "label", "link", "map", "mark", "meta", "meter", "ns1:math", "ns2:svg", "object", "output", "progress", "q", "ruby", "s", "samp", "script", "select", "small", "span", "strong", "sub", "sup", "textarea", "time", "u", "var", "video" or "wbr" (with xmlns:ns1="http://www.w3.org/1998/Math/MathML" xmlns:ns2="http://www.w3.org/2000/svg")'.
ERROR(RSC-005): ./tests/
```