### PR TITLE
docs: Use "Courier New" font to code blocks

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -337,7 +337,7 @@ a tt:hover {
 }
 
 pre {
-    font-family: 'Consolas', 'DejaVu Sans Mono',
+    font-family: 'Consolas', 'Courier New', 'DejaVu Sans Mono',
                  'Bitstream Vera Sans Mono', monospace;
     font-size: 13px;
     letter-spacing: 0.015em;


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- In MacOS, monospace font is not used for code-blocks
- This adds "Courier New" to the candidates of the font settings.
- cssfontstack.com says it is used in 95% for MacOS users: https://www.cssfontstack.com/