### PR TITLE
Add libCEED to EXAMPLES

### DIFF
--- a/EXAMPLES
+++ b/EXAMPLES
@@ -213,6 +213,7 @@ Documentation using sphinx_rtd_theme
 * `Lasagne <https://lasagne.readthedocs.io/>`__
 * `latexindent.pl <https://latexindentpl.readthedocs.io/>`__
 * `Learning Apache Spark with Python <https://runawayhorse001.github.io/LearningApacheSpark>`__
+* `LibCEED <https://libceed.readthedocs.io/>`__
 * `Linguistica <https://linguistica-uchicago.github.io/lxa5/>`__
 * `Linux kernel <https://www.kernel.org/doc/html/latest/index.html>`__
 * `Mailman <http://docs.list.org/>`__


### PR DESCRIPTION
Subject: Adding libCEED to list of projects using Sphinx

- Feature

## Purpose
- Update website

## Detail
- Adding the [libCEED](https://libceed.readthedocs.io/en/latest/) project in the list of projects using Sphinx with the `sphinx_rtd_theme`
