### PR TITLE
autodoc: Add ability to sort member using a custom function

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -649,6 +649,15 @@ class Documenter:
                 fullname = entry[0].name.split('::')[1]
                 return tagorder.get(fullname, len(tagorder))
             memberdocumenters.sort(key=keyfunc)
+        elif member_order == 'bycustomfunction':
+            def custom_key(entry: Tuple[Documenter, bool]) -> Any:
+                result = self.env.events.emit_firstresult(
+                    'autodoc-member-order-custom-function', entry[0])
+                if result is None:
+                    raise RuntimeError("autodoc-member-order-custom-function is not "
+                                       "implemented")
+                return result
+            memberdocumenters.sort(key=custom_key)
 
         for documenter, isattr in memberdocumenters:
             documenter.generate(
@@ -1634,6 +1643,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_event('autodoc-process-docstring')
     app.add_event('autodoc-process-signature')
     app.add_event('autodoc-skip-member')
+    app.add_event('autodoc-member-order-custom-function')
 
     app.connect('config-inited', merge_autodoc_default_flags)
     app.setup_extension('sphinx.ext.autodoc.type_comment')

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -897,6 +897,50 @@ def test_autodoc_member_order(app):
         '   .. py:method:: Class.undocmeth()'
     ]
 
+    # case member-order='bycustomfunction'
+    options = {"members": None,
+               "undoc-members": True,
+               'member-order': 'bycustomfunction',
+               'private-members': True}
+    with pytest.raises(RuntimeError) as context:
+        actual = do_autodoc(app, 'class', 'target.Class', options)
+    assert "autodoc-member-order-custom-function is not implemented" == \
+            str(context.value)
+
+    # Let's sort the member names by reversing them.
+    def autodoc_member_order_function(app, documenter):
+        fullname = documenter.name.split('::')[1]
+        return fullname[::-1]
+
+    app.connect('autodoc-member-order-custom-function', autodoc_member_order_function)
+    # case member-order='bycustomfunction'
+    options = {"members": None,
+               "undoc-members": True,
+               'member-order': 'bycustomfunction',
+               'private-members': True,
+               }
+    actual = do_autodoc(app, 'class', 'target.Class', options)
+
+    assert list(filter(lambda l: '::' in l, actual)) == [
+        '.. py:class:: Class(arg)',
+        '   .. py:attribute:: Class.inst_attr_inline',
+        '   .. py:method:: Class.moore(a, e, f) -> happiness',
+        '   .. py:attribute:: Class.inst_attr_string',
+        '   .. py:method:: Class.meth()',
+        '   .. py:method:: Class.undocmeth()',
+        '   .. py:method:: Class.excludemeth()',
+        '   .. py:method:: Class.skipmeth()',
+        '   .. py:method:: Class.roger(a, *, b=2, c=3, d=4, e=5, f=6)',
+        '   .. py:attribute:: Class.attr',
+        '   .. py:attribute:: Class._private_inst_attr',
+        '   .. py:attribute:: Class.docattr',
+        '   .. py:attribute:: Class.mdocattr',
+        '   .. py:attribute:: Class.udocattr',
+        '   .. py:attribute:: Class.skipattr',
+        '   .. py:attribute:: Class.inst_attr_comment'
+    ]
+
+
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_module_scope(app):


### PR DESCRIPTION
Subject: Adds ability to pass a custom key function which can be used to change the order of the documented methods.

- Against `3.x`
- Feature
- URL: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/sphinx-users/bSAWjiiDWik/V7DC7tYqFwAJ
