### PR TITLE
Fix #7304: pycode: Support operators (BinOp, BoolOp and UnaryOp)

### DIFF
--- a/tests/test_pycode_ast.py
+++ b/tests/test_pycode_ast.py
@@ -16,21 +16,43 @@ from sphinx.pycode import ast
 
 
 @pytest.mark.parametrize('source,expected', [
+    ("a + b", "a + b"),                         # Add
+    ("a and b", "a and b"),                     # And
     ("os.path", "os.path"),                     # Attribute
+    ("1 * 2", "1 * 2"),                         # BinOp
+    ("a & b", "a & b"),                         # BitAnd
+    ("a | b", "a | b"),                         # BitOr
+    ("a ^ b", "a ^ b"),                         # BitXor
+    ("a and b and c", "a and b and c"),         # BoolOp
     ("b'bytes'", "b'bytes'"),                   # Bytes
     ("object()", "object()"),                   # Call
     ("1234", "1234"),                           # Constant
     ("{'key1': 'value1', 'key2': 'value2'}",
      "{'key1': 'value1', 'key2': 'value2'}"),   # Dict
+    ("a / b", "a / b"),                         # Div
     ("...", "..."),                             # Ellipsis
+    ("a // b", "a // b"),                       # FloorDiv
     ("Tuple[int, int]", "Tuple[int, int]"),     # Index, Subscript
+    ("~ 1", "~ 1"),                             # Invert
     ("lambda x, y: x + y",
      "lambda x, y: ..."),                       # Lambda
     ("[1, 2, 3]", "[1, 2, 3]"),                 # List
+    ("a << b", "a << b"),                       # LShift
+    ("a @ b", "a @ b"),                         # MatMult
+    ("a % b", "a % b"),                         # Mod
+    ("a * b", "a * b"),                         # Mult
     ("sys", "sys"),                             # Name, NameConstant
     ("1234", "1234"),                           # Num
+    ("not a", "not a"),                         # Not
+    ("a or b", "a or b"),                       # Or
+    ("a ** b", "a ** b"),                       # Pow
+    ("a >> b", "a >> b"),                       # RShift
     ("{1, 2, 3}", "{1, 2, 3}"),                 # Set
+    ("a - b", "a - b"),                         # Sub
     ("'str'", "'str'"),                         # Str
+    ("+ a", "+ a"),                             # UAdd
+    ("- 1", "- 1"),                             # UnaryOp
+    ("- a", "- a"),                             # USub
     ("(1, 2, 3)", "1, 2, 3"),                   # Tuple
 ])
 def test_unparse(source, expected):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7304 