### PR TITLE
Close #5124: graphviz: :graphviz_dot: option is renamed to :layout:

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Deprecated
 Features added
 --------------
 
+* #5124: graphviz: ``:graphviz_dot:`` option is renamed to ``:layout:``
+
 Bugs fixed
 ----------
 

--- a/doc/usage/extensions/graphviz.rst
+++ b/doc/usage/extensions/graphviz.rst
@@ -63,13 +63,17 @@ It adds these directives:
 
       .. versionadded:: 1.1
 
-   .. rst:directive:option:: graphviz_dot: dot command of the graph
+   .. rst:directive:option:: layout: layout type of the graph
       :type: text
 
-      The graphviz command (ex. ``dot``, ``neato`` and so on) for rendering the
-      graph.  By default, :confval:`graphviz_dot` is used.
+      The layout of the graph (ex. ``dot``, ``neato`` and so on).  A path to the
+      graphviz commands are also allowed.  By default, :confval:`graphviz_dot`
+      is used.
 
       .. versionadded:: 1.4
+      .. versionchanged:: 2.2
+
+         Renamed from ``graphviz_dot``
 
    .. rst:directive:option:: name: label
       :type: text
@@ -114,10 +118,13 @@ It adds these directives:
 
       .. versionadded:: 1.1
 
-   .. rst:directive:option:: graphviz_dot: dot command of the graph
+   .. rst:directive:option:: layout: layout type of the graph
       :type: text
 
       .. versionadded:: 1.4
+      .. versionchanged:: 2.2
+
+         Renamed from ``graphviz_dot``
 
    .. rst:directive:option:: name: label
       :type: text
@@ -156,10 +163,13 @@ It adds these directives:
 
       .. versionadded:: 1.1
 
-   .. rst:directive:option:: graphviz_dot: dot command of the graph
+   .. rst:directive:option:: layout: layout type of the graph
       :type: text
 
       .. versionadded:: 1.4
+      .. versionchanged:: 2.2
+
+         Renamed from ``graphviz_dot``
 
    .. rst:directive:option:: name: label
       :type: text

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -127,7 +127,8 @@ class Graphviz(SphinxDirective):
         'alt': directives.unchanged,
         'align': align_spec,
         'caption': directives.unchanged,
-        'graphviz_dot': directives.unchanged,
+        'layout': directives.unchanged,
+        'graphviz_dot': directives.unchanged,  # an old alias of `layout` option
         'name': directives.unchanged,
     }
 
@@ -161,6 +162,8 @@ class Graphviz(SphinxDirective):
 
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']
+        if 'layout' in self.options:
+            node['options']['graphviz_dot'] = self.options['layout']
         if 'alt' in self.options:
             node['alt'] = self.options['alt']
         if 'align' in self.options:


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #5124 
- This only add an alias of `:graphviz_dot:`. No deprecation.