### PR TITLE
Fix link to pygments lexer in docs

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -441,7 +441,7 @@ If highlighting with the selected language fails (i.e. Pygments emits an
    want to ensure consistent highlighting, you should fix your version of
    Pygments.
 
-__ http://pygments.org/docs/lexers/
+__ http://pygments.org/docs/lexers
 
 .. rst:directive:: .. highlight:: language
 


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose
Pygments website changed hosts and the lexer link with trailing slash gives a 404. Removing trailing slash works.