### PR TITLE
Fix #6331: man: invalid output when doctest follows rubric

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -94,6 +94,7 @@ Bugs fixed
 * #6213: ifconfig: contents after headings are not shown
 * commented term in glossary directive is wrongly recognized
 * #6299: rst domain: rst:directive directive generates waste space
+* #6331: man: invalid output when doctest follows rubric
 
 Testing
 --------

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -282,7 +282,7 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
 
     def depart_rubric(self, node):
         # type: (nodes.Element) -> None
-        pass
+        self.body.append('\n')
 
     def visit_seealso(self, node):
         # type: (nodes.Element) -> None

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -59,3 +59,10 @@ def test_default_man_pages():
     expected = [('index', 'stasi', 'STASI™ Documentation 1.0',
                  ["Wolfgang Schäuble & G'Beckstein"], 1)]
     assert default_man_pages(config) == expected
+
+
+@pytest.mark.sphinx('man', testroot='markup-rubric')
+def test_rubric(app, status, warning):
+    app.build()
+    content = (app.outdir / 'python.1').text()
+    assert 'This is a rubric\n' in content


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6331 
