### PR TITLE
Fix search in dirhtml output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,6 +64,7 @@ Other contributors, listed alphabetically, are:
 * \T. Powers -- HTML output improvements
 * Jeppe Pihl -- literalinclude improvements
 * Rob Ruana -- napoleon extension
+* Vince Salvino -- JavaScript search improvements
 * Stefan Seefeld -- toctree improvements
 * Gregory Szorc -- performance improvements
 * Taku Shimizu -- epub3 builder

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #7184: autodoc: ``*args`` and ``**kwarg`` in type comments are not handled
   properly
+* (#6244, #6387): Search breaks/hangs when built with ``dirhtml``.
 
 Testing
 --------

--- a/doc/templating.rst
+++ b/doc/templating.rst
@@ -121,6 +121,17 @@ The following blocks exist in the ``layout.html`` template:
     The contents of the document itself.  It contains the block "body" where the
     individual content is put by subtemplates like ``page.html``.
 
+    .. note::
+        In order for the built-in JavaScript search to show a page preview on
+        the results page, the document or body content should be wrapped in an
+        HTML element containing the ``role="main"`` attribute. For example:
+
+        .. sourcecode:: html+jinja
+
+            <div role="main">
+              {% block document %}{% endblock %}
+            </div>
+
 `sidebar1` / `sidebar2`
     A possible location for a sidebar.  `sidebar1` appears before the document
     and is empty by default, `sidebar2` after the document and contains the
@@ -427,5 +438,3 @@ are in HTML form), these variables are also available:
 
    * ``includehidden`` (``False`` by default): if true, the TOC tree will also
      contain hidden entries.
-
-

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -63,6 +63,9 @@ var Search = {
       htmlElement.innerHTML = htmlString;
       $(htmlElement).find('.headerlink').remove();
       docContent = $(htmlElement).find('[role=main]')[0];
+      if(docContent === undefined) {
+        return "";
+      }
       return docContent.textContent || docContent.innerText;
   },
 
@@ -245,6 +248,7 @@ var Search = {
       if (results.length) {
         var item = results.pop();
         var listItem = $('<li style="display:none"></li>');
+        var requestUrl = "";
         if (DOCUMENTATION_OPTIONS.BUILDER === 'dirhtml') {
           // dirhtml builder
           var dirname = item[0] + '/';
@@ -253,15 +257,15 @@ var Search = {
           } else if (dirname == 'index/') {
             dirname = '';
           }
-          listItem.append($('<a/>').attr('href',
-            DOCUMENTATION_OPTIONS.URL_ROOT + dirname +
-            highlightstring + item[2]).html(item[1]));
+          requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + dirname;
+
         } else {
           // normal html builders
-          listItem.append($('<a/>').attr('href',
-            item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX +
-            highlightstring + item[2]).html(item[1]));
+          requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
         }
+        listItem.append($('<a/>').attr('href',
+            requestUrl +
+            highlightstring + item[2]).html(item[1]));
         if (item[3]) {
           listItem.append($('<span> (' + item[3] + ')</span>'));
           Search.output.append(listItem);
@@ -269,7 +273,7 @@ var Search = {
             displayNextItem();
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
-          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX,
+          $.ajax({url: requestUrl,
                   dataType: "text",
                   complete: function(jqxhr, textstatus) {
                     var data = jqxhr.responseText;


### PR DESCRIPTION
Subject: The built-in JavaScript search exhibits a rather major bug in that it seems to completely break when the output is generated in `dirhtml` mode, OR if a custom theme is missing a `role="main"` HTML element. This change fixes the search to work correctly in both cases.

### Feature or Bugfix
- Bugfix

### Detail
When built in `dirhtml`, URLs such as `docs/test.html` now become `docs/test/`. However, in many cases the search was performing incorrect ajax queries such as `docs/test/index/` and `docs/test/.html`. My change looks for the correct URL when making ajax calls in the search.

These invalid URLs of course trigger 404s which in turn exposes another bug when trying to process the response HTML and look for a `[role='main']` element. This could also have been causing issues with custom themes that do not implement an element with `role=main`. My change also handles that case: if that element does not exist, an empty string instead is returned.

### Relates
There are a couple related issues, which are marked as "closed", but the issue still persists on sphinx 2.4.x. See #6244 , #6257 , #6387

---

Please provide feedback on if this should be merged into a different branch, or if my Pull Request is missing anything.

