### PR TITLE
Test with pytest-5.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require = {
         'sphinxcontrib-websupport',
     ],
     'test': [
-        'pytest',
+        'pytest < 5.3.3',
         'pytest-cov',
         'html5lib',
         'flake8>=3.5.0',


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
It seems our CI build has been broken since pytest-5.3.3.  This
pins it to 5.3.2 to fix it temporarily.
