### PR TITLE
Update documentation of download role for addition of hash in subdir

### DIFF
--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -189,8 +189,8 @@ Referencing downloadable files
 
    When you use this role, the referenced file is automatically marked for
    inclusion in the output when building (obviously, for HTML output only).
-   All downloadable files are put into the ``_downloads`` subdirectory of the
-   output directory; duplicate filenames are handled.
+   All downloadable files are put into a ``_downloads/<unique hash>/``
+   subdirectory of the output directory; duplicate filenames are handled.
 
    An example::
 


### PR DESCRIPTION
This was changed in gh-5377, but that forgot the (now slightly misleading) documentation.

Discovered in https://github.com/numpy/numpy.org/pull/14, where we were relying on download links being stable.