### PR TITLE
tox: passenv: add TERM

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,14 @@ envlist = docs,flake8,mypy,coverage,py{35,36,37,38,39},du{12,13,14,15}
 [testenv]
 usedevelop = True
 passenv =
-    https_proxy http_proxy no_proxy PERL PERL5LIB PYTEST_ADDOPTS EPUBCHECK_PATH
+    https_proxy
+    http_proxy
+    no_proxy
+    PERL
+    PERL5LIB
+    PYTEST_ADDOPTS
+    EPUBCHECK_PATH
+    TERM
 description =
     py{35,36,37,38,39}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.


### PR DESCRIPTION
tox is stupid to not include TERM by default
(https://github.com/tox-dev/tox/issues/1441).

This makes `tox -e docs` use proper progress indicators.

It splits `passenv` into a list to make diffs easier in the future.

Output from `tox -e docs` before:

```
Running Sphinx v4.0.0+/4633ab906
loading pickled environment... failed
failed: build environment version not current
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 77 source files that are out of date
updating environment: [new config] 77 added, 0 changed, 0 removed
reading sources... [  1%] authors
reading sources... [  2%] changes
reading sources... [  3%] code_of_conduct
reading sources... [  5%] contents
reading sources... [  6%] develop
reading sources... [  7%] development/tutorials/examples/README
reading sources... [  9%] development/tutorials/helloworld
reading sources... [ 10%] development/tutorials/index
reading sources... [ 11%] development/tutorials/recipe
reading sources... [ 12%] development/tutorials/todo
reading sources... [ 14%] devguide
reading sources... [ 15%] examples
reading sources... [ 16%] extdev/appapi
reading sources... [ 18%] extdev/builderapi
reading sources... [ 19%] extdev/collectorapi
reading sources... [ 20%] extdev/deprecated
reading sources... [ 22%] extdev/domainapi
reading sources... [ 23%] extdev/envapi
reading sources... [ 24%] extdev/i18n
reading sources... [ 25%] extdev/index
reading sources... [ 27%] extdev/logging
reading sources... [ 28%] extdev/markupapi
reading sources... [ 29%] extdev/nodes
reading sources... [ 31%] extdev/parserapi
reading sources... [ 32%] extdev/projectapi
reading sources... [ 33%] extdev/utils
reading sources... [ 35%] faq
reading sources... [ 36%] glossary
reading sources... [ 37%] intro
reading sources... [ 38%] latex
reading sources... [ 40%] man/index
reading sources... [ 41%] man/sphinx-apidoc
reading sources... [ 42%] man/sphinx-autogen
reading sources... [ 44%] man/sphinx-build
reading sources... [ 45%] man/sphinx-quickstart
reading sources... [ 46%] templating
reading sources... [ 48%] theming
reading sources... [ 49%] usage/advanced/intl
reading sources... [ 50%] usage/advanced/setuptools
reading sources... [ 51%] usage/advanced/websupport/api
/tmp/tox/home/daniel/Vcs/sphinx/docs/lib/python3.8/site-packages/sphinxcontrib/websupport/__init__.py:18: RemovedInSphinx40Warning: sphinx.util.pycompat.htmlescape is deprecated. Check CHANGES for Sphinx API modifications.
  from sphinxcontrib.websupport.core import WebSupport  # NOQA
reading sources... [ 53%] usage/advanced/websupport/index
reading sources... [ 54%] usage/advanced/websupport/quickstart
reading sources... [ 55%] usage/advanced/websupport/searchadapters
reading sources... [ 57%] usage/advanced/websupport/storagebackends
reading sources... [ 58%] usage/builders/index
reading sources... [ 59%] usage/configuration
reading sources... [ 61%] usage/extensions/autodoc
reading sources... [ 62%] usage/extensions/autosectionlabel
reading sources... [ 63%] usage/extensions/autosummary
reading sources... [ 64%] usage/extensions/coverage
reading sources... [ 66%] usage/extensions/doctest
reading sources... [ 67%] usage/extensions/duration
reading sources... [ 68%] usage/extensions/example_google
reading sources... [ 70%] usage/extensions/example_numpy
reading sources... [ 71%] usage/extensions/extlinks
reading sources... [ 72%] usage/extensions/githubpages
reading sources... [ 74%] usage/extensions/graphviz
reading sources... [ 75%] usage/extensions/ifconfig
reading sources... [ 76%] usage/extensions/imgconverter
reading sources... [ 77%] usage/extensions/index
reading sources... [ 79%] usage/extensions/inheritance
reading sources... [ 80%] usage/extensions/intersphinx
reading sources... [ 81%] usage/extensions/linkcode
reading sources... [ 83%] usage/extensions/math
reading sources... [ 84%] usage/extensions/napoleon
reading sources... [ 85%] usage/extensions/todo
reading sources... [ 87%] usage/extensions/viewcode
reading sources... [ 88%] usage/installation
reading sources... [ 89%] usage/markdown
reading sources... [ 90%] usage/quickstart
reading sources... [ 92%] usage/restructuredtext/basics
reading sources... [ 93%] usage/restructuredtext/directives
reading sources... [ 94%] usage/restructuredtext/domains
reading sources... [ 96%] usage/restructuredtext/field-lists
reading sources... [ 97%] usage/restructuredtext/index
reading sources... [ 98%] usage/restructuredtext/roles
reading sources... [100%] usage/theming

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  1%] authors
writing output... [  2%] changes
writing output... [  3%] code_of_conduct
writing output... [  5%] contents
writing output... [  6%] develop
writing output... [  7%] development/tutorials/examples/README
writing output... [  9%] development/tutorials/helloworld
writing output... [ 10%] development/tutorials/index
writing output... [ 11%] development/tutorials/recipe
writing output... [ 12%] development/tutorials/todo
writing output... [ 14%] devguide
writing output... [ 15%] examples
writing output... [ 16%] extdev/appapi
writing output... [ 18%] extdev/builderapi
writing output... [ 19%] extdev/collectorapi
writing output... [ 20%] extdev/deprecated
writing output... [ 22%] extdev/domainapi
writing output... [ 23%] extdev/envapi
writing output... [ 24%] extdev/i18n
writing output... [ 25%] extdev/index
writing output... [ 27%] extdev/logging
writing output... [ 28%] extdev/markupapi
writing output... [ 29%] extdev/nodes
writing output... [ 31%] extdev/parserapi
writing output... [ 32%] extdev/projectapi
writing output... [ 33%] extdev/utils
writing output... [ 35%] faq
writing output... [ 36%] glossary
writing output... [ 37%] intro
writing output... [ 38%] latex
writing output... [ 40%] man/index
writing output... [ 41%] man/sphinx-apidoc
writing output... [ 42%] man/sphinx-autogen
writing output... [ 44%] man/sphinx-build
writing output... [ 45%] man/sphinx-quickstart
writing output... [ 46%] templating
writing output... [ 48%] theming
writing output... [ 49%] usage/advanced/intl
writing output... [ 50%] usage/advanced/setuptools
writing output... [ 51%] usage/advanced/websupport/api
writing output... [ 53%] usage/advanced/websupport/index
writing output... [ 54%] usage/advanced/websupport/quickstart
writing output... [ 55%] usage/advanced/websupport/searchadapters
writing output... [ 57%] usage/advanced/websupport/storagebackends
writing output... [ 58%] usage/builders/index
writing output... [ 59%] usage/configuration
writing output... [ 61%] usage/extensions/autodoc
writing output... [ 62%] usage/extensions/autosectionlabel
writing output... [ 63%] usage/extensions/autosummary
writing output... [ 64%] usage/extensions/coverage
writing output... [ 66%] usage/extensions/doctest
writing output... [ 67%] usage/extensions/duration
writing output... [ 68%] usage/extensions/example_google
writing output... [ 70%] usage/extensions/example_numpy
writing output... [ 71%] usage/extensions/extlinks
writing output... [ 72%] usage/extensions/githubpages
writing output... [ 74%] usage/extensions/graphviz
writing output... [ 75%] usage/extensions/ifconfig
writing output... [ 76%] usage/extensions/imgconverter
writing output... [ 77%] usage/extensions/index
writing output... [ 79%] usage/extensions/inheritance
writing output... [ 80%] usage/extensions/intersphinx
writing output... [ 81%] usage/extensions/linkcode
writing output... [ 83%] usage/extensions/math
writing output... [ 84%] usage/extensions/napoleon
writing output... [ 85%] usage/extensions/todo
writing output... [ 87%] usage/extensions/viewcode
writing output... [ 88%] usage/installation
writing output... [ 89%] usage/markdown
writing output... [ 90%] usage/quickstart
writing output... [ 92%] usage/restructuredtext/basics
writing output... [ 93%] usage/restructuredtext/directives
writing output... [ 94%] usage/restructuredtext/domains
writing output... [ 96%] usage/restructuredtext/field-lists
writing output... [ 97%] usage/restructuredtext/index
writing output... [ 98%] usage/restructuredtext/roles
writing output... [100%] usage/theming

generating indices...  genindex py-modindexdone
highlighting module code... [  2%] docutils.parsers.rst
highlighting module code... [  4%] logging
highlighting module code... [  7%] sphinx.addnodes
highlighting module code... [  9%] sphinx.application
highlighting module code... [ 11%] sphinx.builders
highlighting module code... [ 14%] sphinx.builders.changes
highlighting module code... [ 16%] sphinx.builders.dirhtml
highlighting module code... [ 19%] sphinx.builders.dummy
highlighting module code... [ 21%] sphinx.builders.epub3
highlighting module code... [ 23%] sphinx.builders.gettext
highlighting module code... [ 26%] sphinx.builders.html
highlighting module code... [ 28%] sphinx.builders.latex
highlighting module code... [ 30%] sphinx.builders.linkcheck
highlighting module code... [ 33%] sphinx.builders.manpage
highlighting module code... [ 35%] sphinx.builders.singlehtml
highlighting module code... [ 38%] sphinx.builders.texinfo
highlighting module code... [ 40%] sphinx.builders.text
highlighting module code... [ 42%] sphinx.builders.xml
highlighting module code... [ 45%] sphinx.config
highlighting module code... [ 47%] sphinx.domains
highlighting module code... [ 50%] sphinx.environment
highlighting module code... [ 52%] sphinx.environment.collectors
highlighting module code... [ 54%] sphinx.errors
highlighting module code... [ 57%] sphinx.events
highlighting module code... [ 59%] sphinx.ext.autodoc
highlighting module code... [ 61%] sphinx.ext.coverage
highlighting module code... [ 64%] sphinx.locale
highlighting module code... [ 66%] sphinx.parsers
highlighting module code... [ 69%] sphinx.project
highlighting module code... [ 71%] sphinx.transforms
highlighting module code... [ 73%] sphinx.transforms.post_transforms
highlighting module code... [ 76%] sphinx.transforms.post_transforms.images
highlighting module code... [ 78%] sphinx.util.docutils
highlighting module code... [ 80%] sphinx.util.logging
highlighting module code... [ 83%] sphinxcontrib.applehelp
highlighting module code... [ 85%] sphinxcontrib.devhelp
highlighting module code... [ 88%] sphinxcontrib.htmlhelp
highlighting module code... [ 90%] sphinxcontrib.qthelp
highlighting module code... [ 92%] sphinxcontrib.serializinghtml
highlighting module code... [ 95%] sphinxcontrib.websupport.core
highlighting module code... [ 97%] sphinxcontrib.websupport.search
highlighting module code... [100%] sphinxcontrib.websupport.storage

writing additional pages...  index search opensearchdone
copying images... [  7%] _static/translation.png
copying images... [ 15%] _static/more.png
copying images... [ 23%] _static/themes/alabaster.png
copying images... [ 30%] _static/themes/classic.png
copying images... [ 38%] _static/themes/sphinxdoc.png
copying images... [ 46%] _static/themes/scrolls.png
copying images... [ 53%] _static/themes/agogo.png
copying images... [ 61%] _static/themes/traditional.png
copying images... [ 69%] _static/themes/nature.png
copying images... [ 76%] _static/themes/haiku.png
copying images... [ 84%] _static/themes/pyramid.png
copying images... [ 92%] _static/themes/bizstyle.png
copying images... [100%] _static/themes/sphinx_rtd_theme.png

copying downloadable files... [ 50%] usage/extensions/example_google.py
copying downloadable files... [100%] usage/extensions/example_numpy.py

copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.
```

After:
```
Running Sphinx v2.4.3
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 5 changed, 0 removed
/tmp/tox/home/daniel/Vcs/sphinx/docs/lib/python3.8/site-packages/sphinxcontrib/websupport/__init__.py:18: RemovedInSphinx40Warning: sphinx.util.pycompat.htmlescape is deprecated. Check CHANGES for Sphinx API modifications.
  from sphinxcontrib.websupport.core import WebSupport  # NOQA
reading sources... [100%] usage/builders/index
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] usage/builders/index
generating indices...  genindex py-modindexdone
highlighting module code... [100%] sphinxcontrib.websupport.storage
writing additional pages...  index search opensearchdone
copying downloadable files... [100%] usage/extensions/example_numpy.py
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/sphinx/html.
```