### PR TITLE
Fix #6271: make clean is catastrophically broken if building into '.'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -68,6 +68,7 @@ Features added
 * #6232: Enable CLI override of Makefile variables
 * #6212 autosummary: Add :confval:`autosummary_imported_members` to display
   imported members on autosummary
+* #6271: ``make clean`` is catastrophically broken if building into '.'
 
 Bugs fixed
 ----------

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -72,10 +72,18 @@ class Make:
 
     def build_clean(self):
         # type: () -> int
+        srcdir = path.abspath(self.srcdir)
+        builddir = path.abspath(self.builddir)
         if not path.exists(self.builddir):
             return 0
         elif not path.isdir(self.builddir):
             print("Error: %r is not a directory!" % self.builddir)
+            return 1
+        elif srcdir == builddir:
+            print("Error: %r is same as source directory!" % self.builddir)
+            return 1
+        elif path.commonpath([srcdir, builddir]) == builddir:
+            print("Error: %r directory contains source directory!" % self.builddir)
             return 1
         print("Removing everything under %r..." % self.builddir)
         for item in os.listdir(self.builddir):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6271 
