### PR TITLE
Don't crash when autodocumenting classes with __slots__ = None

### DIFF
--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -128,7 +128,7 @@ def get_object_members(subject, objpath, attrgetter, analyzer=None):
                 members[name] = Attribute(name, True, value)
 
     # members in __slots__
-    if isclass(subject) and hasattr(subject, '__slots__'):
+    if isclass(subject) and getattr(subject, '__slots__', None) is not None:
         from sphinx.ext.autodoc import SLOTSATTR
 
         for name in subject.__slots__:


### PR DESCRIPTION
Subject: Fix crashes when autodocumenting classes with `__slots__ = None`

### Feature or Bugfix
- Bugfix

### Purpose
Some types (in my tests, this showed up as a weird byproduct of metaclass magic) have None for a `__slots__` value. This is apparently legal python, but it causes autodoc to crash when processing the class.

### Detail
```
Exception occurred:
  File "/home/audrey/.virtualenvs/angr/site-packages/sphinx/ext/autodoc/importer.py", line 136, in get_object_members
    for name in subject.__slots__:
TypeError: 'NoneType' object is not iterable
The full traceback has been saved in /tmp/sphinx-err-efyxublw.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```