### PR TITLE
Remove empty code block in sphinx.util.requests

### DIFF
--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 from typing import Generator, Union
 from urllib.parse import urlsplit
 
-import pkg_resources
 import requests
 
 from sphinx.config import Config
@@ -44,18 +43,6 @@ except ImportError:
     except ImportError:
         # for requests < 2.4.0
         InsecurePlatformWarning = None  # type: ignore
-
-# try to load requests[security] (but only if SSL is available)
-try:
-    import ssl  # NOQA
-except ImportError:
-    pass
-else:
-    try:
-        pkg_resources.require(['requests[security]'])
-    except (pkg_resources.DistributionNotFound,
-            pkg_resources.VersionConflict):
-        pass  # ignored
 
 
 useragent_header = [('User-Agent',


### PR DESCRIPTION
Empty since 19a187cb5443808c284dd9e8f85ad13cba98182b.

If requests is installed with the security extras, they will be loaded
automatically by requests. The is no need to proactively load it. The
block simply did a "pass" in all cases.