### PR TITLE
js domain: Generate node_id in the right way

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,10 @@ Incompatible changes
 * Due to the scoping changes for :rst:dir:`productionlist` some uses of
   :rst:role:`token` must be modified to include the scope which was previously
   ignored.
+* #6903: js domain: Internal data structure has changed. Both objects and
+  modules have node_id for cross reference
+* #7210: js domain: Non intended behavior is removed such as ``parseInt_`` links
+  to ``.. js:function:: parseInt``
 
 Deprecated
 ----------

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -341,8 +341,8 @@ class JavaScriptDomain(Domain):
     def note_object(self, fullname: str, objtype: str, location: Any = None) -> None:
         if fullname in self.objects:
             docname = self.objects[fullname][0]
-            logger.warning(__('duplicate object description of %s, other instance in %s'),
-                           fullname, docname, location=location)
+            logger.warning(__('duplicate %s description of %s, other %s in %s'),
+                           objtype, fullname, objtype, docname, location=location)
         self.objects[fullname] = (self.env.docname, objtype)
 
     @property

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -443,7 +443,7 @@ def make_id(env: "BuildEnvironment", document: nodes.document,
     if prefix:
         idformat = prefix + "-%s"
     else:
-        idformat = document.settings.id_prefix + "%s"
+        idformat = (document.settings.id_prefix or "id") + "%s"
 
     # try to generate node_id by *term*
     if prefix and term:
@@ -451,6 +451,10 @@ def make_id(env: "BuildEnvironment", document: nodes.document,
         if node_id == prefix:
             # *term* is not good to generate a node_id.
             node_id = None
+    elif term:
+        node_id = nodes.make_id(term)
+        if node_id == '':
+            node_id = None  # fallback to None
 
     while node_id is None or node_id in document.ids:
         node_id = idformat % env.new_serialno(prefix)

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -91,22 +91,22 @@ def test_domain_js_objects(app, status, warning):
     assert 'module_b.submodule' in modules
     assert 'module_b.submodule' in objects
 
-    assert objects['module_a.submodule.ModTopLevel'] == ('module', 'class')
-    assert objects['module_a.submodule.ModTopLevel.mod_child_1'] == ('module', 'method')
-    assert objects['module_a.submodule.ModTopLevel.mod_child_2'] == ('module', 'method')
-    assert objects['module_b.submodule.ModTopLevel'] == ('module', 'class')
+    assert objects['module_a.submodule.ModTopLevel'][2] == 'class'
+    assert objects['module_a.submodule.ModTopLevel.mod_child_1'][2] == 'method'
+    assert objects['module_a.submodule.ModTopLevel.mod_child_2'][2] == 'method'
+    assert objects['module_b.submodule.ModTopLevel'][2] == 'class'
 
-    assert objects['TopLevel'] == ('roles', 'class')
-    assert objects['top_level'] == ('roles', 'function')
-    assert objects['NestedParentA'] == ('roles', 'class')
-    assert objects['NestedParentA.child_1'] == ('roles', 'function')
-    assert objects['NestedParentA.any_child'] == ('roles', 'function')
-    assert objects['NestedParentA.NestedChildA'] == ('roles', 'class')
-    assert objects['NestedParentA.NestedChildA.subchild_1'] == ('roles', 'function')
-    assert objects['NestedParentA.NestedChildA.subchild_2'] == ('roles', 'function')
-    assert objects['NestedParentA.child_2'] == ('roles', 'function')
-    assert objects['NestedParentB'] == ('roles', 'class')
-    assert objects['NestedParentB.child_1'] == ('roles', 'function')
+    assert objects['TopLevel'][2] == 'class'
+    assert objects['top_level'][2] == 'function'
+    assert objects['NestedParentA'][2] == 'class'
+    assert objects['NestedParentA.child_1'][2] == 'function'
+    assert objects['NestedParentA.any_child'][2] == 'function'
+    assert objects['NestedParentA.NestedChildA'][2] == 'class'
+    assert objects['NestedParentA.NestedChildA.subchild_1'][2] == 'function'
+    assert objects['NestedParentA.NestedChildA.subchild_2'][2] == 'function'
+    assert objects['NestedParentA.child_2'][2] == 'function'
+    assert objects['NestedParentB'][2] == 'class'
+    assert objects['NestedParentB.child_1'][2] == 'function'
 
 
 @pytest.mark.sphinx('dummy', testroot='domain-js')
@@ -120,21 +120,28 @@ def test_domain_js_find_obj(app, status, warning):
 
     assert (find_obj(None, None, 'NONEXISTANT', 'class') == (None, None))
     assert (find_obj(None, None, 'NestedParentA', 'class') ==
-            ('NestedParentA', ('roles', 'class')))
+            ('NestedParentA', ('roles', 'nestedparenta', 'class')))
     assert (find_obj(None, None, 'NestedParentA.NestedChildA', 'class') ==
-            ('NestedParentA.NestedChildA', ('roles', 'class')))
+            ('NestedParentA.NestedChildA',
+             ('roles', 'nestedparenta-nestedchilda', 'class')))
     assert (find_obj(None, 'NestedParentA', 'NestedChildA', 'class') ==
-            ('NestedParentA.NestedChildA', ('roles', 'class')))
+            ('NestedParentA.NestedChildA',
+             ('roles', 'nestedparenta-nestedchilda', 'class')))
     assert (find_obj(None, None, 'NestedParentA.NestedChildA.subchild_1', 'func') ==
-            ('NestedParentA.NestedChildA.subchild_1', ('roles', 'function')))
+            ('NestedParentA.NestedChildA.subchild_1',
+             ('roles', 'nestedparenta-nestedchilda-subchild-1', 'function')))
     assert (find_obj(None, 'NestedParentA', 'NestedChildA.subchild_1', 'func') ==
-            ('NestedParentA.NestedChildA.subchild_1', ('roles', 'function')))
+            ('NestedParentA.NestedChildA.subchild_1',
+             ('roles', 'nestedparenta-nestedchilda-subchild-1', 'function')))
     assert (find_obj(None, 'NestedParentA.NestedChildA', 'subchild_1', 'func') ==
-            ('NestedParentA.NestedChildA.subchild_1', ('roles', 'function')))
+            ('NestedParentA.NestedChildA.subchild_1',
+             ('roles', 'nestedparenta-nestedchilda-subchild-1', 'function')))
     assert (find_obj('module_a.submodule', 'ModTopLevel', 'mod_child_2', 'meth') ==
-            ('module_a.submodule.ModTopLevel.mod_child_2', ('module', 'method')))
+            ('module_a.submodule.ModTopLevel.mod_child_2',
+             ('module', 'module-a-submodule-modtoplevel-mod-child-2', 'method')))
     assert (find_obj('module_b.submodule', 'ModTopLevel', 'module_a.submodule', 'mod') ==
-            ('module_a.submodule', ('module', 'module')))
+            ('module_a.submodule',
+             ('module', 'module-module-a-submodule', 'module')))
 
 
 def test_get_full_qualified_name():
@@ -198,7 +205,7 @@ def test_js_class(app):
                                                     [desc_parameterlist, ()])],
                                   [desc_content, ()])]))
     assert_node(doctree[0], addnodes.index,
-                entries=[("single", "Application() (class)", "Application", "", None)])
+                entries=[("single", "Application() (class)", "application", "", None)])
     assert_node(doctree[1], addnodes.desc, domain="js", objtype="class", noindex=False)
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6903 
- So far, JS domain generates node_ids (a.k.a. target id) from their object name (ex. `func` from `.. js:function:: func()`).
- JS domain checks conflicts of node_ids between JS objects. But it does not check for other domains. Therefore, they are often conflicted.
- In addition, the generated node_ids do not obey the rule of docutils specification.
- On the other hand, this makes an incompatible changes for domain internal data.