### PR TITLE
Add name option for the index directive

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -885,7 +885,7 @@ mainly contained in information units, such as the language reference.
         .. index:: Python
            :name: py-index
 
-   .. versionadded:: 2.5
+   .. versionadded:: 3.0
 
 .. rst:role:: index
 

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -874,6 +874,19 @@ mainly contained in information units, such as the language reference.
    .. versionchanged:: 1.1
       Added ``see`` and ``seealso`` types, as well as marking main entries.
 
+   .. rubric:: options
+
+   .. rst:directive:option:: name: a label for hyperlink
+      :type: text
+
+      Define implicit target name that can be referenced by using
+      :rst:role:`ref`.  For example::
+
+        .. index:: Python
+           :name: py-index
+
+   .. versionadded:: 2.5
+
 .. rst:role:: index
 
    While the :rst:dir:`index` directive is a block-level markup and links to the

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -77,8 +77,8 @@ class IndexDirective(SphinxDirective):
         arguments = self.arguments[0].split('\n')
 
         if 'name' in self.options:
-            targetid = self.options['name']
-            targetnode = nodes.target('', '', names=[targetid])
+            targetname  = self.options['name']
+            targetnode = nodes.target('', '', names=[targetname])
         else:
             targetid = 'index-%s' % self.env.new_serialno('index')
             targetnode = nodes.target('', '', ids=[targetid])
@@ -89,7 +89,7 @@ class IndexDirective(SphinxDirective):
         indexnode['inline'] = False
         self.set_source_info(indexnode)
         for entry in arguments:
-            indexnode['entries'].extend(process_index_entry(entry, targetid))
+            indexnode['entries'].extend(process_index_entry(entry, targetnode['ids'][0]))
         return [indexnode, targetnode]
 
 

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterable, List, Tuple
 
 from docutils import nodes
 from docutils.nodes import Node, system_message
+from docutils.parsers.rst import directives
 
 from sphinx import addnodes
 from sphinx.domains import Domain
@@ -68,11 +69,16 @@ class IndexDirective(SphinxDirective):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = True
-    option_spec = {}  # type: Dict
+    option_spec = {
+        'name': directives.unchanged,
+    }  # type: Dict
 
     def run(self) -> List[Node]:
         arguments = self.arguments[0].split('\n')
-        targetid = 'index-%s' % self.env.new_serialno('index')
+        if 'name' in self.options:
+            targetid = 'index-%s' % self.options['name']
+        else:
+            targetid = 'index-%s' % self.env.new_serialno('index')
         targetnode = nodes.target('', '', ids=[targetid])
         self.state.document.note_explicit_target(targetnode)
         indexnode = addnodes.index()

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -71,7 +71,7 @@ class IndexDirective(SphinxDirective):
     final_argument_whitespace = True
     option_spec = {
         'name': directives.unchanged,
-    }  # type: Dict
+    }
 
     def run(self) -> List[Node]:
         arguments = self.arguments[0].split('\n')

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -77,7 +77,7 @@ class IndexDirective(SphinxDirective):
         arguments = self.arguments[0].split('\n')
 
         if 'name' in self.options:
-            targetname  = self.options['name']
+            targetname = self.options['name']
             targetnode = nodes.target('', '', names=[targetname])
         else:
             targetid = 'index-%s' % self.env.new_serialno('index')

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -75,11 +75,13 @@ class IndexDirective(SphinxDirective):
 
     def run(self) -> List[Node]:
         arguments = self.arguments[0].split('\n')
-        if 'name' in self.options:
-            targetid = 'index-%s' % self.options['name']
-        else:
-            targetid = 'index-%s' % self.env.new_serialno('index')
+        targetid = 'index-%s' % self.env.new_serialno('index')
         targetnode = nodes.target('', '', ids=[targetid])
+
+        if 'name' in self.options:
+            targetname = self.options['name']
+            targetnode['names'].append(targetname)
+
         self.state.document.note_explicit_target(targetnode)
         indexnode = addnodes.index()
         indexnode['entries'] = []

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -75,12 +75,13 @@ class IndexDirective(SphinxDirective):
 
     def run(self) -> List[Node]:
         arguments = self.arguments[0].split('\n')
-        targetid = 'index-%s' % self.env.new_serialno('index')
-        targetnode = nodes.target('', '', ids=[targetid])
 
         if 'name' in self.options:
-            targetname = self.options['name']
-            targetnode['names'].append(targetname)
+            targetid = self.options['name']
+            targetnode = nodes.target('', '', names=[targetid])
+        else:
+            targetid = 'index-%s' % self.env.new_serialno('index')
+            targetnode = nodes.target('', '', ids=[targetid])
 
         self.state.document.note_explicit_target(targetnode)
         indexnode = addnodes.index()

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -116,20 +116,22 @@ def test_create_seealso_index(app):
 def test_create_index_with_name(app):
     text = (".. index:: single: docutils\n"
             "   :name: ref1\n"
-            ".. index:: see: Python; interpreter\n"
-            "   :name: ref2\n")
+            ".. index:: single: Python\n"
+            "   :name: ref2\n"
+            ".. index:: Sphinx\n")
     restructuredtext.parse(app, text)
     index = IndexEntries(app.env).create_index(app.builder)
 
     # check index is created correctly
-    assert len(index) == 2
-    assert index[0] == ('D', [('docutils', [[('', '#index-0')], [], None])])
-    assert index[1] == ('P', [('Python', [[], [('see interpreter', [])], None])])
+    assert len(index) == 3
+    assert index[0] == ('D', [('docutils', [[('', '#ref1')], [], None])])
+    assert index[1] == ('P', [('Python', [[('', '#ref2')], [], None])])
+    assert index[2] == ('S', [('Sphinx', [[('', '#index-0')], [], None])])
 
     # check the reference labels are created correctly
     std = app.env.get_domain('std')
-    assert std.anonlabels['ref1'] == ('index', 'index-0')
-    assert std.anonlabels['ref2'] == ('index', 'index-1')
+    assert std.anonlabels['ref1'] == ('index', 'ref1')
+    assert std.anonlabels['ref2'] == ('index', 'ref2')
 
 
 @pytest.mark.sphinx('dummy', freshenv=True)

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -113,6 +113,26 @@ def test_create_seealso_index(app):
 
 
 @pytest.mark.sphinx('dummy', freshenv=True)
+def test_create_index_with_name(app):
+    text = (".. index:: single: docutils\n"
+            "   :name: ref1\n"
+            ".. index:: see: Python; interpreter\n"
+            "   :name: ref2\n")
+    restructuredtext.parse(app, text)
+    index = IndexEntries(app.env).create_index(app.builder)
+
+    # check index is created correctly
+    assert len(index) == 2
+    assert index[0] == ('D', [('docutils', [[('', '#index-0')], [], None])])
+    assert index[1] == ('P', [('Python', [[], [('see interpreter', [])], None])])
+
+    # check the reference labels are created correctly
+    std = app.env.get_domain('std')
+    assert std.anonlabels['ref1'] == ('index', 'index-0')
+    assert std.anonlabels['ref2'] == ('index', 'index-1')
+
+
+@pytest.mark.sphinx('dummy', freshenv=True)
 def test_create_index_by_key(app):
     # At present, only glossary directive is able to create index key
     text = (".. glossary::\n"
@@ -126,21 +146,3 @@ def test_create_index_by_key(app):
     assert index[0] == ('D', [('docutils', [[('main', '#term-docutils')], [], None])])
     assert index[1] == ('P', [('Python', [[('main', '#term-python')], [], None])])
     assert index[2] == ('ス', [('スフィンクス', [[('main', '#term-0')], [], 'ス'])])
-
-
-@pytest.mark.sphinx('dummy', freshenv=True)
-def test_create_index_with_name(app):
-    text = (".. index:: single: docutils\n   :name: ref1\n"
-            ".. index:: see: Python; interpreter\n   :name: ref2\n")
-    restructuredtext.parse(app, text)
-    index = IndexEntries(app.env).create_index(app.builder)
-
-    # check index is created correctly
-    assert len(index) == 2
-    assert index[0] == ('D', [('docutils', [[('', '#index-0')], [], None])])
-    assert index[1] == ('P', [('Python', [[], [('see interpreter', [])], None])])
-
-    # check the reference labels are created correctly
-    labels = app.env.domaindata['std']['anonlabels']
-    assert labels['ref1'] == ('index', 'index-0')
-    assert labels['ref2'] == ('index', 'index-1')

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -126,3 +126,14 @@ def test_create_index_by_key(app):
     assert index[0] == ('D', [('docutils', [[('main', '#term-docutils')], [], None])])
     assert index[1] == ('P', [('Python', [[('main', '#term-python')], [], None])])
     assert index[2] == ('ス', [('スフィンクス', [[('main', '#term-0')], [], 'ス'])])
+
+
+@pytest.mark.sphinx('dummy', freshenv=True)
+def test_create_index_with_name(app):
+    text = (".. index:: single: docutils\n   :name: ref1\n"
+            ".. index:: see: Python; interpreter\n   :name: ref2\n")
+    restructuredtext.parse(app, text)
+    index = IndexEntries(app.env).create_index(app.builder)
+    assert len(index) == 2
+    assert index[0] == ('D', [('docutils', [[('', '#index-0')], [], None])])
+    assert index[1] == ('P', [('Python', [[], [('see interpreter', [])], None])])

--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -134,6 +134,13 @@ def test_create_index_with_name(app):
             ".. index:: see: Python; interpreter\n   :name: ref2\n")
     restructuredtext.parse(app, text)
     index = IndexEntries(app.env).create_index(app.builder)
+
+    # check index is created correctly
     assert len(index) == 2
     assert index[0] == ('D', [('docutils', [[('', '#index-0')], [], None])])
     assert index[1] == ('P', [('Python', [[], [('see interpreter', [])], None])])
+
+    # check the reference labels are created correctly
+    labels = app.env.domaindata['std']['anonlabels']
+    assert labels['ref1'] == ('index', 'index-0')
+    assert labels['ref2'] == ('index', 'index-1')


### PR DESCRIPTION
Subject: To allow index hyperlinks to be constructed using a new `:name:` option. 
Feedback on approach welcome, and open to attempting to implement a different approach. 

### Feature or Bugfix
- Feature

### Purpose
The pull request allows the hrefs generated by the [Index Directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup) to be given a name to be used when creating index links rather than simply an integer id that can change if text on a page is reordered. 

For example:

`.. index:: Test1` will generate `test.html#index-0`

Whereas supplying a new name option such as below:

```
.. index:: single: Test1
   :name: mylink
```

Will generate: `test.html#index-mylink`

If the same `name` option is used multiple times for index entries on the same page a warning similar to below is given:

`index.rst:17: WARNING: Duplicate ID: "index-mylink".`

### Detail
An alternative to simply modifying the href would be to construct a proper `:ref:` node. 
This could be achieved using `from sphinx.util.nodes import make_refnode`?

### Relates
-  #1671

