### PR TITLE
 Fix texinfo: ``make install-info`` fails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * #3620: html: Defer searchindex.js rather than loading it via ajax
 * #6113: html: Table cells and list items have large margins
 * #5508: ``linenothreshold`` option for ``highlight`` directive was ignored
+* texinfo: ``make install-info`` causes syntax error
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #6113: html: Table cells and list items have large margins
 * #5508: ``linenothreshold`` option for ``highlight`` directive was ignored
 * texinfo: ``make install-info`` causes syntax error
+* texinfo: ``make install-info`` fails on macOS
 
 Testing
 --------

--- a/sphinx/templates/texinfo/Makefile
+++ b/sphinx/templates/texinfo/Makefile
@@ -17,15 +17,15 @@ html: $(addsuffix .html,$(ALLDOCS))
 pdf: $(addsuffix .pdf,$(ALLDOCS))
 
 install-info: info
-	for f in *.info; do \\
-	  cp -t $(infodir) "$$f" && \\
-	  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" ; \\
+	for f in *.info; do \
+	  cp -t $(infodir) "$$f" && \
+	  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" ; \
 	done
 
 uninstall-info: info
-	for f in *.info; do \\
-	  rm -f "$(infodir)/$$f"  ; \\
-	  $(INSTALL_INFO) --delete --info-dir=$(infodir) "$$f" ; \\
+	for f in *.info; do \
+	  rm -f "$(infodir)/$$f"  ; \
+	  $(INSTALL_INFO) --delete --info-dir=$(infodir) "$$f" ; \
 	done
 
 %.info: %.texi

--- a/sphinx/templates/texinfo/Makefile
+++ b/sphinx/templates/texinfo/Makefile
@@ -18,7 +18,8 @@ pdf: $(addsuffix .pdf,$(ALLDOCS))
 
 install-info: info
 	for f in *.info; do \
-	  cp -t $(infodir) "$$f" && \
+	  mkdir -p $(infodir) && \
+	  cp "$$f" $(infodir) && \
 	  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" ; \
 	done
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix texinfo: ``make install-info`` causes syntax error
- Fix texinfo: ``make install-info`` fails on macOS

