### PR TITLE
Fix #6375: extlinks: Cannot escape angle brackets in link caption

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -114,6 +114,7 @@ Bugs fixed
 * #6165: autodoc: ``tab_width`` setting of docutils has been ignored
 * #6311: autosummary: autosummary table gets confused by complex type hints
 * Generated Makefiles lack a final EOL (refs: #6232)
+* #6375: extlinks: Cannot escape angle brackets in link caption
 
 Testing
 --------

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 # \x00 means the "<" was backslash-escaped
-explicit_title_re = re.compile(r'^(.+?)\s*(?<!\x00)<(.*?)>$', re.DOTALL)
+explicit_title_re = re.compile(r'^(.+?)\s*(?<!\x00)<([^<]*?)>$', re.DOTALL)
 caption_ref_re = explicit_title_re  # b/w compat alias
 
 

--- a/tests/test_util_nodes.py
+++ b/tests/test_util_nodes.py
@@ -17,7 +17,7 @@ from docutils.parsers import rst
 from docutils.utils import new_document
 
 from sphinx.transforms import ApplySourceWorkaround
-from sphinx.util.nodes import NodeMatcher, extract_messages, clean_astext
+from sphinx.util.nodes import NodeMatcher, extract_messages, clean_astext, split_explicit_title
 
 
 def _transform(doctree):
@@ -178,3 +178,18 @@ def test_clean_astext():
     node = nodes.paragraph(text='hello world')
     node += nodes.raw('', 'raw text', format='html')
     assert 'hello world' == clean_astext(node)
+
+
+@pytest.mark.parametrize(
+    'title, expected',
+    [
+        # implicit
+        ('hello', (False, 'hello', 'hello')),
+        # explicit
+        ('hello <world>', (True, 'hello', 'world')),
+        # explicit (title having angle brackets)
+        ('hello <world> <sphinx>', (True, 'hello <world>', 'sphinx')),
+    ]
+)
+def test_split_explicit_target(title, expected):
+    assert expected == split_explicit_title(title)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6375 