### PR TITLE
refactor: deprecate some pycompat functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -99,7 +99,10 @@ Deprecated
 * ``sphinx.util.osutil.EPIPE``
 * ``sphinx.util.osutil.walk()``
 * ``sphinx.util.PeekableIterator``
+* ``sphinx.util.pycompat.TextIOWrapper``
 * ``sphinx.util.pycompat.UnicodeMixin``
+* ``sphinx.util.pycompat.htmlescape``
+* ``sphinx.util.pycompat.indent``
 * ``sphinx.util.pycompat.u``
 * ``sphinx.writers.latex.ExtBabel``
 * ``sphinx.writers.latex.LaTeXTranslator._make_visit_admonition()``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -378,10 +378,25 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``os.walk()``
 
+   * - ``sphinx.util.pycompat.TextIOWrapper``
+     - 2.0
+     - 4.0
+     - ``io.TextIOWrapper``
+
    * - ``sphinx.util.pycompat.UnicodeMixin``
      - 2.0
      - 4.0
      - N/A
+
+   * - ``sphinx.util.pycompat.htmlescape()``
+     - 2.0
+     - 4.0
+     - ``html.escape()``
+
+   * - ``sphinx.util.pycompat.indent()``
+     - 2.0
+     - 4.0
+     - ``textwrap.indent()``
 
    * - ``sphinx.util.pycompat.u``
      - 2.0

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -9,6 +9,7 @@
 """
 
 from os import path
+from textwrap import indent
 from typing import Any, TypeVar
 
 from docutils import nodes
@@ -25,7 +26,6 @@ from sphinx.util.nodes import (
     LITERAL_TYPE_NODES, IMAGE_TYPE_NODES, NodeMatcher,
     extract_messages, is_pending_meta, traverse_translatable_index,
 )
-from sphinx.util.pycompat import indent
 
 if False:
     # For type annotation

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -8,13 +8,13 @@
     :license: BSD, see LICENSE for details.
 """
 
+import html
+import io
 import sys
+import textwrap
 import warnings
-from html import escape as htmlescape  # NOQA
-from io import TextIOWrapper  # NOQA
-from textwrap import indent  # NOQA
 
-from sphinx.deprecation import RemovedInSphinx40Warning
+from sphinx.deprecation import RemovedInSphinx40Warning, deprecated_alias
 from sphinx.locale import __
 from sphinx.util import logging
 
@@ -30,10 +30,6 @@ NoneType = type(None)
 
 # ------------------------------------------------------------------------------
 # Python 2/3 compatibility
-
-# prefix for Unicode strings
-u = ''  # RemovedInSphinx40Warning
-
 
 # sys_encoding: some kind of default system encoding; should be used with
 # a lenient error handler
@@ -99,3 +95,13 @@ def execfile_(filepath, _globals, open=open):
                           'Convert %s to Python 3 syntax.'),
                        filepath)
     exec(code, _globals)
+
+
+deprecated_alias('sphinx.util.pycompat',
+                 {
+                     'TextIOWrapper': io.TextIOWrapper,
+                     'htmlescape': html.escape,
+                     'indent': textwrap.indent,
+                     'u': '',
+                 },
+                 RemovedInSphinx40Warning)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Deprecate `TextIOWrapper`, `htmlescape()` and `indent()` on `sphinx.util.pycompat`.
