### PR TITLE
Fix #6668: LaTeX: Longtable before header has incorrect distance

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,11 @@ Features added
 Bugs fixed
 ----------
 
+* #6668: LaTeX: Longtable before header has incorrect distance
+  (refs: `latex3/latex2e#173`_)
+
+.. _latex3/latex2e#173: https://github.com/latex3/latex2e/issues/173
+
 Testing
 --------
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2019/06/04 v2.1.1 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2019/09/01 v2.3.0 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -119,7 +119,8 @@
    {\dimexpr-\dp\strutbox
             -\spx@ifcaptionpackage{\abovecaptionskip}{\sphinxbaselineskip}%
             +\sphinxbelowcaptionspace\relax}%
-\def\sphinxatlongtableend{\prevdepth\z@\vskip\sphinxtablepost\relax}%
+\def\sphinxatlongtableend{\@nobreakfalse % latex3/latex2e#173
+    \prevdepth\z@\vskip\sphinxtablepost\relax}%
 % B. Table with tabular or tabulary
 \def\sphinxattablestart{\par\vskip\dimexpr\sphinxtablepre\relax}%
 \let\sphinxattableend\sphinxatlongtableend


### PR DESCRIPTION
Bugfix

### Relates
-  latex3/latex2e#173

- #6668 