### PR TITLE
Handle singledispatch functions with rewritten signatures.

### DIFF
--- a/tests/roots/test-ext-autodoc/target/singledispatch.py
+++ b/tests/roots/test-ext-autodoc/target/singledispatch.py
@@ -1,4 +1,11 @@
 from functools import singledispatch
+import inspect
+
+
+def assign_signature(func):
+    # This is intended to cover more complex signature-rewriting decorators.
+    func.__signature__ = inspect.signature(func)
+    return func
 
 
 @singledispatch
@@ -14,6 +21,7 @@ def _func_int(arg, kwarg=None):
 
 
 @func.register(str)
+@assign_signature
 def _func_str(arg, kwarg=None):
     """A function for str."""
     pass


### PR DESCRIPTION
Subject: Handle singledispatch functions with rewritten signatures.

### Feature or Bugfix
- Bugfix

### Purpose
If a singledispatch function has its `__signature__` rewritten, autodoc
fails to annotate that signature because `func.__annotations__` is not
consulted.  Instead, directly assign to `__signature__` instead.

(See example with `@assign_signature` in tests.)

### Relates
- https://github.com/sphinx-doc/sphinx/pull/7234 (thanks for the original implementation!)

---

This fails CI because mypy emits the spurious
```
sphinx/ext/autodoc/__init__.py: note: In member "annotate_to_first_argument" of class "SingledispatchFunctionDocumenter":
275sphinx/ext/autodoc/__init__.py:1113:13: error: "Callable[..., Any]" has no attribute "__signature__"
```
which is clearly wrong, but I'm not sure how to placate it.