### PR TITLE
Drop py35 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,19 @@ env:
 
 matrix:
   include:
-    - python: '3.5'
-      env:
-        - TOXENV=du12
     - python: '3.6'
       env:
-        - TOXENV=du13
+        - TOXENV=du14
     - python: '3.7'
       env:
-        - TOXENV=du14
+        - TOXENV=du15
     - python: '3.8'
       env:
-        - TOXENV=du15
+        - TOXENV=du16
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
     - python: 'nightly'
       env:
-        - TOXENV=du16
+        - TOXENV=py39
     - python: '3.6'
       env: TOXENV=docs
     - python: '3.6'

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Release 4.0.0 (in development)
 Dependencies
 ------------
 
+* Drop python 3.5 support
+
 Incompatible changes
 --------------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Dependencies
 ------------
 
 * Drop python 3.5 support
+* Drop docutils 0.12 and 0.13 support
 
 Incompatible changes
 --------------------

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,11 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.directives.patches.CSVTable``
+* ``sphinx.directives.patches.ListTable``
+* ``sphinx.directives.patches.RSTTable``
+* ``sphinx.util.smartypants``
+
 Features added
 --------------
 

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,26 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.directives.patches.CSVTable``
+     - 4.0
+     - 6.0
+     - ``docutils.parsers.rst.diretives.tables.CSVTable``
+
+   * - ``sphinx.directives.patches.ListTable``
+     - 4.0
+     - 6.0
+     - ``docutils.parsers.rst.diretives.tables.ListSVTable``
+
+   * - ``sphinx.directives.patches.RSTTable``
+     - 4.0
+     - 6.0
+     - ``docutils.parsers.rst.diretives.tables.RSTTable``
+
+   * - ``sphinx.util.smartypants``
+     - 4.0
+     - 6.0
+     - ``docutils.utils.smartyquotes``
+
    * - ``desc_signature['first']``
      -
      - 3.0

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -55,7 +55,7 @@ See the :ref:`pertinent section in the FAQ list <usingwith>`.
 Prerequisites
 -------------
 
-Sphinx needs at least **Python 3.5** to run.
+Sphinx needs at least **Python 3.6** to run.
 It also depends on 3rd party libraries such as docutils_ and jinja2_, but they
 are automatically installed when sphinx is installed.
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -467,11 +467,10 @@ General configuration
 
 .. confval:: smartquotes_action
 
-   This string, for use with Docutils ``0.14`` or later, customizes the Smart
-   Quotes transform.  See the file :file:`smartquotes.py` at the `Docutils
-   repository`__ for details.  The default ``'qDe'`` educates normal **q**\
-   uote characters ``"``, ``'``, em- and en-**D**\ ashes ``---``, ``--``, and
-   **e**\ llipses ``...``.
+   This string customizes the Smart Quotes transform.  See the file
+   :file:`smartquotes.py` at the `Docutils repository`__ for details.  The
+   default ``'qDe'`` educates normal **q**\ uote characters ``"``, ``'``,
+   em- and en-**D**\ ashes ``---``, ``--``, and **e**\ llipses ``...``.
 
    .. versionadded:: 1.6.6
 
@@ -1381,8 +1380,7 @@ that use Sphinx's HTMLWriter class.
 
 .. confval:: html_experimental_html5_writer
 
-   Output is processed with HTML5 writer.  This feature needs docutils 0.13 or
-   newer.  Default is ``False``.
+   Output is processed with HTML5 writer.  Default is ``False``.
 
    .. versionadded:: 1.6
 

--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -12,7 +12,7 @@ Installing Sphinx
 Overview
 --------
 
-Sphinx is written in `Python`__ and supports Python 3.5+.
+Sphinx is written in `Python`__ and supports Python 3.6+.
 
 __ https://docs.python-guide.org/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ paths =
     .
 
 [mypy]
-python_version = 3.5
+python_version = 3.6
 disallow_incomplete_defs = True
 show_column_numbers = True
 show_error_context = True

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'sphinxcontrib-qthelp',
     'Jinja2>=2.3',
     'Pygments>=2.0',
-    'docutils>=0.12',
+    'docutils>=0.14',
     'snowballstemmer>=1.1',
     'babel>=1.3',
     'alabaster>=0.7,<0.8',

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ import sphinx
 with open('README.rst') as f:
     long_desc = f.read()
 
-if sys.version_info < (3, 5):
-    print('ERROR: Sphinx requires at least Python 3.5 to run.')
+if sys.version_info < (3, 6):
+    print('ERROR: Sphinx requires at least Python 3.6 to run.')
     sys.exit(1)
 
 install_requires = [
@@ -198,7 +198,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
@@ -238,7 +237,7 @@ setup(
             'build_sphinx = sphinx.setup_command:BuildDoc',
         ],
     },
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require=extras_require,
     cmdclass=cmdclass,

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -19,10 +19,6 @@ from subprocess import PIPE
 
 from .deprecation import RemovedInNextVersionWarning
 
-if False:
-    # For type annotation
-    from typing import Any  # NOQA
-
 
 # by default, all DeprecationWarning under sphinx package will be emit.
 # Users can avoid this by using environment variable: PYTHONWARNINGS=

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -56,8 +56,8 @@ if __version__.endswith('+'):
     __version__ = __version__[:-1]  # remove '+' for PEP-440 version spec.
     try:
         ret = subprocess.run(['git', 'show', '-s', '--pretty=format:%h'],
-                             stdout=PIPE, stderr=PIPE)
+                             stdout=PIPE, stderr=PIPE, encoding='ascii')
         if ret.stdout:
-            __display_version__ += '/' + ret.stdout.decode('ascii').strip()
+            __display_version__ += '/' + ret.stdout.strip()
     except Exception:
         pass

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -10,14 +10,14 @@
 
 import warnings
 from typing import Any, Dict, List, Sequence
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Node
 
 from sphinx.deprecation import RemovedInSphinx40Warning
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -19,6 +19,7 @@ from collections import deque
 from io import StringIO
 from os import path
 from typing import Any, Callable, Dict, IO, List, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Element, TextElement
@@ -53,9 +54,7 @@ from sphinx.util.osutil import abspath, ensuredir, relpath
 from sphinx.util.tags import Tags
 from sphinx.util.typing import RoleFunction, TitleGetter
 
-if False:
-    # For type annotation
-    from docutils.nodes import Node  # NOQA
+if TYPE_CHECKING:
     from sphinx.builders import Builder
 
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -18,7 +18,7 @@ import warnings
 from collections import deque
 from io import StringIO
 from os import path
-from typing import Any, Callable, Dict, IO, List, Tuple, Union
+from typing import Any, Callable, Dict, IO, List, Tuple, Type, Union
 
 from docutils import nodes
 from docutils.nodes import Element, TextElement
@@ -56,7 +56,6 @@ from sphinx.util.typing import RoleFunction, TitleGetter
 if False:
     # For type annotation
     from docutils.nodes import Node  # NOQA
-    from typing import Type  # for python3.5.1
     from sphinx.builders import Builder
 
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -12,6 +12,7 @@ import pickle
 import time
 from os import path
 from typing import Any, Dict, Iterable, List, Sequence, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -42,8 +43,7 @@ try:
 except ImportError:
     multiprocessing = None
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -11,7 +11,7 @@
 import pickle
 import time
 from os import path
-from typing import Any, Dict, Iterable, List, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Sequence, Set, Tuple, Type, Union
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -44,7 +44,6 @@ except ImportError:
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
 
 

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -12,9 +12,8 @@ import html
 import os
 import re
 import warnings
-from collections import namedtuple
 from os import path
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, NamedTuple, Set, Tuple
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 
 from docutils import nodes
@@ -85,10 +84,30 @@ VECTOR_GRAPHICS_EXTENSIONS = ('.svg',)
 REFURI_RE = re.compile("([^#:]*#)(.*)")
 
 
-ManifestItem = namedtuple('ManifestItem', ['href', 'id', 'media_type'])
-Spine = namedtuple('Spine', ['idref', 'linear'])
-Guide = namedtuple('Guide', ['type', 'title', 'uri'])
-NavPoint = namedtuple('NavPoint', ['navpoint', 'playorder', 'text', 'refuri', 'children'])
+class ManifestItem(NamedTuple):
+    href: str
+    id: str
+    media_type: str
+
+
+class Spine(NamedTuple):
+    idref: str
+    linear: bool
+
+
+class Guide(NamedTuple):
+    type: str
+    title: str
+    uri: str
+
+
+class NavPoint(NamedTuple):
+    navpoint: str
+    playorder: int
+    text: str
+    refuri: str
+    children: List[Any]     # mypy does not support recursive types
+                            # https://github.com/python/mypy/issues/7069
 
 
 def sphinx_smarty_pants(t: str, language: str = 'en') -> str:
@@ -635,7 +654,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         the parent node is reinserted in the subnav.
         """
         navstack = []  # type: List[NavPoint]
-        navstack.append(NavPoint('dummy', '', '', '', []))
+        navstack.append(NavPoint('dummy', 0, '', '', []))
         level = 0
         lastnode = None
         for node in nodes:

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -11,9 +11,8 @@
 
 import html
 import warnings
-from collections import namedtuple
 from os import path
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, NamedTuple, Set, Tuple
 
 from sphinx import package_dir
 from sphinx.application import Sphinx
@@ -29,7 +28,12 @@ from sphinx.util.osutil import make_filename
 logger = logging.getLogger(__name__)
 
 
-NavPoint = namedtuple('NavPoint', ['text', 'refuri', 'children'])
+class NavPoint(NamedTuple):
+    text: str
+    refuri: str
+    children: List[Any]     # mypy does not support recursive types
+                            # https://github.com/python/mypy/issues/7069
+
 
 # writing modes
 PAGE_PROGRESSION_DIRECTIONS = {

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -13,7 +13,7 @@ from collections import defaultdict, OrderedDict
 from datetime import datetime, tzinfo, timedelta
 from os import path, walk, getenv
 from time import time
-from typing import Any, Dict, Iterable, Generator, List, Set, Tuple, Union
+from typing import Any, DefaultDict, Dict, Iterable, Generator, List, Set, Tuple, Union
 from uuid import uuid4
 
 from docutils import nodes
@@ -33,10 +33,6 @@ from sphinx.util.nodes import extract_messages, traverse_translatable_index
 from sphinx.util.osutil import ensuredir, canon_path, relpath
 from sphinx.util.tags import Tags
 from sphinx.util.template import SphinxRenderer
-
-if False:
-    # For type annotation
-    from typing import DefaultDict  # for python3.5.1
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -15,7 +15,7 @@ import sys
 import warnings
 from hashlib import md5
 from os import path
-from typing import Any, Dict, IO, Iterable, Iterator, List, Set, Tuple
+from typing import Any, Dict, IO, Iterable, Iterator, List, Set, Tuple, Type
 
 from docutils import nodes
 from docutils.core import publish_parts
@@ -47,10 +47,6 @@ from sphinx.util.matching import patmatch, Matcher, DOTFILES
 from sphinx.util.osutil import os_path, relative_uri, ensuredir, movefile, copyfile
 from sphinx.util.tags import Tags
 from sphinx.writers.html import HTMLWriter, HTMLTranslator
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 # HTML5 Writer is available or not

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -9,7 +9,7 @@
 """
 
 from os import path
-from typing import Any, Dict, Iterator, Set, Union
+from typing import Any, Dict, Iterator, Set, Type, Union
 
 from docutils import nodes
 from docutils.io import StringOutput
@@ -22,10 +22,6 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 from sphinx.writers.xml import XMLWriter, PseudoXMLWriter
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -39,9 +39,11 @@ CONFIG_FILENAME = 'conf.py'
 UNSERIALIZABLE_TYPES = (type, types.ModuleType, types.FunctionType)
 copyright_year_re = re.compile(r'^((\d{4}-)?)(\d{4})(?=[ ,])')
 
-ConfigValue = NamedTuple('ConfigValue', [('name', str),
-                                         ('value', Any),
-                                         ('rebuild', Union[bool, str])])
+
+class ConfigValue(NamedTuple):
+    name: str
+    value: Any
+    rebuild: Union[bool, str]
 
 
 def is_serializable(obj: Any) -> bool:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -17,6 +17,7 @@ from os import path, getenv
 from typing import (
     Any, Callable, Dict, Generator, Iterator, List, NamedTuple, Set, Tuple, Union
 )
+from typing import TYPE_CHECKING
 
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.errors import ConfigError, ExtensionError
@@ -28,8 +29,7 @@ from sphinx.util.pycompat import execfile_
 from sphinx.util.tags import Tags
 from sphinx.util.typing import NoneType
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/deprecation.py
+++ b/sphinx/deprecation.py
@@ -23,6 +23,10 @@ class RemovedInSphinx50Warning(PendingDeprecationWarning):
     pass
 
 
+class RemovedInSphinx60Warning(PendingDeprecationWarning):
+    pass
+
+
 RemovedInNextVersionWarning = RemovedInSphinx40Warning
 
 

--- a/sphinx/deprecation.py
+++ b/sphinx/deprecation.py
@@ -11,8 +11,7 @@
 import sys
 import warnings
 from importlib import import_module
-from typing import Any, Dict
-from typing import Type  # for python3.5.1
+from typing import Any, Dict, Type
 
 
 class RemovedInSphinx40Warning(DeprecationWarning):

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -10,7 +10,7 @@
 
 import re
 from typing import Any, Dict, List, Tuple
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -26,8 +26,7 @@ from sphinx.util.docfields import DocFieldTransformer, Field, TypedField
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.typing import DirectiveOption
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 from difflib import unified_diff
 from typing import Any, Dict, List, Tuple
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -24,8 +25,7 @@ from sphinx.util import logging
 from sphinx.util import parselinenos
 from sphinx.util.docutils import SphinxDirective
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 logger = logging.getLogger(__name__)

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -8,7 +8,7 @@
 
 import re
 from typing import Any, Dict, List
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -26,8 +26,7 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.matching import Matcher, patfilter
 from sphinx.util.nodes import explicit_title_re
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -6,6 +6,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import warnings
 from typing import Any, Dict, List, Tuple
 from typing import cast
 
@@ -15,6 +16,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives import images, html, tables
 
 from sphinx import addnodes
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.directives import optional_int
 from sphinx.domains.math import MathDomain
 from sphinx.util.docutils import SphinxDirective
@@ -73,6 +75,11 @@ class RSTTable(tables.RSTTable):
 
     Only for docutils-0.13 or older version."""
 
+    def run(self) -> List[Node]:
+        warnings.warn('RSTTable is deprecated.',
+                      RemovedInSphinx60Warning)
+        return super().run()
+
     def make_title(self) -> Tuple[nodes.title, List[system_message]]:
         title, message = super().make_title()
         if title:
@@ -86,6 +93,11 @@ class CSVTable(tables.CSVTable):
 
     Only for docutils-0.13 or older version."""
 
+    def run(self) -> List[Node]:
+        warnings.warn('RSTTable is deprecated.',
+                      RemovedInSphinx60Warning)
+        return super().run()
+
     def make_title(self) -> Tuple[nodes.title, List[system_message]]:
         title, message = super().make_title()
         if title:
@@ -98,6 +110,11 @@ class ListTable(tables.ListTable):
     """The list-table directive which sets source and line information to its caption.
 
     Only for docutils-0.13 or older version."""
+
+    def run(self) -> List[Node]:
+        warnings.warn('RSTTable is deprecated.',
+                      RemovedInSphinx60Warning)
+        return super().run()
 
     def make_title(self) -> Tuple[nodes.title, List[system_message]]:
         title, message = super().make_title()
@@ -209,9 +226,6 @@ class MathDirective(SphinxDirective):
 def setup(app: "Sphinx") -> Dict[str, Any]:
     directives.register_directive('figure', Figure)
     directives.register_directive('meta', Meta)
-    directives.register_directive('table', RSTTable)
-    directives.register_directive('csv-table', CSVTable)
-    directives.register_directive('list-table', ListTable)
     directives.register_directive('code', Code)
     directives.register_directive('math', MathDirective)
 

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -8,7 +8,7 @@
 
 import warnings
 from typing import Any, Dict, List, Tuple
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Node, make_id, system_message
@@ -22,8 +22,7 @@ from sphinx.domains.math import MathDomain
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import set_source_info
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -10,7 +10,7 @@
 """
 
 import copy
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Tuple, Type, Union
 from typing import cast
 
 from docutils import nodes
@@ -25,7 +25,6 @@ from sphinx.util.typing import RoleFunction
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -11,7 +11,7 @@
 
 import copy
 from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Tuple, Type, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, system_message
@@ -23,8 +23,7 @@ from sphinx.locale import _
 from sphinx.roles import XRefRole
 from sphinx.util.typing import RoleFunction
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -8,8 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from collections import namedtuple
-from typing import Any, Dict, List
+from typing import Any, Dict, List, NamedTuple
 from typing import cast
 
 from docutils import nodes
@@ -40,9 +39,13 @@ versionlabel_classes = {
 }
 
 
-# TODO: move to typing.NamedTuple after dropping py35 support (see #5958)
-ChangeSet = namedtuple('ChangeSet',
-                       ['type', 'docname', 'lineno', 'module', 'descname', 'content'])
+class ChangeSet(NamedTuple):
+    type: str
+    docname: str
+    lineno: int
+    module: str
+    descname: str
+    content: str
 
 
 class VersionChange(SphinxDirective):

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -9,7 +9,7 @@
 """
 
 from typing import Any, Dict, List, NamedTuple
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -20,8 +20,7 @@ from sphinx.locale import _
 from sphinx.util.docutils import SphinxDirective
 
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/domains/citation.py
+++ b/sphinx/domains/citation.py
@@ -9,7 +9,7 @@
 """
 
 from typing import Any, Dict, List, Set, Tuple
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element
@@ -21,8 +21,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx.util import logging
 from sphinx.util.nodes import copy_source_info, make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -9,6 +9,7 @@
 """
 
 from typing import Any, Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Node, system_message
@@ -22,8 +23,7 @@ from sphinx.util import split_index_msg
 from sphinx.util.docutils import ReferenceRole, SphinxDirective
 from sphinx.util.nodes import process_index_entry
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/domains/math.py
+++ b/sphinx/domains/math.py
@@ -10,6 +10,7 @@
 
 import warnings
 from typing import Any, Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Element, Node, system_message
@@ -24,8 +25,7 @@ from sphinx.roles import XRefRole
 from sphinx.util import logging
 from sphinx.util.nodes import make_refnode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -14,7 +14,7 @@ import re
 import typing
 import warnings
 from inspect import Parameter
-from typing import Any, Dict, Iterable, Iterator, List, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Tuple, Type
 from typing import cast
 
 from docutils import nodes
@@ -37,10 +37,6 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.inspect import signature_from_str
 from sphinx.util.nodes import make_id, make_refnode
 from sphinx.util.typing import TextlikeNode
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -12,7 +12,7 @@ import re
 import unicodedata
 import warnings
 from copy import copy
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Type, Union
 from typing import cast
 
 from docutils import nodes
@@ -34,7 +34,6 @@ from sphinx.util.typing import RoleFunction
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -13,7 +13,7 @@ import unicodedata
 import warnings
 from copy import copy
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Type, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, system_message
@@ -32,8 +32,7 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import clean_astext, make_id, make_refnode
 from sphinx.util.typing import RoleFunction
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 from copy import copy
 from os import path
 from typing import Any, Callable, Dict, Generator, Iterator, List, Set, Tuple, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -36,8 +36,7 @@ from sphinx.util.docutils import LoggingReporter
 from sphinx.util.i18n import CatalogRepository, docname_to_domain
 from sphinx.util.nodes import is_translatable
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
 

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -9,7 +9,7 @@
 """
 
 from typing import Any, Iterable, List
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -20,8 +20,7 @@ from sphinx.util import url_re, logging
 from sphinx.util.matching import Matcher
 from sphinx.util.nodes import clean_astext, process_only_nodes
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/environment/collectors/__init__.py
+++ b/sphinx/environment/collectors/__init__.py
@@ -9,13 +9,13 @@
 """
 
 from typing import Dict, List, Set
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 
 from sphinx.environment import BuildEnvironment
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from typing import Any, Dict, List, Set, Tuple, TypeVar
+from typing import Any, Dict, List, Set, Tuple, Type, TypeVar
 from typing import cast
 
 from docutils import nodes
@@ -22,10 +22,6 @@ from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.locale import __
 from sphinx.transforms import SphinxContentsFilter
 from sphinx.util import url_re, logging
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 N = TypeVar('N')

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -14,14 +14,14 @@ import warnings
 from collections import defaultdict
 from operator import attrgetter
 from typing import Any, Callable, Dict, List, NamedTuple
+from typing import TYPE_CHECKING
 
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -15,6 +15,7 @@ import re
 import warnings
 from types import ModuleType
 from typing import Any, Callable, Dict, Iterator, List, Sequence, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
 from docutils.statemachine import StringList
 
@@ -34,8 +35,7 @@ from sphinx.util.docstrings import extract_metadata, prepare_docstring
 from sphinx.util.inspect import getdoc, object_description, safe_getattr, stringify_signature
 from sphinx.util.typing import stringify as stringify_typehint
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.ext.autodoc.directive import DocumenterBridge
 
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -14,7 +14,7 @@ import importlib
 import re
 import warnings
 from types import ModuleType
-from typing import Any, Callable, Dict, Iterator, List, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Sequence, Set, Tuple, Type, Union
 
 from docutils.statemachine import StringList
 
@@ -36,7 +36,6 @@ from sphinx.util.typing import stringify as stringify_typehint
 
 if False:
     # For type annotation
-    from typing import Type  # NOQA # for python3.5.1
     from sphinx.ext.autodoc.directive import DocumenterBridge
 
 
@@ -262,7 +261,7 @@ class Documenter:
         self.analyzer = None        # type: ModuleAnalyzer
 
     @property
-    def documenters(self) -> Dict[str, "Type[Documenter]"]:
+    def documenters(self) -> Dict[str, Type["Documenter"]]:
         """Returns registered Documenter classes"""
         return get_documenters(self.env.app)
 
@@ -1591,7 +1590,7 @@ class SlotsAttributeDocumenter(AttributeDocumenter):
             return []
 
 
-def get_documenters(app: Sphinx) -> Dict[str, "Type[Documenter]"]:
+def get_documenters(app: Sphinx) -> Dict[str, Type[Documenter]]:
     """Returns registered Documenter classes"""
     return app.registry.documenters
 

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -7,7 +7,7 @@
 """
 
 import warnings
-from typing import Any, Callable, Dict, List, Set
+from typing import Any, Callable, Dict, List, Set, Type
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -22,10 +22,6 @@ from sphinx.ext.autodoc import Documenter, Options, get_documenters
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective, switch_source_input
 from sphinx.util.nodes import nested_parse_with_titles
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -11,8 +11,7 @@
 import importlib
 import traceback
 import warnings
-from collections import namedtuple
-from typing import Any, Callable, Dict, List, Mapping, Tuple
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Tuple
 
 from sphinx.deprecation import RemovedInSphinx40Warning, deprecated_alias
 from sphinx.util import logging
@@ -122,7 +121,10 @@ def get_module_members(module: Any) -> List[Tuple[str, Any]]:
     return sorted(list(members.values()))
 
 
-Attribute = namedtuple('Attribute', ['name', 'directly_defined', 'value'])
+class Attribute(NamedTuple):
+    name: str
+    directly_defined: bool
+    value: Any
 
 
 def get_object_members(subject: Any, objpath: List[str], attrgetter: Callable,

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -60,7 +60,7 @@ import sys
 import warnings
 from os import path
 from types import ModuleType
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Type
 from typing import cast
 
 from docutils import nodes
@@ -87,10 +87,6 @@ from sphinx.util.docutils import (
 )
 from sphinx.util.matching import Matcher
 from sphinx.writers.html import HTMLTranslator
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -24,7 +24,7 @@ import pydoc
 import re
 import sys
 import warnings
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, List, Set, Tuple, Type
 
 from jinja2 import BaseLoader, FileSystemLoader, TemplateNotFound
 from jinja2.sandbox import SandboxedEnvironment
@@ -43,10 +43,6 @@ from sphinx.util import logging
 from sphinx.util import rst
 from sphinx.util.inspect import safe_getattr
 from sphinx.util.osutil import ensuredir
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -16,7 +16,7 @@ import time
 import warnings
 from io import StringIO
 from os import path
-from typing import Any, Callable, Dict, Iterable, List, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Sequence, Set, Tuple, Type
 
 from docutils import nodes
 from docutils.nodes import Element, Node, TextElement
@@ -35,7 +35,6 @@ from sphinx.util.osutil import relpath
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
 
 

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -17,6 +17,7 @@ import warnings
 from io import StringIO
 from os import path
 from typing import Any, Callable, Dict, Iterable, List, Sequence, Set, Tuple, Type
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Element, Node, TextElement
@@ -33,8 +34,7 @@ from sphinx.util.console import bold  # type: ignore
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.osutil import relpath
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -86,8 +86,8 @@ DOC_BODY_PREVIEW = r'''
 \end{document}
 '''
 
-depth_re = re.compile(br'\[\d+ depth=(-?\d+)\]')
-depthsvg_re = re.compile(br'.*, depth=(.*)pt')
+depth_re = re.compile(r'\[\d+ depth=(-?\d+)\]')
+depthsvg_re = re.compile(r'.*, depth=(.*)pt')
 depthsvgcomment_re = re.compile(r'<!-- DEPTH=(-?\d+) -->')
 
 
@@ -175,10 +175,10 @@ def compile_math(latex: str, builder: Builder) -> str:
         raise MathExtError('latex exited with error', exc.stderr, exc.stdout)
 
 
-def convert_dvi_to_image(command: List[str], name: str) -> Tuple[bytes, bytes]:
+def convert_dvi_to_image(command: List[str], name: str) -> Tuple[str, str]:
     """Convert DVI file to specific image format."""
     try:
-        ret = subprocess.run(command, stdout=PIPE, stderr=PIPE, check=True)
+        ret = subprocess.run(command, stdout=PIPE, stderr=PIPE, check=True, encoding='ascii')
         return ret.stdout, ret.stderr
     except OSError:
         logger.warning(__('%s command %r cannot be run (needed for math '

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -13,16 +13,12 @@
 import inspect
 import re
 from functools import partial
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.locale import _
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 _directive_regex = re.compile(r'\.\. \S+::')

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -9,14 +9,14 @@
 """
 
 from typing import Any, Dict
+from typing import TYPE_CHECKING
 
 from sphinx.config import Config
 from sphinx.errors import VersionRequirementError
 from sphinx.locale import __
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 logger = logging.getLogger(__name__)

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -10,6 +10,7 @@
 import codecs
 import warnings
 from typing import Any, List, Type
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.core import Publisher
@@ -37,8 +38,7 @@ from sphinx.util import UnicodeDecodeErrorHandler
 from sphinx.util.docutils import LoggingReporter
 from sphinx.versioning import UIDTransform
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -9,8 +9,7 @@
 """
 import codecs
 import warnings
-from typing import Any, List
-from typing import Type  # for python3.5.1
+from typing import Any, List, Type
 
 from docutils import nodes
 from docutils.core import Publisher

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -11,6 +11,7 @@
 from os import path
 from pprint import pformat
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
+from typing import TYPE_CHECKING
 
 from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, contextfunction
 from jinja2.environment import Environment
@@ -22,8 +23,7 @@ from sphinx.theming import Theme
 from sphinx.util import logging
 from sphinx.util.osutil import mtimes_of_files
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders import Builder
 
 

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -9,7 +9,7 @@
 """
 
 import warnings
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, Union
 
 import docutils.parsers
 import docutils.parsers.rst
@@ -24,7 +24,6 @@ from sphinx.util.rst import append_epilog, prepend_prolog
 if False:
     # For type annotation
     from docutils.transforms import Transform  # NOQA
-    from typing import Type  # NOQA # for python3.5.1
     from sphinx.application import Sphinx
 
 
@@ -71,7 +70,7 @@ class Parser(docutils.parsers.Parser):
 class RSTParser(docutils.parsers.rst.Parser, Parser):
     """A reST parser for Sphinx."""
 
-    def get_transforms(self) -> List["Type[Transform]"]:
+    def get_transforms(self) -> List[Type[Transform]]:
         """Sphinx's reST parser replaces a transform class for smart-quotes by own's
 
         refs: sphinx.io.SphinxStandaloneReader

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -10,6 +10,7 @@
 
 import warnings
 from typing import Any, Dict, List, Type, Union
+from typing import TYPE_CHECKING
 
 import docutils.parsers
 import docutils.parsers.rst
@@ -21,8 +22,7 @@ from docutils.transforms.universal import SmartQuotes
 from sphinx.deprecation import RemovedInSphinx50Warning
 from sphinx.util.rst import append_epilog, prepend_prolog
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from docutils.transforms import Transform  # NOQA
     from sphinx.application import Sphinx
 
@@ -70,7 +70,7 @@ class Parser(docutils.parsers.Parser):
 class RSTParser(docutils.parsers.rst.Parser, Parser):
     """A reST parser for Sphinx."""
 
-    def get_transforms(self) -> List[Type[Transform]]:
+    def get_transforms(self) -> List[Type["Transform"]]:
         """Sphinx's reST parser replaces a transform class for smart-quotes by own's
 
         refs: sphinx.io.SphinxStandaloneReader

--- a/sphinx/project.py
+++ b/sphinx/project.py
@@ -9,6 +9,7 @@
 """
 
 import os
+from typing import TYPE_CHECKING
 
 from sphinx.locale import __
 from sphinx.util import get_matching_files
@@ -17,9 +18,8 @@ from sphinx.util import path_stabilize
 from sphinx.util.matching import compile_matchers
 from sphinx.util.osutil import SEP, relpath
 
-if False:
-    # For type annotation
-    from typing import Dict, List, Set  # NOQA
+if TYPE_CHECKING:
+    from typing import Dict, List, Set
 
 
 logger = logging.getLogger(__name__)

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -349,7 +349,7 @@ class VariableCommentPicker(ast.NodeVisitor):
         for varname in varnames:
             self.add_entry(varname)
 
-    def visit_AnnAssign(self, node: ast.AST) -> None:  # Note: ast.AnnAssign not found in py35
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         """Handles AnnAssign node and pick up a variable comment."""
         self.visit_Assign(node)  # type: ignore
 

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -11,7 +11,7 @@
 import traceback
 from importlib import import_module
 from types import MethodType
-from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, Union
 
 from docutils import nodes
 from docutils.io import Input
@@ -37,7 +37,6 @@ from sphinx.util.typing import RoleFunction, TitleGetter
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
     from sphinx.ext.autodoc import Documenter
 

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -12,6 +12,7 @@ import traceback
 from importlib import import_module
 from types import MethodType
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.io import Input
@@ -35,8 +36,7 @@ from sphinx.util import logging
 from sphinx.util.logging import prefixed_warnings
 from sphinx.util.typing import RoleFunction, TitleGetter
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.ext.autodoc import Documenter
 

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -11,6 +11,7 @@
 import re
 import warnings
 from typing import Any, Dict, List, Tuple, Type
+from typing import TYPE_CHECKING
 
 from docutils import nodes, utils
 from docutils.nodes import Element, Node, TextElement, system_message
@@ -26,8 +27,7 @@ from sphinx.util.nodes import (
 )
 from sphinx.util.typing import RoleFunction
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -10,8 +10,7 @@
 
 import re
 import warnings
-from typing import Any, Dict, List, Tuple
-from typing import Type  # for python3.5.1
+from typing import Any, Dict, List, Tuple, Type
 
 from docutils import nodes, utils
 from docutils.nodes import Element, Node, TextElement, system_message

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -13,7 +13,7 @@ import re
 import warnings
 from importlib import import_module
 from os import path
-from typing import Any, Dict, IO, Iterable, List, Tuple, Set
+from typing import Any, Dict, IO, Iterable, List, Tuple, Set, Type
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -24,10 +24,6 @@ from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.environment import BuildEnvironment
 from sphinx.search.jssplitter import splitter_code
 from sphinx.util import jsdump, rpartition
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 
 class SearchLanguage:

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -16,6 +16,7 @@ import sys
 from distutils.cmd import Command
 from distutils.errors import DistutilsOptionError, DistutilsExecError
 from io import StringIO
+from typing import TYPE_CHECKING
 
 from sphinx.application import Sphinx
 from sphinx.cmd.build import handle_exception
@@ -23,9 +24,8 @@ from sphinx.util.console import nocolor, color_terminal
 from sphinx.util.docutils import docutils_namespace, patch_docutils
 from sphinx.util.osutil import abspath
 
-if False:
-    # For type annotation
-    from typing import Any, Dict  # NOQA
+if TYPE_CHECKING:
+    from typing import Any, Dict
 
 
 class BuildDoc(Command):

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -76,7 +76,6 @@ def app_params(request: Any, test_params: Dict, shared_result: SharedResult,
     args = [pargs[i] for i in sorted(pargs.keys())]
 
     # ##### process pytest.mark.test_params
-
     if test_params['shared_result']:
         if 'srcdir' in kwargs:
             raise pytest.Exception('You can not spcify shared_result and '

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -14,6 +14,7 @@ import shutil
 import tempfile
 from os import path
 from typing import Any, Dict, List
+from typing import TYPE_CHECKING
 from zipfile import ZipFile
 
 import pkg_resources
@@ -24,8 +25,7 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.osutil import ensuredir
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -10,6 +10,7 @@
 
 import re
 from typing import Any, Dict, Generator, List, Tuple
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Element, Node, Text
@@ -28,8 +29,7 @@ from sphinx.util.docutils import new_document
 from sphinx.util.i18n import format_date
 from sphinx.util.nodes import NodeMatcher, apply_source_workaround, is_smartquotable
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.domain.std import StandardDomain
     from sphinx.environment import BuildEnvironment

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -10,7 +10,7 @@
 
 from os import path
 from textwrap import indent
-from typing import Any, Dict, List, Tuple, TypeVar
+from typing import Any, Dict, List, Tuple, Type, TypeVar
 
 from docutils import nodes
 from docutils.io import StringInput
@@ -31,7 +31,6 @@ from sphinx.util.nodes import (
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
 
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -11,6 +11,7 @@
 from os import path
 from textwrap import indent
 from typing import Any, Dict, List, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.io import StringInput
@@ -29,8 +30,7 @@ from sphinx.util.nodes import (
     extract_messages, is_pending_meta, traverse_translatable_index,
 )
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/transforms/references.py
+++ b/sphinx/transforms/references.py
@@ -9,14 +9,14 @@
 """
 
 from typing import Any, Dict
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.transforms.references import DanglingReferences, Substitutions
 
 from sphinx.transforms import SphinxTransform
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -25,7 +25,7 @@ from hashlib import md5
 from importlib import import_module
 from os import path
 from time import mktime, strptime
-from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, Set, Tuple
+from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, Set, Tuple, Type
 from urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 
 from sphinx.deprecation import RemovedInSphinx40Warning
@@ -51,7 +51,6 @@ from sphinx.util.matching import patfilter  # noqa
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
 
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -26,6 +26,7 @@ from importlib import import_module
 from os import path
 from time import mktime, strptime
 from typing import Any, Callable, Dict, IO, Iterable, Iterator, List, Pattern, Set, Tuple, Type
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit, quote_plus, parse_qsl, urlencode
 
 from sphinx.deprecation import RemovedInSphinx40Warning
@@ -49,8 +50,7 @@ from sphinx.util.nodes import (   # noqa
 from sphinx.util.matching import patfilter  # noqa
 
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/util/compat.py
+++ b/sphinx/util/compat.py
@@ -11,6 +11,7 @@
 import sys
 import warnings
 from typing import Any, Dict
+from typing import TYPE_CHECKING
 
 from docutils.utils import get_source_line
 
@@ -18,8 +19,7 @@ from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.transforms import SphinxTransform
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -10,7 +10,7 @@
 """
 
 import warnings
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Type, Union
 from typing import cast
 
 from docutils import nodes
@@ -22,7 +22,6 @@ from sphinx.util.typing import TextlikeNode
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.environment import BuildEnvironment
     from sphinx.directive import ObjectDescription
 

--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -11,7 +11,7 @@
 
 import warnings
 from typing import Any, Dict, List, Tuple, Type, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -20,8 +20,7 @@ from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.util.typing import TextlikeNode
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
     from sphinx.directive import ObjectDescription
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 from os import path
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, IO, List, Optional, Set, Tuple, Type
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import docutils
 from docutils import nodes
@@ -34,8 +34,7 @@ from sphinx.util.typing import RoleFunction
 logger = logging.getLogger(__name__)
 report_re = re.compile('^(.+?:(?:\\d+)?): \\((DEBUG|INFO|WARNING|ERROR|SEVERE)/(\\d+)?\\) ')
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders import Builder
     from sphinx.config import Config
     from sphinx.environment import BuildEnvironment

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -15,7 +15,7 @@ from copy import copy
 from distutils.version import LooseVersion
 from os import path
 from types import ModuleType
-from typing import Any, Callable, Dict, Generator, IO, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Generator, IO, List, Optional, Set, Tuple, Type
 from typing import cast
 
 import docutils
@@ -36,7 +36,6 @@ report_re = re.compile('^(.+?:(?:\\d+)?): \\((DEBUG|INFO|WARNING|ERROR|SEVERE)/(
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.builders import Builder
     from sphinx.config import Config
     from sphinx.environment import BuildEnvironment

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -11,14 +11,14 @@
 import os
 import posixpath
 from typing import Dict
+from typing import TYPE_CHECKING
 
 from docutils.utils import relative_path
 
 from sphinx.util.osutil import copyfile, ensuredir
 from sphinx.util.typing import PathMatcher
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.util.template import BaseRenderer
 
 

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -14,6 +14,7 @@ import warnings
 from datetime import datetime, timezone
 from os import path
 from typing import Callable, Generator, List, NamedTuple, Set, Tuple
+from typing import TYPE_CHECKING
 
 import babel.dates
 from babel.messages.mofile import write_mo
@@ -26,8 +27,7 @@ from sphinx.util import logging
 from sphinx.util.matching import Matcher
 from sphinx.util.osutil import SEP, canon_path, relpath
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -11,10 +11,9 @@ import gettext
 import os
 import re
 import warnings
-from collections import namedtuple
 from datetime import datetime, timezone
 from os import path
-from typing import Callable, Generator, List, Set, Tuple
+from typing import Callable, Generator, List, NamedTuple, Set, Tuple
 
 import babel.dates
 from babel.messages.mofile import write_mo
@@ -34,7 +33,11 @@ if False:
 
 logger = logging.getLogger(__name__)
 
-LocaleFileInfoBase = namedtuple('CatalogInfo', 'base_dir,domain,charset')
+
+class LocaleFileInfoBase(NamedTuple):
+    base_dir: str
+    domain: str
+    charset: str
 
 
 class CatalogInfo(LocaleFileInfoBase):

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Mapping, List, Tuple
 from typing import cast
 
 from sphinx.deprecation import RemovedInSphinx40Warning, RemovedInSphinx50Warning
-from sphinx.pycode.ast import ast  # for py35-37
+from sphinx.pycode.ast import ast  # for py36-37
 from sphinx.pycode.ast import unparse as ast_unparse
 from sphinx.util import logging
 from sphinx.util.typing import stringify as stringify_annotation

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -11,6 +11,7 @@ import os
 import re
 import zlib
 from typing import Callable, IO, Iterator
+from typing import TYPE_CHECKING
 
 from sphinx.util import logging
 from sphinx.util.typing import Inventory
@@ -19,8 +20,7 @@ from sphinx.util.typing import Inventory
 BUFSIZE = 16 * 1024
 logger = logging.getLogger(__name__)
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -12,7 +12,7 @@ import logging
 import logging.handlers
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, IO, List, Tuple, Union
+from typing import Any, Dict, Generator, IO, List, Tuple, Type, Union
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -23,7 +23,6 @@ from sphinx.util.console import colorize
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
 
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -13,6 +13,7 @@ import logging.handlers
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, IO, List, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -21,8 +22,7 @@ from docutils.utils import get_source_line
 from sphinx.errors import SphinxWarning
 from sphinx.util.console import colorize
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -11,7 +11,7 @@
 import re
 import warnings
 from typing import Any, Callable, Iterable, List, Set, Tuple, Type
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -24,8 +24,7 @@ from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.locale import __
 from sphinx.util import logging
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
     from sphinx.utils.tags import Tags

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -537,10 +537,12 @@ def process_only_nodes(document: Node, tags: "Tags") -> None:
                 node.replace_self(nodes.comment())
 
 
-# monkey-patch Element.copy to copy the rawsource and line
-# for docutils-0.14 or older versions.
-
 def _new_copy(self: Element) -> Element:
+    """monkey-patch Element.copy to copy the rawsource and line
+    for docutils-0.16 or older versions.
+
+    refs: https://sourceforge.net/p/docutils/patches/165/
+    """
     newnode = self.__class__(self.rawsource, **self.attributes)
     if isinstance(self, nodes.Element):
         newnode.source = self.source

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -10,7 +10,7 @@
 
 import re
 import warnings
-from typing import Any, Callable, Iterable, List, Set, Tuple
+from typing import Any, Callable, Iterable, List, Set, Tuple, Type
 from typing import cast
 
 from docutils import nodes
@@ -26,7 +26,6 @@ from sphinx.util import logging
 
 if False:
     # For type annotation
-    from typing import Type  # for python3.5.1
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
     from sphinx.utils.tags import Tags

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -18,7 +18,7 @@ import sys
 import warnings
 from io import StringIO
 from os import path
-from typing import Any, Generator, Iterator, List, Tuple
+from typing import Any, Generator, Iterator, List, Tuple, Type
 
 from sphinx.deprecation import RemovedInSphinx40Warning
 
@@ -27,10 +27,6 @@ try:
     from sphinx.testing.path import path as Path
 except ImportError:
     Path = None  # type: ignore
-
-if False:
-    # For type annotation
-    from typing import Type  # for python3.5.1
 
 # Errnos that we need.
 EEXIST = getattr(errno, 'EEXIST', 0)  # RemovedInSphinx40Warning

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -26,11 +26,17 @@
 """
 
 import re
+import warnings
 from typing import Generator, Iterable, Tuple
 
 from docutils.utils import smartquotes
 
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.util.docutils import __version_info__ as docutils_version
+
+
+warnings.warn('sphinx.util.smartypants is deprecated.',
+              RemovedInSphinx60Warning)
 
 
 langquotes = {'af':           '“”‘’',

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -101,7 +101,7 @@ def _stringify_py37(annotation: Any) -> str:
 
 
 def _stringify_py36(annotation: Any) -> str:
-    """stringify() for py35 and py36."""
+    """stringify() for py36."""
     module = getattr(annotation, '__module__', None)
     if module == 'typing':
         if getattr(annotation, '_name', None):
@@ -129,33 +129,18 @@ def _stringify_py36(annotation: Any) -> str:
             return qualname
     elif isinstance(annotation, typing.GenericMeta):
         params = None
-        if hasattr(annotation, '__args__'):
-            # for Python 3.5.2+
-            if annotation.__args__ is None or len(annotation.__args__) <= 2:  # type: ignore  # NOQA
-                params = annotation.__args__  # type: ignore
-            else:  # typing.Callable
-                args = ', '.join(stringify(arg) for arg
-                                 in annotation.__args__[:-1])  # type: ignore
-                result = stringify(annotation.__args__[-1])  # type: ignore
-                return '%s[[%s], %s]' % (qualname, args, result)
-        elif hasattr(annotation, '__parameters__'):
-            # for Python 3.5.0 and 3.5.1
-            params = annotation.__parameters__  # type: ignore
+        if annotation.__args__ is None or len(annotation.__args__) <= 2:  # type: ignore  # NOQA
+            params = annotation.__args__  # type: ignore
+        else:  # typing.Callable
+            args = ', '.join(stringify(arg) for arg
+                             in annotation.__args__[:-1])  # type: ignore
+            result = stringify(annotation.__args__[-1])  # type: ignore
+            return '%s[[%s], %s]' % (qualname, args, result)
         if params is not None:
             param_str = ', '.join(stringify(p) for p in params)
             return '%s[%s]' % (qualname, param_str)
-    elif (hasattr(typing, 'UnionMeta') and
-          isinstance(annotation, typing.UnionMeta) and  # type: ignore
-          hasattr(annotation, '__union_params__')):  # for Python 3.5
-        params = annotation.__union_params__
-        if params is not None:
-            if len(params) == 2 and params[1] is NoneType:  # type: ignore
-                return 'Optional[%s]' % stringify(params[0])
-            else:
-                param_str = ', '.join(stringify(p) for p in params)
-                return '%s[%s]' % (qualname, param_str)
     elif (hasattr(annotation, '__origin__') and
-          annotation.__origin__ is typing.Union):  # for Python 3.5.2+
+          annotation.__origin__ is typing.Union):
         params = annotation.__args__
         if params is not None:
             if len(params) == 2 and params[1] is NoneType:  # type: ignore
@@ -163,30 +148,5 @@ def _stringify_py36(annotation: Any) -> str:
             else:
                 param_str = ', '.join(stringify(p) for p in params)
                 return 'Union[%s]' % param_str
-    elif (isinstance(annotation, typing.CallableMeta) and  # type: ignore
-          getattr(annotation, '__args__', None) is not None and
-          hasattr(annotation, '__result__')):  # for Python 3.5
-        # Skipped in the case of plain typing.Callable
-        args = annotation.__args__
-        if args is None:
-            return qualname
-        elif args is Ellipsis:
-            args_str = '...'
-        else:
-            formatted_args = (stringify(a) for a in args)
-            args_str = '[%s]' % ', '.join(formatted_args)
-        return '%s[%s, %s]' % (qualname,
-                               args_str,
-                               stringify(annotation.__result__))
-    elif (isinstance(annotation, typing.TupleMeta) and  # type: ignore
-          hasattr(annotation, '__tuple_params__') and
-          hasattr(annotation, '__tuple_use_ellipsis__')):  # for Python 3.5
-        params = annotation.__tuple_params__
-        if params is not None:
-            param_strings = [stringify(p) for p in params]
-            if annotation.__tuple_use_ellipsis__:
-                param_strings.append('...')
-            return '%s[%s]' % (qualname,
-                               ', '.join(param_strings))
 
     return qualname

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -13,14 +13,14 @@ from itertools import product, zip_longest
 from operator import itemgetter
 from os import path
 from typing import Any, Dict, Iterator
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from docutils.nodes import Node
 
 from sphinx.transforms import SphinxTransform
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 try:

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -13,7 +13,7 @@ import os
 import posixpath
 import warnings
 from typing import Any, Iterable, Tuple
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, Text
@@ -27,8 +27,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxTranslator
 from sphinx.util.images import get_image_size
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders.html import StandaloneHTMLBuilder
 
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -12,7 +12,7 @@ import os
 import posixpath
 import warnings
 from typing import Any, Iterable, Tuple
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, Text
@@ -26,8 +26,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxTranslator
 from sphinx.util.images import get_image_size
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders.html import StandaloneHTMLBuilder
 
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -20,7 +20,7 @@ from docutils.writers.html5_polyglot import HTMLTranslator as BaseTranslator
 
 from sphinx import addnodes
 from sphinx.builders import Builder
-from sphinx.deprecation import RemovedInSphinx40Warning
+from sphinx.deprecation import RemovedInSphinx40Warning, RemovedInSphinx60Warning
 from sphinx.locale import admonitionlabels, _, __
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxTranslator
@@ -703,22 +703,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     # overwritten to add even/odd classes
 
-    def generate_targets_for_table(self, node: Element) -> None:
-        """Generate hyperlink targets for tables.
-
-        Original visit_table() generates hyperlink targets inside table tags
-        (<table>) if multiple IDs are assigned to listings.
-        That is invalid DOM structure.  (This is a bug of docutils <= 0.13.1)
-
-        This exports hyperlink targets before tables to make valid DOM structure.
-        """
-        for id in node['ids'][1:]:
-            self.body.append('<span id="%s"></span>' % id)
-            node['ids'].remove(id)
-
     def visit_table(self, node: Element) -> None:
-        self.generate_targets_for_table(node)
-
         self._table_row_index = 0
 
         classes = [cls.strip(' \t\n') for cls in self.settings.table_style.split(',')]
@@ -772,3 +757,19 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     def unknown_visit(self, node: Node) -> None:
         raise NotImplementedError('Unknown node: ' + node.__class__.__name__)
+
+    def generate_targets_for_table(self, node: Element) -> None:
+        """Generate hyperlink targets for tables.
+
+        Original visit_table() generates hyperlink targets inside table tags
+        (<table>) if multiple IDs are assigned to listings.
+        That is invalid DOM structure.  (This is a bug of docutils <= 0.13.1)
+
+        This exports hyperlink targets before tables to make valid DOM structure.
+        """
+        warnings.warn('generate_targets_for_table() is deprecated',
+                      RemovedInSphinx60Warning, stacklevel=2)
+        for id in node['ids'][1:]:
+            self.body.append('<span id="%s"></span>' % id)
+            node['ids'].remove(id)
+

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -772,4 +772,3 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         for id in node['ids'][1:]:
             self.body.append('<span id="%s"></span>' % id)
             node['ids'].remove(id)
-

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -16,7 +16,7 @@ import warnings
 from collections import defaultdict
 from os import path
 from typing import Any, Dict, Iterable, Iterator, List, Tuple, Set, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes, writers
 from docutils.nodes import Element, Node, Text
@@ -42,8 +42,7 @@ except ImportError:
     # In Debain/Ubuntu, roman package is provided as roman, not as docutils.utils.roman
     from roman import toRoman  # type: ignore
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders.latex import LaTeXBuilder
     from sphinx.builders.latex.theming import Theme
 

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -12,7 +12,7 @@ import re
 import textwrap
 from os import path
 from typing import Any, Dict, Iterable, Iterator, List, Pattern, Set, Tuple, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes, writers
 from docutils.nodes import Element, Node, Text
@@ -27,8 +27,7 @@ from sphinx.util.docutils import SphinxTranslator
 from sphinx.util.i18n import format_date
 from sphinx.writers.latex import collected_footnote
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders.texinfo import TexinfoBuilder
 
 

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -13,7 +13,7 @@ import re
 import textwrap
 from itertools import groupby, chain
 from typing import Any, Dict, Generator, List, Iterable, Optional, Set, Tuple, Union
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes, writers
 from docutils.nodes import Element, Node, Text
@@ -23,8 +23,7 @@ from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
 from sphinx.util.docutils import SphinxTranslator
 
-if False:
-    # For type annotation
+if TYPE_CHECKING:
     from sphinx.builders.text import TextBuilder
 
 

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -15,8 +15,6 @@ from xml.etree import ElementTree
 
 import pytest
 
-from sphinx.util import docutils
-
 
 # check given command is runnable
 def runnable(command):
@@ -357,8 +355,6 @@ def test_epub_css_files(app):
             'href="https://example.com/custom.css" />' not in content)
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('epub', testroot='roles-download')
 def test_html_download_role(app, status, warning):
     app.build()

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -19,7 +19,6 @@ from html5lib import HTMLParser
 from sphinx.builders.html import validate_html_extra_path, validate_html_static_path
 from sphinx.errors import ConfigError
 from sphinx.testing.util import strip_escseq
-from sphinx.util import docutils
 from sphinx.util.inventory import InventoryFile
 
 
@@ -407,8 +406,6 @@ def test_html4_output(app, status, warning):
         (".//a[@href='_sources/otherext.foo.txt']", ''),
     ]
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', tags=['testtag'],
                     confoverrides={'html_context.hckey_co': 'hcval_co'})
 @pytest.mark.test_params(shared_result='test_build_html_output')
@@ -418,8 +415,6 @@ def test_html5_output(app, cached_etree_parse, fname, expect):
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html')
 @pytest.mark.test_params(shared_result='test_build_html_output')
 def test_html_download(app):
@@ -444,8 +439,6 @@ def test_html_download(app):
     assert matched.group(1) == filename
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='roles-download')
 def test_html_download_role(app, status, warning):
     app.build()
@@ -524,8 +517,6 @@ def test_html_translator(app):
         (".//h1//span[@class='section-number']", '2.1.1. ', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='tocdepth')
 @pytest.mark.test_params(shared_result='test_build_html_tocdepth')
 def test_tocdepth(app, cached_etree_parse, fname, expect):
@@ -571,8 +562,6 @@ def test_tocdepth(app, cached_etree_parse, fname, expect):
         (".//h4//span[@class='section-number']", '2.1.1. ', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('singlehtml', testroot='tocdepth')
 @pytest.mark.test_params(shared_result='test_build_html_tocdepth')
 def test_tocdepth_singlehtml(app, cached_etree_parse, fname, expect):
@@ -630,8 +619,6 @@ def test_numfig_disabled_warn(app, warning):
          "span[@class='caption-number']", None, True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='numfig')
 @pytest.mark.test_params(shared_result='test_build_html_numfig')
 def test_numfig_disabled(app, cached_etree_parse, fname, expect):
@@ -738,8 +725,6 @@ def test_numfig_without_numbered_toctree_warn(app, warning):
          "span[@class='caption-number']", '^Listing 6 $', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx(
     'html', testroot='numfig',
     srcdir='test_numfig_without_numbered_toctree',
@@ -846,8 +831,6 @@ def test_numfig_with_numbered_toctree_warn(app, warning):
          "span[@class='caption-number']", '^Listing 2.2 $', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='numfig', confoverrides={'numfig': True})
 @pytest.mark.test_params(shared_result='test_build_html_numfig_on')
 def test_numfig_with_numbered_toctree(app, cached_etree_parse, fname, expect):
@@ -951,8 +934,6 @@ def test_numfig_with_prefix_warn(app, warning):
          "span[@class='caption-number']", '^Code-2.2 $', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='numfig',
                     confoverrides={'numfig': True,
                                    'numfig_format': {'figure': 'Figure:%s',
@@ -1057,8 +1038,6 @@ def test_numfig_with_secnum_depth_warn(app, warning):
          "span[@class='caption-number']", '^Listing 2.1.2 $', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='numfig',
                     confoverrides={'numfig': True,
                                    'numfig_secnum_depth': 2})
@@ -1142,8 +1121,6 @@ def test_numfig_with_secnum_depth(app, cached_etree_parse, fname, expect):
          "span[@class='caption-number']", '^Listing 2.2 $', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('singlehtml', testroot='numfig', confoverrides={'numfig': True})
 @pytest.mark.test_params(shared_result='test_build_html_numfig_on')
 def test_numfig_with_singlehtml(app, cached_etree_parse, fname, expect):
@@ -1168,8 +1145,6 @@ def test_numfig_with_singlehtml(app, cached_etree_parse, fname, expect):
         (".//li/p/a/span", 'No.2', True),
     ],
 }))
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='add_enumerable_node',
                     srcdir='test_enumerable_node')
 def test_enumerable_node(app, cached_etree_parse, fname, expect):

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -22,7 +22,6 @@ from sphinx.builders.latex import default_latex_documents
 from sphinx.config import Config
 from sphinx.errors import SphinxError, ThemeError
 from sphinx.testing.util import strip_escseq
-from sphinx.util import docutils
 from sphinx.util.osutil import cd, ensuredir
 from sphinx.writers.latex import LaTeXTranslator
 
@@ -1102,8 +1101,6 @@ def test_maxlistdepth_at_ten(app, status, warning):
     compile_latex_document(app, 'python.tex')
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('latex', testroot='latex-table')
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_tabulars(app, status, warning):
@@ -1173,8 +1170,6 @@ def test_latex_table_tabulars(app, status, warning):
     assert actual == expected
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('latex', testroot='latex-table')
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_longtable(app, status, warning):
@@ -1234,8 +1229,6 @@ def test_latex_table_longtable(app, status, warning):
     assert actual == expected
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('latex', testroot='latex-table')
 @pytest.mark.test_params(shared_result='latex-table')
 def test_latex_table_complex_tables(app, status, warning):

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -16,7 +16,6 @@ import sphinx.domains.cpp as cppDomain
 from sphinx import addnodes
 from sphinx.domains.cpp import DefinitionParser, DefinitionError, NoOldIdError
 from sphinx.domains.cpp import Symbol, _max_id, _id_prefix
-from sphinx.util import docutils
 
 
 def parse(name, string):
@@ -860,8 +859,6 @@ def test_build_domain_cpp_misuse_of_roles(app, status, warning):
     assert len(ws) == len(warn)
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'add_function_parentheses': True})
 def test_build_domain_cpp_with_add_function_parentheses_is_True(app, status, warning):
     app.builder.build_all()
@@ -903,8 +900,6 @@ def test_build_domain_cpp_with_add_function_parentheses_is_True(app, status, war
         check(s, t, f)
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'add_function_parentheses': False})
 def test_build_domain_cpp_with_add_function_parentheses_is_False(app, status, warning):
     app.builder.build_all()

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -24,7 +24,6 @@ from sphinx.addnodes import (
 from sphinx.domains.std import StandardDomain
 from sphinx.testing import restructuredtext
 from sphinx.testing.util import assert_node
-from sphinx.util import docutils
 
 
 def test_process_doc_handle_figure_caption():
@@ -319,8 +318,6 @@ def test_multiple_cmdoptions(app):
     assert domain.progoptions[('cmd', '--output')] == ('index', 'cmdoption-cmd-o')
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx(testroot='productionlist')
 def test_productionlist(app, status, warning):
     app.builder.build_all()

--- a/tests/test_ext_autosectionlabel.py
+++ b/tests/test_ext_autosectionlabel.py
@@ -12,11 +12,7 @@ import re
 
 import pytest
 
-from sphinx.util import docutils
 
-
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel')
 def test_autosectionlabel_html(app, status, warning, skipped_labels=False):
     app.builder.build_all()
@@ -55,15 +51,11 @@ def test_autosectionlabel_html(app, status, warning, skipped_labels=False):
 
 
 # Re-use test definition from above, just change the test root directory
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel-prefix-document')
 def test_autosectionlabel_prefix_document_html(app, status, warning):
     test_autosectionlabel_html(app, status, warning)
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='ext-autosectionlabel',
                     confoverrides={'autosectionlabel_maxdepth': 3})
 def test_autosectionlabel_maxdepth(app, status, warning):

--- a/tests/test_ext_todo.py
+++ b/tests/test_ext_todo.py
@@ -12,11 +12,7 @@ import re
 
 import pytest
 
-from sphinx.util import docutils
 
-
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', testroot='ext-todo', freshenv=True,
                     confoverrides={'todo_include_todos': True, 'todo_emit_warnings': True})
 def test_todo(app, status, warning):

--- a/tests/test_smartquotes.py
+++ b/tests/test_smartquotes.py
@@ -10,8 +10,6 @@
 
 import pytest
 
-from sphinx.util import docutils
-
 
 @pytest.mark.sphinx(buildername='html', testroot='smartquotes', freshenv=True)
 def test_basic(app, status, warning):
@@ -63,8 +61,6 @@ def test_smartquotes_disabled(app, status, warning):
     assert '<p>-- &quot;Sphinx&quot; is a tool that makes it easy ...</p>' in content
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 14),
-                    reason='docutils-0.14 or above is required')
 @pytest.mark.sphinx(buildername='html', testroot='smartquotes', freshenv=True,
                     confoverrides={'smartquotes_action': 'q'})
 def test_smartquotes_action(app, status, warning):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4.0
-envlist = docs,flake8,mypy,coverage,py{35,36,37,38,39},du{12,13,14,15}
+envlist = docs,flake8,mypy,coverage,py{36,37,38,39},du{14,15,16}
 
 [testenv]
 usedevelop = True
@@ -14,12 +14,10 @@ passenv =
     EPUBCHECK_PATH
     TERM
 description =
-    py{35,36,37,38,39}: Run unit tests against {envname}.
+    py{36,37,38,39}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.
 deps =
     git+https://github.com/html5lib/html5lib-python  # refs: https://github.com/html5lib/html5lib-python/issues/419
-    du12: docutils==0.12
-    du13: docutils==0.13.1
     du14: docutils==0.14
     du15: docutils==0.15
     du16: docutils==0.16


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- 4.0 will be released in 2021 Spring. At that time, Ubuntu 16.04 will become EOL. Therefore, we can update dependencies for Ubuntu 18.04 based one.
- For 4.0 development, we can use syntax and features since python 3.6; variable annotations, integrated pathlib support and so on.
- As a first step, this drops python3.5 and docutils-0.14 supports.