### PR TITLE
Fix #6028: graphviz: Ensure the graphviz filenames are reproducible

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given
 * #6019: imgconverter: Including multipage PDF fails
 * #6047: autodoc: ``autofunction`` emits a warning for method objects
+* #6028: graphviz: Ensure the graphviz filenames are reproducible
 
 Testing
 --------

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -194,9 +194,7 @@ class GraphvizSimple(SphinxDirective):
         node = graphviz()
         node['code'] = '%s %s {\n%s\n}\n' % \
                        (self.name, self.arguments[0], '\n'.join(self.content))
-        node['options'] = {
-            'docname': path.splitext(self.state.document.current_source)[0],
-        }
+        node['options'] = {'docname': self.env.docname}
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']
         if 'alt' in self.options:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6028 
