### PR TITLE
typehints: Fix wrong order of info-field-list

### DIFF
--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -9,6 +9,7 @@
 """
 
 import re
+from collections import OrderedDict
 from typing import Any, Dict, Iterable
 from typing import cast
 
@@ -37,13 +38,14 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
     """Record type hints to env object."""
     try:
         if callable(obj):
-            annotations = app.env.temp_data.setdefault('annotations', {}).setdefault(name, {})
+            annotations = app.env.temp_data.setdefault('annotations', {})
+            annotation = annotations.setdefault(name, OrderedDict())
             sig = inspect.signature(obj)
             for param in sig.parameters.values():
                 if param.annotation is not param.empty:
-                    annotations[param.name] = typing.stringify(param.annotation)
+                    annotation[param.name] = typing.stringify(param.annotation)
             if sig.return_annotation is not sig.empty:
-                annotations['return'] = typing.stringify(sig.return_annotation)
+                annotation['return'] = typing.stringify(sig.return_annotation)
     except TypeError:
         pass
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- After merging #6418, CI fails randomly.
- It is caused by order of dict in py35.
- This uses `OrderedDict` to ensure it.