### PR TITLE
Fix #6507: autosummary: crashes without no autosummary_generate setting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ Bugs fixed
 * #5502: linkcheck: Consider HTTP 503 response as not an error
 * #6439: Make generated download links reproducible
 * #6486: UnboundLocalError is raised if broken extension installed
+* #6507: autosummary: crashes without no autosummary_generate setting
 
 Testing
 --------

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -256,19 +256,26 @@ class Autosummary(SphinxDirective):
                 docname = posixpath.join(tree_prefix, real_name)
                 docname = posixpath.normpath(posixpath.join(dirname, docname))
                 if docname not in self.env.found_docs:
+                    location = self.state_machine.get_source_and_line(self.lineno)
                     if excluded(self.env.doc2path(docname, None)):
-                        logger.warning(__('toctree references excluded document %r'), docname)
+                        msg = __('autosummary references excluded document %r. Ignored.')
                     else:
-                        logger.warning(__('toctree references unknown document %r'), docname)
+                        msg = __('autosummary: stub file not found %r. '
+                                 'Check your autosummary_generate setting.')
+
+                    logger.warning(msg, real_name, location=location)
+                    continue
+
                 docnames.append(docname)
 
-            tocnode = addnodes.toctree()
-            tocnode['includefiles'] = docnames
-            tocnode['entries'] = [(None, docn) for docn in docnames]
-            tocnode['maxdepth'] = -1
-            tocnode['glob'] = None
+            if docnames:
+                tocnode = addnodes.toctree()
+                tocnode['includefiles'] = docnames
+                tocnode['entries'] = [(None, docn) for docn in docnames]
+                tocnode['maxdepth'] = -1
+                tocnode['glob'] = None
 
-            nodes.append(autosummary_toc('', '', tocnode))
+                nodes.append(autosummary_toc('', '', tocnode))
 
         return nodes
 

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -302,3 +302,11 @@ def test_generate_autosummary_docs_property(app):
                        ".. currentmodule:: target.methods\n"
                        "\n"
                        ".. autoproperty:: Base.prop")
+
+
+@pytest.mark.sphinx('dummy', testroot='ext-autosummary',
+                    confoverrides={'autosummary_generate': []})
+def test_empty_autosummary_generate(app, status, warning):
+    app.build()
+    assert ("WARNING: autosummary: stub file not found 'autosummary_importfail'"
+            in warning.getvalue())


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6507 