### PR TITLE
docs: drop mention to deprecated method (refs: #6174)

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -827,9 +827,6 @@ class Sphinx:
         For the role content, you have the same syntactical possibilities as
         for standard Sphinx roles (see :ref:`xref-syntax`).
 
-        This method is also available under the deprecated alias
-        :meth:`add_description_unit`.
-
         .. versionchanged:: 1.8
            Add *override* keyword.
         """


### PR DESCRIPTION
### Feature or Bugfix
- docs

### Purpose
- refs: #6174 
