### PR TITLE
Fix #7343: Sphinx builds has been slower since 2.4.0 on debug mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #7343: Sphinx builds has been slower since 2.4.0 on debug mode
+
 Testing
 --------
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -479,8 +479,6 @@ class SphinxTranslator(nodes.NodeVisitor):
         for node_class in node.__class__.__mro__:
             method = getattr(self, 'visit_%s' % (node_class.__name__), None)
             if method:
-                logger.debug('SphinxTranslator.dispatch_visit calling %s for %s',
-                             method.__name__, node)
                 return method(node)
         else:
             super().dispatch_visit(node)
@@ -497,8 +495,6 @@ class SphinxTranslator(nodes.NodeVisitor):
         for node_class in node.__class__.__mro__:
             method = getattr(self, 'depart_%s' % (node_class.__name__), None)
             if method:
-                logger.debug('SphinxTranslator.dispatch_departure calling %s for %s',
-                             method.__name__, node)
                 return method(node)
         else:
             super().dispatch_departure(node)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
For now, the debug log from SphinxTranslator does not help developers.
So this disable the log outputs.  Let's reconsider if we'll need it.
refs: #7343 