### PR TITLE
Fix #6581: :reversed: for toctree does not effect to LaTeX build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,7 @@ Bugs fixed
 * #6906, #6907: autodoc: failed to read the source codes encoeded in cp1251
 * #6961: latex: warning for babel shown twice
 * #7059: latex: LaTeX compilation falls into infinite loop (wrapfig issue)
+* #6581: latex: ``:reversed:`` option for toctree does not effect to LaTeX build
 * #6559: Wrong node-ids are generated in glossary directive
 * #6986: apidoc: misdetects module name for .so file inside module
 * #6899: apidoc: private members are not shown even if ``--private`` given

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -145,6 +145,7 @@ class TocTree(SphinxDirective):
         # entries contains all entries (self references, external links etc.)
         if 'reversed' in self.options:
             toctree['entries'] = list(reversed(toctree['entries']))
+            toctree['includefiles'] = list(reversed(toctree['includefiles']))
 
         return ret
 

--- a/tests/test_directive_other.py
+++ b/tests/test_directive_other.py
@@ -127,6 +127,23 @@ def test_toctree_glob_and_url(app):
 
 
 @pytest.mark.sphinx(testroot='toctree-glob')
+def test_reversed_toctree(app):
+    text = (".. toctree::\n"
+            "   :reversed:\n"
+            "\n"
+            "   foo\n"
+            "   bar/index\n"
+            "   baz\n")
+
+    app.env.find_files(app.config, app.builder)
+    doctree = restructuredtext.parse(app, text, 'index')
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert_node(doctree[0][0],
+                entries=[(None, 'baz'), (None, 'bar/index'), (None, 'foo')],
+                includefiles=['baz', 'bar/index', 'foo'])
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
 def test_toctree_twice(app):
     text = (".. toctree::\n"
             "\n"

--- a/tests/test_environment_toctree.py
+++ b/tests/test_environment_toctree.py
@@ -119,16 +119,14 @@ def test_glob(app):
                              [bullet_list, addnodes.toctree])])  # [0][1][1][1][0]
     assert_node(toctree[0][1][1][1][0], addnodes.toctree, caption=None,
                 glob=True, hidden=False, titlesonly=False,
-                maxdepth=-1, numbered=0, includefiles=includefiles,
+                maxdepth=-1, numbered=0, includefiles=list(reversed(includefiles)),
                 entries=[(None, 'qux/index'), (None, 'baz'), (None, 'bar/bar_3'),
                          (None, 'bar/bar_2'), (None, 'bar/bar_1'), (None, 'bar/index'),
                          (None, 'foo')])
-    includefiles = ['foo', 'bar/index', 'bar/bar_1', 'bar/bar_2',
-                    'bar/bar_3', 'baz', 'qux/index']
 
     # other collections
     assert app.env.toc_num_entries['index'] == 3
-    assert app.env.toctree_includes['index'] == includefiles + includefiles
+    assert app.env.toctree_includes['index'] == includefiles + list(reversed(includefiles))
     for file in includefiles:
         assert 'index' in app.env.files_to_rebuild[file]
     assert 'index' in app.env.glob_toctrees


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6581 