### PR TITLE
Fix #6855: Non-RST translated text should be parsed by the appropriate parser

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.io.FiletypeNotFoundError``
+* ``sphinx.io.get_filetype()``
+
 Features added
 --------------
 

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,16 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.io.FiletypeNotFoundError``
+     - 2.4
+     - 4.0
+     - ``sphinx.errors.FiletypeNotFoundError``
+
+   * - ``sphinx.io.get_filetype()``
+     - 2.4
+     - 4.0
+     - ``sphinx.util.get_filetype()``
+
    * - ``sphinx.builders.gettext.POHEADER``
      - 2.3
      - 4.0

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -126,3 +126,8 @@ class PycodeError(Exception):
 class NoUri(Exception):
     """Raised by builder.get_relative_uri() if there is no URI available."""
     pass
+
+
+class FiletypeNotFoundError(Exception):
+    "Raised by get_filetype() if a filename matches no source suffix."
+    pass

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -27,7 +27,7 @@ from sphinx.transforms.i18n import (
     PreserveTranslatableMessages, Locale, RemoveTranslatableInline,
 )
 from sphinx.transforms.references import SphinxDomains
-from sphinx.util import logging
+from sphinx.util import logging, get_filetype
 from sphinx.util import UnicodeDecodeErrorHandler
 from sphinx.util.docutils import LoggingReporter
 from sphinx.util.rst import append_epilog, docinfo_re, prepend_prolog
@@ -290,20 +290,6 @@ class SphinxRSTFileInput(SphinxBaseFileInput):
                 if not docinfo_re.match(line):
                     break
             return lineno
-
-
-class FiletypeNotFoundError(Exception):
-    pass
-
-
-def get_filetype(source_suffix, filename):
-    # type: (Dict[str, str], str) -> str
-    for suffix, filetype in source_suffix.items():
-        if filename.endswith(suffix):
-            # If default filetype (None), considered as restructuredtext.
-            return filetype or 'restructuredtext'
-    else:
-        raise FiletypeNotFoundError
 
 
 def read_doc(app, env, filename):

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -19,7 +19,10 @@ from docutils.statemachine import StringList, string2lines
 from docutils.transforms.references import DanglingReferences
 from docutils.writers import UnfilteredWriter
 
-from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
+from sphinx.deprecation import (
+    RemovedInSphinx30Warning, RemovedInSphinx40Warning, deprecated_alias
+)
+from sphinx.errors import FiletypeNotFoundError
 from sphinx.transforms import (
     AutoIndexUpgrader, DoctreeReadEvent, FigureAligner, SphinxTransformer
 )
@@ -335,3 +338,11 @@ def read_doc(app, env, filename):
 
     pub.publish()
     return pub.document
+
+
+deprecated_alias('sphinx.io',
+                 {
+                     'FiletypeNotFoundError': FiletypeNotFoundError,
+                     'get_filetype': get_filetype,
+                 },
+                 RemovedInSphinx40Warning)

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -22,7 +22,7 @@ from sphinx.config import Config
 from sphinx.domains.std import make_glossary_term, split_term_classifiers
 from sphinx.locale import __, init as init_locale
 from sphinx.transforms import SphinxTransform
-from sphinx.util import split_index_msg, logging
+from sphinx.util import split_index_msg, logging, get_filetype
 from sphinx.util.i18n import docname_to_domain
 from sphinx.util.nodes import (
     LITERAL_TYPE_NODES, IMAGE_TYPE_NODES, NodeMatcher,
@@ -61,7 +61,8 @@ def publish_msgstr(app: "Sphinx", source: str, source_path: str, source_line: in
         from sphinx.io import SphinxI18nReader
         reader = SphinxI18nReader()
         reader.setup(app)
-        parser = app.registry.create_source_parser(app, 'restructuredtext')
+        filetype = get_filetype(config.source_suffix, source_path)
+        parser = app.registry.create_source_parser(app, filetype)
         doc = reader.read(
             source=StringInput(source=source,
                                source_path="%s:%s:<translated>" % (source_path, source_line)),

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -31,7 +31,9 @@ from urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 from docutils.utils import relative_path
 
 from sphinx.deprecation import RemovedInSphinx30Warning, RemovedInSphinx40Warning
-from sphinx.errors import PycodeError, SphinxParallelError, ExtensionError
+from sphinx.errors import (
+    PycodeError, SphinxParallelError, ExtensionError, FiletypeNotFoundError
+)
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.console import strip_colors, colorize, bold, term_width_line  # type: ignore
@@ -118,6 +120,16 @@ def get_matching_docs(dirname: str, suffixes: List[str],
             if fnmatch.fnmatch(filename, suffixpattern):
                 yield filename[:-len(suffixpattern) + 1]
                 break
+
+
+def get_filetype(source_suffix, filename):
+    # type: (Dict[str, str], str) -> str
+    for suffix, filetype in source_suffix.items():
+        if filename.endswith(suffix):
+            # If default filetype (None), considered as restructuredtext.
+            return filetype or 'restructuredtext'
+    else:
+        raise FiletypeNotFoundError
 
 
 class FilenameUniqDict(dict):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6855 
- This only adds deprecation messages to #6856 
- rebased 2.0 branch.