### PR TITLE
Fixed a bug in intersphinx failure reporting

### DIFF
--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -173,7 +173,7 @@ def fetch_inventory(app, uri, inv):
             f = open(path.join(app.srcdir, inv), 'rb')
     except Exception as err:
         err.args = ('intersphinx inventory %r not fetchable due to %s: %s',
-                    inv, err.__class__, err)
+                    inv, err.__class__, str(err))
         raise
     try:
         if hasattr(f, 'url'):
@@ -191,7 +191,7 @@ def fetch_inventory(app, uri, inv):
                 raise ValueError('unknown or unsupported inventory version: %r' % exc)
     except Exception as err:
         err.args = ('intersphinx inventory %r not readable due to %s: %s',
-                    inv, err.__class__.__name__, err)
+                    inv, err.__class__.__name__, str(err))
         raise
     else:
         return invdata
@@ -234,10 +234,9 @@ def load_mappings(app):
             for fail in failures:
                 logger.info(*fail)
         else:
+            issues = '\n'.join([f[0] % f[1:] for f in failures])
             logger.warning(__("failed to reach any of the inventories "
-                              "with the following issues:"))
-            for fail in failures:
-                logger.warning(*fail)
+                              "with the following issues:") + "\n" + issues)
 
     if update:
         inventories.clear()


### PR DESCRIPTION
Subject: fix a bug in intersphinx reporting failures

I had a published Sphinx doctree at http://de.presto.lino-framework.org with an invalid :xfile:`objects.inv` file so that intersphinx was not able to read it. It said::

  ValueError: unknown or unsupported inventory version: ValueError(u'invalid inventory header: ',)

This message is not the problem (I guess it was because that site was generated with another Sphinx version, but that's unrelevant). My problem is that this error was never reported. It was never reported because :func:`sphinx.ext.intersphinx.fetch_inventories` does something forbidden::

    try:
       ...
    except Exception as err:
        err.args = ('intersphinx inventory %r not fetchable due to %s: %s',
                    inv, err.__class__, err)  # LS20190306
        raise
    try:
        ...
    except Exception as err:
        err.args = ('intersphinx inventory %r not readable due to %s: %s',
                    inv, err.__class__.__name__, err)  # LS20190306

To fix my problem, I replaced both lines::

        err.args = (msgtpl, inv, err.__class__, err)

by::

        err.args = (msgtpl, inv, err.__class__, str(err))

The problem might occur only when there is an additional exception "intersphinx inventory has moved" involved. Here is the output before the bugfix::

    loading intersphinx inventory from http://de.presto.lino-framework.org...
    intersphinx inventory has moved: http://de.presto.lino-framework.org -> http://de.presto.lino-framework.org/
    WARNING: failed to reach any of the inventories with the following issues:
    intersphinx inventory 'http://de.presto.lino-framework.org' not readable due to ValueError: ('intersphinx inventory %r not readable due to %s: %s', 'http://de.presto.lino-framework.org', 'ValueError',  ValueError(...))

Another problem fixed en passant was that intersphinx later reports every failure as a separate call to :func:`warning` and when tolerate_warnings is False, we see only the first warning.

