### PR TITLE
Fix #6136: ``:name:`` option for ``math`` directive causes a crash

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
 * #6047: autodoc: ``autofunction`` emits a warning for method objects
 * #6028: graphviz: Ensure the graphviz filenames are reproducible
 * #6068: doctest: ``skipif`` option may remove the code block from documentation
+* #6136: ``:name:`` option for ``math`` directive causes a crash
 
 Testing
 --------

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -123,13 +123,16 @@ class MathDirective(SphinxDirective):
         latex = '\n'.join(self.content)
         if self.arguments and self.arguments[0]:
             latex = self.arguments[0] + '\n\n' + latex
+        label = self.options.get('label', self.options.get('name'))
         node = nodes.math_block(latex, latex,
                                 docname=self.state.document.settings.env.docname,
-                                number=self.options.get('name'),
-                                label=self.options.get('label'),
+                                number=None,
+                                label=label,
                                 nowrap='nowrap' in self.options)
-        ret = [node]
+        self.add_name(node)
         set_source_info(self, node)
+
+        ret = [node]
         self.add_target(ret)
         return ret
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6136 
