### PR TITLE
Latex: replace polyglossia with babel for zh

### DIFF
--- a/sphinx/builders/latex/constants.py
+++ b/sphinx/builders/latex/constants.py
@@ -184,6 +184,8 @@ ADDITIONAL_SETTINGS = {
         'babel':        '\\usepackage{babel}',
     },
     ('xelatex', 'zh'): {
+        'polyglossia':  '',
+        'babel':        '\\usepackage{babel}',
         'fontenc':      '\\usepackage{xeCJK}',
     },
     ('xelatex', 'el'): {


### PR DESCRIPTION


Subject:  replace polyglossia with babel for zh (Chinese environment)

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix

- Bugfix

### Purpose

as title

### Detail

polyglossia does not compatible with xeCJK.
it would override all Chinese font with Serif family.


### Relates
- <URL or Ticket>

