### PR TITLE
Fix sphinx-autogen commandline in examples

### DIFF
--- a/doc/man/sphinx-autogen.rst
+++ b/doc/man/sphinx-autogen.rst
@@ -73,7 +73,7 @@ If you run the following:
 
 .. code-block:: bash
 
-    $ PYTHONPATH=. sphinx-autodoc doc/index.rst
+    $ PYTHONPATH=. sphinx-autogen docs/index.rst
 
 then the following stub files will be created in ``docs``::
 


### PR DESCRIPTION
Subject: Fix errors in an example in documentation

### Feature or Bugfix
- Bugfix

### Purpose
- The command name is `sphinx-autogen`, not `sphinx-autodoc`.
- The examples uses `docs` directory, not `doc`.