### PR TITLE
Revert "Fix #1063: autodoc: automodule directive handles undocumented module level variables"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #6447: autodoc: Stop to generate document for undocumented module variables
+
 Deprecated
 ----------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -549,10 +549,8 @@ class Documenter:
 
         if self.analyzer:
             attr_docs = self.analyzer.find_attr_docs()
-            tagorder = self.analyzer.tagorder
         else:
             attr_docs = {}
-            tagorder = {}
 
         # process members and determine which to skip
         for (membername, member) in members:
@@ -582,13 +580,12 @@ class Documenter:
                         membername in self.options.special_members:
                     keep = has_doc or self.options.undoc_members
             elif (namespace, membername) in attr_docs:
-                has_doc = bool(attr_docs[namespace, membername])
                 if want_all and membername.startswith('_'):
                     # ignore members whose name starts with _ by default
-                    keep = has_doc and self.options.private_members
+                    keep = self.options.private_members
                 else:
                     # keep documented attributes
-                    keep = has_doc
+                    keep = True
                 isattr = True
             elif want_all and membername.startswith('_'):
                 # ignore members whose name starts with _ by default
@@ -597,8 +594,6 @@ class Documenter:
             else:
                 # ignore undocumented members if :undoc-members: is not given
                 keep = has_doc or self.options.undoc_members
-                # module top level item or not
-                isattr = membername in tagorder
 
             # give the user a chance to decide whether this member
             # should be skipped
@@ -1295,10 +1290,6 @@ class DataDocumenter(ModuleLevelDocumenter):
         # type: () -> str
         return self.get_attr(self.parent or self.object, '__module__', None) \
             or self.modname
-
-    def get_doc(self, encoding=None, ignore=1):
-        # type: (str, int) -> List[List[str]]
-        return []
 
 
 class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: ignore

--- a/tests/roots/test-ext-autodoc/target/module.py
+++ b/tests/roots/test-ext-autodoc/target/module.py
@@ -1,4 +1,0 @@
-#: docstring for CONSTANT1
-CONSTANT1 = ""
-
-CONSTANT2 = ""

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1689,30 +1689,6 @@ def test_partialmethod(app):
     assert list(actual) == expected
 
 
-@pytest.mark.usefixtures('setup_test')
-def test_module_variables():
-    options = {"members": None,
-               "undoc-members": True}
-    actual = do_autodoc(app, 'module', 'target.module', options)
-    assert list(actual) == [
-        '',
-        '.. py:module:: target.module',
-        '',
-        '',
-        '.. py:data:: CONSTANT1',
-        '   :module: target.module',
-        "   :annotation: = ''",
-        '',
-        '   docstring for CONSTANT1',
-        '   ',
-        '',
-        '.. py:data:: CONSTANT2',
-        '   :module: target.module',
-        "   :annotation: = ''",
-        '',
-    ]
-
-
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_typehints_signature(app):
     app.config.autodoc_typehints = "signature"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6447 and #6451 
- The change for #1063 is harmful for many users. So it should be reconsidered again. So this reverts it.
