### PR TITLE
Fix #7156: autodoc: separator for keyword only arguments is not shown

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #7138: autodoc: ``autodoc.typehints`` crashed when variable has unbound object
   as a value
+* #7156: autodoc: separator for keyword only arguments is not shown
 
 Testing
 --------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -387,9 +387,9 @@ def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
         if param.kind != param.POSITIONAL_ONLY and last_kind == param.POSITIONAL_ONLY:
             # PEP-570: Separator for Positional Only Parameter: /
             args.append('/')
-        elif param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
-                                                                param.POSITIONAL_ONLY,
-                                                                None):
+        if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
+                                                              param.POSITIONAL_ONLY,
+                                                              None):
             # PEP-3102: Separator for Keyword Only Parameter: *
             args.append('*')
 

--- a/tests/roots/test-ext-autodoc/target/pep570.py
+++ b/tests/roots/test-ext-autodoc/target/pep570.py
@@ -1,5 +1,11 @@
-def foo(a, b, /, c, d):
+def foo(*, a, b):
     pass
 
-def bar(a, b, /):
+def bar(a, b, /, c, d):
+    pass
+
+def baz(a, /, *, b):
+    pass
+
+def qux(a, b, /):
     pass

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -298,14 +298,21 @@ def test_signature_annotations():
 @pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
 @pytest.mark.sphinx(testroot='ext-autodoc')
 def test_signature_annotations_py38(app):
-    from target.pep570 import foo, bar
+    from target.pep570 import foo, bar, baz, qux
+
+    # case: separator at head
+    sig = inspect.signature(foo)
+    assert stringify_signature(sig) == '(*, a, b)'
 
     # case: separator in the middle
-    sig = inspect.signature(foo)
+    sig = inspect.signature(bar)
     assert stringify_signature(sig) == '(a, b, /, c, d)'
 
+    sig = inspect.signature(baz)
+    assert stringify_signature(sig) == '(a, /, *, b)'
+
     # case: separator at tail
-    sig = inspect.signature(bar)
+    sig = inspect.signature(qux)
     assert stringify_signature(sig) == '(a, b, /)'
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7156 