### PR TITLE
Stop to use cElementTree (deprecated since py33)

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -10,8 +10,8 @@
 
 import os
 import re
-import xml.etree.cElementTree as ElementTree
 from itertools import cycle, chain
+from xml.etree import ElementTree
 
 import pytest
 from html5lib import getTreeBuilder, HTMLParser

--- a/tests/test_build_html5.py
+++ b/tests/test_build_html5.py
@@ -14,8 +14,8 @@
 """
 
 import re
-import xml.etree.cElementTree as ElementTree
 from hashlib import md5
+from xml.etree import ElementTree
 
 import pytest
 from html5lib import getTreeBuilder, HTMLParser


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: https://docs.python.org/3/library/xml.etree.elementtree.html
