### PR TITLE
Add LaTeX styling hook for :kbd: role

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -817,6 +817,8 @@ Macros
      multiple paragraphs in header cells of tables.
   .. versionadded:: 1.6.3
      ``\sphinxstylecodecontinued`` and ``\sphinxstylecodecontinues``.
+  .. versionadded:: 2.4.0
+     ``\sphinxkeyboard``
 - ``\sphinxtableofcontents``: it is a
   wrapper (defined differently in :file:`sphinxhowto.cls` and in
   :file:`sphinxmanual.cls`) of standard ``\tableofcontents``.  The macro

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1836,6 +1836,7 @@
 \protected\def\sphinxtitleref#1{\emph{#1}}
 \protected\def\sphinxmenuselection#1{\emph{#1}}
 \protected\def\sphinxguilabel#1{\emph{#1}}
+\protected\def\sphinxkeyboard#1{\sphinxcode{#1}}
 \protected\def\sphinxaccelerator#1{\underline{#1}}
 \protected\def\sphinxcrossref#1{\emph{#1}}
 \protected\def\sphinxtermref#1{\emph{#1}}

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1935,6 +1935,8 @@ class LaTeXTranslator(SphinxTranslator):
     def visit_literal(self, node: Element) -> None:
         if self.in_title:
             self.body.append(r'\sphinxstyleliteralintitle{\sphinxupquote{')
+        elif 'kbd' in node['classes']:
+            self.body.append(r'\sphinxkeyboard{\sphinxupquote{')
         else:
             self.body.append(r'\sphinxcode{\sphinxupquote{')
 

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -231,6 +231,13 @@ def get_verifier(verify, verify_re):
         r'\sphinxguilabel{Foo}',
     ),
     (
+        # kbd role
+        'verify',
+        ':kbd:`space`',
+        '<p><kbd class="kbd docutils literal notranslate">space</kbd></p>',
+        '\\sphinxkeyboard{\\sphinxupquote{space}}',
+    ),
+    (
         # non-interpolation of dashes in option role
         'verify_re',
         ':option:`--with-option`',


### PR DESCRIPTION
Subject: Add a renewable LaTeX command for keyboard input defined with `:kbd:` role

### Feature or Bugfix
- Feature

### Purpose
The `:kbd:` role can be used to denote input from a keybpard. In HTML, this results in a `<kbd>` element that can be styled with CSS.
In LaTeX, this was treated the same as any other literal. With this PR, it uses a new `\sphinxkeypress` command (defaults to same as literal) which may be renewed to change the appearance

### Relates
- #3160
- #4197

Note: this is based of master, I'm not sure if that was correct.