### PR TITLE
#4649 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -188,6 +188,8 @@ Bugs fixed
 * HTML: Invalid HTML5 file is generated for a glossary having multiple terms for
   one description (refs: #4611)
 * QtHelp: OS dependent path separator is used in .qhp file
+* HTML search: search always returns nothing when multiple search terms are
+  used and one term is shorter than three characters
 
 Testing
 --------

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -428,12 +428,12 @@ var Search = {
       var valid = true;
 
       // check if all requirements are matched
-      var filteredTerms = // as search terms with length < 3 are discarded: ignore
+      var filteredTermCount = // as search terms with length < 3 are discarded: ignore
         searchterms.filter(function(term){return term.length > 2}).length
-      var allRequirementsMatched = fileMap[file].length != searchterms.length &&
-        fileMap[file].length != filteredTerms
-      if (allRequirementsMatched)
-          continue;
+      if (
+        fileMap[file].length != searchterms.length &&
+        fileMap[file].length != filteredTermCount
+      ) continue;
 
       // ensure that none of the excluded terms is in the search result
       for (i = 0; i < excluded.length; i++) {

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -428,7 +428,11 @@ var Search = {
       var valid = true;
 
       // check if all requirements are matched
-      if (fileMap[file].length != searchterms.length)
+      var filteredTerms = // as search terms with length < 3 are discarded: ignore
+        searchterms.filter(function(term){return term.length > 2}).length
+      var allRequirementsMatched = fileMap[file].length != searchterms.length &&
+        fileMap[file].length != filteredTerms
+      if (allRequirementsMatched)
           continue;
 
       // ensure that none of the excluded terms is in the search result


### PR DESCRIPTION
Subject: Fix: search always returns nothing when one term is shorter than 3

### Feature or Bugfix
- Bugfix

### Purpose
The search function considers every page a "miss"/no match if the search contains a term with length <= 2; 
This is problem when users search for filenames, identifiers, et cetera.
This PR changes the behavior to be more lenient in such cases: if an additional search term is of length <= 2, it is ignored (no longer a necessary condition for a match).

### Relates
- Closes #4649

