### PR TITLE
refactor: Convert Epub3Builder.validate_config_values() to a function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,7 @@ Deprecated
   ``IndexBuilder.feed()`` method is deprecated.
 * ``sphinx.addnodes.abbreviation``
 * ``sphinx.application.Sphinx._setting_up_extension``
+* ``sphinx.builders.epub3.Epub3Builder.validate_config_value()``
 * ``sphinx.builders.htmlhelp.HTMLHelpBuilder.open_file()``
 * ``sphinx.cmd.quickstart.term_decode()``
 * ``sphinx.cmd.quickstart.TERM_ENCODING``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -263,6 +263,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``docutils.nodes.abbreviation``
 
+   * - ``sphinx.builders.epub3.Epub3Builder.validate_config_value()``
+     - 2.0
+     - 4.0
+     - ``sphinx.builders.epub3.validate_config_values()``
+
    * - ``sphinx.builders.htmlhelp.HTMLHelpBuilder.open_file()``
      - 2.0
      - 4.0


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Convert Epub3Builder.validate_config_values() to a function
