### PR TITLE
docs: Remove a term "new" from config values

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -315,7 +315,7 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
 Configuration
 -------------
 
-There are also new config values that you can set:
+There are also config values that you can set:
 
 .. confval:: autoclass_content
 

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -131,7 +131,7 @@ Generating stub pages automatically
 -----------------------------------
 
 If you do not want to create stub pages with :program:`sphinx-autogen`, you can
-also use this new config value:
+also use these config values:
 
 .. confval:: autosummary_generate
 

--- a/doc/usage/extensions/coverage.rst
+++ b/doc/usage/extensions/coverage.rst
@@ -13,7 +13,7 @@ This extension features one additional builder, the :class:`CoverageBuilder`.
 
 .. todo:: Write this section.
 
-Several new configuration values can be used to specify what the builder
+Several configuration values can be used to specify what the builder
 should check:
 
 .. confval:: coverage_ignore_modules

--- a/doc/usage/extensions/extlinks.rst
+++ b/doc/usage/extensions/extlinks.rst
@@ -18,7 +18,7 @@ tracker, at :samp:`https://github.com/sphinx-doc/sphinx/issues/{num}`.  Typing
 this URL again and again is tedious, so you can use :mod:`~sphinx.ext.extlinks`
 to avoid repeating yourself.
 
-The extension adds one new config value:
+The extension adds a config value:
 
 .. confval:: extlinks
 

--- a/doc/usage/extensions/graphviz.rst
+++ b/doc/usage/extensions/graphviz.rst
@@ -90,7 +90,7 @@ It adds these directives:
 .. versionadded:: 1.6
    All three directives support a ``name`` option to set the label to graph.
 
-There are also these new config values:
+There are also these config values:
 
 .. confval:: graphviz_dot
 

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -43,7 +43,7 @@ Configuration
 -------------
 
 To use Intersphinx linking, add ``'sphinx.ext.intersphinx'`` to your
-:confval:`extensions` config value, and use these new config values to activate
+:confval:`extensions` config value, and use these config values to activate
 linking:
 
 .. confval:: intersphinx_mapping


### PR DESCRIPTION
### Feature or Bugfix
- docs

### Purpose
- I feel a term "new" is not appropriate in these case.
- I guess this term was used like "additional".