### PR TITLE
Fix #736: Invalid sort in pair index

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Bugs fixed
 * #6511: LaTeX: autonumbered list can not be customized in LaTeX
   since Sphinx 1.8.0 (refs: #6533)
 * #6531: Failed to load last environment object when extension added
+* #736: Invalid sort in pair index
 
 Testing
 --------

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -133,11 +133,21 @@ class IndexEntries:
                 oldsubitems = subitems
                 i += 1
 
+        # sort the sub-index entries
+        def keyfunc2(entry: Tuple[str, List]) -> str:
+            key = unicodedata.normalize('NFD', entry[0].lower())
+            if key.startswith('\N{RIGHT-TO-LEFT MARK}'):
+                key = key[1:]
+            if key[0:1].isalpha() or key.startswith('_'):
+                key = chr(127) + key
+            return key
+
         # group the entries by letter
-        def keyfunc2(item: Tuple[str, List]) -> str:
+        def keyfunc3(item: Tuple[str, List]) -> str:
             # hack: mutating the subitems dicts to a list in the keyfunc
             k, v = item
-            v[1] = sorted((si, se) for (si, (se, void, void)) in v[1].items())
+            v[1] = sorted(((si, se) for (si, (se, void, void)) in v[1].items()),
+                          key=keyfunc2)
             if v[2] is None:
                 # now calculate the key
                 if k.startswith('\N{RIGHT-TO-LEFT MARK}'):
@@ -151,4 +161,4 @@ class IndexEntries:
             else:
                 return v[2]
         return [(key_, list(group))
-                for (key_, group) in groupby(newlist, keyfunc2)]
+                for (key_, group) in groupby(newlist, keyfunc3)]

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -47,19 +47,30 @@ def test_create_pair_index(app):
     app.env.indexentries.clear()
     text = (".. index:: pair: docutils; reStructuredText\n"
             ".. index:: pair: Python; interpreter\n"
-            ".. index:: pair: Sphinx; documentation tool\n")
+            ".. index:: pair: Sphinx; documentation tool\n"
+            ".. index:: pair: Sphinx; :+1:\n"
+            ".. index:: pair: Sphinx; Ель\n"
+            ".. index:: pair: Sphinx; ёлка\n")
     restructuredtext.parse(app, text)
     index = IndexEntries(app.env).create_index(app.builder)
-    assert len(index) == 5
-    assert index[0] == ('D',
+    assert len(index) == 7
+    assert index[0] == ('Symbols', [(':+1:', [[], [('Sphinx', [('', '#index-3')])], None])])
+    assert index[1] == ('D',
                         [('documentation tool', [[], [('Sphinx', [('', '#index-2')])], None]),
                          ('docutils', [[], [('reStructuredText', [('', '#index-0')])], None])])
-    assert index[1] == ('I', [('interpreter', [[], [('Python', [('', '#index-1')])], None])])
-    assert index[2] == ('P', [('Python', [[], [('interpreter', [('', '#index-1')])], None])])
-    assert index[3] == ('R',
+    assert index[2] == ('I', [('interpreter', [[], [('Python', [('', '#index-1')])], None])])
+    assert index[3] == ('P', [('Python', [[], [('interpreter', [('', '#index-1')])], None])])
+    assert index[4] == ('R',
                         [('reStructuredText', [[], [('docutils', [('', '#index-0')])], None])])
-    assert index[4] == ('S',
-                        [('Sphinx', [[], [('documentation tool', [('', '#index-2')])], None])])
+    assert index[5] == ('S',
+                        [('Sphinx', [[],
+                                     [(':+1:', [('', '#index-3')]),
+                                      ('documentation tool', [('', '#index-2')]),
+                                      ('ёлка', [('', '#index-5')]),
+                                      ('Ель', [('', '#index-4')])],
+                                     None])])
+    assert index[6] == ('Е', [('ёлка', [[], [('Sphinx', [('', '#index-5')])], None]),
+                               ('Ель', [[], [('Sphinx', [('', '#index-4')])], None])])
 
 
 @pytest.mark.sphinx('dummy')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #736 
- sub-index items are sorted by codepoint. This starts to use normalized character for sorting.