### PR TITLE
Fix ToC: Move "Intro" to first entry

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -7,6 +7,8 @@ Sphinx documentation contents
 .. toctree::
    :maxdepth: 2
 
+   intro
+
    usage/installation
    usage/quickstart
    usage/restructuredtext/index
@@ -19,7 +21,6 @@ Sphinx documentation contents
    usage/advanced/setuptools
    usage/advanced/websupport/index
 
-   intro
    man/index
    theming
    templating


### PR DESCRIPTION
For some reason, the "Introduction" article is located in the middle of our docs. Shouldn't it be first?
There are probably a lot of other things we can improve in the structure, but this one really looked wrong.
### Feature or Bugfix
- Doc

