### PR TITLE
Introduce SphinxRole class as a base class of roles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -104,6 +104,7 @@ Deprecated
 * ``sphinx.io.SphinxFileInput.supported``
 * ``sphinx.io.SphinxRSTFileInput``
 * ``sphinx.registry.SphinxComponentRegistry.add_source_input()``
+* ``sphinx.roles.abbr_role()``
 * ``sphinx.testing.util.remove_unicode_literal()``
 * ``sphinx.util.attrdict``
 * ``sphinx.util.force_decode()``

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -365,6 +365,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``sphinxcontrib.jsmath``
 
+   * - ``sphinx.roles.abbr_role()``
+     - 2.0
+     - 4.0
+     - ``sphinx.roles.Abbreviation``
+
    * - ``sphinx.testing.util.remove_unicode_literal()``
      - 2.0
      - 4.0


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- So far, we use functions to implement roles. But its argument is difficult to understand for beginners. And it is hard to access `env` and `config` objects originated Sphinx.
- This introduces `SphinxRole` class as a base class of roles. It works like "Directive" class for directive implementations. Developers can create custom roles by subclassing it and override `run()` method.
- As a first step, I replaced `:abbr:` role by the base class.
- If approved, I'll continue to replace other role implemantions.