### PR TITLE
Fix #6299: rst:directive directive generates waste space

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,7 @@ Bugs fixed
   is consisted by non-ASCII characters
 * #6213: ifconfig: contents after headings are not shown
 * commented term in glossary directive is wrongly recognized
+* #6299: rst domain: rst:directive directive generates waste space
 
 Testing
 --------

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -80,7 +80,10 @@ def parse_directive(d):
     if not m:
         return (dir, '')
     parsed_dir, parsed_args = m.groups()
-    return (parsed_dir.strip(), ' ' + parsed_args.strip())
+    if parsed_args.strip():
+        return (parsed_dir.strip(), ' ' + parsed_args.strip())
+    else:
+        return (parsed_dir.strip(), '')
 
 
 class ReSTDirective(ReSTMarkup):

--- a/tests/test_domain_rst.py
+++ b/tests/test_domain_rst.py
@@ -23,7 +23,7 @@ def test_parse_directive():
     assert s == ('foö', '')
 
     s = parse_directive(' ..    foö ::  ')
-    assert s == ('foö', ' ')
+    assert s == ('foö', '')
 
     s = parse_directive('.. foö:: args1 args2')
     assert s == ('foö', ' args1 args2')
@@ -48,8 +48,7 @@ def test_rst_directive(app):
     text = ".. rst:directive:: .. toctree::"
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_name, ".. toctree::"],
-                                                    [desc_addname, " "])],
+                          [desc, ([desc_signature, desc_name, ".. toctree::"],
                                   [desc_content, ()])]))
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6299 