### PR TITLE
add urls to Code and Issue tracker for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,10 @@ setup(
     description='Python documentation generator',
     long_description=long_desc,
     long_description_content_type='text/x-rst',
+    project_urls={
+        "Code": "https://github.com/sphinx-doc/sphinx",
+        "Issue tracker": "https://github.com/sphinx-doc/sphinx/issues",
+    },
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar on [this screen](https://pypi.org/project/Sphinx), as well as including them in API responses to help automation tool find the source code for Sphinx. For example, see Django's [setup.cfg](https://github.com/django/django/blob/master/setup.cfg) and [PyPI listing](https://pypi.org/project/Django/).