### PR TITLE
6824 fix search js bug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,9 @@ Bugs fixed
 * #6813: An orphan warning is emitted for included document on Windows.  Thanks
   to @drillan
 * #6850: Fix smartypants module calls re.sub() with wrong options
+* #6824: HTML search: If a search term is partially matched in the title and
+  fully matched in a text paragraph on the same page, the search does not
+  include this match.
 
 Testing
 --------

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -424,7 +424,7 @@ var Search = {
         for (j = 0; j < _files.length; j++) {
           file = _files[j];
           if (!(file in scoreMap))
-            scoreMap[file] = {}
+            scoreMap[file] = {};
           scoreMap[file][word] = o.score;
         }
       });
@@ -432,7 +432,7 @@ var Search = {
       // create the mapping
       for (j = 0; j < files.length; j++) {
         file = files[j];
-        if (file in fileMap)
+        if (file in fileMap && fileMap[file].indexOf(word) === -1)
           fileMap[file].push(word);
         else
           fileMap[file] = [word];


### PR DESCRIPTION
Subject: Fix bug in JS search

### Feature or Bugfix
- Bugfix

### Purpose
Fix: HTML search: If a search term is partially matched in the title and fully matched in a text paragraph on the same page, the search does not include this match.

### Detail
When I added partial matching, I did not account for this case, in which matches are added to the results overview of a file the twice. I extended a condition to prevent this.

### Relates
Fixes #6824

