### PR TITLE
Fix #7329: autodoc: typehints doc is wrongly generated

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -117,6 +117,8 @@ Bugs fixed
   generated automatically in signatures.
 * #5637: autodoc: Incorrect handling of nested class names on show-inheritance
 * #7267: autodoc: error message for invalid directive options has wrong location
+* #7329: autodoc: info-field-list is wrongly generated from type hints into the
+  class description even if ``autoclass_content='class'`` set
 * #5637: inheritance_diagram: Incorrect handling of nested class names
 * #7139: ``code-block:: guess`` does not work
 * #7278: html search: Fix use of ``html_file_suffix`` instead of

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -43,6 +43,8 @@ def merge_typehints(app: Sphinx, domain: str, objtype: str, contentnode: Element
         return
     if app.config.autodoc_typehints != 'description':
         return
+    if objtype == 'class' and app.config.autoclass_content not in ('init', 'both'):
+        return
 
     signature = cast(addnodes.desc_signature, contentnode.parent[0])
     if signature['module']:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7329 