### PR TITLE
LaTeX: fix #6804

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,8 @@ Bugs fixed
 * #6712: Allow not to install sphinx.testing as runtime (mainly for ALT Linux)
 * #6741: html: search result was broken with empty :confval:`html_file_suffix`
 * #6001: LaTeX does not wrap long code lines at backslash character
+* #6804: LaTeX: PDF build breaks if admonition of danger type contains
+  code-block long enough not to fit on one page
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1111,6 +1111,9 @@
 \newcommand*\sphinxVerbatimTitle {}
 % This box to typeset the caption before framed.sty multiple passes for framing.
 \newbox\sphinxVerbatim@TitleBox
+% This box to measure contents if nested as inner \MakeFramed requires then
+% minipage encapsulation but too long contents then break outer \MakeFramed
+\newbox\sphinxVerbatim@ContentsBox
 % This is a workaround to a "feature" of French lists, when literal block
 % follows immediately; usable generally (does only \par then), a priori...
 \newcommand*\sphinxvspacefixafterfrenchlists{%
@@ -1257,17 +1260,23 @@
   \itemsep   \z@skip
   \topsep    \z@skip
   \partopsep \z@skip
-  % trivlist will set \parsep to \parskip = zero
+  % trivlist will set \parsep to \parskip (which itself is set to zero above)
   % \leftmargin will be set to zero by trivlist
   \rightmargin\z@
   \parindent  \z@% becomes \itemindent. Default zero, but perhaps overwritten.
   \trivlist\item\relax
-     \ifsphinxverbatimwithminipage\spx@inframedtrue\fi
-     % use a minipage if we are already inside a framed environment
-     \ifspx@inframed\noindent\begin{minipage}{\linewidth}\fi
-     \MakeFramed {% adapted over from framed.sty's snugshade environment
+     \ifspx@inframed\setbox\sphinxVerbatim@ContentsBox\vbox\bgroup
+        \@setminipage\hsize\linewidth
+        % use bulk of minipage paragraph shape restores (this is needed
+        % in indented contexts, at least for some)
+        \textwidth\hsize \columnwidth\hsize \@totalleftmargin\z@
+        \leftskip\z@skip \rightskip\z@skip  \@rightskip\z@skip
+     \else
+       \ifsphinxverbatimwithminipage\noindent\begin{minipage}{\linewidth}\fi
+       \MakeFramed {% adapted over from framed.sty's snugshade environment
         \advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize\@setminipage
         }%
+     \fi
      % For grid placement from \strut's in \FancyVerbFormatLine
      \lineskip\z@skip
      % active comma should not be overwritten by \@noligs
@@ -1279,8 +1288,35 @@
 }
 {%
   \endOriginalVerbatim
-  \par\unskip\@minipagefalse\endMakeFramed % from framed.sty snugshade
-  \ifspx@inframed\end{minipage}\fi
+  \ifspx@inframed
+   \egroup % finish \sphinxVerbatim@ContentsBox vbox
+   \ifdim\dimexpr\ht\sphinxVerbatim@ContentsBox+
+         \dp\sphinxVerbatim@ContentsBox+
+         \ht\sphinxVerbatim@TitleBox+
+         \dp\sphinxVerbatim@TitleBox>.9\textheight
+    % long contents: do not \MakeFramed. Do make a caption (either before or
+    % after) if title exists. Continuation hints across pagebreaks dropped.
+    \spx@opt@verbatimwithframefalse
+    \def\sphinxVerbatim@Title{\noindent\box\sphinxVerbatim@TitleBox\par}%
+    \sphinxVerbatim@Before
+    \noindent\unvbox\sphinxVerbatim@ContentsBox\par
+    \sphinxVerbatim@After
+   \else
+    % short enough contents: use \MakeFramed. As it is nested, this requires
+    % minipage encapsulation. May move to next page as it is non-breakable.
+    \noindent\begin{minipage}{\linewidth}%
+     \MakeFramed {% Use it now with the fetched contents
+      \advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize\@setminipage
+      }%
+     \unvbox\sphinxVerbatim@ContentsBox
+     % some of this may be superfluous:
+     \par\unskip\@minipagefalse\endMakeFramed
+    \end{minipage}%
+   \fi
+  \else % non-nested \MakeFramed
+    \par\unskip\@minipagefalse\endMakeFramed % from framed.sty snugshade
+    \ifsphinxverbatimwithminipage\end{minipage}\fi
+  \fi
   \endtrivlist
 }
 \newenvironment {sphinxVerbatimNoFrame}


### PR DESCRIPTION
In case a code-block is in an environment already using the "framed"
package, measure the vertical size needed for the code lines and use a
nested "framed" only if short enough (i.e. at most 90% of text area on a
page).

Long nested contents will drop the inner frame. They lose the background
color as well as the continuation hints across pagebreaks. But the
caption if present is typeset normally. And highlighted lines and line
numbers are rendered with no alteration.

Short nested contents (should) render exactly as before this commit:
they use "framed" but this must be encapsulated in an unbreakable
"minipage". All decoration including caption are obeyed but of course
not the continuation hints are these never apply.


- Bugfix (#6804)

It is difficult to add a test file as only way is too test a PDF build (LaTeX mark-up is not modified, but behaviour of `sphinxVerbatim` is changed).

A priori, the only change for existing project is in case a code-block almost as long as a page (but not quite) was in a danger type admonition. Now, it will lose the framing, but on the other hand it may look better from allowing  a pagebreak. As nobody reported issue #6804 so far, I expect few people put long code-blocks in danger, attention, etc ... admonition. Hence I propose it for 2.3.0 milestone as a non urgent bugfix.

I did some testing with code-blocks inside admonitions inside nested lists to check placement of captions (either on top or below) and highlighted lines and line numbers all were kept as before and it looks ok.



