### PR TITLE
LaTeX: obey spaces from `numfig_format` (figure and table only)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Bugs fixed
 * #3707: latex: no bold checkmark (✔) available.
 * #5605: with the documentation language set to Chinese, English words could not
   be searched.
+* #5889: LaTeX: user ``numfig_format`` is stripped of spaces and may cause
+  build failure
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -796,7 +796,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             ret.append(self.babel_renewcommand('\\figurename', definition))
             if figure[1]:
                 ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@figure{\\figurename\\thefigure%s}\n' %
+                ret.append('\\def\\fnum@figure{\\figurename\\thefigure{}%s}\n' %
                            text_type(figure[1]).strip().translate(tex_escape_map))
                 ret.append('\\makeatother\n')
 
@@ -809,7 +809,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             ret.append(self.babel_renewcommand('\\tablename', definition))
             if table[1]:
                 ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@table{\\tablename\\thetable%s}\n' %
+                ret.append('\\def\\fnum@table{\\tablename\\thetable{}%s}\n' %
                            text_type(table[1]).strip().translate(tex_escape_map))
                 ret.append('\\makeatother\n')
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -792,26 +792,24 @@ class LaTeXTranslator(nodes.NodeVisitor):
             ret.append('\\def\\fnum@figure{%s}\n' %
                        text_type(figure[0]).strip().translate(tex_escape_map))
         else:
-            definition = text_type(figure[0]).strip().translate(tex_escape_map)
+            definition = escape_abbr(text_type(figure[0]).translate(tex_escape_map))
             ret.append(self.babel_renewcommand('\\figurename', definition))
-            if figure[1]:
-                ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@figure{\\figurename\\thefigure{}%s}\n' %
-                           text_type(figure[1]).strip().translate(tex_escape_map))
-                ret.append('\\makeatother\n')
+            ret.append('\\makeatletter\n')
+            ret.append('\\def\\fnum@figure{\\figurename \\thefigure{}%s}\n' %
+                       text_type(figure[1]).translate(tex_escape_map))
+            ret.append('\\makeatother\n')
 
         table = self.builder.config.numfig_format['table'].split('%s', 1)
         if len(table) == 1:
             ret.append('\\def\\fnum@table{%s}\n' %
                        text_type(table[0]).strip().translate(tex_escape_map))
         else:
-            definition = text_type(table[0]).strip().translate(tex_escape_map)
+            definition = escape_abbr(text_type(table[0]).translate(tex_escape_map))
             ret.append(self.babel_renewcommand('\\tablename', definition))
-            if table[1]:
-                ret.append('\\makeatletter\n')
-                ret.append('\\def\\fnum@table{\\tablename\\thetable{}%s}\n' %
-                           text_type(table[1]).strip().translate(tex_escape_map))
-                ret.append('\\makeatother\n')
+            ret.append('\\makeatletter\n')
+            ret.append('\\def\\fnum@table{\\tablename \\thetable{}%s}\n' %
+                       text_type(table[1]).translate(tex_escape_map))
+            ret.append('\\makeatother\n')
 
         codeblock = self.builder.config.numfig_format['code-block'].split('%s', 1)
         if len(codeblock) == 1:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -795,7 +795,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             definition = escape_abbr(text_type(figure[0]).translate(tex_escape_map))
             ret.append(self.babel_renewcommand('\\figurename', definition))
             ret.append('\\makeatletter\n')
-            ret.append('\\def\\fnum@figure{\\figurename \\thefigure{}%s}\n' %
+            ret.append('\\def\\fnum@figure{\\figurename\\thefigure{}%s}\n' %
                        text_type(figure[1]).translate(tex_escape_map))
             ret.append('\\makeatother\n')
 
@@ -807,7 +807,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
             definition = escape_abbr(text_type(table[0]).translate(tex_escape_map))
             ret.append(self.babel_renewcommand('\\tablename', definition))
             ret.append('\\makeatletter\n')
-            ret.append('\\def\\fnum@table{\\tablename \\thetable{}%s}\n' %
+            ret.append('\\def\\fnum@table{\\tablename\\thetable{}%s}\n' %
                        text_type(table[1]).translate(tex_escape_map))
             ret.append('\\makeatother\n')
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -289,9 +289,9 @@ def test_numref_with_prefix2(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Figure:}}' in result
-    assert '\\def\\fnum@figure{\\figurename \\thefigure{}.}' in result
+    assert '\\def\\fnum@figure{\\figurename\\thefigure{}.}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
-    assert '\\def\\fnum@table{\\tablename \\thetable{}:}' in result
+    assert '\\def\\fnum@table{\\tablename\\thetable{}:}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Figure:\\ref{\\detokenize{index:fig1}}.\\@}') in result

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -206,8 +206,8 @@ def test_numref(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}' in result
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table}}' in result
+    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.\\@ }}' in result
+    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table }}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Listing}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Fig.\\@ \\ref{\\detokenize{index:fig1}}}') in result
@@ -289,9 +289,9 @@ def test_numref_with_prefix2(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Figure:}}' in result
-    assert '\\def\\fnum@figure{\\figurename\\thefigure{}.}' in result
+    assert '\\def\\fnum@figure{\\figurename \\thefigure{}.}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
-    assert '\\def\\fnum@table{\\tablename\\thetable{}:}' in result
+    assert '\\def\\fnum@table{\\tablename \\thetable{}:}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Figure:\\ref{\\detokenize{index:fig1}}.\\@}') in result
@@ -324,8 +324,8 @@ def test_numref_with_language_ja(app, status, warning):
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert u'\\renewcommand{\\figurename}{\u56f3}' in result  # 図
-    assert u'\\renewcommand{\\tablename}{\u8868}' in result  # 表
+    assert u'\\renewcommand{\\figurename}{\u56f3 }' in result  # 図
+    assert u'\\renewcommand{\\tablename}{\u8868 }' in result  # 表
     assert u'\\renewcommand{\\literalblockname}{\u30ea\u30b9\u30c8}' in result  # リスト
     assert (u'\\hyperref[\\detokenize{index:fig1}]'
             u'{\u56f3 \\ref{\\detokenize{index:fig1}}}') in result
@@ -422,8 +422,8 @@ def test_babel_with_no_language_settings(app, status, warning):
     assert '\\usepackage[Bjarne]{fncychap}' in result
     assert ('\\addto\\captionsenglish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -443,8 +443,8 @@ def test_babel_with_language_de(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsngerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsngerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsngerman{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsngerman{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert '\\addto\\extrasngerman{\\def\\pageautorefname{Seite}}\n' in result
     assert '\\shorthandoff{"}' in result
 
@@ -464,8 +464,8 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsrussian{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsrussian{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsrussian{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsrussian{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert (u'\\addto\\extrasrussian{\\def\\pageautorefname'
             u'{\u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0430}}\n' in result)
     assert '\\shorthandoff{"}' in result
@@ -486,8 +486,8 @@ def test_babel_with_language_tr(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsturkish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsturkish{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsturkish{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsturkish{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert '\\addto\\extrasturkish{\\def\\pageautorefname{sayfa}}\n' in result
     assert '\\shorthandoff{=}' in result
 
@@ -506,8 +506,8 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\usepackage{times}' in result
     assert '\\usepackage[Sonny]{fncychap}' not in result
     assert '\\renewcommand{\\contentsname}{Table of content}\n' in result
-    assert '\\renewcommand{\\figurename}{Fig.}\n' in result
-    assert '\\renewcommand{\\tablename}{Table.}\n' in result
+    assert '\\renewcommand{\\figurename}{Fig.\\@ }\n' in result
+    assert '\\renewcommand{\\tablename}{Table.\\@ }\n' in result
     assert u'\\def\\pageautorefname{ページ}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -527,8 +527,8 @@ def test_babel_with_unknown_language(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsenglish{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert '\\addto\\extrasenglish{\\def\\pageautorefname{page}}\n' in result
     assert '\\shorthandoff' in result
 
@@ -551,8 +551,8 @@ def test_polyglossia_with_language_de(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsgerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert '\\def\\pageautorefname{Seite}\n' in result
     assert '\\shorthandoff' not in result
 
@@ -573,8 +573,8 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     assert '\\usepackage[Sonny]{fncychap}' in result
     assert ('\\addto\\captionsgerman{\\renewcommand{\\contentsname}{Table of content}}\n'
             in result)
-    assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.}}\n' in result
-    assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.}}\n' in result
+    assert '\\addto\\captionsgerman{\\renewcommand{\\figurename}{Fig.\\@ }}\n' in result
+    assert '\\addto\\captionsgerman{\\renewcommand{\\tablename}{Table.\\@ }}\n' in result
     assert '\\def\\pageautorefname{page}\n' in result
     assert '\\shorthandoff' not in result
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -289,9 +289,9 @@ def test_numref_with_prefix2(app, status, warning):
     print(status.getvalue())
     print(warning.getvalue())
     assert '\\addto\\captionsenglish{\\renewcommand{\\figurename}{Figure:}}' in result
-    assert '\\def\\fnum@figure{\\figurename\\thefigure.}' in result
+    assert '\\def\\fnum@figure{\\figurename\\thefigure{}.}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\tablename}{Tab\\_}}' in result
-    assert '\\def\\fnum@table{\\tablename\\thetable:}' in result
+    assert '\\def\\fnum@table{\\tablename\\thetable{}:}' in result
     assert '\\addto\\captionsenglish{\\renewcommand{\\literalblockname}{Code-}}' in result
     assert ('\\hyperref[\\detokenize{index:fig1}]'
             '{Figure:\\ref{\\detokenize{index:fig1}}.\\@}') in result


### PR DESCRIPTION
Only for figure and table, currently. Code-bloks have some FIXME code to
still be handled.

PDF output should remain unchanged so this is backwards compatible. The
`\nobreakspace` from LaTeX default `\fnum@figure` and replaced by a normal
space (if `numfig_format` left to its `Fig. %s` default).

If figname is an abbreviation (as in default), the dot is followed by a `\@` to
avoid double space. At the location where the `\@` is inserted the `@`
has catcode non-letter so a space after it is not swallowed and remains significant.

MEMO: when this is will be moved to sphinxmessages.sty on master branch
it will be needed to use `\@{}` or to modify locally catcode of `@` to avoid
space swallowing, because then `@` will have catcode letter.

Closes: #5889

- Bugfix

### Relates
- #5890 (see comments in the review I did of it)

