### PR TITLE
Deprecate sphinx.util:detect_encoding()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,10 +10,13 @@ Incompatible changes
 Deprecated
 ----------
 
+* The ``decode`` argument of ``sphinx.pycode.ModuleAnalyzer()``
 * ``sphinx.environment.BuildEnvironment.indexentries``
 * ``sphinx.environment.collectors.indexentries.IndexEntriesCollector``
 * ``sphinx.io.FiletypeNotFoundError``
 * ``sphinx.io.get_filetype()``
+* ``sphinx.pycode.ModuleAnalyzer.encoding``
+* ``sphinx.util.detect_encoding()``
 * ``sphinx.util.get_module_source()``
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``decode`` argument of ``sphinx.pycode.ModuleAnalyzer()``
+     - 2.4
+     - 4.0
+     - N/A
+
    * - ``sphinx.environment.BuildEnvironment.indexentries``
      - 2.4
      - 4.0
@@ -50,6 +55,16 @@ The following is a list of deprecated interfaces.
      - 2.4
      - 4.0
      - N/A
+
+   * - ``sphinx.pycode.ModuleAnalyzer.encoding``
+     - 2.4
+     - 4.0
+     - N/A
+
+   * - ``sphinx.util.detect_encoding()``
+     - 2.4
+     - 4.0
+     - ``tokenize.detect_encoding()``
 
    * - ``sphinx.builders.gettext.POHEADER``
      - 2.3

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -346,6 +346,8 @@ _coding_re = re.compile(r'coding[:=]\s*([-\w.]+)')
 
 def detect_encoding(readline: Callable[[], bytes]) -> str:
     """Like tokenize.detect_encoding() from Py3k, but a bit simplified."""
+    warnings.warn('sphinx.util.detect_encoding() is deprecated',
+                  RemovedInSphinx40Warning)
 
     def read_or_stop() -> bytes:
         try:

--- a/tests/test_pycode.py
+++ b/tests/test_pycode.py
@@ -32,14 +32,12 @@ def test_ModuleAnalyzer_for_string():
     analyzer = ModuleAnalyzer.for_string('print("Hello world")', 'module_name')
     assert analyzer.modname == 'module_name'
     assert analyzer.srcname == '<string>'
-    assert analyzer.encoding is None
 
 
 def test_ModuleAnalyzer_for_file():
     analyzer = ModuleAnalyzer.for_string(SPHINX_MODULE_PATH, 'sphinx')
     assert analyzer.modname == 'sphinx'
     assert analyzer.srcname == '<string>'
-    assert analyzer.encoding is None
 
 
 def test_ModuleAnalyzer_for_module(rootdir):
@@ -47,8 +45,7 @@ def test_ModuleAnalyzer_for_module(rootdir):
     assert analyzer.modname == 'sphinx'
     assert analyzer.srcname in (SPHINX_MODULE_PATH,
                                 os.path.abspath(SPHINX_MODULE_PATH))
-    # source should be loaded via native loader, so don`t know file enconding
-    assert analyzer.encoding == None
+
     path = rootdir / 'test-pycode'
     sys.path.insert(0, path)
     try:
@@ -57,7 +54,6 @@ def test_ModuleAnalyzer_for_module(rootdir):
         assert docs == {('', 'X'): ['It MUST look like X="\u0425"', '']}
     finally:
         sys.path.pop(0)
-    
 
 
 def test_ModuleAnalyzer_for_file_in_egg(rootdir):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- As noted in `detect_encoding()`, it is a copy of `tokenize.detect_encoding()` of python3.
- After we moved to py3, no reason to use a copy.