### PR TITLE
LaTeX: prevent pagebrak separating note from section title

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #6442: LaTeX: admonitions of :rst:dir:`note` type can get separated from
+  immediately preceding section title by pagebreak
+
 Testing
 --------
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2019/01/12 v1.8.4 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2019/06/04 v2.1.1 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -1444,7 +1444,7 @@
 % Some are quite plain
 % the spx@notice@bordercolor etc are set in the sphinxadmonition environment
 \newenvironment{sphinxlightbox}{%
-  \par\allowbreak
+  \par
   \noindent{\color{spx@notice@bordercolor}%
             \rule{\linewidth}{\spx@notice@border}}\par\nobreak
   {\parskip\z@skip\noindent}%


### PR DESCRIPTION
Fixes: #6442

### Relates
- https://groups.google.com/d/msgid/sphinx-users/d4d82967-116c-45a6-9bf6-963fd5c79c8e%40googlegroups.com?utm_medium=email&utm_source=footer  

