### PR TITLE
C++, prevent false warnings from expressions with <

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -5371,9 +5371,13 @@ class DefinitionParser:
                 prevErrors.append((e, "If type argument"))
                 self.pos = pos
                 try:
+                    # actually here we shouldn't use the fallback parser (hence allow=False),
+                    # because if actually took the < in an expression, then we _will_ fail,
+                    # which is handled elsewhere. E.g., :cpp:expr:`A <= 0`.
                     def parser():
                         return self._parse_constant_expression(inTemplate=True)
-                    value = self._parse_expression_fallback([',', '>'], parser)
+                    value = self._parse_expression_fallback(
+                        [',', '>'], parser, allow=False)
                     self.skip_ws()
                     if self.skip_string('>'):
                         parsedEnd = True

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -110,6 +110,20 @@ def test_expressions():
         if id4 is not None:
             idDict[4] = ids % id4
         check('class', 'template<> C<a[%s]>' % expr, idDict)
+
+        class Config:
+            cpp_id_attributes = ["id_attr"]
+            cpp_paren_attributes = ["paren_attr"]
+
+        parser = DefinitionParser(expr, None, Config())
+        parser.allowFallbackExpressionParsing = False
+        ast = parser.parse_expression()
+        res = str(ast)
+        if res != expr:
+            print("")
+            print("Input:    ", expr)
+            print("Result:   ", res)
+            raise DefinitionError("")
     # primary
     exprCheck('nullptr', 'LDnE')
     exprCheck('true', 'L1E')
@@ -214,11 +228,14 @@ def test_expressions():
     exprCheck('5 != 42', 'neL5EL42E')
     # ['<=', '>=', '<', '>']
     exprCheck('5 <= 42', 'leL5EL42E')
+    exprCheck('A <= 42', 'le1AL42E')
     exprCheck('5 >= 42', 'geL5EL42E')
     exprCheck('5 < 42', 'ltL5EL42E')
+    exprCheck('A < 42', 'lt1AL42E')
     exprCheck('5 > 42', 'gtL5EL42E')
     # ['<<', '>>']
     exprCheck('5 << 42', 'lsL5EL42E')
+    exprCheck('A << 42', 'ls1AL42E')
     exprCheck('5 >> 42', 'rsL5EL42E')
     # ['+', '-']
     exprCheck('5 + 42', 'plL5EL42E')


### PR DESCRIPTION
Subject: prevent false warnings from C++ expressions like ``A <= 0``

### Feature or Bugfix
- Bugfix