### PR TITLE
Stop testing with nightly python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       env:
         - TOXENV=du15
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
-    - python: 'nightly'
+    - python: '3.8'
       env:
         - TOXENV=du16
     - python: '3.6'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
At present, latest typted_ast does not support python-3.9a1 or later.
As a result, nightly python in Travis CI gets errored in nearly running.
This stops to use nightly python for testing temporarily.

refs: https://github.com/python/typed_ast/issues/129
