### PR TITLE
Fix #7023: autodoc: partial functions are listed as module members

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,8 @@ Bugs fixed
 * #6986: apidoc: misdetects module name for .so file inside module
 * #6999: napoleon: fails to parse tilde in :exc: role
 * #7023: autodoc: nested partial functions are not listed
+* #7023: autodoc: partial functions imported from other modules are listed as
+  module members without :impoprted-members: option
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -344,10 +344,9 @@ class Documenter:
         if self.options.imported_members:
             return True
 
-        modname = self.get_attr(self.object, '__module__', None)
-        if inspect.ispartial(self.object) and modname == '_functools':  # for pypy
-            return True
-        elif modname and modname != self.modname:
+        subject = inspect.unpartial(self.object)
+        modname = self.get_attr(subject, '__module__', None)
+        if modname and modname != self.modname:
             return False
         return True
 

--- a/tests/roots/test-ext-autodoc/target/imported_members.py
+++ b/tests/roots/test-ext-autodoc/target/imported_members.py
@@ -1,0 +1,1 @@
+from .partialfunction import func2, func3

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1268,6 +1268,17 @@ def test_partialfunction():
 
 
 @pytest.mark.usefixtures('setup_test')
+def test_imported_partialfunction_should_not_shown_without_imported_members():
+    options = {"members": None}
+    actual = do_autodoc(app, 'module', 'target.imported_members', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.imported_members',
+        ''
+    ]
+
+
+@pytest.mark.usefixtures('setup_test')
 def test_bound_method():
     options = {"members": None}
     actual = do_autodoc(app, 'module', 'target.bound_method', options)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7023 