### PR TITLE
Allow setting boolean latex_use_xindy from command line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #6900: Not possible to set :confval:`latex_use_xindy` via ``-D`` option to
+  :program:`sphinx-build`
+
 Testing
 --------
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -459,7 +459,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('latex_logo', None, None, [str])
     app.add_config_value('latex_appendices', [], None)
     app.add_config_value('latex_use_latex_multicolumn', False, None)
-    app.add_config_value('latex_use_xindy', default_latex_use_xindy, None)
+    app.add_config_value('latex_use_xindy', default_latex_use_xindy, None,
+                         ENUM(None, True, False, '1', '0'))
     app.add_config_value('latex_toplevel_sectioning', None, None,
                          ENUM(None, 'part', 'chapter', 'section'))
     app.add_config_value('latex_domain_indices', True, None, [list])

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -65,7 +65,7 @@ class ENUM:
         app.add_config_value('latex_show_urls', 'no', None, ENUM('no', 'footnote', 'inline'))
     """
     def __init__(self, *candidates):
-        # type: (str) -> None
+        # type: (Union[str, bool]) -> None
         self.candidates = candidates
 
     def match(self, value):


### PR DESCRIPTION
Fixes: #6900

Is there any other boolean configuration whose default is a callable?

Relates indirectly #6898 in so far as #6900 prevents indicated advice to solve #6898 use case.