### PR TITLE
Fix #6497: custom lexers fails highlighting when syntax error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6497: custom lexers fails highlighting when syntax error
+
 Testing
 --------
 

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -139,7 +139,8 @@ class PygmentsBridge:
                 lexer = lexers['none']
 
         if lang in lexers:
-            lexer = lexers[lang]
+            # just return custom lexers here (without installing raiseonerror filter)
+            return lexers[lang]
         elif lang in lexer_classes:
             lexer = lexer_classes[lang](**opts)
         else:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6497 