### PR TITLE
Fix #3842: singlehtml: Path to images broken when master doc is not in source root

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -127,6 +127,7 @@ Bugs fixed
 * #7278: html search: Fix use of ``html_file_suffix`` instead of
   ``html_link_suffix`` in search results
 * #7297: html theme: ``bizstyle`` does not support ``sidebarwidth``
+* #3842: singlehtml: Path to images broken when master doc is not in source root
 * #7179: std domain: Fix whitespaces are suppressed on referring GenericObject
 * #7289: console: use bright colors instead of bold
 * #1539: C, parse array types.

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -59,8 +59,8 @@ def relative_uri(base: str, to: str) -> str:
     """Return a relative URL from ``base`` to ``to``."""
     if to.startswith(SEP):
         return to
-    b2 = base.split(SEP)
-    t2 = to.split(SEP)
+    b2 = base.split('#')[0].split(SEP)
+    t2 = to.split('#')[0].split(SEP)
     # remove common segments (except the last segment)
     for x, y in zip(b2[:-1], t2[:-1]):
         if x != y:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #3842 