### PR TITLE
Fix #6986: apidoc: misdetects module name for .so file inside module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,7 @@ Bugs fixed
 * #6906, #6907: autodoc: failed to read the source codes encoeded in cp1251
 * #6961: latex: warning for babel shown twice
 * #6559: Wrong node-ids are generated in glossary directive
+* #6986: apidoc: misdetects module name for .so file inside module
 
 Testing
 --------

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -128,7 +128,7 @@ def create_package_file(root: str, master_package: str, subroot: str, py_files: 
     subpackages = [module_join(master_package, subroot, pkgname)
                    for pkgname in subpackages]
     # build a list of sub modules
-    submodules = [path.splitext(sub)[0] for sub in py_files
+    submodules = [sub.split('.')[0] for sub in py_files
                   if not is_skipped_module(path.join(root, sub), opts, excludes) and
                   sub != INITPY]
     submodules = [module_join(master_package, subroot, modname)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6986 