### PR TITLE
Allow regex patterns for start/end patterns

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Features added
 * #6707: C++, support bit-fields.
 * #267: html: Eliminate prompt characters of doctest block from copyable text
 * #6729: html theme: agogo theme now supports ``rightsidebar`` option
+* #6826: allow regex patterns as start and end patterns for ``literalinclude``
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -616,6 +616,11 @@ __ http://pygments.org/docs/lexers/
    string are included. The ``start-at`` and ``end-at`` options behave in a
    similar way, but the lines containing the matched string are included.
 
+   By default, ``start-after``, ``start-at``, ``end-before``, and
+   ``end-at`` look for fixed strings. The ``regex`` flag can be added
+   to specify that the arguments given for both start and end lines
+   should be treated as regex patterns.
+
    With lines selected using ``start-after`` it is still possible to use
    ``lines``, the first allowed line having by convention the line number
    ``1``.

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -6,6 +6,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import re
 import sys
 import warnings
 from difflib import unified_diff
@@ -309,10 +310,12 @@ class LiteralIncludeReader:
             inclusive = True
         else:
             start = None
+        regex = 'regex' in self.options
 
         if start:
             for lineno, line in enumerate(lines):
-                if start in line:
+                if (not regex and start in line) or \
+                   (regex and re.search(start, line) is not None):
                     if inclusive:
                         if 'lineno-match' in self.options:
                             self.lineno_start += lineno + 1
@@ -340,10 +343,12 @@ class LiteralIncludeReader:
             inclusive = False
         else:
             end = None
+        regex = 'regex' in self.options
 
         if end:
             for lineno, line in enumerate(lines):
-                if end in line:
+                if (not regex and end in line) or \
+                   (regex and re.search(end, line) is not None):
                     if inclusive:
                         return lines[:lineno + 1]
                     else:
@@ -412,6 +417,7 @@ class LiteralInclude(SphinxDirective):
         'class': directives.class_option,
         'name': directives.unchanged,
         'diff': directives.unchanged_required,
+        'regex': directives.flag,
     }
 
     def run(self) -> List[Node]:

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -150,6 +150,18 @@ def test_LiteralIncludeReader_start_at(literal_inc_path):
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_start_at_regex(literal_inc_path):
+    options = {'lineno-match': True, 'start-at': '^class Foo', 'end-at': 'Bar', 'regex': True}
+    reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("class Foo:\n"
+                       "    pass\n"
+                       "\n"
+                       "class Bar:\n")
+    assert reader.lineno_start == 5
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_start_after(literal_inc_path):
     options = {'lineno-match': True, 'start-after': 'Foo', 'end-before': 'Bar'}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)


### PR DESCRIPTION
This adds a feature to handle regex patterns in start and end options for `literalinclude`. Adding a `regex` flag will cause all `start-after`, `start-at`, `end-before`, and/or `end-at` options to be handled as regex patterns instead of fixed strings.

Closes: #6826