### PR TITLE
console: use bright colors instead of bold

### DIFF
--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -132,9 +132,9 @@ _colors = [
     ('lightgray', 'white'),
 ]
 
-for i, (dark, light) in enumerate(_colors):
-    codes[dark] = '\x1b[%im' % (i + 30)
-    codes[light] = '\x1b[%i;01m' % (i + 30)
+for i, (dark, light) in enumerate(_colors, 30):
+    codes[dark] = '\x1b[%im' % i
+    codes[light] = '\x1b[%im' % (i + 60)
 
 _orig_codes = codes.copy()
 


### PR DESCRIPTION
The code apparently comes from pygments where it was fixed to use
aixterm colors (SGR color codes 90-97m) for bright colors instead of
bold.

Ref: https://github.com/kovidgoyal/kitty/issues/197#issuecomment-348062665
Ref: https://github.com/pygments/pygments/commit/433b39cc
Ref: https://github.com/pygments/pygments/issues/1184

This makes a difference for me with kitty, where `-vvv` would result in most of the output being invisble!