### PR TITLE
CI: Pinning coverage < 5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ description =
     py{35,36,37,38}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.
 deps =
+    coverage < 5.0  # refs: https://github.com/sphinx-doc/sphinx/pull/6924
     du12: docutils==0.12
     du13: docutils==0.13.1
     du14: docutils==0.14


### PR DESCRIPTION
### Feature or Bugfix
- Testing

### Purpose
- Pinning coverage < 5.0
- It seems our testing has failed since the package updated.
- This tries to confirm the reason of error with pinning the package to old one.