### PR TITLE
Shorten message on search page

### DIFF
--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -27,10 +27,8 @@
   </p>
   </div>
   <p>
-    {% trans %}From here you can search these documents. Enter your search
-    words into the box below and click "search". Note that the search
-    function will automatically search for all of the words. Pages
-    containing fewer words won't appear in the result list.{% endtrans %}
+    {% trans %}Searching for multiple words only shows matches that contain
+    all words.{% endtrans %}
   </p>
   <form action="" method="get">
     <input type="text" name="q" aria-labelledby="search-documentation" value="" />


### PR DESCRIPTION
Subject: Shorten message on search page

### Purpose
The text was a bit wordy. It's obvious that the search page can be used to search. Also, we don't need to tell people how to use a search field.

The only relevant content of the paragraph is that matches contain all words. That can be described in one concise sentence, which is more likely to be read than a whole paragraph.

Note: This will need translations updates as a follow-up. Should I update the .po files within this PR? It seems these file are not up-to-date anyway and there would be other changes included.