### PR TITLE
Clarify docs on using autosectionlabel prefixes with directories

### DIFF
--- a/doc/usage/extensions/autosectionlabel.rst
+++ b/doc/usage/extensions/autosectionlabel.rst
@@ -39,6 +39,13 @@ Configuration
    avoiding ambiguity when the same section heading appears in different
    documents.
 
+   When ``index.rst`` doesn't reside at your docs root directory, the prefix
+   has to contain any directories relative to it.
+
+   Example: if ``index.rst`` lives at ``example/hello/world/index.rst``, use
+   ``:ref:`example/hello/world/index:Introduction```. (Carefull: no leading
+   ``/`` as necessary with ``:doc:``!)
+
 .. confval:: autosectionlabel_maxdepth
 
    If set, autosectionlabel chooses the sections for labeling by its depth. For


### PR DESCRIPTION
Subject: Clarify docs on using autosectionlabel prefixes with directories

### Bugfix
- Bugfix (documentation)

### Purpose
- People are confused on the usage of `sphinx.ext.autosectionlabel` with files below root directories. The docs should provide a simple example to make this more obvious to use. See also #6352 or https://stackoverflow.com/questions/51161726

### Detail
- See #6352. This is a very simple doc fix.
- I did not add myself to AUTHORS or CHANGES, as this is a very minor doc bug fix.

### Relates
- #6352