### PR TITLE
Fix #6920: sphinx-build: A console message is wrongly highlighted

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -85,6 +85,7 @@ Bugs fixed
   (shows when :confval:`smartquotes` is ``False``)
 * #6876: LaTeX: multi-line display of authors on title page has ragged edges
 * #6887: Sphinx crashes with docutils-0.16b0
+* #6920: sphinx-build: A console message is wrongly highlighted
 
 Testing
 --------

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -304,7 +304,7 @@ class Builder:
         First updates the environment, and then calls :meth:`write`.
         """
         if summary:
-            logger.info(bold(__('building [%s]') % self.name) + ': ' + summary)
+            logger.info(bold(__('building [%s]: ') % self.name) + summary)
 
         # while reading, collect all warnings from docutils
         with logging.pending_warnings():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6920 