### PR TITLE
index directive and role emit deprecation warnings for python index-types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ Features added
   old stub file
 * #5923: autodoc: ``:inherited-members:`` option takes a name of anchestor class
   not to document inherited members of the class and uppers
+* :rst:dir:`index` and :rst:role:`index` emit deprecation warnings for python
+  specific index-types
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -852,6 +852,8 @@ mainly contained in information units, such as the language reference.
       creates the entries ``module; hashlib`` and ``hashlib; module``.  (These
       are Python-specific and therefore deprecated.)
 
+      .. deprecated:: 1.0
+
    You can mark up "main" index entries by prefixing them with an exclamation
    mark.  The references to "main" entries are emphasized in the generated
    index.  For example, if two pages contain ::

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -202,7 +202,7 @@ class Index(SphinxDirective):
         indexnode['inline'] = False
         self.set_source_info(indexnode)
         for entry in arguments:
-            indexnode['entries'].extend(process_index_entry(entry, targetid))
+            indexnode['entries'].extend(process_index_entry(entry, targetid, indexnode))
         return [indexnode, targetnode]
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -363,7 +363,8 @@ indextypes = [
 ]
 
 
-def process_index_entry(entry: str, targetid: str) -> List[Tuple[str, str, str, str, str]]:
+def process_index_entry(entry: str, targetid: str, location: Any = None
+                        ) -> List[Tuple[str, str, str, str, str]]:
     from sphinx.domains.python import pairindextypes
 
     indexentries = []  # type: List[Tuple[str, str, str, str, str]]
@@ -375,6 +376,11 @@ def process_index_entry(entry: str, targetid: str) -> List[Tuple[str, str, str, 
         entry = entry[1:].lstrip()
     for type in pairindextypes:
         if entry.startswith(type + ':'):
+            logger.warning(__('indextype "%s" is deprecated. '
+                              'Please use "pair: %s; %s" instead.'),
+                           type, type, entry[len(type) + 1:].strip(),
+                           location=location)  # RemovedInSphinx50Warning
+
             value = entry[len(type) + 1:].strip()
             value = pairindextypes[type] + '; ' + value
             indexentries.append(('pair', value, targetid, main, None))


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- python specific index-types are marked as deprecated in this commit: https://github.com/sphinx-doc/sphinx/commit/3e9182550a (10years ago!)
- This emits deprecation warnings to remove them in future.