### PR TITLE
Fix parse eggfile on windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 * #5755: C++, fix duplicate declaration error on function templates with constraints
   in the return type.
 * C++, parse unary right fold expressions and binary fold expressions.
+* pycode could not handle egg files on windows
 
 Testing
 --------

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 import re
+from os import path
 from zipfile import ZipFile
 
 from six import iteritems, BytesIO, StringIO
@@ -45,7 +46,7 @@ class ModuleAnalyzer(object):
                 obj = cls(f, modname, filename)
                 cls.cache['file', filename] = obj
         except Exception as err:
-            if '.egg/' in filename:
+            if '.egg' + path.sep in filename:
                 obj = cls.cache['file', filename] = cls.for_egg(filename, modname)
             else:
                 raise PycodeError('error opening %r' % filename, err)
@@ -54,7 +55,8 @@ class ModuleAnalyzer(object):
     @classmethod
     def for_egg(cls, filename, modname):
         # type: (unicode, unicode) -> ModuleAnalyzer
-        eggpath, relpath = re.split('(?<=\\.egg)/', filename)
+        SEP = re.escape(path.sep)
+        eggpath, relpath = re.split('(?<=\\.egg)' + SEP, filename)
         try:
             with ZipFile(eggpath) as egg:
                 code = egg.read(relpath).decode('utf-8')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- pycode could not handle egg files on windows
