### PR TITLE
Removing broken links

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -51,11 +51,11 @@ Using Sphinx with...
 --------------------
 
 Read the Docs
-    https://readthedocs.org is a documentation hosting service based around
+    `Read the Docs <https://readthedocs.org>`_ is a documentation hosting service based around
     Sphinx. They will host sphinx documentation, along with supporting a number
     of other features including version support, PDF generation, and more. The
     `Getting Started
-    <https://read-the-docs.readthedocs.io/en/latest/getting_started.html>`_
+    <https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html>`_
     guide is a good place to start.
 
 Epydoc


### PR DESCRIPTION
Using sphinx with Read the Docs, the Getting Started link has been updated.

Subject: Update links to Read the Docs.

### Feature or Bugfix
- Bugfix

### Purpose
- While developers use this for the first time they again need to google rtd. Now that we have updated it would be clearer.

### Detail
- The Getting Started link is broken.

### Relates
- Observation

