### PR TITLE
Fix #5928: KeyError: 'DOCUTILSCONFIG' when running build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 * #5755: C++, fix duplicate declaration error on function templates with constraints
   in the return type.
 * C++, parse unary right fold expressions and binary fold expressions.
+* #5928: KeyError: 'DOCUTILSCONFIG' when running build
 
 Testing
 --------

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -131,7 +131,7 @@ def using_user_docutils_conf(confdir):
         yield
     finally:
         if docutilsconfig is None:
-            os.environ.pop('DOCUTILSCONFIG')
+            os.environ.pop('DOCUTILSCONFIG', None)
         else:
             os.environ['DOCUTILSCONFIG'] = docutilsconfig
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5928 