### PR TITLE
Fix: #6255. Support IETF :BCP: anchors, like :RFC:.

### DIFF
--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -338,6 +338,43 @@ class RFC(ReferenceRole):
             return base_url + self.inliner.rfc_url % int(ret[0])
 
 
+class BCP(ReferenceRole):
+    def run(self):
+        # type: () -> Tuple[List[nodes.Node], List[nodes.system_message]]  # NOQA
+        target_id = 'index-%s' % self.env.new_serialno('index')
+        entries = [('single', 'BCP; BCP %s' % self.target, target_id, '', None)]
+
+        index = addnodes.index(entries=entries)
+        target = nodes.target('', '', ids=[target_id])
+        self.inliner.document.note_explicit_target(target)
+
+        try:
+            refuri = self.build_uri()
+            reference = nodes.reference('', '', internal=False, refuri=refuri, classes=['bcp'])
+            if self.has_explicit_title:
+                reference += nodes.strong(self.title, self.title)
+            else:
+                title = "BCP " + self.title
+                reference += nodes.strong(title, title)
+        except ValueError:
+            msg = self.inliner.reporter.error('invalid BCP number %s' % self.target,
+                                              line=self.lineno)
+            prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
+            return [prb], [msg]
+
+        return [index, target, reference], []
+
+    def build_uri(self):
+        # type: () -> str
+        self.inliner.bcp_url = "bcp%d"
+        base_url = self.inliner.document.settings.rfc_base_url
+        ret = self.target.split('#', 1)
+        if len(ret) == 2:
+            return base_url + self.inliner.bcp_url % int(ret[0]) + '#' + ret[1]
+        else:
+            return base_url + self.inliner.bcp_url % int(ret[0])
+
+
 _amp_re = re.compile(r'(?<!&)&(?![&\s])')
 
 
@@ -609,6 +646,7 @@ specific_docroles = {
 
     'pep': PEP(),
     'rfc': RFC(),
+    'bcp': BCP(),
     'guilabel': GUILabel(),
     'menuselection': MenuSelection(),
     'file': EmphasizedLiteral(),

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -193,6 +193,27 @@ def get_verifier(verify, verify_re):
          '{\\sphinxstylestrong{RFC 2324\\#id1}}')
     ),
     (
+        # bcp role
+        'verify',
+        ':bcp:`2324`',
+        ('<p><span class="target" id="index-0"></span><a class="bcp reference external" '
+         'href="http://tools.ietf.org/html/bcp2324"><strong>BCP 2324</strong></a></p>'),
+        ('\\index{BCP@\\spxentry{BCP}!BCP 2324@\\spxentry{BCP 2324}}'
+         '\\sphinxhref{http://tools.ietf.org/html/bcp2324}'
+         '{\\sphinxstylestrong{BCP 2324}}')
+    ),
+    (
+        # bcp role with anchor
+        'verify',
+        ':bcp:`2324#id1`',
+        ('<p><span class="target" id="index-0"></span><a class="bcp reference external" '
+         'href="http://tools.ietf.org/html/bcp2324#id1">'
+         '<strong>BCP 2324#id1</strong></a></p>'),
+        ('\\index{BCP@\\spxentry{BCP}!BCP 2324\\#id1@\\spxentry{BCP 2324\\#id1}}'
+         '\\sphinxhref{http://tools.ietf.org/html/bcp2324\\#id1}'
+         '{\\sphinxstylestrong{BCP 2324\\#id1}}')
+    ),
+    (
         # correct interpretation of code with whitespace
         'verify_re',
         '``code   sample``',


### PR DESCRIPTION
Subject: support IETF :BCP: (best current practices)

### Feature or Bugfix
- Feature

### Purpose
- Support IETF :BCP: anchors, like :RFC:.


### Detail
Like RFC, IETF releases Best Current Practices (BCP) that are usually referenced  in technical documents.

This code reuses :RFC: code in roles.py to process BCP.

### Relates
- #6255 

