### PR TITLE
Refactor:moved lines about copying logo into copying images

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -360,12 +360,6 @@ class LaTeXBuilder(Builder):
             copy_asset_file(path.join(staticdirname, 'Makefile_t'),
                             self.outdir, context=context)
 
-        # the logo is handled differently
-        if self.config.latex_logo:
-            if not path.isfile(path.join(self.confdir, self.config.latex_logo)):
-                raise SphinxError(__('logo file %r does not exist') % self.config.latex_logo)
-            else:
-                copy_asset_file(path.join(self.confdir, self.config.latex_logo), self.outdir)
 
     @progress_message(__('copying additional files'))
     def copy_latex_additional_files(self) -> None:
@@ -386,6 +380,11 @@ class LaTeXBuilder(Builder):
                 except Exception as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
+        if self.config.latex_logo:
+            if not path.isfile(path.join(self.confdir, self.config.latex_logo)):
+                raise SphinxError(__('logo file %r does not exist') % self.config.latex_logo)
+            else:
+                copy_asset_file(path.join(self.confdir, self.config.latex_logo), self.outdir)
 
     def write_message_catalog(self) -> None:
         formats = self.config.numfig_format


### PR DESCRIPTION
Subject: Refactoring: moved  lines about copying latex logo into copying images

### Feature or Bugfix

- Refactoring

### Purpose
- To correct function with the porpose in LaTeXBuilder structures.


### Detail
- In sphinx/builders/latex/__init__.py, At LaTeXBuilder, I moved lines about copying latex logo from copy_support_files into copy_image_files.

### Relates
- None

