### PR TITLE
Update Instalation.rst - Docker sphinx-quickstart

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -179,7 +179,7 @@ Please choose one for your purpose.
    When using docker images, please use ``docker run`` command to invoke sphinx commands.  For example,
    you can use following command to create a Sphinx project::
 
-      $ docker run --rm -v /path/to/document:/docs sphinxdoc/sphinx sphinx-quickstart
+      $ docker run -it --rm -v /path/to/document:/docs sphinxdoc/sphinx sphinx-quickstart
 
    And you can following command this to build HTML document::
 


### PR DESCRIPTION
Subject: Docker sphinx-quickstart should be run interactively

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
- I suggest adding the `-it` option to the docker run command for sphinx-quickstart since it is an interactive command.

`-it`: 
* `--interactive , -i` Keep STDIN open even if not attached
* `--tty , -t` Allocate a pseudo-TTY

Without interaction, the process will simply stop with the [Interrupted.] state after the first option
```
$ docker run --rm -v $(pwd):/docs sphinxdoc/sphinx sphinx-quickstart
Welcome to the Sphinx 2.4.4 quickstart utility.

Please enter values for the following settings (just press Enter to
accept a default value, if one is given in brackets).

Selected root path: .

You have two options for placing the build directory for Sphinx output.
Either, you use a directory "_build" within the root path, or you separate
"source" and "build" directories within the root path.
> Separate source and build directories (y/n) [n]: 
[Interrupted.]
```

With interaction, it is now possible to continue the process : 
```
$ docker run -it --rm -v $(pwd):/docs sphinxdoc/sphinx sphinx-quickstart
Welcome to the Sphinx 2.4.4 quickstart utility.

Please enter values for the following settings (just press Enter to
accept a default value, if one is given in brackets).

Selected root path: .

You have two options for placing the build directory for Sphinx output.
Either, you use a directory "_build" within the root path, or you separate
"source" and "build" directories within the root path.
> Separate source and build directories (y/n) [n]: y

The project name will occur in several places in the built documentation.
> Project name: 
...
```

