### PR TITLE
Pin to docutils<0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'sphinxcontrib-qthelp',
     'Jinja2>=2.3',
     'Pygments>=2.0',
-    'docutils>=0.12',
+    'docutils>=0.12,<0.15',
     'snowballstemmer>=1.1',
     'babel>=1.3,!=2.0',
     'alabaster>=0.7,<0.8',


### PR DESCRIPTION
Every dependency should be pinned to an upper bound that represents
a compatible version. The previous docutils pin had no upper bound, and
just broke downstream users now that a new, incompatible docutils version
has come out (0.15), which users pull transitively via direct dependency on
Sphinx. Pin to docutils<0.15 until Sphinx is known to work with docutils 0.15
(at which point the pin should be bumped to "<0.16", keeping the pin within
a compatible range).