### PR TITLE
Warn about dangers of inheriting nodes in conf.py

### DIFF
--- a/doc/development/tutorials/todo.rst
+++ b/doc/development/tutorials/todo.rst
@@ -107,6 +107,20 @@ is just a "general" node.
    <http://docutils.sourceforge.net/docs/ref/doctree.html>`__ and :ref:`Sphinx
    <nodes>`.
 
+.. DANGER::
+
+   It is important to know that while you can extend Sphinx without
+   leaving your ``conf.py``, if you declare an inherited node right
+   there, you'll hit an unobvious :py:class:`PickleError`. So if
+   something goes wrong, please make sure that you put inherited nodes
+   into a separate Python module.
+
+   For more details, see:
+
+   - https://github.com/sphinx-doc/sphinx/issues/6751
+   - https://github.com/sphinx-doc/sphinx/issues/1493
+   - https://github.com/sphinx-doc/sphinx/issues/1424
+
 .. rubric:: The directive classes
 
 A directive class is a class deriving usually from


### PR DESCRIPTION
Closes #6751

Subject: Tell the readers of the TODO extension
         tutorial about the dangers of inheriting
         nodes in conf.py

### Feature or Bugfix
<!-- please choose -->
- Docs
- Bugfix

### Purpose
- Help users not to fall into an unobvious trap of
  putting their inherited `docutils` nodes into
  `conf.py` that causes a hard-to-debug
  `PickleError` popping up in the error log output

### Detail
- https://github.com/sphinx-doc/sphinx/issues/6751
- https://github.com/sphinx-doc/sphinx/issues/1493
- https://github.com/sphinx-doc/sphinx/issues/1424

### Relates

N/A