### PR TITLE
Fix #5966: mathjax has not been loaded on incremental build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
   in an admonition
 * #5231: "make html" does not read and build "po" files in "locale" dir
 * #5954: ``:scale:`` image option may break PDF build if image in an admonition
+* #5966: mathjax has not been loaded on incremental build
 
 Testing
 --------

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -104,6 +104,6 @@ def setup(app):
     app.add_config_value('mathjax_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('mathjax_display', [r'\[', r'\]'], 'html')
     app.add_config_value('mathjax_config', None, 'html')
-    app.connect('env-check-consistency', install_mathjax)
+    app.connect('env-updated', install_mathjax)
 
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5966 
