### PR TITLE
LaTeX: fix ``addtocaptions`` for sphinxmessages.sty_t if 'babel' empty

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -421,7 +421,7 @@ class LaTeXBuilder(Builder):
         # type: () -> None
         formats = self.config.numfig_format
         context = {
-            'addtocaptions': '',
+            'addtocaptions': r'\@iden',
             'figurename': formats.get('figure', '').split('%s', 1),
             'tablename': formats.get('table', '').split('%s', 1),
             'literalblockname': formats.get('code-block', '').split('%s', 1)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -357,9 +357,9 @@ def test_numref_with_language_ja(app, status, warning):
     # sphinxmessages.sty
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
-    assert '\n{\\renewcommand{\\figurename}{図 }}' in result
-    assert '\n{\\renewcommand{\\tablename}{表 }}' in result
-    assert '\n{\\renewcommand{\\literalblockname}{リスト}}' in result
+    assert '\\@iden{\\renewcommand{\\figurename}{図 }}' in result
+    assert '\\@iden{\\renewcommand{\\tablename}{表 }}' in result
+    assert '\\@iden{\\renewcommand{\\literalblockname}{リスト}}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-numfig')
@@ -540,8 +540,8 @@ def test_babel_with_language_ja(app, status, warning):
     result = (app.outdir / 'sphinxmessages.sty').text(encoding='utf8')
     print(result)
     assert r'\def\pageautorefname{ページ}' in result
-    assert '\n{\\renewcommand{\\figurename}{Fig.\\@{} }}' in result
-    assert '\n{\\renewcommand{\\tablename}{Table.\\@{} }}' in result
+    assert '\\@iden{\\renewcommand{\\figurename}{Fig.\\@{} }}' in result
+    assert '\\@iden{\\renewcommand{\\tablename}{Table.\\@{} }}' in result
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
For example if config setting `language` is 'ja' one will see in `sphinxmessages.sty` in latex build repertory:

```
{\renewcommand{\figurename}{図}}

{\renewcommand{\tablename}{表}}
```

but the extra braces annihilate effect of `\renewcommand`.  This was introduced in #5516, sorry for not having paid attention to this.

I use `\@iden` (same as `\@firstofone`) which is LaTeX macro removing braces. We can use `@` letter because we are now in a package file (extension `.sty` and `\ProvidesPackage` macro).

Notice: it is easier to merge 1.8 first (cf #5892) then to merge master into this PR to fix conflicts which will arise (in the two Japanese tests modified here).