### PR TITLE
Add support for zebra-striped tables to LaTeX builder

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -646,6 +646,18 @@ macros may be significant.
 
     .. versionadded:: 1.6.6
 
+``RowEvenColor``
+    default ``{rgb}{0.85,0.85,0.85}``. Background color for even rows in
+    tables, if option :confval:`latex_zebra_stripes` is set to ``True``.
+
+    .. versionadded:: 2.1
+
+``RowOddColor``
+    default ``{rgb}{1,1,1}``. Background color for odd rows in tables, if
+    option :confval:`latex_zebra_stripes` is set to ``True``.
+
+    .. versionadded:: 2.1
+
 .. note::
 
    Starting with this colour key, and for all others coming next, the actual

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2004,6 +2004,15 @@ These options influence LaTeX output.
 
    .. versionadded:: 1.8
 
+.. confval:: latex_zebra_stripes
+
+   If ``True``, render tables with alternating background colors for even and
+   odd rows (so called "zebra striping"). See :ref:`latexsphinxsetup`
+   ``RowEvenColor`` and ``RowOddColor`` for changing the default white-grey
+   color scheme.
+
+   .. versionadded:: 2.1
+
 .. confval:: latex_elements
 
    .. versionadded:: 0.5

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -458,6 +458,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('latex_appendices', [], None)
     app.add_config_value('latex_use_latex_multicolumn', False, None)
     app.add_config_value('latex_use_xindy', default_latex_use_xindy, None)
+    app.add_config_value('latex_zebra_stripes', False, None)
     app.add_config_value('latex_toplevel_sectioning', None, None,
                          ENUM(None, 'part', 'chapter', 'section'))
     app.add_config_value('latex_domain_indices', True, None, [list])

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -201,7 +201,7 @@
 \RequirePackage{framed}
 % The xcolor package draws better fcolorboxes around verbatim code
 \IfFileExists{xcolor.sty}{
-    \RequirePackage{xcolor}
+    \RequirePackage[table]{xcolor}
 }{
     \RequirePackage{color}
 }
@@ -376,6 +376,8 @@
 \sphinxDeclareColorOption{OuterLinkColor}{{rgb}{0.216,0.439,0.388}}
 \sphinxDeclareColorOption{VerbatimColor}{{rgb}{1,1,1}}
 \sphinxDeclareColorOption{VerbatimBorderColor}{{rgb}{0,0,0}}
+\sphinxDeclareColorOption{RowEvenColor}{{rgb}{0.85,0.85,0.85}}
+\sphinxDeclareColorOption{RowOddColor}{{rgb}{1,1,1}}
 % now the colours defined with "sphinx" prefix in their names
 \newcommand*{\sphinxDeclareSphinxColorOption}[2]{%
    % set the initial default

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1178,6 +1178,14 @@ class LaTeXTranslator(SphinxTranslator):
         # type: (nodes.Element) -> None
         self.table.col = 0
 
+        if self.builder.config.latex_zebra_stripes and not isinstance(node.parent, nodes.thead):
+            if self.table.row % 2 == 0:
+                self.body.append(
+                        '\\rowcolor{RowEvenColor}[\\dimexpr\\tabcolsep+0.1pt\\relax]')
+            else:
+                self.body.append(
+                        '\\rowcolor{RowOddColor}[\\dimexpr\\tabcolsep+0.1pt\\relax]')
+
         # fill columns if the row starts with the bottom of multirow cell
         while True:
             cell = self.table.cell(self.table.row, self.table.col)


### PR DESCRIPTION
Subject: Add support for zebra-striped tables to LaTeX builder

### Feature or Bugfix
- Feature

### Purpose
Render tables with alternating background colors for even and odd rows
(so called "zebra striping").

Most useful with #6666.

### TODO

- Allow selective enabling/disabling of zebra-striped tables via a custom option (like :latex-zebra-stripes:)