### PR TITLE
Support translating captions of hidden TOCs

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -113,6 +113,7 @@ class I18nBuilder(Builder):
     versioning_compare = None   # type: bool
                                 # be set by `gettext_uuid`
     use_message_catalog = False
+    supported_hidden_tocs = True
 
     def init(self):
         # type: () -> None

--- a/tests/roots/test-intl/index.txt
+++ b/tests/roots/test-intl/index.txt
@@ -30,3 +30,10 @@ CONTENTS
    refs
    section
    topic
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Hidden Toc
+   :hidden:
+
+   only

--- a/tests/roots/test-intl/xx/LC_MESSAGES/index.po
+++ b/tests/roots/test-intl/xx/LC_MESSAGES/index.po
@@ -19,6 +19,9 @@ msgstr ""
 msgid "Table of Contents"
 msgstr "TABLE OF CONTENTS"
 
+msgid "Hidden Toc"
+msgstr "HIDDEN TOC"
+
 msgid "testdata for i18n"
 msgstr "TESTDATA FOR I18N"
 


### PR DESCRIPTION
Subject: Support translating captions of hidden TOCs to fix #6178 

### Feature or Bugfix
- Bugfix

### Purpose
- This PR adds captions of hidden TOCs into translations to support translating TOC captions only appear in navigation bars.

### Detail
- ``sphinx.builders.Builder`` does not handle hidden items in doctrees by passing ``includehidden=False`` into ``get_and_resolve_doctree`` which is then passed into ``TocTree.resolve``. To reveal TOC captions when building POTs, a class member ``supported_hidden_tocs`` is added and marked as ``True`` in ``I18nBuilder`` to handle those hidden TOC nodes.

### Relates
- #6178 