### PR TITLE
Fix #6096: html: Anchor links are not added to figures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6096: html: Anchor links are not added to figures
+
 Testing
 --------
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -509,9 +509,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         if isinstance(node.parent, nodes.container) and node.parent.get('literal_block'):
             self.add_permalink_ref(node.parent, _('Permalink to this code'))
         elif isinstance(node.parent, nodes.figure):
-            image_nodes = node.parent.traverse(nodes.image)
-            target_node = image_nodes and image_nodes[0] or node.parent
-            self.add_permalink_ref(target_node, _('Permalink to this image'))
+            self.add_permalink_ref(node.parent, _('Permalink to this image'))
         elif node.parent.get('toctree'):
             self.add_permalink_ref(node.parent.parent, _('Permalink to this toctree'))
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -455,9 +455,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         if isinstance(node.parent, nodes.container) and node.parent.get('literal_block'):
             self.add_permalink_ref(node.parent, _('Permalink to this code'))
         elif isinstance(node.parent, nodes.figure):
-            image_nodes = node.parent.traverse(nodes.image)
-            target_node = image_nodes and image_nodes[0] or node.parent
-            self.add_permalink_ref(target_node, _('Permalink to this image'))
+            self.add_permalink_ref(node.parent, _('Permalink to this image'))
         elif node.parent.get('toctree'):
             self.add_permalink_ref(node.parent.parent, _('Permalink to this toctree'))
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1254,6 +1254,15 @@ def test_html_inventory(app):
                                            'The basic Sphinx documentation for testing')
 
 
+@pytest.mark.sphinx('html', testroot='images', confoverrides={'html_sourcelink_suffix': ''})
+def test_html_anchor_for_figure(app):
+    app.builder.build_all()
+    content = (app.outdir / 'index.html').text()
+    assert ('<p class="caption"><span class="caption-text">The caption of pic</span>'
+            '<a class="headerlink" href="#id1" title="Permalink to this image">¶</a></p>'
+            in content)
+
+
 @pytest.mark.sphinx('html', testroot='directives-raw')
 def test_html_raw_directive(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6096 
