### PR TITLE
Deprecate desc_signature['first']

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``desc_signature['first']``
 * ``sphinx.domains.std.StandardDomain.add_object()``
 * ``sphinx.testing.path.Path.text()``
 * ``sphinx.testing.path.Path.bytes()``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``desc_signature['first']``
+     -
+     - 3.0
+     - N/A
+
    * - ``sphinx.domains.std.StandardDomain.add_object()``
      - 3.0
      - 5.0

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -167,7 +167,6 @@ class ObjectDescription(SphinxDirective):
             # add a signature node for each signature in the current unit
             # and add a reference target for it
             signode = addnodes.desc_signature(sig, '')
-            signode['first'] = False
             node.append(signode)
             try:
                 # name can also be a tuple, e.g. (classname, objname);

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -203,7 +203,6 @@ class CObject(ObjectDescription):
         if targetname not in self.state.document.ids:
             signode['names'].append(targetname)
             signode['ids'].append(targetname)
-            signode['first'] = (not self.names)
             self.state.document.note_explicit_target(signode)
 
             domain = cast(CDomain, self.env.get_domain('c'))

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6490,7 +6490,6 @@ class CPPObject(ObjectDescription):
                     continue
                 if id not in self.state.document.ids:
                     signode['ids'].append(id)
-            signode['first'] = (not self.names)  # hmm, what is this about?
             self.state.document.note_explicit_target(signode)
 
     @property
@@ -6772,7 +6771,6 @@ class AliasTransform(SphinxTransform):
             if ast is None:
                 # could not be parsed, so stop here
                 signode = addnodes.desc_signature(sig, '')
-                signode['first'] = False
                 signode.clear()
                 signode += addnodes.desc_name(sig, sig)
                 node.replace_self(signode)
@@ -6816,7 +6814,6 @@ class AliasTransform(SphinxTransform):
 
             if len(symbols) == 0:
                 signode = addnodes.desc_signature(sig, '')
-                signode['first'] = False
                 node.append(signode)
                 signode.clear()
                 signode += addnodes.desc_name(sig, sig)
@@ -6830,7 +6827,6 @@ class AliasTransform(SphinxTransform):
                 options['tparam-line-spec'] = False
                 for s in symbols:
                     signode = addnodes.desc_signature(sig, '')
-                    signode['first'] = False
                     nodes.append(signode)
                     s.declaration.describe_signature(signode, 'markName', self.env, options)
                 node.replace_self(nodes)

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -109,7 +109,6 @@ class JSObject(ObjectDescription):
         if fullname not in self.state.document.ids:
             signode['names'].append(fullname)
             signode['ids'].append(fullname.replace('$', '_S_'))
-            signode['first'] = not self.names
             self.state.document.note_explicit_target(signode)
 
             domain = cast(JavaScriptDomain, self.env.get_domain('js'))

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -311,7 +311,6 @@ class PyObject(ObjectDescription):
         if fullname not in self.state.document.ids:
             signode['names'].append(fullname)
             signode['ids'].append(fullname)
-            signode['first'] = (not self.names)
             self.state.document.note_explicit_target(signode)
 
             domain = cast(PythonDomain, self.env.get_domain('py'))

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -43,7 +43,6 @@ class ReSTMarkup(ObjectDescription):
         if targetname not in self.state.document.ids:
             signode['names'].append(targetname)
             signode['ids'].append(targetname)
-            signode['first'] = (not self.names)
             self.state.document.note_explicit_target(signode)
 
             domain = cast(ReSTDomain, self.env.get_domain('rst'))
@@ -133,7 +132,6 @@ class ReSTDirectiveOption(ReSTMarkup):
         if targetname not in self.state.document.ids:
             signode['names'].append(targetname)
             signode['ids'].append(targetname)
-            signode['first'] = (not self.names)
             self.state.document.note_explicit_target(signode)
 
             objname = ':'.join(filter(None, [directive_name, name]))

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -115,10 +115,6 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
     def visit_desc_signature(self, node: Element) -> None:
         # the id is set automatically
         self.body.append(self.starttag(node, 'dt'))
-        # anchor for per-desc interactive data
-        if node.parent['objtype'] != 'describe' \
-           and node['ids'] and node['first']:
-            self.body.append('<!--[%s]-->' % node['ids'][0])
 
     def depart_desc_signature(self, node: Element) -> None:
         if not node.get('is_multiline'):

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -87,10 +87,6 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     def visit_desc_signature(self, node: Element) -> None:
         # the id is set automatically
         self.body.append(self.starttag(node, 'dt'))
-        # anchor for per-desc interactive data
-        if node.parent['objtype'] != 'describe' \
-           and node['ids'] and node['first']:
-            self.body.append('<!--[%s]-->' % node['ids'][0])
 
     def depart_desc_signature(self, node: Element) -> None:
         if not node.get('is_multiline'):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Deprecate `desc_signature['first']` attribute
- It never become `True`. So no longer used.