### PR TITLE
Stop to test with nightly python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       env:
         - TOXENV=du15
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
-    - python: 'nightly'
+    - python: '3.8'
       env:
         - TOXENV=du16
     - python: '3.6'


### PR DESCRIPTION
### Feature or Bugfix
- Test

### Purpose
It seems nightly python image on Travis CI has broken now.  This
stops to test with it temporarily to make our development keep going.
https://travis-ci.community/t/python-development-versions-no-longer-include-pip/7180
