### PR TITLE
Fix #6452: autosummary: crashed when generating document of properties

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #6448: autodoc: crashed when autodocumenting classes with ``__slots__ = None``
+* #6452: autosummary: crashed when generating document of properties
 
 Testing
 --------

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -221,7 +221,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
                     get_members(obj, {'attribute', 'property'})
 
             parts = name.split('.')
-            if doc.objtype in ('method', 'attribute'):
+            if doc.objtype in ('method', 'attribute', 'property'):
                 mod_name = '.'.join(parts[:-2])
                 cls_name = parts[-2]
                 obj_name = '.'.join(parts[-2:])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6452 