### PR TITLE
WIP: Add inline syntax highlighting using docutils :code: role

### DIFF
--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -599,6 +599,15 @@ class IndexInSectionTitleTransform(SphinxTransform):
                     node.remove(index)
                     node.parent.insert(i + 1, index)
 
+class InlineCodeTransform(SphinxTransform):
+    default_priority = 200
+
+    def apply(self):
+        for node in self.document.traverse(nodes.literal):
+            for subnode in node:
+                if isinstance(subnode, nodes.inline):
+                    # mark inline nodes just under literal node as "code" to handle them in writer!
+                    subnode['code'] = True
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_transform(FootnoteDocnameUpdater)
@@ -610,6 +619,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_post_transform(LiteralBlockTransform)
     app.add_post_transform(MathReferenceTransform)
     app.add_post_transform(ShowUrlsTransform)
+    app.add_post_transform(InlineCodeTransform)
 
     return {
         'version': 'builtin',

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -599,15 +599,17 @@ class IndexInSectionTitleTransform(SphinxTransform):
                     node.remove(index)
                     node.parent.insert(i + 1, index)
 
+
 class InlineCodeTransform(SphinxTransform):
+    """Mark inline nodes just under literal node as "code" to handle them in writer"""
     default_priority = 200
 
     def apply(self):
         for node in self.document.traverse(nodes.literal):
             for subnode in node:
                 if isinstance(subnode, nodes.inline):
-                    # mark inline nodes just under literal node as "code" to handle them in writer!
                     subnode['code'] = True
+
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_transform(FootnoteDocnameUpdater)

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 default_settings = {
     'embed_stylesheet': False,
     'cloak_email_addresses': True,
+    'syntax_highlight': 'short',
     'pep_base_url': 'https://www.python.org/dev/peps/',
     'pep_references': None,
     'rfc_base_url': 'https://tools.ietf.org/html/',

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -537,8 +537,11 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.body.append(self.starttag(node, 'kbd', '',
                                            CLASS='docutils literal notranslate'))
         else:
+            classes = 'docutils literal notranslate'
+            if 'code' in node['classes']:
+                classes += ' highlight'
             self.body.append(self.starttag(node, 'code', '',
-                                           CLASS='docutils literal notranslate'))
+                                           CLASS=classes))
             self.protect_literal_text += 1
 
     def depart_literal(self, node):

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -484,8 +484,11 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.body.append(self.starttag(node, 'kbd', '',
                                            CLASS='docutils literal notranslate'))
         else:
+            classes = 'docutils literal notranslate'
+            if 'code' in node['classes']:
+                classes += ' highlight'
             self.body.append(self.starttag(node, 'code', '',
-                                           CLASS='docutils literal notranslate'))
+                                           CLASS=classes))
             self.protect_literal_text += 1
 
     def depart_literal(self, node):

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -464,7 +464,6 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_footnote = 0
         self.in_caption = 0
         self.in_term = 0
-        self.in_code = 0
         self.needs_linetrimming = 0
         self.in_minipage = 0
         self.no_latex_floats = 0
@@ -2045,8 +2044,6 @@ class LaTeXTranslator(SphinxTranslator):
     def visit_literal(self, node):
         # type: (nodes.Element) -> None
         self.no_contractions += 1
-        if('code' in node.get('classes', [])):
-            self.in_code = 1
         if self.in_title:
             self.body.append(r'\sphinxstyleliteralintitle{\sphinxupquote{')
         else:
@@ -2055,7 +2052,6 @@ class LaTeXTranslator(SphinxTranslator):
     def depart_literal(self, node):
         # type: (nodes.Element) -> None
         self.no_contractions -= 1
-        self.in_code = 0
         self.body.append('}}')
 
     def visit_footnote_reference(self, node):
@@ -2298,7 +2294,7 @@ class LaTeXTranslator(SphinxTranslator):
         elif classes in [['accelerator']]:
             self.body.append(r'\sphinxaccelerator{')
             self.context.append('}')
-        elif classes and self.in_code:
+        elif classes and node.get('code', False):
             self.body.append(r'\PYG{%s}{' % ','.join(classes))
             self.context.append('}')
         elif classes and not self.in_title:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -464,6 +464,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_footnote = 0
         self.in_caption = 0
         self.in_term = 0
+        self.in_code = 0
         self.needs_linetrimming = 0
         self.in_minipage = 0
         self.no_latex_floats = 0
@@ -2044,6 +2045,8 @@ class LaTeXTranslator(SphinxTranslator):
     def visit_literal(self, node):
         # type: (nodes.Element) -> None
         self.no_contractions += 1
+        if('code' in node.get('classes', [])):
+            self.in_code = 1
         if self.in_title:
             self.body.append(r'\sphinxstyleliteralintitle{\sphinxupquote{')
         else:
@@ -2052,6 +2055,7 @@ class LaTeXTranslator(SphinxTranslator):
     def depart_literal(self, node):
         # type: (nodes.Element) -> None
         self.no_contractions -= 1
+        self.in_code = 0
         self.body.append('}}')
 
     def visit_footnote_reference(self, node):
@@ -2293,6 +2297,9 @@ class LaTeXTranslator(SphinxTranslator):
             self.context.append('}')
         elif classes in [['accelerator']]:
             self.body.append(r'\sphinxaccelerator{')
+            self.context.append('}')
+        elif classes and self.in_code:
+            self.body.append(r'\PYG{%s}{' % ','.join(classes))
             self.context.append('}')
         elif classes and not self.in_title:
             self.body.append(r'\DUrole{%s}{' % ','.join(classes))


### PR DESCRIPTION
Subject: support inline syntax highlighting in HTML and LaTeX without extensions

### Feature or Bugfix
- Feature

### Purpose
This PR adds the ability to do syntax highlighting of inline text using the docutils :code: role.

Changes:

- Change default of docutils setting that controls the type of Pygments classes that are added (long names or short). Anyone adding custom CSS 
- Add a CSS class to enable highlighting
- Changes LaTeX output to use `\PYG` for inline code

Things this PR does not do (yet):

- Passing inline code to PygmentsBridge for adding classes. Classes are added by docutils instead. This can cause a small difference in what classes are added, but I could not find a nice way to do this.
- A toggle switch to enable/disable this. It is now always on for :code:
- Verification with a wide array of input
- Documentation (will need to be added if approach is OK)
- Automated tests (will need to be added if approach is OK)

### Relates
- Fixes #5157
