### PR TITLE
apidoc: Insert newlines between submodules

### DIFF
--- a/sphinx/templates/apidoc/package.rst
+++ b/sphinx/templates/apidoc/package.rst
@@ -40,8 +40,8 @@ Submodules
 {{- [submodule, "module"] | join(" ") | e | heading(2) }}
 {% endif %}
 {{ automodule(submodule, automodule_options) }}
-{%- endfor %}
-{% endif %}
+{% endfor %}
+{%- endif %}
 {% endif %}
 
 {%- if not modulefirst and not is_namespace %}

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -467,7 +467,8 @@ def test_package_file(tempdir):
     outdir = path(tempdir)
     (outdir / 'testpkg').makedirs()
     (outdir / 'testpkg' / '__init__.py').write_text('')
-    (outdir / 'testpkg' / 'example.py').write_text('')
+    (outdir / 'testpkg' / 'hello.py').write_text('')
+    (outdir / 'testpkg' / 'world.py').write_text('')
     (outdir / 'testpkg' / 'subpkg').makedirs()
     (outdir / 'testpkg' / 'subpkg' / '__init__.py').write_text('')
     apidoc_main(['-o', tempdir, tempdir / 'testpkg'])
@@ -488,10 +489,18 @@ def test_package_file(tempdir):
                        "Submodules\n"
                        "----------\n"
                        "\n"
-                       "testpkg.example module\n"
-                       "----------------------\n"
+                       "testpkg.hello module\n"
+                       "--------------------\n"
                        "\n"
-                       ".. automodule:: testpkg.example\n"
+                       ".. automodule:: testpkg.hello\n"
+                       "   :members:\n"
+                       "   :undoc-members:\n"
+                       "   :show-inheritance:\n"
+                       "\n"
+                       "testpkg.world module\n"
+                       "--------------------\n"
+                       "\n"
+                       ".. automodule:: testpkg.world\n"
                        "   :members:\n"
                        "   :undoc-members:\n"
                        "   :show-inheritance:\n"


### PR DESCRIPTION
Fix a regression introduced in 2.1.0 where submodules didn't have a
newline between them resulting in the following warning:

    Explicit markup ends without a blank line; unexpected unindent.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Closes: #6440