### PR TITLE
productionlist: Put the full production in production.rawsource

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Incompatible changes
 * #6230: The anchor of term in glossary directive is changed if it is consisted
   by non-ASCII characters
 * #4550: html: Centering tables by default using CSS
+* The ``rawsource`` property of ``production`` nodes now contains the full
+  production rule.
 
 Deprecated
 ----------

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -443,7 +443,7 @@ class ProductionList(SphinxDirective):
                 name, tokens = rule.split(':', 1)
             except ValueError:
                 break
-            subnode = addnodes.production()
+            subnode = addnodes.production(rule)
             subnode['tokenname'] = name.strip()
             if subnode['tokenname']:
                 idname = nodes.make_id('grammar-token-%s' % subnode['tokenname'])


### PR DESCRIPTION
This makes it possible to iterate over the productions and see exactly the text
that was entered by the author, which is useful to e.g. extract information from
the grammar (like syntax-highlighting patterns).