### PR TITLE
Deprecate sphinx.util.pycompat.execfile_()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Deprecated
 * ``sphinx.directives.patches.CSVTable``
 * ``sphinx.directives.patches.ListTable``
 * ``sphinx.directives.patches.RSTTable``
+* ``sphinx.util.pycompat.convert_with_2to3()``
+* ``sphinx.util.pycompat.execfile_()``
 * ``sphinx.util.smartypants``
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -41,6 +41,16 @@ The following is a list of deprecated interfaces.
      - 6.0
      - ``docutils.parsers.rst.diretives.tables.RSTTable``
 
+   * - ``sphinx.util.pycompat.convert_with_2to3()``
+     - 4.0
+     - 6.0
+     - N/A
+
+   * - ``sphinx.util.pycompat.execfile_()``
+     - 4.0
+     - 6.0
+     - N/A
+
    * - ``sphinx.util.smartypants``
      - 4.0
      - 6.0

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -24,8 +24,7 @@ from sphinx.errors import ConfigError, ExtensionError
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.i18n import format_date
-from sphinx.util.osutil import cd
-from sphinx.util.pycompat import execfile_
+from sphinx.util.osutil import cd, fs_encoding
 from sphinx.util.tags import Tags
 from sphinx.util.typing import NoneType
 
@@ -318,7 +317,9 @@ def eval_config_file(filename: str, tags: Tags) -> Dict[str, Any]:
     with cd(path.dirname(filename)):
         # during executing config file, current dir is changed to ``confdir``.
         try:
-            execfile_(filename, namespace)
+            with open(filename, 'rb') as f:
+                code = compile(f.read(), filename.encode(fs_encoding), 'exec')
+                exec(code, namespace)
         except SyntaxError as err:
             msg = __("There is a syntax error in your configuration file: %s\n")
             raise ConfigError(msg % err)

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -15,7 +15,9 @@ import textwrap
 import warnings
 from typing import Any, Callable
 
-from sphinx.deprecation import RemovedInSphinx40Warning, deprecated_alias
+from sphinx.deprecation import (
+    RemovedInSphinx40Warning, RemovedInSphinx60Warning, deprecated_alias
+)
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.console import terminal_safe
@@ -31,6 +33,9 @@ logger = logging.getLogger(__name__)
 # convert_with_2to3():
 # support for running 2to3 over config files
 def convert_with_2to3(filepath: str) -> str:
+    warnings.warn('convert_with_2to3() is deprecated',
+                  RemovedInSphinx60Warning, stacklevel=2)
+
     from lib2to3.refactor import RefactoringTool, get_fixers_from_package
     from lib2to3.pgen2.parse import ParseError
     fixers = get_fixers_from_package('lib2to3.fixes')
@@ -59,6 +64,8 @@ class UnicodeMixin:
 
 
 def execfile_(filepath: str, _globals: Any, open: Callable = open) -> None:
+    warnings.warn('execfile_() is deprecated',
+                  RemovedInSphinx60Warning, stacklevel=2)
     from sphinx.util.osutil import fs_encoding
     with open(filepath, 'rb') as f:
         source = f.read()


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
