### PR TITLE
C++, fix alias declarations, causing problems in Latex and singlehtml

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * texinfo: ``make install-info`` fails on macOS
 * #3079: texinfo: image files are not copied on ``make install-info``
 * #5391: A cross reference in heading is rendered as literal
+* #5946: C++, fix ``cpp:alias`` problems in LaTeX (and singlehtml)
 
 Testing
 --------


### PR DESCRIPTION
Subject: Defer parsing to transform time, and make sure alias nodes are copied in a reasonable way.

### Bugfix

### Relates
- Based on #6131.
- Fixes #5946


