### PR TITLE
Fix #6855: Non-RST translated text should be parsed by the appropriate parser

### DIFF
--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -126,3 +126,8 @@ class PycodeError(Exception):
 class NoUri(Exception):
     """Raised by builder.get_relative_uri() if there is no URI available."""
     pass
+
+
+class FiletypeNotFoundError(Exception):
+    "Raised by get_filetype() if a filename matches no source suffix."
+    pass

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -26,7 +26,7 @@ from sphinx.transforms.i18n import (
     PreserveTranslatableMessages, Locale, RemoveTranslatableInline,
 )
 from sphinx.transforms.references import SphinxDomains
-from sphinx.util import logging
+from sphinx.util import logging, get_filetype
 from sphinx.util import UnicodeDecodeErrorHandler
 from sphinx.util.docutils import LoggingReporter
 from sphinx.versioning import UIDTransform
@@ -190,20 +190,6 @@ class SphinxFileInput(FileInput):
         # type: (Any, Any) -> None
         kwargs['error_handler'] = 'sphinx'
         super().__init__(*args, **kwargs)
-
-
-class FiletypeNotFoundError(Exception):
-    pass
-
-
-def get_filetype(source_suffix, filename):
-    # type: (Dict[str, str], str) -> str
-    for suffix, filetype in source_suffix.items():
-        if filename.endswith(suffix):
-            # If default filetype (None), considered as restructuredtext.
-            return filetype or 'restructuredtext'
-    else:
-        raise FiletypeNotFoundError
 
 
 def read_doc(app, env, filename):

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -22,7 +22,7 @@ from sphinx.config import Config
 from sphinx.domains.std import make_glossary_term, split_term_classifiers
 from sphinx.locale import __, init as init_locale
 from sphinx.transforms import SphinxTransform
-from sphinx.util import split_index_msg, logging
+from sphinx.util import split_index_msg, logging, get_filetype
 from sphinx.util.i18n import docname_to_domain
 from sphinx.util.nodes import (
     LITERAL_TYPE_NODES, IMAGE_TYPE_NODES, NodeMatcher,
@@ -61,7 +61,8 @@ def publish_msgstr(app: "Sphinx", source: str, source_path: str, source_line: in
         from sphinx.io import SphinxI18nReader
         reader = SphinxI18nReader()
         reader.setup(app)
-        parser = app.registry.create_source_parser(app, 'restructuredtext')
+        filetype = get_filetype(config.source_suffix, source_path)
+        parser = app.registry.create_source_parser(app, filetype)
         doc = reader.read(
             source=StringInput(source=source,
                                source_path="%s:%s:<translated>" % (source_path, source_line)),

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -29,7 +29,8 @@ from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, S
 from urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 
 from sphinx.deprecation import RemovedInSphinx40Warning
-from sphinx.errors import PycodeError, SphinxParallelError, ExtensionError
+from sphinx.errors import (  # noqa
+    PycodeError, SphinxParallelError, ExtensionError, FiletypeNotFoundError)
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.console import strip_colors, colorize, bold, term_width_line  # type: ignore
@@ -115,6 +116,16 @@ def get_matching_docs(dirname: str, suffixes: List[str],
             if fnmatch.fnmatch(filename, suffixpattern):
                 yield filename[:-len(suffixpattern) + 1]
                 break
+
+
+def get_filetype(source_suffix, filename):
+    # type: (Dict[str, str], str) -> str
+    for suffix, filetype in source_suffix.items():
+        if filename.endswith(suffix):
+            # If default filetype (None), considered as restructuredtext.
+            return filetype or 'restructuredtext'
+    else:
+        raise FiletypeNotFoundError
 
 
 class FilenameUniqDict(dict):


### PR DESCRIPTION
Closes #6855

### Feature or Bugfix

- Bugfix
