### PR TITLE
LaTeX: refactor visit_enumerated_list() to use \sphinxsetlistlabels

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -413,6 +413,18 @@
 \newcommand\sphinxsetup[1]{\setkeys{sphinx}{#1}}
 
 
+%% ALPHANUMERIC LIST ITEMS
+\newcommand\sphinxsetlistlabels[5]
+{% #1 = style, #2 = enum, #3 = enumnext, #4 = prefix, #5 = suffix
+ % #2 and #3 are counters used by enumerate environement e.g. enumi, enumii.
+ % #1 is a macro such as \arabic or \alph
+ % prefix and suffix are strings (by default empty and a dot).
+ \@namedef{the#2}{#1{#2}}%
+ \@namedef{label#2}{#4\@nameuse{the#2}#5}%
+ \@namedef{p@#3}{\@nameuse{p@#2}#4\@nameuse{the#2}#5}%
+}%
+
+
 %% MAXLISTDEPTH
 %
 % remove LaTeX's cap on nesting depth if 'maxlistdepth' key used.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1373,11 +1373,8 @@ class LaTeXTranslator(SphinxTranslator):
         suffix = node.get('suffix', '.')
 
         self.body.append('\\begin{enumerate}\n')
-        self.body.append('\\def\\the%s{%s{%s}}\n' % (enum, style, enum))
-        self.body.append('\\def\\label%s{%s\\the%s %s}\n' %
-                         (enum, prefix, enum, suffix))
-        self.body.append('\\makeatletter\\def\\p@%s{\\p@%s %s\\the%s %s}\\makeatother\n' %
-                         (enumnext, enum, prefix, enum, suffix))
+        self.body.append('\\sphinxsetlistlabels{%s}{%s}{%s}{%s}{%s}%%\n' %
+                         (style, enum, enumnext, prefix, suffix))
         if 'start' in node:
             self.body.append('\\setcounter{%s}{%d}\n' % (enum, node['start'] - 1))
         if self.table:

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1292,25 +1292,15 @@ def test_latex_nested_enumerated_list(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'python.tex').text(encoding='utf8')
-    assert ('\\def\\theenumi{\\arabic{enumi}}\n'
-            '\\def\\labelenumi{\\theenumi .}\n'
-            '\\makeatletter\\def\\p@enumii{\\p@enumi \\theenumi .}\\makeatother\n'
+    assert ('\\sphinxsetlistlabels{\\arabic}{enumi}{enumii}{}{.}%\n'
             '\\setcounter{enumi}{4}\n' in result)
-    assert ('\\def\\theenumii{\\alph{enumii}}\n'
-            '\\def\\labelenumii{\\theenumii .}\n'
-            '\\makeatletter\\def\\p@enumiii{\\p@enumii \\theenumii .}\\makeatother\n'
+    assert ('\\sphinxsetlistlabels{\\alph}{enumii}{enumiii}{}{.}%\n'
             '\\setcounter{enumii}{3}\n' in result)
-    assert ('\\def\\theenumiii{\\arabic{enumiii}}\n'
-            '\\def\\labelenumiii{\\theenumiii )}\n'
-            '\\makeatletter\\def\\p@enumiv{\\p@enumiii \\theenumiii )}\\makeatother\n'
+    assert ('\\sphinxsetlistlabels{\\arabic}{enumiii}{enumiv}{}{)}%\n'
             '\\setcounter{enumiii}{9}\n' in result)
-    assert ('\\def\\theenumiv{\\arabic{enumiv}}\n'
-            '\\def\\labelenumiv{(\\theenumiv )}\n'
-            '\\makeatletter\\def\\p@enumv{\\p@enumiv (\\theenumiv )}\\makeatother\n'
+    assert ('\\sphinxsetlistlabels{\\arabic}{enumiv}{enumv}{(}{)}%\n'
             '\\setcounter{enumiv}{23}\n' in result)
-    assert ('\\def\\theenumii{\\roman{enumii}}\n'
-            '\\def\\labelenumii{\\theenumii .}\n'
-            '\\makeatletter\\def\\p@enumiii{\\p@enumii \\theenumii .}\\makeatother\n'
+    assert ('\\sphinxsetlistlabels{\\roman}{enumii}{enumiii}{}{.}%\n'
             '\\setcounter{enumii}{2}\n' in result)
 
 


### PR DESCRIPTION
Fixes: #6511

This is only refactoring. But as a result it provides way to fix #6511. As it is not yet decided if #6511 is a "bug" or not, I did not include any addition to CHANGES file.

I hesitated to ask merge to 2.1.3 as it is not clear if bugfix. But this is refactoring which is backwards compatible. 
