### PR TITLE
Add useless visit_pending_xref and depart_pending_xref to fix #6166

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -942,6 +942,14 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         if depart:
             depart(self, node)
 
+    def visit_pending_xref(self, node):
+        # type: (nodes.Node) -> None
+        pass
+
+    def depart_pending_xref(self, node):
+        # type: (nodes.Node) -> None
+        pass
+
     def unknown_visit(self, node):
         # type: (nodes.Node) -> None
         raise NotImplementedError('Unknown node: ' + node.__class__.__name__)


### PR DESCRIPTION
Subject: Add useless `visit_pending_xref` and `depart_pending_xref` to fix #6166

### Bugfix
- Bugfix

### Purpose
- This short PR adds empty methods `visit_pending_xref` and `depart_pending_xref` to never have a `NotImplementedError: Unknown node: pending_xref` exception again.

### Detail
- Empty methods `visit_pending_xref` and `depart_pending_xref` in `sphinx/writers/html.py`
- Maybe necessary to write the same for `html5.py` ? (not sure)

### Relates
- #6166

