### PR TITLE
Close #7108: Allow to show an error message from conf.py via ConfigError

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ Features added
 * #3077: Implement the scoping for :rst:dir:`productionlist` as indicated
   in the documentation.
 * #1027: Support backslash line continuation in :rst:dir:`productionlist`.
+* #7108: config: Allow to show an error message from conf.py via ``ConfigError``
 
 Bugs fixed
 ----------

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -324,6 +324,9 @@ def eval_config_file(filename: str, tags: Tags) -> Dict[str, Any]:
             msg = __("The configuration file (or one of the modules it imports) "
                      "called sys.exit()")
             raise ConfigError(msg)
+        except ConfigError:
+            # pass through ConfigError from conf.py as is.  It will be shown in console.
+            raise
         except Exception:
             msg = __("There is a programmable error in your configuration file:\n\n%s")
             raise ConfigError(msg % traceback.format_exc())


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7108 