### PR TITLE
Fix #6311: autosummary: autosummary table gets confused by complex type hints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -95,6 +95,7 @@ Bugs fixed
 * commented term in glossary directive is wrongly recognized
 * #6299: rst domain: rst:directive directive generates waste space
 * #6331: man: invalid output when doctest follows rubric
+* #6311: autosummary: autosummary table gets confused by complex type hints
 
 Testing
 --------

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -441,6 +441,10 @@ def mangle_signature(sig, max_chars=30):
     s = re.sub(r"\\'", "", s)
     s = re.sub(r"'[^']*'", "", s)
 
+    # Strip arguments of typehints (ex. Tuple[int, str] -> Tuple)
+    while re.search(r'\[[^],][^\[\]]*\]', s):
+        s = re.sub(r'\[[^],][^\[\]]*\]', '', s)
+
     # Parse the signature to arguments + options
     args = []  # type: List[str]
     opts = []  # type: List[str]

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -49,6 +49,8 @@ def test_mangle_signature():
     (a=1, b=2, c=3) :: ([a, b, c])
     (a=1, b=<SomeClass: a, b, c>, c=3) :: ([a, b, c])
     (a: int, b: int) -> str :: (a, b)
+    (a: Tuple[int, str], b: int) :: (a, b)
+    (a: Union[Tuple[int, str], str], b: int) :: (a, b)
     """
 
     TEST = [[y.strip() for y in x.split("::")] for x in TEST.split("\n")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6311 