### PR TITLE
Fix #7435: autodoc_typehints doesn't suppress typehints for classes/methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #7428: py domain: a reference to class ``None`` emits a nitpicky warning
+* #7435: autodoc: ``autodoc_typehints='description'`` doesn't suppress typehints
+  in signature for classes/methods
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1174,7 +1174,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         return ret
 
     def format_args(self, **kwargs: Any) -> str:
-        if self.env.config.autodoc_typehints == 'none':
+        if self.env.config.autodoc_typehints in ('none', 'description'):
             kwargs.setdefault('show_annotation', False)
 
         # for classes, the relevant signature is the __init__ method's
@@ -1430,7 +1430,7 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
         return ret
 
     def format_args(self, **kwargs: Any) -> str:
-        if self.env.config.autodoc_typehints == 'none':
+        if self.env.config.autodoc_typehints in ('none', 'description'):
             kwargs.setdefault('show_annotation', False)
 
         unwrapped = inspect.unwrap(self.object)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7435 