### PR TITLE
Fix #4186: LaTeX: Support upLaTeX as a new latex_engine (experimental)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Features added
 * #1331: Add new config variable: :confval:`user_agent`
 * #6000: LaTeX: have backslash also be an inline literal word wrap break
   character
+* #4186: LaTeX: Support upLaTeX as a new :confval:`latex_engine` (experimental)
 * #6812: Improve a warning message when extensions are not parallel safe
 * #6818: Improve Intersphinx performance for multiple remote inventories.
 * #2546: apidoc: .so file support

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1836,6 +1836,7 @@ These options influence LaTeX output.
    * ``'xelatex'`` -- XeLaTeX
    * ``'lualatex'`` -- LuaLaTeX
    * ``'platex'`` -- pLaTeX (default if :confval:`language` is ``'ja'``)
+   * ``'uplatex'`` -- upLaTeX (experimental)
 
    ``'pdflatex'``\ 's support for Unicode characters is limited.
 
@@ -1860,6 +1861,10 @@ These options influence LaTeX output.
    .. versionchanged:: 2.2.1
 
       Use ``xelatex`` by default for Greek documents.
+
+   .. versionchanged:: 2.3
+
+      Add ``uplatex`` support.
 
    Contrarily to :ref:`MathJaX math rendering in HTML output <math-support>`,
    LaTeX requires some extra configuration to support Unicode literals in

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -427,8 +427,12 @@ def default_latex_engine(config: Config) -> str:
 def default_latex_docclass(config: Config) -> Dict[str, str]:
     """ Better default latex_docclass settings for specific languages. """
     if config.language == 'ja':
-        return {'manual': 'jsbook',
-                'howto': 'jreport'}
+        if config.latex_engine == 'uplatex':
+            return {'manual': 'ujbook',
+                    'howto': 'ujreport'}
+        else:
+            return {'manual': 'jsbook',
+                    'howto': 'jreport'}
     else:
         return {}
 
@@ -454,7 +458,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect('config-inited', validate_config_values)
 
     app.add_config_value('latex_engine', default_latex_engine, None,
-                         ENUM('pdflatex', 'xelatex', 'lualatex', 'platex'))
+                         ENUM('pdflatex', 'xelatex', 'lualatex', 'platex', 'uplatex'))
     app.add_config_value('latex_documents', default_latex_documents, None)
     app.add_config_value('latex_logo', None, None, [str])
     app.add_config_value('latex_appendices', [], None)

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -37,7 +37,7 @@ XINDYOPTS += -M LatinRules.xdy
 # format: pdf or dvi (used only by archive targets)
 FMT = pdf
 
-{% if latex_engine == 'platex' -%}
+{% if latex_engine in ('platex', 'uplatex') -%}
 # latexmkrc is read then overridden by latexmkjarc
 LATEX = latexmk -r latexmkjarc -dvi
 PDFLATEX = latexmk -r latexmkjarc -pdfdvi -dvi- -ps-
@@ -49,7 +49,7 @@ PDFLATEX = latexmk -pdf -dvi- -ps-
 %.png %.gif %.jpg %.jpeg: FORCE_MAKE
 	extractbb '$@'
 
-{% if latex_engine == 'platex' -%}
+{% if latex_engine in ('platex', 'uplatex') -%}
 %.dvi: %.tex $(ALLIMGS) FORCE_MAKE
 	for f in *.pdf; do extractbb "$$f"; done
 	$(LATEX) $(LATEXMKOPTS) '$<'
@@ -62,7 +62,7 @@ PDFLATEX = latexmk -pdf -dvi- -ps-
 %.ps: %.dvi
 	dvips '$<'
 
-{% if latex_engine == 'platex' -%}
+{% if latex_engine in ('platex', 'uplatex') -%}
 %.pdf: %.tex $(ALLIMGS) FORCE_MAKE
 	for f in *.pdf; do extractbb "$$f"; done
 {%- else -%}

--- a/sphinx/texinputs/latexmkjarc_t
+++ b/sphinx/texinputs/latexmkjarc_t
@@ -1,4 +1,4 @@
-$latex = 'platex ' . $ENV{'LATEXOPTS'} . ' -kanji=utf8 %O %S';
+$latex = '{{ latex_engine }} ' . $ENV{'LATEXOPTS'} . ' -kanji=utf8 %O %S';
 $dvipdf = 'dvipdfmx %O -o %D %S';
 $makeindex = 'internal mendex %S %B %D';
 sub mendex {

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -221,6 +221,15 @@ ADDITIONAL_SETTINGS = {
         'fncychap':     '',
         'geometry':     '\\usepackage[dvipdfm]{geometry}',
     },
+    'uplatex': {
+        'latex_engine': 'uplatex',
+        'babel':        '',
+        'classoptions': ',dvipdfmx',
+        'fontpkg':      '\\usepackage{times}',
+        'textgreek':    '',
+        'fncychap':     '',
+        'geometry':     '\\usepackage[dvipdfm]{geometry}',
+    },
 
     # special settings for latex_engine + language_code
     ('xelatex', 'fr'): {


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #4186 
- I'm not familiar with LaTeX and Japanese LaTeX. So I don't know this is appropriate settings. But it seems working fine to me.