### PR TITLE
Fix #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * LaTeX: Remove extraneous space after author names on PDF title page (refs: #6004)
+* #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given
 
 Testing
 --------

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -376,7 +376,7 @@ def validate_config_values(app, config):
     for key in list(config.latex_elements):
         if key not in DEFAULT_SETTINGS:
             msg = __("Unknown configure key: latex_elements[%r]. ignored.")
-            logger.warning(msg % key)
+            logger.warning(msg % (key,))
             config.latex_elements.pop(key)
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6046 
