### PR TITLE
Fix the URL to https://pygments.org/docs/lexers.html

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -574,7 +574,7 @@ General configuration
    A dictionary of options that modify how the lexer specified by
    :confval:`highlight_language` generates highlighted source code. These are
    lexer-specific; for the options understood by each, see the
-   `Pygments documentation <http://pygments.org/docs/lexers/>`_.
+   `Pygments documentation <https://pygments.org/docs/lexers.html>`_.
 
    .. versionadded:: 1.3
 


### PR DESCRIPTION
https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html#showing-code-examples
is pointing to https://pygments.org/docs/lexers/ (404)