### PR TITLE
Fix #7325: html: source_suffix containing dot leads to wrong source link

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -119,6 +119,7 @@ Bugs fixed
 * #7267: autodoc: error message for invalid directive options has wrong location
 * #5637: inheritance_diagram: Incorrect handling of nested class names
 * #7139: ``code-block:: guess`` does not work
+* #7325: html: source_suffix containing dot leads to wrong source link
 * #7278: html search: Fix use of ``html_file_suffix`` instead of
   ``html_link_suffix`` in search results
 * #7179: std domain: Fix whitespaces are suppressed on referring GenericObject

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -552,7 +552,7 @@ class StandaloneHTMLBuilder(Builder):
         title = self.render_partial(title_node)['title'] if title_node else ''
 
         # Suffix for the document
-        source_suffix = path.splitext(self.env.doc2path(docname))[1]
+        source_suffix = self.env.doc2path(docname, False)[len(docname):]
 
         # the name for the copied source
         if self.config.html_copy_source:

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -332,7 +332,7 @@ class BuildEnvironment:
         if suffix:
             warnings.warn('The suffix argument for doc2path() is deprecated.',
                           RemovedInSphinx40Warning)
-        if base not in (True, None):
+        if base not in (True, False, None):
             warnings.warn('The string style base argument for doc2path() is deprecated.',
                           RemovedInSphinx40Warning)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7325 