### PR TITLE
Correct minor typo

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -180,7 +180,7 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
      This can be combined with ``undoc-members`` to document *all* available
      members of the class or module.
 
-     It can take an anchestor class not to document inherited members from it.
+     It can take an ancestor class not to document inherited members from it.
      By default, members of ``object`` class are not documented.  To show them
      all, give ``None`` to the option.
 


### PR DESCRIPTION
Subject: Corrects a typo in documentation

Master branch as it's a documentation change, but if documentation is not rebuilt per merge, could go in 2.x.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Relates
Fixes #7337

