### PR TITLE
doc: Change wording for contents directive (refs: #6265)

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -36,8 +36,8 @@ tables of contents.  The ``toctree`` directive is the central element.
 
 .. note::
 
-   For local tables of contents, use the standard reST :dudir:`contents
-   directive <table-of-contents>`.
+   To create table of contents for current document (.rst file), use the
+   standard reST :dudir:`contents directive <table-of-contents>`.
 
 .. rst:directive:: toctree
 


### PR DESCRIPTION
### Feature or Bugfix
- document

### Purpose
- refs: #6265 
- I modified our docs a little, but we have to modify whole of description for "table of contents" in another time to be clear more.