### PR TITLE
Fix #6244: html: Search function is broken with 3rd party themes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
   references
 * #6245: circular import error on importing SerializingHTMLBuilder
 * #6243: LaTeX: 'releasename' setting for latex_elements is ignored
+* #6244: html: Search function is broken with 3rd party themes
 
 Testing
 --------

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -75,6 +75,16 @@ var Search = {
       }
   },
 
+  loadIndex : function(url) {
+    $.ajax({type: "GET", url: url, data: null,
+            dataType: "script", cache: true,
+            complete: function(jqxhr, textstatus) {
+              if (textstatus != "success") {
+                document.getElementById("searchindexloader").src = url;
+              }
+            }});
+  },
+
   setIndex : function(index) {
     var q;
     this._index = index;


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6244 