### PR TITLE
doc: Remove a mention to todo ext. from env-merge-info

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -268,11 +268,6 @@ connect handlers to the events.  Example:
    environment from the main process.  *docnames* is a set of document names
    that have been read in the subprocess.
 
-   For a sample of how to deal with this event, look at the standard
-   ``sphinx.ext.todo`` extension.  The implementation is often similar to that
-   of :event:`env-purge-doc`, only that information is not removed, but added to
-   the main environment from the other environment.
-
    .. versionadded:: 1.3
 
 .. event:: env-updated (app, env)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- ref: https://github.com/sphinx-doc/sphinx/commit/9abb4820b18201f63d77fdccb4ef394a21442f7a#commitcomment-37670215