### PR TITLE
Fix field lists after switch to HTML5 writer

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -520,14 +520,15 @@ dl.citation > dd:after {
 }
 
 dl.field-list {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: fit-content(30%) auto;
 }
 
 dl.field-list > dt {
-    flex-basis: 20%;
     font-weight: bold;
     word-break: break-word;
+    padding-left: 0.5em;
+    padding-right: 5px;
 }
 
 dl.field-list > dt:after {
@@ -535,8 +536,8 @@ dl.field-list > dt:after {
 }
 
 dl.field-list > dd {
-    flex-basis: 70%;
-    padding-left: 1em;
+    padding-left: 0.5em;
+    margin-top: 0em;
     margin-left: 0em;
     margin-bottom: 0em;
 }

--- a/sphinx/themes/bizstyle/static/bizstyle.css_t
+++ b/sphinx/themes/bizstyle/static/bizstyle.css_t
@@ -412,15 +412,10 @@ p.versionchanged span.versionmodified {
 
 dl.field-list > dt {
     color: white;
-    padding-left: 0.5em;
-    padding-right: 5px;
     background-color: #82A0BE;
 }
 
 dl.field-list > dd {
-    padding-left: 0.5em;
-    margin-top: 0em;
-    margin-left: 0em;
     background-color: #f7f7f7;
 }
 

--- a/sphinx/themes/classic/static/classic.css_t
+++ b/sphinx/themes/classic/static/classic.css_t
@@ -292,7 +292,7 @@ code {
     font-size: 0.95em;
 }
 
-th {
+th, dl.field-list > dt {
     background-color: #ede;
 }
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

Subject: fix HTML rendering of field lists after original switch to the HTML5 writer

### Purpose
See #6604. There was a general problem with alignment between dt dd elements, i.e., field type and field content. The classic theme additionally was missing some colour.

Themes affected/fixed due to changes in basic:
- bizstyle (only technically, it already was fixed in #6262)
- haiku
- classic
- nature
- pyramid
- sphinxdoc

See [field_lists.zip](https://github.com/sphinx-doc/sphinx/files/3461293/field_lists.zip) for screen shots of for version 1.8, 2.13, and with this PR.

Note that both haiku and pyramid still has some alignment problems, though the seem to be present in 1.8 as well.

### Relates
Fixes #6604
Perhaps fixes sympy/sympy#16585

