### PR TITLE
Fix #6240: napoleon: Attributes and Methods sections ignore :noindex: option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -141,6 +141,7 @@ Bugs fixed
 * #2377: C, parse function pointers even in complex types.
 * #7345: sphinx-build: Sphinx crashes if output directory exists as a file
 * #7290: sphinx-build: Ignore bdb.BdbQuit when handling exceptions
+* #6240: napoleon: Attributes and Methods sections ignore :noindex: option
 
 Testing
 --------

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -583,7 +583,11 @@ class GoogleDocstring:
                 if _type:
                     lines.append(':vartype %s: %s' % (_name, _type))
             else:
-                lines.extend(['.. attribute:: ' + _name, ''])
+                lines.append('.. attribute:: ' + _name)
+                if self._opt and 'noindex' in self._opt:
+                    lines.append('   :noindex:')
+                lines.append('')
+
                 fields = self._format_field('', '', _desc)
                 lines.extend(self._indent(fields, 3))
                 if _type:
@@ -641,6 +645,8 @@ class GoogleDocstring:
         lines = []  # type: List[str]
         for _name, _type, _desc in self._consume_fields(parse_type=False):
             lines.append('.. method:: %s' % _name)
+            if self._opt and 'noindex' in self._opt:
+                lines.append('   :noindex:')
             if _desc:
                 lines.extend([''] + self._indent(_desc, 3))
             lines.append('')

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1020,6 +1020,34 @@ Sooper Warning:
             actual = str(GoogleDocstring(docstring, testConfig))
             self.assertEqual(expected, actual)
 
+    def test_noindex(self):
+        docstring = """
+Attributes:
+    arg
+        description
+
+Methods:
+    func(i, j)
+        description
+"""
+
+        expected = """
+.. attribute:: arg
+   :noindex:
+
+   description
+
+.. method:: func(i, j)
+   :noindex:
+
+   
+   description
+"""
+        config = Config()
+        actual = str(GoogleDocstring(docstring, config=config, app=None, what='module',
+                                     options={'noindex': True}))
+        self.assertEqual(expected, actual)
+
 
 class NumpyDocstringTest(BaseDocstringTest):
     docstrings = [(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6240 