### PR TITLE
Use subprocess.run() instead of Popen()

### DIFF
--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -12,8 +12,10 @@
 # (Otherwise getting the version out of it from setup.py is impossible.)
 
 import os
+import subprocess
 import warnings
 from os import path
+from subprocess import PIPE
 
 from .deprecation import RemovedInNextVersionWarning
 
@@ -53,11 +55,9 @@ if __version__.endswith('+'):
     __display_version__ = __version__
     __version__ = __version__[:-1]  # remove '+' for PEP-440 version spec.
     try:
-        import subprocess
-        p = subprocess.Popen(['git', 'show', '-s', '--pretty=format:%h'],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
-        if out:
-            __display_version__ += '/' + out.decode().strip()
+        ret = subprocess.run(['git', 'show', '-s', '--pretty=format:%h'],
+                             stdout=PIPE, stderr=PIPE, encoding='ascii')
+        if ret.stdout:
+            __display_version__ += '/' + ret.stdout.strip()
     except Exception:
         pass

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 from collections import namedtuple
 from io import StringIO
+from subprocess import PIPE
 from tempfile import gettempdir
 
 import pytest
@@ -211,10 +212,7 @@ def if_graphviz_found(app):
     graphviz_dot = getattr(app.config, 'graphviz_dot', '')
     try:
         if graphviz_dot:
-            dot = subprocess.Popen([graphviz_dot, '-V'],
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)  # show version
-            dot.communicate()
+            subprocess.run([graphviz_dot, '-V'], stdout=PIPE, stderr=PIPE)  # show version
             return
     except OSError:  # No such file or directory
         pass

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -11,7 +11,8 @@
 import gettext
 import os
 import re
-from subprocess import Popen, PIPE
+import subprocess
+from subprocess import CalledProcessError, PIPE
 
 import pytest
 
@@ -40,32 +41,26 @@ def test_msgfmt(app):
     (app.outdir / 'en' / 'LC_MESSAGES').makedirs()
     with cd(app.outdir):
         try:
-            p = Popen(['msginit', '--no-translator', '-i', 'markup.pot',
-                       '--locale', 'en_US'],
-                      stdout=PIPE, stderr=PIPE)
+            args = ['msginit', '--no-translator', '-i', 'markup.pot', '--locale', 'en_US']
+            subprocess.run(args, stdout=PIPE, stderr=PIPE, check=True)
         except OSError:
             pytest.skip()  # most likely msginit was not found
-        else:
-            stdout, stderr = p.communicate()
-            if p.returncode != 0:
-                print(stdout)
-                print(stderr)
-                assert False, 'msginit exited with return code %s' % \
-                    p.returncode
+        except CalledProcessError as exc:
+            print(exc.stdout)
+            print(exc.stderr)
+            assert False, 'msginit exited with return code %s' % exc.returncode
+
         assert (app.outdir / 'en_US.po').isfile(), 'msginit failed'
         try:
-            p = Popen(['msgfmt', 'en_US.po', '-o',
-                       os.path.join('en', 'LC_MESSAGES', 'test_root.mo')],
-                      stdout=PIPE, stderr=PIPE)
+            args = ['msgfmt', 'en_US.po', '-o', os.path.join('en', 'LC_MESSAGES', 'test_root.mo')]
+            subprocess.run(args, stdout=PIPE, stderr=PIPE, check=True)
         except OSError:
             pytest.skip()  # most likely msgfmt was not found
-        else:
-            stdout, stderr = p.communicate()
-            if p.returncode != 0:
-                print(stdout)
-                print(stderr)
-                assert False, 'msgfmt exited with return code %s' % \
-                    p.returncode
+        except CalledProcessError as exc:
+            print(exc.stdout)
+            print(exc.stderr)
+            assert False, 'msgfmt exited with return code %s' % exc.returncode
+
         mo = app.outdir / 'en' / 'LC_MESSAGES' / 'test_root.mo'
         assert mo.isfile(), 'msgfmt failed'
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
Since python3.5, subprocess.run() has been introduced. It works a
wrapper of Popen, and it looks much simple and better. This uses it
instead of Popen to make our code simple.
