### PR TITLE
Fix #3859: manpage: code-block captions are not displayed correctly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
 * #6136: ``:name:`` option for ``math`` directive causes a crash
 * #6139: intersphinx: ValueError on failure reporting
 * #6135: changes: Fix UnboundLocalError when any module found
+* #3859: manpage: code-block captions are not displayed correctly
 
 Testing
 --------

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -463,6 +463,21 @@ class ManualPageTranslator(BaseTranslator):
         return self.depart_strong(node)
 
     # overwritten: handle section titles better than in 0.6 release
+    def visit_caption(self, node):
+        # type: (nodes.Element) -> None
+        if isinstance(node.parent, nodes.container) and node.parent.get('literal_block'):
+            self.body.append('.sp\n')
+        else:
+            BaseTranslator.visit_caption(self, node)
+
+    def depart_caption(self, node):
+        # type: (nodes.Element) -> None
+        if isinstance(node.parent, nodes.container) and node.parent.get('literal_block'):
+            self.body.append('\n')
+        else:
+            BaseTranslator.depart_caption(self, node)
+
+    # overwritten: handle section titles better than in 0.6 release
     def visit_title(self, node):
         # type: (nodes.Node) -> None
         if isinstance(node.parent, addnodes.seealso):

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -25,3 +25,24 @@ def test_all(app, status, warning):
     # term of definition list including nodes.strong
     assert '\n.B term1\n' in content
     assert '\nterm2 (\\fBstronged partially\\fP)\n' in content
+
+
+@pytest.mark.sphinx('man', testroot='directive-code')
+def test_captioned_code_block(app, status, warning):
+    app.builder.build_all()
+    content = (app.outdir / 'python.1').text()
+
+    assert ('.sp\n'
+            'caption \\fItest\\fP rb\n'
+            '.INDENT 0.0\n'
+            '.INDENT 3.5\n'
+            '.sp\n'
+            '.nf\n'
+            '.ft C\n'
+            'def ruby?\n'
+            '    false\n'
+            'end\n'
+            '.ft P\n'
+            '.fi\n'
+            '.UNINDENT\n'
+            '.UNINDENT\n' in content)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #3859 
