### PR TITLE
[2.4.x] Specify the target Python version in the mypy configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ paths =
     .
 
 [mypy]
+python_version = 3.5
 disallow_incomplete_defs = True
 show_column_numbers = True
 show_error_context = True

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -56,8 +56,8 @@ if __version__.endswith('+'):
     __version__ = __version__[:-1]  # remove '+' for PEP-440 version spec.
     try:
         ret = subprocess.run(['git', 'show', '-s', '--pretty=format:%h'],
-                             stdout=PIPE, stderr=PIPE, encoding='ascii')
+                             stdout=PIPE, stderr=PIPE)
         if ret.stdout:
-            __display_version__ += '/' + ret.stdout.strip()
+            __display_version__ += '/' + ret.stdout.decode('ascii').strip()
     except Exception:
         pass


### PR DESCRIPTION
Subject: backport of https://github.com/sphinx-doc/sphinx/pull/6648 to fix mypy on 2.x

But this also appears to fix a real bug after all:

> This caught a bug. The subprocess.run() function only started taking the 'encoding' keyword argument starting with Python 3.6.


(cherry picked from commit acb2eadc8e692be4c8212cf1d3697e10e298a384)

Conflicts (trivial):
	setup.cfg

