### PR TITLE
Add TODO comment to help future developer to refactor guess_mimetype

### DIFF
--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -81,6 +81,8 @@ def guess_mimetype(filename='', content=None, default=None):
     if ext in mime_suffixes:
         return mime_suffixes[ext]
     elif content:
+        # TODO: When the content argument is removed, make filename a required
+        # argument.
         warnings.warn('The content argument of guess_mimetype() is deprecated.',
                       RemovedInSphinx30Warning, stacklevel=2)
         return guess_mimetype_for_stream(BytesIO(content), default=default)


### PR DESCRIPTION
All internal uses always pass a filename to `guess_mimetype()` so the default of the empty string has no practical use.