### PR TITLE
Fix #6589: autodoc: Formatting issues with autodoc_typehints='none'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ Bugs fixed
   ``__init__()`` and ``__new__()``
 * #6574: autodoc: :confval:`autodoc_member_order` does not refer order of
   imports when ``'bysource'`` order
+* #6589: autodoc: Formatting issues with autodoc_typehints='none'
 * #6498: autosummary: crashed with wrong autosummary_generate setting
 * #6507: autosummary: crashes without no autosummary_generate setting
 * #6511: LaTeX: autonumbered list can not be customized in LaTeX

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -428,7 +428,7 @@ class Signature:
                         arg.write(': ')
                         arg.write(self.format_annotation(param.annotation))
                 if param.default is not param.empty:
-                    if param.annotation is param.empty:
+                    if param.annotation is param.empty or show_annotation is False:
                         arg.write('=')
                         arg.write(object_description(param.default))
                     else:
@@ -444,7 +444,7 @@ class Signature:
             args.append(arg.getvalue())
             last_kind = param.kind
 
-        if self.return_annotation is inspect.Parameter.empty:
+        if self.return_annotation is inspect.Parameter.empty or show_annotation is False:
             return '(%s)' % ', '.join(args)
         else:
             if 'return' in self.annotations:

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -501,15 +501,15 @@ def test_autodoc_typehints_none(app):
         '.. py:module:: target.typehints',
         '',
         '',
-        '.. py:class:: Math(s, o = None)',
+        '.. py:class:: Math(s, o=None)',
         '   :module: target.typehints',
         '',
         '   ',
-        '   .. py:method:: Math.incr(a, b = 1) -> int',
+        '   .. py:method:: Math.incr(a, b=1)',
         '      :module: target.typehints',
         '   ',
         '',
-        '.. py:function:: incr(a, b = 1) -> int',
+        '.. py:function:: incr(a, b=1)',
         '   :module: target.typehints',
         ''
     ]

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -285,6 +285,10 @@ def test_Signature_annotations():
     sig = inspect.Signature(Node.__init__).format_args()
     assert sig == '(self, parent: Optional[Node]) -> None'
 
+    # show_annotation is False
+    sig = inspect.Signature(f7).format_args(show_annotation=False)
+    assert sig == '(x=None, y={})'
+
 
 def test_safe_getattr_with_default():
     class Foo:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6589 