### PR TITLE
C++, comma operator, pack expansion, error messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Bugs fixed
 * #7370: autosummary: raises UnboundLocalError when unknown module given
 * #7367: C++, alternate operator spellings are now supported.
 * C, alternate operator spellings are now supported.
+* #7368: C++, comma operator in expressions, pack expansion in template
+  argument lists, and more comprehensive error messages in some cases.
 
 Testing
 --------

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -629,6 +629,12 @@ def test_class_definitions():
           {2: 'I0E7has_varI1TNSt6void_tIDTadN1T3varEEEEE'})
 
 
+    check('class', 'template<typename ...Ts> T<int (*)(Ts)...>',
+          {2: 'IDpE1TIJPFi2TsEEE'})
+    check('class', 'template<int... Is> T<(Is)...>',
+          {2: 'I_DpiE1TIJX(Is)EEE', 3: 'I_DpiE1TIJX2IsEEE'})
+
+
 def test_union_definitions():
     check('union', 'A', {2: "1A"})
 

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -274,6 +274,9 @@ def test_expressions():
     exprCheck('a xor_eq 5', 'eO1aL5E')
     exprCheck('a |= 5', 'oR1aL5E')
     exprCheck('a or_eq 5', 'oR1aL5E')
+    exprCheck('a = {1, 2, 3}', 'aS1ailL1EL2EL3EE')
+    # comma operator
+    exprCheck('a, 5', 'cm1aL5E')
 
     # Additional tests
     # a < expression that starts with something that could be a template


### PR DESCRIPTION
Subject: add missing features in the C++ domain and improve certain error messages.

### Feature or Bugfix
- Feature
- Bugfix
- Refactoring

### Purpose
- Parse comma operator expressions, e.g., ``.. cpp:var:: int i = (5, 42)``.
- Parse pack expansions in template argument lists that are not of a bare parameter pack, e.g.,
  ``.. cpp:class:: template<typename ...Ts> T<int (*)(Ts)...>`` or
  ``.. cpp:class:: template<int... Is> T<(Is)...>``.
- Try to emit more potential errors related to failed parsing of template argument lists.

### Detail
- Fixes #7368