### PR TITLE
Fix #6545. Strip doctests for doctest_block nodes.

### DIFF
--- a/tests/roots/test-trim_doctest_flags/index.rst
+++ b/tests/roots/test-trim_doctest_flags/index.rst
@@ -21,3 +21,8 @@ test-trim_doctest_flags
 
    >>> datetime.date.now()   # doctest: +QUX
    datetime.date(2008, 1, 1)
+
+.. doctest_block::
+
+   >>> datetime.date.now()   # doctest: +QUUX
+   datetime.date(2008, 1, 1)

--- a/tests/test_transforms_post_transforms_code.py
+++ b/tests/test_transforms_post_transforms_code.py
@@ -18,6 +18,7 @@ def test_trim_doctest_flags_html(app, status, warning):
     assert 'BAR' in result
     assert 'BAZ' not in result
     assert 'QUX' not in result
+    assert 'QUUX' not in result
 
 
 @pytest.mark.sphinx('latex', testroot='trim_doctest_flags')
@@ -29,3 +30,4 @@ def test_trim_doctest_flags_latex(app, status, warning):
     assert 'BAR' in result
     assert 'BAZ' not in result
     assert 'QUX' not in result
+    assert 'QUUX' not in result


### PR DESCRIPTION
This fixes the regression described in #6545.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
When support for `trim_doctest_flags` was expanded for all output types in #5199, only code literal blocks were checked for doctest flags. However, docutils has a `doctest_block` role that must also be handled. This pull request adds some additional logic to also strip doctest flags from `doctest_block` elements.

### Relates
- #6545
- #5199

