### PR TITLE
Fix use of html_file_suffix instead of html_link_suffix in search results

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -473,6 +473,7 @@ class StandaloneHTMLBuilder(Builder):
             'show_source': self.config.html_show_sourcelink,
             'sourcelink_suffix': self.config.html_sourcelink_suffix,
             'file_suffix': self.out_suffix,
+            'link_suffix': self.link_suffix,
             'script_files': self.script_files,
             'language': self.config.language,
             'css_files': self.css_files,

--- a/sphinx/themes/basic/static/documentation_options.js_t
+++ b/sphinx/themes/basic/static/documentation_options.js_t
@@ -5,6 +5,7 @@ var DOCUMENTATION_OPTIONS = {
     COLLAPSE_INDEX: false,
     BUILDER: '{{ builder }}',
     FILE_SUFFIX: '{{ file_suffix }}',
+    LINK_SUFFIX: '{{ link_suffix }}',
     HAS_SOURCE: {{ has_source|lower }},
     SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
     NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}}

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -251,6 +251,7 @@ var Search = {
         var item = results.pop();
         var listItem = $('<li style="display:none"></li>');
         var requestUrl = "";
+        var linkUrl = "";
         if (DOCUMENTATION_OPTIONS.BUILDER === 'dirhtml') {
           // dirhtml builder
           var dirname = item[0] + '/';
@@ -260,13 +261,15 @@ var Search = {
             dirname = '';
           }
           requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + dirname;
+          linkUrl = requestUrl;
 
         } else {
           // normal html builders
           requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
+          linkUrl = item[0] + DOCUMENTATION_OPTIONS.LINK_SUFFIX;
         }
         listItem.append($('<a/>').attr('href',
-            requestUrl +
+            linkUrl +
             highlightstring + item[2]).html(item[1]));
         if (item[3]) {
           listItem.append($('<span> (' + item[3] + ')</span>'));


### PR DESCRIPTION
The links in the search results have `html_file_suffix` appended instead of `html_link_suffix`.  This fixes that.

To reproduce the bug, build any documentation with `html_file_suffix` set to ".html" and `html_link_suffix` set to "".  The regular links between pages will be extensionless, but the search results will have .html at the end.