### PR TITLE
Adds support for Adobe Illustrator (.ai) to sphinx.ext.imgconverter

### DIFF
--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -27,6 +27,7 @@ class ImagemagickConverter(ImageConverter):
         ('image/svg+xml', 'image/png'),
         ('image/gif', 'image/png'),
         ('application/pdf', 'image/png'),
+        ('application/illustrator', 'image/png'),
     ]
 
     def is_available(self) -> bool:

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -222,7 +222,6 @@ class ImageConverter(BaseImageConverter):
         if '?' in node['candidates']:
             return []
         elif '*' in node['candidates']:
-            from sphinx.util.images import guess_mimetype
             return [guess_mimetype(node['uri'])]
         else:
             return node['candidates'].keys()

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -32,6 +32,7 @@ mime_suffixes = OrderedDict([
     ('.pdf', 'application/pdf'),
     ('.svg', 'image/svg+xml'),
     ('.svgz', 'image/svg+xml'),
+    ('.ai', 'application/illustrator'),
 ])
 
 DataURI = NamedTuple('DataURI', [('mimetype', str),


### PR DESCRIPTION
Subject: Adds support for Adobe Illustrator (.ai) files to the `sphinx.ext.imgconverter` extension.
As asked in #6994 

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
Will automatically convert .ai files to .png for display through Sphinx.

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- #6994 

