### PR TITLE
Fix #6047: autodoc: ``autofunction`` emits a warning for method objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #6026: LaTeX: A cross reference to definition list does not work
 * #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given
 * #6019: imgconverter: Including multipage PDF fails
+* #6047: autodoc: ``autofunction`` emits a warning for method objects
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1056,6 +1056,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             return None
         try:
             if (not isfunction(self.object) and
+                    not inspect.ismethod(self.object) and
                     not isbuiltin(self.object) and
                     not inspect.isclass(self.object) and
                     hasattr(self.object, '__call__')):

--- a/tests/roots/test-ext-autodoc/target/callable.py
+++ b/tests/roots/test-ext-autodoc/target/callable.py
@@ -4,5 +4,10 @@ class Callable():
     def __call__(self, arg1, arg2, **kwargs):
         pass
 
+    def method(self, arg1, arg2):
+        """docstring of Callable.method()."""
+        pass
+
 
 function = Callable()
+method = function.method

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1359,6 +1359,19 @@ def test_autofunction_for_callable(app):
     ]
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autofunction_for_method(app):
+    actual = do_autodoc(app, 'function', 'target.callable.method')
+    assert list(actual) == [
+        '',
+        '.. py:function:: method(arg1, arg2)',
+        '   :module: target.callable',
+        '',
+        '   docstring of Callable.method().',
+        '   '
+    ]
+
+
 @pytest.mark.sphinx('html', testroot='root')
 def test_mocked_module_imports(app):
     options = {"members": 'TestAutodoc,decoratedFunction'}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6047 
