### PR TITLE
Partially revert #6232, synchronize new Makefile with old (refs: #4092)

### DIFF
--- a/sphinx/templates/quickstart/Makefile.new_t
+++ b/sphinx/templates/quickstart/Makefile.new_t
@@ -1,14 +1,12 @@
 # Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line.  For example:
-#     SPHINXOPTS='-E -W -n' make html
-# will run the html builder in a clean environment (-E), treating warnings
-# as errors (-W), in nitpicky mode (-n).
+# You can set these variables from the command line, and also
+# from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     ?= {{ rsrcdir }}
-BUILDDIR      ?= {{ rbuilddir }}
+SOURCEDIR     = {{ rsrcdir }}
+BUILDDIR      = {{ rbuilddir }}
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION

### Relates
- #6232, #4092, discussion at #1368 

At #4092 it was decided to use ``?=`` for old Makefile and ``SPHINXOPTS`` and ``SPHINXBUILD``. So these variables can be overriden not only from command line but from environment. I have some doubts about whether this was good idea (as command line override of Makefile variables is already available), but Sphinx shipped with it for some time now.

The present patch keeps the ``?=`` of #6232 only for these two variables, and of course it keeps the needed blank line at end of the template (else generated Makefiles have no final EOL).

