### PR TITLE
Close #7115: LaTeX: Allow to override LATEXOPTS and LATEXMKOPTS via envvars

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,8 @@ Features added
 * #6446: duration: Add ``sphinx.ext.durations`` to inspect which documents slow
   down the build
 * #6837: LaTeX: Support a nested table
+* #7115: LaTeX: Allow to override LATEXOPTS and LATEXMKOPTS via environment
+  variable
 * #6966: graphviz: Support ``:class:`` option
 * #6696: html: ``:scale:`` option of image/figure directive not working for SVG
   images (imagesize-1.2.0 or above is required)

--- a/sphinx/texinputs/Makefile_t
+++ b/sphinx/texinputs/Makefile_t
@@ -15,13 +15,13 @@ ALLIMGS = $(wildcard *.png *.gif *.jpg *.jpeg)
 # Prefix for archive names
 ARCHIVEPREFIX =
 # Additional LaTeX options (passed via variables in latexmkrc/latexmkjarc file)
-export LATEXOPTS =
+export LATEXOPTS ?=
 # Additional latexmk options
 {% if latex_engine == 'xelatex' -%}
 # with latexmk version 4.52b or higher set LATEXMKOPTS to -xelatex either here
 # or on command line for faster builds.
 {% endif -%}
-LATEXMKOPTS =
+LATEXMKOPTS ?=
 {% if xindy_use -%}
 export XINDYOPTS = {{ xindy_lang_option }} -M sphinx.xdy
 {% if latex_engine == 'pdflatex' -%}


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7115 