### PR TITLE
Fix #6347: autodoc: crashes with a plain Tuple on Python 3.6 and 3.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -119,6 +119,7 @@ Bugs fixed
 * #6351: "Hyperlink target is not referenced" message is shown even if
   referenced
 * #6165: autodoc: ``tab_width`` setting of docutils has been ignored
+* #6347: autodoc: crashes with a plain Tuple on Python 3.6 and 3.5
 * #6311: autosummary: autosummary table gets confused by complex type hints
 * #6350: autosummary: confused by an argument having some kind of default value
 * Generated Makefiles lack a final EOL (refs: #6232)

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -531,6 +531,8 @@ class Signature:
                 args = ', '.join(self.format_annotation(a) for a in annotation.__args__[:-1])
                 returns = self.format_annotation(annotation.__args__[-1])
                 return '%s[[%s], %s]' % (qualname, args, returns)
+            elif annotation._special:
+                return qualname
             else:
                 args = ', '.join(self.format_annotation(a) for a in annotation.__args__)
                 return '%s[%s]' % (qualname, args)
@@ -562,8 +564,11 @@ class Signature:
                 not hasattr(annotation, '__tuple_params__')):
             # This is for Python 3.6+, 3.5 case is handled below
             params = annotation.__args__
-            param_str = ', '.join(self.format_annotation(p) for p in params)
-            return '%s[%s]' % (qualname, param_str)
+            if params:
+                param_str = ', '.join(self.format_annotation(p) for p in params)
+                return '%s[%s]' % (qualname, param_str)
+            else:
+                return qualname
         elif (hasattr(typing, 'GenericMeta') and  # for py36 or below
               isinstance(annotation, typing.GenericMeta)):
             # In Python 3.5.2+, all arguments are stored in __args__,

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -196,7 +196,7 @@ def test_Signature_partialmethod():
 
 def test_Signature_annotations():
     from typing_test_data import (f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10,
-                                  f11, f12, f13, f14, f15, f16, f17, Node)
+                                  f11, f12, f13, f14, f15, f16, f17, f18, Node)
 
     # Class annotations
     sig = inspect.Signature(f0).format_args()
@@ -272,6 +272,9 @@ def test_Signature_annotations():
     # keyword only arguments (2)
     sig = inspect.Signature(f17).format_args()
     assert sig == '(*, arg3, arg4)'
+
+    sig = inspect.Signature(f18).format_args()
+    assert sig == '(self, arg1: Union[int, Tuple] = 10) -> List[Dict]'
 
     # type hints by string
     sig = inspect.Signature(Node.children).format_args()

--- a/tests/typing_test_data.py
+++ b/tests/typing_test_data.py
@@ -1,5 +1,5 @@
 from numbers import Integral
-from typing import Any, List, TypeVar, Union, Callable, Tuple, Optional
+from typing import Any, Dict, List, TypeVar, Union, Callable, Tuple, Optional
 
 
 def f0(x: int, y: Integral) -> None:
@@ -85,6 +85,10 @@ def f16(arg1, arg2, *, arg3=None, arg4=None):
 
 
 def f17(*, arg3, arg4):
+    pass
+
+
+def f18(self, arg1: Union[int, Tuple] = 10) -> List[Dict]:
     pass
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6347 