### PR TITLE
C++, allow 8 and 9 in hexadecimal integer literals.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6286: C++, allow 8 and 9 in hexadecimal integer literals.
+
 Testing
 --------
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -292,7 +292,7 @@ logger = logging.getLogger(__name__)
 
 _integer_literal_re = re.compile(r'[1-9][0-9]*')
 _octal_literal_re = re.compile(r'0[0-7]*')
-_hex_literal_re = re.compile(r'0[xX][0-7a-fA-F][0-7a-fA-F]*')
+_hex_literal_re = re.compile(r'0[xX][0-9a-fA-F][0-9a-fA-F]*')
 _binary_literal_re = re.compile(r'0[bB][01][01]*')
 _integer_suffix_re = re.compile(r'')
 _float_literal_re = re.compile(r'''(?x)

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -114,7 +114,7 @@ def test_expressions():
     exprCheck('nullptr', 'LDnE')
     exprCheck('true', 'L1E')
     exprCheck('false', 'L0E')
-    ints = ['5', '0', '075', '0xF', '0XF', '0b1', '0B1']
+    ints = ['5', '0', '075', '0x0123456789ABCDEF', '0XF', '0b1', '0B1']
     unsignedSuffix = ['', 'u', 'U']
     longSuffix = ['', 'l', 'L', 'll', 'LL']
     for i in ints:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Fix a stupid copy-paste error in the regex for hex literals.

### Relates
- Fixes #6286.

