### PR TITLE
doc/{Makefile,make.bat}: remove unused SPHINXPROJ

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,6 @@ PYTHON ?= python3
 # You can set these variables from the command line.
 SPHINXOPTS   =
 SPHINXBUILD  = $(PYTHON) ../sphinx/cmd/build.py
-SPHINXPROJ   = sphinx
 SOURCEDIR    = .
 BUILDDIR     = _build
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -7,7 +7,6 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=sphinx-doc
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
Appears to have been forgotten in f101bb661.