### PR TITLE
test: encoding="utf-8" is no longer needed on reading text

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1293,7 +1293,7 @@ def test_html_anchor_for_figure(app):
 @pytest.mark.sphinx('html', testroot='directives-raw')
 def test_html_raw_directive(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
 
     # standard case
     assert 'standalone raw directive (HTML)' in result
@@ -1347,7 +1347,7 @@ def test_html_style(app, status, warning):
 def test_html_remote_images(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert ('<img alt="https://www.python.org/static/img/python-logo.png" '
             'src="https://www.python.org/static/img/python-logo.png" />' in result)
     assert not (app.outdir / 'python-logo.png').exists()
@@ -1359,7 +1359,7 @@ def test_html_sidebar(app, status, warning):
 
     # default for alabaster
     app.builder.build_all()
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert ('<div class="sphinxsidebar" role="navigation" '
             'aria-label="main navigation">' in result)
     assert '<h1 class="logo"><a href="#">Python</a></h1>' in result
@@ -1374,7 +1374,7 @@ def test_html_sidebar(app, status, warning):
     # only relations.html
     app.config.html_sidebars = {'**': ['relations.html']}
     app.builder.build_all()
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert ('<div class="sphinxsidebar" role="navigation" '
             'aria-label="main navigation">' in result)
     assert '<h1 class="logo"><a href="#">Python</a></h1>' not in result
@@ -1388,7 +1388,7 @@ def test_html_sidebar(app, status, warning):
     # no sidebars
     app.config.html_sidebars = {'**': []}
     app.builder.build_all()
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert ('<div class="sphinxsidebar" role="navigation" '
             'aria-label="main navigation">' not in result)
     assert '<h1 class="logo"><a href="#">Python</a></h1>' not in result
@@ -1419,10 +1419,10 @@ def test_html_manpage(app, cached_etree_parse, fname, expect):
 def test_html_baseurl(app, status, warning):
     app.build()
 
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert '<link rel="canonical" href="https://example.com/index.html" />' in result
 
-    result = (app.outdir / 'qux' / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'qux' / 'index.html').read_text()
     assert '<link rel="canonical" href="https://example.com/qux/index.html" />' in result
 
 
@@ -1432,10 +1432,10 @@ def test_html_baseurl(app, status, warning):
 def test_html_baseurl_and_html_file_suffix(app, status, warning):
     app.build()
 
-    result = (app.outdir / 'index.htm').read_text(encoding='utf8')
+    result = (app.outdir / 'index.htm').read_text()
     assert '<link rel="canonical" href="https://example.com/subdir/index.htm" />' in result
 
-    result = (app.outdir / 'qux' / 'index.htm').read_text(encoding='utf8')
+    result = (app.outdir / 'qux' / 'index.htm').read_text()
     assert '<link rel="canonical" href="https://example.com/subdir/qux/index.htm" />' in result
 
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -113,7 +113,7 @@ def test_build_latex_doc(app, status, warning, engine, docclass):
 @pytest.mark.sphinx('latex')
 def test_writer(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'sphinxtests.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxtests.tex').read_text()
 
     assert ('\\begin{sphinxfigure-in-table}\n\\centering\n\\capstart\n'
             '\\noindent\\sphinxincludegraphics{{img}.png}\n'
@@ -156,7 +156,7 @@ def test_latex_warnings(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='basic')
 def test_latex_basic(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'test.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'test.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -168,7 +168,7 @@ def test_latex_basic(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='basic', confoverrides={'language': 'zh'})
 def test_latex_additional_settings_for_language_code(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'test.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'test.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -178,7 +178,7 @@ def test_latex_additional_settings_for_language_code(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='basic', confoverrides={'language': 'el'})
 def test_latex_additional_settings_for_greek(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'test.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'test.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -189,7 +189,7 @@ def test_latex_additional_settings_for_greek(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='latex-title')
 def test_latex_title_after_admonitions(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'test.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'test.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -200,7 +200,7 @@ def test_latex_title_after_admonitions(app, status, warning):
                     confoverrides={'release': '1.0'})
 def test_latex_release(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'test.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'test.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -212,7 +212,7 @@ def test_latex_release(app, status, warning):
                     confoverrides={'numfig': True})
 def test_numref(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -238,7 +238,7 @@ def test_numref(app, status, warning):
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.\@{} }}' in result
     assert r'\addto\captionsenglish{\renewcommand{\tablename}{Table }}' in result
@@ -254,7 +254,7 @@ def test_numref(app, status, warning):
                                      'section': 'SECTION-%s'}})
 def test_numref_with_prefix1(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -286,7 +286,7 @@ def test_numref_with_prefix1(app, status, warning):
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
     assert r'\addto\captionsenglish{\renewcommand{\tablename}{Tab\_}}' in result
@@ -302,7 +302,7 @@ def test_numref_with_prefix1(app, status, warning):
                                      'section': 'SECTION_%s_'}})
 def test_numref_with_prefix2(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -328,7 +328,7 @@ def test_numref_with_prefix2(app, status, warning):
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Figure:}}' in result
     assert r'\def\fnum@figure{\figurename\thefigure{}.}' in result
@@ -342,7 +342,7 @@ def test_numref_with_prefix2(app, status, warning):
     confoverrides={'numfig': True, 'language': 'ja'})
 def test_numref_with_language_ja(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -368,7 +368,7 @@ def test_numref_with_language_ja(app, status, warning):
             '\\nameref{\\detokenize{foo:foo}}}') in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert '\\@iden{\\renewcommand{\\figurename}{図 }}' in result
     assert '\\@iden{\\renewcommand{\\tablename}{表 }}' in result
@@ -379,10 +379,10 @@ def test_numref_with_language_ja(app, status, warning):
 def test_latex_obey_numfig_is_false(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'SphinxManual.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxManual.tex').read_text()
     assert '\\usepackage{sphinx}' in result
 
-    result = (app.outdir / 'SphinxHowTo.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxHowTo.tex').read_text()
     assert '\\usepackage{sphinx}' in result
 
 
@@ -392,10 +392,10 @@ def test_latex_obey_numfig_is_false(app, status, warning):
 def test_latex_obey_numfig_secnum_depth_is_zero(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'SphinxManual.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxManual.tex').read_text()
     assert '\\usepackage[,nonumfigreset,mathnumfig]{sphinx}' in result
 
-    result = (app.outdir / 'SphinxHowTo.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxHowTo.tex').read_text()
     assert '\\usepackage[,nonumfigreset,mathnumfig]{sphinx}' in result
 
 
@@ -405,10 +405,10 @@ def test_latex_obey_numfig_secnum_depth_is_zero(app, status, warning):
 def test_latex_obey_numfig_secnum_depth_is_two(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'SphinxManual.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxManual.tex').read_text()
     assert '\\usepackage[,numfigreset=2,mathnumfig]{sphinx}' in result
 
-    result = (app.outdir / 'SphinxHowTo.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxHowTo.tex').read_text()
     assert '\\usepackage[,numfigreset=3,mathnumfig]{sphinx}' in result
 
 
@@ -418,10 +418,10 @@ def test_latex_obey_numfig_secnum_depth_is_two(app, status, warning):
 def test_latex_obey_numfig_but_math_numfig_false(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'SphinxManual.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxManual.tex').read_text()
     assert '\\usepackage[,numfigreset=1]{sphinx}' in result
 
-    result = (app.outdir / 'SphinxHowTo.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'SphinxHowTo.tex').read_text()
     assert '\\usepackage[,numfigreset=2]{sphinx}' in result
 
 
@@ -430,7 +430,7 @@ def test_latex_add_latex_package(app, status, warning):
     app.add_latex_package('foo')
     app.add_latex_package('bar', 'baz')
     app.builder.build_all()
-    result = (app.outdir / 'test.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'test.tex').read_text()
     assert '\\usepackage{foo}' in result
     assert '\\usepackage[baz]{bar}' in result
 
@@ -438,7 +438,7 @@ def test_latex_add_latex_package(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='latex-babel')
 def test_babel_with_no_language_settings(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -451,7 +451,7 @@ def test_babel_with_no_language_settings(app, status, warning):
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{page}' in result
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -463,7 +463,7 @@ def test_babel_with_no_language_settings(app, status, warning):
     confoverrides={'language': 'de'})
 def test_babel_with_language_de(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -476,7 +476,7 @@ def test_babel_with_language_de(app, status, warning):
     assert '\\shorthandoff{"}' in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{Seite}' in result
     assert r'\addto\captionsngerman{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -488,7 +488,7 @@ def test_babel_with_language_de(app, status, warning):
     confoverrides={'language': 'ru'})
 def test_babel_with_language_ru(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -501,7 +501,7 @@ def test_babel_with_language_ru(app, status, warning):
     assert '\\shorthandoff{"}' in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{страница}' in result
     assert r'\addto\captionsrussian{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -513,7 +513,7 @@ def test_babel_with_language_ru(app, status, warning):
     confoverrides={'language': 'tr'})
 def test_babel_with_language_tr(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -526,7 +526,7 @@ def test_babel_with_language_tr(app, status, warning):
     assert '\\shorthandoff{=}' in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{sayfa}' in result
     assert r'\addto\captionsturkish{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -538,7 +538,7 @@ def test_babel_with_language_tr(app, status, warning):
     confoverrides={'language': 'ja'})
 def test_babel_with_language_ja(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -550,7 +550,7 @@ def test_babel_with_language_ja(app, status, warning):
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{ページ}' in result
     assert '\\@iden{\\renewcommand{\\figurename}{Fig.\\@{} }}' in result
@@ -562,7 +562,7 @@ def test_babel_with_language_ja(app, status, warning):
     confoverrides={'language': 'unknown'})
 def test_babel_with_unknown_language(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -577,7 +577,7 @@ def test_babel_with_unknown_language(app, status, warning):
     assert "WARNING: no Babel option known for language 'unknown'" in warning.getvalue()
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{page}' in result
     assert r'\addto\captionsenglish{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -589,7 +589,7 @@ def test_babel_with_unknown_language(app, status, warning):
     confoverrides={'language': 'de', 'latex_engine': 'lualatex'})
 def test_polyglossia_with_language_de(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -603,7 +603,7 @@ def test_polyglossia_with_language_de(app, status, warning):
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{Seite}' in result
     assert r'\addto\captionsgerman{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -615,7 +615,7 @@ def test_polyglossia_with_language_de(app, status, warning):
     confoverrides={'language': 'de-1901', 'latex_engine': 'lualatex'})
 def test_polyglossia_with_language_de_1901(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -629,7 +629,7 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
     assert '\\shorthandoff' not in result
 
     # sphinxmessages.sty
-    result = (app.outdir / 'sphinxmessages.sty').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxmessages.sty').read_text()
     print(result)
     assert r'\def\pageautorefname{page}' in result
     assert r'\addto\captionsgerman{\renewcommand{\figurename}{Fig.\@{} }}' in result
@@ -639,7 +639,7 @@ def test_polyglossia_with_language_de_1901(app, status, warning):
 @pytest.mark.sphinx('latex')
 def test_footnote(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'sphinxtests.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxtests.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -666,7 +666,7 @@ def test_footnote(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='footnotes')
 def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -707,7 +707,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     confoverrides={'latex_show_urls': 'inline'})
 def test_latex_show_urls_is_inline(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -752,7 +752,7 @@ def test_latex_show_urls_is_inline(app, status, warning):
     confoverrides={'latex_show_urls': 'footnote'})
 def test_latex_show_urls_is_footnote(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -806,7 +806,7 @@ def test_latex_show_urls_is_footnote(app, status, warning):
     confoverrides={'latex_show_urls': 'no'})
 def test_latex_show_urls_is_no(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -856,7 +856,7 @@ def test_latex_show_urls_footnote_and_substitutions(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='image-in-section')
 def test_image_in_section(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -882,7 +882,7 @@ def test_latex_logo_if_not_found(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='toctree-maxdepth')
 def test_toctree_maxdepth_manual(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -899,7 +899,7 @@ def test_toctree_maxdepth_manual(app, status, warning):
     ]})
 def test_toctree_maxdepth_howto(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -913,7 +913,7 @@ def test_toctree_maxdepth_howto(app, status, warning):
     confoverrides={'master_doc': 'foo'})
 def test_toctree_not_found(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -927,7 +927,7 @@ def test_toctree_not_found(app, status, warning):
     confoverrides={'master_doc': 'bar'})
 def test_toctree_without_maxdepth(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -940,7 +940,7 @@ def test_toctree_without_maxdepth(app, status, warning):
     confoverrides={'master_doc': 'qux'})
 def test_toctree_with_deeper_maxdepth(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -953,7 +953,7 @@ def test_toctree_with_deeper_maxdepth(app, status, warning):
     confoverrides={'latex_toplevel_sectioning': None})
 def test_latex_toplevel_sectioning_is_None(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -965,7 +965,7 @@ def test_latex_toplevel_sectioning_is_None(app, status, warning):
     confoverrides={'latex_toplevel_sectioning': 'part'})
 def test_latex_toplevel_sectioning_is_part(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -983,7 +983,7 @@ def test_latex_toplevel_sectioning_is_part(app, status, warning):
                    ]})
 def test_latex_toplevel_sectioning_is_part_with_howto(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -997,7 +997,7 @@ def test_latex_toplevel_sectioning_is_part_with_howto(app, status, warning):
     confoverrides={'latex_toplevel_sectioning': 'chapter'})
 def test_latex_toplevel_sectioning_is_chapter(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -1013,7 +1013,7 @@ def test_latex_toplevel_sectioning_is_chapter(app, status, warning):
                    ]})
 def test_latex_toplevel_sectioning_is_chapter_with_howto(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -1025,7 +1025,7 @@ def test_latex_toplevel_sectioning_is_chapter_with_howto(app, status, warning):
     confoverrides={'latex_toplevel_sectioning': 'section'})
 def test_latex_toplevel_sectioning_is_section(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -1036,7 +1036,7 @@ def test_latex_toplevel_sectioning_is_section(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='maxlistdepth')
 def test_maxlistdepth_at_ten(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
@@ -1049,7 +1049,7 @@ def test_maxlistdepth_at_ten(app, status, warning):
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_tabulars(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     tables = {}
     for chap in re.split(r'\\(?:section|chapter){', result)[1:]:
         sectname, content = chap.split('}', 1)
@@ -1120,7 +1120,7 @@ def test_latex_table_tabulars(app, status, warning):
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_longtable(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     tables = {}
     for chap in re.split(r'\\(?:section|chapter){', result)[1:]:
         sectname, content = chap.split('}', 1)
@@ -1181,7 +1181,7 @@ def test_latex_table_longtable(app, status, warning):
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_complex_tables(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     tables = {}
     for chap in re.split(r'\\(?:section|renewcommand){', result)[1:]:
         sectname, content = chap.split('}', 1)
@@ -1205,7 +1205,7 @@ def test_latex_table_complex_tables(app, status, warning):
                     confoverrides={'templates_path': ['_mytemplates/latex']})
 def test_latex_table_custom_template_caseA(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert 'SALUT LES COPAINS' in result
 
 
@@ -1213,7 +1213,7 @@ def test_latex_table_custom_template_caseA(app, status, warning):
                     confoverrides={'templates_path': ['_mytemplates']})
 def test_latex_table_custom_template_caseB(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert 'SALUT LES COPAINS' not in result
 
 
@@ -1221,14 +1221,14 @@ def test_latex_table_custom_template_caseB(app, status, warning):
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_custom_template_caseC(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert 'SALUT LES COPAINS' not in result
 
 
 @pytest.mark.sphinx('latex', testroot='directives-raw')
 def test_latex_raw_directive(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
 
     # standard case
     assert 'standalone raw directive (HTML)' not in result
@@ -1244,7 +1244,7 @@ def test_latex_raw_directive(app, status, warning):
 def test_latex_images(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
 
     # images are copied
     assert '\\sphinxincludegraphics{{python-logo}.png}' in result
@@ -1268,7 +1268,7 @@ def test_latex_images(app, status, warning):
 def test_latex_index(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert ('A \\index{famous@\\spxentry{famous}}famous '
             '\\index{equation@\\spxentry{equation}}equation:\n' in result)
     assert ('\n\\index{Einstein@\\spxentry{Einstein}}'
@@ -1282,7 +1282,7 @@ def test_latex_index(app, status, warning):
 def test_latex_equations(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     expected = (app.srcdir / 'expects' / 'latex-equations.tex').read_text().strip()
 
     assert expected in result
@@ -1292,7 +1292,7 @@ def test_latex_equations(app, status, warning):
 def test_latex_image_in_parsed_literal(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert ('{\\sphinxunactivateextrasandspace \\raisebox{-0.5\\height}'
             '{\\sphinxincludegraphics[height=2.00000cm]{{pic}.png}}'
             '}AFTER') in result
@@ -1302,7 +1302,7 @@ def test_latex_image_in_parsed_literal(app, status, warning):
 def test_latex_nested_enumerated_list(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert ('\\sphinxsetlistlabels{\\arabic}{enumi}{enumii}{}{.}%\n'
             '\\setcounter{enumi}{4}\n' in result)
     assert ('\\sphinxsetlistlabels{\\alph}{enumii}{enumiii}{}{.}%\n'
@@ -1319,7 +1319,7 @@ def test_latex_nested_enumerated_list(app, status, warning):
 def test_latex_thebibliography(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(result)
     assert ('\\begin{sphinxthebibliography}{AuthorYe}\n'
             '\\bibitem[AuthorYear]{index:authoryear}\n'
@@ -1332,7 +1332,7 @@ def test_latex_thebibliography(app, status, warning):
 def test_latex_glossary(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert ('\\item[{änhlich\\index{änhlich@\\spxentry{änhlich}|spxpagem}'
             r'\phantomsection'
             r'\label{\detokenize{index:term-anhlich}}}] \leavevmode' in result)
@@ -1356,7 +1356,7 @@ def test_latex_glossary(app, status, warning):
 def test_latex_labels(app, status, warning):
     app.builder.build_all()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
 
     # figures
     assert (r'\caption{labeled figure}'
@@ -1403,7 +1403,7 @@ def test_latex_labels(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='latex-figure-in-admonition')
 def test_latex_figure_in_admonition(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert(r'\begin{figure}[H]' in result)
 
 
@@ -1433,7 +1433,7 @@ def test_includegraphics_oversized(app, status, warning):
 @pytest.mark.sphinx('latex', testroot='index_on_title')
 def test_index_on_title(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert ('\\chapter{Test for index in top level title}\n'
             '\\label{\\detokenize{contents:test-for-index-in-top-level-title}}'
             '\\index{index@\\spxentry{index}}\n'

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -49,7 +49,7 @@ def test_texinfo_warnings(app, status, warning):
 def test_texinfo(app, status, warning):
     TexinfoTranslator.ignore_missing_images = True
     app.builder.build_all()
-    result = (app.outdir / 'sphinxtests.texi').read_text(encoding='utf8')
+    result = (app.outdir / 'sphinxtests.texi').read_text()
     assert ('@anchor{markup doc}@anchor{11}'
             '@anchor{markup id1}@anchor{12}'
             '@anchor{markup testing-various-markup}@anchor{13}' in result)

--- a/tests/test_build_text.py
+++ b/tests/test_build_text.py
@@ -209,7 +209,7 @@ def test_list_items_in_admonition(app, status, warning):
 @with_text_app()
 def test_secnums(app, status, warning):
     app.builder.build_all()
-    index = (app.outdir / 'index.txt').read_text(encoding='utf8')
+    index = (app.outdir / 'index.txt').read_text()
     lines = index.splitlines()
     assert lines[0] == "* 1. Section A"
     assert lines[1] == ""
@@ -218,7 +218,7 @@ def test_secnums(app, status, warning):
     assert lines[4] == "  * 2.1. Sub Ba"
     assert lines[5] == ""
     assert lines[6] == "  * 2.2. Sub Bb"
-    doc2 = (app.outdir / 'doc2.txt').read_text(encoding='utf8')
+    doc2 = (app.outdir / 'doc2.txt').read_text()
     expect = (
         "2. Section B\n"
         "************\n"
@@ -235,7 +235,7 @@ def test_secnums(app, status, warning):
 
     app.config.text_secnumber_suffix = " "
     app.builder.build_all()
-    index = (app.outdir / 'index.txt').read_text(encoding='utf8')
+    index = (app.outdir / 'index.txt').read_text()
     lines = index.splitlines()
     assert lines[0] == "* 1 Section A"
     assert lines[1] == ""
@@ -244,7 +244,7 @@ def test_secnums(app, status, warning):
     assert lines[4] == "  * 2.1 Sub Ba"
     assert lines[5] == ""
     assert lines[6] == "  * 2.2 Sub Bb"
-    doc2 = (app.outdir / 'doc2.txt').read_text(encoding='utf8')
+    doc2 = (app.outdir / 'doc2.txt').read_text()
     expect = (
         "2 Section B\n"
         "***********\n"
@@ -261,7 +261,7 @@ def test_secnums(app, status, warning):
 
     app.config.text_add_secnumbers = False
     app.builder.build_all()
-    index = (app.outdir / 'index.txt').read_text(encoding='utf8')
+    index = (app.outdir / 'index.txt').read_text()
     lines = index.splitlines()
     assert lines[0] == "* Section A"
     assert lines[1] == ""
@@ -270,7 +270,7 @@ def test_secnums(app, status, warning):
     assert lines[4] == "  * Sub Ba"
     assert lines[5] == ""
     assert lines[6] == "  * Sub Bb"
-    doc2 = (app.outdir / 'doc2.txt').read_text(encoding='utf8')
+    doc2 = (app.outdir / 'doc2.txt').read_text()
     expect = (
         "Section B\n"
         "*********\n"

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -262,7 +262,7 @@ def test_autosummary_generate_overwrite2(app_params, make_app):
 @pytest.mark.sphinx('latex', **default_kw)
 def test_autosummary_latex_table_colspec(app, status, warning):
     app.builder.build_all()
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     print(status.getvalue())
     print(warning.getvalue())
     assert r'\begin{longtable}[c]{\X{1}{2}\X{1}{2}}' in result

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -122,7 +122,7 @@ def test_theme_sidebars(app, status, warning):
     app.build()
 
     # test-theme specifies globaltoc and searchbox as default sidebars
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert '<h3><a href="#">Table of Contents</a></h3>' in result
     assert '<h3>Related Topics</h3>' not in result
     assert '<h3>This Page</h3>' not in result

--- a/tests/test_transforms_post_transforms_code.py
+++ b/tests/test_transforms_post_transforms_code.py
@@ -13,7 +13,7 @@ import pytest
 def test_trim_doctest_flags_html(app, status, warning):
     app.build()
 
-    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    result = (app.outdir / 'index.html').read_text()
     assert 'FOO' not in result
     assert 'BAR' in result
     assert 'BAZ' not in result
@@ -25,7 +25,7 @@ def test_trim_doctest_flags_html(app, status, warning):
 def test_trim_doctest_flags_latex(app, status, warning):
     app.build()
 
-    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    result = (app.outdir / 'python.tex').read_text()
     assert 'FOO' not in result
     assert 'BAR' in result
     assert 'BAZ' not in result


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since py3, "utf-8" is mainly used for file encoding (via locale settings). So encoding parameter is no longer needed.