### PR TITLE
Clarify docs on using autosectionlabel prefixes with directories

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,24 @@
+Release 2.3.1 (in development)
+==============================
+
+Dependencies
+------------
+
+Incompatible changes
+--------------------
+
+Deprecated
+----------
+
+Features added
+--------------
+
+Bugs fixed
+----------
+
+Testing
+--------
+
 Release 2.3.0 (released Dec 15, 2019)
 =====================================
 

--- a/doc/usage/extensions/autosectionlabel.rst
+++ b/doc/usage/extensions/autosectionlabel.rst
@@ -39,6 +39,13 @@ Configuration
    avoiding ambiguity when the same section heading appears in different
    documents.
 
+   When ``index.rst`` doesn't reside at your docs root directory, the prefix
+   has to contain any directories relative to it.
+
+   Example: if ``index.rst`` lives at ``example/hello/world/index.rst``, use
+   ``:ref:`example/hello/world/index:Introduction```. (Carefull: no leading
+   ``/`` as necessary with ``:doc:``!)
+
 .. confval:: autosectionlabel_maxdepth
 
    If set, autosectionlabel chooses the sections for labeling by its depth. For

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -32,8 +32,8 @@ if 'PYTHONWARNINGS' not in os.environ:
 warnings.filterwarnings('ignore', "'U' mode is deprecated",
                         DeprecationWarning, module='docutils.io')
 
-__version__ = '2.3.0'
-__released__ = '2.3.0'  # used when Sphinx builds its own docs
+__version__ = '2.3.1+'
+__released__ = '2.3.1'  # used when Sphinx builds its own docs
 
 #: Version info for better programmatic use.
 #:
@@ -43,7 +43,7 @@ __released__ = '2.3.0'  # used when Sphinx builds its own docs
 #:
 #: .. versionadded:: 1.2
 #:    Before version 1.2, check the string ``sphinx.__version__``.
-version_info = (2, 3, 0, 'final', 0)
+version_info = (2, 3, 1, 'beta', 0)
 
 package_dir = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Subject: Clarify docs on using autosectionlabel prefixes with directories

### Bugfix
- Bugfix (documentation)

### Purpose
- People are confused on the usage of `sphinx.ext.autosectionlabel` with files below root directories. The docs should provide a simple example to make this more obvious to use. See also #6352 or https://stackoverflow.com/questions/51161726
- n/a

### Detail
- See #6352. This is a very simple doc fix.
- I did not add myself to AUTHORS or CHANGES, as this is a very minor doc bug fix.

### Relates
- #6352

