### PR TITLE
Fix #6351: "Hyperlink target is not referenced" message is shown even if referenced

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -96,6 +96,8 @@ Bugs fixed
 * commented term in glossary directive is wrongly recognized
 * #6299: rst domain: rst:directive directive generates waste space
 * #6331: man: invalid output when doctest follows rubric
+* #6351: "Hyperlink target is not referenced" message is shown even if
+  referenced
 
 Testing
 --------

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -16,6 +16,7 @@ from docutils.io import FileInput, NullOutput
 from docutils.parsers.rst import Parser as RSTParser
 from docutils.readers import standalone
 from docutils.statemachine import StringList, string2lines
+from docutils.transforms.references import DanglingReferences
 from docutils.writers import UnfilteredWriter
 
 from sphinx.deprecation import RemovedInSphinx30Warning
@@ -64,7 +65,15 @@ class SphinxBaseReader(standalone.Reader):
 
     def get_transforms(self):
         # type: () -> List[Type[Transform]]
-        return super().get_transforms() + self.transforms
+        transforms = super().get_transforms() + self.transforms
+
+        # remove transforms which is not needed for Sphinx
+        unused = [DanglingReferences]
+        for transform in unused:
+            if transform in transforms:
+                transforms.remove(transform)
+
+        return transforms
 
     def new_document(self):
         # type: () -> nodes.document


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6351 
