### PR TITLE
Avoid collisions of path name

### DIFF
--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -13,7 +13,7 @@ import posixpath
 import re
 import sys
 import warnings
-from hashlib import md5
+from hashlib import sha512
 from os import path
 from typing import Any, Dict, IO, Iterable, Iterator, List, Set, Tuple
 
@@ -70,14 +70,14 @@ return_codes_re = re.compile('[\r\n]+')
 def get_stable_hash(obj: Any) -> str:
     """
     Return a stable hash for a Python data structure.  We can't just use
-    the md5 of str(obj) since for example dictionary items are enumerated
+    the sha512 of str(obj) since for example dictionary items are enumerated
     in unpredictable order due to hash randomization in newer Pythons.
     """
     if isinstance(obj, dict):
         return get_stable_hash(list(obj.items()))
     elif isinstance(obj, (list, tuple)):
         obj = sorted(get_stable_hash(o) for o in obj)
-    return md5(str(obj).encode()).hexdigest()
+    return sha512(str(obj).encode()).hexdigest()
 
 
 class Stylesheet(str):

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -12,7 +12,7 @@
 import posixpath
 import re
 import subprocess
-from hashlib import sha1
+from hashlib import sha512
 from os import path
 from subprocess import CalledProcessError, PIPE
 from typing import Any, Dict, List, Tuple
@@ -66,7 +66,7 @@ class ClickableMapDefinition:
         if self.id == '%3':
             # graphviz generates wrong ID if graph name not specified
             # https://gitlab.com/graphviz/graphviz/issues/1327
-            hashed = sha1(dot.encode()).hexdigest()
+            hashed = sha512(dot.encode()).hexdigest()
             self.id = 'grapviz%s' % hashed[-10:]
             self.content[0] = self.content[0].replace('%3', self.id)
 
@@ -212,7 +212,7 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict,
     hashkey = (code + str(options) + str(graphviz_dot) +
                str(self.builder.config.graphviz_dot_args)).encode()
 
-    fname = '%s-%s.%s' % (prefix, sha1(hashkey).hexdigest(), format)
+    fname = '%s-%s.%s' % (prefix, sha512(hashkey).hexdigest(), format)
     relfn = posixpath.join(self.builder.imgpath, fname)
     outfn = path.join(self.builder.outdir, self.builder.imagedir, fname)
 

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from hashlib import sha1
+from hashlib import sha512
 from os import path
 from subprocess import CalledProcessError, PIPE
 from typing import Any, Dict, List, Tuple
@@ -262,7 +262,7 @@ def render_math(self: HTMLTranslator, math: str) -> Tuple[str, int]:
                                  self.builder.config,
                                  self.builder.confdir)
 
-    filename = "%s.%s" % (sha1(latex.encode()).hexdigest(), image_format)
+    filename = "%s.%s" % (sha512(latex.encode()).hexdigest(), image_format)
     relfn = posixpath.join(self.builder.imgpath, 'math', filename)
     outfn = path.join(self.builder.outdir, self.builder.imagedir, 'math', filename)
     if path.isfile(outfn):

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -38,7 +38,7 @@ r"""
 import builtins
 import inspect
 import re
-from hashlib import md5
+from hashlib import sha512
 from importlib import import_module
 from typing import Any, Dict, Iterable, List, Tuple
 from typing import cast
@@ -385,7 +385,7 @@ class InheritanceDiagram(SphinxDirective):
 
 def get_graph_hash(node: inheritance_diagram) -> str:
     encoded = (node['content'] + str(node['parts'])).encode()
-    return md5(encoded).hexdigest()[-10:]
+    return sha512(encoded).hexdigest()[-10:]
 
 
 def html_visit_inheritance_diagram(self: HTMLTranslator, node: inheritance_diagram) -> None:

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -9,7 +9,7 @@
 """
 
 import os
-from hashlib import sha1
+from hashlib import sha512
 from math import ceil
 from typing import Any, Dict, List, Tuple
 
@@ -64,12 +64,12 @@ class ImageDownloader(BaseImageConverter):
                 basename = basename.split('?')[0]
             if basename == '' or len(basename) > MAX_FILENAME_LEN:
                 filename, ext = os.path.splitext(node['uri'])
-                basename = sha1(filename.encode()).hexdigest() + ext
+                basename = sha512(filename.encode()).hexdigest() + ext
 
             dirname = node['uri'].replace('://', '/').translate({ord("?"): "/",
                                                                  ord("&"): "/"})
             if len(dirname) > MAX_FILENAME_LEN:
-                dirname = sha1(dirname.encode()).hexdigest()
+                dirname = sha512(dirname.encode()).hexdigest()
             ensuredir(os.path.join(self.imagedir, dirname))
             path = os.path.join(self.imagedir, dirname, basename)
 
@@ -131,7 +131,7 @@ class DataURIExtractor(BaseImageConverter):
             return
 
         ensuredir(os.path.join(self.imagedir, 'embeded'))
-        digest = sha1(image.data).hexdigest()
+        digest = sha512(image.data).hexdigest()
         path = os.path.join(self.imagedir, 'embeded', digest + ext)
         self.app.env.original_image_uri[path] = node['uri']
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -21,7 +21,7 @@ import warnings
 from codecs import BOM_UTF8
 from collections import deque
 from datetime import datetime
-from hashlib import md5
+from hashlib import sha512
 from importlib import import_module
 from os import path
 from time import mktime, strptime
@@ -168,7 +168,7 @@ class DownloadFiles(dict):
 
     def add_file(self, docname: str, filename: str) -> str:
         if filename not in self:
-            digest = md5(filename.encode()).hexdigest()
+            digest = sha512(filename.encode()).hexdigest()
             dest = '%s/%s' % (digest, os.path.basename(filename))
             self[filename] = (set(), dest)
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -10,7 +10,7 @@
 
 import os
 import re
-from hashlib import md5
+from hashlib import sha512
 from itertools import cycle, chain
 
 import pytest
@@ -452,9 +452,9 @@ def test_html_download(app):
 @pytest.mark.sphinx('html', testroot='roles-download')
 def test_html_download_role(app, status, warning):
     app.build()
-    digest = md5(b'dummy.dat').hexdigest()
+    digest = sha512(b'dummy.dat').hexdigest()
     assert (app.outdir / '_downloads' / digest / 'dummy.dat').exists()
-    digest_another = md5(b'another/dummy.dat').hexdigest()
+    digest_another = sha512(b'another/dummy.dat').hexdigest()
     assert (app.outdir / '_downloads' / digest_another / 'dummy.dat').exists()
 
     content = (app.outdir / 'index.html').text()

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -10,6 +10,8 @@
 
 import re
 
+from hashlib import sha512
+
 import pytest
 
 from sphinx.ext.graphviz import ClickableMapDefinition
@@ -129,7 +131,7 @@ def test_graphviz_parse_mapfile():
                '</map>')
     cmap = ClickableMapDefinition('dummy.map', content, code)
     assert cmap.filename == 'dummy.map'
-    assert cmap.id == 'grapvizb08107169e'
+    assert cmap.id == 'grapviz%s' % sha512(code.encode()).hexdigest()[-10:]
     assert len(cmap.clickable) == 0
     assert cmap.generate_clickable_map() == ''
 
@@ -145,7 +147,7 @@ def test_graphviz_parse_mapfile():
                '</map>')
     cmap = ClickableMapDefinition('dummy.map', content, code)
     assert cmap.filename == 'dummy.map'
-    assert cmap.id == 'grapviza4ccdd48ce'
+    assert cmap.id == 'grapviz%s' % sha512(code.encode()).hexdigest()[-10:]
     assert len(cmap.clickable) == 1
     assert cmap.generate_clickable_map() == content.replace('%3', cmap.id)
 


### PR DESCRIPTION
Hi sphinx project. I made PR which use sha512 to avoid using md5 and sha1. Thank you for reading.

Subject: Avoid using insecure hash functions

### Feature
- Feature

### Purpose
- Use of insecure MD2, MD4, MD5, or SHA1 hash function. Use SHA2 or SHA3 instead.

### Detail
- None

### Relates
- None
