### PR TITLE
Fix 'Use of \@icentercr doesn't match its definition.' LaTeX build crash

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ Bugs fixed
 * #6068: doctest: ``skipif`` option may remove the code block from documentation
 * #6136: ``:name:`` option for ``math`` directive causes a crash
 * #6139: intersphinx: ValueError on failure reporting
+* #6149: LaTeX: ``:index:`` role in top level titles causes ``Use of
+  \@icentercr doesn't match its definition`` error on latexpdf build
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2019/01/12 v1.8.4 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2019/03/08 v1.8.5 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -1823,4 +1823,30 @@
 
 % Tell TeX about pathological hyphenation cases:
 \hyphenation{Base-HTTP-Re-quest-Hand-ler}
+
+% Deep LaTeX hack as Bjarne style of fncychap applies \MakeUppercase to
+% chapter titles, which is incompatible with \index there.
+\DeclareRobustCommand\sphinxFixMakeUpperOrLowercase{%
+   \def\protected@edef{% wow!
+      \begingroup
+      \def\myendgroup{\expandafter\endgroup}%\reserved@a will follow
+      \let\protect\@unexpandable@protect
+      % the arguments will be upper- or lowercased but at least
+      % incomprehensible low level LaTeX errors will not be raised
+      % This behaves ok in section titles : the \index, \glossary, \label
+      % will swallow their arguments as usual and not end up in toc file.
+      \let\index\relax
+      \let\glossary\relax
+      \let\label\relax
+      \afterassignment\myendgroup
+      \edef}%
+}%
+% cf source2.pdf File O: ltfinal.dtx, \MakeUppercase definition
+\protected@edef\MakeUppercase#1{%
+    {\sphinxFixMakeUpperOrLowercase\MakeUppercase{#1}}%
+}%
+\protected@edef\MakeLowercase#1{%
+    {\sphinxFixMakeUpperOrLowercase\MakeLowercase{#1}}%
+}%
+
 \endinput

--- a/tests/roots/test-root/contents.txt
+++ b/tests/roots/test-root/contents.txt
@@ -68,3 +68,6 @@ Test for indirect hyperlink targets
 ===================================
 
 :ref:`indirect hyperref <other-label>`
+
+Test for :index:`index` in top level title
+==========================================


### PR DESCRIPTION
Closes: #6149

