### PR TITLE
Fix py domain: duplicated warning does not point the location of source code

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* py domain: duplicated warning does not point the location of source code
+
 Testing
 --------
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -337,7 +337,8 @@ class PyObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
 
             domain = cast(PythonDomain, self.env.get_domain('py'))
-            domain.note_object(fullname, self.objtype)
+            domain.note_object(fullname, self.objtype,
+                               location=(self.env.docname, self.lineno))
 
         indextext = self.get_index_text(modname, name_cls)
         if indextext:
@@ -752,7 +753,7 @@ class PyModule(SphinxDirective):
                                self.options.get('synopsis', ''),
                                self.options.get('platform', ''),
                                'deprecated' in self.options)
-            domain.note_object(modname, 'module')
+            domain.note_object(modname, 'module', location=(self.env.docname, self.lineno))
 
             targetnode = nodes.target('', '', ids=['module-' + modname],
                                       ismod=True)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- location parameter is missing...