### PR TITLE
Unpin coverage package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ markers =
 
 [coverage:run]
 branch = True
+parallel = True
 source = sphinx
 
 [coverage:report]

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ description =
     py{35,36,37,38,39}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.
 deps =
-    coverage < 5.0  # refs: https://github.com/sphinx-doc/sphinx/pull/6924
     git+https://github.com/html5lib/html5lib-python ; python_version >= "3.9"  # refs: https://github.com/html5lib/html5lib-python/issues/419
     du12: docutils==0.12
     du13: docutils==0.13.1


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
coverage-5.0 expects to set "parallel = True" on config file.
refs: https://github.com/nedbat/coveragepy/issues/716#issuecomment-429491441
