### PR TITLE
Fix #6387: html search: failed to search document with haiku and scrolls themes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -121,6 +121,7 @@ Bugs fixed
 * Generated Makefiles lack a final EOL (refs: #6232)
 * #6375: extlinks: Cannot escape angle brackets in link caption
 * #6378: linkcheck: Send commonly used User-Agent
+* #6387: html search: failed to search document with haiku and scrolls themes
 
 Testing
 --------

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -51,7 +51,7 @@
       <div class="topnav" role="navigation" aria-label="top navigation">
       {{ nav() }}
       </div>
-      <div class="content">
+      <div class="content" role="main">
         {#{%- if display_toc %}
         <div id="toc">
           <h3>{{ _('Table of Contents') }}</h3>

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -42,7 +42,9 @@
           {{ toc }}
         </div>
         {%- endif %}
+        <div role="main">
         {% block body %}{% endblock %}
+        </div>
       </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6387 