### PR TITLE
Fix typo in the french translation

### DIFF
--- a/sphinx/locale/fr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fr/LC_MESSAGES/sphinx.po
@@ -2678,7 +2678,7 @@ msgstr "signature invalide pour auto%s (%r)"
 #: sphinx/ext/autodoc/__init__.py:400
 #, python-format
 msgid "error while formatting arguments for %s: %s"
-msgstr "erreur pendant la mise en forme de l 'argument %s:%s"
+msgstr "erreur pendant la mise en forme de l'argument %s:%s"
 
 #: sphinx/ext/autodoc/__init__.py:512
 #, python-format


### PR DESCRIPTION
Subject: Fix typo in the french translation

### Feature or Bugfix
- Bugfix

### Purpose
- I'm removing an extraneous space in the french translation.
