### PR TITLE
Fix the ranking of search results

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -319,12 +319,13 @@ var Search = {
     for (var prefix in objects) {
       for (var name in objects[prefix]) {
         var fullname = (prefix ? prefix + '.' : '') + name;
-        if (fullname.toLowerCase().indexOf(object) > -1) {
+        var fullnameLower = fullname.toLowerCase()
+        if (fullnameLower.indexOf(object) > -1) {
           var score = 0;
-          var parts = fullname.split('.');
+          var parts = fullnameLower.split('.');
           // check for different match types: exact matches of full name or
           // "last name" (i.e. last dotted part)
-          if (fullname == object || parts[parts.length - 1] == object) {
+          if (fullnameLower == object || parts[parts.length - 1] == object) {
             score += Scorer.objNameMatch;
           // matches in last name
           } else if (parts[parts.length - 1].indexOf(object) > -1) {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

The ranking of search results in `searchtools.js` depends on calculated matching score. The matching is checked by `fullname.toLowerCase().indexOf(object)`, however the scoring for matched object names is based on original `fullname` rather than lower-cased `fullname`. For example, this would casuse the result `some.package.FooBar` to be ranked very low in a search query of `FooBar`.

This PR fixes such behavior by computing match scores based on lower-cased `fullname`.