### PR TITLE
refactor: move NoUri to sphinx.errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.environment.NoUri``
 * ``sphinx.ext.autodoc.importer.MockFinder``
 * ``sphinx.ext.autodoc.importer.MockLoader``
 * ``sphinx.ext.autodoc.importer.mock()``
@@ -20,6 +21,8 @@ Deprecated
 * ``sphinx.util.i18n.find_catalog()``
 * ``sphinx.util.i18n.find_catalog_files()``
 * ``sphinx.util.i18n.find_catalog_source_files()``
+
+For more details, see :ref:`deprecation APIs list <dev-deprecated-apis>`.
 
 Features added
 --------------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -234,6 +234,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.environment.NoUri``
+     - 2.1
+     - 4.0
+     - ``sphinx.errors.NoUri``
+
    * - ``sphinx.ext.autodoc.importer.MockFinder``
      - 2.1
      - 4.0

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -23,9 +23,8 @@ from sphinx.builders.latex.transforms import (
 )
 from sphinx.builders.latex.util import ExtBabel
 from sphinx.config import ENUM
-from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
-from sphinx.errors import SphinxError
+from sphinx.errors import NoUri, SphinxError
 from sphinx.locale import _, __
 from sphinx.transforms import SphinxTransformer
 from sphinx.util import texescape, logging, progress_message, status_iterator

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -15,7 +15,7 @@ from docutils.io import FileOutput
 
 from sphinx import addnodes
 from sphinx.builders import Builder
-from sphinx.environment import NoUri
+from sphinx.errors import NoUri
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util import progress_message

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -18,8 +18,8 @@ from docutils.io import FileOutput
 from sphinx import addnodes
 from sphinx import package_dir
 from sphinx.builders import Builder
-from sphinx.environment import NoUri
 from sphinx.environment.adapters.asset import ImageAdapter
+from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util import progress_message, status_iterator

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -19,7 +19,7 @@ from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
-from sphinx.environment import NoUri
+from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.roles import XRefRole
 from sphinx.transforms import SphinxTransform

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -22,6 +22,7 @@ from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
+from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.roles import XRefRole
 from sphinx.util import ws_re, logging, docname_join
@@ -838,8 +839,6 @@ class StandardDomain(Domain):
 
     def _resolve_citation_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         # type: (BuildEnvironment, str, Builder, str, str, addnodes.pending_xref, nodes.Element) -> nodes.Element  # NOQA
-        from sphinx.environment import NoUri
-
         docname, labelid, lineno = self.data['citations'].get(target, ('', '', 0))
         if not docname:
             if 'ids' in node:

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -17,7 +17,9 @@ from io import BytesIO
 from os import path
 
 from sphinx import addnodes
-from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
+from sphinx.deprecation import (
+    RemovedInSphinx30Warning, RemovedInSphinx40Warning, deprecated_alias
+)
 from sphinx.environment.adapters.toctree import TocTree
 from sphinx.errors import SphinxError, BuildEnvironmentError, DocumentError, ExtensionError
 from sphinx.locale import __
@@ -76,11 +78,6 @@ versioning_conditions = {
     'none': False,
     'text': is_translatable,
 }  # type: Dict[str, Union[bool, Callable]]
-
-
-class NoUri(Exception):
-    """Raised by get_relative_uri if there is no URI available."""
-    pass
 
 
 class BuildEnvironment:
@@ -784,3 +781,13 @@ class BuildEnvironment:
         node['version'] = version
         node.line = lineno
         self.get_domain('changeset').note_changeset(node)  # type: ignore
+
+
+from sphinx.errors import NoUri  # NOQA
+
+
+deprecated_alias('sphinx.environment',
+                 {
+                     'NoUri': NoUri,
+                 },
+                 RemovedInSphinx30Warning)

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -12,6 +12,7 @@ import re
 import unicodedata
 from itertools import groupby
 
+from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.util import split_into, logging
 
@@ -33,8 +34,6 @@ class IndexEntries:
                      _fixre=re.compile(r'(.*) ([(][^()]*[)])')):
         # type: (Builder, bool, Pattern) -> List[Tuple[str, List[Tuple[str, Any]]]]
         """Create the real index from the collected index entries."""
-        from sphinx.environment import NoUri
-
         new = {}  # type: Dict[str, List]
 
         def add_entry(word, subword, main, link=True, dic=new, key=None):

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -121,3 +121,8 @@ class PycodeError(Exception):
         if len(self.args) > 1:
             res += ' (exception was: %r)' % self.args[1]
         return res
+
+
+class NoUri(Exception):
+    """Raised by builder.get_relative_uri() if there is no URI available."""
+    pass

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -18,7 +18,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 
 import sphinx
-from sphinx.environment import NoUri
+from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -13,7 +13,7 @@ from typing import cast
 from docutils import nodes
 
 from sphinx import addnodes
-from sphinx.environment import NoUri
+from sphinx.errors import NoUri
 from sphinx.locale import __
 from sphinx.transforms import SphinxTransform
 from sphinx.util import logging


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `NoUri` is placed at `sphinx.environment`. But it is not related with the module.
- In addition, importing it on global level sometime causes a recursive import.
- I think `sphinx.errors` is better place for the exception.
