### PR TITLE
Add get_secnumber to simplify add_secnumber

### DIFF
--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -279,10 +279,11 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.depart_admonition(node)
 
     def get_secnumber(self, node):
-        # type: (nodes.Element) -> None
+        # type: (nodes.Element) -> Tuple[int, ...]
         if node.get('secnumber'):
             return node['secnumber']
-        elif isinstance(node.parent, nodes.section):
+
+        if isinstance(node.parent, nodes.section):
             if self.builder.name == 'singlehtml':
                 docname = self.docnames[-1]
                 anchorname = "%s/#%s" % (docname, node.parent['ids'][0])
@@ -292,15 +293,18 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
                 anchorname = '#' + node.parent['ids'][0]
                 if anchorname not in self.builder.secnumbers:
                     anchorname = ''  # try first heading which has no anchor
+
             if self.builder.secnumbers.get(anchorname):
                 return self.builder.secnumbers[anchorname]
+
         return None
 
     def add_secnumber(self, node):
+        # type: (nodes.Element) -> None
         secnumber = self.get_secnumber(node)
         if secnumber:
-            self.body.append('<span class="sectnum">%s</span>' %
-                '.'.join(map(str, secnumber)) + self.secnumber_suffix)
+            self.body.append('<span class="section-number">%s</span>' %
+                ('.'.join(map(str, secnumber)) + self.secnumber_suffix))
 
     def add_fignumber(self, node):
         # type: (nodes.Element) -> None

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -278,11 +278,10 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         # type: (nodes.Element) -> None
         self.depart_admonition(node)
 
-    def add_secnumber(self, node):
+    def get_secnumber(self, node):
         # type: (nodes.Element) -> None
         if node.get('secnumber'):
-            self.body.append('.'.join(map(str, node['secnumber'])) +
-                             self.secnumber_suffix)
+            return node['secnumber']
         elif isinstance(node.parent, nodes.section):
             if self.builder.name == 'singlehtml':
                 docname = self.docnames[-1]
@@ -294,9 +293,13 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
                 if anchorname not in self.builder.secnumbers:
                     anchorname = ''  # try first heading which has no anchor
             if self.builder.secnumbers.get(anchorname):
-                numbers = self.builder.secnumbers[anchorname]
-                self.body.append('.'.join(map(str, numbers)) +
-                                 self.secnumber_suffix)
+                return self.builder.secnumbers[anchorname]
+        return None
+
+    def add_secnumber(self, node):
+        secnumber = self.get_secnumber(node)
+        if secnumber:
+            self.body.append('.'.join(map(str, secnumber)) + self.secnumber_suffix)
 
     def add_fignumber(self, node):
         # type: (nodes.Element) -> None

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -299,7 +299,8 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     def add_secnumber(self, node):
         secnumber = self.get_secnumber(node)
         if secnumber:
-            self.body.append('.'.join(map(str, secnumber)) + self.secnumber_suffix)
+            self.body.append('<span class="sectnum">%s</span>' %
+                '.'.join(map(str, secnumber)) + self.secnumber_suffix)
 
     def add_fignumber(self, node):
         # type: (nodes.Element) -> None


### PR DESCRIPTION
Subject: isolate complexity of `add_secnumber` to fulfil #6613

### Feature

Currently, the section numbers are part of the title: 

```html
<h2>
    9.1 Calling conventions
    <a class="headerlink" href="#calling-conventions">¶</a>
</h2>
```

It would be useful to have a custom CSS style for the numbers  and in this case, isolating the numbers woule be useful.

```html
<h2>
    <span class="numsect">9.1</span>Calling conventions
    <a class="headerlink" href="#calling-conventions">¶</a>
</h2>
```

### Purpose

Single responsability of method is not respected on `add_fignumber` which does:

- Retrieve the section number
- Insert it into the document

### Relates
- #6613
- #6622
