### PR TITLE
Fix #7276: cpp: objects generate hypertarget names unexpectedly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@ Incompatible changes
 * #6903: Internal data structure of Python, reST and standard domains have
   changed.  The node_id is added to the index of objects and modules.  Now they
   contains a pair of docname and node_id for cross reference.
+* #7276: C++ domain: Non intended behavior is removed such as ``say_hello_``
+  links to ``.. cpp:function:: say_hello()``
 * #7210: js domain: Non intended behavior is removed such as ``parseInt_`` links
   to ``.. js:function:: parseInt``
 * #7229: rst domain: Non intended behavior is removed such as ``numref_`` links

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6512,10 +6512,6 @@ class CPPObject(ObjectDescription):
             names = self.env.domaindata['cpp']['names']
             if name not in names:
                 names[name] = ast.symbol.docname
-                signode['names'].append(name)
-            else:
-                # print("[CPP] non-unique name:", name)
-                pass
             # always add the newest id
             assert newestId
             signode['ids'].append(newestId)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- refs: #7276 
- I think this would not be an expected behavior. So I'm going to remove `signode['names']` assignment. Is my understand correct?
- I also thought to change node_id generation mechanism to use `make_id()`. But cpp domain is too complicated to me. And it seems it already has its own ID generation engine. So it does not cause a problem like #6903. So I'd like to keep as is now.

@jakobandersen Could you review this and give an advice to me.