### PR TITLE
Escape some links in HTML templates

### DIFF
--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -14,13 +14,13 @@
     <div class="header-wrapper" role="banner">
       <div class="header">
         {%- if logo %}
-          <p class="logo"><a href="{{ pathto(master_doc) }}">
+          <p class="logo"><a href="{{ pathto(master_doc)|e }}">
             <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
           </a></p>
         {%- endif %}
         {%- block headertitle %}
         <div class="headertitle"><a
-          href="{{ pathto(master_doc) }}">{{ shorttitle|e }}</a></div>
+          href="{{ pathto(master_doc)|e }}">{{ shorttitle|e }}</a></div>
         {%- endblock %}
         <div class="rel" role="navigation" aria-label="related navigation">
           {%- for rellink in rellinks|reverse %}

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -15,7 +15,7 @@
       <div class="header">
         {%- if logo %}
           <p class="logo"><a href="{{ pathto(master_doc)|e }}">
-            <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+            <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
           </a></p>
         {%- endif %}
         {%- block headertitle %}
@@ -24,7 +24,7 @@
         {%- endblock %}
         <div class="rel" role="navigation" aria-label="related navigation">
           {%- for rellink in rellinks|reverse %}
-          <a href="{{ pathto(rellink[0]) }}" title="{{ rellink[1]|striptags|e }}"
+          <a href="{{ pathto(rellink[0])|e }}" title="{{ rellink[1]|striptags|e }}"
              {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>
           {%- if not loop.last %}{{ reldelim2 }}{% endif %}
           {%- endfor %}
@@ -78,7 +78,7 @@
         <div class="left">
           <div role="navigation" aria-label="related navigaton">
             {%- for rellink in rellinks|reverse %}
-            <a href="{{ pathto(rellink[0]) }}" title="{{ rellink[1]|striptags|e }}"
+            <a href="{{ pathto(rellink[0])|e }}" title="{{ rellink[1]|striptags|e }}"
               {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>
             {%- if not loop.last %}{{ reldelim2 }}{% endif %}
             {%- endfor %}

--- a/sphinx/themes/basic/domainindex.html
+++ b/sphinx/themes/basic/domainindex.html
@@ -43,7 +43,7 @@
               id="toggle-{{ groupid.next() }}" style="display: none" alt="-" />
            {%- endif %}</td>
        <td>{% if grouptype == 2 %}&#160;&#160;&#160;{% endif %}
-       {% if page %}<a href="{{ pathto(page) }}#{{ anchor }}">{% endif -%}
+       {% if page %}<a href="{{ pathto(page)|e }}#{{ anchor }}">{% endif -%}
        <code class="xref">{{ name|e }}</code>
        {%- if page %}</a>{% endif %}
      {%- if extra %} <em>({{ extra|e }})</em>{% endif -%}

--- a/sphinx/themes/basic/globaltoc.html
+++ b/sphinx/themes/basic/globaltoc.html
@@ -7,5 +7,5 @@
     :copyright: Copyright 2007-2020 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-<h3><a href="{{ pathto(master_doc) }}">{{ _('Table of Contents') }}</a></h3>
+<h3><a href="{{ pathto(master_doc)|e }}">{{ _('Table of Contents') }}</a></h3>
 {{ toctree() }}

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -32,7 +32,7 @@
       <ul>
         {%- for rellink in rellinks %}
         <li class="right" {% if loop.first %}style="margin-right: 10px"{% endif %}>
-          <a href="{{ pathto(rellink[0]) }}" title="{{ rellink[1]|striptags|e }}"
+          <a href="{{ pathto(rellink[0])|e }}" title="{{ rellink[1]|striptags|e }}"
              {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>
           {%- if not loop.first %}{{ reldelim2 }}{% endif %}</li>
         {%- endfor %}
@@ -54,7 +54,7 @@
           {%- block sidebarlogo %}
           {%- if logo %}
             <p class="logo"><a href="{{ pathto(master_doc)|e }}">
-              <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+              <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
             </a></p>
           {%- endif %}
           {%- endblock %}
@@ -94,13 +94,13 @@
 {%- endmacro %}
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1)|e }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     {%- for css in css_files %}
       {%- if css|attr("filename") %}
     {{ css_tag(css) }}
       {%- else %}
-    <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
       {%- endif %}
     {%- endfor %}
 {%- endmacro %}
@@ -139,7 +139,7 @@
           href="{{ pathto('_static/opensearch.xml', 1) }}"/>
     {%- endif %}
     {%- if favicon %}
-    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1)|e }}"/>
     {%- endif %}
     {%- endif %}
 {%- block linktags %}

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -37,7 +37,7 @@
           {%- if not loop.first %}{{ reldelim2 }}{% endif %}</li>
         {%- endfor %}
         {%- block rootrellink %}
-        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc) }}">{{ shorttitle|e }}</a>{{ reldelim1 }}</li>
+        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc)|e }}">{{ shorttitle|e }}</a>{{ reldelim1 }}</li>
         {%- endblock %}
         {%- for parent in parents %}
           <li class="nav-item nav-item-{{ loop.index }}"><a href="{{ parent.link|e }}" {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>{{ reldelim1 }}</li>
@@ -53,7 +53,7 @@
         <div class="sphinxsidebarwrapper">
           {%- block sidebarlogo %}
           {%- if logo %}
-            <p class="logo"><a href="{{ pathto(master_doc) }}">
+            <p class="logo"><a href="{{ pathto(master_doc)|e }}">
               <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
             </a></p>
           {%- endif %}

--- a/sphinx/themes/basic/localtoc.html
+++ b/sphinx/themes/basic/localtoc.html
@@ -8,6 +8,6 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if display_toc %}
-  <h3><a href="{{ pathto(master_doc) }}">{{ _('Table of Contents') }}</a></h3>
+  <h3><a href="{{ pathto(master_doc)|e }}">{{ _('Table of Contents') }}</a></h3>
   {{ toc }}
 {%- endif %}

--- a/sphinx/themes/basic/opensearch.xml
+++ b/sphinx/themes/basic/opensearch.xml
@@ -7,7 +7,7 @@
        template="{{ use_opensearch }}/{{ pathto('search') }}?q={searchTerms}"/>
   <LongName>{{ docstitle|e }}</LongName>
 {%- if favicon %}
-  <Image height="16" width="16" type="image/x-icon">{{ use_opensearch }}/{{ pathto('_static/' + favicon, 1) }}</Image>
+  <Image height="16" width="16" type="image/x-icon">{{ use_opensearch }}/{{ pathto('_static/' + favicon, 1)|e }}</Image>
 {%- endif %}
 {% block extra %} {# Put e.g. an <Image> element here. #} {% endblock %}
 </OpenSearchDescription>

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -21,7 +21,7 @@
         «&#160;&#160;<a href="{{ prev.link|e }}">{{ prev.title }}</a>
         &#160;&#160;::&#160;&#160;
         {%- endif %}
-        <a class="uplink" href="{{ pathto(master_doc) }}">{{ _('Contents') }}</a>
+        <a class="uplink" href="{{ pathto(master_doc)|e }}">{{ _('Contents') }}</a>
         {%- if next %}
         &#160;&#160;::&#160;&#160;
         <a href="{{ next.link|e }}">{{ next.title }}</a>&#160;&#160;»

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -36,11 +36,11 @@
         {%- block haikuheader %}
         {%- if theme_full_logo != "false" %}
         <a href="{{ pathto('index') }}">
-          <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+          <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
         </a>
         {%- else %}
         {%- if logo -%}
-          <img class="rightlogo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+          <img class="rightlogo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
         {%- endif -%}
         <h1 class="heading"><a href="{{ pathto('index') }}">
           <span>{{ shorttitle|e }}</span></a></h1>

--- a/sphinx/themes/pyramid/layout.html
+++ b/sphinx/themes/pyramid/layout.html
@@ -12,7 +12,7 @@
 {%- if logo %}
 <div class="header" role="banner">
   <div class="logo">
-    <a href="{{ pathto(master_doc) }}">
+    <a href="{{ pathto(master_doc)|e }}">
       <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
     </a>
   </div>

--- a/sphinx/themes/pyramid/layout.html
+++ b/sphinx/themes/pyramid/layout.html
@@ -13,7 +13,7 @@
 <div class="header" role="banner">
   <div class="logo">
     <a href="{{ pathto(master_doc)|e }}">
-      <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+      <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
     </a>
   </div>
 </div>

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -30,7 +30,7 @@
         {%- if prev %}
         <a href="{{ prev.link|e }}">&laquo; {{ prev.title }}</a> |
         {%- endif %}
-        <a href="{{ pathto(current_page_name) if current_page_name else '#' }}">{{ title }}</a>
+        <a href="{{ pathto(current_page_name)|e if current_page_name else '#' }}">{{ title }}</a>
         {%- if next %}
         | <a href="{{ next.link|e }}">{{ next.title }} &raquo;</a>
         {%- endif %}


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

If a user chooses a strange `master_doc`, e.g.:

    master_doc = 'my"index'

... the links to the main page will be broken.

Same for `logo`, `favicon` and style sheets.

If a user chooses strange characters for sub-directories of the source directory, "previous" and "next" links might be broken, too.