### PR TITLE
Fix #6026: LaTeX: A cross reference to definition list does not work

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * LaTeX: Remove extraneous space after author names on PDF title page (refs: #6004)
+* #6026: LaTeX: A cross reference to definition list does not work
 
 Testing
 --------

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -238,6 +238,15 @@ def traverse_parent(node, cls=None):
         node = node.parent
 
 
+def get_prev_node(node):
+    # type: (nodes.Node) -> nodes.Node
+    pos = node.parent.index(node)
+    if pos > 0:
+        return node.parent[pos - 1]
+    else:
+        return None
+
+
 def traverse_translatable_index(doctree):
     # type: (nodes.Node) -> Iterable[Tuple[nodes.Node, List[unicode]]]
     """Traverse translatable index node from a document tree."""

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -29,7 +29,7 @@ from sphinx.errors import SphinxError
 from sphinx.locale import admonitionlabels, _, __
 from sphinx.util import split_into, logging
 from sphinx.util.i18n import format_date
-from sphinx.util.nodes import clean_astext
+from sphinx.util.nodes import clean_astext, get_prev_node
 from sphinx.util.template import LaTeXRenderer
 from sphinx.util.texescape import tex_escape_map, tex_replace_map
 
@@ -1876,9 +1876,15 @@ class LaTeXTranslator(nodes.NodeVisitor):
         elif domain.get_enumerable_node_type(next_node) and domain.get_numfig_title(next_node):
             return
 
-        if 'refuri' in node or 'refid' in node or 'refname' in node:
-            # skip indirect targets (external hyperlink and internal links)
+        if 'refuri' in node:
             return
+        if node.get('refid'):
+            prev_node = get_prev_node(node)
+            if isinstance(prev_node, nodes.reference) and node['refid'] == prev_node['refid']:
+                # a target for a hyperlink reference having alias
+                pass
+            else:
+                add_target(node['refid'])
         for id in node['ids']:
             add_target(id)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6026 
