### PR TITLE
Close #6712: Allow not to install sphinx.testing on ALT Linux

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #6704: linkcheck: Be defensive and handle newly defined HTTP error code
 * #6655: image URLs containing ``data:`` causes gettext builder crashed
 * #6584: i18n: Error when compiling message catalogs on Hindi
+* #6712: Allow not to install sphinx.testing as runtime (mainly for ALT Linux)
 
 Testing
 --------

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -22,7 +22,12 @@ from os import path
 from typing import Any, Generator, Iterator, List, Tuple
 
 from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
-from sphinx.testing.path import path as Path
+
+try:
+    # for ALT Linux (#6712)
+    from sphinx.testing.path import path as Path
+except ImportError:
+    Path = None  # type: ignore
 
 if False:
     # For type annotation
@@ -178,7 +183,7 @@ fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
 
 def abspath(pathdir: str) -> str:
-    if isinstance(pathdir, Path):
+    if Path is not None and isinstance(pathdir, Path):
         return pathdir.abspath()
     else:
         pathdir = path.abspath(pathdir)


### PR DESCRIPTION

### Feature or Bugfix
- Refactoring

### Purpose
- To follow ALT Linux's policy, this enables to work Sphinx without sphinx.testing package.
- refs: #6712 
