### PR TITLE
Fix #5502: linkcheck: Consider HTTP 503 response as not an error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * py domain: duplicated warning does not point the location of source code
 * #1125: html theme: scrollbar is hard to see on classic theme and macOS
+* #5502: linkcheck: Consider HTTP 503 response as not an error
 
 Testing
 --------

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -159,6 +159,9 @@ class CheckExternalLinksBuilder(Builder):
                 if err.response.status_code == 401:
                     # We'll take "Unauthorized" as working.
                     return 'working', ' - unauthorized', 0
+                elif err.response.status_code == 503:
+                    # We'll take "Service Unavailable" as ignored.
+                    return 'ignored', str(err), 0
                 else:
                     return 'broken', str(err), 0
             except Exception as err:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #5502

