### PR TITLE
Fix #7418: std domain: duplication warning for glossary terms is case insensitive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #7418: std domain: :rst:dir:`term` role becomes case sensitive
+
 Deprecated
 ----------
 
@@ -17,6 +19,7 @@ Bugs fixed
 ----------
 
 * #7428: py domain: a reference to class ``None`` emits a nitpicky warning
+* #7418: std domain: duplication warning for glossary terms is case insensitive
 
 Testing
 --------

--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -27,7 +27,7 @@ Discovery of builders by entry point
 
 .. versionadded:: 1.6
 
-:term:`Builder` extensions can be discovered by means of `entry points`_ so
+:term:`builder` extensions can be discovered by means of `entry points`_ so
 that they do not have to be listed in the :confval:`extensions` configuration
 value.
 

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -305,7 +305,7 @@ def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], index
         term['ids'].append(node_id)
 
     std = cast(StandardDomain, env.get_domain('std'))
-    std.note_object('term', termtext.lower(), node_id, location=term)
+    std.note_object('term', termtext, node_id, location=term)
 
     # add an index entry too
     indexnode = addnodes.index()
@@ -565,7 +565,7 @@ class StandardDomain(Domain):
         # links to tokens in grammar productions
         'token':   TokenXRefRole(),
         # links to terms in glossary
-        'term':    XRefRole(lowercase=True, innernodeclass=nodes.inline,
+        'term':    XRefRole(innernodeclass=nodes.inline,
                             warn_dangling=True),
         # links to headings or arbitrary labels
         'ref':     XRefRole(lowercase=True, innernodeclass=nodes.inline,

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -99,7 +99,7 @@ def test_glossary(app):
     text = (".. glossary::\n"
             "\n"
             "   term1\n"
-            "   term2\n"
+            "   TERM2\n"
             "       description\n"
             "\n"
             "   term3 : classifier\n"
@@ -114,7 +114,7 @@ def test_glossary(app):
     assert_node(doctree, (
         [glossary, definition_list, ([definition_list_item, ([term, ("term1",
                                                                      index)],
-                                                             [term, ("term2",
+                                                             [term, ("TERM2",
                                                                      index)],
                                                              definition)],
                                      [definition_list_item, ([term, ("term3",
@@ -127,7 +127,7 @@ def test_glossary(app):
     assert_node(doctree[0][0][0][0][1],
                 entries=[("single", "term1", "term-term1", "main", None)])
     assert_node(doctree[0][0][0][1][1],
-                entries=[("single", "term2", "term-term2", "main", None)])
+                entries=[("single", "TERM2", "term-TERM2", "main", None)])
     assert_node(doctree[0][0][0][2],
                 [definition, nodes.paragraph, "description"])
     assert_node(doctree[0][0][1][0][1],
@@ -143,7 +143,7 @@ def test_glossary(app):
     # index
     objects = list(app.env.get_domain("std").get_objects())
     assert ("term1", "term1", "term", "index", "term-term1", -1) in objects
-    assert ("term2", "term2", "term", "index", "term-term2", -1) in objects
+    assert ("TERM2", "TERM2", "term", "index", "term-TERM2", -1) in objects
     assert ("term3", "term3", "term", "index", "term-term3", -1) in objects
     assert ("term4", "term4", "term", "index", "term-term4", -1) in objects
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7418 