### PR TITLE
Ensure getdoc always trims whitespace

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -609,7 +609,10 @@ def getdoc(obj: Any, attrgetter: Callable = safe_getattr,
     doc = attrgetter(obj, '__doc__', None)
     if ispartial(obj) and doc == obj.__class__.__doc__:
         return getdoc(obj.func)
-    elif doc is None and allow_inherited:
+    elif doc is not None:
+        # clean the docstring for consistency with getdoc below
+        doc = inspect.cleandoc(obj)
+    elif allow_inherited:
         doc = inspect.getdoc(obj)
 
     return doc

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -609,10 +609,10 @@ def getdoc(obj: Any, attrgetter: Callable = safe_getattr,
     doc = attrgetter(obj, '__doc__', None)
     if ispartial(obj) and doc == obj.__class__.__doc__:
         return getdoc(obj.func)
-    elif doc is not None:
-        # clean the docstring for consistency with getdoc below
-        doc = inspect.cleandoc(obj)
-    elif allow_inherited:
+    elif doc is None and allow_inherited:
         doc = inspect.getdoc(obj)
+    elif isinstance(doc, str):
+        # clean the docstring for consistency with getdoc above
+        doc = inspect.cleandoc(obj)
 
     return doc

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -613,6 +613,6 @@ def getdoc(obj: Any, attrgetter: Callable = safe_getattr,
         doc = inspect.getdoc(obj)
     elif isinstance(doc, str):
         # clean the docstring for consistency with getdoc above
-        doc = inspect.cleandoc(obj)
+        doc = inspect.cleandoc(doc)
 
     return doc


### PR DESCRIPTION
This change makes it so the whitespace is always trimmed, for consistency.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Make it so inherited and non-inherited docstrings with `autoclass_content = both` render the same way.

### Detail
Before this patch:
* `getdoc(obj, allow_inherited=True)` trims whitespace
* `getdoc(obj, allow_inherited=False)` does not trim whitespace

After:
* Both calls trim whitespace

### Relates

