### PR TITLE
test: Use get_doctree() to load doctree files

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,7 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-import pickle
 import sys
 from textwrap import dedent
 
@@ -110,7 +109,7 @@ def test_image_glob(app, status, warning):
     app.builder.build_all()
 
     # index.rst
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    doctree = app.env.get_doctree('index')
 
     assert isinstance(doctree[0][1], nodes.image)
     assert doctree[0][1]['candidates'] == {'*': 'rimg.png'}
@@ -135,7 +134,7 @@ def test_image_glob(app, status, warning):
     assert doctree[0][4][0]['uri'] == 'img.*'
 
     # subdir/index.rst
-    doctree = pickle.loads((app.doctreedir / 'subdir/index.doctree').bytes())
+    doctree = app.env.get_doctree('subdir/index')
 
     assert isinstance(doctree[0][1], nodes.image)
     sub = path('subdir')

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -8,8 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-import pickle
-
 import pytest
 
 from sphinx import addnodes
@@ -19,7 +17,7 @@ from sphinx import addnodes
 def test_autodoc(app, status, warning):
     app.builder.build_all()
 
-    content = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    content = app.env.get_doctree('index')
     assert isinstance(content[3], addnodes.desc)
     assert content[3][0].astext() == 'autodoc_dummy_module.test'
     assert content[3][1].astext() == 'Dummy function using dummy.*'

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -10,7 +10,6 @@
 """
 
 import os
-import pickle
 import re
 
 import pytest
@@ -1188,9 +1187,9 @@ def test_text_references(app, warning):
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_image_glob_intl(app):
     app.build()
-    # index.rst
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
 
+    # index.rst
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0][1], nodes.image, uri='rimg.xx.png',
                 candidates={'*': 'rimg.xx.png'})
 
@@ -1210,8 +1209,7 @@ def test_image_glob_intl(app):
                             'image/png': 'img.png'})
 
     # subdir/index.rst
-    doctree = pickle.loads((app.doctreedir / 'subdir/index.doctree').bytes())
-
+    doctree = app.env.get_doctree('subdir/index')
     assert_node(doctree[0][1], nodes.image, uri='subdir/rimg.xx.png',
                 candidates={'*': 'subdir/rimg.xx.png'})
 
@@ -1236,9 +1234,9 @@ def test_image_glob_intl(app):
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_image_glob_intl_using_figure_language_filename(app):
     app.build()
-    # index.rst
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
 
+    # index.rst
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0][1], nodes.image, uri='rimg.png.xx',
                 candidates={'*': 'rimg.png.xx'})
 
@@ -1258,8 +1256,7 @@ def test_image_glob_intl_using_figure_language_filename(app):
                             'image/png': 'img.png'})
 
     # subdir/index.rst
-    doctree = pickle.loads((app.doctreedir / 'subdir/index.doctree').bytes())
-
+    doctree = app.env.get_doctree('subdir/index')
     assert_node(doctree[0][1], nodes.image, uri='subdir/rimg.png',
                 candidates={'*': 'subdir/rimg.png'})
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -8,7 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-import pickle
 import re
 
 import pytest
@@ -408,8 +407,8 @@ def test_XRefRole(inliner):
 @pytest.mark.sphinx('dummy', testroot='prolog')
 def test_rst_prolog(app, status, warning):
     app.builder.build_all()
-    rst = pickle.loads((app.doctreedir / 'restructuredtext.doctree').bytes())
-    md = pickle.loads((app.doctreedir / 'markdown.doctree').bytes())
+    rst = app.env.get_doctree('restructuredtext')
+    md = app.env.get_doctree('markdown')
 
     # rst_prolog
     assert_node(rst[0], nodes.paragraph)
@@ -432,7 +431,7 @@ def test_rst_prolog(app, status, warning):
 @pytest.mark.sphinx('dummy', testroot='keep_warnings')
 def test_keep_warnings_is_True(app, status, warning):
     app.builder.build_all()
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0], nodes.section)
     assert len(doctree[0]) == 2
     assert_node(doctree[0][1], nodes.system_message)
@@ -442,7 +441,7 @@ def test_keep_warnings_is_True(app, status, warning):
                     confoverrides={'keep_warnings': False})
 def test_keep_warnings_is_False(app, status, warning):
     app.builder.build_all()
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0], nodes.section)
     assert len(doctree[0]) == 1
 
@@ -450,7 +449,7 @@ def test_keep_warnings_is_False(app, status, warning):
 @pytest.mark.sphinx('dummy', testroot='refonly_bullet_list')
 def test_compact_refonly_bullet_list(app, status, warning):
     app.builder.build_all()
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0], nodes.section)
     assert len(doctree[0]) == 5
 
@@ -470,7 +469,7 @@ def test_default_role1(app, status, warning):
     app.builder.build_all()
 
     # default-role: pep
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0], nodes.section)
     assert_node(doctree[0][1], nodes.paragraph)
     assert_node(doctree[0][1][0], addnodes.index)
@@ -478,7 +477,7 @@ def test_default_role1(app, status, warning):
     assert_node(doctree[0][1][2], nodes.reference, classes=["pep"])
 
     # no default-role
-    doctree = pickle.loads((app.doctreedir / 'foo.doctree').bytes())
+    doctree = app.env.get_doctree('foo')
     assert_node(doctree[0], nodes.section)
     assert_node(doctree[0][1], nodes.paragraph)
     assert_node(doctree[0][1][0], nodes.title_reference)
@@ -491,7 +490,7 @@ def test_default_role2(app, status, warning):
     app.builder.build_all()
 
     # default-role directive is stronger than configratuion
-    doctree = pickle.loads((app.doctreedir / 'index.doctree').bytes())
+    doctree = app.env.get_doctree('index')
     assert_node(doctree[0], nodes.section)
     assert_node(doctree[0][1], nodes.paragraph)
     assert_node(doctree[0][1][0], addnodes.index)
@@ -499,7 +498,7 @@ def test_default_role2(app, status, warning):
     assert_node(doctree[0][1][2], nodes.reference, classes=["pep"])
 
     # default_role changes the default behavior
-    doctree = pickle.loads((app.doctreedir / 'foo.doctree').bytes())
+    doctree = app.env.get_doctree('foo')
     assert_node(doctree[0], nodes.section)
     assert_node(doctree[0][1], nodes.paragraph)
     assert_node(doctree[0][1][0], nodes.inline, classes=["guilabel"])


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To be our test more essential, use `env.get_doctree()` to load a doctree file.
