### PR TITLE
Fix #6803: Disable parallel build on macOS and py38+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #6803: For security reason of python, parallel mode is disabled on macOS and
+  Python3.8+
+
 Deprecated
 ----------
 
@@ -19,6 +22,7 @@ Bugs fixed
 * #6776: LaTeX: 2019-10-01 LaTeX release breaks :file:`sphinxcyrillic.sty`
 * #6815: i18n: French, Hindi, Japanese and Korean translation messages has been
   broken
+* #6803: parallel build causes AttributeError on macOS and Python3.8
 
 Testing
 --------

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require = {
         'html5lib',
         'flake8>=3.5.0',
         'flake8-import-order',
-        'mypy>=0.740',
+        'mypy>=0.750',
         'docutils-stubs',
     ],
 }

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -12,6 +12,7 @@
 
 import os
 import pickle
+import platform
 import sys
 import warnings
 from collections import deque
@@ -198,6 +199,12 @@ class Sphinx:
 
         # say hello to the world
         logger.info(bold(__('Running Sphinx v%s') % sphinx.__display_version__))
+
+        # notice for parallel build on macOS and py38+
+        if sys.version_info > (3, 8) and platform.system() == 'Darwin' and parallel > 1:
+            logger.info(bold(__("For security reason, parallel mode is disabled on macOS and "
+                                "python3.8 and above.  For more details, please read "
+                                "https://github.com/sphinx-doc/sphinx/issues/6803")))
 
         # status code for command-line application
         self.statuscode = 0

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -129,7 +129,7 @@ class TokenProcessor:
     def __init__(self, buffers: List[str]) -> None:
         lines = iter(buffers)
         self.buffers = buffers
-        self.tokens = tokenize.generate_tokens(lambda: next(lines))
+        self.tokens = tokenize.generate_tokens(lambda: next(lines))  # type: ignore
         self.current = None     # type: Token
         self.previous = None    # type: Token
 

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -9,6 +9,8 @@
 """
 
 import os
+import platform
+import sys
 import time
 import traceback
 from math import sqrt
@@ -26,7 +28,12 @@ logger = logging.getLogger(__name__)
 
 
 # our parallel functionality only works for the forking Process
-parallel_available = multiprocessing and (os.name == 'posix')
+#
+# Note: "fork" is not recommended on macOS and py38+.
+#       see https://bugs.python.org/issue33725
+parallel_available = (multiprocessing and
+                      (os.name == 'posix') and
+                      not (sys.version_info > (3, 8) and platform.system() == 'Darwin'))
 
 
 class SerialTasks:

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -10,6 +10,8 @@
 
 import codecs
 import os
+import platform
+import sys
 
 import pytest
 from docutils import nodes
@@ -276,6 +278,8 @@ def test_colored_logs(app, status, warning):
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+@pytest.mark.xfail(platform.system() == 'Darwin' and sys.version_info > (3, 8),
+                   reason="Not working on macOS and py38")
 def test_logging_in_ParallelTasks(app, status, warning):
     logging.setup(app, status, warning)
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6803 and #6865 
- Since python3.8, the default start method of multiprocessing has changed to "spawn" on macOS for security reasons. The implementation for parallel build are strongly coupled with "fork" method. So this disables the feature temporarily (until reimplemented whole of parallel build feature).
- We can switch the start method to "fork" manually. But it is risky choice. So this does not do that.