### PR TITLE
C++, suppress some warnings that can never be fixed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,8 @@ Bugs fixed
   function overloads.
 * #5078: C++, fix cross reference lookup when a directive contains multiple
   declarations.
+* C++, suppress warnings for directly dependent typenames in cross references
+  generated automatically in signatures.
 
 Testing
 --------

--- a/tests/roots/test-domain-cpp/warn-template-param-qualified-name.rst
+++ b/tests/roots/test-domain-cpp/warn-template-param-qualified-name.rst
@@ -1,0 +1,11 @@
+.. default-domain:: cpp
+
+.. class:: template<typename T> A
+
+   .. type:: N1 = T::typeOk
+
+   - Not ok, warn: :type:`T::typeWarn`
+
+   .. type:: N2 = T::U::typeOk
+
+   - Not ok, warn: :type:`T::U::typeWarn`

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -806,6 +806,15 @@ def test_build_domain_cpp_multi_decl_lookup(app, status, warning):
     assert len(ws) == 0
 
 
+@pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
+def test_build_domain_cpp_warn_template_param_qualified_name(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "warn-template-param-qualified-name")
+    assert len(ws) == 2
+    assert "WARNING: cpp:type reference target not found: T::typeWarn" in ws[0]
+    assert "WARNING: cpp:type reference target not found: T::U::typeWarn" in ws[1]
+
+
 @pytest.mark.sphinx(testroot='domain-cpp')
 def test_build_domain_cpp_misuse_of_roles(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
In templates one may reference a name nested inside a template parameter. It will never be possible to resolve that reference, so warnings should not be generated for them, except if the user explicitly made the reference in a role. Example:
```rst
.. default-domain:: cpp

.. class:: template<typename T> A

   .. type:: N1 = T::typeOk

   - Not ok, warn: :type:`T::typeWarn`

   .. type:: N2 = T::U::typeOk

   - Not ok, warn: :type:`T::U::typeWarn`
```
(This is not a general detection of dependent typenames, only when a nested name specifier is an identifier denoting a template parameter.)