### PR TITLE
Close #6729: HTML theme: agogo theme now supports rightsidebar option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Features added
 
 * #6707: C++, support bit-fields.
 * #267: html: Eliminate prompt characters of doctest block from copyable text
+* #6729: html theme: agogo theme now supports ``rightsidebar`` option
 
 Bugs fixed
 ----------

--- a/doc/usage/theming.rst
+++ b/doc/usage/theming.rst
@@ -237,6 +237,8 @@ These themes are:
   - **documentwidth** (CSS length): Width of the document (without sidebar),
     default 50em.
   - **sidebarwidth** (CSS length): Width of the sidebar, default 20em.
+  - **rightsidebar** (true or false): Put the sidebar on the right side.
+    Defaults to ``True``.
   - **bgcolor** (CSS color): Background color.
   - **headerbg** (CSS value for "background"): background for the header area,
     default a grayish gradient.

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -33,15 +33,7 @@
     </div>
 {% endblock %}
 
-{% block content %}
-    <div class="content-wrapper">
-      <div class="content">
-        <div class="document">
-          {%- block document %}
-            {{ super() }}
-          {%- endblock %}
-        </div>
-        <div class="sidebar">
+{%- macro agogo_sidebar() %}
           {%- block sidebartoc %}
           <h3>{{ _('Table of Contents') }}</h3>
           {{ toctree() }}
@@ -55,7 +47,26 @@
             </form>
           </div>
           {%- endblock %}
+{% endmacro %}
+
+{% block content %}
+    <div class="content-wrapper">
+      <div class="content">
+        {%- if not theme_rightsidebar|tobool %}
+        <div class="sidebar">
+          {{ agogo_sidebar() }}
         </div>
+        {%- endif %}
+        <div class="document">
+          {%- block document %}
+            {{ super() }}
+          {%- endblock %}
+        </div>
+        {%- if theme_rightsidebar|tobool %}
+        <div class="sidebar">
+          {{ agogo_sidebar() }}
+        </div>
+        {%- endif %}
         <div class="clearer"></div>
       </div>
     </div>

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -175,7 +175,11 @@ div.document {
 }
 
 div.body {
+  {%- if theme_rightsidebar|tobool %}
   padding-right: 2em;
+  {%- else %}
+  padding-left: 2em;
+  {% endif %}
   text-align: {{ theme_textalign }};
 }
 
@@ -270,7 +274,11 @@ div.document ol {
 
 div.sidebar {
   width: {{ theme_sidebarwidth|todim }};
+  {%- if theme_rightsidebar|tobool %}
   float: right;
+  {%- else %}
+  float: left;
+  {%- endif %}
   font-size: .9em;
 }
 

--- a/sphinx/themes/agogo/theme.conf
+++ b/sphinx/themes/agogo/theme.conf
@@ -8,6 +8,7 @@ bodyfont = "Verdana", Arial, sans-serif
 headerfont = "Georgia", "Times New Roman", serif
 pagewidth = 70em
 documentwidth = 50em
+rightsidebar = true
 sidebarwidth = 20em
 bgcolor = #eeeeec
 headerbg = #555573 url(bgtop.png) top left repeat-x


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Adds `rightsidebar` option to place sidebar arbitrary position (defaults to right: `true`).
- refs: #6729 
