### PR TITLE
Fix #6113: html: Table cells and list items have large margins

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #6096: html: Anchor links are not added to figures
 * #3620: html: Defer searchindex.js rather than loading it via ajax
+* #6113: html: Table cells and list items have large margins
 * #5508: ``linenothreshold`` option for ``highlight`` directive was ignored
 
 Testing

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -401,11 +401,13 @@ table.citation td {
     border-bottom: none;
 }
 
+th > p:first-child,
 td > p:first-child {
     margin-top: 0px;
 }
 
-td > p:only-child {
+th > p:last-child,
+td > p:last-child {
     margin-bottom: 0px;
 }
 
@@ -482,7 +484,7 @@ li > p:first-child {
     margin-top: 0px;
 }
 
-li > p:only-child {
+li > p:last-child {
     margin-bottom: 0px;
 }
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6113 
- This also fixes a margin of list item.