### PR TITLE
imgmath: Use template file for LaTeX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,9 @@ Deprecated
 * ``sphinx.ext.autodoc.importer.MockLoader``
 * ``sphinx.ext.autodoc.importer.mock()``
 * ``sphinx.ext.autosummary.autolink_role()``
+* ``sphinx.ext.imgmath.DOC_BODY``
+* ``sphinx.ext.imgmath.DOC_BODY_PREVIEW``
+* ``sphinx.ext.imgmath.DOC_HEAD``
 * ``sphinx.transforms.CitationReferences``
 * ``sphinx.transforms.SmartQuotesSkipper``
 * ``sphinx.util.docfields.DocFieldTransformer.preprocess_fieldtypes()``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -177,6 +177,21 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``sphinx.ext.autosummary.AutoLink``
 
+   * - ``sphinx.ext.imgmath.DOC_BODY``
+     - 2.1
+     - 4.0
+     - N/A
+
+   * - ``sphinx.ext.imgmath.DOC_BODY_PREVIEW``
+     - 2.1
+     - 4.0
+     - N/A
+
+   * - ``sphinx.ext.imgmath.DOC_HEAD``
+     - 2.1
+     - 4.0
+     - N/A
+
    * - ``sphinx.transforms.CitationReferences``
      - 2.1
      - 4.0

--- a/sphinx/templates/imgmath/preview.tex_t
+++ b/sphinx/templates/imgmath/preview.tex_t
@@ -1,0 +1,18 @@
+\documentclass[12pt]{article}
+\usepackage[utf8x]{inputenc}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{amssymb}
+\usepackage{amsfonts}
+\usepackage{anyfontsize}
+\usepackage{bm}
+\pagestyle{empty}
+<%= preamble %>
+
+\usepackage[active]{preview}
+
+\begin{document}
+\begin{preview}
+\fontsize{<%= fontsize %>}{<%= baselineskip %}}\selectfont <%= math %>
+\end{preview}
+\end{document}

--- a/sphinx/templates/imgmath/template.tex_t
+++ b/sphinx/templates/imgmath/template.tex_t
@@ -1,0 +1,14 @@
+\documentclass[12pt]{article}
+\usepackage[utf8x]{inputenc}
+\usepackage{amsmath}
+\usepackage{amsthm}
+\usepackage{amssymb}
+\usepackage{amsfonts}
+\usepackage{anyfontsize}
+\usepackage{bm}
+\pagestyle{empty}
+<%= preamble %>
+
+\begin{document}
+\fontsize{<%= fontsize %>}{<%= baselineskip %>}\selectfont <%= math %>
+\end{document}

--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -67,9 +67,10 @@ class SphinxRenderer(FileRenderer):
 
 
 class LaTeXRenderer(SphinxRenderer):
-    def __init__(self):
-        # type: () -> None
-        template_path = os.path.join(package_dir, 'templates', 'latex')
+    def __init__(self, template_path=None):
+        # type: (str) -> None
+        if template_path is None:
+            template_path = os.path.join(package_dir, 'templates', 'latex')
         super().__init__(template_path)
 
         # use texescape as escape filter


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Before modifying imgmath, this starts to use template file to generate LaTeX source.
- It makes imgmath module simple.