### PR TITLE
Fix #5959: classifier delimiter is not shown

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -537,6 +537,12 @@ dl.glossary dt {
     font-style: oblique;
 }
 
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}
+
 abbr, acronym {
     border-bottom: dotted 1px;
     cursor: help;


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5959 
