### PR TITLE
Expand use of path2doc, combine 'compile_xxx' and 'build_xxx' functions and move file validation into builder

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -340,13 +340,10 @@ class Sphinx:
         self.phase = BuildPhase.READING
         try:
             if force_all:
-                self.builder.compile_all_catalogs()
                 self.builder.build_all()
             elif filenames:
-                self.builder.compile_specific_catalogs(filenames)
                 self.builder.build_specific(filenames)
             else:
-                self.builder.compile_update_catalogs()
                 self.builder.build_update()
 
             self.events.emit('build-finished', None)

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -267,30 +267,31 @@ class Builder:
 
     def build_specific(self, filenames: List[str]) -> None:
         """Only rebuild as much as needed for changes in the *filenames*."""
-        # bring the filenames to the canonical format, that is,
-        # relative to the source directory and without source_suffix.
-        dirlen = len(self.srcdir) + 1
-        to_write = []
-        suffixes: Tuple[str] = tuple(self.config.source_suffix)  # type: ignore
+        docnames: List[str] = []
+
         for filename in filenames:
             filename = path.normpath(path.abspath(filename))
+
             if not filename.startswith(self.srcdir):
                 logger.warning(__('file %r given on command line is not under the '
                                   'source directory, ignoring'), filename)
                 continue
+
             if not path.isfile(filename):
                 logger.warning(__('file %r given on command line does not exist, '
                                   'ignoring'), filename)
                 continue
-            filename = filename[dirlen:]
-            for suffix in suffixes:
-                if filename.endswith(suffix):
-                    filename = filename[:-len(suffix)]
-                    break
-            filename = filename.replace(path.sep, SEP)
-            to_write.append(filename)
-        self.build(to_write, method='specific',
-                   summary=__('%d source files given on command line') % len(to_write))
+
+            docname = self.env.path2doc(filename)
+            if not docname:
+                logger.warning(__('file %r given on command line is not a valid '
+                                  'document, ignoring'), filename)
+                continue
+
+            docnames.append(docname)
+
+        self.build(docnames, method='specific',
+                   summary=__('%d source files given on command line') % len(docnames))
 
     def build_update(self) -> None:
         """Only rebuild what was changed or added since last build."""

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -252,6 +252,7 @@ class Builder:
         message = __('targets for %d po files that are specified') % len(catalogs)
         self.compile_catalogs(catalogs, message)
 
+    # TODO(stephenfin): This would make more sense as 'compile_outdated_catalogs'
     def compile_update_catalogs(self) -> None:
         repo = CatalogRepository(self.srcdir, self.config.locale_dirs,
                                  self.config.language, self.config.source_encoding)
@@ -263,6 +264,8 @@ class Builder:
 
     def build_all(self) -> None:
         """Build all source files."""
+        self.compile_all_catalogs()
+
         self.build(None, summary=__('all source files'), method='all')
 
     def build_specific(self, filenames: List[str]) -> None:
@@ -290,11 +293,15 @@ class Builder:
 
             docnames.append(docname)
 
+        self.compile_specific_catalogs(filenames)
+
         self.build(docnames, method='specific',
                    summary=__('%d source files given on command line') % len(docnames))
 
     def build_update(self) -> None:
         """Only rebuild what was changed or added since last build."""
+        self.compile_update_catalogs()
+
         to_build = self.get_outdated_docs()
         if isinstance(to_build, str):
             self.build(['__all__'], to_build)

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -275,14 +275,14 @@ class Builder:
         for filename in filenames:
             filename = path.normpath(path.abspath(filename))
 
+            if not path.isfile(filename):
+                logger.warning(__('file %r given on command line does not exist, '),
+                               filename)
+                continue
+
             if not filename.startswith(self.srcdir):
                 logger.warning(__('file %r given on command line is not under the '
                                   'source directory, ignoring'), filename)
-                continue
-
-            if not path.isfile(filename):
-                logger.warning(__('file %r given on command line does not exist, '
-                                  'ignoring'), filename)
                 continue
 
             docname = self.env.path2doc(filename)

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -209,16 +209,7 @@ def build_main(argv: List[str] = sys.argv[1:]) -> int:
     if not args.doctreedir:
         args.doctreedir = os.path.join(args.outputdir, '.doctrees')
 
-    # handle remaining filename arguments
-    filenames = args.filenames
-    missing_files = []
-    for filename in filenames:
-        if not os.path.isfile(filename):
-            missing_files.append(filename)
-    if missing_files:
-        parser.error(__('cannot find files %r') % missing_files)
-
-    if args.force_all and filenames:
+    if args.force_all and args.filenames:
         parser.error(__('cannot combine -a option and filenames'))
 
     if args.color == 'no' or (args.color == 'auto' and not color_terminal()):
@@ -276,7 +267,7 @@ def build_main(argv: List[str] = sys.argv[1:]) -> int:
                          warning, args.freshenv, args.warningiserror,
                          args.tags, args.verbosity, args.jobs, args.keep_going,
                          args.pdb)
-            app.build(args.force_all, filenames)
+            app.build(args.force_all, args.filenames)
             return app.statuscode
     except (Exception, KeyboardInterrupt) as exc:
         handle_exception(app, args, exc, error)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -149,7 +149,7 @@ def test_build_specific(app):
                  app.srcdir / 'subdir/../subdir/excluded.txt']  # not normalized
     app.build(False, filenames)
 
-    expected = ['index', 'img.png', 'subdir/includes', 'subdir/excluded']
+    expected = ['index', 'subdir/includes', 'subdir/excluded']
     app.builder.build.assert_called_with(expected,
                                          method='specific',
-                                         summary='4 source files given on command line')
+                                         summary='3 source files given on command line')


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
We provide a `path2doc` helper to convert filenames to their equivalent "docnames". However, we do this translation manually in a few places. Stop doing that.