### PR TITLE
Fix #7138: autodoc: crashed when variable has unbound object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #7138: autodoc: ``autodoc.typehints`` crashed when variable has unbound object
+  as a value
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -46,7 +46,7 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
                     annotation[param.name] = typing.stringify(param.annotation)
             if sig.return_annotation is not sig.empty:
                 annotation['return'] = typing.stringify(sig.return_annotation)
-    except TypeError:
+    except (TypeError, ValueError):
         pass
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7138 