### PR TITLE
C, alternative spellings of operators

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #7364: autosummary: crashed when :confval:`autosummary_generate` is False
 * #7370: autosummary: raises UnboundLocalError when unknown module given
 * #7367: C++, alternate operator spellings are now supported.
+* C, alternate operator spellings are now supported.
 
 Testing
 --------

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -172,7 +172,9 @@ def test_expressions():
     exprCheck('+5')
     exprCheck('-5')
     exprCheck('!5')
+    exprCheck('not 5')
     exprCheck('~5')
+    exprCheck('compl 5')
     exprCheck('sizeof(T)')
     exprCheck('sizeof -42')
     exprCheck('alignof(T)')
@@ -180,13 +182,19 @@ def test_expressions():
     exprCheck('(int)2')
     # binary op
     exprCheck('5 || 42')
+    exprCheck('5 or 42')
     exprCheck('5 && 42')
+    exprCheck('5 and 42')
     exprCheck('5 | 42')
+    exprCheck('5 bitor 42')
     exprCheck('5 ^ 42')
+    exprCheck('5 xor 42')
     exprCheck('5 & 42')
+    exprCheck('5 bitand 42')
     # ['==', '!=']
     exprCheck('5 == 42')
     exprCheck('5 != 42')
+    exprCheck('5 not_eq 42')
     # ['<=', '>=', '<', '>']
     exprCheck('5 <= 42')
     exprCheck('5 >= 42')
@@ -215,8 +223,11 @@ def test_expressions():
     exprCheck('a >>= 5')
     exprCheck('a <<= 5')
     exprCheck('a &= 5')
+    exprCheck('a and_eq 5')
     exprCheck('a ^= 5')
+    exprCheck('a xor_eq 5')
     exprCheck('a |= 5')
+    exprCheck('a or_eq 5')
 
 
 def test_type_definitions():


### PR DESCRIPTION
Support the operator macros, https://en.cppreference.com/w/c/language/operator_alternative.

### Feature or Bugfix
- Feature
- Bugfix

### Relates
Similar to #7373.

