### PR TITLE
Remove redundant type="text/javascript" from <script> elements

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -30,7 +30,7 @@
       .related { display: none; }
       {% endif %}
     </style>
-    <script type="text/javascript">
+    <script>
       // intelligent scrolling of the sidebar content
       $(window).scroll(function() {
         var sb = $('.sphinxsidebarwrapper');

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -91,7 +91,7 @@ Google Analytics
 
       {%- block extrahead %}
       {{ super() }}
-      <script type="text/javascript">
+      <script>
         var _gaq = _gaq || [];
         _gaq.push(['_setAccount', 'XXX account number XXX']);
         _gaq.push(['_trackPageview']);
@@ -103,7 +103,7 @@ Google Analytics
       <div class="footer">This page uses <a href="https://analytics.google.com/">
       Google Analytics</a> to collect statistics. You can disable it by blocking
       the JavaScript coming from www.google-analytics.com.
-      <script type="text/javascript">
+      <script>
         (function() {
           var ga = document.createElement('script');
           ga.src = ('https:' == document.location.protocol ?
@@ -134,7 +134,6 @@ Google Search
                (function() {
                   var cx = '......';
                   var gcse = document.createElement('script');
-                  gcse.type = 'text/javascript';
                   gcse.async = true;
                   gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
                   var s = document.getElementsByTagName('script')[0];

--- a/sphinx/builders/html.py
+++ b/sphinx/builders/html.py
@@ -146,7 +146,6 @@ class JavaScript(str):
         self = str.__new__(cls, filename)  # type: ignore
         self.filename = filename
         self.attributes = attributes
-        self.attributes.setdefault('type', 'text/javascript')
 
         return self
 
@@ -1136,7 +1135,6 @@ def setup_js_tag_helper(app: Sphinx, pagename: str, templatexname: str,
                 attrs.append('src="%s"' % pathto(js.filename, resource=True))
         else:
             # str value (old styled)
-            attrs.append('type="text/javascript"')
             attrs.append('src="%s"' % pathto(js, resource=True))
         return '<script %s>%s</script>' % (' '.join(attrs), body)
 

--- a/sphinx/themes/basic/domainindex.html
+++ b/sphinx/themes/basic/domainindex.html
@@ -12,7 +12,7 @@
 {% block extrahead %}
 {{ super() }}
 {% if not embedded and collapse_index %}
-    <script type="text/javascript">
+    <script>
       DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true;
     </script>
 {% endif %}

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -87,7 +87,7 @@
 {%- endmacro %}
 
 {%- macro script() %}
-    <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+    <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for js in script_files %}
     {{ js_tag(js) }}
     {%- endfor %}

--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -11,16 +11,16 @@
 {% set title = _('Search') %}
 {%- block scripts %}
     {{ super() }}
-    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
-  <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
+  <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
   {{ super() }}
 {% endblock %}
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>
   <div id="fallback" class="admonition warning">
-  <script type="text/javascript">$('#fallback').hide();</script>
+  <script>$('#fallback').hide();</script>
   <p>
     {% trans %}Please activate JavaScript to enable the search
     functionality.{% endtrans %}

--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -17,5 +17,5 @@
     </form>
     </div>
 </div>
-<script type="text/javascript">$('#searchbox').show(0);</script>
+<script>$('#searchbox').show(0);</script>
 {%- endif %}

--- a/sphinx/themes/bizstyle/layout.html
+++ b/sphinx/themes/bizstyle/layout.html
@@ -11,7 +11,7 @@
 
 {%- block scripts %}
     {{ super() }}
-    <script type="text/javascript" src="{{ pathto('_static/bizstyle.js', 1) }}"></script>
+    <script src="{{ pathto('_static/bizstyle.js', 1) }}"></script>
 {%- endblock %}
 
 {# put the sidebar before the body #}
@@ -26,6 +26,6 @@
 {%- block extrahead %}
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <!--[if lt IE 9]>
-    <script type="text/javascript" src="_static/css3-mediaqueries.js"></script>
+    <script src="_static/css3-mediaqueries.js"></script>
     <![endif]-->
 {%- endblock %}

--- a/sphinx/themes/classic/layout.html
+++ b/sphinx/themes/classic/layout.html
@@ -12,6 +12,6 @@
 {%- block scripts %}
     {{ super() }}
     {% if theme_collapsiblesidebar|tobool %}
-    <script type="text/javascript" src="{{ pathto('_static/sidebar.js', 1) }}"></script>
+    <script src="{{ pathto('_static/sidebar.js', 1) }}"></script>
     {% endif %}
 {%- endblock %}

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -15,7 +15,7 @@
 {%- endblock %}
 {%- block scripts %}
     {{ super() }}
-    <script type="text/javascript" src="{{ pathto('_static/theme_extras.js', 1) }}"></script>
+    <script src="{{ pathto('_static/theme_extras.js', 1) }}"></script>
 {%- endblock %}
 {# do not display relbars #}
 {% block relbar1 %}{% endblock %}

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1216,8 +1216,8 @@ def test_html_assets(app):
             'href="https://example.com/custom.css" />' in content)
 
     # html_js_files
-    assert '<script type="text/javascript" src="_static/js/custom.js"></script>' in content
-    assert ('<script async="async" type="text/javascript" src="https://example.com/script.js">'
+    assert '<script src="_static/js/custom.js"></script>' in content
+    assert ('<script async="async" src="https://example.com/script.js">'
             '</script>' in content)
 
 

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -70,7 +70,7 @@ def test_mathjax_options(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').text()
-    assert ('<script async="async" integrity="sha384-0123456789" type="text/javascript" '
+    assert ('<script async="async" integrity="sha384-0123456789" '
             'src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?'
             'config=TeX-AMS-MML_HTMLorMML"></script>' in content)
 


### PR DESCRIPTION
In HTML5, `<script>` elements default to MIME type text/javascript. The HTML5 living standard and MDN recommend against including the attribute.

From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type

> The HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.

From https://html.spec.whatwg.org/#the-script-element

> Authors should omit the type attribute instead of redundantly setting it.