### PR TITLE
Use a string with warning in `handle_signature`

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -334,7 +334,7 @@ class PyObject(ObjectDescription):
                 # it supports to represent optional arguments (ex. "func(foo [, bar])")
                 _pseudo_parse_arglist(signode, arglist)
             except NotImplementedError as exc:
-                logger.warning(exc)
+                logger.warning("could not parse arglist (%r): %s", arglist, exc)
                 _pseudo_parse_arglist(signode, arglist)
         else:
             if self.needs_arglist():


### PR DESCRIPTION
Previously it would pass in the exception object itself, which then
might crash filters that are using `record.msg.startswith` etc.

The warning was triggered for me with `sig = foo: int = -1`, where it
appears to not handle negative numbers (have not investigated, Python 3.8.1).

The code was added recently (c4d7f4d6c), so this is targeting 3.x.