### PR TITLE
Clean up import for annotations

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -40,7 +40,7 @@ except ImportError:
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterable, List, Sequence, Set, Tuple, Type, Union  # NOQA
+    from typing import Any, Dict, Iterable, List, Sequence, Set, Tuple, Type, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -36,7 +36,6 @@ except ImportError:
 if False:
     # For type annotation
     from typing import Any, Dict, List, Set, Tuple  # NOQA
-    from sphinx.application import Sphinx  # NOQA
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -25,8 +25,7 @@ from sphinx.util.osutil import make_filename
 
 if False:
     # For type annotation
-    from typing import Any, Dict, Iterable, List, Set, Tuple  # NOQA
-    from docutils import nodes  # NOQA
+    from typing import Any, Dict, List, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -11,6 +11,7 @@
 import os
 from os import path
 
+from docutils import nodes
 from docutils.frontend import OptionParser
 
 import sphinx.builders.latex.nodes  # NOQA  # Workaround: import this before writer to avoid ImportError
@@ -42,7 +43,6 @@ from sphinx.writers.latex import (
 
 if False:
     # For type annotation
-    from docutils import nodes  # NOQA
     from typing import Any, Dict, Iterable, List, Tuple, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
@@ -295,7 +295,6 @@ class LaTeXBuilder(Builder):
 
     def assemble_doctree(self, indexfile, toctree_only, appendices):
         # type: (str, bool, List[str]) -> nodes.document
-        from docutils import nodes  # NOQA
         self.docnames = set([indexfile] + appendices)
         logger.info(darkgreen(indexfile) + " ", nonl=True)
         tree = self.env.get_doctree(indexfile)

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -21,7 +21,7 @@ from sphinx.util.nodes import NodeMatcher
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Set, Tuple, Union  # NOQA
+    from typing import Any, List, Set, Tuple  # NOQA
 
 URI_SCHEMES = ('mailto:', 'http:', 'https:', 'ftp:')
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -30,7 +30,7 @@ from sphinx.util.requests import is_ssl_error
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Set, Tuple, Union  # NOQA
+    from typing import Any, Dict, List, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.util.requests.requests import Response  # NOQA
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -27,7 +27,7 @@ from sphinx.util.typing import NoneType
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Generator, Iterator, List, Set, Tuple, Union  # NOQA
+    from typing import Callable, Dict, Generator, Iterator, List, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.util.tags import Tags  # NOQA

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -35,8 +35,6 @@ if False:
     # For type annotation
     from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
-    from sphinx.config import Config  # NOQA
-    from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.util.docfields import Field  # NOQA
     from sphinx.util.typing import DirectiveOption  # NOQA
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -26,7 +26,7 @@ from sphinx.util.nodes import explicit_title_re, set_source_info, \
 
 if False:
     # For type annotation
-    from typing import Any, Dict, Generator, List, Tuple  # NOQA
+    from typing import Any, Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
 

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -24,7 +24,6 @@ from sphinx.util.nodes import make_refnode
 if False:
     # For type annotation
     from typing import Any, Dict, Iterator, List, Tuple  # NOQA
-    from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/domains/math.py
+++ b/sphinx/domains/math.py
@@ -20,7 +20,7 @@ from sphinx.util.nodes import make_refnode
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, Union  # NOQA
+    from typing import Any, Dict, Iterable, List, Tuple  # NOQA
     from sphinx import addnodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -26,7 +26,7 @@ from sphinx.util.nodes import make_refnode
 
 if False:
     # For type annotation
-    from typing import Any, Dict, Iterable, Iterator, List, Tuple, Type, Union  # NOQA
+    from typing import Any, Dict, Iterable, Iterator, List, Tuple, Type  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -30,7 +30,7 @@ from sphinx.util.nodes import is_translatable
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, IO, Iterator, List, Optional, Pattern, Set, Tuple, Type, Union, Generator  # NOQA
+    from typing import Any, Callable, Dict, IO, Iterator, List, Optional, Set, Tuple, Union  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -24,8 +24,7 @@ from sphinx.util.images import guess_mimetype
 
 if False:
     # For type annotation
-    from typing import Dict, List, Set, Tuple  # NOQA
-    from docutils import nodes  # NOQA
+    from typing import Dict, List, Set  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 

--- a/sphinx/environment/collectors/metadata.py
+++ b/sphinx/environment/collectors/metadata.py
@@ -17,7 +17,6 @@ from sphinx.environment.collectors import EnvironmentCollector
 if False:
     # For type annotation
     from typing import Dict, Set  # NOQA
-    from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 

--- a/sphinx/environment/collectors/title.py
+++ b/sphinx/environment/collectors/title.py
@@ -16,7 +16,6 @@ from sphinx.transforms import SphinxContentsFilter
 if False:
     # For type annotation
     from typing import Dict, Set  # NOQA
-    from docutils import nodes  # NOQA
     from sphinx.sphinx import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -21,9 +21,8 @@ from sphinx.util import url_re, logging
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Set, Tuple, Type, TypeVar  # NOQA
+    from typing import Dict, List, Set, Tuple, Type, TypeVar  # NOQA
     from sphinx.application import Sphinx  # NOQA
-    from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 
     N = TypeVar('N')

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -33,9 +33,7 @@ from sphinx.util.inspect import Signature, isdescriptor, safe_getmembers, \
 if False:
     # For type annotation
     from types import ModuleType  # NOQA
-    from typing import Any, Callable, Dict, Iterator, List, Sequence, Set, Tuple, Type, Union  # NOQA
-    from docutils import nodes  # NOQA
-    from docutils.utils import Reporter  # NOQA
+    from typing import Callable, Dict, Iterator, List, Sequence, Set, Tuple, Type, Union  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -17,9 +17,8 @@ from sphinx.util.nodes import nested_parse_with_titles
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, List, Set, Type  # NOQA
+    from typing import Callable, Dict, List, Set, Type  # NOQA
     from docutils.parsers.rst.state import RSTState  # NOQA
-    from docutils.statemachine import StateMachine, StringList  # NOQA
     from docutils.utils import Reporter  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -24,7 +24,7 @@ from sphinx.util.inspect import isenumclass, safe_getattr
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Sequence, Tuple, Union  # NOQA
+    from typing import Any, Callable, Dict, Generator, Iterator, List, Sequence, Tuple, Union  # NOQA
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -24,11 +24,6 @@ if False:
 
 logger = logging.getLogger(__name__)
 
-if False:
-    # For type annotation
-    from typing import Any, Dict  # NOQA
-    from sphinx.application import Sphinx  # NOQA
-
 
 def get_node_depth(node):
     i = 0

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -41,9 +41,7 @@ from sphinx.util.rst import escape as rst_escape
 if False:
     # For type annotation
     from typing import Any, Callable, Dict, List, Tuple, Type, Union  # NOQA
-    from sphinx import addnodes  # NOQA
     from sphinx.builders import Builder  # NOQA
-    from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.ext.autodoc import Documenter  # NOQA
 
 

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -23,7 +23,7 @@ from sphinx.util.inspect import safe_getattr
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, IO, List, Pattern, Set, Tuple  # NOQA
+    from typing import Any, Dict, IO, List, Pattern, Set, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -34,7 +34,7 @@ from sphinx.util.osutil import relpath
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, IO, Iterable, List, Optional, Sequence, Set, Tuple, Type  # NOQA
+    from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -31,7 +31,6 @@ from sphinx.util.png import read_png_depth, write_png_depth
 if False:
     # For type annotation
     from typing import Any, Dict, List, Tuple, Union  # NOQA
-    from sphinx.addnodes import displaymath  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.config import Config  # NOQA

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -55,7 +55,7 @@ from sphinx.util.docutils import SphinxDirective
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Tuple, Dict, Optional  # NOQA
+    from typing import Any, Dict, List, Optional, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.writers.html import HTMLTranslator  # NOQA

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -41,7 +41,7 @@ from sphinx.util.inventory import InventoryFile
 
 if False:
     # For type annotation
-    from typing import Any, Dict, IO, List, Tuple, Union  # NOQA
+    from typing import Any, Dict, IO, List, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA

--- a/sphinx/ext/mathbase.py
+++ b/sphinx/ext/mathbase.py
@@ -22,7 +22,7 @@ from sphinx.domains.math import MathReferenceRole as EqXRefRole  # NOQA  # to ke
 
 if False:
     # For type annotation
-    from typing import Any, Callable, List, Tuple  # NOQA
+    from typing import Callable, Tuple  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.writers.html import HTMLTranslator  # NOQA
 

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -14,7 +14,7 @@ import warnings
 from pygments import highlight
 from pygments.filters import ErrorToken
 from pygments.formatters import HtmlFormatter, LatexFormatter
-from pygments.lexer import Lexer  # NOQA
+from pygments.lexer import Lexer
 from pygments.lexers import get_lexer_by_name, guess_lexer
 from pygments.lexers import PythonLexer, Python3Lexer, PythonConsoleLexer, \
     CLexer, TextLexer, RstLexer

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -9,6 +9,7 @@
 """
 import codecs
 import warnings
+from typing import Any
 
 from docutils.core import Publisher
 from docutils.io import FileInput, NullOutput
@@ -16,7 +17,6 @@ from docutils.parsers.rst import Parser as RSTParser
 from docutils.readers import standalone
 from docutils.statemachine import StringList, string2lines
 from docutils.writers import UnfilteredWriter
-from typing import Any, Union  # NOQA
 
 from sphinx.deprecation import RemovedInSphinx30Warning
 from sphinx.transforms import (
@@ -39,14 +39,13 @@ from sphinx.versioning import UIDTransform
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Tuple, Type, Union  # NOQA
+    from typing import Dict, List, Tuple, Type  # NOQA
     from docutils import nodes  # NOQA
     from docutils.frontend import Values  # NOQA
     from docutils.io import Input  # NOQA
     from docutils.parsers import Parser  # NOQA
     from docutils.transforms import Transform  # NOQA
     from sphinx.application import Sphinx  # NOQA
-    from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
 
 

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -23,7 +23,7 @@ from sphinx.util.osutil import mtimes_of_files
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, List, Iterator, Tuple, Union  # NOQA
+    from typing import Dict, List, Union  # NOQA
     from jinja2.environment import Environment  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.theming import Theme  # NOQA

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -18,7 +18,7 @@ from sphinx.deprecation import RemovedInSphinx30Warning
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple, Union  # NOQA
+    from typing import Any, Callable, Dict, Iterable, List, Tuple, Union  # NOQA
 
 
 class _TranslationProxy(UserString):

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -18,7 +18,7 @@ from tokenize import COMMENT, NL
 
 if False:
     # For type annotation
-    from typing import Any, Dict, IO, List, Tuple  # NOQA
+    from typing import Any, Dict, List, Tuple  # NOQA
 
 comment_re = re.compile('^\\s*#: ?(.*)\r?\n?$')
 indent_re = re.compile('^\\s*$')

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -25,7 +25,7 @@ from sphinx.util.osutil import abspath
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Tuple  # NOQA
+    from typing import Any, Dict  # NOQA
 
 
 class BuildDoc(Command):

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -25,7 +25,6 @@ from sphinx.util.osutil import relpath
 
 if False:
     # For type annotation
-    from typing import List  # NOQA
     from typing import Any, Dict, Generator, IO, List, Pattern  # NOQA
 
 

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 if False:
     # For type annotation
-    from typing import Any, Dict, Iterator, List, Tuple  # NOQA
+    from typing import Any, Dict, List  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
 NODEFAULT = object()

--- a/sphinx/transforms/post_transforms/compat.py
+++ b/sphinx/transforms/post_transforms/compat.py
@@ -20,12 +20,8 @@ from sphinx.util import logging
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterable, List, Tuple  # NOQA
-    from docutils.parsers.rst.states import Inliner  # NOQA
-    from docutils.writers.html4css1 import Writer  # NOQA
+    from typing import Any, Dict  # NOQA
     from sphinx.application import Sphinx  # NOQA
-    from sphinx.builders import Builder  # NOQA
-    from sphinx.environment import BuildEnvironment  # NOQA
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -48,7 +48,7 @@ from sphinx.util.matching import patfilter  # noqa
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, Sequence, Set, Tuple, Type, Union  # NOQA
+    from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, Set, Tuple, Type, Union  # NOQA
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -18,7 +18,6 @@ from sphinx import addnodes
 if False:
     # For type annotation
     from typing import Any, Dict, Type, Union  # NOQA
-    from sphinx.domains import Domain  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.util.typing import TextlikeNode  # NOQA
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -42,7 +42,6 @@ if False:
     from sphinx.builders import Builder  # NOQA
     from sphinx.config import Config  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
-    from sphinx.io import SphinxFileInput  # NOQA
     from sphinx.util.typing import RoleFunction  # NOQA
 
 

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -27,7 +27,7 @@ except ImportError:
 
 if False:
     # For type annotation
-    from typing import Dict, IO, List, Tuple  # NOQA
+    from typing import IO, Tuple  # NOQA
 
 mime_suffixes = OrderedDict([
     ('.gif', 'image/gif'),

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -15,7 +15,7 @@ from sphinx.util import logging
 
 if False:
     # For type annotation
-    from typing import Callable, Dict, IO, Iterator, Tuple  # NOQA
+    from typing import Callable, IO, Iterator  # NOQA
     from sphinx.builders import Builder  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
     from sphinx.util.typing import Inventory  # NOQA

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -22,7 +22,6 @@ from sphinx.util.console import colorize
 if False:
     # For type annotation
     from typing import Any, Dict, Generator, IO, List, Tuple, Type, Union  # NOQA
-    from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -19,7 +19,7 @@ from sphinx.util import logging
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Iterable, List, Optional, Set, Tuple, Type  # NOQA
+    from typing import Callable, Iterable, List, Optional, Set, Tuple, Type  # NOQA
     from docutils.parsers.rst.states import Inliner  # NOQA
     from docutils.statemachine import StringList  # NOQA
     from sphinx.builders import Builder  # NOQA

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -24,7 +24,7 @@ from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warnin
 
 if False:
     # For type annotation
-    from typing import Any, Iterator, List, Tuple, Union  # NOQA
+    from typing import Any, Iterator, List, Tuple  # NOQA
 
 # Errnos that we need.
 EEXIST = getattr(errno, 'EEXIST', 0)  # RemovedInSphinx40Warning

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -22,7 +22,7 @@ from sphinx.util.typing import NoneType
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Generator  # NOQA
+    from typing import Any, Callable  # NOQA
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/writers/xml.py
+++ b/sphinx/writers/xml.py
@@ -12,7 +12,7 @@ from docutils.writers.docutils_xml import Writer as BaseXMLWriter
 
 if False:
     # For type annotation
-    from typing import Any, Tuple  # NOQA
+    from typing import Any  # NOQA
     from sphinx.builders import Builder  # NOQA
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- New flake8 command supports py2 style type annotations. So `NOQA` comment is not needed for them.
- This removes the comment all, and also removes unused import
