### PR TITLE
Revert "C++, conditionally disable test on sys.maxunicode"

### DIFF
--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -9,7 +9,6 @@
 """
 
 import re
-import sys
 
 import pytest
 
@@ -152,9 +151,8 @@ def test_expressions():
         exprCheck(p + "'\\x0A'", t + "10")
         exprCheck(p + "'\\u0a42'", t + "2626")
         exprCheck(p + "'\\u0A42'", t + "2626")
-        if sys.maxunicode > 65535:
-            exprCheck(p + "'\\U0001f34c'", t + "127820")
-            exprCheck(p + "'\\U0001F34C'", t + "127820")
+        exprCheck(p + "'\\U0001f34c'", t + "127820")
+        exprCheck(p + "'\\U0001F34C'", t + "127820")
 
     # TODO: user-defined lit
     exprCheck('(... + Ns)', '(... + Ns)', id4='flpl2Ns')


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- This reverts commit 2a544b4ec3bce0bd6c11d7fda8df5a04013eca1f.
- It is no longer needed because it is only for py2.
- refs: #5351 and #5356