### PR TITLE
Fix #7184: fix property access of vararg and kwarg.

### DIFF
--- a/sphinx/ext/autodoc/type_comment.py
+++ b/sphinx/ext/autodoc/type_comment.py
@@ -55,7 +55,7 @@ def signature_from_ast(node: ast.FunctionDef, bound_method: bool,
 
     if node.args.vararg:
         param = Parameter(node.args.vararg.arg, Parameter.VAR_POSITIONAL,
-                          annotation=arg.type_comment or Parameter.empty)
+                          annotation=node.args.vararg.type_comment or Parameter.empty)
         params.append(param)
 
     for arg in node.args.kwonlyargs:
@@ -65,7 +65,7 @@ def signature_from_ast(node: ast.FunctionDef, bound_method: bool,
 
     if node.args.kwarg:
         param = Parameter(node.args.kwarg.arg, Parameter.VAR_KEYWORD,
-                          annotation=arg.type_comment or Parameter.empty)
+                          annotation=node.args.kwarg.type_comment or Parameter.empty)
         params.append(param)
 
     # Remove first parameter when *obj* is bound_method


### PR DESCRIPTION
This PR addresses #7184.

### Feature or Bugfix
- Bugfix

### Description

The `arg` variables at L58 and L68 of `sphinx/ext/sutodoc/type_comment.py` are not defined. I think they are corresponding to `node.args.vararg` and `node.args.kwargs`, respectively.
  