### PR TITLE
C++, fix some cross referencing issues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -43,7 +43,10 @@ Features added
 Bugs fixed
 ----------
 
-* C++, fix cross reference lookup in certain cases involving function overloads.
+* C++, fix cross reference lookup in certain cases involving
+  function overloads.
+* #5078: C++, fix cross reference lookup when a directive contains multiple
+  declarations.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -43,6 +43,8 @@ Features added
 Bugs fixed
 ----------
 
+* C++, fix cross reference lookup in certain cases involving function overloads.
+
 Testing
 --------
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3701,7 +3701,7 @@ class Symbol:
 
             yield from c.children_recurse_anon
 
-    def get_lookup_key(self)-> "LookupKey":
+    def get_lookup_key(self) -> "LookupKey":
         # The pickle files for the environment and for each document are distinct.
         # The environment has all the symbols, but the documents has xrefs that
         # must know their scope. A lookup key is essentially a specification of
@@ -6762,8 +6762,8 @@ class AliasTransform(SphinxTransform):
                 node.replace_self(signode)
                 continue
 
-            rootSymbol = self.env.domains['cpp'].data['root_symbol']
-            parentSymbol = rootSymbol.direct_lookup(parentKey)
+            rootSymbol = self.env.domains['cpp'].data['root_symbol']  # type: Symbol
+            parentSymbol = rootSymbol.direct_lookup(parentKey)  # type: Symbol
             if not parentSymbol:
                 print("Target: ", sig)
                 print("ParentKey: ", parentKey)
@@ -6778,9 +6778,12 @@ class AliasTransform(SphinxTransform):
                     templateDecls = ns.templatePrefix.templates
                 else:
                     templateDecls = []
-                symbols = parentSymbol.find_name(name, templateDecls, 'any',
+                symbols = parentSymbol.find_name(nestedName=name,
+                                                 templateDecls=templateDecls,
+                                                 typ='any',
                                                  templateShorthand=True,
-                                                 matchSelf=True, recurseInAnon=True)
+                                                 matchSelf=True, recurseInAnon=True,
+                                                 searchInSiblings=False)
                 if symbols is None:
                     symbols = []
             else:
@@ -7240,7 +7243,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     return {
         'version': 'builtin',
-        'env_version': 1,
+        'env_version': 2,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -61,7 +61,7 @@ default_settings = {
 
 # This is increased every time an environment attribute is added
 # or changed to properly invalidate pickle files.
-ENV_VERSION = 57
+ENV_VERSION = 56
 
 # config status
 CONFIG_OK = 1

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -61,7 +61,7 @@ default_settings = {
 
 # This is increased every time an environment attribute is added
 # or changed to properly invalidate pickle files.
-ENV_VERSION = 56
+ENV_VERSION = 57
 
 # config status
 CONFIG_OK = 1

--- a/tests/roots/test-domain-cpp/lookup-key-overload.rst
+++ b/tests/roots/test-domain-cpp/lookup-key-overload.rst
@@ -1,0 +1,8 @@
+.. default-domain:: cpp
+
+.. namespace:: lookup_key_overload
+
+.. function:: void g(int a)
+.. function:: void g(double b)
+
+   :var:`b`

--- a/tests/roots/test-domain-cpp/multi-decl-lookup.rst
+++ b/tests/roots/test-domain-cpp/multi-decl-lookup.rst
@@ -1,0 +1,24 @@
+.. default-domain:: cpp
+
+.. namespace:: multi_decl_lookup
+
+.. function:: void f1(int a)
+              void f1(double b)
+
+   - a: :var:`a`
+   - b: :var:`b`
+
+.. function:: template<typename T> void f2(int a)
+              template<typename U> void f2(double b)
+
+   - T: :type:`T`
+   - U: :type:`U`
+
+
+.. class:: template<typename T> A
+           template<typename U> B
+
+   .. function:: void f3()
+
+      - T: :type:`T`
+      - U: :type:`U`

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -796,10 +796,13 @@ def filter_warnings(warning, file):
     return res
 
 
-@pytest.mark.sphinx(testroot='domain-cpp')
+@pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
 def test_build_domain_cpp_multi_decl_lookup(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "lookup-key-overload")
+    assert len(ws) == 0
+
+    ws = filter_warnings(warning, "multi-decl-lookup")
     assert len(ws) == 0
 
 

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -797,6 +797,13 @@ def filter_warnings(warning, file):
 
 
 @pytest.mark.sphinx(testroot='domain-cpp')
+def test_build_domain_cpp_multi_decl_lookup(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "lookup-key-overload")
+    assert len(ws) == 0
+
+
+@pytest.mark.sphinx(testroot='domain-cpp')
 def test_build_domain_cpp_misuse_of_roles(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "roles-targets-ok")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
When a cross-referencing role is used it must know which scope to start lookup in. This scope specification did not take function overloads into account meaning that it references to template and function parameters could reported as not found, if the wrong starting point happened to be selected.

When more than one declaration is written in a directive it should be possible to reference any template and function paramters, even though the starting point for lookup technically is a just one of the declarations. Now references will select the first match starting from the last declaration.

See the two new test files for specific examples.

### Relates
- Fixes #5078

