### PR TITLE
Explicitly treat ObjectDescription._doc_field_type_map as an instance variable

### DIFF
--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -71,6 +71,7 @@ class ObjectDescription(SphinxDirective):
     _doc_field_type_map = {}  # type: Dict[str, Tuple[Field, bool]]
 
     def _process_type_map(self, typelist):
+        # type: () -> Dict[str, Tuple[Field, bool]]
         typemap = {}
         for field in typelist:
             for name in field.names:

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -70,25 +70,17 @@ class ObjectDescription(SphinxDirective):
     # Warning: this might be removed in future version. Don't touch this from extensions.
     _doc_field_type_map = {}  # type: Dict[str, Tuple[Field, bool]]
 
-    def _process_type_map(self, typelist):
-        # type: (List[Field]) -> Dict[str, Tuple[Field, bool]]
-        typemap = {}
-        for field in typelist:
-            for name in field.names:
-                typemap[name] = (field, False)
-            if field.is_typed:
-                typed_field = cast(TypedField, field)
-                for name in typed_field.typenames:
-                    typemap[name] = (field, True)
-        return typemap
-
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        SphinxDirective.__init__(self, *args, **kwargs)
-        self._doc_field_type_map = self._process_type_map(self.doc_field_types)
-
     def get_field_type_map(self):
         # type: () -> Dict[str, Tuple[Field, bool]]
+        if self._doc_field_type_map == {}:
+            self._doc_field_type_map = {}
+            for field in self.doc_field_types:
+                for name in field.names:
+                    self._doc_field_type_map[name] = (field, False)
+                if field.is_typed:
+                    typed_field = cast(TypedField, field)
+                    for name in typed_field.typenames:
+                        self._doc_field_type_map[name] = (field, True)
         return self._doc_field_type_map
 
     def get_signatures(self):

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -70,18 +70,23 @@ class ObjectDescription(SphinxDirective):
     # Warning: this might be removed in future version. Don't touch this from extensions.
     _doc_field_type_map = {}  # type: Dict[str, Tuple[Field, bool]]
 
+    def _process_type_map(self, typelist):
+        typemap = {}
+        for field in typelist:
+            for name in field.names:
+                typemap[name] = (field, False)
+            if field.is_typed:
+                typed_field = cast(TypedField, field)
+                for name in typed_field.typenames:
+                    typemap[name] = (field, True)
+        return typemap
+
+    def __init__(self, *args, **kwargs):
+        SphinxDirective.__init__(self, *args, **kwargs)
+        self._doc_field_type_map = self._process_type_map(self.doc_field_types)
+
     def get_field_type_map(self):
         # type: () -> Dict[str, Tuple[Field, bool]]
-        if self._doc_field_type_map == {}:
-            for field in self.doc_field_types:
-                for name in field.names:
-                    self._doc_field_type_map[name] = (field, False)
-
-                if field.is_typed:
-                    typed_field = cast(TypedField, field)
-                    for name in typed_field.typenames:
-                        self._doc_field_type_map[name] = (field, True)
-
         return self._doc_field_type_map
 
     def get_signatures(self):

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -77,10 +77,12 @@ class ObjectDescription(SphinxDirective):
             for field in self.doc_field_types:
                 for name in field.names:
                     self._doc_field_type_map[name] = (field, False)
+
                 if field.is_typed:
                     typed_field = cast(TypedField, field)
                     for name in typed_field.typenames:
                         self._doc_field_type_map[name] = (field, True)
+
         return self._doc_field_type_map
 
     def get_signatures(self):

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -71,7 +71,7 @@ class ObjectDescription(SphinxDirective):
     _doc_field_type_map = {}  # type: Dict[str, Tuple[Field, bool]]
 
     def _process_type_map(self, typelist):
-        # type: () -> Dict[str, Tuple[Field, bool]]
+        # type: (List[Field]) -> Dict[str, Tuple[Field, bool]]
         typemap = {}
         for field in typelist:
             for name in field.names:
@@ -83,6 +83,7 @@ class ObjectDescription(SphinxDirective):
         return typemap
 
     def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         SphinxDirective.__init__(self, *args, **kwargs)
         self._doc_field_type_map = self._process_type_map(self.doc_field_types)
 


### PR DESCRIPTION
Subject: Aims to address [issue #6478](https://github.com/sphinx-doc/sphinx/issues/6478)

### Feature or Bugfix

- Bugfix

### Purpose
Explicitly treat `ObjectDescription._doc_field_type_map` population as an instance variable so that we can be sure that Domains with objects that define their own field types will render properly on the output.

### Detail

- Left `ObjectDescription._doc_field_type_map` declaration alone and in place in
  case there are other factors at play that require it declared on the class.

- Ensured that `ObjectDescription.get_field_type_map()` made sure to populate the instance scoped version of `_doc_field_type_map` and not the class scoped version of the variable. 

### Relates
- #6478 

