### PR TITLE
Add data accessors and helper methods to PythonDomain

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,7 +48,11 @@ Features added
 --------------
 
 * Add a helper class ``sphinx.transforms.post_transforms.SphinxPostTransform``
-* Add a helper method ``SphinxDirective.set_source_info()``
+* Add helper methods
+
+  - ``PythonDomain.note_object()``
+  - ``SphinxDirective.set_source_info()``
+
 * #6180: Support ``--keep-going`` with BuildDoc setup command
 * ``math`` directive now supports ``:class:`` option
 * todo: ``todo`` directive now supports ``:name:`` option

--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ Features added
 * Add a helper class ``sphinx.transforms.post_transforms.SphinxPostTransform``
 * Add helper methods
 
+  - ``PythonDomain.note_module()``
   - ``PythonDomain.note_object()``
   - ``SphinxDirective.set_source_info()``
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -782,14 +782,19 @@ class PythonDomain(Domain):
         # type: () -> Dict[str, Tuple[str, str]]
         return self.data.setdefault('objects', {})  # fullname -> docname, objtype
 
+    @property
+    def modules(self):
+        # type: () -> Dict[str, Tuple[str, str, str, bool]]
+        return self.data.setdefault('modules', {})  # modname -> docname, synopsis, platform, deprecated  # NOQA
+
     def clear_doc(self, docname):
         # type: (str) -> None
         for fullname, (fn, _l) in list(self.objects.items()):
             if fn == docname:
                 del self.objects[fullname]
-        for modname, (fn, _x, _x, _x) in list(self.data['modules'].items()):
+        for modname, (fn, _x, _x, _y) in list(self.modules.items()):
             if fn == docname:
-                del self.data['modules'][modname]
+                del self.modules[modname]
 
     def merge_domaindata(self, docnames, otherdata):
         # type: (List[str], Dict) -> None
@@ -799,7 +804,7 @@ class PythonDomain(Domain):
                 self.objects[fullname] = (fn, objtype)
         for modname, data in otherdata['modules'].items():
             if data[0] in docnames:
-                self.data['modules'][modname] = data
+                self.modules[modname] = data
 
     def find_obj(self, env, modname, classname, name, type, searchmode=0):
         # type: (BuildEnvironment, str, str, str, str, int) -> List[Tuple[str, Any]]
@@ -908,7 +913,7 @@ class PythonDomain(Domain):
     def _make_module_refnode(self, builder, fromdocname, name, contnode):
         # type: (Builder, str, str, nodes.Node) -> nodes.Element
         # get additional info for modules
-        docname, synopsis, platform, deprecated = self.data['modules'][name]
+        docname, synopsis, platform, deprecated = self.modules[name]
         title = name
         if synopsis:
             title += ': ' + synopsis
@@ -921,7 +926,7 @@ class PythonDomain(Domain):
 
     def get_objects(self):
         # type: () -> Iterator[Tuple[str, str, str, str, str, int]]
-        for modname, info in self.data['modules'].items():
+        for modname, info in self.modules.items():
             yield (modname, modname, 'module', info[0], 'module-' + modname, 0)
         for refname, (docname, type) in self.objects.items():
             if type != 'module':  # modules are already handled

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -585,12 +585,11 @@ class PyModule(SphinxDirective):
         self.env.ref_context['py:module'] = modname
         ret = []  # type: List[nodes.Node]
         if not noindex:
-            self.env.domaindata['py']['modules'][modname] = (self.env.docname,
-                                                             self.options.get('synopsis', ''),
-                                                             self.options.get('platform', ''),
-                                                             'deprecated' in self.options)
-            # make a duplicate entry in 'objects' to facilitate searching for
-            # the module in PythonDomain.find_obj()
+            # note module to the domain
+            domain.note_module(modname,
+                               self.options.get('synopsis', ''),
+                               self.options.get('platform', ''),
+                               'deprecated' in self.options)
             domain.note_object(modname, 'module')
 
             targetnode = nodes.target('', '', ids=['module-' + modname],
@@ -797,6 +796,14 @@ class PythonDomain(Domain):
     def modules(self):
         # type: () -> Dict[str, Tuple[str, str, str, bool]]
         return self.data.setdefault('modules', {})  # modname -> docname, synopsis, platform, deprecated  # NOQA
+
+    def note_module(self, name, synopsis, platform, deprecated):
+        # type: (str, str, str, bool) -> None
+        """Note a python module for cross reference.
+
+        .. versionadded:: 2.1
+        """
+        self.modules[name] = (self.env.docname, synopsis, platform, deprecated)
 
     def clear_doc(self, docname):
         # type: (str) -> None


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To prevent to touch self.data directly in domain code, this adds data accessors "objects" and "modules" to PythonDomain.
- This makes our code simple and readable.
- This also adds new helper methods `note_object()` and `note_module()`