### PR TITLE
Fix #7423: crashed when giving a non-string object to logger

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #7423: crashed when giving a non-string object to logger
+
 Testing
 --------
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -412,7 +412,7 @@ class WarningIsErrorFilter(logging.Filter):
                 message = record.msg  # use record.msg itself
 
             if location:
-                raise SphinxWarning(location + ":" + message)
+                raise SphinxWarning(location + ":" + str(message))
             else:
                 raise SphinxWarning(message)
         else:

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -48,6 +48,14 @@ def test_info_and_warning(app, status, warning):
     assert 'message5' in warning.getvalue()
 
 
+def test_Exception(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+
+    logger.info(Exception)
+    assert "<class 'Exception'>" in status.getvalue()
+
+
 def test_verbosity_filter(app, status, warning):
     # verbosity = 0: INFO
     app.verbosity = 0


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7423 