### PR TITLE
Be precise about which document is missing.

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -144,7 +144,7 @@ class LaTeXBuilder(Builder):
     def get_target_uri(self, docname, typ=None):
         # type: (str, str) -> str
         if docname not in self.docnames:
-            raise NoUri
+            raise NoUri(docname)
         else:
             return '%' + docname
 

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -59,7 +59,7 @@ class ManualPageBuilder(Builder):
         # type: (str, str) -> str
         if typ == 'token':
             return ''
-        raise NoUri
+        raise NoUri(docname)
 
     @progress_message(__('writing'))
     def write(self, *ignored):

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -69,7 +69,7 @@ class TexinfoBuilder(Builder):
     def get_target_uri(self, docname, typ=None):
         # type: (str, str) -> str
         if docname not in self.docnames:
-            raise NoUri
+            raise NoUri(docname)
         else:
             return '%' + docname
 


### PR DESCRIPTION
fixes #6582

With this patch I see:

```
sphinx.errors.NoUri: c-api/code
```

Which is probably better.