### PR TITLE
refactor: import_object() allows to import nested objects (ex. nested class)

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,11 +15,11 @@ import pytest
 from mock import patch
 
 import sphinx
-from sphinx.errors import PycodeError
+from sphinx.errors import ExtensionError, PycodeError
 from sphinx.testing.util import strip_escseq
 from sphinx.util import (
     SkipProgressMessage, display_chunk, encode_uri, ensuredir, get_module_source,
-    parselinenos, progress_message, status_iterator, xmlname_checker
+    import_object, parselinenos, progress_message, status_iterator, xmlname_checker
 )
 from sphinx.util import logging
 
@@ -69,6 +69,26 @@ def test_get_module_source():
         get_module_source('builtins')
     with pytest.raises(PycodeError):
         get_module_source('itertools')
+
+
+def test_import_object():
+    module = import_object('sphinx')
+    assert module.__name__ == 'sphinx'
+
+    module = import_object('sphinx.application')
+    assert module.__name__ == 'sphinx.application'
+
+    obj = import_object('sphinx.application.Sphinx')
+    assert obj.__name__ == 'Sphinx'
+
+    with pytest.raises(ExtensionError) as exc:
+        import_object('sphinx.unknown_module')
+    assert exc.value.args[0] == 'Could not import sphinx.unknown_module'
+
+    with pytest.raises(ExtensionError) as exc:
+        import_object('sphinx.unknown_module', 'my extension')
+    assert exc.value.args[0] == ('Could not import sphinx.unknown_module '
+                                 '(needed for my extension)')
 
 
 @pytest.mark.sphinx('dummy')


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Allow to import nested objects (ex. nested class)
- Make readable