### PR TITLE
Add globaltoc_collapse and globaltoc_includehidden options

### DIFF
--- a/doc/usage/theming.rst
+++ b/doc/usage/theming.rst
@@ -155,6 +155,21 @@ These themes are:
     previous/next page using the keyboard's left and right arrows.  Defaults to
     ``False``.
 
+  .. versionadded:: 3.1
+
+    The following options:
+
+  - **globaltoc_collapse** (true or false): Only expand subsections
+    of the current document in ``globaltoc.html``
+    (see :confval:`html_sidebars`).
+    Defaults to ``True``.
+
+  - **globaltoc_includehidden** (true or false): Show even those
+    subsections in ``globaltoc.html`` (see :confval:`html_sidebars`)
+    which have been included with the ``:hidden:`` flag of the
+    :rst:dir:`toctree` directive.
+    Defaults to ``False``.
+
 **alabaster**
   `Alabaster theme`_ is a modified "Kr" Sphinx theme from @kennethreitz
   (especially as used in his Requests project), which was itself originally

--- a/doc/usage/theming.rst
+++ b/doc/usage/theming.rst
@@ -155,20 +155,20 @@ These themes are:
     previous/next page using the keyboard's left and right arrows.  Defaults to
     ``False``.
 
-  .. versionadded:: 3.1
-
-    The following options:
-
   - **globaltoc_collapse** (true or false): Only expand subsections
     of the current document in ``globaltoc.html``
     (see :confval:`html_sidebars`).
     Defaults to ``True``.
+
+    .. versionadded:: 3.1
 
   - **globaltoc_includehidden** (true or false): Show even those
     subsections in ``globaltoc.html`` (see :confval:`html_sidebars`)
     which have been included with the ``:hidden:`` flag of the
     :rst:dir:`toctree` directive.
     Defaults to ``False``.
+
+    .. versionadded:: 3.1
 
 **alabaster**
   `Alabaster theme`_ is a modified "Kr" Sphinx theme from @kennethreitz

--- a/sphinx/themes/basic/globaltoc.html
+++ b/sphinx/themes/basic/globaltoc.html
@@ -8,4 +8,4 @@
     :license: BSD, see LICENSE for details.
 #}
 <h3><a href="{{ pathto(master_doc)|e }}">{{ _('Table of Contents') }}</a></h3>
-{{ toctree() }}
+{{ toctree(includehidden=theme_globaltoc_includehidden, collapse=theme_globaltoc_collapse) }}

--- a/sphinx/themes/basic/theme.conf
+++ b/sphinx/themes/basic/theme.conf
@@ -10,3 +10,5 @@ sidebarwidth = 230
 body_min_width = 450
 body_max_width = 800
 navigation_with_keys = False
+globaltoc_collapse = true
+globaltoc_includehidden = false


### PR DESCRIPTION
I thought since the `toctree()` function has these options, it would make sense to have those as theme options as well, wouldn't it?

If this is considered for merging, I can add docs.