### PR TITLE
Fix #5070: epub: Wrong internal href fragment links

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #6584: i18n: Error when compiling message catalogs on Hindi
 * #6708: mathbase: Some deprecated functions have removed
 * #6709: autodoc: mock object does not work as a class decorator
+* #5070: epub: Wrong internal href fragment links
 * #6712: Allow not to install sphinx.testing as runtime (mainly for ALT Linux)
 
 Testing

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -272,7 +272,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 if ':' in node_id:
                     target['ids'][i] = self.fix_fragment('', node_id)
 
-            next_node = target.next_node(siblings=True)  # type: Node
+            next_node = target.next_node(ascend=True)  # type: Node
             if isinstance(next_node, nodes.Element):
                 for i, node_id in enumerate(next_node['ids']):
                     if ':' in node_id:

--- a/tests/roots/test-epub-anchor-id/index.rst
+++ b/tests/roots/test-epub-anchor-id/index.rst
@@ -5,4 +5,9 @@ test-epub-anchor-id
 
 blah blah blah
 
+.. setting:: STATICFILES_SECTION
+
+blah blah blah
+==============
+
 see :setting:`STATICFILES_FINDERS`

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -321,6 +321,7 @@ def test_epub_anchor_id(app):
 
     html = (app.outdir / 'index.xhtml').text()
     assert '<p id="std-setting-STATICFILES_FINDERS">blah blah blah</p>' in html
+    assert '<span id="std-setting-STATICFILES_SECTION"></span><h1>blah blah blah</h1>' in html
     assert 'see <a class="reference internal" href="#std-setting-STATICFILES_FINDERS">' in html
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/issues/5070#issuecomment-536120713
- The format of hyperlink targets before section title has not been modified