### PR TITLE
Close #5993: Use envvar ``$SSL_CERT_FILE`` to the default for tls_cacerts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -176,7 +176,8 @@ Features added
 * #6016: HTML search: A placeholder for the search summary prevents search
   result links from changing their position when the search terminates.  This
   makes navigating search results easier.
-  
+* #5993: Use envvar ``$SSL_CERT_FILE`` to the default for :confval:`tls_cacerts`
+
 Bugs fixed
 ----------
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -502,12 +502,16 @@ General configuration
 
 .. confval:: tls_cacerts
 
-   A path to a certification file of CA or a path to directory which
-   contains the certificates.  This also allows a dictionary mapping
-   hostname to the path to certificate file.
+   A path to a certification file of CA or a path to directory which contains
+   the certificates.  This also allows a dictionary mapping hostname to the
+   path to certificate file.  Default is the value of environment variable
+   ``SSL_CERT_FILE``.
    The certificates are used to verify server certifications.
 
    .. versionadded:: 1.5
+
+   .. versionchanged:: 2.0
+      ``$SSL_CERT_FILE`` is used to default.
 
 .. confval:: today
              today_fmt

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -79,6 +79,11 @@ class ENUM:
 string_classes = [str]  # type: List
 
 
+def default_tls_cacerts(config):
+    # type: (Config) -> str
+    return getenv('SSL_CERT_FILE')
+
+
 class Config:
     """Configuration file abstraction.
 
@@ -146,7 +151,7 @@ class Config:
         'math_eqref_format': (None, 'env', [str]),
         'math_numfig': (True, 'env', []),
         'tls_verify': (True, 'env', []),
-        'tls_cacerts': (None, 'env', []),
+        'tls_cacerts': (default_tls_cacerts, 'env', []),
         'smartquotes': (True, 'env', []),
         'smartquotes_action': ('qDe', 'env', []),
         'smartquotes_excludes': ({'languages': ['ja'],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@
     :copyright: Copyright 2007-2019 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import os
 import mock
 import pytest
 
@@ -198,6 +199,25 @@ def test_builtin_conf(app, status, warning):
     assert 'primary_domain' not in warnings, (
         'override to None on builtin "primary_domain" should NOT raise a type '
         'warning')
+
+
+def test_tls_cacerts():
+    try:
+        cert_file = os.environ.pop('SSL_CERT_FILE', None)
+
+        config = Config()
+        assert config.tls_cacerts is None
+
+        os.environ['SSL_CERT_FILE'] = '/path/to/cert'
+        config = Config()
+        assert config.tls_cacerts == '/path/to/cert'
+    except Exception:
+        if cert_file:
+            os.environ['SSL_CERT_FILE'] = cert_file
+        else:
+            os.environ.pop('SSL_CERT_FILE', None)
+
+
 
 
 # example classes for type checking


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #5993 
- I choose `SSL_CERT_FILE`. It seems commonly used in other softwares.