### PR TITLE
LaTeX: remove usage of \scalebox by incorporating scale in height/width

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #5936: LaTeX: PDF build broken by inclusion of image taller than page height
   in an admonition
 * #5231: "make html" does not read and build "po" files in "locale" dir
+* #5954: ``:scale:`` image option may break PDF build if image in an admonition
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -441,15 +441,15 @@ def rstdim_to_latexdim(width_str, scale = 100):
         elif unit == "%":
             res = "%.3f\\linewidth" % (float(amount) / 100.0)
     else:
-        amount = float(amount) * scale / 100.0
+        amount_float = float(amount) * scale / 100.0
         if unit in ('', "px"):
-            res = "%.5f\\sphinxpxdimen" % amount
+            res = "%.5f\\sphinxpxdimen" % amount_float
         elif unit == 'pt':
-            res = '%.5fbp' % amount
+            res = '%.5fbp' % amount_float
         elif unit == "%":
-            res = "%.5f\\linewidth" % (amount / 100.0)
+            res = "%.5f\\linewidth" % (amount_float / 100.0)
         else:
-            res = "%.5f%s" % (amount, unit)
+            res = "%.5f%s" % (amount_float, unit)
     return res
 
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1225,7 +1225,7 @@ def test_latex_image_in_parsed_literal(app, status, warning):
 
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
     assert ('{\\sphinxunactivateextrasandspace \\raisebox{-0.5\\height}'
-            '{\\scalebox{2.000000}{\\sphinxincludegraphics[height=1cm]{{pic}.png}}}'
+            '{\\sphinxincludegraphics[height=2.00000cm]{{pic}.png}}'
             '}AFTER') in result
 
 


### PR DESCRIPTION
Closes: #5954
