### PR TITLE
Fix #6620: i18n: classifiers of definition list are not translated with docutils-0.15

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -58,6 +58,8 @@ Bugs fixed
 * #6549: sphinx-build: Escaped characters in error messages
 * #6545: doctest comments not getting trimmed since Sphinx 1.8.0
 * #6561: glossary: Wrong hyperlinks are generated for non alphanumeric terms
+* #6620: i18n: classifiers of definition list are not translated with
+  docutils-0.15
 
 Testing
 --------

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -133,6 +133,9 @@ def apply_source_workaround(node: Element) -> None:
         node.source = definition_list_item.source
         node.line = definition_list_item.line - 1
         node.rawsource = node.astext()  # set 'classifier1' (or 'classifier2')
+    elif isinstance(node, nodes.classifier) and not node.source:
+        # docutils-0.15 fills in rawsource attribute, but not in source.
+        node.source = node.parent.source
     if isinstance(node, nodes.image) and node.source is None:
         logger.debug('[i18n] PATCH: %r to have source, line: %s',
                      get_full_module_name(node), repr_domxml(node))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6620 