### PR TITLE
Fix #5958: versionadded directive causes crash with Python 3.5.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * #5954: ``:scale:`` image option may break PDF build if image in an admonition
 * #5960: LaTeX: modified PDF layout since September 2018 TeXLive update of
   :file:`parskip.sty`
+* #5958: versionadded directive causes crash with Python 3.5.0
 
 Testing
 --------

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from typing import NamedTuple
+from collections import namedtuple
 
 from docutils import nodes
 from six import iteritems
@@ -44,12 +44,9 @@ locale.versionlabels = DeprecatedDict(
 )
 
 
-ChangeSet = NamedTuple('ChangeSet', [('type', str),
-                                     ('docname', str),
-                                     ('lineno', int),
-                                     ('module', str),
-                                     ('descname', str),
-                                     ('content', str)])
+# TODO: move to typing.NamedTuple after dropping py35 support (see #5958)
+ChangeSet = namedtuple('ChangeSet',
+                       ['type', 'docname', 'lineno', 'module', 'descname', 'content'])
 
 
 class VersionChange(SphinxDirective):
@@ -135,7 +132,7 @@ class ChangeSetDomain(Domain):
         version = node['version']
         module = self.env.ref_context.get('py:module')
         objname = self.env.temp_data.get('object')
-        changeset = ChangeSet(node['type'], self.env.docname, node.line,  # type: ignore
+        changeset = ChangeSet(node['type'], self.env.docname, node.line,
                               module, objname, node.astext())
         self.data['changes'].setdefault(version, []).append(changeset)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5958 
