### PR TITLE
Fix #7401: Incorrect argument is passed for env-get-outdated handlers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Bugs fixed
 * #7301: capital characters are not allowed for node_id
 * #7301: epub: duplicated node_ids are generated
 * #6564: html: a width of table was ignored on HTML builder
+* #7401: Incorrect argument is passed for :event:`env-get-outdated` handlers
 
 Testing
 --------

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -379,7 +379,7 @@ class Builder:
         added, changed, removed = self.env.get_outdated_files(updated)
 
         # allow user intervention as well
-        for docs in self.events.emit('env-get-outdated', self, added, changed, removed):
+        for docs in self.events.emit('env-get-outdated', self.env, added, changed, removed):
             changed.update(set(docs) & self.env.found_docs)
 
         # if files were added or removed, all documents with globbed toctrees


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7401 