### PR TITLE
Fix #6196: py domain: unexpected prefix is generated

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6196: py domain: unexpected prefix is generated
+
 Testing
 --------
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -262,7 +262,8 @@ class PyObject(ObjectDescription):
         classname = self.env.ref_context.get('py:class')
         if classname:
             add_module = False
-            if name_prefix and name_prefix.startswith(classname):
+            if name_prefix and (name_prefix == classname or
+                                name_prefix.startswith(classname + ".")):
                 fullname = name_prefix + name
                 # class name is given again in the signature
                 name_prefix = name_prefix[len(classname):].lstrip('.')

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -273,3 +273,20 @@ def test_pydata_signature(app):
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="data",
                 domain="py", objtype="data", noindex=False)
+
+
+def test_pyobject_prefix(app):
+    text = (".. py:class:: Foo\n"
+            "\n"
+            "   .. py:method:: Foo.say\n"
+            "   .. py:method:: FooBar.say")
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree, (addnodes.index,
+                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                                                    [desc_name, "Foo"])],
+                                  [desc_content, (addnodes.index,
+                                                  desc,
+                                                  addnodes.index,
+                                                  desc)])]))
+    assert doctree[1][1][1].astext().strip() == 'say'           # prefix is stripped
+    assert doctree[1][1][3].astext().strip() == 'FooBar.say'    # not stripped


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6196 