### PR TITLE
agogo theme: ensure hidden toctree is show on Table of Contents

### DIFF
--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -44,7 +44,7 @@
         <div class="sidebar">
           {%- block sidebartoc %}
           <h3>{{ _('Table of Contents') }}</h3>
-          {{ toctree() }}
+          {{ toctree(includehidden=True) }}
           {%- endblock %}
           {%- block sidebarsearch %}
           <div role="search">


### PR DESCRIPTION
The hidden option for the toctree directive is meant to hide from the
document at the location of the directive.  This for when the links
are to be inserted in the HTML sidebar.  However, since version 1.2,
the toctree() template function requires the includehidden=True
option.

---

Using the agogo theme, if a document has the toctree set to hidden (because one wants to have it displayed on the sidebar instead of inserted in the document), then the Table of Contents on the side bar will be empty. This fixes it by setting `includehidden=True` when calling `toctree()` template function. This is required since sphinx 1.2.

I am not sure if the same should be done to `sphinx/themes/basic/globaltoc.html`