### PR TITLE
Deprecate sphinx.util.inspect.getargspec()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Deprecated
 * ``sphinx.domains.std.StandardDomain.add_object()``
 * ``sphinx.testing.path.Path.text()``
 * ``sphinx.testing.path.Path.bytes()``
+* ``sphinx.util.inspect.getargspec()``
 
 Features added
 --------------

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -41,6 +41,11 @@ The following is a list of deprecated interfaces.
      - 5.0
      - ``sphinx.testing.path.Path.read_bytes()``
 
+   * - ``sphinx.util.inspect.getargspec()``
+     - 3.0
+     - 5.0
+     - ``inspect.getargspec()``
+
    * - ``decode`` argument of ``sphinx.pycode.ModuleAnalyzer()``
      - 2.4
      - 4.0

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -22,7 +22,7 @@ from inspect import (  # NOQA
 from io import StringIO
 from typing import Any, Callable, Mapping, List, Tuple
 
-from sphinx.deprecation import RemovedInSphinx40Warning
+from sphinx.deprecation import RemovedInSphinx40Warning, RemovedInSphinx50Warning
 from sphinx.util import logging
 from sphinx.util.typing import stringify as stringify_annotation
 
@@ -54,6 +54,8 @@ memory_address_re = re.compile(r' at 0x[0-9a-f]{8,16}(?=>)', re.IGNORECASE)
 def getargspec(func):
     """Like inspect.getfullargspec but supports bound methods, and wrapped
     methods."""
+    warnings.warn('sphinx.ext.inspect.getargspec() is deprecated',
+                  RemovedInSphinx50Warning)
     # On 3.5+, signature(int) or similar raises ValueError. On 3.4, it
     # succeeds with a bogus signature. We want a TypeError uniformly, to
     # match historical behavior.


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `getargspec()` was copied from Python-3.5 to implement `Signature()` class. But the class has already been deprecated. So it is no longer used in Sphinx.