### PR TITLE
Fix test: imgconverter expects size of images fixed

### DIFF
--- a/tests/roots/test-ext-imgconverter/svgimg.svg
+++ b/tests/roots/test-ext-imgconverter/svgimg.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="60" width="60">
     <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
 </svg>

--- a/tests/roots/test-images/subdir/svgimg.svg
+++ b/tests/roots/test-images/subdir/svgimg.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="60" width="60">
     <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
 </svg>

--- a/tests/roots/test-images/subdir/svgimg.xx.svg
+++ b/tests/roots/test-images/subdir/svgimg.xx.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="60" width="60">
     <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
 </svg>

--- a/tests/roots/test-root/svgimg.svg
+++ b/tests/roots/test-root/svgimg.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="60" width="60">
     <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
 </svg>

--- a/tests/roots/test-warnings/svgimg.svg
+++ b/tests/roots/test-warnings/svgimg.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="60" width="60">
     <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
 </svg>


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Some version of imagemagick expects size of images fixed
