### PR TITLE
Fix search bug with empty html_file_suffix using html builder

### DIFF
--- a/sphinx/builders/dirhtml.py
+++ b/sphinx/builders/dirhtml.py
@@ -9,7 +9,7 @@
 """
 
 from os import path
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
@@ -44,10 +44,6 @@ class DirectoryHTMLBuilder(StandaloneHTMLBuilder):
                                     'index' + self.out_suffix)
 
         return outfilename
-
-    def prepare_writing(self, docnames: Set[str]) -> None:
-        super().prepare_writing(docnames)
-        self.globalcontext['no_search_suffix'] = True
 
 
 # for compatibility

--- a/sphinx/themes/basic/static/documentation_options.js_t
+++ b/sphinx/themes/basic/static/documentation_options.js_t
@@ -3,7 +3,8 @@ var DOCUMENTATION_OPTIONS = {
     VERSION: '{{ release|e }}',
     LANGUAGE: '{{ language }}',
     COLLAPSE_INDEX: false,
-    FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
+    BUILDER: '{{ builder }}',
+    FILE_SUFFIX: '{{ file_suffix }}',
     HAS_SOURCE: {{ has_source|lower }},
     SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
     NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}}

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -245,7 +245,7 @@ var Search = {
       if (results.length) {
         var item = results.pop();
         var listItem = $('<li style="display:none"></li>');
-        if (DOCUMENTATION_OPTIONS.FILE_SUFFIX === '') {
+        if (DOCUMENTATION_OPTIONS.BUILDER === 'dirhtml') {
           // dirhtml builder
           var dirname = item[0] + '/';
           if (dirname.match(/\/index\/$/)) {


### PR DESCRIPTION
searchtools.js erroneously assumes that when FILE_SUFFIX is empty, the dirhtml builder is used.  This results in it erroneously appending a '/' to target links if the regular html builder is used with an empty `html_file_suffix`.

This is fixed in this PR by using null instead of the empty string in the case that the dirhtml builder is used.  Though, perhaps it would be cleaner to leave FILE_SUFFIX alone and instead rely on a separate BUILDER property?