### PR TITLE
Fix missing commas after PEP-570 separators

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -72,12 +72,12 @@ def _parse_arglist(arglist: str) -> addnodes.desc_parameterlist:
     for param in sig.parameters.values():
         if param.kind != param.POSITIONAL_ONLY and last_kind == param.POSITIONAL_ONLY:
             # PEP-570: Separator for Positional Only Parameter: /
-            params += nodes.Text('/')
+            params += addnodes.desc_parameter('', nodes.Text('/'))
         if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
                                                               param.POSITIONAL_ONLY,
                                                               None):
             # PEP-3102: Separator for Keyword Only Parameter: *
-            params += nodes.Text('*')
+            params += addnodes.desc_parameter('', nodes.Text('*'))
 
         node = addnodes.desc_parameter()
         if param.kind == param.VAR_POSITIONAL:
@@ -100,7 +100,7 @@ def _parse_arglist(arglist: str) -> addnodes.desc_parameterlist:
 
     if last_kind == Parameter.POSITIONAL_ONLY:
         # PEP-570: Separator for Positional Only Parameter: /
-        params += nodes.Text('/')
+        params += addnodes.desc_parameter('', nodes.Text('/'))
 
     return params
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -278,7 +278,7 @@ def test_pyfunction_signature_full_py38(app):
     text = ".. py:function:: hello(*, a)"
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1][0][1],
-                [desc_parameterlist, ("*",
+                [desc_parameterlist, ([desc_parameter, "*"],
                                       [desc_parameter, ("a",
                                                         "=None")])])
 
@@ -287,9 +287,9 @@ def test_pyfunction_signature_full_py38(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, ([desc_parameter, "a"],
-                                      "/",
+                                      [desc_parameter, "/"],
                                       [desc_parameter, "b"],
-                                      "*",
+                                      [desc_parameter, "*"],
                                       [desc_parameter, ("c",
                                                         "=None")])])
 
@@ -298,8 +298,8 @@ def test_pyfunction_signature_full_py38(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, ([desc_parameter, "a"],
-                                      "/",
-                                      "*",
+                                      [desc_parameter, "/"],
+                                      [desc_parameter, "*"],
                                       [desc_parameter, ("b",
                                                         "=None")])])
 
@@ -308,7 +308,7 @@ def test_pyfunction_signature_full_py38(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, ([desc_parameter, "a"],
-                                      "/")])
+                                      [desc_parameter, "/"])])
 
 
 def test_optional_pyfunction_signature(app):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- PEP-570 based functions are wrongly rendered
- Commas are needed after separators:
  <img width="401" alt="スクリーンショット 2020-02-24 2 04 50" src="https://user-images.githubusercontent.com/748828/75116288-0c5be700-56aa-11ea-807b-5ca9ce36acf8.png">
- refs: #7155 