### PR TITLE
Fix #6406: Wrong year is returned for ``SOURCE_DATE_EPOCH``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -125,6 +125,7 @@ Bugs fixed
 * #6375: extlinks: Cannot escape angle brackets in link caption
 * #6378: linkcheck: Send commonly used User-Agent
 * #6387: html search: failed to search document with haiku and scrolls themes
+* #6406: Wrong year is returned for ``SOURCE_DATE_EPOCH``
 
 Testing
 --------

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -248,7 +248,7 @@ date_format_mappings = {
     '%x':  'medium',  # Locale’s appropriate date representation.
     '%X':  'medium',  # Locale’s appropriate time representation.
     '%y':  'YY',      # Year without century as a zero-padded decimal number.
-    '%Y':  'YYYY',    # Year with century as a decimal number.
+    '%Y':  'yyyy',    # Year with century as a decimal number.
     '%Z':  'zzzz',    # Time zone name (no characters if no time zone exists).
     '%%':  '%',
 }


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6406 