### PR TITLE
Fix deprecation warnings for sphinx.builder.htmlhelp is not shown

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
 * deprecation warnings are not emitted
 
   - sphinx.application.CONFIG_FILENAME
+  - sphinx.builders.htmlhelp
   - :confval:`viewcode_import`
 
 * #6220, #6225: napoleon: AttributeError is raised for raised section having

--- a/sphinx/builders/htmlhelp.py
+++ b/sphinx/builders/htmlhelp.py
@@ -24,7 +24,7 @@ if False:
     from sphinx.application import Sphinx  # NOQA
 
 
-deprecated_alias('sphinx.builders.devhelp',
+deprecated_alias('sphinx.builders.htmlhelp',
                  {
                      'chm_locales': chm_locales,
                      'chm_htmlescape': chm_htmlescape,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
