### PR TITLE
#36 add Google Search how-to to FAQ

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -119,6 +119,36 @@ Google Analytics
       {% endblock %}
 
 
+Google Search
+   To replace Sphinx's built-in search function with Google Search, proceed as
+   follows:
+
+   1. Go to https://cse.google.com/cse/all to create the Google Search code
+      snippet.
+
+   2. Copy the code snippet and paste it into ``_templates/searchbox`` in your
+      Sphinx project:
+
+      .. code-block:: html+django
+
+         <div>
+            <h3>{{ _('Quick search') }}</h3>
+            <script>
+               (function() {
+                  var cx = '......';
+                  var gcse = document.createElement('script');
+                  gcse.type = 'text/javascript';
+                  gcse.async = true;
+                  gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+                  var s = document.getElementsByTagName('script')[0];
+                  s.parentNode.insertBefore(gcse, s);
+               })();
+            </script>
+           <gcse:search></gcse:search>
+         </div>
+
+   3. Add ``searchbox.html`` to the :confval:`html_sidebars` configuration value.
+
 .. _api role: https://git.savannah.gnu.org/cgit/kenozooid.git/tree/doc/extapi.py
 .. _xhtml to reST: http://docutils.sourceforge.net/sandbox/xhtml2rest/xhtml2rest.py
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -88,7 +88,7 @@ MediaWiki
 Google Analytics
    You can use a custom ``layout.html`` template, like this:
 
-   .. code-block:: html+django
+   .. code-block:: html+jinja
 
       {% extends "!layout.html" %}
 
@@ -126,10 +126,10 @@ Google Search
    1. Go to https://cse.google.com/cse/all to create the Google Search code
       snippet.
 
-   2. Copy the code snippet and paste it into ``_templates/searchbox`` in your
-      Sphinx project:
+   2. Copy the code snippet and paste it into ``_templates/searchbox.html`` in
+      your Sphinx project:
 
-      .. code-block:: html+django
+      .. code-block:: html+jinja
 
          <div>
             <h3>{{ _('Quick search') }}</h3>


### PR DESCRIPTION
Subject: Adds "how to" replace built-in search with Google Search

### Feature or Bugfix
Docs

### Purpose
- Adds brief instructions on how to replace built-in search with Google search, as outlined in #36.
- I added it to the FAQ, because it did not "feel" in place in the theming/templating sections.

### Relates
- Closes #36 

