### PR TITLE
Get rid of comma in sphinx-apidoc documentation

### DIFF
--- a/doc/man/sphinx-apidoc.rst
+++ b/doc/man/sphinx-apidoc.rst
@@ -5,7 +5,7 @@ Synopsis
 --------
 
 **sphinx-apidoc** [*OPTIONS*] -o <*OUTPUT_PATH*> <*MODULE_PATH*>
-[*EXCLUDE_PATTERN*, ...]
+[*EXCLUDE_PATTERN* ...]
 
 Description
 -----------


### PR DESCRIPTION
Subject: Get rid of comma in sphinx-apidoc documentation

### Feature or Bugfix
- Bugfix

### Purpose
- Nixing the comma in documentation for sphinx-apidoc (`EXCLUDE PATTERN, ...`) because it's not supposed to be there.  Experienced coders will omit the comma automatically, but beginners will struggle with it.  It's not doctrinaire and it's also against the style of sphinx-build documentation, which does not include a comma to separate arguments.  Basically, if I struggled for an hour with this, I'm sure others have too.


### Detail
-  See the **additional context** section of the cited issue below for references to style guides and stackoverflow questions on the topic.

### Relates
- #6674 

