### PR TITLE
Fix #6652: Run tests with wrong latex_documents setting

### DIFF
--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -98,7 +98,7 @@ def skip_if_stylefiles_notfound(testfunc):
 @pytest.mark.sphinx('latex')
 def test_build_latex_doc(app, status, warning, engine, docclass):
     app.config.latex_engine = engine
-    app.config.latex_documents[0] = app.config.latex_documents[0][:4] + (docclass,)
+    app.config.latex_documents = [app.config.latex_documents[0][:4] + (docclass,)]
     app.builder.init_context()
 
     LaTeXTranslator.ignore_missing_images = True


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6652 