### PR TITLE
Give a warning when extensions are explicitly not parallel safe

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1190,28 +1190,33 @@ class Sphinx:
 
         ``typ`` is a type of processing; ``'read'`` or ``'write'``.
         """
+
         if typ == 'read':
             attrname = 'parallel_read_safe'
-            message = __("the %s extension does not declare if it is safe "
-                         "for parallel reading, assuming it isn't - please "
-                         "ask the extension author to check and make it "
-                         "explicit")
+            message_none = __("the %s extension does not declare if it is safe "
+                              "for parallel reading, assuming it isn't - please "
+                              "ask the extension author to check and make it "
+                              "explicit")
+            message_false = "the %s extension is not safe for parallel reading"
         elif typ == 'write':
             attrname = 'parallel_write_safe'
-            message = __("the %s extension does not declare if it is safe "
-                         "for parallel writing, assuming it isn't - please "
-                         "ask the extension author to check and make it "
-                         "explicit")
+            message_none = __("the %s extension does not declare if it is safe "
+                              "for parallel writing, assuming it isn't - please "
+                              "ask the extension author to check and make it "
+                              "explicit")
+            message_false = "the %s extension is not safe for parallel writing"
         else:
             raise ValueError('parallel type %s is not supported' % typ)
 
         for ext in self.extensions.values():
             allowed = getattr(ext, attrname, None)
             if allowed is None:
-                logger.warning(message, ext.name)
+                logger.warning(message_none, ext.name)
                 logger.warning(__('doing serial %s'), typ)
                 return False
             elif not allowed:
+                logger.warning(message_false, ext.name)
+                logger.warning(__('doing serial %s'), typ)
                 return False
 
         return True

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1190,32 +1190,31 @@ class Sphinx:
 
         ``typ`` is a type of processing; ``'read'`` or ``'write'``.
         """
-
         if typ == 'read':
             attrname = 'parallel_read_safe'
-            message_none = __("the %s extension does not declare if it is safe "
-                              "for parallel reading, assuming it isn't - please "
-                              "ask the extension author to check and make it "
-                              "explicit")
-            message_false = "the %s extension is not safe for parallel reading"
+            message_not_declared = __("the %s extension does not declare if it "
+                                      "is safe for parallel reading, assuming "
+                                      "it isn't - please ask the extension author "
+                                      "to check and make it explicit")
+            message_not_safe = __("the %s extension is not safe for parallel reading")
         elif typ == 'write':
             attrname = 'parallel_write_safe'
-            message_none = __("the %s extension does not declare if it is safe "
-                              "for parallel writing, assuming it isn't - please "
-                              "ask the extension author to check and make it "
-                              "explicit")
-            message_false = "the %s extension is not safe for parallel writing"
+            message_not_declared = __("the %s extension does not declare if it "
+                                      "is safe for parallel writing, assuming "
+                                      "it isn't - please ask the extension author "
+                                      "to check and make it explicit")
+            message_not_safe = __("the %s extension is not safe for parallel writing")
         else:
             raise ValueError('parallel type %s is not supported' % typ)
 
         for ext in self.extensions.values():
             allowed = getattr(ext, attrname, None)
             if allowed is None:
-                logger.warning(message_none, ext.name)
+                logger.warning(message_not_declared, ext.name)
                 logger.warning(__('doing serial %s'), typ)
                 return False
             elif not allowed:
-                logger.warning(message_false, ext.name)
+                logger.warning(message_not_safe, ext.name)
                 logger.warning(__('doing serial %s'), typ)
                 return False
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -105,7 +105,7 @@ def test_add_is_parallel_allowed(app, status, warning):
 
     app.setup_extension('read_serial')
     assert app.is_parallel_allowed('read') is False
-    assert ("the read_serial extension is not safe for parallel reading") in warning.getvalue()
+    assert "the read_serial extension is not safe for parallel reading" in warning.getvalue()
     warning.truncate(0)  # reset warnings
     assert app.is_parallel_allowed('write') is True
     assert warning.getvalue() == ''

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -105,6 +105,8 @@ def test_add_is_parallel_allowed(app, status, warning):
 
     app.setup_extension('read_serial')
     assert app.is_parallel_allowed('read') is False
+    assert ("the read_serial extension is not safe for parallel reading") in warning.getvalue()
+    warning.truncate(0)  # reset warnings
     assert app.is_parallel_allowed('write') is True
     assert warning.getvalue() == ''
     app.extensions.pop('read_serial')


### PR DESCRIPTION
### Feature or Bugfix
I would personally treat this as a bug fix since the previous behavior was confusing.

### Purpose
Currently, if building a set of docs with a number of extensions in parallel, if one of the extensions explicitly declares itself to be unsafe, the build falls back to a serial build silently, with no way of knowing what extension caused this. Rather than have to dig into the source code for each extension, it's much simpler to just warn the user if the build is falling back to a serial build and what extension caused this. I think it makes sense to include this since if the user is opting in to a parallel build, anything that prevents that from happening should be explicitly stated.


