### PR TITLE
Fix #6455: napoleon: docstrings for properties are not processed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Bugs fixed
   immediately preceding section title by pagebreak
 * #6448: autodoc: crashed when autodocumenting classes with ``__slots__ = None``
 * #6452: autosummary: crashed when generating document of properties
+* #6455: napoleon: docstrings for properties are not processed
 
 Testing
 --------

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -555,7 +555,7 @@ class GoogleDocstring:
         # type: () -> None
         self._parsed_lines = self._consume_empty()
 
-        if self._name and (self._what == 'attribute' or self._what == 'data'):
+        if self._name and self._what in ('attribute', 'data', 'property'):
             # Implicit stop using StopIteration no longer allowed in
             # Python 3.7; see PEP 479
             res = []  # type: List[str]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6455 