### PR TITLE
add svg_link_prefix option to inheritance_diagram

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Deprecated
 
 Features added
 --------------
+* #6454: An ``svg_link_prefix`` option was added to the inheritance diagram extension
 
 Bugs fixed
 ----------

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -403,25 +403,26 @@ def html_visit_inheritance_diagram(self, node):
     Output the graph for HTML.  This will insert a PNG with clickable
     image map.
     """
+    env = self.builder.env
     graph = node['graph']
 
     graph_hash = get_graph_hash(node)
     name = 'inheritance%s' % graph_hash
 
     # Create a mapping from fully-qualified class names to URLs.
-    graphviz_output_format = self.builder.env.config.graphviz_output_format.upper()
+    graphviz_output_format = env.config.graphviz_output_format.upper()
     current_filename = self.builder.current_docname + self.builder.out_suffix
     urls = {}
     pending_xrefs = cast(Iterable[addnodes.pending_xref], node)
     for child in pending_xrefs:
         if child.get('refuri') is not None:
             if graphviz_output_format == 'SVG':
-                urls[child['reftitle']] = "../" + child.get('refuri')
+                urls[child['reftitle']] = env.config.svg_link_prefix + child.get('refuri')
             else:
                 urls[child['reftitle']] = child.get('refuri')
         elif child.get('refid') is not None:
             if graphviz_output_format == 'SVG':
-                urls[child['reftitle']] = '../' + current_filename + '#' + child.get('refid')
+                urls[child['reftitle']] = env.config.svg_link_prefix + current_filename + '#' + child.get('refid')
             else:
                 urls[child['reftitle']] = '#' + child.get('refid')
 
@@ -483,4 +484,5 @@ def setup(app):
     app.add_config_value('inheritance_node_attrs', {}, False)
     app.add_config_value('inheritance_edge_attrs', {}, False)
     app.add_config_value('inheritance_alias', {}, False)
+    app.add_config_value('svg_link_prefix', '../', False)
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -422,7 +422,8 @@ def html_visit_inheritance_diagram(self, node):
                 urls[child['reftitle']] = child.get('refuri')
         elif child.get('refid') is not None:
             if graphviz_output_format == 'SVG':
-                urls[child['reftitle']] = env.config.svg_link_prefix + current_filename + '#' + child.get('refid')
+                urls[child['reftitle']] = (env.config.svg_link_prefix + current_filename +
+                                           '#' + child.get('refid'))
             else:
                 urls[child['reftitle']] = '#' + child.get('refid')
 


### PR DESCRIPTION
Subject: Add an option to set the prefix for links in SVG inheritance diagrams

### Feature or Bugfix
- Feature

### Purpose
- Provide a way for extensions or projects that embed the inheritance diagram SVG in pages to have the links work.

### Detail
As discussed in astropy/astropy#4935 and #2484, the inheritance diagram machinery currently yields broken links as we implemented it in sphinx-automodapi and astropy.  You can see an example here: https://docs.astropy.org/en/v3.1.2/coordinates/index.html#class-inheritance-diagram .  The gist of the problem (as discussed in #2484) is that we embed the SVG in the page. This means the path to the actual class pages don't have the `'..'` that apparently gets created when embedding as a separate file. (FWIW, the links *originally* worked when we first did this, but then the changes in #967 ended up breaking it.  And here we are years later with me finally having realized the underlying cause!).

So this PR introduces a new config option in inheritance_diagram that sets the prefix.  The default is still `../`, so it shouldn't break other code, but it will then be possible to supress the `..` in cases like ours where it's breaking the links.  I *think* it may partly address #3176 by giving that use case the flexibility to pick their own prefix as well (although I'm not 100% sure about that one).

### Relates
- #2484
- #3176
- astropy/astropy#4935
