### PR TITLE
Deprecate sphinx.util:get_module_source()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Deprecated
 * ``sphinx.environment.collectors.indexentries.IndexEntriesCollector``
 * ``sphinx.io.FiletypeNotFoundError``
 * ``sphinx.io.get_filetype()``
+* ``sphinx.util.get_module_source()``
 
 Features added
 --------------

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -46,6 +46,11 @@ The following is a list of deprecated interfaces.
      - 4.0
      - ``sphinx.util.get_filetype()``
 
+   * - ``sphinx.util.get_module_source()``
+     - 2.4
+     - 4.0
+     - N/A
+
    * - ``sphinx.builders.gettext.POHEADER``
      - 2.3
      - 4.0

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -282,6 +282,8 @@ def get_module_source(modname: str) -> Tuple[str, str]:
     Can return ('file', 'filename') in which case the source is in the given
     file, or ('string', 'source') which which case the source is the string.
     """
+    warnings.warn('get_module_source() is deprecated.',
+                  RemovedInSphinx40Warning, stacklevel=2)
     try:
         mod = import_module(modname)
     except Exception as err:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
