### PR TITLE
Enable intersphinx with Sphinx's documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,6 +7,7 @@ import sphinx
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo',
               'sphinx.ext.autosummary', 'sphinx.ext.extlinks',
+              'sphinx.ext.intersphinx',
               'sphinx.ext.viewcode', 'sphinx.ext.inheritance_diagram']
 
 master_doc = 'contents'


### PR DESCRIPTION
It changes the output already (cf. #7280) (GitHub ate the previous comment because the diff is too big), e.g.

```diff
diff -Nr doc/_build/html/extdev/appapi.html doc/_build.intersphinx/html/extdev/appapi.html
706c706
< the <code class="xref py py-func docutils literal notranslate"><span class="pre">getattr()</span></code> builtin, as the autodoc attribute getter for
---
> the <a class="reference external" href="https://docs.python.org/3/library/functions.html#getattr" title="(in Python v3.8)"><code class="xref py py-func docutils literal notranslate"><span class="pre">getattr()</span></code></a> builtin, as the autodoc attribute getter for
709c709
< <code class="xref py py-func docutils literal notranslate"><span class="pre">getattr()</span></code>.</p>
---
…
diff -Nr doc/_build/html/usage/restructuredtext/roles.html doc/_build.intersphinx/html/usage/restructuredtext/roles.html
483c483
< those created using <code class="xref py py-mod docutils literal notranslate"><span class="pre">curses</span></code> or other text-based libraries.  Any label
---
> those created using <a class="reference external" href="https://docs.python.org/3/library/curses.html#module-curses" title="(in Python v3.8)"><code class="xref py py-mod docutils literal notranslate"><span class="pre">curses</span></code></a> or other text-based libraries.  Any label
```

I want to use it for improvements to `CONTRIBUTING.rst`.

The mapping for Python exists already, since 2010 (580e1c90d).