### PR TITLE
Propagate maxdepth option through package documents

### DIFF
--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -175,6 +175,7 @@ def create_package_file(root: str, master_package: str, subroot: str, py_files: 
         'separatemodules': opts.separatemodules,
         'automodule_options': options,
         'show_headings': not opts.noheadings,
+        'maxdepth': opts.maxdepth,
     }
     text = ReSTRenderer([user_template_dir, template_dir]).render('package.rst_t', context)
     write_file(pkgname, text, opts)

--- a/sphinx/templates/apidoc/package.rst_t
+++ b/sphinx/templates/apidoc/package.rst_t
@@ -7,6 +7,7 @@
 
 {%- macro toctree(docnames) -%}
 .. toctree::
+   :maxdepth: {{ maxdepth }}
 {% for docname in docnames %}
    {{ docname }}
 {%- endfor %}

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -121,15 +121,16 @@ def test_pep_0420_enabled_separate(make_app, apidoc):
 
     with open(outdir / 'a.b.c.rst') as f:
         rst = f.read()
-        assert ".. toctree::\n\n   a.b.c.d\n" in rst
+
+        assert ".. toctree::\n   :maxdepth: 4\n\n   a.b.c.d\n" in rst
 
     with open(outdir / 'a.b.e.rst') as f:
         rst = f.read()
-        assert ".. toctree::\n\n   a.b.e.f\n" in rst
+        assert ".. toctree::\n   :maxdepth: 4\n\n   a.b.e.f\n" in rst
 
     with open(outdir / 'a.b.x.rst') as f:
         rst = f.read()
-        assert ".. toctree::\n\n   a.b.x.y\n" in rst
+        assert ".. toctree::\n   :maxdepth: 4\n\n   a.b.x.y\n" in rst
 
     app = make_app('text', srcdir=outdir)
     app.build()
@@ -485,6 +486,7 @@ def test_package_file(tempdir):
                        "-----------\n"
                        "\n"
                        ".. toctree::\n"
+                       "   :maxdepth: 4\n"
                        "\n"
                        "   testpkg.subpkg\n"
                        "\n"
@@ -546,6 +548,7 @@ def test_package_file_separate(tempdir):
                        "----------\n"
                        "\n"
                        ".. toctree::\n"
+                       "   :maxdepth: 4\n"
                        "\n"
                        "   testpkg.example\n"
                        "\n"


### PR DESCRIPTION
Subject: Propagate maxdepth option through package documents
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
Currently, the `maxdepth` parameter does only affect to the table of contents located at `tocfile`. I think that it could be more usefull if it applies to all recursively created table of contents (on subpackages or submodules).

### Detail
The applied change is so simple. It just injects the `maxdepth` parameter into the package's template and sets to the `:maxdepth:` option of the corresponding `toctree`.

### Relates
- Corresponding `sphinx-apidoc`'s documentation https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html#cmdoption-sphinx-apidoc-d
- Propagate maxdepth option through package documents #7309
