### PR TITLE
Fix #6567: autodoc: autodoc_inherit_docstrings does not effect to __init__()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,8 @@ Bugs fixed
 * #5502: linkcheck: Consider HTTP 503 response as not an error
 * #6439: Make generated download links reproducible
 * #6486: UnboundLocalError is raised if broken extension installed
+* #6567: autodoc: :confval:`autodoc_inherit_docstrings` does not effect to
+  ``__init__()`` and ``__new__()``
 * #6498: autosummary: crashed with wrong autosummary_generate setting
 * #6507: autosummary: crashes without no autosummary_generate setting
 * #6511: LaTeX: autonumbered list can not be customized in LaTeX

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1128,8 +1128,9 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         # for classes, what the "docstring" is can be controlled via a
         # config value; the default is only the class docstring
         if content in ('both', 'init'):
-            initdocstring = self.get_attr(
-                self.get_attr(self.object, '__init__', None), '__doc__')
+            __init__ = self.get_attr(self.object, '__init__', None)
+            initdocstring = getdoc(__init__, self.get_attr,
+                                   self.env.config.autodoc_inherit_docstrings)
             # for new-style classes, no __init__ means default __init__
             if (initdocstring is not None and
                 (initdocstring == object.__init__.__doc__ or  # for pypy
@@ -1137,8 +1138,9 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
                 initdocstring = None
             if not initdocstring:
                 # try __new__
-                initdocstring = self.get_attr(
-                    self.get_attr(self.object, '__new__', None), '__doc__')
+                __new__ = self.get_attr(self.object, '__new__', None)
+                initdocstring = getdoc(__new__, self.get_attr,
+                                       self.env.config.autodoc_inherit_docstrings)
                 # for new-style classes, no __new__ means default __new__
                 if (initdocstring is not None and
                     (initdocstring == object.__new__.__doc__ or  # for pypy

--- a/tests/roots/test-ext-autodoc/target/autoclass_content.py
+++ b/tests/roots/test-ext-autodoc/target/autoclass_content.py
@@ -33,3 +33,15 @@ class F:
 
     def __new__(cls):
         """__new__ docstring"""
+
+
+class G(C):
+    """A class inherits __init__ without docstring."""
+    def __init__(self):
+        pass
+
+
+class H(E):
+    """A class inherits __new__ without docstring."""
+    def __init__(self):
+        pass

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -62,6 +62,18 @@ def test_autoclass_content_class(app):
         '   :module: target.autoclass_content',
         '',
         '   A class having both __init__ and __new__',
+        '   ',
+        '',
+        '.. py:class:: G()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class inherits __init__ without docstring.',
+        '   ',
+        '',
+        '.. py:class:: H()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class inherits __new__ without docstring.',
         '   '
     ]
 
@@ -110,6 +122,18 @@ def test_autoclass_content_init(app):
         '   :module: target.autoclass_content',
         '',
         '   __init__ docstring',
+        '   ',
+        '',
+        '.. py:class:: G()',
+        '   :module: target.autoclass_content',
+        '',
+        '   __init__ docstring',
+        '   ',
+        '',
+        '.. py:class:: H()',
+        '   :module: target.autoclass_content',
+        '',
+        '   __new__ docstring',
         '   '
     ]
 
@@ -164,6 +188,22 @@ def test_autoclass_content_both(app):
         '   A class having both __init__ and __new__',
         '   ',
         '   __init__ docstring',
+        '   ',
+        '',
+        '.. py:class:: G()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class inherits __init__ without docstring.',
+        '   ',
+        '   __init__ docstring',
+        '   ',
+        '',
+        '.. py:class:: H()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class inherits __new__ without docstring.',
+        '   ',
+        '   __new__ docstring',
         '   '
     ]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6567 