### PR TITLE
Close #6966: graphviz: Support ``:class:`` option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ Features added
 * #6446: duration: Add ``sphinx.ext.durations`` to inspect which documents slow
   down the build
 * #6837: LaTeX: Support a nested table
+* #6966: graphviz: Support ``:class:`` option
 
 Bugs fixed
 ----------

--- a/doc/usage/extensions/graphviz.rst
+++ b/doc/usage/extensions/graphviz.rst
@@ -82,6 +82,13 @@ It adds these directives:
 
       .. versionadded:: 1.6
 
+   .. rst:directive:option:: class: class names
+      :type: a list of class names separeted by spaces
+
+      The class name of the graph.
+
+      .. versionadded:: 2.4
+
 
 .. rst:directive:: graph
 
@@ -131,6 +138,13 @@ It adds these directives:
 
       .. versionadded:: 1.6
 
+   .. rst:directive:option:: class: class names
+      :type: a list of class names separeted by spaces
+
+      The class name of the graph.
+
+      .. versionadded:: 2.4
+
 
 .. rst:directive:: digraph
 
@@ -175,6 +189,13 @@ It adds these directives:
       :type: text
 
       .. versionadded:: 1.6
+
+   .. rst:directive:option:: class: class names
+      :type: a list of class names separeted by spaces
+
+      The class name of the graph.
+
+      .. versionadded:: 2.4
 
 
 There are also these config values:

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -121,6 +121,7 @@ class Graphviz(SphinxDirective):
         'layout': directives.unchanged,
         'graphviz_dot': directives.unchanged,  # an old alias of `layout` option
         'name': directives.unchanged,
+        'class': directives.class_option,
     }
 
     def run(self) -> List[Node]:
@@ -158,6 +159,8 @@ class Graphviz(SphinxDirective):
             node['alt'] = self.options['alt']
         if 'align' in self.options:
             node['align'] = self.options['align']
+        if 'class' in self.options:
+            node['classes'] = self.options['class']
 
         if 'caption' not in self.options:
             self.add_name(node)
@@ -182,6 +185,7 @@ class GraphvizSimple(SphinxDirective):
         'caption': directives.unchanged,
         'graphviz_dot': directives.unchanged,
         'name': directives.unchanged,
+        'class': directives.class_option,
     }
 
     def run(self) -> List[Node]:
@@ -195,6 +199,8 @@ class GraphvizSimple(SphinxDirective):
             node['alt'] = self.options['alt']
         if 'align' in self.options:
             node['align'] = self.options['align']
+        if 'class' in self.options:
+            node['classes'] = self.options['class']
 
         if 'caption' not in self.options:
             self.add_name(node)
@@ -267,10 +273,8 @@ def render_dot_html(self: HTMLTranslator, node: graphviz, code: str, options: Di
         logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode
 
-    if imgcls:
-        imgcls += " graphviz"
-    else:
-        imgcls = "graphviz"
+    classes = [imgcls, 'graphviz'] + node.get('classes', [])
+    imgcls = ' '.join(filter(None, classes))
 
     if fname is None:
         self.body.append(self.encode(code))

--- a/tests/roots/test-ext-graphviz/index.rst
+++ b/tests/roots/test-ext-graphviz/index.rst
@@ -14,8 +14,9 @@ Hello |graph| graphviz world
 
 .. digraph:: foo
    :graphviz_dot: neato
+   :class: neato_graph
 
-   bar -> baz
+   baz -> qux
 
 
 .. graphviz:: graph.dot

--- a/tests/test_ext_graphviz.py
+++ b/tests/test_ext_graphviz.py
@@ -29,8 +29,9 @@ def test_graphviz_png_html(app, status, warning):
     html = 'Hello <div class="graphviz"><img .*?/></div>\n graphviz world'
     assert re.search(html, content, re.S)
 
-    html = '<img src=".*?" alt="digraph {\n  bar -&gt; baz\n}" class="graphviz" />'
-    assert re.search(html, content, re.M)
+    html = ('<img src=".*?" alt="digraph foo {\nbaz -&gt; qux\n}" '
+            'class="graphviz neato-graph" />')
+    assert re.search(html, content, re.S)
 
     html = (r'<div class="figure align-right" .*?>\s*'
             r'<div class="graphviz"><img .*?/></div>\s*<p class="caption">'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #6966 
- `:class:` is a one of common directive option
  - see https://docutils.sourceforge.io/docs/ref/rst/directives.html#common-options