### PR TITLE
Fix #3079: texinfo: image files are not copied on ``make install-info``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* texinfo: image files are copied into ``name-figure`` directory
+
 Deprecated
 ----------
 
@@ -22,6 +24,7 @@ Bugs fixed
 * #5508: ``linenothreshold`` option for ``highlight`` directive was ignored
 * texinfo: ``make install-info`` causes syntax error
 * texinfo: ``make install-info`` fails on macOS
+* #3079: texinfo: image files are not copied on ``make install-info``
 
 Testing
 --------

--- a/sphinx/templates/texinfo/Makefile
+++ b/sphinx/templates/texinfo/Makefile
@@ -20,12 +20,18 @@ install-info: info
 	for f in *.info; do \
 	  mkdir -p $(infodir) && \
 	  cp "$$f" $(infodir) && \
-	  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" ; \
+	  $(INSTALL_INFO) --info-dir=$(infodir) "$$f" && \
+	  \
+	  FIGURE_DIR="`basename \"$$f\" .info`-figures" && \
+	  if [ -e "$$FIGURE_DIR" ]; then \
+	    cp -r "$$FIGURE_DIR" $(infodir) ; \
+	  fi; \
 	done
 
 uninstall-info: info
 	for f in *.info; do \
 	  rm -f "$(infodir)/$$f"  ; \
+	  rm -rf "$(infodir)/`basename '$$f' .info`-figures" && \
 	  $(INSTALL_INFO) --delete --info-dir=$(infodir) "$$f" ; \
 	done
 

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1355,8 +1355,9 @@ class TexinfoTranslator(SphinxTranslator):
         width = self.tex_image_length(attrs.get('width', ''))
         height = self.tex_image_length(attrs.get('height', ''))
         alt = self.escape_arg(attrs.get('alt', ''))
+        filename = "%s-figures/%s" % (self.elements['filename'][:-5], name)  # type: ignore
         self.body.append('\n@image{%s,%s,%s,%s,%s}\n' %
-                         (name, width, height, alt, ext[1:]))
+                         (filename, width, height, alt, ext[1:]))
 
     def depart_image(self, node):
         # type: (nodes.Element) -> None


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #3079 
