### PR TITLE
Be defensive and handle newly defined HTTP error code

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -237,13 +237,16 @@ class CheckExternalLinksBuilder(Builder):
             else:
                 logger.info(red('broken    ') + uri + red(' - ' + info))
         elif status == 'redirected':
-            text, color = {
-                301: ('permanently', darkred),
-                302: ('with Found', purple),
-                303: ('with See Other', purple),
-                307: ('temporarily', turquoise),
-                0:   ('with unknown code', purple),
-            }[code]
+            try:
+                text, color = {
+                    301: ('permanently', darkred),
+                    302: ('with Found', purple),
+                    303: ('with See Other', purple),
+                    307: ('temporarily', turquoise),
+                    0:   ('with unknown code', purple),
+                }[code]
+            except KeyError:
+                text, color = ('with unknown code', purple)
             self.write_entry('redirected ' + text, docname, lineno,
                              uri + ' to ' + info)
             logger.info(color('redirect  ') + uri + color(' - ' + text + ' to ' + info))


### PR DESCRIPTION
Subject: Handle unregistered HTTP error code

### Feature or Bugfix

- Bugfix

### Purpose

-  8c651b8  implements a change to the linkcheck builder to handle HTTP error codes undefined in the library such as the newly proposed https://tools.ietf.org/html/rfc7538. At the moment, Sphinx will fail with an internal error. With this change, a non-registered HTTP error code will be treated in the same way as HTTP error code 0 i.e. as an unknown code.
- Two potential options in addition to this change would be to either register the code 308 in the list of HTTP codes and effectively treat it like 301 or treat unregistered HTTP error code like broken links a few lines above i.e. log them at a warn level and fail the build depending on the options.

### Detail

- A minimal reproducible example (valid today) can be constructed by creating a fresh Sphinx repo, adding a single link to http://www.hypertable.com/ and running the linkchecker
