### PR TITLE
Closes #5635: autosummary: Add autosummary_mock_imports to mock external libraries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -160,6 +160,8 @@ Features added
 * #5533: autodoc: :confval:`autodoc_default_options` supports ``member-order``
 * #5394: autodoc: Display readable names in type annotations for mocked objects
 * #5459: autodoc: :confval:`autodoc_default_options` accepts ``True`` as a value
+* #5635: autosummary: Add :confval:`autosummary_mock_imports` to mock external
+  libraries on importing targets
 * #4018: htmlhelp: Add :confval:`htmlhelp_file_suffix` and
   :confval:`htmlhelp_link_suffix`
 * #5559: text: Support complex tables (colspan and rowspan)

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -143,6 +143,11 @@ also use this new config value:
    The new files will be placed in the directories specified in the
    ``:toctree:`` options of the directives.
 
+.. confval:: autosummary_mock_imports
+
+   This value contains a list of modules to be mocked up.  See
+   :confval:`autodoc_mock_imports` for more details.  It defaults to
+   :confval:`autodoc_mock_imports`.
 
 Customizing templates
 ---------------------

--- a/tests/roots/test-ext-autosummary-mock_imports/conf.py
+++ b/tests/roots/test-ext-autosummary-mock_imports/conf.py
@@ -1,0 +1,7 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autosummary']
+autosummary_generate = True
+autosummary_mock_imports = ['unknown']

--- a/tests/roots/test-ext-autosummary-mock_imports/foo.py
+++ b/tests/roots/test-ext-autosummary-mock_imports/foo.py
@@ -1,0 +1,6 @@
+import unknown
+
+
+class Foo(unknown.Class):
+    """Foo class"""
+    pass

--- a/tests/roots/test-ext-autosummary-mock_imports/index.rst
+++ b/tests/roots/test-ext-autosummary-mock_imports/index.rst
@@ -1,0 +1,7 @@
+test-ext-autosummary-mock_imports
+=================================
+
+.. autosummary::
+   :toctree: generated
+
+   foo

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -8,6 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import sys
 from io import StringIO
 
 import pytest
@@ -229,3 +230,15 @@ def test_import_by_name():
     assert obj == sphinx.ext.autosummary.Autosummary.get_items
     assert parent is sphinx.ext.autosummary.Autosummary
     assert modname == 'sphinx.ext.autosummary'
+
+
+@pytest.mark.sphinx('dummy', testroot='ext-autosummary-mock_imports')
+def test_autosummary_mock_imports(app, status, warning):
+    try:
+        app.build()
+        assert warning.getvalue() == ''
+
+        # generated/foo is generated successfully
+        assert app.env.get_doctree('generated/foo')
+    finally:
+        sys.modules.pop('foo', None)  # unload foo module


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #5635
