### PR TITLE
test: Do test with python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
     - python: '3.7'
       env:
         - TOXENV=du14
+    - python: '3.8'
+      env:
+        - TOXENV=du15
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
     - python: 'nightly'
       env: TOXENV=py38


### PR DESCRIPTION
### Feature or Bugfix
- Testing

### Purpose
- Now we are going to test with 3.5, 3.6, 3.7 and nightly. In this moment, nightly equals to 3.8.0+. But it will move to 3.9.0 in nearly future.
- This does testing with python3.8 explicitly.
- Sadly, this increases time of CI. But it is needed to keep tested.