### PR TITLE
Fix #7223: Sphinx builds has been slower since 2.4.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #7197: LaTeX: platex cause error to build image directive with target url
+* #7223: Sphinx builds has been slower since 2.4.0
 
 Testing
 --------

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -347,7 +347,7 @@ class SphinxComponentRegistry:
 
     def add_translator(self, name: str, translator: "Type[nodes.NodeVisitor]",
                        override: bool = False) -> None:
-        logger.debug('[app] Change of translator for the %s builder.' % name)
+        logger.debug('[app] Change of translator for the %s builder.', name)
         if name in self.translators and not override:
             raise ExtensionError(__('Translator for %r already exists') % name)
         self.translators[name] = translator

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -479,8 +479,8 @@ class SphinxTranslator(nodes.NodeVisitor):
         for node_class in node.__class__.__mro__:
             method = getattr(self, 'visit_%s' % (node_class.__name__), None)
             if method:
-                logger.debug('SphinxTranslator.dispatch_visit calling %s for %s' %
-                             (method.__name__, node))
+                logger.debug('SphinxTranslator.dispatch_visit calling %s for %s',
+                             method.__name__, node)
                 return method(node)
         else:
             super().dispatch_visit(node)
@@ -497,8 +497,8 @@ class SphinxTranslator(nodes.NodeVisitor):
         for node_class in node.__class__.__mro__:
             method = getattr(self, 'depart_%s' % (node_class.__name__), None)
             if method:
-                logger.debug('SphinxTranslator.dispatch_departure calling %s for %s' %
-                             (method.__name__, node))
+                logger.debug('SphinxTranslator.dispatch_departure calling %s for %s',
+                             method.__name__, node)
                 return method(node)
         else:
             super().dispatch_departure(node)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7223 
- debug message should not be evaluated when not debug mode.