### PR TITLE
Fix doc: html_baseurl was added in 1.8.0

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -864,6 +864,8 @@ that use Sphinx's HTMLWriter class.
    The URL which points to the root of the HTML documentation.  It is used to
    indicate the location of document like ``canonical_url``.
 
+   .. versionadded:: 1.8
+
 .. confval:: html_context
 
    A dictionary of values to pass into the template engine's context for all


### PR DESCRIPTION
### Feature or Bugfix
- Documentation
- Bugfix

### Purpose
- no `versionadded` label there
