### PR TITLE
LaTeX: stop using extractbb for image inclusion in Japanese documents

### DIFF
--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -10,7 +10,6 @@ ALLDVI = $(addsuffix .dvi,$(ALLDOCS))
 ALLXDV =
 {% endif -%}
 ALLPS  = $(addsuffix .ps,$(ALLDOCS))
-ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
 
 # Prefix for archive names
 ARCHIVEPREFIX =
@@ -46,15 +45,7 @@ LATEX = latexmk -dvi
 PDFLATEX = latexmk -pdf -dvi- -ps-
 {% endif %}
 
-%.png %.gif %.jpg %.jpeg: FORCE_MAKE
-	extractbb '$@'
-
-{% if latex_engine == 'platex' -%}
-%.dvi: %.tex $(ALLIMGS) FORCE_MAKE
-	for f in *.pdf; do extractbb "$$f"; done
-	$(LATEX) $(LATEXMKOPTS) '$<'
-
-{% elif latex_engine != 'xelatex' -%}
+{% if latex_engine != 'xelatex' -%}
 %.dvi: %.tex FORCE_MAKE
 	$(LATEX) $(LATEXMKOPTS) '$<'
 
@@ -62,12 +53,7 @@ PDFLATEX = latexmk -pdf -dvi- -ps-
 %.ps: %.dvi
 	dvips '$<'
 
-{% if latex_engine == 'platex' -%}
-%.pdf: %.tex $(ALLIMGS) FORCE_MAKE
-	for f in *.pdf; do extractbb "$$f"; done
-{%- else -%}
 %.pdf: %.tex FORCE_MAKE
-{%- endif %}
 	$(PDFLATEX) $(LATEXMKOPTS) '$<'
 
 all: $(ALLPDF)

--- a/sphinx/texinputs/make.bat_t
+++ b/sphinx/texinputs/make.bat_t
@@ -31,11 +31,6 @@ if "%1" == "" goto all-pdf
 
 if "%1" == "all-pdf" (
 	:all-pdf
-{%- if latex_engine == 'platex' %}
-	for %%i in (*.png *.gif *.jpg *.jpeg *.pdf) do (
-		extractbb %%i
-	)
-{%- endif %}
 	for %%i in (*.tex) do (
 		%PDFLATEX% %LATEXMKOPTS% %%i
 	)


### PR DESCRIPTION
Since TeXLive2015, the dvipdfmx binary does not need extra .xbb files
for images (which were produced using extractbb).

I propose to wait for Sphinx 3.0 because although a TeXLive2015-based TeX distribution is listed as requirement since Sphinx 2.0, it is not needed to really force users to upgrade only to help us trim a few lines on our side which are neither an added feature nor a bugfix but simply some steps which were mandatory in the past and are now not needed.

Or at least wait until we shift from platex to uplatex for Japanese projects (refs: https://github.com/sphinx-doc/sphinx/issues/4187#issuecomment-471262204)

edit: I forgot to add [this link](https://tug.org/pipermail/tex-live/2017-January/039545.html) for source of information about `extractbb` unneeded since TL2015.