### PR TITLE
Force last update datetime value to always be UTC

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -286,7 +286,7 @@ def format_date(format, date=None, language=None):
         if source_date_epoch is not None:
             date = datetime.utcfromtimestamp(float(source_date_epoch))
         else:
-            date = datetime.now()
+            date = datetime.utcnow()
 
     result = []
     tokens = date_format_re.split(format)


### PR DESCRIPTION
Subject: We should use UTC datetime values for build times, always

### Feature or Bugfix
- Bugfix

### Purpose
This fix forces `last_updated` build-time values to always be expressed as UTC times, so that if someone builds docs that use a full date-time stamp, with timezone, in their output template, the formatted time gets properly represented as (and labelled as) a UTC time value.

### Details
- If SOURCE_DATE_EPOCH is set in the environment, then the build date will use
  UTC as the timezone.

- If it's not set in the environment, we should do the same thing and use UTC
  as the timezone for the build date.

- `datetime.now()` produces a naive system-time datetime object; `datetime.utcnow()`
  produces the aware, UTC-oriented datetime object.

### Relates
Please see https://github.com/sphinx-doc/sphinx/issues/6527


