### PR TITLE
Add ObjectDescription.transform_content()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Deprecated
 Features added
 --------------
 
+* Added ``ObjectDescription.transform_content()``.
+
 Bugs fixed
 ----------
 

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -126,6 +126,15 @@ class ObjectDescription(SphinxDirective):
         """
         pass
 
+    def transform_content(self, contentnode: addnodes.desc_content) -> None:
+        """
+        Called after creating the content through nested parsing,
+        but before the ``object-description-transform`` event is emitted,
+        and before the info-fields are transformed.
+        Can be used to manipulate the content.
+        """
+        pass
+
     def after_content(self) -> None:
         """
         Called after parsing content. Used to reset information about the
@@ -198,6 +207,7 @@ class ObjectDescription(SphinxDirective):
             self.env.temp_data['object'] = self.names[0]
         self.before_content()
         self.state.nested_parse(self.content, self.content_offset, contentnode)
+        self.transform_content(contentnode)
         self.env.app.emit('object-description-transform',
                           self.domain, self.objtype, contentnode)
         DocFieldTransformer(self).transform_all(contentnode)


### PR DESCRIPTION
I unfortunately forgot about this change before the closure for beta, but it would be really nice to get it merged for 3.0 if possible.

### Feature or Bugfix
- Feature

### Purpose
The ``before_content()`` and ``after_content()`` methods are used to set scoping information in the domains. However, there is no way (at least not an easy one) to extend existing object descriptions for injecting extra content. Currently this gives a lot of problems with wrong scoping in Breathe. This change will make it very easy to inject additional content as if it was generated by the rst parser.

### Detail
Another solution would have been to add ``self`` as argument when the ``object-description-transform`` event is emitted, so all data is available there. Though, that would be breaking change, and I think this has better usability.