### PR TITLE
C and C++, do not recurse in anon symbols when adding new symbols

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * C, alternate operator spellings are now supported.
 * #7368: C++, comma operator in expressions, pack expansion in template
   argument lists, and more comprehensive error messages in some cases.
+* C, C++, fix crash and wrong duplicate warnings related to anon symbols.
 
 Testing
 --------

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1675,7 +1675,7 @@ class Symbol:
                                            onMissingQualifiedSymbol,
                                            ancestorLookupType=None,
                                            matchSelf=False,
-                                           recurseInAnon=True,
+                                           recurseInAnon=False,
                                            searchInSiblings=False)
         assert lookupResult is not None  # we create symbols all the way, so that can't happen
         symbols = list(lookupResult.symbols)

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4159,7 +4159,7 @@ class Symbol:
                                            ancestorLookupType=None,
                                            templateShorthand=False,
                                            matchSelf=False,
-                                           recurseInAnon=True,
+                                           recurseInAnon=False,
                                            correctPrimaryTemplateArgs=True,
                                            searchInSiblings=False)
         assert lookupResult is not None  # we create symbols all the way, so that can't happen

--- a/tests/roots/test-domain-c/anon-dup-decl.rst
+++ b/tests/roots/test-domain-c/anon-dup-decl.rst
@@ -1,0 +1,5 @@
+.. c:struct:: anon_dup_decl
+
+	.. c:struct:: @a.A
+	.. c:struct:: @b.A
+	.. c:struct:: A

--- a/tests/roots/test-domain-cpp/anon-dup-decl.rst
+++ b/tests/roots/test-domain-cpp/anon-dup-decl.rst
@@ -1,0 +1,4 @@
+.. cpp:namespace:: anon_dup_decl
+.. cpp:class:: @a::A
+.. cpp:class:: @b::A
+.. cpp:class:: A

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -474,6 +474,15 @@ def test_build_domain_c(app, status, warning):
     assert len(ws) == 0
 
 
+@pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
+def test_build_domain_c_anon_dup_decl(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "anon-dup-decl")
+    assert len(ws) == 2
+    assert "WARNING: c:identifier reference target not found: @a" in ws[0]
+    assert "WARNING: c:identifier reference target not found: @b" in ws[1]
+
+
 def test_cfunction(app):
     text = (".. c:function:: PyObject* "
             "PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)")

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -913,6 +913,15 @@ def test_build_domain_cpp_backslash_ok(app, status, warning):
     assert "WARNING: Parsing of expression failed. Using fallback parser." in ws[0]
 
 
+@pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
+def test_build_domain_cpp_anon_dup_decl(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "anon-dup-decl")
+    assert len(ws) == 2
+    assert "WARNING: cpp:identifier reference target not found: @a" in ws[0]
+    assert "WARNING: cpp:identifier reference target not found: @b" in ws[1]
+
+
 @pytest.mark.sphinx(testroot='domain-cpp')
 def test_build_domain_cpp_misuse_of_roles(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
While looking up matching symbols for addition, don't skip through anon symbols. If too many false duplicates, it will crash.

### Detail
See the files ``tests/roots/test-domain-{c,cpp}/anon-dup-decl.rst``
