### PR TITLE
Skip escaping navpoint because it's HTML safe

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -655,7 +655,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         if incr:
             self.playorder += 1
         self.tocid += 1
-        return NavPoint(self.esc('navPoint%d' % self.tocid), self.playorder,
+        return NavPoint('navPoint%d' % self.tocid, self.playorder,
                         node['text'], node['refuri'], [])
 
     def build_navpoints(self, nodes):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- because navpoint id is consist of ASCII characters. escaping is not needed.

