### PR TITLE
C++, fix merging overloaded functions in parallel builds.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #7428: py domain: a reference to class ``None`` emits a nitpicky warning
+* #7438: C++, fix merging overloaded functions in parallel builds.
 
 Testing
 --------


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Fixes #7438.

To reproduce, have sufficiently many rst files, where one of them contains an overloaded function where a pending xref will be made. E.g.,
```rst
 .. cpp:function:: std::string f(int)
 .. cpp:function:: std::string f(double)
```
