### PR TITLE
C++, expression list rendering

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,9 +16,12 @@ Features added
 Bugs fixed
 ----------
 
-* C++, don't crash when using the ``struct`` role in some cases.
-* C++, don't warn when using the ``var``/``member`` role for function
-  parameters.
+* C++:
+
+  - Don't crash when using the ``struct`` role in some cases.
+  - Don't warn when using the ``var``/``member`` role for function
+    parameters.
+  - Render call and braced-init expressions correctly.
 
 Testing
 --------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3262,7 +3262,7 @@ class ASTParenExprList(ASTBase):
                 signode.append(nodes.Text(', '))
             else:
                 first = False
-                e.describe_signature(signode, mode, env, symbol)
+            e.describe_signature(signode, mode, env, symbol)
         signode.append(nodes.Text(')'))
 
 
@@ -3292,7 +3292,7 @@ class ASTBracedInitList(ASTBase):
                 signode.append(nodes.Text(', '))
             else:
                 first = False
-                e.describe_signature(signode, mode, env, symbol)
+            e.describe_signature(signode, mode, env, symbol)
         if self.trailingComma:
             signode.append(nodes.Text(','))
         signode.append(nodes.Text('}'))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (not urgent)

### Purpose
Only the first argument of expression lists in parenthesis or braces were rendered correctly.
```rst
- :cpp:expr:`f(a)`, ok
- :cpp:expr:`f(a, b)`, was missing b
- :cpp:expr:`f(a, b, c)`, was missing b and c
- :cpp:expr:`f{a}`, ok
- :cpp:expr:`f{a, b}`, was missing b
- :cpp:expr:`f{a, b, c}`, was missing b and c
```
