### PR TITLE
Specify the target Python version in the mypy configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ paths =
     .
 
 [mypy]
+python_version = 3.5
 show_column_numbers = True
 show_error_context = True
 ignore_missing_imports = True

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -56,8 +56,8 @@ if __version__.endswith('+'):
     __version__ = __version__[:-1]  # remove '+' for PEP-440 version spec.
     try:
         ret = subprocess.run(['git', 'show', '-s', '--pretty=format:%h'],
-                             stdout=PIPE, stderr=PIPE, encoding='ascii')
+                             stdout=PIPE, stderr=PIPE)
         if ret.stdout:
-            __display_version__ += '/' + ret.stdout.strip()
+            __display_version__ += '/' + ret.stdout.decode('ascii').strip()
     except Exception:
         pass


### PR DESCRIPTION
Currently targets Python 3.5.

This caught a bug. The `subprocess.run()` function only started taking the 'encoding' keyword argument starting with Python 3.6.

https://docs.python.org/3/library/subprocess.html#subprocess.run