### PR TITLE
autosectionlabel: add type for suppress_warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -99,6 +99,7 @@ Features added
 * #6306: html: Add a label to search form for accessability purposes
 * #6358: The ``rawsource`` property of ``production`` nodes now contains the
   full production rule
+* #6373: Allow suppression of autosectionlabel warnings
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -296,25 +296,26 @@ General configuration
 
    Sphinx supports following warning types:
 
-   * app.add_node
-   * app.add_directive
-   * app.add_role
-   * app.add_generic_role
-   * app.add_source_parser
-   * download.not_readable
-   * image.not_readable
-   * ref.term
-   * ref.ref
-   * ref.numref
-   * ref.keyword
-   * ref.option
-   * ref.citation
-   * ref.footnote
-   * ref.doc
-   * ref.python
-   * misc.highlighting_failure
-   * toc.secnum
-   * epub.unknown_project_files
+   * ``app.add_node``
+   * ``app.add_directive``
+   * ``app.add_role``
+   * ``app.add_generic_role``
+   * ``app.add_source_parser``
+   * ``download.not_readable``
+   * ``image.not_readable``
+   * ``ref.term``
+   * ``ref.ref``
+   * ``ref.numref``
+   * ``ref.keyword``
+   * ``ref.option``
+   * ``ref.citation``
+   * ``ref.footnote``
+   * ``ref.doc``
+   * ``ref.python``
+   * ``misc.highlighting_failure``
+   * ``toc.secnum``
+   * ``epub.unknown_project_files``
+   * ``autosectionlabel.*``
 
    You can choose from these types.
 
@@ -333,6 +334,10 @@ General configuration
    .. versionchanged:: 1.6
 
       Added ``ref.footnote``
+
+   .. versionchanged:: 2.1
+
+      Added ``autosectionlabel.*``
 
 .. confval:: needs_sphinx
 

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -55,7 +55,7 @@ def register_sections_as_label(app, document):
         if name in labels:
             logger.warning(__('duplicate label %s, other instance in %s'),
                            name, app.env.doc2path(labels[name][0]),
-                           location=node)
+                           location=node, type='autosectionlabel', subtype=docname)
 
         anonlabels[name] = docname, labelid
         labels[name] = docname, labelid, sectname


### PR DESCRIPTION
This sets the subtype to the filename, which means that you can suppress warnings for individual paths.

For example for the following warning:

```
path/to/file.rst:5547: WARNING: duplicate label path/to/file:label, other instance in /path/to/file.rst
```

You would add this to `config.py` to suppress all warnings:

```python
extensions = [
    'sphinx.ext.autosectionlabel',
]

autosectionlabel_prefix_document = True

suppress_warnings = [
    'autosectionlabel.*',
]
```

To suppress warnings for the individual file path you would do:

```python
suppress_warnings = [
    'autosectionlabel.path/to/file',
]
```

Fixes: https://github.com/sphinx-doc/sphinx/issues/6371