### PR TITLE
Ignore bdb.BdbQuit when handling exceptions

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -29,6 +29,11 @@ from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 
 def handle_exception(app: Sphinx, args: Any, exception: BaseException, stderr: IO = sys.stderr) -> None:  # NOQA
+    import bdb
+
+    if isinstance(exception, bdb.BdbQuit):
+        return
+
     if args.pdb:
         import pdb
         print(red(__('Exception occurred while building, starting debugger:')),


### PR DESCRIPTION
`bdb.BdbQuit` is used when quitting the debugger.
It should not a) cause the debugger to be started (with `-P` / `--pdb`),
and b) not a "crash" to be logged.

This helps when using `pdb.set_trace()` manually, and quitting it with
`q`.

It gets used in `build_main`, and `BuildDoc.run` (distutils command).