### PR TITLE
Add sphinxcontrib-beamer to list of extensions for 2.x release.

### DIFF
--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -36,6 +36,7 @@ This is the current list of contributed extensions in that repository:
 - astah: embed diagram by using astah
 - autoanysrc: Gather reST documentation from any source files
 - autorun: Execute code in a ``runblock`` directive
+- beamer_: A builder for Beamer (LaTeX) output.
 - blockdiag: embed block diagrams by using blockdiag_
 - cacoo: embed diagram from Cacoo
 - cf3domain: a domain for CFEngine 3 policies
@@ -148,3 +149,4 @@ started with writing your own extensions.
 .. _domaintools: https://bitbucket.org/klorenz/sphinxcontrib-domaintools
 .. _restbuilder: https://pypi.org/project/sphinxcontrib-restbuilder/
 .. _Lasso: http://www.lassosoft.com/
+.. _beamer: https://pypi.org/project/sphinxcontrib-beamer/


### PR DESCRIPTION
Change-Id: I943e42508cc8ca4e20c65803c1bca225195ddd0e

Subject: Add sphinxcontrib-beamer to the list of extensions for 2.x release.

### Feature or Bugfix
- Feature

### Purpose
I recently developed a Sphinx extension to output Beamer presentations for personal use. It is currently available on PyPI so it may as well be referenced from the Sphinx documentation.

### Detail
None

### Relates
- [master PR](https://github.com/sphinx-doc/sphinx/pull/6893)

