### PR TITLE
Feature: Update event autodoc-skip-member to pass what object the member is from

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -574,9 +574,13 @@ Skipping members
 autodoc allows the user to define a custom method for determining whether a
 member should be included in the documentation by using the following event:
 
-.. event:: autodoc-skip-member (app, what, name, obj, skip, options)
+.. event:: autodoc-skip-member (app, what, name, obj, member_of, skip, options)
 
    .. versionadded:: 0.5
+
+   .. versionchanged:: 3.0
+
+      Added parameter ``member_of``.
 
    Emitted when autodoc has to decide whether a member should be included in the
    documentation.  The member is excluded if a handler returns ``True``.  It is
@@ -593,6 +597,7 @@ member should be included in the documentation by using the following event:
       ``"attribute"``)
    :param name: the fully qualified name of the object
    :param obj: the object itself
+   :param member_of: the object that ``obj`` is a member of
    :param skip: a boolean indicating if autodoc will skip this member if the
       user handler does not override the decision
    :param options: the options given to the directive: an object with attributes

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -148,6 +148,11 @@ also use these config values:
       Emits :event:`autodoc-skip-member` event as :mod:`~sphinx.ext.autodoc`
       does.
 
+   .. versionchanged:: 3.0
+
+      Emitted :event:`autodoc-skip-member` event has parameter ``member_of``
+      as :mod:`~sphinx.ext.autodoc` does.
+
 .. confval:: autosummary_generate_overwrite
 
    If true, autosummary already overwrites stub files by generated contents.

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -18,7 +18,7 @@ import warnings
 from collections import deque
 from io import StringIO
 from os import path
-from typing import Any, Callable, Dict, IO, List, Tuple, Union
+from typing import Any, Callable, Dict, IO, List, Optional, Tuple, Union
 
 from docutils import nodes
 from docutils.nodes import Element, TextElement
@@ -494,13 +494,18 @@ class Sphinx:
             rebuild = 'env' if rebuild else ''
         self.config.add(name, default, rebuild, types)
 
-    def add_event(self, name: str) -> None:
+    def add_event(
+            self,
+            name: str,
+            argument_description: Optional[str] = None,
+            validator: Optional[Callable[[Callable, str, str], Callable]] = None
+    ) -> None:
         """Register an event called *name*.
 
         This is needed to be able to emit it.
         """
         logger.debug('[app] adding event: %r', name)
-        self.events.add(name)
+        self.events.add(name, argument_description, validator)
 
     def set_translator(self, name: str, translator_class: "Type[nodes.NodeVisitor]",
                        override: bool = False) -> None:

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -143,10 +143,10 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
         if not template.exists(template_name):
             template_name = 'autosummary/base.rst'
 
-    def skip_member(obj: Any, name: str, objtype: str) -> bool:
+    def skip_member(obj: Any, name: str, objtype: str, member_of: Any) -> bool:
         try:
             return app.emit_firstresult('autodoc-skip-member', objtype, name,
-                                        obj, False, {})
+                                        obj, member_of, False, {})
         except Exception as exc:
             logger.warning(__('autosummary: failed to determine %r to be documented.'
                               'the following exception was raised:\n%s'),
@@ -166,7 +166,7 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
             if documenter.objtype in types:
                 # skip imported members if expected
                 if imported or getattr(value, '__module__', None) == obj.__name__:
-                    skipped = skip_member(value, name, documenter.objtype)
+                    skipped = skip_member(value, name, documenter.objtype, obj)
                     if skipped is True:
                         pass
                     elif skipped is False:

--- a/tests/roots/test-ext-autosummary-skip-member/conf.py
+++ b/tests/roots/test-ext-autosummary-skip-member/conf.py
@@ -9,7 +9,7 @@ autosummary_generate = True
 autodoc_default_options = {'members': True}
 
 
-def skip_member(app, what, name, obj, skip, options):
+def skip_member(app, what, name, obj, member_of, skip, options):
     if name == 'skipmeth':
         return True
     elif name == '_privatemeth':

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -114,7 +114,7 @@ def process_signature(app, what, name, obj, options, args, retann):
         return '42', None
 
 
-def skip_member(app, what, name, obj, skip, options):
+def skip_member(app, what, name, obj, member_of, skip, options):
     if name in ('__special1__', '__special2__'):
         return skip
     if name.startswith('__'):


### PR DESCRIPTION
In some cases the name and object is not sufficient information to know if a member should be skipped or not. This PR adds the object `obj` is a member of (`member_of`) in order to give more context to the handler.

In order to be a minimally breaking change the event system is updated to allow events to be registered with an "upgrader"/"validator" function which can return a wrapped fallback. This will work properly when a user "connects" to the event with a function that expects an explicit number of arguments. If the function instead takes `*args` and then unpacks or uses subscripts in the handler this will be a breaking change.

The reason for this change is you may want to redact `obj` only if it is a member of a subclass of some type `T` and as is you either have to blindly redact `obj` if the name matches some name you may want to look for, but you have no ability to actually make sure it's on the right type. By having `member_of` you could check `issubclass(member_of, T)` to make sure you are redacting the right members for the right object(s).