### PR TITLE
[RFC] Simplified 'sphinx-build'

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo',
               'sphinx.ext.viewcode', 'sphinx.ext.inheritance_diagram']
 
 master_doc = 'contents'
+output_dir = '../build'
 templates_path = ['_templates']
 exclude_patterns = ['_build']
 

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -4,13 +4,15 @@ sphinx-build
 Synopsis
 --------
 
-**sphinx-build** [*options*] <*sourcedir*> <*outputdir*> [*filenames* ...]
+**sphinx-build** [*options*] <*sourcedir*> [<*outputdir*> [*filenames* ...]]
 
 Description
 -----------
 
 :program:`sphinx-build` generates documentation from the files in
-``<sourcedir>`` and places it in the ``<outputdir>``.
+``<sourcedir>`` and places it in the ``<outputdir>``. If no ``<outputdir>`` is
+provided, Sphinx will attempt to use the ``output_dir`` configuration option to
+configure this.
 
 :program:`sphinx-build` looks for ``<sourcedir>/conf.py`` for the configuration
 settings.  :manpage:`sphinx-quickstart(1)` may be used to generate template

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -4,7 +4,7 @@ sphinx-build
 Synopsis
 --------
 
-**sphinx-build** [*options*] <*sourcedir*> [<*outputdir*> [*filenames* ...]]
+**sphinx-build** [*options*] [<*sourcedir*> [<*outputdir*> [*filenames* ...]]]
 
 Description
 -----------
@@ -12,7 +12,9 @@ Description
 :program:`sphinx-build` generates documentation from the files in
 ``<sourcedir>`` and places it in the ``<outputdir>``. If no ``<outputdir>`` is
 provided, Sphinx will attempt to use the ``output_dir`` configuration option to
-configure this.
+configure this. If no ``<sourcedir>`` is provided, Sphinx will attempt to find
+documentation in a list of commonly used documentation source folders relative
+to where the application is run from.
 
 :program:`sphinx-build` looks for ``<sourcedir>/conf.py`` for the configuration
 settings.  :manpage:`sphinx-quickstart(1)` may be used to generate template

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -96,7 +96,7 @@ def jobs_argument(value: str) -> int:
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        usage='%(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]',
+        usage='%(prog)s [OPTIONS] SOURCEDIR [OUTPUTDIR [FILENAMES...]]',
         epilog=__('For more information, visit <http://sphinx-doc.org/>.'),
         description=__("""
 Generate documentation from source files.
@@ -120,8 +120,9 @@ files can be built by specifying individual filenames.
 
     parser.add_argument('sourcedir',
                         help=__('path to documentation source files'))
-    parser.add_argument('outputdir',
-                        help=__('path to output directory'))
+    parser.add_argument('outputdir', nargs='?',
+                        help=__('path to output directory. If omitted, the \'output_dir\' '
+                                'setting is used'))
     parser.add_argument('filenames', nargs='*',
                         help=__('a list of specific files to rebuild. Ignored '
                                 'if -a is specified'))
@@ -206,7 +207,7 @@ def build_main(argv: List[str] = sys.argv[1:]) -> int:
     elif not args.confdir:
         args.confdir = args.sourcedir
 
-    if not args.doctreedir:
+    if args.outputdir and not args.doctreedir:
         args.doctreedir = os.path.join(args.outputdir, '.doctrees')
 
     # handle remaining filename arguments

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -113,6 +113,7 @@ class Config:
         'figure_language_filename': ('{root}.{language}{ext}', 'env', [str]),
 
         'master_doc': ('index', 'env', []),
+        'output_dir': (None, 'env', [str]),
         'source_suffix': ({'.rst': 'restructuredtext'}, 'env', Any),
         'source_encoding': ('utf-8-sig', 'env', []),
         'source_parsers': ({}, 'env', []),

--- a/tests/cmd/test_build_cmd.py
+++ b/tests/cmd/test_build_cmd.py
@@ -12,16 +12,44 @@
 import os
 from unittest import mock
 
-from sphinx.cmd.build import main
+from sphinx.cmd.build import main, _find_source_dir
+
+
+@mock.patch('os.listdir')
+@mock.patch('os.path.isdir')
+@mock.patch('os.path.exists')
+def test_find_source_dir(mock_exists, mock_isdir, mock_listdir):
+    """Test basic behavior of source dir."""
+    src_dir = os.path.join('doc', 'source')
+
+    def path_exists(path):
+        return path == os.path.join(src_dir, 'conf.py')
+
+    def path_isdir(path):
+        return path == 'doc'  # mimic only the 'doc' directory existing
+
+    def listdir(path):
+        return ['stuff', 'source']
+
+    mock_exists.side_effect = path_exists
+    mock_isdir.side_effect = path_isdir
+    mock_listdir.side_effect = listdir
+
+    assert _find_source_dir() == src_dir
+
+    # we should only have checked 'doc' since no other directory "existed"
+    mock_listdir.assert_called_once_with('doc')
 
 
 @mock.patch('os.path.isfile', new=mock.Mock(return_value=True))
+@mock.patch('sphinx.cmd.build._find_source_dir')
 @mock.patch('sphinx.cmd.build.Sphinx')
-def test_posargs_full(mock_sphinx):
+def test_posargs_full(mock_sphinx, mock_find_src):
     """Validate behavior with the full complement of posargs."""
     args = ['srcdir', 'outdir', 'file_a', 'file_b', 'file_c']
     main(args)
 
+    mock_find_src.assert_not_called()
     mock_sphinx.assert_called_once_with(
         args[0], args[0], args[1], os.path.join(args[1], '.doctrees'),
         mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
@@ -29,12 +57,14 @@ def test_posargs_full(mock_sphinx):
     mock_sphinx.return_value.build.assert_called_once_with(False, args[2:])
 
 
+@mock.patch('sphinx.cmd.build._find_source_dir')
 @mock.patch('sphinx.cmd.build.Sphinx')
-def test_posargs_no_filenames(mock_sphinx):
+def test_posargs_no_filenames(mock_sphinx, mock_find_src):
     """Validate behavior with the source and output dir posarg."""
     args = ['srcdir', 'outdir']
     main(args)
 
+    mock_find_src.assert_not_called()
     mock_sphinx.assert_called_once_with(
         args[0], args[0], args[1], os.path.join(args[1], '.doctrees'),
         mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
@@ -42,13 +72,31 @@ def test_posargs_no_filenames(mock_sphinx):
     mock_sphinx.return_value.build.assert_called_once_with(False, [])
 
 
+@mock.patch('sphinx.cmd.build._find_source_dir')
 @mock.patch('sphinx.cmd.build.Sphinx')
-def test_posargs_no_outputdir(mock_sphinx):
+def test_posargs_no_outputdir(mock_sphinx, mock_find_src):
     """Validate behavior with only the source dir posarg."""
     args = ['srcdir']
     main(args)
 
+    mock_find_src.assert_not_called()
     mock_sphinx.assert_called_once_with(
         args[0], args[0], None, None, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
+        mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY)
+    mock_sphinx.return_value.build.assert_called_once_with(False, [])
+
+
+@mock.patch('sphinx.cmd.build._find_source_dir', return_value='srcdir')
+@mock.patch('sphinx.cmd.build.Sphinx')
+def test_posargs_none(mock_sphinx, mock_find_src):
+    """Validate behavior with no posargs."""
+    args = []
+    main(args)
+
+    srcdir = mock_find_src.return_value
+
+    mock_find_src.assert_called_once_with()
+    mock_sphinx.assert_called_once_with(
+        srcdir, srcdir, None, None, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
         mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY)
     mock_sphinx.return_value.build.assert_called_once_with(False, [])

--- a/tests/cmd/test_build_cmd.py
+++ b/tests/cmd/test_build_cmd.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""
+    test_build
+    ~~~~~~~~~~
+
+    Test the :module:`sphinx.cmd.build` module.
+
+    :copyright: Copyright 2007-2019 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import os
+from unittest import mock
+
+from sphinx.cmd.build import main
+
+
+@mock.patch('os.path.isfile', new=mock.Mock(return_value=True))
+@mock.patch('sphinx.cmd.build.Sphinx')
+def test_posargs_full(mock_sphinx):
+    """Validate behavior with the full complement of posargs."""
+    args = ['srcdir', 'outdir', 'file_a', 'file_b', 'file_c']
+    main(args)
+
+    mock_sphinx.assert_called_once_with(
+        args[0], args[0], args[1], os.path.join(args[1], '.doctrees'),
+        mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
+        mock.ANY, mock.ANY, mock.ANY)
+    mock_sphinx.return_value.build.assert_called_once_with(False, args[2:])
+
+
+@mock.patch('sphinx.cmd.build.Sphinx')
+def test_posargs_no_filenames(mock_sphinx):
+    """Validate behavior with the source and output dir posarg."""
+    args = ['srcdir', 'outdir']
+    main(args)
+
+    mock_sphinx.assert_called_once_with(
+        args[0], args[0], args[1], os.path.join(args[1], '.doctrees'),
+        mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
+        mock.ANY, mock.ANY, mock.ANY)
+    mock_sphinx.return_value.build.assert_called_once_with(False, [])
+
+
+@mock.patch('sphinx.cmd.build.Sphinx')
+def test_posargs_no_outputdir(mock_sphinx):
+    """Validate behavior with only the source dir posarg."""
+    args = ['srcdir']
+    main(args)
+
+    mock_sphinx.assert_called_once_with(
+        args[0], args[0], None, None, mock.ANY, mock.ANY, mock.ANY, mock.ANY,
+        mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY, mock.ANY)
+    mock_sphinx.return_value.build.assert_called_once_with(False, [])


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose

Make sphinx-build easier to call by moving configuration of the build directory to the configuration file and auto-detecting the source directory. This will allow most users to call sphinx-build without any arguments.

### Detail
- `sphinx-build`: Configure `outdir` from `conf.py`

  This is part one of two of the "make 'sphinx-build' easier to call" effort. In this part, we allow users to define the build directory in the 'conf.py' file. This means a user no longer needs to pass the option via the command line, though they can continue to do so if they wish.

  We use the behavior of the setuptools extension, whereby the results are output to a subfolder in the outdir named after the code of the builder. For example, if using the 'html' builder with 'output_dir = "test"', files would be written to 'test/html'.

- `sphinx-build`: Guess `sourcedir` if none provided

  This is part two of two of the "make 'sphinx-build' easier to call" effort. In this part, we attempt to guess where the source directory is if the user does not provide one. This is possible because many users use one of three directory names - doc, docs, or Documentation - for their documentation. We check these, along with a possible 'source' subdirectory, which is based on Sphinx's own defaults, for a 'conf.py' file. Is one is found, we assume this is the documentation source. This means a user no longer needs to pass any argument to 'sphinx-build' is they do not wish to.

  This is, of course, best-effort, and users can continue to provide these options manually if they so wish.

You can validate this right now by pulling down the pull request and running `sphinx-build` without any arguments. The required change has been made to `conf.py`.