### PR TITLE
LaTeX: avoid ragged line endings in case of multi-line author display

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -80,6 +80,7 @@ Bugs fixed
   include this match.
 * #6848: config.py shouldn't pop extensions from overrides
 * #6867: text: extra spaces are inserted to hyphenated words on folding lines
+* #6876: LaTeX: multi-line display of authors on title page has ragged edges
 
 Testing
 --------

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -3,7 +3,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesClass{sphinxhowto}[2018/12/23 v2.0 Document class (Sphinx howto)]
+\ProvidesClass{sphinxhowto}[2019/12/01 v2.3.0 Document class (Sphinx howto)]
 
 % 'oneside' option overriding the 'twoside' default
 \newif\if@oneside
@@ -27,6 +27,17 @@
 \setcounter{secnumdepth}{2}
 \setcounter{tocdepth}{2}% i.e. section and subsection
 
+% Adapt \and command to the flushright context of \sphinxmaketitle, to
+% avoid ragged line endings if author names do not fit all on one single line
+\DeclareRobustCommand{\and}{%
+    \end{tabular}\kern-\tabcolsep
+    \allowbreak
+    \hskip\dimexpr1em+\tabcolsep\@plus.17fil\begin{tabular}[t]{c}%
+}%
+% If it is desired that each author name be on its own line, use in preamble:
+%\DeclareRobustCommand{\and}{%
+%   \end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}%
+%}%
 % Change the title page to look a bit better, and fit in with the fncychap
 % ``Bjarne'' style a bit better.
 %

--- a/sphinx/texinputs/sphinxmanual.cls
+++ b/sphinx/texinputs/sphinxmanual.cls
@@ -3,7 +3,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesClass{sphinxmanual}[2018/12/23 v2.0 Document class (Sphinx manual)]
+\ProvidesClass{sphinxmanual}[2019/12/01 v2.3.0 Document class (Sphinx manual)]
 
 % chapters starting at odd pages (overridden by 'openany' document option)
 \PassOptionsToClass{openright}{\sphinxdocclass}
@@ -30,6 +30,17 @@
 \setcounter{secnumdepth}{2}
 \setcounter{tocdepth}{1}
 
+% Adapt \and command to the flushright context of \sphinxmaketitle, to
+% avoid ragged line endings if author names do not fit all on one single line
+\DeclareRobustCommand{\and}{%
+    \end{tabular}\kern-\tabcolsep
+    \allowbreak
+    \hskip\dimexpr1em+\tabcolsep\@plus.17fil\begin{tabular}[t]{c}%
+}%
+% If it is desired that each author name be on its own line, use in preamble:
+%\DeclareRobustCommand{\and}{%
+%   \end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}%
+%}%
 % Change the title page to look a bit better, and fit in with the fncychap
 % ``Bjarne'' style a bit better.
 %


### PR DESCRIPTION
Closes #6876

- Bugfix

### Relates
- #6005

The comment at #6005 about `\begin{tabular}[c@{}]` applies here too, as using this in `\sphinxmaketitle` would need to be matched anyhow also with a change to  `\and` macro. This patch only redefines `\and`.

The output for projects with author names fitting on one signe line is exactly unchanged.

Sphinx users can obtain some special effect by own definition of `\and`, code comment indicates how to get each author name on its own line (however if mark-up uses `\\` to add some address underneath of author name, the result will look bad due to `c` usage in `tabular` giving centered columns; one can replace by `r` in `\and` redefinition, but there still remains one `c` in `\sphinxmaketitle` macro...)

