### PR TITLE
Fix AppleHelpBuilder#build_helpindex() raises AppleHelpCodeSigningFailed

### DIFF
--- a/sphinx/builders/applehelp.py
+++ b/sphinx/builders/applehelp.py
@@ -213,7 +213,7 @@ class AppleHelpBuilder(StandaloneHTMLBuilder):
             except OSError:
                 raise AppleHelpIndexerFailed(__('Command not found: %s') % args[0])
             except CalledProcessError as exc:
-                raise AppleHelpCodeSigningFailed(exc.stdout)
+                raise AppleHelpIndexerFailed(exc.stdout)
 
     def do_codesign(self):
         # type: () -> None


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- #5920 wrongly used AppleHelpCodeSigningFailed exception.
