### PR TITLE
Add long description content type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,7 @@ setup(
     author_email='georg@python.org',
     description='Python documentation generator',
     long_description=long_desc,
+    long_description_content_type='text/x-rst',
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/utils/release-checklist
+++ b/utils/release-checklist
@@ -12,7 +12,8 @@ for stable releases
 * ``git commit -am 'Bump to X.Y.Z final'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist``
-* ``twine upload dist/<Sphinx-X.Y.Z files> --sign --identity [your GPG key]``
+* ``twine check dist/Sphinx-X.Y.Z*``
+* ``twine upload dist/Sphinx-X.Y.Z* --sign --identity [your GPG key]``
 * open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.Z``
 * ``python utils/bump_version.py --in-develop X.Y.Zb0`` (ex. 1.5.3b0)
@@ -39,7 +40,8 @@ for first beta releases
 * ``git commit -am 'Bump to X.Y.0 beta1'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist``
-* ``twine upload dist/<Sphinx-X.Y.Z files> --sign --identity [your GPG key]``
+* ``twine check dist/Sphinx-X.Y.Z*``
+* ``twine upload dist/Sphinx-X.Y.Z* --sign --identity [your GPG key]``
 * open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.0b1``
 * ``python utils/bump_version.py --in-develop X.Y.0b2`` (ex. 1.6.0b2)
@@ -69,7 +71,8 @@ for other beta releases
 * ``git commit -am 'Bump to X.Y.0 betaN'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist``
-* ``twine upload dist/<Sphinx-X.Y.Z files> --sign --identity [your GPG key]``
+* ``twine check dist/Sphinx-X.Y.Z*``
+* ``twine upload dist/Sphinx-X.Y.Z* --sign --identity [your GPG key]``
 * open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.0bN``
 * ``python utils/bump_version.py --in-develop X.Y.0bM`` (ex. 1.6.0b3)
@@ -98,7 +101,8 @@ for major releases
 * ``git commit -am 'Bump to X.Y.0 final'``
 * ``make clean``
 * ``python setup.py release bdist_wheel sdist``
-* ``twine upload dist/<Sphinx-X.Y.Z files> --sign --identity [your GPG key]``
+* ``twine check dist/Sphinx-X.Y.Z*``
+* ``twine upload dist/Sphinx-X.Y.Z* --sign --identity [your GPG key]``
 * open https://pypi.org/project/Sphinx/ and check there are no obvious errors
 * ``git tag vX.Y.0``
 * ``python utils/bump_version.py --in-develop X.Y.1b0`` (ex. 1.6.1b0)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose

I noticed "twine check" raises warning for our package:
```
Checking distribution dist/Sphinx-2.0.0.dev20190310-py2.py3-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Passed
Checking distribution dist/Sphinx-2.0.0.dev20190310.tar.gz: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Passed
```

- Add long_description_content_type to package metadata
- Do "twine check" before uploading package
