### PR TITLE
Fix #6549: sphinx-build: Escaped characters in error messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Bugs fixed
 * #6511: LaTeX: autonumbered list can not be customized in LaTeX
   since Sphinx 1.8.0 (refs: #6533)
 * #6531: Failed to load last environment object when extension added
+* #6549: sphinx-build: Escaped characters in error messages
 
 Testing
 --------

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -47,7 +47,7 @@ def handle_exception(app: Sphinx, args: Any, exception: BaseException, stderr: I
             print(terminal_safe(exception.args[0]), file=stderr)
         elif isinstance(exception, SphinxError):
             print(red('%s:' % exception.category), file=stderr)
-            print(terminal_safe(str(exception)), file=stderr)
+            print(str(exception), file=stderr)
         elif isinstance(exception, UnicodeError):
             print(red(__('Encoding error:')), file=stderr)
             print(terminal_safe(str(exception)), file=stderr)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6549 