### PR TITLE
docs: JS domain does not support reset current module

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1294,8 +1294,6 @@ The JavaScript domain (name **js**) provides the following directives:
    specified.  If this option is specified, the directive will only update the
    current module name.
 
-   To clear the current module, set the module name to ``null`` or ``None``
-
    .. versionadded:: 1.6
 
 .. rst:directive:: .. js:function:: name(signature)


### PR DESCRIPTION
### Feature or Bugfix
- docs

### Purpose
- refs: #3572 
