### PR TITLE
Fix #6936: sphinx-autogen: raises AttributeError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #6936: sphinx-autogen: raises AttributeError
+
 Testing
 --------
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -59,6 +59,11 @@ class DummyApplication:
         self.registry = SphinxComponentRegistry()
         self.messagelog = []  # type: List[str]
         self.verbosity = 0
+        self._warncount = 0
+        self.warningiserror = False
+
+    def emit_firstresult(self, *args) -> None:
+        pass
 
 
 def setup_documenters(app: Any) -> None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6936 

I confirmed this fixes #6936 with following Dockerfile:
```
FROM tk0miya/sphinx-html

RUN git clone https://github.com/Unidata/MetPy
WORKDIR /docs/MetPy
RUN pip3 install .
WORKDIR /docs/MetPy/docs
RUN pip3 install git+https://github.com/tk0miya/sphinx@6936_autogen_raises_AttributeError
RUN sphinx-autogen api/index.rst
```