### PR TITLE
Close #7341: py domain: type annotations are converted to cross refs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -83,6 +83,7 @@ Features added
 * #6417: py domain: Allow to make a style for arguments of functions and methods
 * #7238, #7239: py domain: Emit a warning on describing a python object if the
   entry is already added as the same name
+* #7341: py domain: type annotations in singature are converted to cross refs
 * Support priority of event handlers. For more detail, see
   :py:meth:`.Sphinx.connect()`
 * #3077: Implement the scoping for :rst:dir:`productionlist` as indicated

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -30,6 +30,7 @@ from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType, Index, IndexEntry
 from sphinx.environment import BuildEnvironment
 from sphinx.locale import _, __
+from sphinx.pycode.ast import ast, parse as ast_parse
 from sphinx.roles import XRefRole
 from sphinx.util import logging
 from sphinx.util.docfields import Field, GroupedField, TypedField
@@ -67,6 +68,58 @@ pairindextypes = {
 }
 
 
+def _parse_annotation(annotation: str) -> List[Node]:
+    """Parse type annotation."""
+    def make_xref(text: str) -> addnodes.pending_xref:
+        return pending_xref('', nodes.Text(text),
+                            refdomain='py', reftype='class', reftarget=text)
+
+    def unparse(node: ast.AST) -> List[Node]:
+        if isinstance(node, ast.Attribute):
+            return [nodes.Text("%s.%s" % (unparse(node.value)[0], node.attr))]
+        elif isinstance(node, ast.Expr):
+            return unparse(node.value)
+        elif isinstance(node, ast.Index):
+            return unparse(node.value)
+        elif isinstance(node, ast.List):
+            result = [addnodes.desc_sig_punctuation('', '[')]  # type: List[Node]
+            for elem in node.elts:
+                result.extend(unparse(elem))
+                result.append(addnodes.desc_sig_punctuation('', ', '))
+            result.pop()
+            result.append(addnodes.desc_sig_punctuation('', ']'))
+            return result
+        elif isinstance(node, ast.Module):
+            return sum((unparse(e) for e in node.body), [])
+        elif isinstance(node, ast.Name):
+            return [nodes.Text(node.id)]
+        elif isinstance(node, ast.Subscript):
+            result = unparse(node.value)
+            result.append(addnodes.desc_sig_punctuation('', '['))
+            result.extend(unparse(node.slice))
+            result.append(addnodes.desc_sig_punctuation('', ']'))
+            return result
+        elif isinstance(node, ast.Tuple):
+            result = []
+            for elem in node.elts:
+                result.extend(unparse(elem))
+                result.append(addnodes.desc_sig_punctuation('', ', '))
+            result.pop()
+            return result
+        else:
+            raise SyntaxError  # unsupported syntax
+
+    try:
+        tree = ast_parse(annotation)
+        result = unparse(tree)
+        for i, node in enumerate(result):
+            if isinstance(node, nodes.Text):
+                result[i] = make_xref(str(node))
+        return result
+    except SyntaxError:
+        return [make_xref(annotation)]
+
+
 def _parse_arglist(arglist: str) -> addnodes.desc_parameterlist:
     """Parse a list of arguments using AST parser"""
     params = addnodes.desc_parameterlist(arglist)
@@ -93,9 +146,10 @@ def _parse_arglist(arglist: str) -> addnodes.desc_parameterlist:
             node += addnodes.desc_sig_name('', param.name)
 
         if param.annotation is not param.empty:
+            children = _parse_annotation(param.annotation)
             node += addnodes.desc_sig_punctuation('', ':')
             node += nodes.Text(' ')
-            node += addnodes.desc_sig_name('', param.annotation)
+            node += addnodes.desc_sig_name('', '', *children)  # type: ignore
         if param.default is not param.empty:
             if param.annotation is not param.empty:
                 node += nodes.Text(' ')
@@ -354,7 +408,8 @@ class PyObject(ObjectDescription):
                 signode += addnodes.desc_parameterlist()
 
         if retann:
-            signode += addnodes.desc_returns(retann, retann)
+            children = _parse_annotation(retann)
+            signode += addnodes.desc_returns(retann, '', *children)
 
         anno = self.options.get('annotation')
         if anno:

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -63,7 +63,7 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
                         'The node%s has %d child nodes, not one' % (xpath, len(node))
                     assert_node(node[0], cls[1:], xpath=xpath + "[0]", **kwargs)
         elif isinstance(cls, tuple):
-            assert isinstance(node, nodes.Element), \
+            assert isinstance(node, (list, nodes.Element)), \
                 'The node%s does not have any items' % xpath
             assert len(node) == len(cls), \
                 'The node%s has %d child nodes, not %r' % (xpath, len(node), len(cls))


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7341 

- With this change, the example on #7341 is converted to this image: 
<img width="484" alt="スクリーンショット 2020-03-21 14 41 58" src="https://user-images.githubusercontent.com/748828/77220309-2f32cb80-6b82-11ea-8ea0-8a14f49546ca.png">
