### PR TITLE
LaTeX: Avoid section titles at the end of a page

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -40,7 +40,7 @@
 % for \text macro and \iffirstchoice@ conditional even if amsmath not loaded
 \RequirePackage{amstext}
 \RequirePackage{textcomp}% "warn" option issued from template
-\RequirePackage{titlesec}
+\RequirePackage[nobottomtitles*]{titlesec}
 \@ifpackagelater{titlesec}{2016/03/15}%
  {\@ifpackagelater{titlesec}{2016/03/21}%
   {}%


### PR DESCRIPTION
The topic directive uses in LaTeX rendering a framed box which
encourages a pagebreak before it even if the element is a section title.
This can be avoided with the nobottomtitles option of the titlesec
package.

Fixes: #6618