### PR TITLE
Fix misplaced flags in re.sub() call

### DIFF
--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -155,7 +155,7 @@ def educateQuotes(text: str, language: str = 'en') -> str:
 
     # Special case for decade abbreviations (the '80s):
     if language.startswith('en'):  # TODO similar cases in other languages?
-        text = re.sub(r"""'(?=\d{2}s)""", apostrophe, text, re.UNICODE)
+        text = re.sub(r"""'(?=\d{2}s)""", apostrophe, text, flags=re.UNICODE)
 
     close_class = r"""[^\ \t\r\n\[\{\(\-]"""
     dec_dashes = r"""&#8211;|&#8212;"""


### PR DESCRIPTION
Subject: Fix misplaced flags in a `re.sub()` call

### Feature or Bugfix
- Bugfix

### Purpose

`sphinx.util.smartypants` has the following code:
```python
text = re.sub(r"""'(?=\d{2}s)""", apostrophe, text, re.UNICODE)
```
But the 4th argument of `re.sub()` is maximum number of substitutions, not flags.