### PR TITLE
LaTeX: escape fewer Unicode chars if engine is lualatex or xelatex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -43,7 +43,8 @@ Bugs fixed
   .. _latex3/latex2e#173: https://github.com/latex3/latex2e/issues/173
 * #6618: LaTeX: Avoid section names at the end of a page
 * #6738: LaTeX: Do not replace unicode characters by LaTeX macros on unicode
-  supported LaTeX engines
+  supported LaTeX engines: ¶, §, €, ∞, ±, →, ‣, –, superscript and subscript
+  digits go through "as is" (as default OpenType font supports them)
 * #6704: linkcheck: Be defensive and handle newly defined HTTP error code
 * #6655: image URLs containing ``data:`` causes gettext builder crashed
 * #6584: i18n: Error when compiling message catalogs on Hindi

--- a/sphinx/util/texescape.py
+++ b/sphinx/util/texescape.py
@@ -20,29 +20,28 @@ tex_replacements = [
     ('_', r'\_'),
     ('{', r'\{'),
     ('}', r'\}'),
-    ('[', r'{[}'),
-    (']', r'{]}'),
-    ('`', r'{}`'),
     ('\\', r'\textbackslash{}'),
     ('~', r'\textasciitilde{}'),
+    ('^', r'\textasciicircum{}'),
+    # map chars to avoid mis-interpretation in LaTeX
+    ('[', r'{[}'),
+    (']', r'{]}'),
+    # map chars to avoid TeX ligatures
+    # 1. ' - and , not here for some legacy reason
+    # 2. no effect with lualatex (done otherwise: #5790)
+    ('`', r'{}`'),
     ('<', r'\textless{}'),
     ('>', r'\textgreater{}'),
-    ('^', r'\textasciicircum{}'),
+    # map char for some unknown reason.  TODO: remove this?
+    ('|', r'\textbar{}'),
     # map special Unicode characters to TeX commands
-    ('¶', r'\P{}'),
-    ('§', r'\S{}'),
-    ('€', r'\texteuro{}'),
-    ('±', r'\(\pm\)'),
-    ('→', r'\(\rightarrow\)'),
-    ('‣', r'\(\rightarrow\)'),
     ('✓', r'\(\checkmark\)'),
     ('✔', r'\(\pmb{\checkmark}\)'),
     # used to separate -- in options
     ('﻿', r'{}'),
     # map some special Unicode characters to similar ASCII ones
+    # (even for Unicode LaTeX as may not be supported by OpenType font)
     ('⎽', r'\_'),
-    ('–', r'\textendash{}'),
-    ('|', r'\textbar{}'),
     ('ℯ', r'e'),
     ('ⅈ', r'i'),
     # Greek alphabet not escaped: pdflatex handles it via textalpha and inputenc
@@ -52,8 +51,15 @@ tex_replacements = [
 # A map Unicode characters to LaTeX representation
 # (for LaTeX engines which don't support unicode)
 unicode_tex_replacements = [
-    # map special Unicode characters to TeX commands
+    # map some more common Unicode characters to TeX commands
+    ('¶', r'\P{}'),
+    ('§', r'\S{}'),
+    ('€', r'\texteuro{}'),
     ('∞', r'\(\infty\)'),
+    ('±', r'\(\pm\)'),
+    ('→', r'\(\rightarrow\)'),
+    ('‣', r'\(\rightarrow\)'),
+    ('–', r'\textendash{}'),
     # superscript
     ('⁰', r'\(\sp{\text{0}}\)'),
     ('¹', r'\(\sp{\text{1}}\)'),


### PR DESCRIPTION
### Relates
- #6738, #6750, #6832 

See https://github.com/sphinx-doc/sphinx/pull/6750#discussion_r337611209

Note: I don't know why `|` gets TeX-escaped. I have left it for backwards compatibility but perhaps it can be removed (for all engines; I tested briefly no problem with Japanese if not TeX-escaped).

edit: the `|` needs some kind of escaping if it ends up in `\index{...}` LaTeX macro. See https://github.com/sphinx-doc/sphinx/pull/6835#discussion_r347154883