### PR TITLE
Fix #7195: todo: emit doctree-resolved event with non-document node incorrectly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #7189: autodoc: classmethod coroutines are not detected
 * #7183: intersphinx: ``:attr:`` reference to property is broken
 * #6244, #6387: html search: Search breaks/hangs when built with dirhtml builder
+* #7195: todo: emit doctree-resolved event with non-document node incorrectly
 
 
 Testing


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7195 