### PR TITLE
ENH: Explain warnings-as-errors

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -348,9 +348,16 @@ class Sphinx:
             status = (self.statuscode == 0 and
                       __('succeeded') or __('finished with problems'))
             if self._warncount:
-                logger.info(bold(__('build %s, %s warning.',
-                                    'build %s, %s warnings.', self._warncount) %
-                                 (status, self._warncount)))
+                if self.warningiserror:
+                    msg = __('build %s, %s warning (with warnings treated as errors).',
+                             'build %s, %s warnings (with warnings treated as errors).',
+                             self._warncount)
+                else:
+                    msg = __('build %s, %s warning.',
+                             'build %s, %s warnings.',
+                             self._warncount)
+
+                logger.info(bold(msg % (status, self._warncount)))
             else:
                 logger.info(bold(__('build %s.') % status))
 


### PR DESCRIPTION
Subject: Make clear why build fails on CIs

### Feature or Bugfix
- Feature

### Purpose
- In our automated doc builds we run `-W --keep-going`. Contributors make doc errors that we rightfully treat as warnings. They are confused why the CircleCI build log says there were errors. This makes it clearer that "build finished with problems, 1 warning." is actually problematic, and that they should look to see what the warning is, since it's treated as an error.

### Detail
Changes:
```
build finished with problems, 1 warning.
```
To
```
build finished with problems, 1 warning (with warnings treated as errors).
```