### PR TITLE
format_date(): use "aware" local datetime by default (refs: #6528)

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -12,7 +12,7 @@ import os
 import re
 import warnings
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 from os import path
 from typing import Callable, Generator, List, Set, Tuple
 
@@ -274,7 +274,7 @@ def format_date(format: str, date: datetime = None, language: str = None) -> str
         if source_date_epoch is not None:
             date = datetime.utcfromtimestamp(float(source_date_epoch))
         else:
-            date = datetime.utcnow()
+            date = datetime.now(timezone.utc).astimezone()
 
     result = []
     tokens = date_format_re.split(format)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- This gives system timezone information to default value of ``format_date()``.  And it does not modifies the timestamp to UTC.
- refs: #6528 
