### PR TITLE
Remove "universal" configuration from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,9 +5,6 @@ license_file = LICENSE
 tag_build = .dev
 tag_date = true
 
-[bdist_wheel]
-universal = 1
-
 [aliases]
 release = egg_info -Db ''
 upload = upload --sign --identity=36580288


### PR DESCRIPTION
Sphinx is Python-3-only and therefore is not a universal wheel. It
should still distribute a 'py3' wheel, just not a universal one.

From https://wheel.readthedocs.io/en/stable/user_guide.html

> If your project contains no C extensions and is expected to work on
> both Python 2 and 3, you will want to tell wheel to produce universal
> wheels by adding this to your setup.cfg file: …

As Sphinx doesn't work on Python 2, it should not be universal.