### PR TITLE
Fix the string in quickstart for 'path' argument of parser

### DIFF
--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -510,7 +510,7 @@ Makefile to be used with sphinx-build.
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('path', metavar='PROJECT_DIR', default='.', nargs='?',
-                        help=__('output path'))
+                        help=__('project root'))
 
     group = parser.add_argument_group(__('Structure options'))
     group.add_argument('--sep', action='store_true', default=None,


### PR DESCRIPTION
I noticed that doing ``sphinx-quickstart --help`` produced

```
positional arguments:
  PROJECT_DIR           répertoire de sortie
```

in French translation, but checking the sphinx.po file I saw that problem was in original string which looked as `output path`. This appears to be wrong. This variable refers to the project root.

This is same as #6304 but with the correct branch in my fork of main repo...