### PR TITLE
add documenter parameter to autodoc-process-signature

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -409,9 +409,20 @@ class Documenter:
 
         retann = self.retann
 
-        result = self.env.events.emit_firstresult('autodoc-process-signature',
-                                                  self.objtype, self.fullname,
-                                                  self.object, self.options, args, retann)
+        # NOTE: in Sphinx-4.x the `event_args` can return to being direct
+        # arguments to a `self.env.events.emit_firstresult` call.
+        event_args = ('autodoc-process-signature', self.objtype, self.fullname,
+                      self.object, self.options, args, retann)
+        try:
+            result = self.env.events.emit_firstresult(*event_args, self)
+        except TypeError:
+            # process_signature() takes 7 positional arguments but 8 were given
+            warnings.warn('autodoc-process-signature event takes 8 arguments '
+                          'since Sphinx-2.1.  The 8th argument is `documenter`, '
+                          'which is a sphinx.ext.autodoc.Documenter instance.',
+                          RemovedInSphinx40Warning)
+            result = self.env.events.emit_firstresult(*event_args)
+
         if result:
             args, retann = result
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -123,7 +123,7 @@ def process_docstring(app, what, name, obj, options, lines):
         lines.extend(['42', ''])
 
 
-def process_signature(app, what, name, obj, options, args, retann):
+def process_signature(app, what, name, obj, options, args, retann, documenter):
     processed_signatures.append((what, name))
     if name == 'bar':
         return '42', None


### PR DESCRIPTION
- Enables users to easily remove type hints from signatures.
- Fixes #6361

Subject: Enable users to remove type hints with autodoc.

### Feature or Bugfix

- Feature

### Purpose

This is option (2) described in #6361.