### PR TITLE
Fix #5906: LaTeX Builder is not initialized correctly on test_markup

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -90,8 +90,7 @@ def verify_re_latex(app, parse):
         document = parse(rst)
         app.builder = LaTeXBuilder(app)
         app.builder.set_environment(app.env)
-        app.builder.init_context()
-        app.builder.init_babel()
+        app.builder.init()
         latex_translator = ForgivingLaTeXTranslator(document, app.builder)
         latex_translator.first_document = -1  # don't write \begin{document}
         document.walkabout(latex_translator)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5906 
