### PR TITLE
Fix #6379: py domain: Module index (py-modindex.html) has duplicate titles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -110,6 +110,7 @@ Bugs fixed
 * #6213: ifconfig: contents after headings are not shown
 * commented term in glossary directive is wrongly recognized
 * #6299: rst domain: rst:directive directive generates waste space
+* #6379: py domain: Module index (py-modindex.html) has duplicate titles
 * #6331: man: invalid output when doctest follows rubric
 * #6351: "Hyperlink target is not referenced" message is shown even if
   referenced

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -858,7 +858,6 @@ class PythonModuleIndex(Index):
                         last = entries[-1]
                         entries[-1] = IndexEntry(last[0], 1, last[2], last[3],
                                                  last[4], last[5], last[6])
-                    entries.append(IndexEntry(stripped + package, 1, '', '', '', '', ''))
                 elif not prev_modname.startswith(package):
                     # submodule without parent in list, add dummy entry
                     entries.append(IndexEntry(stripped + package, 1, '', '', '', '', ''))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6379 