### PR TITLE
Fix #5995: autodoc: autodoc_mock_imports conflict with metaclass

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #5960: LaTeX: modified PDF layout since September 2018 TeXLive update of
   :file:`parskip.sty`
 * #5958: versionadded directive causes crash with Python 3.5.0
+* #5995: autodoc: autodoc_mock_imports conflict with metaclass on Python 3.7
 
 Testing
 --------

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -57,7 +57,7 @@ class _MockObject(object):
 
     def __mro_entries__(self, bases):
         # type: (Tuple) -> Tuple
-        return bases
+        return (self.__class__,)
 
     def __getitem__(self, key):
         # type: (str) -> _MockObject

--- a/tests/test_ext_autodoc_importer.py
+++ b/tests/test_ext_autodoc_importer.py
@@ -9,6 +9,11 @@
     :license: BSD, see LICENSE for details.
 """
 
+import abc
+import sys
+
+import pytest
+
 from sphinx.ext.autodoc.importer import _MockObject
 
 
@@ -29,3 +34,21 @@ def test_MockObject():
     assert isinstance(obj, SubClass)
     assert obj.method() == "string"
     assert isinstance(obj.other_method(), SubClass)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='Only for py37 or above')
+def test_abc_MockObject():
+    mock = _MockObject()
+
+    class Base:
+        @abc.abstractmethod
+        def __init__(self):
+            pass
+
+    class Derived(Base, mock.SubClass):
+        pass
+
+    obj = Derived()
+    assert isinstance(obj, Base)
+    assert isinstance(obj, _MockObject)
+    assert isinstance(obj.some_method(), Derived)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5995 
