### PR TITLE
C domain rewrite

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,7 +25,7 @@ Incompatible changes
 * Due to the scoping changes for :rst:dir:`productionlist` some uses of
   :rst:role:`token` must be modified to include the scope which was previously
   ignored.
-* #6903: Internal data structure of C, Python, reST and standard domains have
+* #6903: Internal data structure of Python, reST and standard domains have
   changed.  The node_id is added to the index of objects and modules.  Now they
   contains a pair of docname and node_id for cross reference.
 * #7276: C++ domain: Non intended behavior is removed such as ``say_hello_``
@@ -38,6 +38,8 @@ Incompatible changes
   links to ``.. py:function:: say_hello()``
 * #7246: py domain: Drop special cross reference helper for exceptions,
   functions and methods
+* The C domain has been rewritten, with additional directives and roles.
+  The existing ones are now more strict, resulting in new warnings.
 
 Deprecated
 ----------
@@ -91,6 +93,14 @@ Features added
   using ``:nosearch:`` file-wide metadata
 * #7142: html theme: Add a theme option: ``pygments_dark_style`` to switch the
   style of code-blocks in dark mode
+* The C domain has been rewritten adding for example:
+
+  - Cross-referencing respecting the current scope.
+  - Possible to document anonymous entities.
+  - More specific directives and roles for each type of entitiy,
+    e.g., handling scoping of enumerators.
+  - New role :rst:role:`c:expr` for rendering expressions and types
+    in text.
 
 Bugs fixed
 ----------
@@ -109,6 +119,8 @@ Bugs fixed
   ``html_link_suffix`` in search results
 * #7179: std domain: Fix whitespaces are suppressed on referring GenericObject
 * #7289: console: use bright colors instead of bold
+* #1539: C, parse array types.
+* #2377: C, parse function pointers even in complex types.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,8 @@ Incompatible changes
   functions and methods
 * The C domain has been rewritten, with additional directives and roles.
   The existing ones are now more strict, resulting in new warnings.
+* The attribute ``sphinx_cpp_tagname`` in the ``desc_signature_line`` node
+  has been renamed to ``sphinx_line_type``.
 
 Deprecated
 ----------

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -556,43 +556,29 @@ The C domain (name **c**) is suited for documentation of C API.
 
    Describes a C function. The signature should be given as in C, e.g.::
 
-      .. c:function:: PyObject* PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)
-
-   This is also used to describe function-like preprocessor macros.  The names
-   of the arguments should be given so they may be used in the description.
+      .. c:function:: PyObject *PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)
 
    Note that you don't have to backslash-escape asterisks in the signature, as
    it is not parsed by the reST inliner.
 
 .. rst:directive:: .. c:member:: declaration
+                   .. c:var:: declaration
 
-   Describes a C struct member. Example signature::
+   Describes a C struct member or variable. Example signature::
 
-      .. c:member:: PyObject* PyTypeObject.tp_bases
-
-   The text of the description should include the range of values allowed, how
-   the value should be interpreted, and whether the value can be changed.
-   References to structure members in text should use the ``member`` role.
+      .. c:member:: PyObject *PyTypeObject.tp_bases
 
 .. rst:directive:: .. c:macro:: name
+                   .. c:macro:: name(arg list)
 
-   Describes a "simple" C macro.  Simple macros are macros which are used for
-   code expansion, but which do not take arguments so cannot be described as
-   functions.  This is a simple C-language ``#define``.  Examples of its use in
-   the Python documentation include :c:macro:`PyObject_HEAD` and
-   :c:macro:`Py_BEGIN_ALLOW_THREADS`.
+   Describes a C macro, i.e., a C-language ``#define``, without the replacement
+   text.
 
-.. rst:directive:: .. c:type:: name
+.. rst:directive:: .. c:type:: typedef-like declaration
+                   .. c:type:: name
 
-   Describes a C type (whether defined by a typedef or struct). The signature
-   should just be the type name.
-
-.. rst:directive:: .. c:var:: declaration
-
-   Describes a global C variable.  The signature should include the type, such
-   as::
-
-      .. c:var:: PyObject* PyClass_Type
+   Describes a C type, either as a typedef, or the alias for an unspecified
+   type.
 
 .. _c-roles:
 
@@ -607,20 +593,17 @@ are defined in the documentation:
    Reference a C-language function. Should include trailing parentheses.
 
 .. rst:role:: c:member
+              c:data
 
-   Reference a C-language member of a struct.
+   Reference a C-language member of a struct or variable.
 
 .. rst:role:: c:macro
 
-   Reference a "simple" C macro, as defined above.
+   Reference a simple C macro, as defined above.
 
 .. rst:role:: c:type
 
    Reference a C-language type.
-
-.. rst:role:: c:data
-
-   Reference a C-language variable.
 
 
 .. _cpp-domain:

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -674,6 +674,38 @@ Explicit ref: :c:var:`Data.@data.a`. Short-hand ref: :c:var:`Data.a`.
 .. versionadded:: 3.0
 
 
+Inline Expressions and Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rst:role:: c:expr
+              c:texpr
+
+   Insert a C expression or type either as inline code (``cpp:expr``)
+   or inline text (``cpp:texpr``). For example::
+
+      .. c:var:: int a = 42
+
+      .. c:function:: int f(int i)
+
+      An expression: :c:expr:`a * f(a)` (or as text: :c:texpr:`a * f(a)`).
+
+      A type: :c:expr:`const Data*`
+      (or as text :c:texpr:`const Data*`).
+
+   will be rendered as follows:
+
+   .. c:var:: int a = 42
+
+   .. c:function:: int f(int i)
+
+   An expression: :c:expr:`a * f(a)` (or as text: :c:texpr:`a * f(a)`).
+
+   A type: :c:expr:`const Data*`
+   (or as text :c:texpr:`const Data*`).
+
+   .. versionadded:: 3.0
+
+
 .. _cpp-domain:
 
 The C++ Domain

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -552,6 +552,15 @@ The C Domain
 
 The C domain (name **c**) is suited for documentation of C API.
 
+.. rst:directive:: .. c:member:: declaration
+                   .. c:var:: declaration
+
+   Describes a C struct member or variable. Example signature::
+
+      .. c:member:: PyObject *PyTypeObject.tp_bases
+
+   The difference between the two directives is only cosmetic.
+
 .. rst:directive:: .. c:function:: function prototype
 
    Describes a C function. The signature should be given as in C, e.g.::
@@ -561,18 +570,38 @@ The C domain (name **c**) is suited for documentation of C API.
    Note that you don't have to backslash-escape asterisks in the signature, as
    it is not parsed by the reST inliner.
 
-.. rst:directive:: .. c:member:: declaration
-                   .. c:var:: declaration
-
-   Describes a C struct member or variable. Example signature::
-
-      .. c:member:: PyObject *PyTypeObject.tp_bases
-
 .. rst:directive:: .. c:macro:: name
                    .. c:macro:: name(arg list)
 
    Describes a C macro, i.e., a C-language ``#define``, without the replacement
    text.
+
+   .. versionadded:: 3.0
+      The function style variant.
+
+.. rst:directive:: .. c:struct:: name
+
+   Describes a C struct.
+
+   .. versionadded:: 3.0
+
+.. rst:directive:: .. c:union:: name
+
+   Describes a C union.
+
+   .. versionadded:: 3.0
+
+.. rst:directive:: .. c:enum:: name
+
+   Describes a C enum.
+
+   .. versionadded:: 3.0
+
+.. rst:directive:: .. c:enumerator:: name
+
+   Describes a C enumerator.
+
+   .. versionadded:: 3.0
 
 .. rst:directive:: .. c:type:: typedef-like declaration
                    .. c:type:: name
@@ -588,22 +617,61 @@ Cross-referencing C constructs
 The following roles create cross-references to C-language constructs if they
 are defined in the documentation:
 
-.. rst:role:: c:func
-
-   Reference a C-language function. Should include trailing parentheses.
-
 .. rst:role:: c:member
               c:data
+              c:var
+              c:func
+              c:macro
+              c:struct
+              c:union
+              c:enum
+              c:enumerator
+              c:type
 
-   Reference a C-language member of a struct or variable.
+   Reference a C declaration, as defined above.
+   Note that :rst:role:`c:member`, :rst:role:`c:data`, and
+   :rst:role:`c:var` are equivalent.
 
-.. rst:role:: c:macro
+   .. versionadded:: 3.0
+      The var, struct, union, enum, and enumerator roles.
 
-   Reference a simple C macro, as defined above.
 
-.. rst:role:: c:type
+Anonymous Entities
+~~~~~~~~~~~~~~~~~~
 
-   Reference a C-language type.
+C supports anonymous structs, enums, and unions.
+For the sake of documentation they must be given some name that starts with
+``@``, e.g., ``@42`` or ``@data``.
+These names can also be used in cross-references,
+though nested symbols will be found even when omitted.
+The ``@...`` name will always be rendered as **[anonymous]** (possibly as a
+link).
+
+Example::
+
+   .. c:struct:: Data
+
+      .. c:union:: @data
+
+         .. c:var:: int a
+
+         .. c:var:: double b
+
+   Explicit ref: :c:var:`Data.@data.a`. Short-hand ref: :c:var:`Data.a`.
+
+This will be rendered as:
+
+.. c:struct:: Data
+
+   .. c:union:: @data
+
+      .. c:var:: int a
+
+      .. c:var:: double b
+
+Explicit ref: :c:var:`Data.@data.a`. Short-hand ref: :c:var:`Data.a`.
+
+.. versionadded:: 3.0
 
 
 .. _cpp-domain:

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -119,7 +119,7 @@ class desc_signature_line(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     It should only be used in a ``desc_signature`` with ``is_multiline`` set.
     Set ``add_permalink = True`` for the line that should get the permalink.
     """
-    sphinx_cpp_tagname = ''
+    sphinx_line_type = ''
 
 
 # nodes to use within a desc_signature or desc_signature_line

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1215,8 +1215,14 @@ class ASTDeclaration(ASTBase):
                            env: "BuildEnvironment", options: Dict) -> None:
         verify_description_mode(mode)
         assert self.symbol
-
-        mainDeclNode = signode
+        # The caller of the domain added a desc_signature node.
+        # Always enable multiline:
+        signode['is_multiline'] = True
+        # Put each line in a desc_signature_line node.
+        mainDeclNode = addnodes.desc_signature_line()
+        mainDeclNode.sphinx_c_tagname = 'declarator'
+        mainDeclNode['add_permalink'] = not self.symbol.isRedeclaration
+        signode += mainDeclNode
 
         if self.objectType == 'member':
             pass

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3304,7 +3304,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     return {
         'version': 'builtin',
-        'env_version': 1,
+        'env_version': 2,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -655,10 +655,7 @@ class ASTDeclSpecsSimple(ASTBase):
         def _add(modifiers: List[Node], text: str) -> None:
             if len(modifiers) > 0:
                 modifiers.append(nodes.Text(' '))
-            # TODO: should probably do
-            # modifiers.append(addnodes.desc_annotation(text, text))
-            # but for now emulate the old output:
-            modifiers.append(nodes.Text(text))
+            modifiers.append(addnodes.desc_annotation(text, text))
 
         for attr in self.attrs:
             if len(modifiers) > 0:

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -2910,16 +2910,17 @@ class DefinitionParser(BaseParser):
         self.assert_end()
         return name
 
-    def parse_expression(self):
+    def parse_expression(self) -> Union[ASTExpression, ASTType]:
         pos = self.pos
+        res = None  # type: Union[ASTExpression, ASTType]
         try:
-            expr = self._parse_expression()
+            res = self._parse_expression()
             self.skip_ws()
             self.assert_end()
         except DefinitionError as exExpr:
             self.pos = pos
             try:
-                expr = self._parse_type(False)
+                res = self._parse_type(False)
                 self.skip_ws()
                 self.assert_end()
             except DefinitionError as exType:
@@ -2928,7 +2929,7 @@ class DefinitionParser(BaseParser):
                 errs.append((exExpr, "If expression"))
                 errs.append((exType, "If type"))
                 raise self._make_multi_error(errs, header)
-        return expr
+        return res
 
 
 def _make_phony_error_name() -> ASTNestedName:

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -10,7 +10,7 @@
 
 import re
 from typing import (
-    Any, Callable, Dict, Iterator, List, Tuple, Type, Union
+    Any, Callable, Dict, Iterator, List, Type, Tuple, Union
 )
 from typing import cast
 
@@ -25,7 +25,6 @@ from sphinx.builders import Builder
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.environment import BuildEnvironment
-from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.roles import XRefRole
 from sphinx.util import logging
@@ -1220,7 +1219,7 @@ class ASTDeclaration(ASTBase):
         signode['is_multiline'] = True
         # Put each line in a desc_signature_line node.
         mainDeclNode = addnodes.desc_signature_line()
-        mainDeclNode.sphinx_c_tagname = 'declarator'
+        mainDeclNode.sphinx_line_type = 'declarator'
         mainDeclNode['add_permalink'] = not self.symbol.isRedeclaration
         signode += mainDeclNode
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -33,7 +33,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx.transforms.post_transforms import ReferencesResolver
 from sphinx.util import logging
 from sphinx.util.cfamily import (
-    NoOldIdError, ASTBase, verify_description_mode, StringifyTransform,
+    NoOldIdError, ASTBaseBase, verify_description_mode, StringifyTransform,
     BaseParser, DefinitionError, UnsupportedMultiCharacterCharLiteral,
     identifier_re, anon_identifier_re, integer_literal_re, octal_literal_re,
     hex_literal_re, binary_literal_re, float_literal_re,
@@ -553,6 +553,10 @@ class _DuplicateSymbolError(Exception):
 
     def __str__(self) -> str:
         return "Internal C++ duplicate symbol error:\n%s" % self.symbol.dump(0)
+
+
+class ASTBase(ASTBaseBase):
+    pass
 
 
 ################################################################################

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -9,9 +9,8 @@
 """
 
 import re
-import warnings
 from typing import (
-    Any, Callable, Dict, Iterator, List, Match, Pattern, Tuple, Type, TypeVar, Union
+    Any, Callable, Dict, Iterator, List, Tuple, Type, TypeVar, Union
 )
 
 from docutils import nodes, utils
@@ -24,7 +23,6 @@ from sphinx.addnodes import desc_signature, pending_xref
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.config import Config
-from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.environment import BuildEnvironment
@@ -70,7 +68,7 @@ T = TypeVar('T')
 
     Each signature is in a desc_signature node, where all children are
     desc_signature_line nodes. Each of these lines will have the attribute
-    'sphinx_cpp_tagname' set to one of the following (prioritized):
+    'sphinx_line_type' set to one of the following (prioritized):
     - 'declarator', if the line contains the name of the declared object.
     - 'templateParams', if the line starts a template parameter list,
     - 'templateParams', if the line has template parameters
@@ -1604,7 +1602,7 @@ class ASTTemplateParams(ASTBase):
         def makeLine(parentNode: desc_signature = parentNode) -> addnodes.desc_signature_line:
             signode = addnodes.desc_signature_line()
             parentNode += signode
-            signode.sphinx_cpp_tagname = 'templateParams'
+            signode.sphinx_line_type = 'templateParams'
             return signode
         if self.isNested:
             lineNode = parentNode  # type: Element
@@ -1713,7 +1711,7 @@ class ASTTemplateIntroduction(ASTBase):
         # Note: 'lineSpec' has no effect on template introductions.
         signode = addnodes.desc_signature_line()
         parentNode += signode
-        signode.sphinx_cpp_tagname = 'templateIntroduction'
+        signode.sphinx_line_type = 'templateIntroduction'
         self.concept.describe_signature(signode, 'markType', env, symbol)
         signode += nodes.Text('{')
         first = True
@@ -3416,7 +3414,7 @@ class ASTDeclaration(ASTBase):
         signode['is_multiline'] = True
         # Put each line in a desc_signature_line node.
         mainDeclNode = addnodes.desc_signature_line()
-        mainDeclNode.sphinx_cpp_tagname = 'declarator'
+        mainDeclNode.sphinx_line_type = 'declarator'
         mainDeclNode['add_permalink'] = not self.symbol.isRedeclaration
 
         if self.templatePrefix:

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -77,7 +77,7 @@ class NoOldIdError(Exception):
         return str(self)
 
 
-class ASTBase:
+class ASTBaseBase:
     def __eq__(self, other: Any) -> bool:
         if type(self) is not type(other):
             return False

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -1,10 +1,10 @@
 """
     sphinx.util.cfamily
-    ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~
 
     Utility functions common to the C and C++ domains.
 
-    :copyright: Copyright 2020-2020 by the Sphinx team, see AUTHORS.
+    :copyright: Copyright 2007-2020 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
 
@@ -12,7 +12,7 @@ import re
 import warnings
 from copy import deepcopy
 from typing import (
-    Any, Callable, Dict, Iterator, List, Match, Pattern, Tuple, Type, TypeVar, Union
+    Any, Callable, List, Match, Pattern, Tuple
 )
 
 from sphinx.deprecation import RemovedInSphinx40Warning

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -31,6 +31,35 @@ identifier_re = re.compile(r'''(?x)
     )
     [a-zA-Z0-9_]*\b
 ''')
+integer_literal_re = re.compile(r'[1-9][0-9]*')
+octal_literal_re = re.compile(r'0[0-7]*')
+hex_literal_re = re.compile(r'0[xX][0-9a-fA-F][0-9a-fA-F]*')
+binary_literal_re = re.compile(r'0[bB][01][01]*')
+float_literal_re = re.compile(r'''(?x)
+    [+-]?(
+    # decimal
+      ([0-9]+[eE][+-]?[0-9]+)
+    | ([0-9]*\.[0-9]+([eE][+-]?[0-9]+)?)
+    | ([0-9]+\.([eE][+-]?[0-9]+)?)
+    # hex
+    | (0[xX][0-9a-fA-F]+[pP][+-]?[0-9a-fA-F]+)
+    | (0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9a-fA-F]+)?)
+    | (0[xX][0-9a-fA-F]+\.([pP][+-]?[0-9a-fA-F]+)?)
+    )
+''')
+char_literal_re = re.compile(r'''(?x)
+    ((?:u8)|u|U|L)?
+    '(
+      (?:[^\\'])
+    | (\\(
+        (?:['"?\\abfnrtv])
+      | (?:[0-7]{1,3})
+      | (?:x[0-9a-fA-F]{2})
+      | (?:u[0-9a-fA-F]{4})
+      | (?:U[0-9a-fA-F]{8})
+      ))
+    )'
+''')
 
 
 def verify_description_mode(mode: str) -> None:
@@ -77,6 +106,15 @@ class ASTBase:
 
     def __repr__(self) -> str:
         return '<%s>' % self.__class__.__name__
+
+
+class UnsupportedMultiCharacterCharLiteral(Exception):
+    @property
+    def decoded(self) -> str:
+        warnings.warn('%s.decoded is deprecated. '
+                      'Coerce the instance to a string instead.' % self.__class__.__name__,
+                      RemovedInSphinx40Warning, stacklevel=2)
+        return str(self)
 
 
 class DefinitionError(Exception):

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -1,0 +1,209 @@
+"""
+    sphinx.util.cfamily
+    ~~~~~~~~~~~~~~~~
+
+    Utility functions common to the C and C++ domains.
+
+    :copyright: Copyright 2020-2020 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+import warnings
+from copy import deepcopy
+from typing import (
+    Any, Callable, Dict, Iterator, List, Match, Pattern, Tuple, Type, TypeVar, Union
+)
+
+from sphinx.deprecation import RemovedInSphinx40Warning
+
+
+StringifyTransform = Callable[[Any], str]
+
+
+_whitespace_re = re.compile(r'(?u)\s+')
+anon_identifier_re = re.compile(r'(@[a-zA-Z0-9_])[a-zA-Z0-9_]*\b')
+identifier_re = re.compile(r'''(?x)
+    (   # This 'extends' _anon_identifier_re with the ordinary identifiers,
+        # make sure they are in sync.
+        (~?\b[a-zA-Z_])  # ordinary identifiers
+    |   (@[a-zA-Z0-9_])  # our extension for names of anonymous entities
+    )
+    [a-zA-Z0-9_]*\b
+''')
+
+
+def verify_description_mode(mode: str) -> None:
+    if mode not in ('lastIsName', 'noneIsName', 'markType', 'markName', 'param'):
+        raise Exception("Description mode '%s' is invalid." % mode)
+
+
+class NoOldIdError(Exception):
+    # Used to avoid implementing unneeded id generation for old id schemes.
+    @property
+    def description(self) -> str:
+        warnings.warn('%s.description is deprecated. '
+                      'Coerce the instance to a string instead.' % self.__class__.__name__,
+                      RemovedInSphinx40Warning, stacklevel=2)
+        return str(self)
+
+
+class ASTBase:
+    def __eq__(self, other: Any) -> bool:
+        if type(self) is not type(other):
+            return False
+        try:
+            for key, value in self.__dict__.items():
+                if value != getattr(other, key):
+                    return False
+        except AttributeError:
+            return False
+        return True
+
+    __hash__ = None  # type: Callable[[], int]
+
+    def clone(self) -> Any:
+        """Clone a definition expression node."""
+        return deepcopy(self)
+
+    def _stringify(self, transform: StringifyTransform) -> str:
+        raise NotImplementedError(repr(self))
+
+    def __str__(self) -> str:
+        return self._stringify(lambda ast: str(ast))
+
+    def get_display_string(self) -> str:
+        return self._stringify(lambda ast: ast.get_display_string())
+
+    def __repr__(self) -> str:
+        return '<%s>' % self.__class__.__name__
+
+
+class DefinitionError(Exception):
+    @property
+    def description(self) -> str:
+        warnings.warn('%s.description is deprecated. '
+                      'Coerce the instance to a string instead.' % self.__class__.__name__,
+                      RemovedInSphinx40Warning, stacklevel=2)
+        return str(self)
+
+
+class BaseParser:
+    def __init__(self, definition: Any, warnEnv: Any) -> None:
+        self.warnEnv = warnEnv
+        self.definition = definition.strip()
+        self.pos = 0
+        self.end = len(self.definition)
+        self.last_match = None  # type: Match
+        self._previous_state = (0, None)  # type: Tuple[int, Match]
+        self.otherErrors = []  # type: List[DefinitionError]
+
+        # in our tests the following is set to False to capture bad parsing
+        self.allowFallbackExpressionParsing = True
+
+    def _make_multi_error(self, errors: List[Any], header: str) -> DefinitionError:
+        if len(errors) == 1:
+            if len(header) > 0:
+                return DefinitionError(header + '\n' + str(errors[0][0]))
+            else:
+                return DefinitionError(str(errors[0][0]))
+        result = [header, '\n']
+        for e in errors:
+            if len(e[1]) > 0:
+                ident = '  '
+                result.append(e[1])
+                result.append(':\n')
+                for line in str(e[0]).split('\n'):
+                    if len(line) == 0:
+                        continue
+                    result.append(ident)
+                    result.append(line)
+                    result.append('\n')
+            else:
+                result.append(str(e[0]))
+        return DefinitionError(''.join(result))
+
+    def status(self, msg: str) -> None:
+        # for debugging
+        indicator = '-' * self.pos + '^'
+        print("%s\n%s\n%s" % (msg, self.definition, indicator))
+
+    def fail(self, msg: str) -> None:
+        errors = []
+        indicator = '-' * self.pos + '^'
+        exMain = DefinitionError(
+            'Invalid definition: %s [error at %d]\n  %s\n  %s' %
+            (msg, self.pos, self.definition, indicator))
+        errors.append((exMain, "Main error"))
+        for err in self.otherErrors:
+            errors.append((err, "Potential other error"))
+        self.otherErrors = []
+        raise self._make_multi_error(errors, '')
+
+    def warn(self, msg: str) -> None:
+        if self.warnEnv:
+            self.warnEnv.warn(msg)
+        else:
+            print("Warning: %s" % msg)
+
+    def match(self, regex: Pattern) -> bool:
+        match = regex.match(self.definition, self.pos)
+        if match is not None:
+            self._previous_state = (self.pos, self.last_match)
+            self.pos = match.end()
+            self.last_match = match
+            return True
+        return False
+
+    def skip_string(self, string: str) -> bool:
+        strlen = len(string)
+        if self.definition[self.pos:self.pos + strlen] == string:
+            self.pos += strlen
+            return True
+        return False
+
+    def skip_word(self, word: str) -> bool:
+        return self.match(re.compile(r'\b%s\b' % re.escape(word)))
+
+    def skip_ws(self) -> bool:
+        return self.match(_whitespace_re)
+
+    def skip_word_and_ws(self, word: str) -> bool:
+        if self.skip_word(word):
+            self.skip_ws()
+            return True
+        return False
+
+    def skip_string_and_ws(self, string: str) -> bool:
+        if self.skip_string(string):
+            self.skip_ws()
+            return True
+        return False
+
+    @property
+    def eof(self) -> bool:
+        return self.pos >= self.end
+
+    @property
+    def current_char(self) -> str:
+        try:
+            return self.definition[self.pos]
+        except IndexError:
+            return 'EOF'
+
+    @property
+    def matched_text(self) -> str:
+        if self.last_match is not None:
+            return self.last_match.group()
+        else:
+            return None
+
+    def read_rest(self) -> str:
+        rv = self.definition[self.pos:]
+        self.pos = self.end
+        return rv
+
+    def assert_end(self) -> None:
+        self.skip_ws()
+        if not self.eof:
+            self.fail('Expected end of definition.')

--- a/tests/roots/test-domain-c/conf.py
+++ b/tests/roots/test-domain-c/conf.py
@@ -1,0 +1,1 @@
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-c/index.rst
+++ b/tests/roots/test-domain-c/index.rst
@@ -7,11 +7,32 @@ directives
 .. c:function:: int hello(char *name)
 
 .. c:member:: float Sphinx.version
+.. c:var:: int version
 
 .. c:macro::  IS_SPHINX
-
 .. c:macro::  SPHINX(arg1, arg2)
 
-.. c:type:: Sphinx
+.. c:struct:: MyStruct
+.. c:union:: MyUnion
+.. c:enum:: MyEnum
 
-.. c:var:: int version
+   .. c:enumerator:: MyEnumerator
+
+      :c:enumerator:`MyEnumerator`
+
+   :c:enumerator:`MyEnumerator`
+
+:c:enumerator:`MyEnumerator`
+
+.. c:type:: Sphinx
+.. c:type:: int SphinxVersionNum
+
+
+.. c:struct:: A
+
+   .. c:union:: @data
+
+      .. c:member:: int a
+
+- :c:member:`A.@data.a`
+- :c:member:`A.a`

--- a/tests/roots/test-domain-c/index.rst
+++ b/tests/roots/test-domain-c/index.rst
@@ -4,7 +4,7 @@ test-domain-c
 directives
 ----------
 
-.. c:function:: int hello(char *name)
+.. c:function:: int hello(const char *name)
 
    :rtype: int
 

--- a/tests/roots/test-domain-c/index.rst
+++ b/tests/roots/test-domain-c/index.rst
@@ -6,6 +6,12 @@ directives
 
 .. c:function:: int hello(char *name)
 
+   :rtype: int
+
+.. c:function:: MyStruct hello2(char *name)
+
+   :rtype: MyStruct
+
 .. c:member:: float Sphinx.version
 .. c:var:: int version
 

--- a/tests/roots/test-domain-c/index.rst
+++ b/tests/roots/test-domain-c/index.rst
@@ -1,0 +1,17 @@
+test-domain-c
+=============
+
+directives
+----------
+
+.. c:function:: int hello(char *name)
+
+.. c:member:: float Sphinx.version
+
+.. c:macro::  IS_SPHINX
+
+.. c:macro::  SPHINX(arg1, arg2)
+
+.. c:type:: Sphinx
+
+.. c:var:: int version

--- a/tests/roots/test-domain-c/index.rst
+++ b/tests/roots/test-domain-c/index.rst
@@ -36,3 +36,11 @@ directives
 
 - :c:member:`A.@data.a`
 - :c:member:`A.a`
+
+- :c:expr:`unsigned int`
+- :c:texpr:`unsigned int`
+
+.. c:var:: A a
+
+- :c:expr:`a->b`
+- :c:texpr:`a->b`

--- a/tests/roots/test-root/objects.txt
+++ b/tests/roots/test-root/objects.txt
@@ -107,15 +107,15 @@ Referring to :func:`nothing <>`.
 C items
 =======
 
-.. c:function:: Sphinx_DoSomething()
+.. c:function:: void Sphinx_DoSomething()
 
-.. c:member:: SphinxStruct.member
+.. c:member:: int SphinxStruct.member
 
 .. c:macro:: SPHINX_USE_PYTHON
 
 .. c:type:: SphinxType
 
-.. c:var:: sphinx_global
+.. c:var:: int sphinx_global
 
 
 Javascript items

--- a/tests/test_build_changes.py
+++ b/tests/test_build_changes.py
@@ -28,7 +28,7 @@ def test_build(app):
     assert path_html in htmltext
 
     malloc_html = (
-        '<b>Test_Malloc</b>: <i>changed:</i> Changed in version 0.6:'
+        '<b>void *Test_Malloc(size_t n)</b>: <i>changed:</i> Changed in version 0.6:'
         ' Can now be replaced with a different allocator.</a>')
     assert malloc_html in htmltext
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -289,11 +289,11 @@ def test_html4_output(app, status, warning):
         (".//a[@class='reference internal'][@href='#errmod-error']/strong", 'Error'),
         # C references
         (".//span[@class='pre']", 'CFunction()'),
-        (".//a[@href='#c-sphinx-dosomething']", ''),
-        (".//a[@href='#c-sphinxstruct-member']", ''),
-        (".//a[@href='#c-sphinx-use-python']", ''),
-        (".//a[@href='#c-sphinxtype']", ''),
-        (".//a[@href='#c-sphinx-global']", ''),
+        (".//a[@href='#c.Sphinx_DoSomething']", ''),
+        (".//a[@href='#c.SphinxStruct.member']", ''),
+        (".//a[@href='#c.SPHINX_USE_PYTHON']", ''),
+        (".//a[@href='#c.SphinxType']", ''),
+        (".//a[@href='#c.sphinx_global']", ''),
         # test global TOC created by toctree()
         (".//ul[@class='current']/li[@class='toctree-l1 current']/a[@href='#']",
          'Testing object descriptions'),

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -108,6 +108,8 @@ def test_expressions():
     exprCheck('int *restrict*')
     exprCheck('int *(*)(double)')
     exprCheck('const int*')
+    exprCheck('__int64')
+    exprCheck('unsigned __int64')
 
     # actual expressions
 
@@ -260,6 +262,8 @@ def test_member_definitions():
     check('member', 'double a', {1: 'a'})
 
     check('member', 'unsigned long a', {1: 'a'})
+    check('member', '__int64 a', {1: 'a'})
+    check('member', 'unsigned __int64 a', {1: 'a'})
 
     check('member', 'int .a', {1: 'a'})
 

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -8,73 +8,549 @@
     :license: BSD, see LICENSE for details.
 """
 
-from docutils import nodes
+import re
 
+import pytest
+
+from docutils import nodes
+import sphinx.domains.c as cDomain
 from sphinx import addnodes
 from sphinx.addnodes import (
     desc, desc_addname, desc_annotation, desc_content, desc_name, desc_optional,
     desc_parameter, desc_parameterlist, desc_returns, desc_signature, desc_type,
     pending_xref
 )
+from sphinx.domains.c import DefinitionParser, DefinitionError
+from sphinx.domains.c import _max_id, _id_prefix, Symbol
 from sphinx.testing import restructuredtext
 from sphinx.testing.util import assert_node
+from sphinx.util import docutils
+
+
+def parse(name, string):
+    parser = DefinitionParser(string, None)
+    parser.allowFallbackExpressionParsing = False
+    ast = parser.parse_declaration(name, name)
+    parser.assert_end()
+    return ast
+
+
+def check(name, input, idDict, output=None):
+    # first a simple check of the AST
+    if output is None:
+        output = input
+    ast = parse(name, input)
+    res = str(ast)
+    if res != output:
+        print("")
+        print("Input:    ", input)
+        print("Result:   ", res)
+        print("Expected: ", output)
+        raise DefinitionError("")
+    rootSymbol = Symbol(None, None, None, None)
+    symbol = rootSymbol.add_declaration(ast, docname="TestDoc")
+    parentNode = addnodes.desc()
+    signode = addnodes.desc_signature(input, '')
+    parentNode += signode
+    ast.describe_signature(signode, 'lastIsName', symbol, options={})
+
+    idExpected = [None]
+    for i in range(1, _max_id + 1):
+        if i in idDict:
+            idExpected.append(idDict[i])
+        else:
+            idExpected.append(idExpected[i - 1])
+    idActual = [None]
+    for i in range(1, _max_id + 1):
+        #try:
+        id = ast.get_id(version=i)
+        assert id is not None
+        idActual.append(id[len(_id_prefix[i]):])
+        #except NoOldIdError:
+        #    idActual.append(None)
+
+    res = [True]
+    for i in range(1, _max_id + 1):
+        res.append(idExpected[i] == idActual[i])
+
+    if not all(res):
+        print("input:    %s" % input.rjust(20))
+        for i in range(1, _max_id + 1):
+            if res[i]:
+                continue
+            print("Error in id version %d." % i)
+            print("result:   %s" % idActual[i])
+            print("expected: %s" % idExpected[i])
+        #print(rootSymbol.dump(0))
+        raise DefinitionError("")
+
+
+def test_expressions():
+    return  # TODO
+    def exprCheck(expr, id, id4=None):
+        ids = 'IE1CIA%s_1aE'
+        idDict = {2: ids % expr, 3: ids % id}
+        if id4 is not None:
+            idDict[4] = ids % id4
+        check('class', 'template<> C<a[%s]>' % expr, idDict)
+    # primary
+    exprCheck('nullptr', 'LDnE')
+    exprCheck('true', 'L1E')
+    exprCheck('false', 'L0E')
+    ints = ['5', '0', '075', '0x0123456789ABCDEF', '0XF', '0b1', '0B1']
+    unsignedSuffix = ['', 'u', 'U']
+    longSuffix = ['', 'l', 'L', 'll', 'LL']
+    for i in ints:
+        for u in unsignedSuffix:
+            for l in longSuffix:
+                expr = i + u + l
+                exprCheck(expr, 'L' + expr + 'E')
+                expr = i + l + u
+                exprCheck(expr, 'L' + expr + 'E')
+    for suffix in ['', 'f', 'F', 'l', 'L']:
+        for e in [
+                '5e42', '5e+42', '5e-42',
+                '5.', '5.e42', '5.e+42', '5.e-42',
+                '.5', '.5e42', '.5e+42', '.5e-42',
+                '5.0', '5.0e42', '5.0e+42', '5.0e-42']:
+            expr = e + suffix
+            exprCheck(expr, 'L' + expr + 'E')
+        for e in [
+                'ApF', 'Ap+F', 'Ap-F',
+                'A.', 'A.pF', 'A.p+F', 'A.p-F',
+                '.A', '.ApF', '.Ap+F', '.Ap-F',
+                'A.B', 'A.BpF', 'A.Bp+F', 'A.Bp-F']:
+            expr = "0x" + e + suffix
+            exprCheck(expr, 'L' + expr + 'E')
+    exprCheck('"abc\\"cba"', 'LA8_KcE')  # string
+    exprCheck('this', 'fpT')
+    # character literals
+    for p, t in [('', 'c'), ('u8', 'c'), ('u', 'Ds'), ('U', 'Di'), ('L', 'w')]:
+        exprCheck(p + "'a'", t + "97")
+        exprCheck(p + "'\\n'", t + "10")
+        exprCheck(p + "'\\012'", t + "10")
+        exprCheck(p + "'\\0'", t + "0")
+        exprCheck(p + "'\\x0a'", t + "10")
+        exprCheck(p + "'\\x0A'", t + "10")
+        exprCheck(p + "'\\u0a42'", t + "2626")
+        exprCheck(p + "'\\u0A42'", t + "2626")
+        exprCheck(p + "'\\U0001f34c'", t + "127820")
+        exprCheck(p + "'\\U0001F34C'", t + "127820")
+
+    # TODO: user-defined lit
+    exprCheck('(... + Ns)', '(... + Ns)', id4='flpl2Ns')
+    exprCheck('(Ns + ...)', '(Ns + ...)', id4='frpl2Ns')
+    exprCheck('(Ns + ... + 0)', '(Ns + ... + 0)', id4='fLpl2NsL0E')
+    exprCheck('(5)', 'L5E')
+    exprCheck('C', '1C')
+    # postfix
+    exprCheck('A(2)', 'cl1AL2EE')
+    exprCheck('A[2]', 'ix1AL2E')
+    exprCheck('a.b.c', 'dtdt1a1b1c')
+    exprCheck('a->b->c', 'ptpt1a1b1c')
+    exprCheck('i++', 'pp1i')
+    exprCheck('i--', 'mm1i')
+    exprCheck('dynamic_cast<T&>(i)++', 'ppdcR1T1i')
+    exprCheck('static_cast<T&>(i)++', 'ppscR1T1i')
+    exprCheck('reinterpret_cast<T&>(i)++', 'pprcR1T1i')
+    exprCheck('const_cast<T&>(i)++', 'ppccR1T1i')
+    exprCheck('typeid(T).name', 'dtti1T4name')
+    exprCheck('typeid(a + b).name', 'dttepl1a1b4name')
+    # unary
+    exprCheck('++5', 'pp_L5E')
+    exprCheck('--5', 'mm_L5E')
+    exprCheck('*5', 'deL5E')
+    exprCheck('&5', 'adL5E')
+    exprCheck('+5', 'psL5E')
+    exprCheck('-5', 'ngL5E')
+    exprCheck('!5', 'ntL5E')
+    exprCheck('~5', 'coL5E')
+    exprCheck('sizeof...(a)', 'sZ1a')
+    exprCheck('sizeof(T)', 'st1T')
+    exprCheck('sizeof -42', 'szngL42E')
+    exprCheck('alignof(T)', 'at1T')
+    exprCheck('noexcept(-42)', 'nxngL42E')
+    # new-expression
+    exprCheck('new int', 'nw_iE')
+    exprCheck('new volatile int', 'nw_ViE')
+    exprCheck('new int[42]', 'nw_AL42E_iE')
+    exprCheck('new int()', 'nw_ipiE')
+    exprCheck('new int(5, 42)', 'nw_ipiL5EL42EE')
+    exprCheck('::new int', 'nw_iE')
+    exprCheck('new int{}', 'nw_iilE')
+    exprCheck('new int{5, 42}', 'nw_iilL5EL42EE')
+    # delete-expression
+    exprCheck('delete p', 'dl1p')
+    exprCheck('delete [] p', 'da1p')
+    exprCheck('::delete p', 'dl1p')
+    exprCheck('::delete [] p', 'da1p')
+    # cast
+    exprCheck('(int)2', 'cviL2E')
+    # binary op
+    exprCheck('5 || 42', 'ooL5EL42E')
+    exprCheck('5 && 42', 'aaL5EL42E')
+    exprCheck('5 | 42', 'orL5EL42E')
+    exprCheck('5 ^ 42', 'eoL5EL42E')
+    exprCheck('5 & 42', 'anL5EL42E')
+    # ['==', '!=']
+    exprCheck('5 == 42', 'eqL5EL42E')
+    exprCheck('5 != 42', 'neL5EL42E')
+    # ['<=', '>=', '<', '>']
+    exprCheck('5 <= 42', 'leL5EL42E')
+    exprCheck('5 >= 42', 'geL5EL42E')
+    exprCheck('5 < 42', 'ltL5EL42E')
+    exprCheck('5 > 42', 'gtL5EL42E')
+    # ['<<', '>>']
+    exprCheck('5 << 42', 'lsL5EL42E')
+    exprCheck('5 >> 42', 'rsL5EL42E')
+    # ['+', '-']
+    exprCheck('5 + 42', 'plL5EL42E')
+    exprCheck('5 - 42', 'miL5EL42E')
+    # ['*', '/', '%']
+    exprCheck('5 * 42', 'mlL5EL42E')
+    exprCheck('5 / 42', 'dvL5EL42E')
+    exprCheck('5 % 42', 'rmL5EL42E')
+    # ['.*', '->*']
+    exprCheck('5 .* 42', 'dsL5EL42E')
+    exprCheck('5 ->* 42', 'pmL5EL42E')
+    # conditional
+    # TODO
+    # assignment
+    exprCheck('a = 5', 'aS1aL5E')
+    exprCheck('a *= 5', 'mL1aL5E')
+    exprCheck('a /= 5', 'dV1aL5E')
+    exprCheck('a %= 5', 'rM1aL5E')
+    exprCheck('a += 5', 'pL1aL5E')
+    exprCheck('a -= 5', 'mI1aL5E')
+    exprCheck('a >>= 5', 'rS1aL5E')
+    exprCheck('a <<= 5', 'lS1aL5E')
+    exprCheck('a &= 5', 'aN1aL5E')
+    exprCheck('a ^= 5', 'eO1aL5E')
+    exprCheck('a |= 5', 'oR1aL5E')
+
+    # Additional tests
+    # a < expression that starts with something that could be a template
+    exprCheck('A < 42', 'lt1AL42E')
+    check('function', 'template<> void f(A<B, 2> &v)',
+          {2: "IE1fR1AI1BX2EE", 3: "IE1fR1AI1BXL2EEE", 4: "IE1fvR1AI1BXL2EEE"})
+    exprCheck('A<1>::value', 'N1AIXL1EEE5valueE')
+    check('class', "template<int T = 42> A", {2: "I_iE1A"})
+    check('enumerator', 'A = std::numeric_limits<unsigned long>::max()', {2: "1A"})
+
+    exprCheck('operator()()', 'clclE')
+    exprCheck('operator()<int>()', 'clclIiEE')
+
+    # pack expansion
+    exprCheck('a(b(c, 1 + d...)..., e(f..., g))', 'cl1aspcl1b1cspplL1E1dEcl1esp1f1gEE')
+
+
+def test_type_definitions():
+    check('type', "T", {1: "T"})
+    check('type', "struct T", {1: 'T'})
+    check('type', "enum T", {1: 'T'})
+    check('type', "union T", {1: 'T'})
+
+    check('type', "bool *b", {1: 'b'})
+    check('type', "bool *const b", {1: 'b'})
+    check('type', "bool *volatile const b", {1: 'b'})
+    check('type', "bool *volatile const b", {1: 'b'})
+    check('type', "bool *volatile const *b", {1: 'b'})
+    check('type', "bool b[]", {1: 'b'})
+    check('type', "long long int foo", {1: 'foo'})
+    # test decl specs on right
+    check('type', "bool const b", {1: 'b'})
+
+    # from breathe#267 (named function parameters for function pointers
+    check('type', 'void (*gpio_callback_t)(struct device *port, uint32_t pin)',
+          {1: 'gpio_callback_t'})
+
+
+def test_macro_definitions():
+    check('macro', 'M', {1: 'M'})
+    check('macro', 'M()', {1: 'M'})
+    check('macro', 'M(arg)', {1: 'M'})
+    check('macro', 'M(arg1, arg2)', {1: 'M'})
+    check('macro', 'M(arg1, arg2, arg3)', {1: 'M'})
+    check('macro', 'M(...)', {1: 'M'})
+    check('macro', 'M(arg, ...)', {1: 'M'})
+    check('macro', 'M(arg1, arg2, ...)', {1: 'M'})
+    check('macro', 'M(arg1, arg2, arg3, ...)', {1: 'M'})
+
+
+def test_member_definitions():
+    check('member', 'void a', {1: 'a'})
+    check('member', '_Bool a', {1: 'a'})
+    check('member', 'bool a', {1: 'a'})
+    check('member', 'char a', {1: 'a'})
+    check('member', 'int a', {1: 'a'})
+    check('member', 'float a', {1: 'a'})
+    check('member', 'double a', {1: 'a'})
+
+    check('member', 'unsigned long a', {1: 'a'})
+
+    check('member', 'int .a', {1: 'a'})
+
+    check('member', 'int *a', {1: 'a'})
+    check('member', 'int **a', {1: 'a'})
+    check('member', 'const int a', {1: 'a'})
+    check('member', 'volatile int a', {1: 'a'})
+    check('member', 'restrict int a', {1: 'a'})
+    check('member', 'volatile const int a', {1: 'a'})
+    check('member', 'restrict const int a', {1: 'a'})
+    check('member', 'restrict volatile int a', {1: 'a'})
+    check('member', 'restrict volatile const int a', {1: 'a'})
+
+    check('member', 'T t', {1: 't'})
+    check('member', 'struct T t', {1: 't'})
+    check('member', 'enum T t', {1: 't'})
+    check('member', 'union T t', {1: 't'})
+
+    check('member', 'int a[]', {1: 'a'})
+
+    check('member', 'int (*p)[]', {1: 'p'})
+
+    check('member', 'int a[42]', {1: 'a'})
+    check('member', 'int a = 42', {1: 'a'})
+    check('member', 'T a = {}', {1: 'a'})
+    check('member', 'T a = {1}', {1: 'a'})
+    check('member', 'T a = {1, 2}', {1: 'a'})
+    check('member', 'T a = {1, 2, 3}', {1: 'a'})
+
+    # test from issue #1539
+    check('member', 'CK_UTF8CHAR model[16]', {1: 'model'})
+
+    check('member', 'auto int a', {1: 'a'})
+    check('member', 'register int a', {1: 'a'})
+    check('member', 'extern int a', {1: 'a'})
+    check('member', 'static int a', {1: 'a'})
+
+    check('member', 'thread_local int a', {1: 'a'})
+    check('member', '_Thread_local int a', {1: 'a'})
+    check('member', 'extern thread_local int a', {1: 'a'})
+    check('member', 'thread_local extern int a', {1: 'a'},
+          'extern thread_local int a')
+    check('member', 'static thread_local int a', {1: 'a'})
+    check('member', 'thread_local static int a', {1: 'a'},
+          'static thread_local int a')
+
+    check('member', 'int b : 3', {1: 'b'})
+
+
+def test_function_definitions():
+    check('function', 'void f()', {1: 'f'})
+    check('function', 'void f(int)', {1: 'f'})
+    check('function', 'void f(int i)', {1: 'f'})
+    check('function', 'void f(int i, int j)', {1: 'f'})
+    check('function', 'void f(...)', {1: 'f'})
+    check('function', 'void f(int i, ...)', {1: 'f'})
+    check('function', 'void f(struct T)', {1: 'f'})
+    check('function', 'void f(struct T t)', {1: 'f'})
+    check('function', 'void f(union T)', {1: 'f'})
+    check('function', 'void f(union T t)', {1: 'f'})
+    check('function', 'void f(enum T)', {1: 'f'})
+    check('function', 'void f(enum T t)', {1: 'f'})
+
+    # test from issue #1539
+    check('function', 'void f(A x[])', {1: 'f'})
+
+    # test from issue #2377
+    check('function', 'void (*signal(int sig, void (*func)(int)))(int)', {1: 'signal'})
+
+    check('function', 'extern void f()', {1: 'f'})
+    check('function', 'static void f()', {1: 'f'})
+    check('function', 'inline void f()', {1: 'f'})
+
+    # tests derived from issue #1753 (skip to keep sanity)
+    check('function', "void f(float *q(double))", {1: 'f'})
+    check('function', "void f(float *(*q)(double))", {1: 'f'})
+    check('function', "void f(float (*q)(double))", {1: 'f'})
+    check('function', "int (*f(double d))(float)", {1: 'f'})
+    check('function', "int (*f(bool b))[5]", {1: 'f'})
+    check('function', "void f(int *const p)", {1: 'f'})
+    check('function', "void f(int *volatile const p)", {1: 'f'})
+
+    # from breathe#223
+    check('function', 'void f(struct E e)', {1: 'f'})
+    check('function', 'void f(enum E e)', {1: 'f'})
+    check('function', 'void f(union E e)', {1: 'f'})
+
+
+def test_union_definitions():
+    return  # TODO
+    check('union', 'A', {2: "1A"})
+
+
+def test_enum_definitions():
+    return  # TODO
+    check('enum', 'A', {2: "1A"})
+    check('enum', 'A : std::underlying_type<B>::type', {2: "1A"})
+    check('enum', 'A : unsigned int', {2: "1A"})
+    check('enum', 'public A', {2: "1A"}, output='A')
+    check('enum', 'private A', {2: "1A"})
+
+    check('enumerator', 'A', {2: "1A"})
+    check('enumerator', 'A = std::numeric_limits<unsigned long>::max()', {2: "1A"})
+
+
+def test_anon_definitions():
+    return  # TODO
+    check('class', '@a', {3: "Ut1_a"})
+    check('union', '@a', {3: "Ut1_a"})
+    check('enum', '@a', {3: "Ut1_a"})
+    check('class', '@1', {3: "Ut1_1"})
+    check('class', '@a::A', {3: "NUt1_a1AE"})
+
+
+def test_initializers():
+    return  # TODO
+    idsMember = {1: 'v__T', 2: '1v'}
+    idsFunction = {1: 'f__T', 2: '1f1T'}
+    idsTemplate = {2: 'I_1TE1fv', 4: 'I_1TE1fvv'}
+    # no init
+    check('member', 'T v', idsMember)
+    check('function', 'void f(T v)', idsFunction)
+    check('function', 'template<T v> void f()', idsTemplate)
+    # with '=', assignment-expression
+    check('member', 'T v = 42', idsMember)
+    check('function', 'void f(T v = 42)', idsFunction)
+    check('function', 'template<T v = 42> void f()', idsTemplate)
+    # with '=', braced-init
+    check('member', 'T v = {}', idsMember)
+    check('function', 'void f(T v = {})', idsFunction)
+    check('function', 'template<T v = {}> void f()', idsTemplate)
+    check('member', 'T v = {42, 42, 42}', idsMember)
+    check('function', 'void f(T v = {42, 42, 42})', idsFunction)
+    check('function', 'template<T v = {42, 42, 42}> void f()', idsTemplate)
+    check('member', 'T v = {42, 42, 42,}', idsMember)
+    check('function', 'void f(T v = {42, 42, 42,})', idsFunction)
+    check('function', 'template<T v = {42, 42, 42,}> void f()', idsTemplate)
+    check('member', 'T v = {42, 42, args...}', idsMember)
+    check('function', 'void f(T v = {42, 42, args...})', idsFunction)
+    check('function', 'template<T v = {42, 42, args...}> void f()', idsTemplate)
+    # without '=', braced-init
+    check('member', 'T v{}', idsMember)
+    check('member', 'T v{42, 42, 42}', idsMember)
+    check('member', 'T v{42, 42, 42,}', idsMember)
+    check('member', 'T v{42, 42, args...}', idsMember)
+    # other
+    check('member', 'T v = T{}', idsMember)
+
+
+def test_attributes():
+    return  # TODO
+    # style: C++
+    check('member', '[[]] int f', {1: 'f__i', 2: '1f'})
+    check('member', '[ [ ] ] int f', {1: 'f__i', 2: '1f'},
+          # this will fail when the proper grammar is implemented
+          output='[[ ]] int f')
+    check('member', '[[a]] int f', {1: 'f__i', 2: '1f'})
+    # style: GNU
+    check('member', '__attribute__(()) int f', {1: 'f__i', 2: '1f'})
+    check('member', '__attribute__((a)) int f', {1: 'f__i', 2: '1f'})
+    check('member', '__attribute__((a, b)) int f', {1: 'f__i', 2: '1f'})
+    # style: user-defined id
+    check('member', 'id_attr int f', {1: 'f__i', 2: '1f'})
+    # style: user-defined paren
+    check('member', 'paren_attr() int f', {1: 'f__i', 2: '1f'})
+    check('member', 'paren_attr(a) int f', {1: 'f__i', 2: '1f'})
+    check('member', 'paren_attr("") int f', {1: 'f__i', 2: '1f'})
+    check('member', 'paren_attr(()[{}][]{}) int f', {1: 'f__i', 2: '1f'})
+    with pytest.raises(DefinitionError):
+        parse('member', 'paren_attr(() int f')
+    with pytest.raises(DefinitionError):
+        parse('member', 'paren_attr([) int f')
+    with pytest.raises(DefinitionError):
+        parse('member', 'paren_attr({) int f')
+    with pytest.raises(DefinitionError):
+        parse('member', 'paren_attr([)]) int f')
+    with pytest.raises(DefinitionError):
+        parse('member', 'paren_attr((])) int f')
+    with pytest.raises(DefinitionError):
+        parse('member', 'paren_attr({]}) int f')
+
+    # position: decl specs
+    check('function', 'static inline __attribute__(()) void f()',
+          {1: 'f', 2: '1fv'},
+          output='__attribute__(()) static inline void f()')
+    check('function', '[[attr1]] [[attr2]] void f()',
+          {1: 'f', 2: '1fv'},
+          output='[[attr1]] [[attr2]] void f()')
+    # position: declarator
+    check('member', 'int *[[attr]] i', {1: 'i__iP', 2: '1i'})
+    check('member', 'int *const [[attr]] volatile i', {1: 'i__iPVC', 2: '1i'},
+          output='int *[[attr]] volatile const i')
+    check('member', 'int &[[attr]] i', {1: 'i__iR', 2: '1i'})
+    check('member', 'int *[[attr]] *i', {1: 'i__iPP', 2: '1i'})
+
+
+def test_xref_parsing():
+    return  # TODO
+    def check(target):
+        class Config:
+            cpp_id_attributes = ["id_attr"]
+            cpp_paren_attributes = ["paren_attr"]
+        parser = DefinitionParser(target, None, Config())
+        ast, isShorthand = parser.parse_xref_object()
+        parser.assert_end()
+    check('f')
+    check('f()')
+    check('void f()')
+    check('T f()')
+
+
+# def test_print():
+#     # used for getting all the ids out for checking
+#     for a in ids:
+#         print(a)
+#     raise DefinitionError("")
+
+
+def filter_warnings(warning, file):
+    lines = warning.getvalue().split("\n");
+    res = [l for l in lines if "domain-c" in l and "{}.rst".format(file) in l and
+           "WARNING: document isn't included in any toctree" not in l]
+    print("Filtered warnings for file '{}':".format(file))
+    for w in res:
+        print(w)
+    return res
+
+
+@pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
+def test_build_domain_c(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "index")
+    assert len(ws) == 0
 
 
 def test_cfunction(app):
     text = (".. c:function:: PyObject* "
             "PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)")
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree,
-                (addnodes.index,
-                 [desc, ([desc_signature, ([desc_type, ([pending_xref, "PyObject"],
-                                                        "* ")],
-                                           [desc_name, "PyType_GenericAlloc"],
-                                           [desc_parameterlist, (desc_parameter,
-                                                                 desc_parameter)])],
-                         desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="function",
                 domain="c", objtype="function", noindex=False)
-    assert_node(doctree[1][0][2][0],
-                [desc_parameter, ([pending_xref, "PyTypeObject"],
-                                  [nodes.emphasis, "\xa0*type"])])
-    assert_node(doctree[1][0][2][1],
-                [desc_parameter, ([pending_xref, "Py_ssize_t"],
-                                  [nodes.emphasis, "\xa0nitems"])])
 
     domain = app.env.get_domain('c')
     entry = domain.objects.get('PyType_GenericAlloc')
-    assert entry == ('index', 'c-pytype-genericalloc', 'function')
+    assert entry == ('index', 'c.PyType_GenericAlloc', 'function')
 
 
 def test_cmember(app):
     text = ".. c:member:: PyObject* PyTypeObject.tp_bases"
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree,
-                (addnodes.index,
-                 [desc, ([desc_signature, ([desc_type, ([pending_xref, "PyObject"],
-                                                        "* ")],
-                                           [desc_name, "PyTypeObject.tp_bases"])],
-                         desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="member",
                 domain="c", objtype="member", noindex=False)
 
     domain = app.env.get_domain('c')
     entry = domain.objects.get('PyTypeObject.tp_bases')
-    assert entry == ('index', 'c-pytypeobject-tp-bases', 'member')
+    assert entry == ('index', 'c.PyTypeObject.tp_bases', 'member')
 
 
 def test_cvar(app):
     text = ".. c:var:: PyObject* PyClass_Type"
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree,
-                (addnodes.index,
-                 [desc, ([desc_signature, ([desc_type, ([pending_xref, "PyObject"],
-                                                        "* ")],
-                                           [desc_name, "PyClass_Type"])],
-                         desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="var",
                 domain="c", objtype="var", noindex=False)
 
     domain = app.env.get_domain('c')
     entry = domain.objects.get('PyClass_Type')
-    assert entry == ('index', 'c-pyclass-type', 'var')
+    assert entry == ('index', 'c.PyClass_Type', 'var')

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -246,9 +246,6 @@ def test_expressions():
 
 def test_type_definitions():
     check('type', "T", {1: "T"})
-    check('type', "struct T", {1: 'T'})
-    check('type', "enum T", {1: 'T'})
-    check('type', "union T", {1: 'T'})
 
     check('type', "bool *b", {1: 'b'})
     check('type', "bool *const b", {1: 'b'})
@@ -301,9 +298,6 @@ def test_member_definitions():
     check('member', 'restrict volatile const int a', {1: 'a'})
 
     check('member', 'T t', {1: 't'})
-    check('member', 'struct T t', {1: 't'})
-    check('member', 'enum T t', {1: 't'})
-    check('member', 'union T t', {1: 't'})
 
     check('member', 'int a[]', {1: 'a'})
 
@@ -376,20 +370,18 @@ def test_function_definitions():
 
 
 def test_union_definitions():
-    return  # TODO
-    check('union', 'A', {2: "1A"})
+    check('struct', 'A', {1: 'A'})
+
+
+def test_union_definitions():
+    check('union', 'A', {1: 'A'})
 
 
 def test_enum_definitions():
-    return  # TODO
-    check('enum', 'A', {2: "1A"})
-    check('enum', 'A : std::underlying_type<B>::type', {2: "1A"})
-    check('enum', 'A : unsigned int', {2: "1A"})
-    check('enum', 'public A', {2: "1A"}, output='A')
-    check('enum', 'private A', {2: "1A"})
+    check('enum', 'A', {1: 'A'})
 
-    check('enumerator', 'A', {2: "1A"})
-    check('enumerator', 'A = std::numeric_limits<unsigned long>::max()', {2: "1A"})
+    check('enumerator', 'A', {1: 'A'})
+    check('enumerator', 'A = 42', {1: 'A'})
 
 
 def test_anon_definitions():


### PR DESCRIPTION
Subject: essentially a rewrite of the C domain to fix issues and enable further development

### Feature or Bugfix
- Feature
- Bugfix
- Refactoring

### Purpose
The original implementation of the C domain relied on regex matching to parse signatures. While it works for many cases, there is a limit. This rewrite is in the same style as the C++ domain, and some details are shared between the two domains. It is naturally a large breaking change, but I believe it is necessary for furture improvement of the domain. In order to make some simple kind of judgement of the changes I have updated the cpython documentation as best as possible: https://github.com/jakobandersen/cpython/tree/doc_fixes

- xref lookup now respects the scope that it was declared in.
- Anonymous entities can now be declared with appropriate lookup rules.
- The ``c:type`` directive seemed to have been a catch-all for many signatures which made it difficult to parse and generate appropriate output. It has been changed to be much stricter and only allow either a name or a typedef-like declaration.
- There are new directives for structs, unions, enums, and enumerators. Lookup rules for enumerators are as expected from the language.
- New xref roles has been added in conjunction with the directives. (The issue from #7243 is not yet fixed yet)
- An ``c:expr`` role has been added to typeset a type of an expression in text. In particular while one before could write ``... a :c:type:`int` and then ...`` or ``... a :c:type:`char*` and then ...`` this will now trigger an error as the ``c:type`` strictly is for cross-referencing. Instead one should use the ``c:expr`` role.
- This PR incidentally reverts PR #7269 (sorry), except the removal of the ``signode['names'].append(targetname)`` thing. However, the ID generation is now guaranteed to produce different IDs for different declarations, and they are produced from parsed input (i.e., no arbitrary code injection).

### Detail
- Fixes #1539
- Fixes #2377