### PR TITLE
C++, fix parsing of full xrefs.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Bugs fixed
   - sphinx.application.CONFIG_FILENAME
   - :confval:`viewcode_import`
 
+* #6208: C++, properly parse full xrefs that happen to have a short xref as prefix.
+
 Testing
 --------
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6391,6 +6391,7 @@ class DefinitionParser:
             # if there are '()' left, just skip them
             self.skip_ws()
             self.skip_string('()')
+            self.assert_end()
             templatePrefix = self._check_template_consistency(name, templatePrefix,
                                                               fullSpecShorthand=True)
             res1 = ASTNamespace(name, templatePrefix)
@@ -6403,6 +6404,7 @@ class DefinitionParser:
                 # if there are '()' left, just skip them
                 self.skip_ws()
                 self.skip_string('()')
+                self.assert_end()
                 return res2, False
             except DefinitionError as e2:
                 errs = []
@@ -7145,7 +7147,6 @@ class CPPDomain(Domain):
         parser = DefinitionParser(target, warner, env.config)
         try:
             ast, isShorthand = parser.parse_xref_object()
-            parser.assert_end()
         except DefinitionError as e:
             def findWarning(e):  # as arg to stop flake8 from complaining
                 if typ != 'any' and typ != 'func':
@@ -7154,7 +7155,6 @@ class CPPDomain(Domain):
                 parser2 = DefinitionParser(target[:-2], warner, env.config)
                 try:
                     parser2.parse_xref_object()
-                    parser2.assert_end()
                 except DefinitionError as e2:
                     return target[:-2], e2
                 # strange, that we don't get the error now, use the original

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -755,6 +755,20 @@ def test_attributes():
     check('member', 'int *[[attr]] *i', {1: 'i__iPP', 2: '1i'})
 
 
+def test_xref_parsing():
+    def check(target):
+        class Config:
+            cpp_id_attributes = ["id_attr"]
+            cpp_paren_attributes = ["paren_attr"]
+        parser = DefinitionParser(target, None, Config())
+        ast, isShorthand = parser.parse_xref_object()
+        parser.assert_end()
+    check('f')
+    check('f()')
+    check('void f()')
+    check('T f()')
+
+
 # def test_print():
 #     # used for getting all the ids out for checking
 #     for a in ids:


### PR DESCRIPTION
If a full xref has a short xref as prefix, e.g., ``T f()``, parsing would fail.

### Relates
- Fixes #6208

