### PR TITLE
Fix #5889: LaTeX: user numfig_format is stripped of spaces and may cause build failure

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,8 +15,11 @@ Features added
 
 Bugs fixed
 ----------
+
 * #5605: with the documentation language set to Chinese, English words could not
   be searched.
+* #5889: LaTeX: user ``numfig_format`` is stripped of spaces and may cause build
+  failure
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -796,7 +796,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             ret.append(self.babel_renewcommand('\\figurename', definition))
             if figure[1]:
                 ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@figure{\\figurename\\thefigure%s}\n' %
+                ret.append('\\def\\fnum@figure{\\figurename\\thefigure\\relax{}%s}\n' %
                            text_type(figure[1]).strip().translate(tex_escape_map))
                 ret.append('\\makeatother\n')
 
@@ -809,7 +809,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             ret.append(self.babel_renewcommand('\\tablename', definition))
             if table[1]:
                 ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@table{\\tablename\\thetable%s}\n' %
+                ret.append('\\def\\fnum@table{\\tablename\\thetable\\relax{}%s}\n' %
                            text_type(table[1]).strip().translate(tex_escape_map))
                 ret.append('\\makeatother\n')
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -289,9 +289,9 @@ def test_numref_with_prefix2(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Figure:}}' in result
-    assert '\\def\\fnum@figure{\\figurename\\thefigure.}' in result
+    assert '\\def\\fnum@figure{\\figurename\\thefigure\\relax{}.}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
-    assert '\\def\\fnum@table{\\tablename\\thetable:}' in result
+    assert '\\def\\fnum@table{\\tablename\\thetable\\relax{}:}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Figure:\\ref{\\detokenize{index:fig1}}.\\@}') in result


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5889 
