### PR TITLE
Fix #6641: Undefined control sequence \sphinxmaketitle

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,7 @@ Features added
 Bugs fixed
 ----------
 
-* #6641: LaTeX: Undefined control sequence `\sphinxmaketitle`
+* #6641: LaTeX: Undefined control sequence ``\sphinxmaketitle``
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6641: LaTeX: Undefined control sequence `\sphinxmaketitle`
+
 Testing
 --------
 

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2019/06/04 v2.1.1 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2019/09/02 v2.2.1 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -527,6 +527,7 @@
 \fi
 
 % make commands known to non-Sphinx document classes
+\providecommand*{\sphinxmaketitle}{\maketitle}
 \providecommand*{\sphinxtableofcontents}{\tableofcontents}
 \ltx@ifundefined{sphinxthebibliography}
  {\newenvironment


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

Fixes a regression introduced at 1.8.3

### Relates
- #6641 
- The `\sphinxmaketitle` was added at #5850 (1.8.3) but only projects using the Sphinx "docclasses" `'howto'/'manual'` defined this LaTeX macro.

