### PR TITLE
Fix #6605: autodoc: crashed when target code contains custom method-like objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,7 @@ Bugs fixed
   imports when ``'bysource'`` order
 * #6574: autodoc: missing type annotation for variadic and keyword parameters
 * #6589: autodoc: Formatting issues with autodoc_typehints='none'
+* #6605: autodoc: crashed when target code contains custom method-like objects
 * #6498: autosummary: crashed with wrong autosummary_generate setting
 * #6507: autosummary: crashes without no autosummary_generate setting
 * #6511: LaTeX: autonumbered list can not be customized in LaTeX

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -207,9 +207,12 @@ def isbuiltin(obj: Any) -> bool:
 
 def iscoroutinefunction(obj: Any) -> bool:
     """Check if the object is coroutine-function."""
-    if inspect.iscoroutinefunction(obj):
+    if hasattr(obj, '__code__') and inspect.iscoroutinefunction(obj):
+        # check obj.__code__ because iscoroutinefunction() crashes for custom method-like
+        # objects (see https://github.com/sphinx-doc/sphinx/issues/6605)
         return True
-    elif ispartial(obj) and inspect.iscoroutinefunction(obj.func):
+    elif (ispartial(obj) and hasattr(obj.func, '__code__') and
+          inspect.iscoroutinefunction(obj.func)):
         # partialed
         return True
     else:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6605 