### PR TITLE
LaTeX: Do not escape € wrongly (refs: 0103ff2a2b6, #6835)

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2164,8 +2164,6 @@ class LaTeXTranslator(SphinxTranslator):
                 node.rawsource, lang, opts=opts, linenos=linenos,
                 location=(self.curfilestack[-1], node.line), **highlight_args
             )
-            # workaround for Unicode issue
-            hlcode = hlcode.replace('€', '@texteuro[]')
             if self.in_footnote:
                 self.body.append('\n\\sphinxSetupCodeBlockInFootnote')
                 hlcode = hlcode.replace('\\begin{Verbatim}',


### PR DESCRIPTION
As discussed https://github.com/sphinx-doc/sphinx/pull/6834#issuecomment-555017048, merge of #6835 revealed a probably copy paste error in 6 years old 0103ff2a2b6. (at least I don't understand what it was supposed to do)

I tested 

```rest
TEST
====

€ ``€``

::

   notallowedinidentifiers = '€'


>>> notallowedinidentifiers = '€'
>>> notallowedinidentifiers
'€'
```

with make latexpdf and non-escaped `€` does not seem to raise any problem.

Also ok

```rest
.. parsed-literal::

   abc = :math:`€`
```

tried out this also as parsed literals were mentioned at https://github.com/sphinx-doc/sphinx/issues/929

(testing done with `latex_engine = 'xelatex'` so that since #6835 € is not tex-escaped)