### PR TITLE
Fix #6568: autosummary_imported_members is not working for submodules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -77,6 +77,8 @@ Bugs fixed
 * #7023: autodoc: partial functions imported from other modules are listed as
   module members without :impoprted-members: option
 * #6889: autodoc: Trailing comma in ``:members::`` option causes cryptic warning
+* #6568: autosummary: ``autosummary_imported_members`` is ignored on generating
+  a stub file for submodule
 * #7055: linkcheck: redirect is treated as an error
 
 Testing

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -293,7 +293,8 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
         generate_autosummary_docs(new_files, output_dir=output_dir,
                                   suffix=suffix, warn=warn, info=info,
                                   base_path=base_path, builder=builder,
-                                  template_dir=template_dir, app=app)
+                                  template_dir=template_dir,
+                                  imported_members=imported_members, app=app)
 
 
 # -- Finding documented entries in files ---------------------------------------


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6568 