### PR TITLE
Clarify documentation on use of doctest extension

### DIFF
--- a/doc/usage/extensions/doctest.rst
+++ b/doc/usage/extensions/doctest.rst
@@ -11,11 +11,15 @@
            pair: testing; snippets
 
 
-This extension allows you to test snippets in the documentation in a natural
-way.  It works by collecting specially-marked up code blocks and running them as
-doctest tests.
+It is often helpful to include snippets of code in your documentation and
+demonstrate the results of executing it. But it is important to ensure that
+the documentation stays up-to-date with the code.
 
-Within one document, test code is partitioned in *groups*, where each group
+This extension allows you to test such code snippets in the documentation in
+a natural way.  If you mark the code blocks as shown here, the ``doctest''
+builder will collect them and run them as doctest tests.
+
+Within each document, you can assign each snippet to a *group*. Each group
 consists of:
 
 * zero or more *setup code* blocks (e.g. importing the module to test)

--- a/doc/usage/extensions/doctest.rst
+++ b/doc/usage/extensions/doctest.rst
@@ -12,11 +12,11 @@
 
 
 It is often helpful to include snippets of code in your documentation and
-demonstrate the results of executing it. But it is important to ensure that
+demonstrate the results of executing them. But it is important to ensure that
 the documentation stays up-to-date with the code.
 
 This extension allows you to test such code snippets in the documentation in
-a natural way.  If you mark the code blocks as shown here, the ``doctest''
+a natural way.  If you mark the code blocks as shown here, the ``doctest``
 builder will collect them and run them as doctest tests.
 
 Within each document, you can assign each snippet to a *group*. Each group


### PR DESCRIPTION
Subject: Clarify documentation on use of doctest extension

### Feature or Bugfix
- Feature

### Purpose
When I first read this section, I was mightily confused due to lack of context and the use of the passive voice.
I think this phrasing clarifies the context and indicates more clearly what the documentation author does
vs what the doctest extension and builder do.
But I'm a newbie here, so please ensure that I got this right....