### PR TITLE
Enable CLI override of Makefile variables.

### DIFF
--- a/sphinx/templates/quickstart/Makefile.new_t
+++ b/sphinx/templates/quickstart/Makefile.new_t
@@ -1,11 +1,14 @@
 # Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-SOURCEDIR     = {{ rsrcdir }}
-BUILDDIR      = {{ rbuilddir }}
+# You can set these variables from the command line.  For example:
+#     SPHINXOPTS='-E -W -n' make html
+# will run the html builder in a clean environment (-E), treating warnings
+# as errors (-W), in nitpicky mode (-n).
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     ?= {{ rsrcdir }}
+BUILDDIR      ?= {{ rbuilddir }}
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -17,3 +20,4 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+


### PR DESCRIPTION
Subject: Enable CLI override of Makefile variables.  Generate POSIX compliant Makefile.

### Feature or Bugfix

- Bugfix

### Purpose

The `?=` setting in `Makefile` allows users to specify e.g., `SPHINXOPTS='...' make <builder>`.  Expanded comment to give example of how to do that in template.

The other bug being fixed here is that the generated `Makefile` is missing the final newline.  I figured I'd just throw the fix in here since it's pretty minor.  I can create a separate issue and PR if desired, but that feels like overkill to me :)

### Detail

- Make sure `Makefile` generates `?=` variable setting so that they actually can be overriden on the command line.
- Make sure rendered `Makefile` has a final newline.

### Relates

- #1368

P.S. I think I got the right branches here, let me know if I should cherry pick this to another branch.
