### PR TITLE
Support coverage_ignore_py in the coverage extension

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Other contributors, listed alphabetically, are:
 * Stephen Finucane -- setup command improvements and documentation
 * Daniel Pizetta -- inheritance diagram improvements
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils
+* Adrián Chaves (Gallaecio) -- coverage builder improvements
 
 Many thanks for all contributions!
 

--- a/CHANGES
+++ b/CHANGES
@@ -99,6 +99,7 @@ Features added
 * #6306: html: Add a label to search form for accessability purposes
 * #6358: The ``rawsource`` property of ``production`` nodes now contains the
   full production rule
+* Support a new ``coverage_ignore_pyobjects`` option in the coverage builder
 
 Bugs fixed
 ----------

--- a/doc/usage/extensions/coverage.rst
+++ b/doc/usage/extensions/coverage.rst
@@ -22,6 +22,16 @@ should check:
 
 .. confval:: coverage_ignore_classes
 
+.. confval:: coverage_ignore_pyobjects
+
+   List of `Python regular expressions`_.
+
+   If any of these regular expressions matches any part of the full import path
+   of a Python object, that Python object is excluded from the documentation
+   coverage report.
+
+   .. versionadded:: 2.1
+
 .. confval:: coverage_c_path
 
 .. confval:: coverage_c_regexes
@@ -40,3 +50,5 @@ should check:
    ``False`` by default.
 
    .. versionadded:: 1.1
+
+.. _Python regular expressions: https://docs.python.org/library/re

--- a/tests/roots/test-ext-coverage/conf.py
+++ b/tests/roots/test-ext-coverage/conf.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage']
+
+coverage_ignore_pyobjects = [
+    r'^coverage_ignored(\..*)?$',
+    r'\.Ignored$',
+    r'\.Documented\.ignored\d$',
+]

--- a/tests/roots/test-ext-coverage/coverage_ignored.py
+++ b/tests/roots/test-ext-coverage/coverage_ignored.py
@@ -1,0 +1,22 @@
+class Documented:
+    """Documented"""
+
+    def ignored1(self):
+        pass
+
+    def ignored2(self):
+        pass
+
+    def not_ignored1(self):
+        pass
+
+    def not_ignored2(self):
+        pass
+
+
+class Ignored:
+    pass
+
+
+class NotIgnored:
+    pass

--- a/tests/roots/test-ext-coverage/coverage_not_ignored.py
+++ b/tests/roots/test-ext-coverage/coverage_not_ignored.py
@@ -1,0 +1,22 @@
+class Documented:
+    """Documented"""
+
+    def ignored1(self):
+        pass
+
+    def ignored2(self):
+        pass
+
+    def not_ignored1(self):
+        pass
+
+    def not_ignored2(self):
+        pass
+
+
+class Ignored:
+    pass
+
+
+class NotIgnored:
+    pass

--- a/tests/roots/test-ext-coverage/index.rst
+++ b/tests/roots/test-ext-coverage/index.rst
@@ -1,0 +1,6 @@
+.. automodule:: coverage_ignored
+   :members:
+
+
+.. automodule:: coverage_not_ignored
+   :members:

--- a/tests/test_ext_coverage.py
+++ b/tests/test_ext_coverage.py
@@ -45,3 +45,22 @@ def test_build(app, status, warning):
     assert 'classes' in undoc_py['autodoc_target']
     assert 'Class' in undoc_py['autodoc_target']['classes']
     assert 'undocmeth' in undoc_py['autodoc_target']['classes']['Class']
+
+
+@pytest.mark.sphinx('coverage', testroot='ext-coverage')
+def test_coverage_ignore_pyobjects(app, status, warning):
+    app.builder.build_all()
+    actual = (app.outdir / 'python.txt').text()
+    expected = '''Undocumented Python objects
+===========================
+coverage_not_ignored
+--------------------
+Classes:
+ * Documented -- missing methods:
+
+   - not_ignored1
+   - not_ignored2
+ * NotIgnored
+
+'''
+    assert actual == expected


### PR DESCRIPTION
Subject: Extend the existing coverage extension with an option that allows ignoring Python API members regardless of their type, and based on their full import path.

### Feature or Bugfix
- Feature

### Purpose
Currently, the coverage extension only allows ignoring Python API members based on their base name and type. This means that you cannot ignore a specific attribute name on a specific class, it’s either all or none. It also mean that you cannot use a single expression to ignore Python API members of different types. You cannot ignore specific class attributes either.

This new setting allows doing all of it with a simple list of regular expressions that are checked against the full import path of any Python API member.

### Relates
- https://github.com/scrapy/scrapy/pull/3567

