### PR TITLE
Fix #6067: latexpdf image :target: changes output

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * LaTeX: Remove extraneous space after author names on PDF title page (refs: #6004)
 * #6026: LaTeX: A cross reference to definition list does not work
 * #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given
+* #6067: LaTeX: images having a target are concatenated to next line
 * #6019: imgconverter: Including multipage PDF fails
 * #6047: autodoc: ``autofunction`` emits a warning for method objects
 

--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #6026: LaTeX: A cross reference to definition list does not work
 * #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given
 * #6067: LaTeX: images having a target are concatenated to next line
+* #6067: LaTeX: images having a target are not aligned even if specified
 * #6019: imgconverter: Including multipage PDF fails
 * #6047: autodoc: ``autofunction`` emits a warning for method objects
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1987,6 +1987,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
             for id in node.get('ids'):
                 anchor = not self.in_caption
                 self.body += self.hypertarget(id, anchor=anchor)
+        if not self.is_inline(node):
+            self.body.append('\n')
         uri = node.get('refuri', '')
         if not uri and node.get('refid'):
             uri = '%' + self.curfilestack[-1] + '#' + node['refid']
@@ -2039,6 +2041,8 @@ class LaTeXTranslator(nodes.NodeVisitor):
     def depart_reference(self, node):
         # type: (nodes.Node) -> None
         self.body.append(self.context.pop())
+        if not self.is_inline(node):
+            self.body.append('\n')
 
     def visit_number_reference(self, node):
         # type: (nodes.Node) -> None

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1655,7 +1655,11 @@ class LaTeXTranslator(nodes.NodeVisitor):
                     # in reverse order
         post = []   # type: List[unicode]
         include_graphics_options = []
-        is_inline = self.is_inline(node)
+        has_hyperlink = isinstance(node.parent, nodes.reference)
+        if has_hyperlink:
+            is_inline = self.is_inline(node.parent)
+        else:
+            is_inline = self.is_inline(node)
         if 'width' in attrs:
             if 'scale' in attrs:
                 w = self.latex_image_length(attrs['width'], attrs['scale'])
@@ -1697,7 +1701,7 @@ class LaTeXTranslator(nodes.NodeVisitor):
         if self.in_parsed_literal:
             pre.append('{\\sphinxunactivateextrasandspace ')
             post.append('}')
-        if not is_inline:
+        if not is_inline and not has_hyperlink:
             pre.append('\n\\noindent')
             post.append('\n')
         pre.reverse()

--- a/tests/roots/test-images/index.rst
+++ b/tests/roots/test-images/index.rst
@@ -15,6 +15,9 @@ test-image
 
 .. image:: testimäge.png
 
+.. image:: rimg.png
+   :target: https://www.sphinx-doc.org/
+
 .. a remote image
 .. image:: https://www.python.org/static/img/python-logo.png
 

--- a/tests/roots/test-images/index.rst
+++ b/tests/roots/test-images/index.rst
@@ -18,6 +18,10 @@ test-image
 .. image:: rimg.png
    :target: https://www.sphinx-doc.org/
 
+.. image:: rimg.png
+   :align: center
+   :target: https://www.python.org/
+
 .. a remote image
 .. image:: https://www.python.org/static/img/python-logo.png
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1184,15 +1184,23 @@ def test_latex_raw_directive(app, status, warning):
 
 
 @pytest.mark.sphinx('latex', testroot='images')
-def test_latex_remote_images(app, status, warning):
+def test_latex_images(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'Python.tex').text(encoding='utf8')
+
+    # images are copied
     assert '\\sphinxincludegraphics{{python-logo}.png}' in result
     assert (app.outdir / 'python-logo.png').exists()
+
+    # not found images
     assert '\\sphinxincludegraphics{{NOT_EXIST}.PNG}' not in result
     assert ('WARNING: Could not fetch remote image: '
             'http://example.com/NOT_EXIST.PNG [404]' in warning.getvalue())
+
+    # an image having target
+    assert ('\\sphinxhref{https://www.sphinx-doc.org/}'
+            '{\\sphinxincludegraphics{{rimg}.png}}\n\n' in result)
 
 
 @pytest.mark.sphinx('latex', testroot='latex-index')

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1202,6 +1202,10 @@ def test_latex_images(app, status, warning):
     assert ('\\sphinxhref{https://www.sphinx-doc.org/}'
             '{\\sphinxincludegraphics{{rimg}.png}}\n\n' in result)
 
+    # a centerized image having target
+    assert ('\\sphinxhref{https://www.python.org/}{{\\hspace*{\\fill}'
+            '\\sphinxincludegraphics{{rimg}.png}\\hspace*{\\fill}}}\n\n' in result)
+
 
 @pytest.mark.sphinx('latex', testroot='latex-index')
 def test_latex_index(app, status, warning):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix #6067: LaTeX: images having a target are not aligned even if specified
- Fix #6067: LaTeX: images having a target are concatenated to next line
