### PR TITLE
Close #7025: html search: full text search can be disabled via metadata

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -161,6 +161,8 @@ Features added
 * #6966: graphviz: Support ``:class:`` option
 * #6696: html: ``:scale:`` option of image/figure directive not working for SVG
   images (imagesize-1.2.0 or above is required)
+* #7025: html search: full text search can be disabled for individual document
+  using ``:nosearch:`` file-wide metadata
 * #6994: imgconverter: Support illustrator file (.ai) to .png conversion
 * autodoc: Support Positional-Only Argument separator (PEP-570 compliant)
 * autodoc: Support type annotations for variables

--- a/doc/usage/restructuredtext/field-lists.rst
+++ b/doc/usage/restructuredtext/field-lists.rst
@@ -51,3 +51,12 @@ At the moment, these metadata fields are recognized:
        :orphan:
 
    .. versionadded:: 1.0
+
+``nosearch``
+   If set, full text search for this file is disabled. ::
+
+       :nosearch:
+
+   .. note:: object search is still available even if `nosearch` option is set.
+
+   .. versionadded:: 2.4

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -847,7 +847,11 @@ class StandaloneHTMLBuilder(Builder):
         if self.indexer is not None and title:
             filename = self.env.doc2path(pagename, base=None)
             try:
-                self.indexer.feed(pagename, filename, title, doctree)
+                metadata = self.env.metadata.get(pagename, {})
+                if 'nosearch' in metadata:
+                    self.indexer.feed(pagename, filename, '', new_document(''))
+                else:
+                    self.indexer.feed(pagename, filename, title, doctree)
             except TypeError:
                 # fallback for old search-adapters
                 self.indexer.feed(pagename, title, doctree)  # type: ignore

--- a/tests/roots/test-search/nosearch.rst
+++ b/tests/roots/test-search/nosearch.rst
@@ -1,0 +1,7 @@
+:nosearch:
+
+nosearch
+========
+
+zfs
+latex

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -116,7 +116,7 @@ def test_term_in_heading_and_section(app, status, warning):
     # if search term is in the title of one doc and in the text of another
     # both documents should be a hit in the search index as a title,
     # respectively text hit
-    assert 'textinhead:1' in searchindex
+    assert 'textinhead:2' in searchindex
     assert 'textinhead:0' in searchindex
 
 
@@ -252,3 +252,13 @@ def test_search_index_gen_zh(app, status, warning):
     assert 'chinesetest' in searchindex
     assert 'chinesetesttwo' in searchindex
     assert 'cas' in searchindex
+
+
+@pytest.mark.sphinx(testroot='search')
+def test_nosearch(app):
+    app.build()
+    index = jsload(app.outdir / 'searchindex.js')
+    assert index['docnames'] == ['index', 'nosearch', 'tocitem']
+    assert 'latex' not in index['terms']
+    assert 'zfs' in index['terms']
+    assert index['terms']['zfs'] == 0  # zfs on nosearch.rst is not registered to index


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7025 