### PR TITLE
Fix #6718: i18n: KeyError is raised if section title and table title are same

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Bugs fixed
 * #6704: linkcheck: Be defensive and handle newly defined HTTP error code
 * #6655: image URLs containing ``data:`` causes gettext builder crashed
 * #6584: i18n: Error when compiling message catalogs on Hindi
+* #6718: i18n: KeyError is raised if section title and table title are same
 
 Testing
 --------

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -134,7 +134,7 @@ class Locale(SphinxTransform):
             processed = False  # skip flag
 
             # update title(section) target name-id mapping
-            if isinstance(node, nodes.title):
+            if isinstance(node, nodes.title) and isinstance(node.parent, nodes.section):
                 section_node = node.parent
                 new_name = nodes.fully_normalize_name(patch.astext())
                 old_name = nodes.fully_normalize_name(node.astext())


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- A process for section title accidentally takes a title node for non-section node. As a result, KeyError was raised.
- refs: #6718 
