### PR TITLE
Revert "Enable patch status check for Codecov"

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,6 @@ coverage:
     project:
       default:
         enabled: no
+    patch:
+      default:
+        enabled: no


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- This reverts commit f09adc0af8bebc061eb697597de8c2988f560a25.
- Now codecov warns if some PR makes coverage rate lower. But it does not help us...