### PR TITLE
Clarify option directive usage

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1225,6 +1225,8 @@ There is a set of directives allowing documenting command-line programs:
    The directive will create cross-reference targets for the given options,
    referenceable by :rst:role:`option` (in the example case, you'd use something
    like ``:option:`dest_dir```, ``:option:`-m```, or ``:option:`--module```).
+   When used within the :rst:dir:`program` directive, however, it is mandatory
+   to also specify the program *name* (e.g. ``:option:`python -m```).
 
    ``cmdoption`` directive is a deprecated alias for the ``option`` directive.
 


### PR DESCRIPTION
Subject: Add example to ``option`` directive used within ``program``.

### Feature or Bugfix
- Docs update

### Purpose
- It's not quite clear how to reference an option correctly. This PR makes it more explicit in the docs.

### Detail
- Add a sentence to the `option` directive description with an example how to use it within the `program` directive.

### Relates
- #6221 

