### PR TITLE
Make the background of inheritance diagrams transparent

### DIFF
--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -247,6 +247,7 @@ class InheritanceGraph:
     default_graph_attrs = {
         'rankdir': 'LR',
         'size': '"8.0, 12.0"',
+        'bgcolor': 'transparent',
     }
     default_node_attrs = {
         'shape': 'box',
@@ -254,7 +255,8 @@ class InheritanceGraph:
         'height': 0.25,
         'fontname': '"Vera Sans, DejaVu Sans, Liberation Sans, '
                     'Arial, Helvetica, sans"',
-        'style': '"setlinewidth(0.5)"',
+        'style': '"setlinewidth(0.5),filled"',
+        'fillcolor': 'white',
     }
     default_edge_attrs = {
         'arrowsize': 0.5,


### PR DESCRIPTION
Previously they would be emitted with a white background

### Feature or Bugfix
<!-- please choose -->
- Bugfix, but of a graphical shortcoming that could be considered by design

### Purpose
- Make the inheritance diagram look better against non-white backgrounds

### Detail
- See https://external-builds.readthedocs.io/html/cocotb/1232/library_reference.html#simulation-object-handles, there is a hard-to-see white box around the diagram
- See https://www.sphinx-doc.org/en/master/_images/inheritance-6ec4ecfe071c19b248df3c1dd661ee3fb719255c.png for an internal example

### Relates
- <URL or Ticket>

