### PR TITLE
Fix #7370: autosummary: raises UnboundLocalError when unknown module given

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #7370: autosummary: raises UnboundLocalError when unknown module given
+
 Testing
 --------
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -279,7 +279,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
         try:
             name, obj, parent, mod_name = import_by_name(entry.name)
         except ImportError as e:
-            _warn(__('[autosummary] failed to import %r: %s') % (name, e))
+            _warn(__('[autosummary] failed to import %r: %s') % (entry.name, e))
             continue
 
         content = generate_autosummary_content(name, obj, parent, template, entry.template,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7370 