### PR TITLE
LaTeX: Allow to override papersize and pointsize from LaTeX themes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Features added
 --------------
 
 * LaTeX: Make the ``toplevel_sectioning`` setting optional in LaTeX theme
+* LaTeX: Allow to override papersize and pointsize from LaTeX themes
 
 Bugs fixed
 ----------

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -314,6 +314,8 @@ class LaTeXBuilder(Builder):
         self.context['title'] = title
         self.context['author'] = author
         self.context['docclass'] = theme.docclass
+        self.context['papersize'] = theme.papersize
+        self.context['pointsize'] = theme.pointsize
         self.context['wrapperclass'] = theme.wrapperclass
 
     def assemble_doctree(self, indexfile: str, toctree_only: bool, appendices: List[str]) -> nodes.document:  # NOQA

--- a/sphinx/builders/latex/constants.py
+++ b/sphinx/builders/latex/constants.py
@@ -69,8 +69,8 @@ LUALATEX_DEFAULT_FONTPKG = XELATEX_DEFAULT_FONTPKG
 
 DEFAULT_SETTINGS = {
     'latex_engine':    'pdflatex',
-    'papersize':       'letterpaper',
-    'pointsize':       '10pt',
+    'papersize':       '',
+    'pointsize':       '',
     'pxunit':          '.75bp',
     'classoptions':    '',
     'extraclassoptions': '',

--- a/sphinx/builders/latex/theming.py
+++ b/sphinx/builders/latex/theming.py
@@ -35,32 +35,24 @@ class BuiltInTheme(Theme):
     """A built-in LaTeX theme."""
 
     def __init__(self, name: str, config: Config) -> None:
-        # Note: Don't call supermethod here.
-        self.name = name
-        self.latex_docclass = config.latex_docclass  # type: Dict[str, str]
+        super().__init__(name)
 
-    @property
-    def docclass(self) -> str:  # type: ignore
-        if self.name == 'howto':
-            return self.latex_docclass.get('howto', 'article')
+        if name == 'howto':
+            self.docclass = config.latex_docclass.get('howto', 'article')
         else:
-            return self.latex_docclass.get('manual', 'report')
+            self.docclass = config.latex_docclass.get('manual', 'report')
 
-    @property
-    def wrapperclass(self) -> str:  # type: ignore
-        if self.name in ('manual', 'howto'):
-            return 'sphinx' + self.name
+        if name in ('manual', 'howto'):
+            self.wrapperclass = 'sphinx' + name
         else:
-            return self.name
+            self.wrapperclass = name
 
-    @property
-    def toplevel_sectioning(self) -> str:  # type: ignore
         # we assume LaTeX class provides \chapter command except in case
         # of non-Japanese 'howto' case
-        if self.name == 'howto' and not self.docclass.startswith('j'):
-            return 'section'
+        if name == 'howto' and not self.docclass.startswith('j'):
+            self.toplevel_sectioning = 'section'
         else:
-            return 'chapter'
+            self.toplevel_sectioning = 'chapter'
 
 
 class UserTheme(Theme):

--- a/tests/roots/test-latex-theme/theme/custom/theme.conf
+++ b/tests/roots/test-latex-theme/theme/custom/theme.conf
@@ -1,4 +1,6 @@
 [theme]
 docclass = book
 wrapperclass = sphinxbook
+papersize = a4paper
+pointsize = 12pt
 toplevel_sectioning = chapter

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -221,7 +221,18 @@ def test_latex_theme(app, status, warning):
     result = (app.outdir / 'python.tex').read_text(encoding='utf8')
     print(result)
     assert r'\def\sphinxdocclass{book}' in result
-    assert r'\documentclass[letterpaper,10pt,english]{sphinxbook}' in result
+    assert r'\documentclass[a4paper,12pt,english]{sphinxbook}' in result
+
+
+@pytest.mark.sphinx('latex', testroot='latex-theme',
+                    confoverrides={'latex_elements': {'papersize': 'b5paper',
+                                                      'pointsize': '9pt'}})
+def test_latex_theme_papersize(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'python.tex').read_text(encoding='utf8')
+    print(result)
+    assert r'\def\sphinxdocclass{book}' in result
+    assert r'\documentclass[b5paper,9pt,english]{sphinxbook}' in result
 
 
 @pytest.mark.sphinx('latex', testroot='basic', confoverrides={'language': 'zh'})


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- LaTeX: Allow to override papersize and pointsize from LaTeX themes
- ~~This contains a commit of #7412~~