### PR TITLE
Fix #6776: 2019-10-01 LaTeX release breaks sphinxcyrillic.sty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6776: LaTeX: 2019-10-01 LaTeX release breaks :file:`sphinxcyrillic.sty`
+
 Testing
 --------
 

--- a/sphinx/texinputs/sphinxcyrillic.sty
+++ b/sphinx/texinputs/sphinxcyrillic.sty
@@ -11,7 +11,7 @@
 \ProcessLocalKeyvalOptions* % ignore class options
 
 \ifspx@cyropt@Xtwo
-% original code by tex.sx user egreg:
+% original code by tex.sx user egreg (updated 2019/10/28):
 %   https://tex.stackexchange.com/a/460325/
 % 159 Cyrillic glyphs as available in X2 TeX 8bit font encoding
 % This assumes inputenc loaded with utf8 option, or LaTeX release
@@ -27,7 +27,9 @@
     {Ӎ}{ӎ}{Ӕ}{ӕ}{Ә}{ә}{Ӡ}{ӡ}{Ө}{ө}\do
   {%
     \begingroup\def\IeC{\protect\DeclareTextSymbolDefault}%
-    \protected@edef\@temp{\endgroup\next{X2}}\@temp
+    \protected@edef\@temp{\endgroup
+    \@ifl@t@r{\fmtversion}{2019/10/01}{\csname u8:\next\endcsname}{\next}}%
+    \@temp{X2}%
   }%
 \else
 \ifspx@cyropt@TtwoA

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -41,6 +41,7 @@ html_last_updated_fmt = '%b %d, %Y'
 html_context = {'hckey': 'hcval', 'hckey_co': 'wrong_hcval_co'}
 
 latex_additional_files = ['svgimg.svg']
+latex_elements = {'fontenc':'\\usepackage[X2,LGR,T1]{fontenc}'}
 
 coverage_c_path = ['special/*.h']
 coverage_c_regexes = {'function': r'^PyAPI_FUNC\(.*\)\s+([^_][\w_]+)'}

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -41,7 +41,6 @@ html_last_updated_fmt = '%b %d, %Y'
 html_context = {'hckey': 'hcval', 'hckey_co': 'wrong_hcval_co'}
 
 latex_additional_files = ['svgimg.svg']
-latex_elements = {'fontenc':'\\usepackage[X2,LGR,T1]{fontenc}'}
 
 coverage_c_path = ['special/*.h']
 coverage_c_regexes = {'function': r'^PyAPI_FUNC\(.*\)\s+([^_][\w_]+)'}


### PR DESCRIPTION
<s>I have added to the `conf.py` of `test-root` the setting of fontenc key triggering loading of `sphinxcyrillic.sty` which was broken by LaTeX 2019-10-01.</s> Removed in later commit as it meant  adding texlive-lang-greek and texlive-lang-cyrillic as Debian requirements for LaTeX testing on ci/circleci.

But currently it is uneasy to test this PR as LaTeX 2019-10-01 breaks Sphinx tests for another reason (#6777). (one needs to comment out the ``test-root/images.txt``  last line).

I have tested directly that the fix works for #6776, for 2019-10-01 LaTeX, and does not break with earlier LaTeX (with earlier LaTeX, the Sphinx code basically is not changed from before). I tested that building own Sphinx PDF documentation works with this PR.