### PR TITLE
Fix #7137: viewcode: Avoid to crash when non-python code given

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * #7146: autodoc: IndexError is raised on suppressed type_comment found
 * #7161: autodoc: typehints extension does not support parallel build
 * #7151: crashed when extension assigns a value to ``env.indexentries``
+* #7137: viewcode: Avoid to crash when non-python code given
 
 Testing
 --------

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -66,11 +66,11 @@ def doctree_read(app: Sphinx, doctree: Node) -> None:
         if code_tags is None:
             try:
                 analyzer = ModuleAnalyzer.for_module(modname)
+                analyzer.find_tags()
             except Exception:
                 env._viewcode_modules[modname] = False  # type: ignore
                 return
 
-            analyzer.find_tags()
             code = analyzer.code
             tags = analyzer.tags
         else:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7137 