### PR TITLE
 Add line numbers in ``sphinx.ext.viewdoc``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,9 @@ Features added
   in many more places.
 * #5474: coverage: Print summary statistics tables.
   Patch by Jorge Leitao.
+* #6319: viewcode: Add :confval:`viewcode_line_numbers` to control
+  whether line numbers are added to rendered source code.
+  Patch by Ben Krikler.
 
 Bugs fixed
 ----------

--- a/doc/usage/extensions/viewcode.rst
+++ b/doc/usage/extensions/viewcode.rst
@@ -72,6 +72,7 @@ Configuration
       Some reader's rendering result are corrupted and
       `epubcheck <https://github.com/IDPF/epubcheck>`_'s score
       becomes worse even if the reader supports.
+
 .. confval:: viewcode_line_numbers
 
    Default: ``False``.

--- a/doc/usage/extensions/viewcode.rst
+++ b/doc/usage/extensions/viewcode.rst
@@ -72,6 +72,13 @@ Configuration
       Some reader's rendering result are corrupted and
       `epubcheck <https://github.com/IDPF/epubcheck>`_'s score
       becomes worse even if the reader supports.
+.. confval:: viewcode_line_numbers
+
+   Default: ``False``.
+
+   If set to ``True``, inline line numbers will be added to the highlighted code.
+
+   .. versionadded:: 7.2
 
 .. event:: viewcode-find-source (app, modname)
 

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -253,7 +253,7 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
             lexer = env.config.highlight_language
         else:
             lexer = 'python'
-        linenos = 'inline' * env.config.viewcode_linenumbers
+        linenos = 'inline' * env.config.viewcode_line_numbers
         highlighted = highlighter.highlight_block(code, lexer, linenos=linenos)
         lines = highlighted.splitlines()
         # split off wrap markup from the first line of the actual code
@@ -267,7 +267,7 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
             lines[start] = (
                 '<a class="viewcode-block viewcode-back" ' +
-                'id="%s" href="%s">%s</a>' % (name, backlink, _('[docs]')) +
+                f'id="{name}" href="{backlink}">{_("[docs]")}</a>\n' +
                 lines[start])
 
         # try to find parents (for submodules)
@@ -325,7 +325,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value('viewcode_import', None, False)
     app.add_config_value('viewcode_enable_epub', False, False)
     app.add_config_value('viewcode_follow_imported_members', True, False)
-    app.add_config_value('viewcode_linenumbers', False, 'env', (bool,))
+    app.add_config_value('viewcode_line_numbers', False, 'env', (bool,))
     app.connect('doctree-read', doctree_read)
     app.connect('env-merge-info', env_merge_info)
     app.connect('env-purge-doc', env_purge_doc)

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -350,7 +350,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value('viewcode_import', None, False)
     app.add_config_value('viewcode_enable_epub', False, False)
     app.add_config_value('viewcode_follow_imported_members', True, False)
-    app.add_config_value('viewcode_linenumbers', False, False)
+    app.add_config_value('viewcode_linenumbers', False, 'env')
     app.connect('doctree-read', doctree_read)
     app.connect('env-merge-info', env_merge_info)
     app.connect('env-purge-doc', env_purge_doc)

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -268,9 +268,9 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
         for name, docname in used.items():
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
-            lines[start] = (
-                    f'<div class="viewcode-block" id="{name}">\n'
-                    f'<a class="viewcode-back" href="{backlink}">{_("[docs]")}</a>\n' + lines[start])
+            lines[start] = (f'<div class="viewcode-block" id="{name}">\n'
+                            f'<a class="viewcode-back" href="{backlink}">{_("[docs]")}</a>\n'
+                            + lines[start])
             lines[min(end, max_index)] += '</div>\n'
 
         # try to find parents (for submodules)

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -255,6 +255,7 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
             lexer = 'python'
         linenos = 'inline' * env.config.viewcode_line_numbers
         highlighted = highlighter.highlight_block(code, lexer, linenos=linenos)
+        # split the code into lines
         lines = highlighted.splitlines()
         # split off wrap markup from the first line of the actual code
         before, after = lines[0].split('<pre>')

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -265,11 +265,12 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
         # the collected tags (HACK: this only works if the tag boundaries are
         # properly nested!)
         max_index = len(lines) - 1
+        link_text = _('[docs]')
         for name, docname in used.items():
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
             lines[start] = (f'<div class="viewcode-block" id="{name}">\n'
-                            f'<a class="viewcode-back" href="{backlink}">{_("[docs]")}</a>\n'
+                            f'<a class="viewcode-back" href="{backlink}">{link_text}</a>\n'
                             + lines[start])
             lines[min(end, max_index)] += '</div>\n'
 

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -203,7 +203,7 @@ def get_module_filename(app: Sphinx, modname: str) -> str | None:
             return None
 
 
-def split_code_lines(lines):
+def split_code_lines(lines: list[str]) -> tuple[list[str], list[str], list[str]]:
     end_header_string = 'td class="code">'
     header = []
     for i, line in enumerate(lines):

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -281,9 +281,7 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
         lines[0:1] = [before + '<pre>', after]
         # nothing to do for the last line; it always starts with </pre> anyway
         # now that we have code lines (starting at index 1), insert anchors for
-        # the collected tags (HACK: this only works if the tag boundaries are
-        # properly nested!)
-        maxindex = len(lines) - 1
+        # the collected tags
         for name, docname in used.items():
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -288,7 +288,7 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
             lines[start] = (
-                '<a class="viewcode-block viewcode-back"' +
+                '<a class="viewcode-block viewcode-back" ' +
                 'id="%s" href="%s">%s</a>' % (name, backlink, _('[docs]')) +
                 lines[start])
 

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -262,14 +262,16 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
         lines[0:1] = [before + '<pre>', after]
         # nothing to do for the last line; it always starts with </pre> anyway
         # now that we have code lines (starting at index 1), insert anchors for
-        # the collected tags
+        # the collected tags (HACK: this only works if the tag boundaries are
+        # properly nested!)
+        max_index = len(lines) - 1
         for name, docname in used.items():
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
             lines[start] = (
-                '<a class="viewcode-block viewcode-back" ' +
-                f'id="{name}" href="{backlink}">{_("[docs]")}</a>\n' +
-                lines[start])
+                    f'<div class="viewcode-block" id="{name}">\n'
+                    f'<a class="viewcode-back" href="{backlink}">{_("[docs]")}</a>\n' + lines[start])
+            lines[min(end, max_index)] += '</div>\n'
 
         # try to find parents (for submodules)
         parents = []

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -203,6 +203,22 @@ def get_module_filename(app: Sphinx, modname: str) -> str | None:
             return None
 
 
+def split_code_lines(lines):
+    end_header_string = 'td class="code">'
+    header = []
+    for i, line in enumerate(lines):
+        if end_header_string in line:
+            last_header_index = i
+            last_header_line = line
+            break
+        header.append(line)
+    last_header, first_line = last_header_line.split(end_header_string)
+    header.append(last_header + end_header_string)
+    footer = lines[-1:]
+    lines = [first_line] + lines[last_header_index + 1:-1]
+    return header, lines, footer
+
+
 def should_generate_module_page(app: Sphinx, modname: str) -> bool:
     """Check generation of module page is needed."""
     module_filename = get_module_filename(app, modname)
@@ -253,9 +269,13 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
             lexer = env.config.highlight_language
         else:
             lexer = 'python'
-        highlighted = highlighter.highlight_block(code, lexer, linenos=False)
-        # split the code into lines
+        linenos = env.config.viewcode_linenumbers
+        highlighted = highlighter.highlight_block(code, lexer, linenos=linenos)
         lines = highlighted.splitlines()
+        if linenos:
+            # If we're including line numbers, need to split out the actual
+            # code lines in the html from the line numbering
+            header, lines, footer = split_code_lines(lines)
         # split off wrap markup from the first line of the actual code
         before, after = lines[0].split('<pre>')
         lines[0:1] = [before + '<pre>', after]
@@ -268,10 +288,13 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
             lines[start] = (
-                '<div class="viewcode-block" id="%s"><a class="viewcode-back" '
-                'href="%s">%s</a>' % (name, backlink, _('[docs]')) +
+                '<a class="viewcode-block viewcode-back"' +
+                'id="%s" href="%s">%s</a>' % (name, backlink, _('[docs]')) +
                 lines[start])
-            lines[min(end, maxindex)] += '</div>'
+
+        if linenos:
+            lines = header + lines + footer
+
         # try to find parents (for submodules)
         parents = []
         parent = modname
@@ -327,6 +350,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value('viewcode_import', None, False)
     app.add_config_value('viewcode_enable_epub', False, False)
     app.add_config_value('viewcode_follow_imported_members', True, False)
+    app.add_config_value('viewcode_linenumbers', False, False)
     app.connect('doctree-read', doctree_read)
     app.connect('env-merge-info', env_merge_info)
     app.connect('env-purge-doc', env_purge_doc)

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -32,8 +32,8 @@ def check_viewcode_output(app, status, warning):
 
     result = (app.outdir / '_modules/spam/mod1.html').read_text(encoding='utf8')
     result = re.sub('<span class="[^"]{,2}">', '<span>', result)  # filter pygments classes
-    assert ('<a class="viewcode-block viewcode-back" id="Class1" '
-            'href="../../index.html#spam.Class1">[docs]</a>\n') in result
+    assert ('<div class="viewcode-block" id="Class1">\n'
+            '<a class="viewcode-back" href="../../index.html#spam.Class1">[docs]</a>\n') in result
     assert '<span>@decorator</span>\n' in result
     assert '<span>class</span> <span>Class1</span><span>:</span>\n' in result
     if pygments.__version__ >= '2.14.0':

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -39,7 +39,7 @@ def check_viewcode_output(app, status, warning):
     if pygments.__version__ >= '2.14.0':
         assert '<span>    </span><span>&quot;&quot;&quot;</span>\n' in result
     else:
-        assert '    <span>&quot;&quot;&quot;</span>\n'  in result
+        assert '    <span>&quot;&quot;&quot;</span>\n' in result
     assert '<span>    this is Class1</span>\n' in result
     assert '<span>    &quot;&quot;&quot;</span>\n' in result
 

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -31,33 +31,30 @@ def check_viewcode_output(app, status, warning):
     assert result.count('this is the class attribute class_attr') == 2
 
     result = (app.outdir / '_modules/spam/mod1.html').read_text(encoding='utf8')
-    result = re.sub('<span class=".*?">', '<span>', result)  # filter pygments classes
+    result = re.sub('<span class="[^"]{,2}">', '<span>', result)  # filter pygments classes
+    assert ('<a class="viewcode-block viewcode-back" id="Class1" '
+            'href="../../index.html#spam.Class1">[docs]</a>\n') in result
+    assert '<span>@decorator</span>\n' in result
+    assert '<span>class</span> <span>Class1</span><span>:</span>\n' in result
     if pygments.__version__ >= '2.14.0':
-        assert ('<a class="viewcode-block viewcode-back" '
-                'id="Class1" href="../../index.html#spam.Class1">[docs]</a>'
-                '<span>@decorator</span>\n'
-                '<span>class</span> <span>Class1</span><span>:</span>\n'
-                '<span>    </span><span>&quot;&quot;&quot;</span>\n'
-                '<span>    this is Class1</span>\n'
-                '<span>    &quot;&quot;&quot;</span></div>\n') in result
+        assert '<span>    </span><span>&quot;&quot;&quot;</span>\n' in result
     else:
-        assert ('<div class="viewcode-block" id="Class1"><a class="viewcode-back" '
-                'href="../../index.html#spam.Class1">[docs]</a>'
-                '<span>@decorator</span>\n'
-                '<span>class</span> <span>Class1</span><span>:</span>\n'
-                '    <span>&quot;&quot;&quot;</span>\n'
-                '<span>    this is Class1</span>\n'
-                '<span>    &quot;&quot;&quot;</span>\n') in result
+        assert '    <span>&quot;&quot;&quot;</span>\n'  in result
+    assert '<span>    this is Class1</span>\n' in result
+    assert '<span>    &quot;&quot;&quot;</span>\n' in result
+
     return result
 
 
-@pytest.mark.sphinx(testroot='ext-viewcode', confoverrides={"viewcode_linenumbers": True}, freshenv=True)
+@pytest.mark.sphinx(testroot='ext-viewcode', freshenv=True,
+                    confoverrides={"viewcode_line_numbers": True})
 def test_viewcode_linenos(app, status, warning):
     result = check_viewcode_output(app, status, warning)
-    assert '<table class="highlighttable"><tr><td class="linenos">' in result
+    assert '<span class="linenos"> 1</span>' in result
 
 
-@pytest.mark.sphinx(testroot='ext-viewcode', confoverrides={"viewcode_linenumbers": False}, freshenv=True)
+@pytest.mark.sphinx(testroot='ext-viewcode', freshenv=True,
+                    confoverrides={"viewcode_line_numbers": False})
 def test_viewcode(app, status, warning):
     result = check_viewcode_output(app, status, warning)
     assert 'class="linenos">' not in result

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -34,8 +34,8 @@ def test_viewcode(app, status, warning):
     result = (app.outdir / '_modules/spam/mod1.html').read_text(encoding='utf8')
     result = re.sub('<span class=".*?">', '<span>', result)  # filter pygments classes
     if pygments.__version__ >= '2.14.0':
-        assert ('<div class="viewcode-block" id="Class1"><a class="viewcode-back" '
-                'href="../../index.html#spam.Class1">[docs]</a>'
+        assert ('<a class="viewcode-block viewcode-back" '
+                'id="Class1" href="../../index.html#spam.Class1">[docs]</a>'
                 '<span>@decorator</span>\n'
                 '<span>class</span> <span>Class1</span><span>:</span>\n'
                 '<span>    </span><span>&quot;&quot;&quot;</span>\n'
@@ -48,7 +48,7 @@ def test_viewcode(app, status, warning):
                 '<span>class</span> <span>Class1</span><span>:</span>\n'
                 '    <span>&quot;&quot;&quot;</span>\n'
                 '<span>    this is Class1</span>\n'
-                '<span>    &quot;&quot;&quot;</span></div>\n') in result
+                '<span>    &quot;&quot;&quot;</span>\n') in result
 
 
 @pytest.mark.sphinx('epub', testroot='ext-viewcode')

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -7,9 +7,7 @@ import pygments
 import pytest
 
 
-def check_viewcode_output(app, status, warning):
-    app.builder.build_all()
-
+def check_viewcode_output(app, warning):
     warnings = re.sub(r'\\+', '/', warning.getvalue())
     assert re.findall(
         r"index.rst:\d+: WARNING: Object named 'func1' not found in include " +
@@ -48,15 +46,21 @@ def check_viewcode_output(app, status, warning):
 
 @pytest.mark.sphinx(testroot='ext-viewcode', freshenv=True,
                     confoverrides={"viewcode_line_numbers": True})
-def test_viewcode_linenos(app, status, warning):
-    result = check_viewcode_output(app, status, warning)
+def test_viewcode_linenos(app, warning):
+    shutil.rmtree(app.outdir / '_modules', ignore_errors=True)
+    app.builder.build_all()
+
+    result = check_viewcode_output(app, warning)
     assert '<span class="linenos"> 1</span>' in result
 
 
 @pytest.mark.sphinx(testroot='ext-viewcode', freshenv=True,
                     confoverrides={"viewcode_line_numbers": False})
-def test_viewcode(app, status, warning):
-    result = check_viewcode_output(app, status, warning)
+def test_viewcode(app, warning):
+    shutil.rmtree(app.outdir / '_modules', ignore_errors=True)
+    app.builder.build_all()
+
+    result = check_viewcode_output(app, warning)
     assert 'class="linenos">' not in result
 
 

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -7,8 +7,7 @@ import pygments
 import pytest
 
 
-@pytest.mark.sphinx(testroot='ext-viewcode', freshenv=True)
-def test_viewcode(app, status, warning):
+def check_viewcode_output(app, status, warning):
     app.builder.build_all()
 
     warnings = re.sub(r'\\+', '/', warning.getvalue())
@@ -49,6 +48,19 @@ def test_viewcode(app, status, warning):
                 '    <span>&quot;&quot;&quot;</span>\n'
                 '<span>    this is Class1</span>\n'
                 '<span>    &quot;&quot;&quot;</span>\n') in result
+    return result
+
+
+@pytest.mark.sphinx(testroot='ext-viewcode', confoverrides={"viewcode_linenumbers": True}, freshenv=True)
+def test_viewcode_linenos(app, status, warning):
+    result = check_viewcode_output(app, status, warning)
+    assert '<table class="highlighttable"><tr><td class="linenos">' in result
+
+
+@pytest.mark.sphinx(testroot='ext-viewcode', confoverrides={"viewcode_linenumbers": False}, freshenv=True)
+def test_viewcode(app, status, warning):
+    result = check_viewcode_output(app, status, warning)
+    assert 'class="linenos">' not in result
 
 
 @pytest.mark.sphinx('epub', testroot='ext-viewcode')


### PR DESCRIPTION
Subject: Add an option to the viewcode extension to include line-numbering in the output

### Feature or Bugfix
- Feature
- (and included in here, I believe is potentially a Bugfix; this wasn't the original intention, so I could split it out)

### Purpose
I felt that it could help a project I was working on if I the source code as highlighted by the `viewcode` extension could include line numbers.  When I looked into the viewcode source, it seemed relatively straightforward to add this, and so as a way to learn a bit about the internals of sphinx I took a go at it.
At that point, it seemed like it could be something of use / interest and worth contributing back to the main repository.  I'm sorry that this hasn't followed what I believe is the normal approach to adding a feature (I read the Contributing guidelines, and whilst it didn't look like a hard rule, I think I should have opened an issue first)!

### Detail
Along the way though, I noticed that, at least in my browser (Firefox 66.0.2) the extra `div` inserted around the `[docs]` link in the highlighted sourcecode output was adding an extra line intermittently (this was with tag v2.0.1 of Sphinx).  The div only seems to have served to add a css class, so I have moved that css class to the `<a>` element instead and removed the encasing `div`.  I appreciate that might be a bit drastic (for example, styles might be selecting on the `div`), but it did fix the issue.  It seems #4701 and #4709 concerned this problem as well, but as far as I could tell the fix as implemented has only partially worked.

### Relates
- #4701
- #4709