### PR TITLE
Fix #6486: UnboundLocalError is raised if broken extension installed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
 * #1125: html theme: scrollbar is hard to see on classic theme and macOS
 * #5502: linkcheck: Consider HTTP 503 response as not an error
 * #6439: Make generated download links reproducible
+* #6486: UnboundLocalError is raised if broken extension installed
 
 Testing
 --------

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -188,7 +188,7 @@ class sphinx_domains:
 
     def __exit__(self, exc_type: Type[Exception], exc_value: Exception, traceback: Any) -> bool:  # NOQA
         self.disable()
-        return True
+        return False
 
     def enable(self) -> None:
         self.directive_func = directives.directive


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6486 