### PR TITLE
README: remove stray "__"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,6 @@ Please adhere to our `code of conduct`__.
 
 __ http://www.sphinx-doc.org/en/master/code_of_conduct.html
 
-__
-
 Testing
 =======
 


### PR DESCRIPTION
Subject: Remove stray `__` from README

### Feature or Bugfix

- Bugfix

### Purpose

Fixes:
    
    README.rst:: (ERROR/3) Anonymous hyperlink mismatch: 10 references but 11 targets.