### PR TITLE
Fix documentation typo on the directives page

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -519,7 +519,7 @@ __ http://pygments.org/docs/lexers
 
       .. versionadded:: 1.3
 
-   .. rst:directive:option:: emphasized-lines: line numbers
+   .. rst:directive:option:: emphasize-lines: line numbers
       :type: comma separated numbers
 
       Empahsize particular lines of the code block::


### PR DESCRIPTION
### Feature or Bugfix
- Docs Bugfix

### Purpose
Fix that the `emphasize-lines` option is mistyped as `emphasized-lines` on the documentation page.


