### PR TITLE
AppVeyor must be failed when pytest has any test failures.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ test_script:
       if (-not $tests) { $tests = '' }
       & "C:\Python$($env:PYTHON)\python.exe" -m pytest $test_ignore.Split(' ') --junitxml .junit.xml $tests.Split(' ')
       Pop-Location
-      if ($LastExitCode -eq 1) { Write-Host "Test Failures Occurred, leaving for test result parsing" }
+      if ($LastExitCode -eq 1) { Write-Host "Test Failures Occurred, leaving for test result parsing"; exit $LastExitCode }
       elseif ($LastExitCode -ne 0) { Write-Host "Other Error Occurred, aborting"; exit $LastExitCode }
 
 after_test:

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -316,7 +316,8 @@ def read_doc(app, env, filename):
         pub = Publisher(reader=reader,
                         parser=parser,
                         writer=SphinxDummyWriter(),
-                        source_class=SphinxFileInput)
+                        source_class=SphinxFileInput,
+                        destination=NullOutput())
         pub.process_programmatic_settings(None, env.settings, None)
         pub.set_source(source_path=filename)
 


### PR DESCRIPTION
### Feature or Bugfix
- Fix AppVeyor (Windows) CI status

### Purpose
- AppVeyor must be failed when pytest has any test failures.
- fix setup.py build_sphinx error on Windows.
