### PR TITLE
Fix #5948: LaTeX: duplicated labels are generated for sections

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * #5954: ``:scale:`` image option may break PDF build if image in an admonition
 * #5960: LaTeX: modified PDF layout since September 2018 TeXLive update of
   :file:`parskip.sty`
+* #5948: LaTeX: duplicated labels are generated for sections
 * #5958: versionadded directive causes crash with Python 3.5.0
 * #5995: autodoc: autodoc_mock_imports conflict with metaclass on Python 3.7
 * #5871: texinfo: a section title ``.`` is not allowed

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1876,10 +1876,9 @@ class LaTeXTranslator(nodes.NodeVisitor):
         elif domain.get_enumerable_node_type(next_node) and domain.get_numfig_title(next_node):
             return
 
-        if 'refuri' in node:
+        if 'refuri' in node or 'refid' in node or 'refname' in node:
+            # skip indirect targets (external hyperlink and internal links)
             return
-        if node.get('refid'):
-            add_target(node['refid'])
         for id in node['ids']:
             add_target(id)
 

--- a/tests/roots/test-latex-labels/index.rst
+++ b/tests/roots/test-latex-labels/index.rst
@@ -68,3 +68,5 @@ subsubsection
 .. toctree::
 
    otherdoc
+
+* Embeded standalone hyperlink reference(refs: #5948): `subsection <section1_>`_.

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1336,3 +1336,7 @@ def test_latex_labels(app, status, warning):
     assert ('\\subsection{otherdoc}\n'
             r'\label{\detokenize{otherdoc:otherdoc}}'
             r'\label{\detokenize{otherdoc::doc}}' in result)
+
+
+    # Embeded standalone hyperlink reference (refs: #5948)
+    assert result.count(r'\label{\detokenize{index:section1}}') == 1


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5948 
