### PR TITLE
Support --keep-going with BuildDoc setup command

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -186,7 +186,7 @@ files can be built by specifying individual filenames.
     group.add_argument('-W', action='store_true', dest='warningiserror',
                        help=__('turn warnings into errors'))
     group.add_argument('--keep-going', action='store_true', dest='keep_going',
-                       help=__("With -W, Keep going when getting warnings"))
+                       help=__("With -W, keep going when getting warnings"))
     group.add_argument('-T', action='store_true', dest='traceback',
                        help=__('show full traceback on exception'))
     group.add_argument('-P', action='store_true', dest='pdb',

--- a/sphinx/locale/sphinx.pot
+++ b/sphinx/locale/sphinx.pot
@@ -1252,7 +1252,7 @@ msgid "turn warnings into errors"
 msgstr ""
 
 #: sphinx/cmd/build.py:189
-msgid "With -W, Keep going when getting warnings"
+msgid "With -W, keep going when getting warnings"
 msgstr ""
 
 #: sphinx/cmd/build.py:191

--- a/sphinx/locale/sphinx.pot
+++ b/sphinx/locale/sphinx.pot
@@ -1252,7 +1252,7 @@ msgid "turn warnings into errors"
 msgstr ""
 
 #: sphinx/cmd/build.py:189
-msgid "With -W, keep going when getting warnings"
+msgid "With -W, Keep going when getting warnings"
 msgstr ""
 
 #: sphinx/cmd/build.py:191

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -85,6 +85,7 @@ class BuildDoc(Command):
         ('copyright', None, 'The copyright string'),
         ('pdb', None, 'Start pdb on exception'),
         ('nitpicky', 'n', 'nit-picky mode, warn about all missing references'),
+        ('keep-going', None, 'With -W, keep going when getting warnings'),
     ]
     boolean_options = ['fresh-env', 'all-files', 'warning-is-error',
                        'link-index', 'nitpicky']
@@ -106,6 +107,7 @@ class BuildDoc(Command):
         self.verbosity = 0
         self.traceback = False
         self.nitpicky = False
+        self.keep_going = False
 
     def _guess_source_dir(self):
         # type: () -> str
@@ -186,7 +188,8 @@ class BuildDoc(Command):
                                  builder_target_dir, self.doctree_dir,
                                  builder, confoverrides, status_stream,
                                  freshenv=self.fresh_env,
-                                 warningiserror=self.warning_is_error)
+                                 warningiserror=self.warning_is_error,
+                                 keep_going=self.keep_going)
                     app.build(force_all=self.all_files)
                     if app.statuscode:
                         raise DistutilsExecError(


### PR DESCRIPTION
This allows for `tox -e docs -- -n -W --keep-going`.