### PR TITLE
Remove outdated fallback to 'import Image'

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1713,9 +1713,9 @@ the `Dublin Core metadata <http://dublincore.org/>`_.
 
    This flag determines if sphinx should try to fix image formats that are not
    supported by some epub readers.  At the moment palette images with a small
-   color table are upgraded.  You need the Python Image Library (Pillow the
-   successor of the PIL) installed to use this option.  The default value is
-   ``False`` because the automatic conversion may lose information.
+   color table are upgraded.  You need Pillow, the Python Image Library,
+   installed to use this option.  The default value is ``False`` because the
+   automatic conversion may lose information.
 
    .. versionadded:: 1.2
 

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -29,10 +29,7 @@ from sphinx.util.osutil import ensuredir, copyfile
 try:
     from PIL import Image
 except ImportError:
-    try:
-        import Image
-    except ImportError:
-        Image = None
+    Image = None
 
 if False:
     # For type annotation
@@ -401,9 +398,9 @@ class EpubBuilder(StandaloneHTMLBuilder):
 
     def copy_image_files_pil(self):
         # type: () -> None
-        """Copy images using the PIL.
-        The method tries to read and write the files with the PIL,
-        converting the format and resizing the image if necessary/possible.
+        """Copy images using Pillow, the Python Imaging Libary.
+        The method tries to read and write the files with Pillow, converting
+        the format and resizing the image if necessary/possible.
         """
         ensuredir(path.join(self.outdir, self.imagedir))
         for src in status_iterator(self.images, 'copying images... ', "brown",
@@ -424,7 +421,8 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 continue
             if self.config.epub_fix_images:
                 if img.mode in ('P',):
-                    # See PIL documentation for Image.convert()
+                    # See the Pillow documentation for Image.convert()
+                    # https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.convert
                     img = img.convert()
             if self.config.epub_max_image_width > 0:
                 (width, height) = img.size
@@ -441,12 +439,12 @@ class EpubBuilder(StandaloneHTMLBuilder):
     def copy_image_files(self):
         # type: () -> None
         """Copy image files to destination directory.
-        This overwritten method can use the PIL to convert image files.
+        This overwritten method can use Pillow to convert image files.
         """
         if self.images:
             if self.config.epub_fix_images or self.config.epub_max_image_width:
                 if not Image:
-                    logger.warning(__('PIL not found - copying image files'))
+                    logger.warning(__('Pillow not found - copying image files'))
                     super().copy_image_files()
                 else:
                     self.copy_image_files_pil()

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -21,12 +21,9 @@ import imagesize
 from sphinx.deprecation import RemovedInSphinx30Warning
 
 try:
-    from PIL import Image        # check for the Python Imaging Library
+    from PIL import Image
 except ImportError:
-    try:
-        import Image
-    except ImportError:
-        Image = None
+    Image = None
 
 if False:
     # For type annotation
@@ -53,7 +50,7 @@ def get_image_size(filename):
         if size[0] == -1:
             size = None
 
-        if size is None and Image:  # fallback to PIL
+        if size is None and Image:  # fallback to Pillow
             im = Image.open(filename)
             size = im.size
             try:


### PR DESCRIPTION
The fallback 'import Image' was added in commit 99621d7a01638872a5af727aaa8714b269c0f769 for the PIL package. However, the PIL package is no longer maintained and does not support Python 3.
Development has moved to the Pillow package which always installs to the PIL namespace.

Pillow repo: https://github.com/python-pillow/Pillow
Old PIL website: http://www.pythonware.com/products/pil/