### PR TITLE
Fix #6813: An orphan warning is emitted for included document on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,9 @@ Bugs fixed
   code-block long enough not to fit on one page
 * #6809: LaTeX: code-block in a danger type admonition can easily spill over
   bottom of page
+* #6813: An orphan warning is emitted for included document on Windows.  Thanks
+  to @drillan
+
 
 Testing
 --------

--- a/sphinx/project.py
+++ b/sphinx/project.py
@@ -13,6 +13,7 @@ import os
 from sphinx.locale import __
 from sphinx.util import get_matching_files
 from sphinx.util import logging
+from sphinx.util import path_stabilize
 from sphinx.util.matching import compile_matchers
 from sphinx.util.osutil import SEP, relpath
 
@@ -71,6 +72,7 @@ class Project:
             filename = relpath(filename, self.srcdir)
         for suffix in self.source_suffix:
             if filename.endswith(suffix):
+                filename = path_stabilize(filename)
                 return filename[:-len(suffix)]
 
         # the file does not have docname


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6813 