### PR TITLE
std domain: Generate node_id for generic objects and targets in the right way

### DIFF
--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -320,9 +320,13 @@ def test_epub_anchor_id(app):
     app.build()
 
     html = (app.outdir / 'index.xhtml').read_text()
-    assert '<p id="std-setting-STATICFILES_FINDERS">blah blah blah</p>' in html
-    assert '<span id="std-setting-STATICFILES_SECTION"></span><h1>blah blah blah</h1>' in html
-    assert 'see <a class="reference internal" href="#std-setting-STATICFILES_FINDERS">' in html
+    assert ('<p id="std-setting-staticfiles-finders">'
+            '<span id="std-setting-STATICFILES_FINDERS"></span>'
+            'blah blah blah</p>' in html)
+    assert ('<span id="std-setting-staticfiles-section"></span>'
+            '<span id="std-setting-STATICFILES_SECTION"></span>'
+            '<h1>blah blah blah</h1>' in html)
+    assert 'see <a class="reference internal" href="#std-setting-staticfiles-finders">' in html
 
 
 @pytest.mark.sphinx('epub', testroot='html_assets')

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -218,7 +218,7 @@ def test_html4_output(app, status, warning):
          "[@class='rfc reference external']/strong", 'RFC 1'),
         (".//a[@href='https://tools.ietf.org/html/rfc1.html']"
          "[@class='rfc reference external']/strong", 'Request for Comments #1'),
-        (".//a[@href='objects.html#envvar-HOME']"
+        (".//a[@href='objects.html#envvar-home']"
          "[@class='reference internal']/code/span[@class='pre']", 'HOME'),
         (".//a[@href='#with']"
          "[@class='reference internal']/code/span[@class='pre']", '^with$'),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- refs: #6903, #7210
- separated from #7230 and refactored.