### PR TITLE
Fix #6263: html: HTML5Translator crashed with invalid field node

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Bugs fixed
 * #6245: circular import error on importing SerializingHTMLBuilder
 * #6243: LaTeX: 'releasename' setting for latex_elements is ignored
 * #6244: html: Search function is broken with 3rd party themes
+* #6263: html: HTML5Translator crashed with invalid field node
 
 Testing
 --------

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -68,6 +68,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.param_separator = ''
         self.optional_param_level = 0
         self._table_row_index = 0
+        self._fieldlist_row_index = 0
         self.required_params_left = 0
 
     def visit_start_of_file(self, node):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6263 