### PR TITLE
Fix #6899: apidoc: private members are not shown even if --private given

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,7 @@ Bugs fixed
 * #6961: latex: warning for babel shown twice
 * #6559: Wrong node-ids are generated in glossary directive
 * #6986: apidoc: misdetects module name for .so file inside module
+* #6899: apidoc: private members are not shown even if ``--private`` given
 * #6999: napoleon: fails to parse tilde in :exc: role
 * #7019: gettext: Absolute path used in message catalogs
 * #7023: autodoc: nested partial functions are not listed

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -20,6 +20,7 @@ import locale
 import os
 import sys
 import warnings
+from copy import copy
 from fnmatch import fnmatch
 from importlib.machinery import EXTENSION_SUFFIXES
 from os import path
@@ -107,12 +108,16 @@ def format_directive(module: str, package: str = None) -> str:
 def create_module_file(package: str, basename: str, opts: Any,
                        user_template_dir: str = None) -> None:
     """Build the text of the file and write the file."""
+    options = copy(OPTIONS)
+    if opts.includeprivate and 'private-members' not in options:
+        options.append('private-members')
+
     qualname = module_join(package, basename)
     context = {
         'show_headings': not opts.noheadings,
         'basename': basename,
         'qualname': qualname,
-        'automodule_options': OPTIONS,
+        'automodule_options': options,
     }
     text = ReSTRenderer([user_template_dir, template_dir]).render('module.rst_t', context)
     write_file(qualname, text, opts)
@@ -133,6 +138,9 @@ def create_package_file(root: str, master_package: str, subroot: str, py_files: 
                   sub != INITPY]
     submodules = [module_join(master_package, subroot, modname)
                   for modname in submodules]
+    options = copy(OPTIONS)
+    if opts.includeprivate and 'private-members' not in options:
+        options.append('private-members')
 
     pkgname = module_join(master_package, subroot)
     context = {
@@ -142,7 +150,7 @@ def create_package_file(root: str, master_package: str, subroot: str, py_files: 
         'is_namespace': is_namespace,
         'modulefirst': opts.modulefirst,
         'separatemodules': opts.separatemodules,
-        'automodule_options': OPTIONS,
+        'automodule_options': options,
         'show_headings': not opts.noheadings,
     }
     text = ReSTRenderer([user_template_dir, template_dir]).render('package.rst_t', context)

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -408,11 +408,13 @@ def test_private(tempdir):
     # without --private option
     apidoc_main(['-o', tempdir, tempdir])
     assert (tempdir / 'hello.rst').exists()
+    assert ':private-members:' not in (tempdir / 'hello.rst').text()
     assert not (tempdir / '_world.rst').exists()
 
     # with --private option
-    apidoc_main(['--private', '-o', tempdir, tempdir])
+    apidoc_main(['--private', '-f', '-o', tempdir, tempdir])
     assert (tempdir / 'hello.rst').exists()
+    assert ':private-members:' in (tempdir / 'hello.rst').text()
     assert (tempdir / '_world.rst').exists()
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6899 

### Remaining Tasks

- [x] Tests
- [x] CHANGES