### PR TITLE
Show deprecation warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * deprecation warnings are not emitted
 
   - sphinx.application.CONFIG_FILENAME
+  - :confval:`viewcode_import`
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,9 @@ Bugs fixed
 ----------
 
 * LaTeX: some system labels are not translated
+* deprecation warnings are not emitted
+
+  - sphinx.application.CONFIG_FILENAME
 
 Testing
 --------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -24,9 +24,8 @@ from docutils.parsers.rst import Directive, roles
 import sphinx
 from sphinx import package_dir, locale
 from sphinx.config import Config
-from sphinx.config import CONFIG_FILENAME  # NOQA # for compatibility (RemovedInSphinx30)
 from sphinx.deprecation import (
-    RemovedInSphinx30Warning, RemovedInSphinx40Warning
+    RemovedInSphinx30Warning, RemovedInSphinx40Warning, deprecated_alias
 )
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import ApplicationError, ConfigError, VersionRequirementError
@@ -1247,3 +1246,12 @@ class TemplateBridge:
         specified context (a Python dictionary).
         """
         raise NotImplementedError('must be implemented in subclasses')
+
+
+from sphinx.config import CONFIG_FILENAME  # NOQA
+
+deprecated_alias('sphinx.application',
+                 {
+                     'CONFIG_FILENAME': CONFIG_FILENAME,
+                 },
+                 RemovedInSphinx30Warning)

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -251,6 +251,7 @@ def setup(app):
     app.add_config_value('viewcode_import', None, False)
     app.add_config_value('viewcode_enable_epub', False, False)
     app.add_config_value('viewcode_follow_imported_members', True, False)
+    app.connect('config-inited', migrate_viewcode_import)
     app.connect('doctree-read', doctree_read)
     app.connect('env-merge-info', env_merge_info)
     app.connect('html-collect-pages', collect_pages)

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -21,6 +21,7 @@ from io import StringIO
 from os import path
 
 from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
+from sphinx.testing.path import path as Path
 
 if False:
     # For type annotation
@@ -190,15 +191,18 @@ fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
 def abspath(pathdir):
     # type: (str) -> str
-    pathdir = path.abspath(pathdir)
-    if isinstance(pathdir, bytes):
-        try:
-            pathdir = pathdir.decode(fs_encoding)
-        except UnicodeDecodeError:
-            raise UnicodeDecodeError('multibyte filename not supported on '
-                                     'this filesystem encoding '
-                                     '(%r)' % fs_encoding)
-    return pathdir
+    if isinstance(pathdir, Path):
+        return pathdir.abspath()
+    else:
+        pathdir = path.abspath(pathdir)
+        if isinstance(pathdir, bytes):
+            try:
+                pathdir = pathdir.decode(fs_encoding)
+            except UnicodeDecodeError:
+                raise UnicodeDecodeError('multibyte filename not supported on '
+                                         'this filesystem encoding '
+                                         '(%r)' % fs_encoding)
+        return pathdir
 
 
 def getcwd():

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -90,7 +90,7 @@ def test_inheritance_diagram_latex_alias(app, status, warning):
 
 
 def test_import_classes(rootdir):
-    from sphinx.application import Sphinx, TemplateBridge
+    from sphinx.parsers import Parser, RSTParser
     from sphinx.util.i18n import CatalogInfo
 
     try:
@@ -120,16 +120,16 @@ def test_import_classes(rootdir):
         assert classes == []
 
         # all of classes in the module
-        classes = import_classes('sphinx.application', None)
-        assert set(classes) == {Sphinx, TemplateBridge}
+        classes = import_classes('sphinx.parsers', None)
+        assert set(classes) == {Parser, RSTParser}
 
         # specified class in the module
-        classes = import_classes('sphinx.application.Sphinx', None)
-        assert classes == [Sphinx]
+        classes = import_classes('sphinx.parsers.Parser', None)
+        assert classes == [Parser]
 
         # specified class in current module
-        classes = import_classes('Sphinx', 'sphinx.application')
-        assert classes == [Sphinx]
+        classes = import_classes('Parser', 'sphinx.parsers')
+        assert classes == [Parser]
 
         # relative module name to current module
         classes = import_classes('i18n.CatalogInfo', 'sphinx.util')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- `viewcode_import` and `sphinx.application.CONFIG_FILENAME` has been marked as deprecated. But no warnings are emitted for them.
