### PR TITLE
Fix a typo in issue template: htps:// → https:// default project URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Steps to reproduce the behavior:
 ```
 <Paste your command-line here which cause the problem>
 
-$ git clone htps://github.com/.../some_project
+$ git clone https://github.com/.../some_project
 $ cd some_project
 $ pip install -r requirements.txt
 $ cd docs


### PR DESCRIPTION
Subject: Fix a typo in issue template: htps:// → https:// default project URL

### Bugfix
- Bugfix

### Purpose
- Just correct a typo in this issue template: the htps:// url obviously doesn't work.
