### PR TITLE
Keep all backslashes in domain directives.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,12 @@ Incompatible changes
   The existing ones are now more strict, resulting in new warnings.
 * The attribute ``sphinx_cpp_tagname`` in the ``desc_signature_line`` node
   has been renamed to ``sphinx_line_type``.
+* #6462: double backslashes in domain directives are no longer replaced by
+  single backslashes as default. Each class derived from ObjectDescription
+  may reenable the stripping for it self. A new configuration value
+  :confval:`signature_backslash_strip_domain_override` can be used by users
+  to reenable it per domain as well. Setting it to ``[]`` will reinstate the
+  old behaviour with backslash stripping in every domain.
 
 Deprecated
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -43,11 +43,8 @@ Incompatible changes
 * The attribute ``sphinx_cpp_tagname`` in the ``desc_signature_line`` node
   has been renamed to ``sphinx_line_type``.
 * #6462: double backslashes in domain directives are no longer replaced by
-  single backslashes as default. Each class derived from ObjectDescription
-  may reenable the stripping for it self. A new configuration value
-  :confval:`signature_backslash_strip_domain_override` can be used by users
-  to reenable it per domain as well. Setting it to ``[]`` will reinstate the
-  old behaviour with backslash stripping in every domain.
+  single backslashes as default. A new configuration value
+  :confval:`strip_signature_backslash` can be used by users to reenable it.
 
 Deprecated
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -634,14 +634,13 @@ General configuration
    .. versionchanged:: 1.1
       Now also removes ``<BLANKLINE>``.
 
-.. confval:: signature_backslash_strip_domain_override
+.. confval:: strip_signature_backslash
 
-    A list of domain names for which to forcibly reinstate backslash stripping.
-    The value ``None`` means "no domains" while ``[]`` means every domain
-    (i.e., the behaviour before version 3.0).
-    Default is ``None``.
-    When backslash stripping is enabled then every occurrence of ``\\`` in a domain
-    directive will be changed to ``\``, even within string literals.
+   Default is ``False``.
+   When backslash stripping is enabled then every occurrence of ``\\`` in a
+   domain directive will be changed to ``\``, even within string literals.
+   This was the behaviour before version 3.0, and setting this variable to
+   ``True`` will reinstate that behaviour.
 
     .. versionadded:: 3.0
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -634,6 +634,17 @@ General configuration
    .. versionchanged:: 1.1
       Now also removes ``<BLANKLINE>``.
 
+.. confval:: signature_backslash_strip_domain_override
+
+    A list of domain names for which to forcibly reinstate backslash stripping.
+    The value ``None`` means "no domains" while ``[]`` means every domain
+    (i.e., the behaviour before version 3.0).
+    Default is ``None``.
+    When backslash stripping is enabled then every occurrence of ``\\`` in a domain
+    directive will be changed to ``\``, even within string literals.
+
+    .. versionadded:: 3.0
+
 
 .. _intl-options:
 

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -60,7 +60,6 @@ class ObjectDescription(SphinxDirective):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = True
-    strip_backslashes = None
     option_spec = {
         'noindex': directives.flag,
     }  # type: Dict[str, DirectiveOption]
@@ -92,28 +91,9 @@ class ObjectDescription(SphinxDirective):
         """
         Retrieve the signatures to document from the directive arguments.  By
         default, signatures are given as arguments, one per line.
-
-        Backslash-escaping of newlines is supported.
         """
         lines = nl_escape_re.sub('', self.arguments[0]).split('\n')
-
-        # Stripping of backslashes can be overridden by the user config,
-        # otherwise the object it self may have an opinion, and
-        # otherwise we don't do stripping.
-        do_stripping = False
-        conf_stripping = self.env.config.signature_backslash_strip_domain_override
-        if conf_stripping is None:
-            # no user config override, use the object opinion if any
-            if self.strip_backslashes is not None:
-                do_stripping = self.strip_backslashes
-        else:
-            # could be overridden by the user
-            if len(conf_stripping) == 0:
-                # override always (i.e., the old behaviour)
-                do_stripping = True
-            elif self.domain is not None:
-                do_stripping = self.domain in conf_stripping
-        if do_stripping:
+        if self.config.strip_signature_backslash:
             # remove backslashes to support (dummy) escapes; helps Vim highlighting
             return [strip_backslash_re.sub(r'\1', line.strip()) for line in lines]
         else:
@@ -318,7 +298,7 @@ deprecated_alias('sphinx.directives',
 
 
 def setup(app: "Sphinx") -> Dict[str, Any]:
-    app.add_config_value("signature_backslash_strip_domain_override", None, 'env')
+    app.add_config_value("strip_signature_backslash", False, 'env')
     directives.register_directive('default-role', DefaultRole)
     directives.register_directive('default-domain', DefaultDomain)
     directives.register_directive('describe', ObjectDescription)

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1043,8 +1043,9 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
                 sig = inspect.signature(self.object.__init__, bound_method=True)
                 args = stringify_signature(sig, show_return_annotation=False, **kwargs)
 
-        # escape backslashes for reST
-        args = args.replace('\\', '\\\\')
+        if self.env.config.strip_signature_backslash:
+            # escape backslashes for reST
+            args = args.replace('\\', '\\\\')
         return args
 
     def document_members(self, all_members: bool = False) -> None:
@@ -1437,8 +1438,9 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
             sig = inspect.signature(self.object, bound_method=True)
         args = stringify_signature(sig, **kwargs)
 
-        # escape backslashes for reST
-        args = args.replace('\\', '\\\\')
+        if self.env.config.strip_signature_backslash:
+            # escape backslashes for reST
+            args = args.replace('\\', '\\\\')
         return args
 
     def add_directive_header(self, sig: str) -> None:

--- a/tests/roots/test-domain-cpp/backslash.rst
+++ b/tests/roots/test-domain-cpp/backslash.rst
@@ -1,0 +1,1 @@
+.. cpp:var:: char c = '\\'

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -193,7 +193,7 @@ def test_format_signature():
     assert formatsig('function', 'f', f, None, None) == '(a, b, c=1, **d)'
     assert formatsig('function', 'f', f, 'a, b, c, d', None) == '(a, b, c, d)'
     assert formatsig('function', 'f', f, None, 'None') == '(a, b, c=1, **d) -> None'
-    assert formatsig('function', 'g', g, None, None) == r"(a='\\n')"
+    assert formatsig('function', 'g', g, None, None) == r"(a='\n')"
 
     # test for classes
     class D:
@@ -247,12 +247,12 @@ def test_format_signature():
     assert formatsig('method', 'H.foo', H.foo1, None, None) == '(b, *c)'
     assert formatsig('method', 'H.foo', H.foo1, 'a', None) == '(a)'
     assert formatsig('method', 'H.foo', H.foo2, None, None) == '(*c)'
-    assert formatsig('method', 'H.foo', H.foo3, None, None) == r"(d='\\n')"
+    assert formatsig('method', 'H.foo', H.foo3, None, None) == r"(d='\n')"
 
     # test bound methods interpreted as functions
     assert formatsig('function', 'foo', H().foo1, None, None) == '(b, *c)'
     assert formatsig('function', 'foo', H().foo2, None, None) == '(*c)'
-    assert formatsig('function', 'foo', H().foo3, None, None) == r"(d='\\n')"
+    assert formatsig('function', 'foo', H().foo3, None, None) == r"(d='\n')"
 
     # test exception handling (exception is caught and args is '')
     directive.env.config.autodoc_docstring_signature = False

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -845,6 +845,22 @@ def test_build_domain_cpp_warn_template_param_qualified_name(app, status, warnin
     assert "WARNING: cpp:type reference target not found: T::U::typeWarn" in ws[1]
 
 
+@pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
+def test_build_domain_cpp_backslash_ok(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "backslash")
+    assert len(ws) == 0
+
+
+@pytest.mark.sphinx(testroot='domain-cpp',
+                    confoverrides={'nitpicky': True, 'strip_signature_backslash': True})
+def test_build_domain_cpp_backslash_ok(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "backslash")
+    assert len(ws) == 1
+    assert "WARNING: Parsing of expression failed. Using fallback parser." in ws[0]
+
+
 @pytest.mark.sphinx(testroot='domain-cpp')
 def test_build_domain_cpp_misuse_of_roles(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
Subject: modify the central line handler for domain directives to not touch double backslashes.

### Feature or Bugfix
- Bugfix

### Purpose
It looks like a long time ago an extra regex replacement was inserted in function that handles escaped line breaks in domain directives. It replaces two consecutive backslashes with a single backlash. This means that users/tools must escape all backslashes in declarations once more. Breathe doesn't do this, does autodoc?
This PR changes the default behaviour so not backslash stripping is being done by default.
If a domain is specifically designed to rely on the stripping, it can set ``strip_backslashes = True`` in the subclasses of ``ObjectDescription``.
Users can selectively reenable the stripping in specific domains with a new configuration value ``signature_backslash_strip_domain_override`` (a list of domain names). The default is ``None``, while the empty list ``[]`` reverts *all* domains to the old behaviour.

### Relates
- #6462 (see also this for an example for reproduction)