### PR TITLE
LaTeX: remove extra space after author on title page in PDF

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* LaTeX: Remove extraneous space after author names on PDF title page (refs: #6004)
+
 Testing
 --------
 

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -46,7 +46,7 @@
     {\Large
       \begin{tabular}[t]{c}
         \@author
-      \end{tabular}}\par
+      \end{tabular}\kern-\tabcolsep}\par
     \vspace{25pt}
     \@date \par
     \py@authoraddress \par

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -55,7 +55,7 @@
       {\LARGE
         \begin{tabular}[t]{c}
           \@author
-        \end{tabular}
+        \end{tabular}\kern-\tabcolsep
         \par}
       \vfill\vfill
       {\large


### PR DESCRIPTION
Closes: #6004

Comment: ``\begin{tabular}[@{}c@{}]`` does not work in case of multiple
authors separated by \and in latex_documents, because latex has this
definition of \and :

```
macro:->\end {tabular}\hskip 1em \@plus .17fil\begin {tabular}[t]{c}
```

which means we would need to modify it to read

```
macro:->\end {tabular}\hskip 1em \@plus .17fil\begin {tabular}[t]{@{}c@{}}
```

(or only one ``@{}`` at end) modifying space between two authors.

Subject: <short purpose of this pull request>

If requalified as bugfix, I will rebase on 1.8 and update CHANGES accordingly.

