### PR TITLE
``math`` directive does not support ``:class:`` option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Features added
 * Add a helper class ``sphinx.transforms.post_transforms.SphinxPostTransform``
 * Add a helper method ``SphinxDirective.set_source_info()``
 * #6180: Support ``--keep-going`` with BuildDoc setup command
+* ``math`` directive now supports ``:class:`` option
 
 Bugs fixed
 ----------

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -165,6 +165,7 @@ class MathDirective(SphinxDirective):
     option_spec = {
         'label': directives.unchanged,
         'name': directives.unchanged,
+        'class': directives.class_option,
         'nowrap': directives.flag,
     }
 
@@ -175,6 +176,7 @@ class MathDirective(SphinxDirective):
             latex = self.arguments[0] + '\n\n' + latex
         label = self.options.get('label', self.options.get('name'))
         node = nodes.math_block(latex, latex,
+                                classes=self.options.get('class', []),
                                 docname=self.env.docname,
                                 number=None,
                                 label=label,


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
``:class:`` option is a common options for all directives.  But
our implementation does not support it so far.  This adds support
for the option.
