### PR TITLE
Remove redundant mypy config 'incremental'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ show_column_numbers = True
 show_error_context = True
 ignore_missing_imports = True
 follow_imports = skip
-incremental = True
 check_untyped_defs = True
 warn_unused_ignores = True
 strict_optional = False

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras_require = {
         'html5lib',
         'flake8>=3.5.0',
         'flake8-import-order',
-        'mypy>=0.470',
+        'mypy>=0.590',
         'docutils-stubs',
     ],
 }


### PR DESCRIPTION
The mypy config 'incremental` has defaulted as true since version 0.590. Can drop the local override. For details, see:

https://github.com/python/mypy/commit/6b13652a466ccb102987a2ab1fa93d4b52fd8e3f