### PR TITLE
refactor: test_build_html.py

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -10,19 +10,15 @@
 
 import os
 import re
-import xml.etree.cElementTree as ElementTree
 from itertools import cycle, chain
 
 import pytest
-from html5lib import getTreeBuilder, HTMLParser
+from html5lib import HTMLParser
 
 from sphinx.errors import ConfigError
 from sphinx.testing.util import strip_escseq
 from sphinx.util.inventory import InventoryFile
 
-
-TREE_BUILDER = getTreeBuilder('etree', implementation=ElementTree)
-HTML_PARSER = HTMLParser(TREE_BUILDER, namespaceHTMLElements=False)
 
 ENV_WARNINGS = """\
 %(root)s/autodoc_fodder.py:docstring of autodoc_fodder.MarkupError:\\d+: \
@@ -53,7 +49,7 @@ def cached_etree_parse():
         if fname in etree_cache:
             return etree_cache[fname]
         with (fname).open('rb') as fp:
-            etree = HTML_PARSER.parse(fp)
+            etree = HTMLParser(namespaceHTMLElements=False).parse(fp)
             etree_cache.clear()
             etree_cache[fname] = etree
             return etree

--- a/tests/test_build_html5.py
+++ b/tests/test_build_html5.py
@@ -14,17 +14,13 @@
 """
 
 import re
-import xml.etree.cElementTree as ElementTree
 from hashlib import md5
 
 import pytest
-from html5lib import getTreeBuilder, HTMLParser
+from html5lib import HTMLParser
 from test_build_html import flat_dict, tail_check, check_xpath
 
 from sphinx.util.docutils import is_html5_writer_available
-
-TREE_BUILDER = getTreeBuilder('etree', implementation=ElementTree)
-HTML_PARSER = HTMLParser(TREE_BUILDER, namespaceHTMLElements=False)
 
 
 etree_cache = {}
@@ -37,7 +33,7 @@ def cached_etree_parse():
         if fname in etree_cache:
             return etree_cache[fname]
         with (fname).open('rb') as fp:
-            etree = HTML_PARSER.parse(fp)
+            etree = HTMLParser(namespaceHTMLElements=False).parse(fp)
             etree_cache.clear()
             etree_cache[fname] = etree
             return etree


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- html5lib uses etree by default. So any options are not needed.
