### PR TITLE
Clarify MathJax extension usage

### DIFF
--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -16,7 +16,7 @@ Math support for HTML outputs in Sphinx
 
 Since mathematical notation isn't natively supported by HTML in any way, Sphinx
 gives a math support to HTML document with several extensions.  These use the
-Sphinx :rst:dir:`directives <math>` and :rst:role:`roles <math>`.
+reStructuredText math :rst:dir:`directive <math>` and :rst:role:`role <math>`.
 
 :mod:`sphinx.ext.imgmath` -- Render math as images
 --------------------------------------------------
@@ -129,12 +129,16 @@ built:
 
 This extension puts math as-is into the HTML files.  The JavaScript package
 MathJax_ is then loaded and transforms the LaTeX markup to readable math live in
-the browser.  Reminder: you should use the math :rst:dir:`directives <math>` and
-:rst:role:`roles <math>`, not the native MathJax ``$$``, ``\(``, etc.
+the browser.
 
 Because MathJax (and the necessary fonts) is very large, it is not included in
-Sphinx and your build will include resources from a external site (by
-default cdnjs.cloudflare.com).
+Sphinx but is set to automatically include it from a third-party site.
+
+.. attention::
+
+   You should use the math :rst:dir:`directive <math>` and
+   :rst:role:`role <math>`, not the native MathJax ``$$``, ``\(``, etc.
+
 
 .. confval:: mathjax_path
 
@@ -143,8 +147,9 @@ default cdnjs.cloudflare.com).
 
    The default is the ``https://`` URL that loads the JS files from the
    `cdnjs`__ Content Delivery Network. See the `MathJax Getting Started
-   page`__ for details. If you want MathJax to be available offline, you have
-   to download it and set this value to a different path.
+   page`__ for details. If you want MathJax to be available offline or
+   without including resources from a third-party site, you have to
+   download it and set this value to a different path.
 
    __ https://cdnjs.com
 

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -15,7 +15,8 @@ Math support for HTML outputs in Sphinx
    So mathbase extension is no longer needed.
 
 Since mathematical notation isn't natively supported by HTML in any way, Sphinx
-gives a math support to HTML document with several extensions.
+gives a math support to HTML document with several extensions.  These use the
+Sphinx :rst:dir:`directives <math>` and :rst:role:`roles <math>`.
 
 :mod:`sphinx.ext.imgmath` -- Render math as images
 --------------------------------------------------
@@ -128,10 +129,12 @@ built:
 
 This extension puts math as-is into the HTML files.  The JavaScript package
 MathJax_ is then loaded and transforms the LaTeX markup to readable math live in
-the browser.
+the browser.  Reminder: you should use the math :rst:dir:`directives <math>` and
+:rst:role:`roles <math>`, not the native MathJax ``$$``, ``\(``, etc.
 
 Because MathJax (and the necessary fonts) is very large, it is not included in
-Sphinx.
+Sphinx and your build will include resources from a external site (by
+default cdnjs.cloudflare.com).
 
 .. confval:: mathjax_path
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (docs)

### Purpose

- We recently hit an issue where we expected the MathJax extension to   work with the default MathJax markup.  Obviously that shouldn't bethe case (since then other formats couldn't use the math), but it can't hurt to include a hint.

### Detail

- Link from the math HTML extension page to the relevant roles/directives.
- Also make it explicit that MathJax has a default, and that it's an external resource that will be dynamically linked.
- My only consideration is that possibly it doesn't deserve an explicit mention in the MathJax section, only in the page prologue.  But assuming MathJax is so common and has it's other similar syntax, I mentioned it there too.
- The mention of the CDN was to make people think at least a little bit before including stuff from all over.

Note: we tested this the wrong way, but not the right way.  Also let me know if this is the wrong way to do things.

I'm submitting this to the 2.0, please let me know if it should target another branch.