### PR TITLE
refactor: Set source_info to nodes

### DIFF
--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -171,6 +171,7 @@ class ObjectDescription(SphinxDirective):
             # add a signature node for each signature in the current unit
             # and add a reference target for it
             signode = addnodes.desc_signature(sig, '')
+            self.set_source_info(signode)
             node.append(signode)
             try:
                 # name can also be a tuple, e.g. (classname, objname);

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -112,8 +112,7 @@ class JSObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
 
             domain = cast(JavaScriptDomain, self.env.get_domain('js'))
-            domain.note_object(fullname, self.objtype,
-                               location=(self.env.docname, self.lineno))
+            domain.note_object(fullname, self.objtype, location=signode)
 
         indextext = self.get_index_text(mod_name, name_obj)
         if indextext:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -365,8 +365,7 @@ class PyObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
 
             domain = cast(PythonDomain, self.env.get_domain('py'))
-            domain.note_object(fullname, self.objtype,
-                               location=(self.env.docname, self.lineno))
+            domain.note_object(fullname, self.objtype, location=signode)
 
         indextext = self.get_index_text(modname, name_cls)
         if indextext:

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -46,7 +46,7 @@ class ReSTMarkup(ObjectDescription):
             self.state.document.note_explicit_target(signode)
 
             domain = cast(ReSTDomain, self.env.get_domain('rst'))
-            domain.note_object(self.objtype, name, location=(self.env.docname, self.lineno))
+            domain.note_object(self.objtype, name, location=signode)
 
         indextext = self.get_index_text(self.objtype, name)
         if indextext:
@@ -136,7 +136,7 @@ class ReSTDirectiveOption(ReSTMarkup):
 
             objname = ':'.join(filter(None, [directive_name, name]))
             domain = cast(ReSTDomain, self.env.get_domain('rst'))
-            domain.note_object(self.objtype, objname, location=(self.env.docname, self.lineno))
+            domain.note_object(self.objtype, objname, location=signode)
 
         if directive_name:
             key = name[0].upper()

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -81,8 +81,7 @@ class GenericObject(ObjectDescription):
                                               targetname, '', None))
 
         std = cast(StandardDomain, self.env.get_domain('std'))
-        std.note_object(self.objtype, name, targetname,
-                        location=(self.env.docname, self.lineno))
+        std.note_object(self.objtype, name, targetname, location=signode)
 
 
 class EnvVar(GenericObject):
@@ -127,6 +126,7 @@ class Target(SphinxDirective):
         fullname = ws_re.sub(' ', self.arguments[0].strip())
         targetname = '%s-%s' % (self.name, fullname)
         node = nodes.target('', '', ids=[targetname])
+        self.set_source_info(node)
         self.state.document.note_explicit_target(node)
         ret = [node]  # type: List[Node]
         if self.indextemplate:
@@ -144,7 +144,7 @@ class Target(SphinxDirective):
             _, name = self.name.split(':', 1)
 
         std = cast(StandardDomain, self.env.get_domain('std'))
-        std.note_object(name, fullname, targetname, location=(self.env.docname, self.lineno))
+        std.note_object(name, fullname, targetname, location=node)
 
         return ret
 
@@ -165,7 +165,7 @@ class Cmdoption(ObjectDescription):
                 logger.warning(__('Malformed option description %r, should '
                                   'look like "opt", "-opt args", "--opt args", '
                                   '"/opt args" or "+opt args"'), potential_option,
-                               location=(self.env.docname, self.lineno))
+                               location=signode)
                 continue
             optname, args = m.groups()
             if count:
@@ -274,7 +274,7 @@ def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], index
         term['ids'].append(node_id)
 
     std = cast(StandardDomain, env.get_domain('std'))
-    std.note_object('term', termtext.lower(), node_id, location=(env.docname, lineno))
+    std.note_object('term', termtext.lower(), node_id, location=term)
 
     # add an index entry too
     indexnode = addnodes.index()
@@ -439,6 +439,7 @@ class ProductionList(SphinxDirective):
     def run(self) -> List[Node]:
         domain = cast(StandardDomain, self.env.get_domain('std'))
         node = addnodes.productionlist()  # type: Element
+        self.set_source_info(node)
         # The backslash handling is from ObjectDescription.get_signatures
         nl_escape_re = re.compile(r'\\\n')
         lines = nl_escape_re.sub('', self.arguments[0]).split('\n')
@@ -474,7 +475,7 @@ class ProductionList(SphinxDirective):
                 else:
                     objName = name
                 domain.note_object(objtype='token', name=objName, labelid=idname,
-                                   location=(self.env.docname, self.lineno))
+                                   location=node)
             subnode.extend(token_xrefs(tokens, productionGroup))
             node.append(subnode)
         return [node]

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -183,7 +183,7 @@ def test_glossary_warning(app, status, warning):
             "   term-case4\n"
             "   term-case4\n")
     restructuredtext.parse(app, text, "case4")
-    assert ("case4.txt:3: WARNING: duplicate term description of term-case4, "
+    assert ("case4.rst:3: WARNING: duplicate term description of term-case4, "
             "other instance in case4" in warning.getvalue())
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Set source_info to signatures, targets and productionlist nodes.
- As a side effect, It helps to call logger easily.