### PR TITLE
Allow autosummary to document modules exposed through __all__

### DIFF
--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -241,6 +241,11 @@ The following variables available in the templates:
    List containing names of "public" attributes in the class.  Only available
    for classes.
 
+.. data:: public_modules
+
+   List containing names of "public" sub-modules in the module, i.e. modules
+   exposed in `__all__`. Only available for modules.
+
 
 Additionally, the following filters are available
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -196,7 +196,8 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                     except ImportError:
                         continue
                     finally:
-                        sys.modules.pop(name + '.' + item)
+                        if item in sys.modules:
+                            sys.modules.pop(name + '.' + item)
                     items.append(name + '.' + item)
                 return items
 

--- a/tests/roots/test-ext-autosummary-all_modules/__init__.py
+++ b/tests/roots/test-ext-autosummary-all_modules/__init__.py
@@ -1,0 +1,3 @@
+__all__ = [
+    'autosummary_dummy_package'
+]

--- a/tests/roots/test-ext-autosummary-all_modules/_template/module.rst
+++ b/tests/roots/test-ext-autosummary-all_modules/_template/module.rst
@@ -1,0 +1,43 @@
+{{ fullname | escape | underline }}
+
+.. rubric:: Description
+
+.. automodule:: {{ fullname }}
+
+   {% block public_modules %}
+   {% if public_modules %}
+   .. rubric:: Modules
+
+   .. autosummary::
+      :toctree:
+   {% for item in public_modules %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/tests/roots/test-ext-autosummary-all_modules/autosummary_dummy_package/__init__.py
+++ b/tests/roots/test-ext-autosummary-all_modules/autosummary_dummy_package/__init__.py
@@ -1,0 +1,6 @@
+from .autosummary_dummy_module import Bar, foo
+
+
+__all__ = [
+    'autosummary_dummy_module'
+]

--- a/tests/roots/test-ext-autosummary-all_modules/autosummary_dummy_package/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary-all_modules/autosummary_dummy_package/autosummary_dummy_module.py
@@ -1,0 +1,8 @@
+class Bar:
+    """Bar class"""
+    pass
+
+
+def foo():
+    """Foo function"""
+    pass

--- a/tests/roots/test-ext-autosummary-all_modules/conf.py
+++ b/tests/roots/test-ext-autosummary-all_modules/conf.py
@@ -1,0 +1,8 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autosummary']
+templates_path = ['_template']
+autosummary_generate = True
+autosummary_imported_members = True

--- a/tests/roots/test-ext-autosummary-all_modules/index.rst
+++ b/tests/roots/test-ext-autosummary-all_modules/index.rst
@@ -1,0 +1,8 @@
+test-ext-autosummary-mock_imports
+=================================
+
+.. autosummary::
+   :toctree: generated
+   :template: module.rst
+
+   autosummary_dummy_package

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -242,3 +242,33 @@ def test_autosummary_mock_imports(app, status, warning):
         assert app.env.get_doctree('generated/foo')
     finally:
         sys.modules.pop('foo', None)  # unload foo module
+
+
+@pytest.mark.sphinx('dummy', testroot='ext-autosummary-all_modules')
+def test_autosummary_all_modules(app, status, warning):
+    try:
+        app.build()
+        # generated/foo is generated successfully
+        assert app.env.get_doctree('generated/autosummary_dummy_package')
+        assert app.env.get_doctree('generated/autosummary_dummy_package.autosummary_dummy_module')
+
+        module = (app.srcdir / 'generated' / 'autosummary_dummy_package.rst').text()
+        assert ('   .. rubric:: Modules\n'
+                '\n'
+                '   .. autosummary::\n'
+                '      :toctree:\n'
+                '   \n'
+                '      autosummary_dummy_package.autosummary_dummy_module\n' in module)
+
+        module = (app.srcdir / 'generated' /
+                  'autosummary_dummy_package.autosummary_dummy_module.rst').text()
+        assert ('   .. autosummary::\n'
+                '   \n'
+                '      Bar\n'
+                '   \n' in module)
+        assert ('   .. autosummary::\n'
+                '   \n'
+                '      foo\n'
+                '   \n' in module)
+    finally:
+        sys.modules.pop('autosummary_dummy_package', None)


### PR DESCRIPTION
Allow `autosummary` to document modules exposed through `__all__`

### Feature or Bugfix
- Feature

### Purpose
Autosummary ignores the `__all__` attribute of modules, and does not provide a way of automatically generating documentation them.

Consider the example of the included test:

`__init__.py`:
```python
__all__ = [
    'bar'
]
```

`bar/__init__.py`:
```python
# empty file
```

`bar/foo.py`:
```python
class Baz:
   pass
```

This PR allows auto-documenting the module `bar`, by using the new jinja template variable `public_modules` (which contains everything in `__all__`), provided that the user provides an appropriate `_template`. See the included test for detail

### Relates
- #4247
- #4372
- #5877

