### PR TITLE
Test with docutils-0.14 (previous release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - TOXENV=du13
     - python: '3.7'
       env:
-        - TOXENV=py37
+        - TOXENV=du14
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
     - python: 'nightly'
       env: TOXENV=py38

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4.0
-envlist = docs,flake8,mypy,coverage,py{35,36,37,38},du{12,13,14}
+envlist = docs,flake8,mypy,coverage,py{35,36,37,38},du{12,13,14,15}
 
 [testenv]
 usedevelop = True
@@ -13,6 +13,7 @@ deps =
     du12: docutils==0.12
     du13: docutils==0.13.1
     du14: docutils==0.14
+    du15: docutils==0.15
 extras =
     test
 setenv =


### PR DESCRIPTION
### Feature or Bugfix
- Testing

### Purpose
- docutils-0.15 is released today.
- This goes to test with docutils-0.14 in py37 env to integrated previous release.