### PR TITLE
Close #6239: latex: Support to build Chinese documents

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Incompatible changes
 * #6230: The anchor of term in glossary directive is changed if it is consisted
   by non-ASCII characters
 * #4550: html: Centering tables by default using CSS
+* #6239: latex: xelatex and xeCJK are used for Chinese documents by default
 
 Deprecated
 ----------
@@ -105,6 +106,7 @@ Features added
   full production rule
 * #6373: autosectionlabel: Allow suppression of warnings
 * coverage: Support a new ``coverage_ignore_pyobjects`` option
+* #6239: latex: Support to build Chinese documents
 
 Bugs fixed
 ----------

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -180,12 +180,10 @@ class LaTeXBuilder(Builder):
         # Add special settings for latex_engine
         self.context.update(ADDITIONAL_SETTINGS.get(self.config.latex_engine, {}))
 
-        # for xelatex+French, don't use polyglossia by default
-        if self.config.latex_engine == 'xelatex':
-            if self.config.language:
-                if self.config.language[:2] == 'fr':
-                    self.context['polyglossia'] = ''
-                    self.context['babel'] = r'\usepackage{babel}'
+        # Add special settings for (latex_engine, language_code)
+        if self.config.language:
+            key = (self.config.latex_engine, self.config.language[:2])
+            self.context.update(ADDITIONAL_SETTINGS.get(key, {}))
 
         # Apply extension settings to context
         self.context['packages'] = self.usepackages
@@ -441,6 +439,8 @@ def default_latex_engine(config):
     """ Better default latex_engine settings for specific languages. """
     if config.language == 'ja':
         return 'platex'
+    elif (config.language or '').startswith('zh'):
+        return 'xelatex'
     else:
         return 'pdflatex'
 

--- a/sphinx/builders/latex/util.py
+++ b/sphinx/builders/latex/util.py
@@ -47,11 +47,13 @@ class ExtBabel(Babel):
             # polyglossia calls new orthography (Neue Rechtschreibung) as
             # german (with new spelling option).
             return 'german'
-        elif not language:
+        elif language:
+            return language
+        elif language_code.startswith('zh'):
+            return 'english'  # fallback to english (behaves like supported)
+        else:
             self.supported = False
             return 'english'  # fallback to english
-        else:
-            return language
 
     def get_mainlanguage_options(self):
         # type: () -> str

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -216,7 +216,17 @@ ADDITIONAL_SETTINGS = {
         'fncychap':     '',
         'geometry':     '\\usepackage[dvipdfm]{geometry}',
     },
-}  # type: Dict[str, Dict[str, Any]]
+
+    # special settings for latex_engine + language_code
+    ('xelatex', 'fr'): {
+        # use babel instead of polyglossia by default
+        'polyglossia':  '',
+        'babel':        '\\usepackage{babel}',
+    },
+    ('xelatex', 'zh'): {
+        'fontenc':      '\\usepackage{xeCJK}',
+    },
+}  # type: Dict[Any, Dict[str, Any]]
 
 EXTRA_RE = re.compile(r'^(.*\S)\s+\(([^()]*)\)\s*$')
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -165,6 +165,16 @@ def test_latex_basic(app, status, warning):
     assert r'\renewcommand{\releasename}{}' in result
 
 
+@pytest.mark.sphinx('latex', testroot='basic', confoverrides={'language': 'zh'})
+def test_latex_additional_settings_for_language_code(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'test.tex').text(encoding='utf8')
+    print(result)
+    print(status.getvalue())
+    print(warning.getvalue())
+    assert r'\usepackage{xeCJK}' in result
+
+
 @pytest.mark.sphinx('latex', testroot='latex-title')
 def test_latex_title_after_admonitions(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #6239 

So far, Sphinx can't build Chinese document correctly by default settings. So Chinese users would customize their settings to build PDF correctly. I'm afraid this breaks their project. But this surely improves Sphinx. So it would be better to add this into next minor release.