### PR TITLE
Fix #6149: LaTeX: :index: role titles causes build error of LaTeX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
 * #6046: LaTeX: ``TypeError`` is raised when invalid latex_elements given
 * #6067: LaTeX: images having a target are concatenated to next line
 * #6067: LaTeX: images having a target are not aligned even if specified
+* #6149: LaTeX: ``:index:`` role in titles causes ``Use of \@icentercr doesn't
+  match its definition`` error on latexpdf build
 * #6019: imgconverter: Including multipage PDF fails
 * #6047: autodoc: ``autofunction`` emits a warning for method objects
 * #6028: graphviz: Ensure the graphviz filenames are reproducible

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -20,7 +20,7 @@ from sphinx.builders import Builder
 from sphinx.builders.latex.transforms import (
     BibliographyTransform, CitationReferenceTransform, MathReferenceTransform,
     FootnoteDocnameUpdater, LaTeXFootnoteTransform, LiteralBlockTransform,
-    ShowUrlsTransform, DocumentTargetTransform,
+    ShowUrlsTransform, DocumentTargetTransform, IndexInSectionTitleTransform,
 )
 from sphinx.config import string_classes, ENUM
 from sphinx.environment import NoUri
@@ -284,7 +284,8 @@ class LaTeXBuilder(Builder):
                                     ShowUrlsTransform,
                                     LaTeXFootnoteTransform,
                                     LiteralBlockTransform,
-                                    DocumentTargetTransform])
+                                    DocumentTargetTransform,
+                                    IndexInSectionTitleTransform])
         transformer.apply_transforms()
 
     def finish(self):

--- a/tests/roots/test-index_on_title/contents.rst
+++ b/tests/roots/test-index_on_title/contents.rst
@@ -1,0 +1,5 @@
+index_on_title
+==============
+
+Test for :index:`index` in top level title
+------------------------------------------

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1349,6 +1349,15 @@ def test_latex_labels(app, status, warning):
             r'\label{\detokenize{otherdoc:otherdoc}}'
             r'\label{\detokenize{otherdoc::doc}}' in result)
 
-
     # Embeded standalone hyperlink reference (refs: #5948)
     assert result.count(r'\label{\detokenize{index:section1}}') == 1
+
+
+@pytest.mark.sphinx('latex', testroot='index_on_title')
+def test_index_on_title(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'Python.tex').text(encoding='utf8')
+    assert ('\\chapter{Test for index in top level title}\n'
+            '\\label{\\detokenize{contents:test-for-index-in-top-level-title}}'
+            '\\index{index@\\spxentry{index}}\n'
+            in result)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6149 and #6150 
