### PR TITLE
Fix #5391: A cross reference in heading is rendered as literal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * #5508: ``linenothreshold`` option for ``highlight`` directive was ignored
 * texinfo: ``make install-info`` causes syntax error
 * texinfo: ``make install-info`` fails on macOS
+* #5391: A cross reference in heading is rendered as literal
 
 Testing
 --------

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -340,11 +340,7 @@ class SphinxContentsFilter(ContentsFilter):
     Used with BuildEnvironment.add_toc_from() to discard cross-file links
     within table-of-contents link nodes.
     """
-    def visit_pending_xref(self, node):
-        # type: (addnodes.pending_xref) -> None
-        text = node.astext()
-        self.parent.append(nodes.literal(text, text))
-        raise nodes.SkipNode
+    visit_pending_xref = ContentsFilter.ignore_node_but_process_children
 
     def visit_image(self, node):
         # type: (nodes.image) -> None


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5391 
