### PR TITLE
Add testcase a partialmethod not having docstring (refs: #7023)

### DIFF
--- a/tests/roots/test-ext-autodoc/target/partialmethod.py
+++ b/tests/roots/test-ext-autodoc/target/partialmethod.py
@@ -14,5 +14,5 @@ class Cell(object):
     #: Make a cell alive.
     set_alive = partialmethod(set_state, True)
 
+    # a partialmethod with no docstring
     set_dead = partialmethod(set_state, False)
-    """Make a cell dead."""

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1324,12 +1324,6 @@ def test_partialmethod(app):
         '      Make a cell alive.',
         '      ',
         '   ',
-        '   .. py:method:: Cell.set_dead()',
-        '      :module: target.partialmethod',
-        '   ',
-        '      Make a cell dead.',
-        '      ',
-        '   ',
         '   .. py:method:: Cell.set_state(state)',
         '      :module: target.partialmethod',
         '   ',
@@ -1338,6 +1332,41 @@ def test_partialmethod(app):
     ]
 
     options = {"members": None}
+    actual = do_autodoc(app, 'class', 'target.partialmethod.Cell', options)
+    assert list(actual) == expected
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_partialmethod_undoc_members(app):
+    expected = [
+        '',
+        '.. py:class:: Cell',
+        '   :module: target.partialmethod',
+        '',
+        '   An example for partialmethod.',
+        '   ',
+        '   refs: https://docs.python.jp/3/library/functools.html#functools.partialmethod',
+        '   ',
+        '   ',
+        '   .. py:method:: Cell.set_alive()',
+        '      :module: target.partialmethod',
+        '   ',
+        '      Make a cell alive.',
+        '      ',
+        '   ',
+        '   .. py:method:: Cell.set_dead()',
+        '      :module: target.partialmethod',
+        '   ',
+        '   ',
+        '   .. py:method:: Cell.set_state(state)',
+        '      :module: target.partialmethod',
+        '   ',
+        '      Update state of cell to *state*.',
+        '      ',
+    ]
+
+    options = {"members": None,
+               "undoc-members": None}
     actual = do_autodoc(app, 'class', 'target.partialmethod.Cell', options)
     assert list(actual) == expected
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: #7023 (Problem 2)