### PR TITLE
Add a label to search input for accessability purposes

### DIFF
--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -9,10 +9,10 @@
 #}
 {%- if pagename != "search" and builder != "singlehtml" %}
 <div id="searchbox" style="display: none" role="search">
-  <h3>{{ _('Quick search') }}</h3>
+  <h3 id="searchlabel">{{ _('Quick search') }}</h3>
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" />
+      <input type="text" name="q" aria-labelledby="searchlabel" />
       <input type="submit" value="{{ _('Go') }}" />
     </form>
     </div>

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1338,7 +1338,7 @@ def test_html_sidebar(app, status, warning):
     assert '<h1 class="logo"><a href="#">Python</a></h1>' in result
     assert '<h3>Navigation</h3>' in result
     assert '<h3>Related Topics</h3>' in result
-    assert '<h3>Quick search</h3>' in result
+    assert '<h3 id="searchlabel">Quick search</h3>' in result
 
     app.builder.add_sidebars('index', ctx)
     assert ctx['sidebars'] == ['about.html', 'navigation.html', 'relations.html',
@@ -1353,7 +1353,7 @@ def test_html_sidebar(app, status, warning):
     assert '<h1 class="logo"><a href="#">Python</a></h1>' not in result
     assert '<h3>Navigation</h3>' not in result
     assert '<h3>Related Topics</h3>' in result
-    assert '<h3>Quick search</h3>' not in result
+    assert '<h3 id="searchlabel">Quick search</h3>' not in result
 
     app.builder.add_sidebars('index', ctx)
     assert ctx['sidebars'] == ['relations.html']
@@ -1367,7 +1367,7 @@ def test_html_sidebar(app, status, warning):
     assert '<h1 class="logo"><a href="#">Python</a></h1>' not in result
     assert '<h3>Navigation</h3>' not in result
     assert '<h3>Related Topics</h3>' not in result
-    assert '<h3>Quick search</h3>' not in result
+    assert '<h3 id="searchlabel">Quick search</h3>' not in result
 
     app.builder.add_sidebars('index', ctx)
     assert ctx['sidebars'] == []

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -126,4 +126,4 @@ def test_theme_sidebars(app, status, warning):
     assert '<h3><a href="#">Table of Contents</a></h3>' in result
     assert '<h3>Related Topics</h3>' not in result
     assert '<h3>This Page</h3>' not in result
-    assert '<h3>Quick search</h3>' in result
+    assert '<h3 id="searchlabel">Quick search</h3>' in result


### PR DESCRIPTION
Subject: Improve accessibility of the quick search box

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
Accessibility is important. Those with screen readers should be made aware that this is the quick search input.

### Detail
I just added an id to the "Quick Search" header and pointed the ARIA attribute to use that as a description.

### Relates
None