### PR TITLE
refactor: correct interface of directive() and role() to docutils'

### DIFF
--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -17,7 +17,7 @@ from copy import copy
 from distutils.version import LooseVersion
 from os import path
 from types import ModuleType
-from typing import Any, Callable, Dict, Generator, IO, List, Set, Tuple, Type
+from typing import Any, Callable, Dict, Generator, IO, List, Optional, Set, Tuple, Type
 from typing import cast
 
 import docutils
@@ -194,8 +194,8 @@ class sphinx_domains:
         self.directive_func = directives.directive
         self.role_func = roles.role
 
-        directives.directive = self.lookup_directive  # type: ignore
-        roles.role = self.lookup_role  # type: ignore
+        directives.directive = self.lookup_directive
+        roles.role = self.lookup_role
 
     def disable(self) -> None:
         directives.directive = self.directive_func
@@ -229,17 +229,17 @@ class sphinx_domains:
 
         raise ElementLookupError
 
-    def lookup_directive(self, name: str, lang_module: ModuleType, document: nodes.document) -> Tuple[Type[Directive], List[system_message]]:  # NOQA
+    def lookup_directive(self, directive_name: str, language_module: ModuleType, document: nodes.document) -> Tuple[Optional[Type[Directive]], List[system_message]]:  # NOQA
         try:
-            return self.lookup_domain_element('directive', name)
+            return self.lookup_domain_element('directive', directive_name)
         except ElementLookupError:
-            return self.directive_func(name, lang_module, document)
+            return self.directive_func(directive_name, language_module, document)
 
-    def lookup_role(self, name: str, lang_module: ModuleType, lineno: int, reporter: Reporter) -> Tuple[RoleFunction, List[system_message]]:  # NOQA
+    def lookup_role(self, role_name: str, language_module: ModuleType, lineno: int, reporter: Reporter) -> Tuple[RoleFunction, List[system_message]]:  # NOQA
         try:
-            return self.lookup_domain_element('role', name)
+            return self.lookup_domain_element('role', role_name)
         except ElementLookupError:
-            return self.role_func(name, lang_module, lineno, reporter)
+            return self.role_func(role_name, language_module, lineno, reporter)
 
 
 class WarningStream:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -27,7 +27,7 @@ NoneType = type(None)
 PathMatcher = Callable[[str], bool]
 
 # common role functions
-RoleFunction = Callable[[str, str, str, int, Inliner, Dict, List[str]],
+RoleFunction = Callable[[str, str, str, int, Inliner, Dict[str, Any], List[str]],
                         Tuple[List[nodes.Node], List[nodes.system_message]]]
 
 # title getter functions for enumerable nodes (see sphinx.domains.std)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `sphinx_domain.lookup_directive` and `.lookup_role` has different interface with docutils'
- This corrects them to right one.
