### PR TITLE
Fix #6561: glossary: Wrong hyperlinks are generated for non alphanumeric terms

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -54,6 +54,7 @@ Bugs fixed
 * #5592: std domain: :rst:dir:`option` directive registers an index entry for
   each comma separated option
 * #6549: sphinx-build: Escaped characters in error messages
+* #6561: glossary: Wrong hyperlinks are generated for non alphanumeric terms
 
 Testing
 --------

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -255,9 +255,9 @@ def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], index
         new_id = nodes.make_id('term-' + termtext)
         if new_id == 'term':
             # the term is not good for node_id.  Generate it by sequence number instead.
-            new_id = 'term-' + str(len(gloss_entries))
-    if new_id in gloss_entries:
-        new_id = 'term-' + str(len(gloss_entries))
+            new_id = 'term-%d' % env.new_serialno('glossary')
+    while new_id in gloss_entries:
+        new_id = 'term-%d' % env.new_serialno('glossary')
     gloss_entries.add(new_id)
 
     std = cast(StandardDomain, env.get_domain('std'))

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -244,6 +244,17 @@ def test_glossary_sorted(app):
                 [nodes.definition, nodes.paragraph, "description"])
 
 
+def test_glossary_alphanumeric(app):
+    text = (".. glossary::\n"
+            "\n"
+            "   1\n"
+            "   /\n")
+    restructuredtext.parse(app, text)
+    objects = list(app.env.get_domain("std").get_objects())
+    assert ("1", "1", "term", "index", "term-1", -1) in objects
+    assert ("/", "/", "term", "index", "term-0", -1) in objects
+
+
 def test_cmdoption(app):
     text = (".. program:: ls\n"
             "\n"

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -131,4 +131,4 @@ def test_create_index_by_key(app):
     assert len(index) == 3
     assert index[0] == ('D', [('docutils', [[('main', '#term-docutils')], [], None])])
     assert index[1] == ('P', [('Python', [[('main', '#term-python')], [], None])])
-    assert index[2] == ('ス', [('スフィンクス', [[('main', '#term-2')], [], 'ス'])])
+    assert index[2] == ('ス', [('スフィンクス', [[('main', '#term-0')], [], 'ス'])])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6561 