### PR TITLE
BLD: tox.ini: flake8: add whitelist_externals for latest tox instead of adding dep, pass posargs through

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,10 +28,12 @@ commands=
 basepython = python3
 description =
     Run style checks.
+whitelist_externals =
+    flake8
 extras =
     lint
 commands =
-    flake8
+    flake8 {posargs}
 
 [testenv:pylint]
 basepython = python3


### PR DESCRIPTION
BLD: tox.ini: flake8: add whitelist_externals for latest tox instead of adding dep, pass posargs through

Subject: Update tox.ini for latest tox version and pass posargs through

### Feature or Bugfix
- Feature: ENH
- Bugfix: BUG
- Build: BLD

### Purpose
- BLD: tox.ini: flake8: add whitelist_externals for latest tox instead of adding dep, pass posargs through

### Detail
Passing posargs through makes it possible to check specific files:
```
tox -e flake8 -- ./tests/test_build.py
```

Specifying `whitelist_externals` eliminates an error message without requiring (re)install of flake8 for every run as adding to `deps` would result in.
https://tox.readthedocs.io/en/latest/config.html#conf-whitelist_externals

### Relates
- #7103
