### PR TITLE
C/C++, fix lack of error stringification

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #7423: C/C++, properly stringify error messages.
+
 Testing
 --------
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3086,7 +3086,7 @@ class CObject(ObjectDescription):
             ast = self.parse_definition(parser)
             parser.assert_end()
         except DefinitionError as e:
-            logger.warning(e, location=signode)
+            logger.warning(str(e), location=signode)
             # It is easier to assume some phony name than handling the error in
             # the possibly inner declarations.
             name = _make_phony_error_name()

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6633,7 +6633,7 @@ class CPPObject(ObjectDescription):
             ast = self.parse_definition(parser)
             parser.assert_end()
         except DefinitionError as e:
-            logger.warning(e, location=signode)
+            logger.warning(str(e), location=signode)
             # It is easier to assume some phony name than handling the error in
             # the possibly inner declarations.
             name = _make_phony_error_name()
@@ -6743,7 +6743,7 @@ class CPPNamespaceObject(SphinxDirective):
                 ast = parser.parse_namespace_object()
                 parser.assert_end()
             except DefinitionError as e:
-                logger.warning(e, location=self.get_source_info())
+                logger.warning(str(e), location=self.get_source_info())
                 name = _make_phony_error_name()
                 ast = ASTNamespace(name, None)
             symbol = rootSymbol.add_name(ast.nestedName, ast.templatePrefix)
@@ -6771,7 +6771,7 @@ class CPPNamespacePushObject(SphinxDirective):
             ast = parser.parse_namespace_object()
             parser.assert_end()
         except DefinitionError as e:
-            logger.warning(e, location=self.get_source_info())
+            logger.warning(str(e), location=self.get_source_info())
             name = _make_phony_error_name()
             ast = ASTNamespace(name, None)
         oldParent = self.env.temp_data.get('cpp:parent_symbol', None)
@@ -6842,7 +6842,7 @@ class AliasTransform(SphinxTransform):
                 ast, isShorthand = parser.parse_xref_object()
                 parser.assert_end()
             except DefinitionError as e:
-                logger.warning(e, location=node)
+                logger.warning(str(e), location=node)
                 ast, isShorthand = None, None
 
             if ast is None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
The switch to the new'ish logging facilities in the C and C++ domains was not quite correct. In a few places the logged exception was not stringified.

### Detail
- Fixes #7423, hopefully. I have not yet been able to reproduced without venv.
