### PR TITLE
refactor: separate ReSTMarkup.get_index_text() to subclasses

### DIFF
--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -58,10 +58,6 @@ class ReSTMarkup(ObjectDescription):
 
     def get_index_text(self, objectname, name):
         # type: (str, str) -> str
-        if self.objtype == 'directive':
-            return _('%s (directive)') % name
-        elif self.objtype == 'role':
-            return _('%s (role)') % name
         return ''
 
 
@@ -96,6 +92,10 @@ class ReSTDirective(ReSTMarkup):
             signode += addnodes.desc_addname(args, args)
         return name
 
+    def get_index_text(self, objectname, name):
+        # type: (str, str) -> str
+        return _('%s (directive)') % name
+
 
 class ReSTRole(ReSTMarkup):
     """
@@ -105,6 +105,10 @@ class ReSTRole(ReSTMarkup):
         # type: (str, addnodes.desc_signature) -> str
         signode += addnodes.desc_name(':%s:' % sig, ':%s:' % sig)
         return sig
+
+    def get_index_text(self, objectname, name):
+        # type: (str, str) -> str
+        return _('%s (role)') % name
 
 
 class ReSTDomain(Domain):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
According to the principle, the parent class; ReSTMarkup should not
know about children.
