### PR TITLE
Fix #7184: autodoc: *args and **kwarg in type comments are not handled

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #7184: autodoc: ``*args`` and ``**kwarg`` in type comments are not handled
+  properly
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/type_comment.py
+++ b/sphinx/ext/autodoc/type_comment.py
@@ -55,7 +55,7 @@ def signature_from_ast(node: ast.FunctionDef, bound_method: bool,
 
     if node.args.vararg:
         param = Parameter(node.args.vararg.arg, Parameter.VAR_POSITIONAL,
-                          annotation=arg.type_comment or Parameter.empty)
+                          annotation=node.args.vararg.type_comment or Parameter.empty)
         params.append(param)
 
     for arg in node.args.kwonlyargs:
@@ -65,7 +65,7 @@ def signature_from_ast(node: ast.FunctionDef, bound_method: bool,
 
     if node.args.kwarg:
         param = Parameter(node.args.kwarg.arg, Parameter.VAR_KEYWORD,
-                          annotation=arg.type_comment or Parameter.empty)
+                          annotation=node.args.kwarg.type_comment or Parameter.empty)
         params.append(param)
 
     # Remove first parameter when *obj* is bound_method

--- a/tests/roots/test-ext-autodoc/target/typehints.py
+++ b/tests/roots/test-ext-autodoc/target/typehints.py
@@ -41,4 +41,3 @@ def missing_attr(c,
                  ):
     # type: (...) -> str
     return a + (b or "")
-


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7184 