### PR TITLE
Fix #6793: texinfo: Code examples broken following "sidebar"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
 * #5070: epub: Wrong internal href fragment links
 * #6712: Allow not to install sphinx.testing as runtime (mainly for ALT Linux)
 * #6741: html: search result was broken with empty :confval:`html_file_suffix`
+* #6793: texinfo: Code examples broken following "sidebar"
 
 Testing
 --------

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1284,6 +1284,7 @@ class TexinfoTranslator(SphinxTranslator):
         title = cast(nodes.title, node[0])
         self.visit_rubric(title)
         self.body.append('%s\n' % self.escape(title.astext()))
+        self.depart_rubric(title)
 
     def depart_topic(self, node):
         # type: (nodes.Element) -> None


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6793 