### PR TITLE
Fix #6140: Use unittest.mock instead of mock

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Bugs fixed
 * texinfo: ``make install-info`` fails on macOS
 * #3079: texinfo: image files are not copied on ``make install-info``
 * #5391: A cross reference in heading is rendered as literal
+* #5946: C++, fix ``cpp:alias`` problems in LaTeX (and singlehtml)
 
 Testing
 --------

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ extras_require = {
         'colorama>=0.3.5',
     ],
     'test': [
-        'mock',
         'pytest',
         'pytest-cov',
         'html5lib',

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,8 +10,8 @@
 
 import sys
 from textwrap import dedent
+from unittest import mock
 
-import mock
 import pytest
 from docutils import nodes
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,9 @@
     :copyright: Copyright 2007-2019 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-import mock
+
+from unittest import mock
+
 import pytest
 
 import sphinx
@@ -257,7 +259,7 @@ def test_conf_warning_message(logger, name, default, annotation, actual, message
     config.add(name, default, False, annotation or ())
     config.init_values()
     check_confval_types(None, config)
-    logger.warning.assert_called()
+    assert logger.warning.called
     assert logger.warning.call_args[0][0] == message
 
 
@@ -276,7 +278,7 @@ def test_check_enum_failed(logger):
     config.add('value', 'default', False, ENUM('default', 'one', 'two'))
     config.init_values()
     check_confval_types(None, config)
-    logger.warning.assert_called()
+    assert logger.warning.called
 
 
 @mock.patch("sphinx.config.logger")
@@ -294,4 +296,4 @@ def test_check_enum_for_list_failed(logger):
     config.add('value', 'default', False, ENUM('default', 'one', 'two'))
     config.init_values()
     check_confval_types(None, config)
-    logger.warning.assert_called()
+    assert logger.warning.called

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -8,9 +8,10 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import Mock
+
 import pytest
 from docutils import nodes
-from mock import Mock
 
 from sphinx import addnodes
 from sphinx.domains.javascript import JavaScriptDomain

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -8,9 +8,10 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import Mock
+
 import pytest
 from docutils import nodes
-from mock import Mock
 
 from sphinx import addnodes
 from sphinx.domains.python import py_sig_re, _pseudo_parse_arglist, PythonDomain

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -8,7 +8,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import mock
+from unittest import mock
+
 from docutils import nodes
 
 from sphinx.domains.std import StandardDomain

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -9,8 +9,7 @@
 """
 
 from collections import namedtuple
-
-import mock
+from unittest import mock
 
 from sphinx import locale
 from sphinx.environment.adapters.indexentries import IndexEntries

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -10,11 +10,13 @@
 
 import sys
 from io import StringIO
+from unittest.mock import Mock
 
 import pytest
 
 from sphinx.ext.autosummary import mangle_signature, import_by_name, extract_summary
 from sphinx.testing.util import etree_parse
+from sphinx.util.docutils import new_document
 
 html_warnfile = StringIO()
 
@@ -57,8 +59,6 @@ def test_mangle_signature():
 
 
 def test_extract_summary(capsys):
-    from sphinx.util.docutils import new_document
-    from mock import Mock
     settings = Mock(language_code='',
                     id_prefix='',
                     auto_id_prefix='',

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -11,8 +11,8 @@
 import os
 import unittest
 from io import BytesIO
+from unittest import mock
 
-import mock
 import pytest
 import requests
 from docutils import nodes

--- a/tests/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon.py
@@ -10,9 +10,7 @@
 """
 
 from collections import namedtuple
-from unittest import TestCase
-
-import mock
+from unittest import TestCase, mock
 
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon import _process_docstring, _skip_member, Config, setup

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -12,9 +12,7 @@
 from collections import namedtuple
 from inspect import cleandoc
 from textwrap import dedent
-from unittest import TestCase
-
-import mock
+from unittest import TestCase, mock
 
 from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -8,7 +8,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-import mock
+from unittest import mock
+
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexer import RegexLexer
 from pygments.token import Text, Name

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -8,8 +8,9 @@
     :license: BSD, see LICENSE for details.
 """
 
+from unittest.mock import Mock
+
 from docutils import nodes
-from mock import Mock
 
 from sphinx.roles import EmphasizedLiteral
 from sphinx.testing.util import assert_node

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,9 +10,9 @@
 
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 import sphinx
 from sphinx.errors import PycodeError

--- a/tests/test_util_fileutil.py
+++ b/tests/test_util_fileutil.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-import mock
+from unittest import mock
 
 from sphinx.jinja2glue import BuiltinTemplateLoader
 from sphinx.util.fileutil import copy_asset, copy_asset_file


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: #6140 
