### PR TITLE
Fix #1125: html theme: scrollbar is hard to see on classic theme and macOS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #1125: html theme: scrollbar is hard to see on classic theme and macOS
+
 Testing
 --------
 

--- a/sphinx/themes/classic/static/classic.css_t
+++ b/sphinx/themes/classic/static/classic.css_t
@@ -13,6 +13,11 @@
 
 /* -- page layout ----------------------------------------------------------- */
 
+html {
+    /* CSS hack for macOS's scrollbar (see #1125) */
+    background-color: #FFFFFF;
+}
+
 body {
     font-family: {{ theme_bodyfont }};
     font-size: 100%;


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #1125 
- After this change:

![スクリーンショット 2019-06-02 12 04 43](https://user-images.githubusercontent.com/748828/58756230-c9138400-852e-11e9-8b92-24ee54d951c3.png)
![スクリーンショット 2019-06-02 12 05 01](https://user-images.githubusercontent.com/748828/58756231-cb75de00-852e-11e9-87ea-885ea84a1fda.png)
