### PR TITLE
refactor: compile .mo file only if needed on testing

### DIFF
--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -61,7 +61,9 @@ def build_mo():
                 if not mo.parent.exists():
                     mo.parent.makedirs()
 
-                write_mo(mo, read_po(po))
+                if not mo.exists() or mo.stat().st_mtime < po.stat().st_mtime:
+                    # compile .mo file only if needed
+                    write_mo(mo, read_po(po))
     return builder
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To reduce our testing time, skip compilation of .mo files if not needed.
- In our testing, .po files are not modified. so compilation is only needed for first test case.