### PR TITLE
imgmath: Replace utf8x by utf8 in templates for latex snippets

### DIFF
--- a/sphinx/templates/imgmath/preview.tex_t
+++ b/sphinx/templates/imgmath/preview.tex_t
@@ -1,5 +1,5 @@
 \documentclass[12pt]{article}
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{amsmath}
 \usepackage{amsthm}
 \usepackage{amssymb}

--- a/sphinx/templates/imgmath/template.tex_t
+++ b/sphinx/templates/imgmath/template.tex_t
@@ -1,5 +1,5 @@
 \documentclass[12pt]{article}
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{amsmath}
 \usepackage{amsthm}
 \usepackage{amssymb}


### PR DESCRIPTION
Follow-up to #6308 (and #6310).