### PR TITLE
DOC: add Greek to list of supported languages

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -667,6 +667,7 @@ documentation on :ref:`intl` for details.
    * ``cs`` -- Czech
    * ``da`` -- Danish
    * ``de`` -- German
+   * ``el`` -- Greek
    * ``en`` -- English
    * ``es`` -- Spanish
    * ``et`` -- Estonian


### PR DESCRIPTION
A new volunteer (see https://www.transifex.com/sphinx-doc/public/) has completed translation of Sphinx into Greek!

Support for Greek as main language for LaTeX is there since 2.2.1. I don't know if any special difficulty with other builders than HTML and LaTeX which would explain why Greek was not yet listed (it already got some translation work back in 2015).