### PR TITLE
Close #4550: All tables and figures without ``align`` option are displayed to center

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,7 @@ Incompatible changes
 * LaTeX: graphics inclusion of oversized images rescales to not exceed
   the text width and height, even if width and/or height option were used.
   (refs: #5956)
+* #4550: All tables and figures without ``align`` option are displayed to center
 
 Deprecated
 ----------

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -21,7 +21,7 @@ from typing import Any, Union  # NOQA
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.transforms import (
     ApplySourceWorkaround, ExtraTranslatableNodes, CitationReferences,
-    DefaultSubstitutions, MoveModuleTargets, HandleCodeBlocks, SortIds,
+    DefaultSubstitutions, MoveModuleTargets, HandleCodeBlocks, SortIds, FigureAligner,
     AutoNumbering, AutoIndexUpgrader, FilterSystemMessages,
     UnreferencedFootnotesDetector, SphinxSmartQuotes, DoctreeReadEvent, ManpageLink
 )
@@ -96,7 +96,7 @@ class SphinxStandaloneReader(SphinxBaseReader):
     """
     transforms = [ApplySourceWorkaround, ExtraTranslatableNodes, PreserveTranslatableMessages,
                   Locale, CitationReferences, DefaultSubstitutions, MoveModuleTargets,
-                  HandleCodeBlocks, AutoNumbering, AutoIndexUpgrader, SortIds,
+                  HandleCodeBlocks, AutoNumbering, AutoIndexUpgrader, SortIds, FigureAligner,
                   RemoveTranslatableInline, FilterSystemMessages, RefOnlyBulletListTransform,
                   UnreferencedFootnotesDetector, SphinxSmartQuotes, ManpageLink,
                   SphinxDomains, SubstitutionDefinitionsRemover, DoctreeReadEvent,

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -23,7 +23,7 @@ from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.docutils import new_document
 from sphinx.util.i18n import format_date
-from sphinx.util.nodes import apply_source_workaround, is_smartquotable
+from sphinx.util.nodes import NodeMatcher, apply_source_workaround, is_smartquotable
 
 if False:
     # For type annotation
@@ -307,6 +307,19 @@ class UnreferencedFootnotesDetector(SphinxTransform):
                 logger.warning(__('Footnote [#] is not referenced.'),
                                type='ref', subtype='footnote',
                                location=node)
+
+
+class FigureAligner(SphinxTransform):
+    """
+    Align figures to center by default.
+    """
+    default_priority = 700
+
+    def apply(self, **kwargs):
+        # type: (Any) -> None
+        matcher = NodeMatcher(nodes.table, nodes.figure)
+        for node in self.document.traverse(matcher):  # type: nodes.Element
+            node.setdefault('align', 'center')
 
 
 class FilterSystemMessages(SphinxTransform):

--- a/tests/roots/test-latex-table/expects/longtable.tex
+++ b/tests/roots/test-latex-table/expects/longtable.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|l|l|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-caption}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|l|l|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|l|l|}
 \sphinxthelongtablecaptionisattop
 \caption{caption for longtable\strut}\label{\detokenize{longtable:id1}}\\*[\sphinxlongtablecapskipadjust]
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-problematic-cell}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{2}{\X{1}{2}|}}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|*{2}{\X{1}{2}|}}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-both-stub-columns-and-problematic-cell}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{3}{\X{1}{3}|}}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|*{3}{\X{1}{3}|}}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-verbatim}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|*{2}{\X{1}{2}|}}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|*{2}{\X{1}{2}|}}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-widths-option}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|\X{30}{100}|\X{70}{100}|}
 \hline\noalign{\phantomsection\label{\detokenize{longtable:namedlongtable}}\label{\detokenize{longtable:mylongtable}}}%
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-having-both-widths-and-problematic-cell}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|\X{30}{100}|\X{70}{100}|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
@@ -1,6 +1,6 @@
 \label{\detokenize{longtable:longtable-with-tabularcolumn}}
 
-\begin{savenotes}\sphinxatlongtablestart\begin{longtable}{|c|c|}
+\begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|c|c|}
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -527,7 +527,7 @@ def test_numfig_disabled_warn(app, warning):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", None, True),
         (".//table/caption/span[@class='caption-number']", None, True),
         (".//div[@class='code-block-caption']/"
@@ -544,21 +544,21 @@ def test_numfig_disabled_warn(app, warning):
         (".//li/a/span", '^Sect.1 Foo$', True),
     ],
     'foo.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", None, True),
         (".//table/caption/span[@class='caption-number']", None, True),
         (".//div[@class='code-block-caption']/"
          "span[@class='caption-number']", None, True),
     ],
     'bar.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", None, True),
         (".//table/caption/span[@class='caption-number']", None, True),
         (".//div[@class='code-block-caption']/"
          "span[@class='caption-number']", None, True),
     ],
     'baz.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", None, True),
         (".//table/caption/span[@class='caption-number']", None, True),
         (".//div[@class='code-block-caption']/"
@@ -593,9 +593,9 @@ def test_numfig_without_numbered_toctree_warn(app, warning):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 9 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 10 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 9 $', True),
@@ -617,13 +617,13 @@ def test_numfig_without_numbered_toctree_warn(app, warning):
         (".//li/code/span", '^Sect.{number}$', True),
     ],
     'foo.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1 $', True),
@@ -643,11 +643,11 @@ def test_numfig_without_numbered_toctree_warn(app, warning):
          "span[@class='caption-number']", '^Listing 4 $', True),
     ],
     'bar.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 5 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 7 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 8 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 5 $', True),
@@ -663,7 +663,7 @@ def test_numfig_without_numbered_toctree_warn(app, warning):
          "span[@class='caption-number']", '^Listing 8 $', True),
     ],
     'baz.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 6 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 6 $', True),
@@ -699,9 +699,9 @@ def test_numfig_with_numbered_toctree_warn(app, warning):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1 $', True),
@@ -723,13 +723,13 @@ def test_numfig_with_numbered_toctree_warn(app, warning):
         (".//li/a/span", '^Sect.1 Foo$', True),
     ],
     'foo.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.2 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1.1 $', True),
@@ -749,11 +749,11 @@ def test_numfig_with_numbered_toctree_warn(app, warning):
          "span[@class='caption-number']", '^Listing 1.4 $', True),
     ],
     'bar.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 2.1 $', True),
@@ -769,7 +769,7 @@ def test_numfig_with_numbered_toctree_warn(app, warning):
          "span[@class='caption-number']", '^Listing 2.4 $', True),
     ],
     'baz.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 2.2 $', True),
@@ -802,9 +802,9 @@ def test_numfig_with_prefix_warn(app, warning):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Tab_1 $', True),
@@ -826,13 +826,13 @@ def test_numfig_with_prefix_warn(app, warning):
         (".//li/a/span", '^Sect.1 Foo$', True),
     ],
     'foo.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:1.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:1.2 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:1.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:1.4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Tab_1.1 $', True),
@@ -852,11 +852,11 @@ def test_numfig_with_prefix_warn(app, warning):
          "span[@class='caption-number']", '^Code-1.4 $', True),
     ],
     'bar.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:2.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:2.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:2.4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Tab_2.1 $', True),
@@ -872,7 +872,7 @@ def test_numfig_with_prefix_warn(app, warning):
          "span[@class='caption-number']", '^Code-2.4 $', True),
     ],
     'baz.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Figure:2.2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Tab_2.2 $', True),
@@ -906,9 +906,9 @@ def test_numfig_with_secnum_depth_warn(app, warning):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1 $', True),
@@ -930,13 +930,13 @@ def test_numfig_with_secnum_depth_warn(app, warning):
         (".//li/a/span", '^Sect.1 Foo$', True),
     ],
     'foo.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.1.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.1.2 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.2.1 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1.1 $', True),
@@ -956,11 +956,11 @@ def test_numfig_with_secnum_depth_warn(app, warning):
          "span[@class='caption-number']", '^Listing 1.2.1 $', True),
     ],
     'bar.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.1.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.1.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.2.1 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 2.1.1 $', True),
@@ -976,7 +976,7 @@ def test_numfig_with_secnum_depth_warn(app, warning):
          "span[@class='caption-number']", '^Listing 2.2.1 $', True),
     ],
     'baz.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.1.2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 2.1.2 $', True),
@@ -994,9 +994,9 @@ def test_numfig_with_secnum_depth(app, cached_etree_parse, fname, expect):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1 $', True),
@@ -1016,13 +1016,13 @@ def test_numfig_with_secnum_depth(app, cached_etree_parse, fname, expect):
         (".//li/a/span", '^Section.2.1$', True),
         (".//li/a/span", '^Fig.1 should be Fig.1$', True),
         (".//li/a/span", '^Sect.1 Foo$', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.2 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 1.4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 1.1 $', True),
@@ -1040,11 +1040,11 @@ def test_numfig_with_secnum_depth(app, cached_etree_parse, fname, expect):
          "span[@class='caption-number']", '^Listing 1.3 $', True),
         (".//div[@class='code-block-caption']/"
          "span[@class='caption-number']", '^Listing 1.4 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.1 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.3 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.4 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 2.1 $', True),
@@ -1058,7 +1058,7 @@ def test_numfig_with_secnum_depth(app, cached_etree_parse, fname, expect):
          "span[@class='caption-number']", '^Listing 2.3 $', True),
         (".//div[@class='code-block-caption']/"
          "span[@class='caption-number']", '^Listing 2.4 $', True),
-        (".//div[@class='figure']/p[@class='caption']/"
+        (".//div[@class='figure align-center']/p[@class='caption']/"
          "span[@class='caption-number']", '^Fig. 2.2 $', True),
         (".//table/caption/span[@class='caption-number']",
          '^Table 2.2 $', True),
@@ -1076,12 +1076,12 @@ def test_numfig_with_singlehtml(app, cached_etree_parse, fname, expect):
 
 @pytest.mark.parametrize("fname,expect", flat_dict({
     'index.html': [
-        (".//div[@class='figure']/p[@class='caption']/span[@class='caption-number']",
-         "Fig. 1", True),
-        (".//div[@class='figure']/p[@class='caption']/span[@class='caption-number']",
-         "Fig. 2", True),
-        (".//div[@class='figure']/p[@class='caption']/span[@class='caption-number']",
-         "Fig. 3", True),
+        (".//div[@class='figure align-center']/p[@class='caption']"
+         "/span[@class='caption-number']", "Fig. 1", True),
+        (".//div[@class='figure align-center']/p[@class='caption']"
+         "/span[@class='caption-number']", "Fig. 2", True),
+        (".//div[@class='figure align-center']/p[@class='caption']"
+         "/span[@class='caption-number']", "Fig. 3", True),
         (".//div//span[@class='caption-number']", "No.1 ", True),
         (".//div//span[@class='caption-number']", "No.2 ", True),
         (".//li/a/span", 'Fig. 1', True),

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -203,7 +203,7 @@ def test_autosummary_latex_table_colspec(app, status, warning):
     result = (app.outdir / 'python.tex').text(encoding='utf8')
     print(status.getvalue())
     print(warning.getvalue())
-    assert r'\begin{longtable}{\X{1}{2}\X{1}{2}}' in result
+    assert r'\begin{longtable}[c]{\X{1}{2}\X{1}{2}}' in result
     assert r'p{0.5\linewidth}' not in result
 
 

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -21,7 +21,7 @@ def test_graphviz_png_html(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').text()
-    html = (r'<div class="figure" .*?>\s*'
+    html = (r'<div class="figure align-center" .*?>\s*'
             r'<div class="graphviz"><img .*?/></div>\s*<p class="caption">'
             r'<span class="caption-text">caption of graph</span>.*</p>\s*</div>')
     assert re.search(html, content, re.S)
@@ -52,7 +52,7 @@ def test_graphviz_svg_html(app, status, warning):
 
     content = (app.outdir / 'index.html').text()
 
-    html = (r'<div class=\"figure\" .*?>\n'
+    html = (r'<div class=\"figure align-center\" .*?>\n'
             r'<div class="graphviz"><object data=\".*\.svg\".*>\n'
             r'\s*<p class=\"warning\">digraph foo {\n'
             r'bar -&gt; baz\n'

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -23,7 +23,7 @@ def test_inheritance_diagram_png_html(app, status, warning):
 
     content = (app.outdir / 'index.html').text()
 
-    pattern = ('<div class="figure" id="id1">\n'
+    pattern = ('<div class="figure align-center" id="id1">\n'
                '<div class="graphviz">'
                '<img src="_images/inheritance-\\w+.png" alt="Inheritance diagram of test.Foo" '
                'class="inheritance graphviz" /></div>\n<p class="caption">'
@@ -40,7 +40,7 @@ def test_inheritance_diagram_svg_html(app, status, warning):
 
     content = (app.outdir / 'index.html').text()
 
-    pattern = ('<div class="figure" id="id1">\n'
+    pattern = ('<div class="figure align-center" id="id1">\n'
                '<div class="graphviz">'
                '<object data="_images/inheritance-\\w+.svg" '
                'type="image/svg\\+xml" class="inheritance graphviz">\n'
@@ -80,7 +80,7 @@ def test_inheritance_diagram_latex_alias(app, status, warning):
 
     content = (app.outdir / 'index.html').text()
 
-    pattern = ('<div class="figure" id="id1">\n'
+    pattern = ('<div class="figure align-center" id="id1">\n'
                '<div class="graphviz">'
                '<img src="_images/inheritance-\\w+.png" alt="Inheritance diagram of test.Foo" '
                'class="inheritance graphviz" /></div>\n<p class="caption">'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #4550
