### PR TITLE
gettext: Use template file to generate message catalog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.builders.gettext.POHEADER``
 * ``sphinx.io.SphinxStandaloneReader.app``
 * ``sphinx.io.SphinxStandaloneReader.env``
 

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.builders.gettext.POHEADER``
+     - 2.3
+     - 4.0
+     - ``sphinx/templates/gettext/message.pot_t`` (template file)
+
    * - ``sphinx.io.SphinxStandaloneReader.app``
      - 2.3
      - 4.0

--- a/sphinx/templates/gettext/message.pot_t
+++ b/sphinx/templates/gettext/message.pot_t
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) {{ copyright }}
+# This file is distributed under the same license as the {{ project }} package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: {{ project|e }} {{ version|e }}\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: {{ ctime|e }}\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+{% for message in messages %}
+{% if display_location -%}
+{% for source, line in message.locations -%}
+#: {{ source }}:{{ line }}
+{% endfor -%}
+{% endif -%}
+
+{% if display_uuid -%}
+{% for uuid in message.uuids -%}
+#: {{ uuid }}
+{% endfor -%}
+{% endif -%}
+
+msgid "{{ message.text|e }}"
+msgstr ""
+{% endfor -%}


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- As a preparation of #6781, this replaces string concatenations in gettext builder by template file.