### PR TITLE
Make imgmath_use_preview work also for svg output

### DIFF
--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -95,19 +95,17 @@ built:
 
 .. confval:: imgmath_use_preview
 
-   ``dvipng`` has the ability to determine the "depth" of the rendered text: for
-   example, when typesetting a fraction inline, the baseline of surrounding text
-   should not be flush with the bottom of the image, rather the image should
-   extend a bit below the baseline.  This is what TeX calls "depth".  When this
-   is enabled, the images put into the HTML document will get a
-   ``vertical-align`` style that correctly aligns the baselines.
+   ``dvipng`` and ``dvisvgm`` have the ability to collect from LaTeX the
+   "depth" of the rendered text: an inline image should use this "depth" in a
+   ``vertical-align`` style to be correctly aligned with surrounding text.
 
-   Unfortunately, this only works when the `preview-latex package`_ is
-   installed. Therefore, the default for this option is ``False``.
+   This mechanism requires the `LaTeX preview package`_ (available as
+   ``preview-latex-style`` on Ubuntu xenial).  Therefore, the default for this
+   option is ``False`` but it is strongly recommended to set it to ``True``.
 
-   .. versionchanged:: 2.1.0
+   .. versionchanged:: 2.1
 
-      This option can also be used with ``imgmath_image_format`` set to ``'svg'``.
+      This option can be used with the ``'svg'`` :confval:`imgmath_image_format`.
 
 .. confval:: imgmath_add_tooltips
 
@@ -221,4 +219,4 @@ package jsMath_.  It provides this config value:
 .. _dvisvgm: http://dvisvgm.bplaced.net/
 .. _MathJax: https://www.mathjax.org/
 .. _jsMath: http://www.math.union.edu/~dpvc/jsmath/
-.. _preview-latex package: https://www.gnu.org/software/auctex/preview-latex.html
+.. _LaTeX preview package: https://www.gnu.org/software/auctex/preview-latex.html

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -105,8 +105,9 @@ built:
    Unfortunately, this only works when the `preview-latex package`_ is
    installed. Therefore, the default for this option is ``False``.
 
-   Currently this option is only used when ``imgmath_image_format`` is
-   ``'png'``.
+   .. versionchanged:: 2.1.0
+
+      This option can also be used with ``imgmath_image_format`` set to ``'svg'``.
 
 .. confval:: imgmath_add_tooltips
 

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -30,74 +30,21 @@ This extension renders math via LaTeX and dvipng_ or dvisvgm_ into PNG or SVG
 images. This of course means that the computer where the docs are built must
 have both programs available.
 
-There are various config values you can set to influence how the images are
-built:
+There are various configuration values you can set to influence how the images
+are built:
 
 .. confval:: imgmath_image_format
 
-   The output image format. The default is ``'png'``.  It should be either
-   ``'png'`` or ``'svg'``.
-
-.. confval:: imgmath_latex
-
-   The command name with which to invoke LaTeX.  The default is ``'latex'``; you
-   may need to set this to a full path if ``latex`` is not in the executable
-   search path.
-
-   Since this setting is not portable from system to system, it is normally not
-   useful to set it in ``conf.py``; rather, giving it on the
-   :program:`sphinx-build` command line via the :option:`-D <sphinx-build -D>`
-   option should be preferable, like this::
-
-      sphinx-build -b html -D imgmath_latex=C:\tex\latex.exe . _build/html
-
-   This value should only contain the path to the latex executable, not further
-   arguments; use :confval:`imgmath_latex_args` for that purpose.
-
-.. confval:: imgmath_dvipng
-
-   The command name with which to invoke ``dvipng``.  The default is
-   ``'dvipng'``; you may need to set this to a full path if ``dvipng`` is not in
-   the executable search path. This option is only used when
-   ``imgmath_image_format`` is set to ``'png'``.
-
-.. confval:: imgmath_dvisvgm
-
-   The command name with which to invoke ``dvisvgm``.  The default is
-   ``'dvisvgm'``; you may need to set this to a full path if ``dvisvgm`` is not
-   in the executable search path.  This option is only used when
-   ``imgmath_image_format`` is ``'svg'``.
-
-.. confval:: imgmath_latex_args
-
-   Additional arguments to give to latex, as a list.  The default is an empty
-   list.
-
-.. confval:: imgmath_latex_preamble
-
-   Additional LaTeX code to put into the preamble of the short LaTeX files that
-   are used to translate the math snippets.  This is empty by default.  Use it
-   e.g. to add more packages whose commands you want to use in the math.
-
-.. confval:: imgmath_dvipng_args
-
-   Additional arguments to give to dvipng, as a list.  The default value is
-   ``['-gamma', '1.5', '-D', '110', '-bg', 'Transparent']`` which makes the
-   image a bit darker and larger then it is by default, and produces PNGs with a
-   transparent background.  This option is used only when
-   ``imgmath_image_format`` is ``'png'``.
-
-.. confval:: imgmath_dvisvgm_args
-
-   Additional arguments to give to dvisvgm, as a list.  The default value is
-   ``['--no-fonts']``.  This option is used only when ``imgmath_image_format``
-   is ``'svg'``.
+   The output image format. The default is ``'png'``. It should be either
+   ``'png'`` or ``'svg'``. The image is produced by first executing ``latex``
+   on the TeX mathematical mark-up then (depending on the requested format)
+   either `dvipng`_ or `dvisvgm`_.
 
 .. confval:: imgmath_use_preview
 
-   ``dvipng`` and ``dvisvgm`` have the ability to collect from LaTeX the
-   "depth" of the rendered text: an inline image should use this "depth" in a
-   ``vertical-align`` style to be correctly aligned with surrounding text.
+   ``dvipng`` and ``dvisvgm`` both have the ability to collect from LaTeX the
+   "depth" of the rendered math: an inline image should use this "depth" in a
+   ``vertical-align`` style to get correctly aligned with surrounding text.
 
    This mechanism requires the `LaTeX preview package`_ (available as
    ``preview-latex-style`` on Ubuntu xenial).  Therefore, the default for this
@@ -116,6 +63,67 @@ built:
 
    The font size (in ``pt``) of the displayed math.  The default value is
    ``12``.  It must be a positive integer.
+
+.. confval:: imgmath_latex
+
+   The command name with which to invoke LaTeX.  The default is ``'latex'``; you
+   may need to set this to a full path if ``latex`` is not in the executable
+   search path.
+
+   Since this setting is not portable from system to system, it is normally not
+   useful to set it in ``conf.py``; rather, giving it on the
+   :program:`sphinx-build` command line via the :option:`-D <sphinx-build -D>`
+   option should be preferable, like this::
+
+      sphinx-build -b html -D imgmath_latex=C:\tex\latex.exe . _build/html
+
+   This value should only contain the path to the latex executable, not further
+   arguments; use :confval:`imgmath_latex_args` for that purpose.
+
+.. confval:: imgmath_latex_args
+
+   Additional arguments to give to latex, as a list.  The default is an empty
+   list.
+
+.. confval:: imgmath_latex_preamble
+
+   Additional LaTeX code to put into the preamble of the LaTeX files used to
+   translate the math snippets.  This is left empty by default.  Use it
+   e.g. to add packages which modify the fonts used for math, such as
+   ``'\\usepackage{newtxsf}'`` for sans-serif fonts, or
+   ``'\\usepackage{fouriernc}'`` for serif fonts.  Indeed, the default LaTeX
+   math fonts have rather thin glyphs which (in HTML output) often do not
+   match well with the font for text.
+
+.. confval:: imgmath_dvipng
+
+   The command name to invoke ``dvipng``.  The default is
+   ``'dvipng'``; you may need to set this to a full path if ``dvipng`` is not in
+   the executable search path. This option is only used when
+   ``imgmath_image_format`` is set to ``'png'``.
+
+.. confval:: imgmath_dvipng_args
+
+   Additional arguments to give to dvipng, as a list.  The default value is
+   ``['-gamma', '1.5', '-D', '110', '-bg', 'Transparent']`` which makes the
+   image a bit darker and larger then it is by default (this compensates
+   somewhat for the thinness of default LaTeX math fonts), and produces PNGs with a
+   transparent background.  This option is used only when
+   ``imgmath_image_format`` is ``'png'``.
+
+.. confval:: imgmath_dvisvgm
+
+   The command name to invoke ``dvisvgm``.  The default is
+   ``'dvisvgm'``; you may need to set this to a full path if ``dvisvgm`` is not
+   in the executable search path.  This option is only used when
+   ``imgmath_image_format`` is ``'svg'``.
+
+.. confval:: imgmath_dvisvgm_args
+
+   Additional arguments to give to dvisvgm, as a list. The default value is
+   ``['--no-fonts']``, which means that ``dvisvgm`` will render glyphs as path
+   elements (cf the `dvisvgm FAQ`_). This option is used only when
+   ``imgmath_image_format`` is ``'svg'``.
 
 
 :mod:`sphinx.ext.mathjax` -- Render math via JavaScript
@@ -216,7 +224,8 @@ package jsMath_.  It provides this config value:
 
 
 .. _dvipng: https://savannah.nongnu.org/projects/dvipng/
-.. _dvisvgm: http://dvisvgm.bplaced.net/
+.. _dvisvgm: https://dvisvgm.de/
+.. _dvisvgm FAQ: https://dvisvgm.de/FAQ
 .. _MathJax: https://www.mathjax.org/
 .. _jsMath: http://www.math.union.edu/~dpvc/jsmath/
 .. _LaTeX preview package: https://www.gnu.org/software/auctex/preview-latex.html

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -91,6 +91,7 @@ DOC_BODY_PREVIEW = r'''
 
 depth_re = re.compile(br'\[\d+ depth=(-?\d+)\]')
 depthsvg_re = re.compile(br'.*, depth=(.*)pt')
+depthsvgcomment_re = re.compile(r'<!-- DEPTH=(-?\d+) -->')
 
 
 def read_svg_depth(filename):
@@ -100,7 +101,11 @@ def read_svg_depth(filename):
     with open(filename, 'r') as f:
         for line in f:
             pass
-        return int(line[11:-4])
+        # Only last line is checked
+        matched = depthsvgcomment_re.match(line)
+        if matched:
+            return int(matched.group(1))
+        return None
 
 
 def write_svg_depth(filename, depth):

--- a/sphinx/templates/imgmath/preview.tex_t
+++ b/sphinx/templates/imgmath/preview.tex_t
@@ -9,7 +9,7 @@
 \pagestyle{empty}
 <%= preamble %>
 
-\usepackage[active]{preview}
+\usepackage[active<%= tightpage %>]{preview}
 
 \begin{document}
 \begin{preview}


### PR DESCRIPTION
Currently, inline mathematics in svg format is not well aligned with surrounding text.

This PR improves the situation.

Relates: #5301