### PR TITLE
Add py.typed to make PEP-561 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,9 @@ setup(
     ],
     platforms='any',
     packages=find_packages(exclude=['tests', 'utils']),
+    package_data = {
+        'sphinx': ['py.typed'],
+    },
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Make module PEP-561 compatible

### Relates
- #6780 

