### PR TITLE
 Add :classmethod: and :staticmethod: options to py:method directive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,8 @@ Features added
 * #6232: Enable CLI override of Makefile variables
 * #6212 autosummary: Add :confval:`autosummary_imported_members` to display
   imported members on autosummary
+* Add ``:classmethod:`` and ``:staticmethod:`` options to :rst:dir:`py:method`
+  directive
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -216,6 +216,13 @@ The following directives are provided for module and class contents:
    described for ``function``.  See also :ref:`signatures` and
    :ref:`info-field-lists`.
 
+   The ``classmethod`` option and ``staticmethod`` option can be given (with
+   no value) to indicate the method is a class method (or a static method).
+
+   .. versionchanged:: 2.1
+
+      ``:classmethod:`` and ``:staticmethod:`` options added.
+
 .. rst:directive:: .. py:staticmethod:: name(parameters)
 
    Like :rst:dir:`py:method`, but indicates that the method is a static method.

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -692,9 +692,9 @@ def test_autodoc_members(app):
     actual = do_autodoc(app, 'class', 'target.Base', options)
     assert list(filter(lambda l: '::' in l, actual)) == [
         '.. py:class:: Base',
-        '   .. py:classmethod:: Base.inheritedclassmeth()',
+        '   .. py:method:: Base.inheritedclassmeth()',
         '   .. py:method:: Base.inheritedmeth()',
-        '   .. py:staticmethod:: Base.inheritedstaticmeth(cls)'
+        '   .. py:method:: Base.inheritedstaticmeth(cls)'
     ]
 
     # default specific-members
@@ -703,7 +703,7 @@ def test_autodoc_members(app):
     assert list(filter(lambda l: '::' in l, actual)) == [
         '.. py:class:: Base',
         '   .. py:method:: Base.inheritedmeth()',
-        '   .. py:staticmethod:: Base.inheritedstaticmeth(cls)'
+        '   .. py:method:: Base.inheritedstaticmeth(cls)'
     ]
 
 
@@ -714,7 +714,7 @@ def test_autodoc_exclude_members(app):
     actual = do_autodoc(app, 'class', 'target.Base', options)
     assert list(filter(lambda l: '::' in l, actual)) == [
         '.. py:class:: Base',
-        '   .. py:classmethod:: Base.inheritedclassmeth()'
+        '   .. py:method:: Base.inheritedclassmeth()'
     ]
 
     # members vs exclude-members
@@ -742,9 +742,9 @@ def test_autodoc_undoc_members(app):
         '   .. py:attribute:: Class.inst_attr_string',
         '   .. py:attribute:: Class.mdocattr',
         '   .. py:method:: Class.meth()',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
         '   .. py:attribute:: Class.prop',
-        '   .. py:classmethod:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
+        '   .. py:method:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
         '   .. py:attribute:: Class.skipattr',
         '   .. py:method:: Class.skipmeth()',
         '   .. py:attribute:: Class.udocattr',
@@ -759,11 +759,11 @@ def test_autodoc_inherited_members(app):
     actual = do_autodoc(app, 'class', 'target.Class', options)
     assert list(filter(lambda l: 'method::' in l, actual)) == [
         '   .. py:method:: Class.excludemeth()',
-        '   .. py:classmethod:: Class.inheritedclassmeth()',
+        '   .. py:method:: Class.inheritedclassmeth()',
         '   .. py:method:: Class.inheritedmeth()',
-        '   .. py:staticmethod:: Class.inheritedstaticmeth(cls)',
+        '   .. py:method:: Class.inheritedstaticmeth(cls)',
         '   .. py:method:: Class.meth()',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
         '   .. py:method:: Class.skipmeth()'
     ]
 
@@ -822,9 +822,9 @@ def test_autodoc_special_members(app):
         '   .. py:attribute:: Class.inst_attr_string',
         '   .. py:attribute:: Class.mdocattr',
         '   .. py:method:: Class.meth()',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
         '   .. py:attribute:: Class.prop',
-        '   .. py:classmethod:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
+        '   .. py:method:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
         '   .. py:attribute:: Class.skipattr',
         '   .. py:method:: Class.skipmeth()',
         '   .. py:attribute:: Class.udocattr',
@@ -943,6 +943,34 @@ def test_autodoc_inner_class(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_classmethod(app):
+    actual = do_autodoc(app, 'method', 'target.Base.inheritedclassmeth')
+    assert list(actual) == [
+        '',
+        '.. py:method:: Base.inheritedclassmeth()',
+        '   :module: target',
+        '   :classmethod:',
+        '',
+        '   Inherited class method.',
+        '   '
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_staticmethod(app):
+    actual = do_autodoc(app, 'method', 'target.Base.inheritedstaticmeth')
+    assert list(actual) == [
+        '',
+        '.. py:method:: Base.inheritedstaticmeth(cls)',
+        '   :module: target',
+        '   :staticmethod:',
+        '',
+        '   Inherited static method.',
+        '   '
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_descriptor(app):
     actual = do_autodoc(app, 'attribute', 'target.Class.descr')
     assert list(actual) == [
@@ -991,8 +1019,8 @@ def test_autodoc_member_order(app):
         '   .. py:attribute:: Class.docattr',
         '   .. py:attribute:: Class.udocattr',
         '   .. py:attribute:: Class.mdocattr',
-        '   .. py:classmethod:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
         '   .. py:attribute:: Class.inst_attr_inline',
         '   .. py:attribute:: Class.inst_attr_comment',
         '   .. py:attribute:: Class.inst_attr_string',
@@ -1009,8 +1037,8 @@ def test_autodoc_member_order(app):
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.excludemeth()',
         '   .. py:method:: Class.meth()',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
-        '   .. py:classmethod:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
         '   .. py:method:: Class.skipmeth()',
         '   .. py:method:: Class.undocmeth()',
         '   .. py:attribute:: Class._private_inst_attr',
@@ -1043,9 +1071,9 @@ def test_autodoc_member_order(app):
         '   .. py:attribute:: Class.inst_attr_string',
         '   .. py:attribute:: Class.mdocattr',
         '   .. py:method:: Class.meth()',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
         '   .. py:attribute:: Class.prop',
-        '   .. py:classmethod:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
+        '   .. py:method:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
         '   .. py:attribute:: Class.skipattr',
         '   .. py:method:: Class.skipmeth()',
         '   .. py:attribute:: Class.udocattr',
@@ -1642,7 +1670,7 @@ def test_autodoc_default_options_with_values(app):
         '   .. py:attribute:: Class.docattr',
         '   .. py:attribute:: Class.udocattr',
         '   .. py:attribute:: Class.mdocattr',
-        '   .. py:classmethod:: Class.moore(a, e, f) -> happiness',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
         '   .. py:attribute:: Class.inst_attr_inline',
         '   .. py:attribute:: Class.inst_attr_comment',
         '   .. py:attribute:: Class.inst_attr_string',

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -315,25 +315,54 @@ def test_pyfunction(app):
     assert domain.objects['func'] == ('index', 'function')
 
 
-def test_pymethod(app):
+def test_pymethod_options(app):
     text = (".. py:class:: Class\n"
             "\n"
-            "   .. py:method:: meth\n")
+            "   .. py:method:: meth1\n"
+            "   .. py:method:: meth2\n"
+            "      :classmethod:\n"
+            "   .. py:method:: meth3\n"
+            "      :staticmethod:\n")
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_annotation, "class "],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
+                                                  desc,
+                                                  addnodes.index,
+                                                  desc,
+                                                  addnodes.index,
                                                   desc)])]))
 
+    # method
     assert_node(doctree[1][1][0], addnodes.index,
-                entries=[('single', 'meth() (Class method)', 'Class.meth', '', None)])
-    assert_node(doctree[1][1][1], ([desc_signature, ([desc_name, "meth"],
+                entries=[('single', 'meth1() (Class method)', 'Class.meth1', '', None)])
+    assert_node(doctree[1][1][1], ([desc_signature, ([desc_name, "meth1"],
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
-    assert 'Class.meth' in domain.objects
-    assert domain.objects['Class.meth'] == ('index', 'method')
+    assert 'Class.meth1' in domain.objects
+    assert domain.objects['Class.meth1'] == ('index', 'method')
+
+    # :classmethod:
+    assert_node(doctree[1][1][2], addnodes.index,
+                entries=[('single', 'meth2() (Class class method)', 'Class.meth2', '', None)])
+    assert_node(doctree[1][1][3], ([desc_signature, ([desc_annotation, "classmethod "],
+                                                     [desc_name, "meth2"],
+                                                     [desc_parameterlist, ()])],
+                                   [desc_content, ()]))
+    assert 'Class.meth2' in domain.objects
+    assert domain.objects['Class.meth2'] == ('index', 'method')
+
+    # :staticmethod:
+    assert_node(doctree[1][1][4], addnodes.index,
+                entries=[('single', 'meth3() (Class static method)', 'Class.meth3', '', None)])
+    assert_node(doctree[1][1][5], ([desc_signature, ([desc_annotation, "static "],
+                                                     [desc_name, "meth3"],
+                                                     [desc_parameterlist, ()])],
+                                   [desc_content, ()]))
+    assert 'Class.meth3' in domain.objects
+    assert domain.objects['Class.meth3'] == ('index', 'method')
 
 
 def test_pyclassmethod(app):
@@ -354,7 +383,7 @@ def test_pyclassmethod(app):
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
     assert 'Class.meth' in domain.objects
-    assert domain.objects['Class.meth'] == ('index', 'classmethod')
+    assert domain.objects['Class.meth'] == ('index', 'method')
 
 
 def test_pystaticmethod(app):
@@ -375,7 +404,7 @@ def test_pystaticmethod(app):
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
     assert 'Class.meth' in domain.objects
-    assert domain.objects['Class.meth'] == ('index', 'staticmethod')
+    assert domain.objects['Class.meth'] == ('index', 'method')
 
 
 def test_pyattribute(app):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Add :classmethod: and :staticmethod: options to py:method directive
- autodoc: Use new options for py:method directive
