### PR TITLE
Don't return False always on __exit__()

### DIFF
--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -187,9 +187,8 @@ class sphinx_domains:
     def __enter__(self) -> None:
         self.enable()
 
-    def __exit__(self, exc_type: "Type[Exception]", exc_value: Exception, traceback: Any) -> bool:  # type: ignore # NOQA
+    def __exit__(self, exc_type: "Type[Exception]", exc_value: Exception, traceback: Any) -> None:  # NOQA
         self.disable()
-        return False
 
     def enable(self) -> None:
         self.directive_func = directives.directive


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose

According to the python/mypy#7214, mypy-0.740 prefers a return value of
`__exit__()` method which does not swallow exceptions is None
instead of bool.
