### PR TITLE
test: declare pytest markers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,11 @@ strict_optional = False
 filterwarnings =
     all
     ignore::DeprecationWarning:docutils.io
+markers =
+    sphinx
+    apidoc
+    setup_command
+    test_params
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
To stop PytestUnknownMarkWarning, this declares markers on setup.cfg
https://docs.pytest.org/en/latest/mark.html