### PR TITLE
Fix #7428: py domain: a reference to class ``None`` emits a nitpicky warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #7428: py domain: a reference to class ``None`` emits a nitpicky warning
+
 Testing
 --------
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1311,7 +1311,7 @@ def builtin_resolver(app: Sphinx, env: BuildEnvironment,
 
     if node.get('refdomain') != 'py':
         return None
-    elif node.get('reftype') == 'obj' and node.get('reftarget') == 'None':
+    elif node.get('reftype') in ('class', 'obj') and node.get('reftarget') == 'None':
         return contnode
     elif node.get('reftype') in ('class', 'exc'):
         reftarget = node.get('reftarget')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7428 