### PR TITLE
Fixes #6759: validation of html static paths and extra paths no longe…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Other contributors, listed alphabetically, are:
 * Henrique Bastos -- SVG support for graphviz extension
 * Daniel Bültmann -- todo extension
 * Marco Buttu -- doctest extension (pyversion option)
+* Nathan Damon -- bugfix in validation of static paths in html builders
 * Etienne Desautels -- apidoc module
 * Michael Droettboom -- inheritance_diagram extension
 * Charles Duffy -- original graphviz extension

--- a/CHANGES
+++ b/CHANGES
@@ -90,6 +90,7 @@ Bugs fixed
 
 * #6641: LaTeX: Undefined control sequence ``\sphinxmaketitle``
 * #6710: LaTeX not well configured for Greek language as main language
+* #6759: validation of html static paths and extra paths no longer throws an error if the paths are in different directories
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -90,7 +90,8 @@ Bugs fixed
 
 * #6641: LaTeX: Undefined control sequence ``\sphinxmaketitle``
 * #6710: LaTeX not well configured for Greek language as main language
-* #6759: validation of html static paths and extra paths no longer throws an error if the paths are in different directories
+* #6759: validation of html static paths and extra paths no longer throws
+  an error if the paths are in different directories
 
 Testing
 --------

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1125,9 +1125,9 @@ def validate_html_extra_path(app: Sphinx, config: Config) -> None:
             logger.warning(__('html_extra_path entry %r does not exist'), entry)
             config.html_extra_path.remove(entry)
         else:
-            try: 
-                common_path = path.commonpath([app.outdir, extra_path]) 
-            except ValueError: # different directories, can skip to next
+            try:
+                common_path = path.commonpath([app.outdir, extra_path])
+            except ValueError:  # different directories, can skip to next
                 continue
             if common_path == app.outdir:
                 logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
@@ -1144,7 +1144,7 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
         else:
             try:
                 common_path = path.commonpath([app.outdir, static_path])
-            except ValueError: # different directories, can skip to next
+            except ValueError:  # different directories, can skip to next
                 continue
             if common_path == app.outdir:
                 logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1124,9 +1124,14 @@ def validate_html_extra_path(app: Sphinx, config: Config) -> None:
         if not path.exists(extra_path):
             logger.warning(__('html_extra_path entry %r does not exist'), entry)
             config.html_extra_path.remove(entry)
-        elif path.commonpath([app.outdir, extra_path]) == app.outdir:
-            logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
-            config.html_extra_path.remove(entry)
+        else:
+            try: 
+                common_path = path.commonpath([app.outdir, extra_path]) 
+            except ValueError: # different directories, can skip to next
+                continue
+            if common_path == app.outdir:
+                logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
+                config.html_extra_path.remove(entry)
 
 
 def validate_html_static_path(app: Sphinx, config: Config) -> None:
@@ -1136,9 +1141,14 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
         if not path.exists(static_path):
             logger.warning(__('html_static_path entry %r does not exist'), entry)
             config.html_static_path.remove(entry)
-        elif path.commonpath([app.outdir, static_path]) == app.outdir:
-            logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)
-            config.html_static_path.remove(entry)
+        else:
+            try:
+                common_path = path.commonpath([app.outdir, static_path])
+            except ValueError: # different directories, can skip to next
+                continue
+            if common_path == app.outdir:
+                logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)
+                config.html_static_path.remove(entry)
 
 
 def validate_html_logo(app: Sphinx, config: Config) -> None:

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1124,16 +1124,10 @@ def validate_html_extra_path(app: Sphinx, config: Config) -> None:
         if not path.exists(extra_path):
             logger.warning(__('html_extra_path entry %r does not exist'), entry)
             config.html_extra_path.remove(entry)
-        else:
-            try:
-                common_path = path.commonpath([app.outdir, extra_path])
-            except ValueError as e:  # different directories, can skip to next
-                if e.args[0] != "Paths don't have the same drive":
-                    raise e
-                continue
-            if common_path == app.outdir:
-                logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
-                config.html_extra_path.remove(entry)
+        elif (path.splitdrive(app.outdir)[0] == path.splitdrive(extra_path) and
+              path.commonpath([app.outdir, extra_path]) == app.outdir):
+            logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
+            config.html_extra_path.remove(entry)
 
 
 def validate_html_static_path(app: Sphinx, config: Config) -> None:
@@ -1143,16 +1137,10 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
         if not path.exists(static_path):
             logger.warning(__('html_static_path entry %r does not exist'), entry)
             config.html_static_path.remove(entry)
-        else:
-            try:
-                common_path = path.commonpath([app.outdir, static_path])
-            except ValueError as e:  # different directories, can skip to next
-                if e.args[0] != "Paths don't have the same drive":
-                    raise e
-                continue
-            if common_path == app.outdir:
-                logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)
-                config.html_static_path.remove(entry)
+        elif (path.splitdrive(app.outdir)[0] == path.splitdrive(static_path) and
+              path.commonpath([app.outdir, static_path]) == app.outdir):
+            logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)
+            config.html_static_path.remove(entry)
 
 
 def validate_html_logo(app: Sphinx, config: Config) -> None:

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1124,7 +1124,7 @@ def validate_html_extra_path(app: Sphinx, config: Config) -> None:
         if not path.exists(extra_path):
             logger.warning(__('html_extra_path entry %r does not exist'), entry)
             config.html_extra_path.remove(entry)
-        elif (path.splitdrive(app.outdir)[0] == path.splitdrive(extra_path) and
+        elif (path.splitdrive(app.outdir)[0] == path.splitdrive(extra_path)[0] and
               path.commonpath([app.outdir, extra_path]) == app.outdir):
             logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
             config.html_extra_path.remove(entry)
@@ -1137,7 +1137,7 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
         if not path.exists(static_path):
             logger.warning(__('html_static_path entry %r does not exist'), entry)
             config.html_static_path.remove(entry)
-        elif (path.splitdrive(app.outdir)[0] == path.splitdrive(static_path) and
+        elif (path.splitdrive(app.outdir)[0] == path.splitdrive(static_path)[0] and
               path.commonpath([app.outdir, static_path]) == app.outdir):
             logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)
             config.html_static_path.remove(entry)

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -1127,7 +1127,9 @@ def validate_html_extra_path(app: Sphinx, config: Config) -> None:
         else:
             try:
                 common_path = path.commonpath([app.outdir, extra_path])
-            except ValueError:  # different directories, can skip to next
+            except ValueError as e:  # different directories, can skip to next
+                if e.args[0] != "Paths don't have the same drive":
+                    raise e
                 continue
             if common_path == app.outdir:
                 logger.warning(__('html_extra_path entry %r is placed inside outdir'), entry)
@@ -1144,7 +1146,9 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
         else:
             try:
                 common_path = path.commonpath([app.outdir, static_path])
-            except ValueError:  # different directories, can skip to next
+            except ValueError as e:  # different directories, can skip to next
+                if e.args[0] != "Paths don't have the same drive":
+                    raise e
                 continue
             if common_path == app.outdir:
                 logger.warning(__('html_static_path entry %r is placed inside outdir'), entry)


### PR DESCRIPTION
…r throws an error if the paths are in different directories

Subject: Reimplement behavior from 2.1.2

### Feature or Bugfix
- Bugfix

### Purpose
See my issue created. Hopefully I'm doing this right, this is my first pull request, kinda nervous
### Detail
In essence, the sys.path.commonpath function throws a Value Error if the paths are in different drives. Sphinx has previously had no issue writing to a different drive than the source, but this validation step throws an error. Now, if the drives are different, the error is caught. Since the purpose of the function was to check if the source and static directories was the same, it would evaluate to True if commonpath didn't raise an error.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/6759

