### PR TITLE
Stop to use $SPHINX_TEST_TEMPDIR envvar

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -183,6 +183,8 @@ Bugs fixed
 Testing
 --------
 
+* Stop to use ``SPHINX_TEST_TEMPDIR`` envvar
+
 Release 1.8.4 (in development)
 ==============================
 

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -14,7 +14,6 @@ import sys
 from collections import namedtuple
 from io import StringIO
 from subprocess import PIPE
-from tempfile import gettempdir
 
 import pytest
 
@@ -221,11 +220,15 @@ def if_graphviz_found(app):
 
 
 @pytest.fixture(scope='session')
-def sphinx_test_tempdir():
+def sphinx_test_tempdir(tmpdir_factory):
     """
     temporary directory that wrapped with `path` class.
     """
-    return util.path(os.environ.get('SPHINX_TEST_TEMPDIR', gettempdir())).abspath()
+    tmpdir = os.environ.get('SPHINX_TEST_TEMPDIR')  # RemovedInSphinx40Warning
+    if tmpdir is None:
+        tmpdir = tmpdir_factory.getbasetemp()
+
+    return util.path(tmpdir).abspath()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@
 """
 
 import os
-import shutil
 
 import docutils
 import pytest
@@ -30,24 +29,6 @@ def rootdir():
 def pytest_report_header(config):
     return ("libraries: Sphinx-%s, docutils-%s" %
             (sphinx.__display_version__, docutils.__version__))
-
-
-def _initialize_test_directory(session):
-    testroot = os.path.join(str(session.config.rootdir), 'tests')
-    tempdir = os.path.abspath(os.getenv('SPHINX_TEST_TEMPDIR',
-                              os.path.join(testroot, 'build')))
-    os.environ['SPHINX_TEST_TEMPDIR'] = tempdir
-
-    print('Temporary files will be placed in %s.' % tempdir)
-
-    if os.path.exists(tempdir):
-        shutil.rmtree(tempdir)
-
-    os.makedirs(tempdir)
-
-
-def pytest_sessionstart(session):
-    _initialize_test_directory(session)
 
 
 def pytest_assertrepr_compare(op, left, right):

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ extras =
     websupport
 setenv =
     PYTHONWARNINGS = all,ignore::ImportWarning:pkgutil,ignore::ImportWarning:importlib._bootstrap,ignore::ImportWarning:importlib._bootstrap_external,ignore::ImportWarning:pytest_cov.plugin,ignore::DeprecationWarning:site,ignore::DeprecationWarning:_pytest.assertion.rewrite,ignore::DeprecationWarning:_pytest.fixtures,ignore::DeprecationWarning:distutils
-    SPHINX_TEST_TEMPDIR = {envdir}/testbuild
 commands=
     pytest --durations 25 {posargs}
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
At once, we added $SPHINX_TEST_TEMPDIR to keep intermediate files of
testing to investigate the failures.  At present, we've used pytest
as a test runner.  And it keeps temporary directories of last 3
testings.  So this starts to use it instead of $SPHINX_TEST_TEMPDIR.
https://docs.pytest.org/en/latest/tmpdir.html#the-default-base-temporary-directory
