### PR TITLE
Handle latex_use_xindy bool confval with callable default specially

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #6900: Not possible to set :confval:`latex_use_xindy` via ``-D`` option to
+  :program:`sphinx-build`
+
 Testing
 --------
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -222,7 +222,7 @@ class Config:
                                  (name, name + '.key=value'))
             elif isinstance(defvalue, list):
                 return value.split(',')
-            elif isinstance(defvalue, int):
+            elif isinstance(defvalue, int) or name == 'latex_use_xindy':
                 try:
                     return int(value)
                 except ValueError:


### PR DESCRIPTION
Fixes: #6900


- Bugfix

This is alternative to #6902. It identifies better the root of the problem but still feels more like a temporary workaround than a fully satisfying fix.

For this reason I did not add a test yet.