### PR TITLE
LaTeX: inhibit so-called TeX Ligatures with xelatex and lualatex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -81,6 +81,8 @@ Bugs fixed
   include this match.
 * #6848: config.py shouldn't pop extensions from overrides
 * #6867: text: extra spaces are inserted to hyphenated words on folding lines
+* #6886: LaTeX: xelatex converts straight double quotes into right curly ones
+  (shows when :confval:`smartquotes` is ``False``)
 * #6876: LaTeX: multi-line display of authors on title page has ragged edges
 
 Testing

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -334,12 +334,19 @@ into the generated ``.tex`` files.  Its ``'sphinxsetup'`` key is described
      .. versionchanged:: 2.0
         ``'lualatex'`` executes
         ``\defaultfontfeatures[\rmfamily,\sffamily]{}`` to disable TeX
-        ligatures.
+        ligatures transforming `<<` and `>>` as escaping working with
+        ``pdflatex/xelatex`` failed with ``lualatex``.
      .. versionchanged:: 2.0
         Detection of ``LGR``, ``T2A``, ``X2`` to trigger support of
         occasional Greek or Cyrillic (``'pdflatex'`` only, as this support
         is provided natively by ``'platex'`` and only requires suitable
         font with ``'xelatex'/'lualatex'``).
+     .. versionchanged:: 2.3.0
+        ``'xelatex'`` also executes
+        ``\defaultfontfeatures[\rmfamily,\sffamily]{}`` in order to avoid
+        contractions of ``--`` into en-dash or transforms of straight quotes
+        into curly ones in PDF (in non-literal text paragraphs) despite
+        :confval:`smartquotes` being set to ``False``.
 
   ``'textgreek'``
      The default (``'pdflatex'`` only) is

--- a/sphinx/templates/latex/longtable.tex_t
+++ b/sphinx/templates/latex/longtable.tex_t
@@ -20,7 +20,7 @@
 \endfirsthead
 
 \multicolumn{<%= table.colcount %>}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- <%= _('continued from previous page') %>}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} <%= _('continued from previous page') %>}}}\\
 \hline
 <%= ''.join(table.header) %>
 \endhead

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -194,7 +194,8 @@ ADDITIONAL_SETTINGS = {
         'latex_engine': 'xelatex',
         'polyglossia':  '\\usepackage{polyglossia}',
         'babel':        '',
-        'fontenc':      '\\usepackage{fontspec}',
+        'fontenc':     ('\\usepackage{fontspec}\n'
+                        '\\defaultfontfeatures[\\rmfamily,\\sffamily,\\ttfamily]{}'),
         'fontpkg':      XELATEX_DEFAULT_FONTPKG,
         'textgreek':    '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'
@@ -205,7 +206,7 @@ ADDITIONAL_SETTINGS = {
         'polyglossia':  '\\usepackage{polyglossia}',
         'babel':        '',
         'fontenc':     ('\\usepackage{fontspec}\n'
-                        '\\defaultfontfeatures[\\rmfamily,\\sffamily]{}'),
+                        '\\defaultfontfeatures[\\rmfamily,\\sffamily,\\ttfamily]{}'),
         'fontpkg':      LUALATEX_DEFAULT_FONTPKG,
         'textgreek':    '',
         'utf8extra':   ('\\catcode`^^^^00a0\\active\\protected\\def^^^^00a0'

--- a/tests/roots/test-latex-table/expects/longtable.tex
+++ b/tests/roots/test-latex-table/expects/longtable.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_align.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_align.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -13,7 +13,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
@@ -13,7 +13,7 @@ header3
 \endfirsthead
 
 \multicolumn{3}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1

--- a/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
@@ -11,7 +11,7 @@ header2
 \endfirsthead
 
 \multicolumn{2}{c}%
-{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} -- continued from previous page}}}\\
+{\makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}}\\
 \hline
 \sphinxstyletheadfamily 
 header1


### PR DESCRIPTION
Closes: #6886

It is difficult to understand why fontspec _by default_ turns straight
double quotes " into ” i.e. right curly ones, calling this "TeX
ligature", but that's life and fortunately fontspec also provides a way
to turn this off. With this workaround also a straight ' in LaTeX file,
(i.e. a straight ' in source and smartquotes = False was used) will not
become a curly quote and this is an advantage compared to the pdflatex
situation.

We suppress TeX Ligatures also for \ttfamily (used in code-blocks) but
that appears to be already the case with fontspec although user manual
does not seem explicit (and no list of what exactly the TeX Ligatures
are is to be found in fontspec user documentation, one has to go into
its source code). (the fact that Pygmentize escapes the " to \char`\"
TeX mark-up would not by itself prevent the transformation into a curly
double quote, it is because fontspec does not apply this transform to
monospace typeface that it did not show).

### Feature or Bugfix
- Bugfix


### Relates

Closes #6886. Relates #5790 in so far as the fix used at #5790 for a lualatex behavior is taken over and applied also to xelatex.