### PR TITLE
Fix #6464: Update invalid links for language codes references

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -250,7 +250,7 @@ the source and the compiled catalogs.
 
 When a new locale is submitted, add a new directory with the ISO 639-1 language
 identifier and put ``sphinx.po`` in there.  Don't forget to update the possible
-values for :confval:`language` in ``doc/config.rst``.
+values for :confval:`language` in ``doc/usage/configuration.rst``.
 
 The Sphinx core messages can also be translated on `Transifex
 <https://www.transifex.com/>`_.  There exists a client tool named ``tx`` in the

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -310,7 +310,7 @@ you can select a language here by its language code. Sphinx will then
 translate text that it generates into that language.
 
 For a list of supported codes, see
-http://sphinx-doc.org/config.html#confval-language.'''))
+https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language.'''))
         d['language'] = do_prompt(__('Project language'), 'en')
         if d['language'] == 'en':
             d['language'] = None

--- a/sphinx/locale/ar/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ar/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/bn/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/bn/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ca/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ca/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/cak/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/cak/LC_MESSAGES/sphinx.po
@@ -1448,8 +1448,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nWe xetz'ib'an ri wuj pa jun ch'abäl man Q'anch' ta,\nyatikïr nacha' jun chïk runuk'unem ch'ab'äl wawe' chi Sphinx tiq'ax\nruch'abäl ri wuj xtik'iyij pa ri ch'ab'äl re.\n\nChi natz'u rucholajem runuk'unem ch'ab'äl k'o chïk pa Sphinx, tab'e pa\nhttp://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nWe xetz'ib'an ri wuj pa jun ch'abäl man Q'anch' ta,\nyatikïr nacha' jun chïk runuk'unem ch'ab'äl wawe' chi Sphinx tiq'ax\nruch'abäl ri wuj xtik'iyij pa ri ch'ab'äl re.\n\nChi natz'u rucholajem runuk'unem ch'ab'äl k'o chïk pa Sphinx, tab'e pa\nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/cs/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/cs/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/cy/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/cy/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/da/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/da/LC_MESSAGES/sphinx.po
@@ -1450,7 +1450,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/de/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/de/LC_MESSAGES/sphinx.po
@@ -1451,7 +1451,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/el/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/el/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/eo/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/eo/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/es/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/es/LC_MESSAGES/sphinx.po
@@ -1454,8 +1454,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nSi los documentos están escritos en un idioma distinto al Inglés,\npuedes seleccionar un idioma aqui a través de su código. Sphinx traducirá\nlos textos que genere en dicho idioma.\n\nPara una lista de los códigos soportados visita: \nhttp://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nSi los documentos están escritos en un idioma distinto al Inglés,\npuedes seleccionar un idioma aqui a través de su código. Sphinx traducirá\nlos textos que genere en dicho idioma.\n\nPara una lista de los códigos soportados visita: \nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/et/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/et/LC_MESSAGES/sphinx.po
@@ -1451,8 +1451,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nKui su dokumendid pole kirjutatud inglise keeles, siis võid siin määrata\nkeele vastava keelekoodi abil. Sel juhul tõlgib Sphinx enda genereeritud\nteksti vastavasse keelde.\n\nToetatud keelekoodide kohta vaata\nhttp://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nKui su dokumendid pole kirjutatud inglise keeles, siis võid siin määrata\nkeele vastava keelekoodi abil. Sel juhul tõlgib Sphinx enda genereeritud\nteksti vastavasse keelde.\n\nToetatud keelekoodide kohta vaata\nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/eu/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/eu/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/fa/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fa/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/fi/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fi/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/fr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fr/LC_MESSAGES/sphinx.po
@@ -1465,8 +1465,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nSi le documents doit être écrit dans une autre langue que l'anglais, vous pouvez choisir une langue ici en saisissant son code. Sphinx traduira le texte qu'il génère dans cette langue. Pour une liste des codes supportés : http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nSi le documents doit être écrit dans une autre langue que l'anglais, vous pouvez choisir une langue ici en saisissant son code. Sphinx traduira le texte qu'il génère dans cette langue. Pour une liste des codes supportés : https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/he/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/he/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/hi/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/hi/LC_MESSAGES/sphinx.po
@@ -1449,8 +1449,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nयदि प्रलेखों को अंग्रेजी के अलावा अन्य किसी भाषा में लिखा जाना है,\nतो यहाँ पर आप भाषा का कूटशब्द दे सकते हैं. स्फिंक्स तदपुरांत,\nजो वाक्यांश बनाता है उसे उस भाषा में अनुवादित करेगा.\n\nमान्य भाषा कूटशब्द सूची यहाँ पर देखें\nhttp://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nयदि प्रलेखों को अंग्रेजी के अलावा अन्य किसी भाषा में लिखा जाना है,\nतो यहाँ पर आप भाषा का कूटशब्द दे सकते हैं. स्फिंक्स तदपुरांत,\nजो वाक्यांश बनाता है उसे उस भाषा में अनुवादित करेगा.\n\nमान्य भाषा कूटशब्द सूची यहाँ पर देखें\nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/hi_IN/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/hi_IN/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/hr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/hr/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/hu/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/hu/LC_MESSAGES/sphinx.po
@@ -1452,7 +1452,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/id/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/id/LC_MESSAGES/sphinx.po
@@ -1451,7 +1451,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/it/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/it/LC_MESSAGES/sphinx.po
@@ -1452,7 +1452,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ja/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ja/LC_MESSAGES/sphinx.po
@@ -1460,8 +1460,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nドキュメントを英語以外の言語で書く場合は、\n 言語コードで言語を選択できます。Sphinx は生成したテキストをその言語に翻訳します。\n\nサポートされているコードのリストについては、\nhttp://sphinx-doc.org/config.html#confval-language を参照してください。"
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nドキュメントを英語以外の言語で書く場合は、\n 言語コードで言語を選択できます。Sphinx は生成したテキストをその言語に翻訳します。\n\nサポートされているコードのリストについては、\nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language を参照してください。"
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/ko/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ko/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/lt/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/lt/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/lv/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/lv/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/mk/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/mk/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/nb_NO/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/nb_NO/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ne/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ne/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/nl/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/nl/LC_MESSAGES/sphinx.po
@@ -1453,7 +1453,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/pl/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/pl/LC_MESSAGES/sphinx.po
@@ -1451,8 +1451,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\nJeśli dokumenty mają być pisane w języku innym niż angielski,\nmożesz tutaj wybrać język przez jego kod. Sphinx następnie\nprzetłumaczy tekst, który generuje, na ten język.\n\nListę wspieranych kodów znajdziesz na\nhttp://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\nJeśli dokumenty mają być pisane w języku innym niż angielski,\nmożesz tutaj wybrać język przez jego kod. Sphinx następnie\nprzetłumaczy tekst, który generuje, na ten język.\n\nListę wspieranych kodów znajdziesz na\nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/pt/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/pt/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/pt_BR/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/pt_BR/LC_MESSAGES/sphinx.po
@@ -1451,7 +1451,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/pt_PT/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/pt_PT/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ro/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ro/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ru/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ru/LC_MESSAGES/sphinx.po
@@ -1453,7 +1453,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/si/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/si/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sk/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/sk/LC_MESSAGES/sphinx.po
@@ -1450,7 +1450,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sl/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/sl/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sphinx.pot
+++ b/sphinx/locale/sphinx.pot
@@ -1461,7 +1461,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/sr/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sr@latin/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/sr@latin/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sr_RS/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/sr_RS/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/sv/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/sv/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ta/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ta/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/tr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/tr/LC_MESSAGES/sphinx.po
@@ -1449,7 +1449,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/uk_UA/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/uk_UA/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/ur/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ur/LC_MESSAGES/sphinx.po
@@ -1447,7 +1447,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/vi/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/vi/LC_MESSAGES/sphinx.po
@@ -1448,7 +1448,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314

--- a/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
@@ -1456,8 +1456,8 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
-msgstr "\n如果用英语以外的语言编写文档，你可以在此按语言代码选择语种。\nSphinx 会把内置文本翻译成相应语言的版本。\n\n支持的语言代码列表见：\nhttp://sphinx-doc.org/config.html#confval-language。"
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
+msgstr "\n如果用英语以外的语言编写文档，你可以在此按语言代码选择语种。\nSphinx 会把内置文本翻译成相应语言的版本。\n\n支持的语言代码列表见：\nhttps://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language。"
 
 #: sphinx/cmd/quickstart.py:314
 msgid "Project language"

--- a/sphinx/locale/zh_TW/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/zh_TW/LC_MESSAGES/sphinx.po
@@ -1453,7 +1453,7 @@ msgid ""
 "translate text that it generates into that language.\n"
 "\n"
 "For a list of supported codes, see\n"
-"http://sphinx-doc.org/config.html#confval-language."
+"https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language."
 msgstr ""
 
 #: sphinx/cmd/quickstart.py:314


### PR DESCRIPTION
Subject: Update invalid links

### Feature or Bugfix
- Bugfix

### Purpose
- fix #6464 