### PR TITLE
Fix #6243: LaTeX: releasename setting for latex_elements is ignored

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
 * #6220, #6225: napoleon: AttributeError is raised for raised section having
   references
 * #6245: circular import error on importing SerializingHTMLBuilder
+* #6243: LaTeX: 'releasename' setting for latex_elements is ignored
 
 Testing
 --------

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -213,7 +213,7 @@ class LaTeXBuilder(Builder):
         self.context['indexname'] = _('Index')
         if self.config.release:
             # Show the release label only if release value exists
-            self.context['releasename'] = _('Release')
+            self.context.setdefault('releasename', _('Release'))
 
     def init_babel(self):
         # type: () -> None


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6243 