### PR TITLE
initial implementation of sectioning (DO NOT MERGE)

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -113,6 +113,29 @@ In short:
   refer to ``Queue.Queue.get`` but only display ``get`` as the link text.
 
 
+Table of Contents
+~~~~~~~~~~~~~~~~~
+
+The directive option flag ``:section:`` wraps a description in a
+section. Like other sections, the object will have an entry in the
+table of contents. For example::
+  .. cpp::function int fun1(int a)
+     :section:
+
+  .. cpp::function int fun2(int a)
+     :section:
+
+Is the same as::
+
+  fun1
+  -----
+  .. cpp::function int fun1(int a)
+
+  fun2
+  -----
+  .. cpp::function int fun2(int a)
+
+
 The Python Domain
 -----------------
 

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -60,6 +60,7 @@ class ObjectDescription(SphinxDirective):
     final_argument_whitespace = True
     option_spec = {
         'noindex': directives.flag,
+        'section': directives.flag,
     }  # type: Dict[str, DirectiveOption]
 
     # types of doc fields that this directive handles, see sphinx.util.docfields
@@ -130,7 +131,8 @@ class ObjectDescription(SphinxDirective):
         """
         pass
 
-    def run(self) -> List[Node]:
+#    def run(self) -> List[Node]:
+    def run(self) -> Any:
         """
         Main directive entry function, called by docutils upon encountering the
         directive.
@@ -160,7 +162,6 @@ class ObjectDescription(SphinxDirective):
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
         node['noindex'] = noindex = ('noindex' in self.options)
-
         self.names = []  # type: List[Any]
         signatures = self.get_signatures()
         for i, sig in enumerate(signatures):
@@ -196,7 +197,16 @@ class ObjectDescription(SphinxDirective):
         DocFieldTransformer(self).transform_all(contentnode)
         self.env.temp_data['object'] = None
         self.after_content()
-        return [self.indexnode, node]
+
+        if 'section' in self.options:
+            sec = nodes.section()
+            sec += nodes.title('', self.names[0])
+            self.state.document.set_id(sec)
+            sec += node
+            return [self.indexnode, sec]
+        else:
+            return [self.indexnode, node]
+
 
 
 class DefaultRole(SphinxDirective):

--- a/tests/roots/test-domain-cpp/index.rst
+++ b/tests/roots/test-domain-cpp/index.rst
@@ -51,3 +51,22 @@ directives
 .. cpp:function:: void paren_6::operator()(int)
 .. cpp:function:: void paren_7::operator()(int)
 .. cpp:function:: void paren_8::operator()(int)
+
+
+.. cpp:function:: void sec_1(int, float)
+   :section:
+.. cpp:function:: void sec_2(int, float)
+   :section:
+.. cpp:function:: void sec_3(int, float)
+   :section:
+.. cpp:function:: void sec_4(int, float)
+   :section:
+.. cpp:function:: void sec_5::operator()(int)
+   :section:
+.. cpp:function:: void sec_6::operator()(int)
+   :section:
+.. cpp:function:: void sec_7::operator()(int)
+   :section:
+.. cpp:function:: void sec_8::operator()(int)
+   :section:
+		  


### PR DESCRIPTION
Subject: option to add TOC entry for function, class, etc

### Feature or Bugfix
- Feature

### Purpose
- Partially addresses #6316. I like to organize my API in groups that are nested in sections. An entire group should be on a single (html) page and appear individually in the TOC. I looked at alternatives like exhale and breathe-apidoc and explain the issues in #michaeljones/breathe#466

I am seeking comments on API and implementation and do not expect the PR to be merged in its current form.

Some things that are missing:
* method to apply it to groups of definitions without explicitly adding :section: to each
  My hope is to add the same option to doxygengroup in breathe and have it generate :section: for 
  every entry. A config variable would also be useful.
* call the option :section: or :toc:?
* Section name is full signature. Need to make it match the index name
* Understanding of what should happen for nested objects
* probably more ...

I added a few sentences to the sphinx documentation to explain how it is used.

Thanks to @melvinvermeeren & @jakobandersen for their help so far.


