### PR TITLE
Use "docs" extra on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,5 @@ jobs:
     steps:
       - checkout
       - run: /python3.6/bin/pip install -U pip setuptools
-      - run: /python3.6/bin/pip install -U .[test,websupport]
+      - run: /python3.6/bin/pip install -U .[test]
       - run: make test PYTHON=/python3.6/bin/python


### PR DESCRIPTION
"websupport" is not in `extras_require`.

It might not be necessary at all - but I expect it to result in more coverage likely.
If not necessary/wanted it should be removed instead.