### PR TITLE
Fix #6867: text: extra spaces are inserted to hyphenated words on folding lines

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Incompatible changes
   match the first line of the code block.
 * #1331: Change default User-Agent header to ``"Sphinx/X.Y.Z requests/X.Y.Z
   python/X.Y.Z"``.  It can be changed via :confval:`user_agent`.
+* #6867: text: content of admonitions starts after a blank line
 
 Deprecated
 ----------
@@ -78,6 +79,7 @@ Bugs fixed
   fully matched in a text paragraph on the same page, the search does not
   include this match.
 * #6848: config.py shouldn't pop extensions from overrides
+* #6867: text: extra spaces are inserted to hyphenated words on folding lines
 
 Testing
 --------

--- a/tests/test_build_text.py
+++ b/tests/test_build_text.py
@@ -31,16 +31,18 @@ def test_maxwitdh_with_prefix(app, status, warning):
     lines = result.splitlines()
     line_widths = [column_width(line) for line in lines]
     assert max(line_widths) < MAXWIDTH
-    assert lines[0].startswith('See also: ham')
-    assert lines[1].startswith('  ham')
-    assert lines[2] == ''
-    assert lines[3].startswith('* ham')
-    assert lines[4].startswith('  ham')
-    assert lines[5] == ''
-    assert lines[6].startswith('* ham')
-    assert lines[7].startswith('  ham')
-    assert lines[8] == ''
-    assert lines[9].startswith('spam egg')
+    assert lines[0].startswith('See also:')
+    assert lines[1].startswith('')
+    assert lines[2].startswith('  ham')
+    assert lines[3].startswith('  ham')
+    assert lines[4] == ''
+    assert lines[5].startswith('* ham')
+    assert lines[6].startswith('  ham')
+    assert lines[7] == ''
+    assert lines[8].startswith('* ham')
+    assert lines[9].startswith('  ham')
+    assert lines[10] == ''
+    assert lines[11].startswith('spam egg')
 
 
 @with_text_app()

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -315,7 +315,8 @@ def test_text_seealso(app):
               "\n*********************\n"
               "\nSee also: SHORT TEXT 1\n"
               "\nSee also: LONG TEXT 1\n"
-              "\nSee also: SHORT TEXT 2\n"
+              "\nSee also:\n"
+              "\n  SHORT TEXT 2\n"
               "\n  LONG TEXT 2\n")
     assert result == expect
 
@@ -356,7 +357,9 @@ def test_text_figure_captions(app):
               "14.4. IMAGE UNDER NOTE\n"
               "======================\n"
               "\n"
-              "Note: [image: i18n under note][image]\n"
+              "Note:\n"
+              "\n"
+              "  [image: i18n under note][image]\n"
               "\n"
               "     [image: img under note][image]\n")
     assert result == expect


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6867 
- Not to call needless `do_format()` twice, I changed the rule for admonition. After this change, it starts after a blank line.

Before:
```
See also: blah blah blah ...
  blah blah blah ...
```
After:
```
See also:

  blah blah blah ...
  blah blah blah ...
```