### PR TITLE
 Ignore filenames without file extensions given to ``Builder.build_specific()``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Dependencies
 Incompatible changes
 --------------------
 
+* Ignore filenames without file extension given to ``Builder.build_specific()``
+  API directly
+
 Deprecated
 ----------
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -298,8 +298,7 @@ class Builder:
                 logger.warning(__('file %r given on command line is not under the '
                                   'source directory, ignoring'), filename)
                 continue
-            if not (path.isfile(filename) or
-                    any(path.isfile(filename + suffix) for suffix in suffixes)):
+            if not path.isfile(filename):
                 logger.warning(__('file %r given on command line does not exist, '
                                   'ignoring'), filename)
                 continue

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -131,7 +131,7 @@ def test_build_specific(app):
                  app.srcdir / 'subdir/../subdir/excluded.txt']  # not normalized
     app.build(False, filenames)
 
-    expected = ['index', 'images', 'img.png', 'subdir/includes', 'subdir/excluded']
+    expected = ['index', 'img.png', 'subdir/includes', 'subdir/excluded']
     app.builder.build.assert_called_with(expected,
                                          method='specific',
-                                         summary='5 source files given on command line')
+                                         summary='4 source files given on command line')

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -7,6 +7,9 @@
     :copyright: Copyright 2007-2019 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+
+from unittest.mock import Mock
+
 import pytest
 from docutils import nodes
 
@@ -113,3 +116,22 @@ def test_add_is_parallel_allowed(app, status, warning):
             "for parallel reading, assuming it isn't - please ") in warning.getvalue()
     app.extensions.pop('write_serial')
     warning.truncate(0)  # reset warnings
+
+
+@pytest.mark.sphinx('dummy', testroot='root')
+def test_build_specific(app):
+    app.builder.build = Mock()
+    filenames = [app.srcdir / 'index.txt',                      # normal
+                 app.srcdir / 'images',                         # without suffix
+                 app.srcdir / 'notfound.txt',                   # not found
+                 app.srcdir / 'img.png',                        # unknown suffix
+                 '/index.txt',                                  # external file
+                 app.srcdir / 'subdir',                         # directory
+                 app.srcdir / 'subdir/includes.txt',            # file on subdir
+                 app.srcdir / 'subdir/../subdir/excluded.txt']  # not normalized
+    app.build(False, filenames)
+
+    expected = ['index', 'images', 'img.png', 'subdir/includes', 'subdir/excluded']
+    app.builder.build.assert_called_with(expected,
+                                         method='specific',
+                                         summary='5 source files given on command line')


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
So far, ``Builder.build_specific()`` accpets filnames without file
extension. On the other hand, ``sphinx-build`` command does not accept
such files. So the special handling code is only working for 3rd party
applications. The behavior is not consistent. In addition, that is not
helpful for users.
This removes such behavior from builders. This does not change Sphinx
application itself. It only effects to the applications which uses the
API directly.