### PR TITLE
Fix #7355: autodoc: a signature of cython-function is not recognized well

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Bugs fixed
 * #7301: capital characters are not allowed for node_id
 * #7301: epub: duplicated node_ids are generated
 * #6564: html: a width of table was ignored on HTML builder
+* #7355: autodoc: a signature of cython-function is not recognized well
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1019,6 +1019,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             if (not inspect.isfunction(self.object) and
                     not inspect.ismethod(self.object) and
                     not inspect.isbuiltin(self.object) and
+                    not inspect.is_cython_function_or_method(self.object) and
                     not inspect.isclass(self.object) and
                     hasattr(self.object, '__call__')):
                 self.env.app.emit('autodoc-before-process-signature',

--- a/tests/roots/test-ext-autodoc/target/cython.pyx
+++ b/tests/roots/test-ext-autodoc/target/cython.pyx
@@ -1,6 +1,6 @@
 # cython: binding=True
 
-def foo(*args, **kwargs):
+def foo(x: int, *args, y: str, **kwargs):
     """Docstring."""
 
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1641,7 +1641,7 @@ def test_cython():
         '      Docstring.',
         '',
         '',
-        '.. py:function:: foo(*args, **kwargs)',
+        '.. py:function:: foo(x: int, *args, y: str, **kwargs)',
         '   :module: target.cython',
         '',
         '   Docstring.',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/pull/7355#discussion_r400750202