### PR TITLE
Fix #7345: sphinx-build: Sphinx crashes if output directory exists as a file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -132,6 +132,7 @@ Bugs fixed
 * #7289: console: use bright colors instead of bold
 * #1539: C, parse array types.
 * #2377: C, parse function pointers even in complex types.
+* #7345: sphinx-build: Sphinx crashes if output directory exists as a file
 
 Testing
 --------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -163,6 +163,10 @@ class Sphinx:
             raise ApplicationError(__('Cannot find source directory (%s)') %
                                    self.srcdir)
 
+        if path.exists(self.outdir) and not path.isdir(self.outdir):
+            raise ApplicationError(__('Output directory (%s) is not a directory') %
+                                   self.srcdir)
+
         if self.srcdir == self.outdir:
             raise ApplicationError(__('Source directory and destination '
                                       'directory cannot be identical'))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7345 