### PR TITLE
Make generated download links reproducible

### DIFF
--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -137,7 +137,7 @@ class DownloadFileCollector(EnvironmentCollector):
                     logger.warning(__('download file not readable: %s') % filename,
                                    location=node, type='download', subtype='not_readable')
                     continue
-                node['filename'] = app.env.dlfiles.add_file(app.env.docname, filename)
+                node['filename'] = app.env.dlfiles.add_file(app.env.docname, rel_filename)
 
 
 def setup(app):

--- a/tests/roots/test-roles-download/another/dummy.dat
+++ b/tests/roots/test-roles-download/another/dummy.dat
@@ -1,0 +1,1 @@
+this one will have some content

--- a/tests/roots/test-roles-download/index.rst
+++ b/tests/roots/test-roles-download/index.rst
@@ -2,5 +2,6 @@ test-roles-download
 ===================
 
 * :download:`dummy.dat`
+* :download:`another/dummy.dat`
 * :download:`not_found.dat`
 * :download:`Sphinx logo <http://www.sphinx-doc.org/en/master/_static/sphinxheader.png>`

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -453,6 +453,8 @@ def test_html_download_role(app, status, warning):
     app.build()
     digest = md5(b'dummy.dat').hexdigest()
     assert (app.outdir / '_downloads' / digest / 'dummy.dat').exists()
+    digest_another = md5(b'another/dummy.dat').hexdigest()
+    assert (app.outdir / '_downloads' / digest_another / 'dummy.dat').exists()
 
     content = (app.outdir / 'index.html').text()
     assert (('<li><p><a class="reference download internal" download="" '
@@ -460,6 +462,11 @@ def test_html_download_role(app, status, warning):
              '<code class="xref download docutils literal notranslate">'
              '<span class="pre">dummy.dat</span></code></a></p></li>' % digest)
             in content)
+    assert (('<li><p><a class="reference download internal" download="" '
+             'href="_downloads/%s/dummy.dat">'
+             '<code class="xref download docutils literal notranslate">'
+             '<span class="pre">another/dummy.dat</span></code></a></p></li>' %
+             digest_another) in content)
     assert ('<li><p><code class="xref download docutils literal notranslate">'
             '<span class="pre">not_found.dat</span></code></p></li>' in content)
     assert ('<li><p><a class="reference download external" download="" '

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -451,7 +451,7 @@ def test_html_download(app):
 @pytest.mark.sphinx('html', testroot='roles-download')
 def test_html_download_role(app, status, warning):
     app.build()
-    digest = md5((app.srcdir / 'dummy.dat').encode()).hexdigest()
+    digest = md5(b'dummy.dat').hexdigest()
     assert (app.outdir / '_downloads' / digest / 'dummy.dat').exists()
 
     content = (app.outdir / 'index.html').text()


### PR DESCRIPTION
Without this change, the hexdigest generated in `DownloadFiles.add_file()` depends on `source_dir`, which causes problems for [reproducible builds] effort. Just using the path fragment relative to `source_dir` should be sufficient.

In the second commit I added a test to make sure download files with the same name but in different directories are still handled correctly.

[reproducible builds]: https://reproducible-builds.org/