### PR TITLE
Do not include xmlns attribute with HTML 5 doctype

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -108,7 +108,7 @@
 {%- if html_tag %}
 {{ html_tag }}
 {%- else %}
-<html xmlns="http://www.w3.org/1999/xhtml"{% if language is not none %} lang="{{ language }}"{% endif %}>
+<html{% if not html5_doctype %} xmlns="http://www.w3.org/1999/xhtml"{% endif %}{% if language is not none %} lang="{{ language }}"{% endif %}>
 {%- endif %}
   <head>
     {%- if not html5_doctype and not skip_ua_compatible %}


### PR DESCRIPTION
Subject: fix detection of documents generated with Sphinx by shared-mime-info

### Feature or Bugfix
- Bugfix

### Purpose
- shared-mime-info is a package to detect mime types of files.
- When a document contains `<html xmlns="http://www.w3.org/1999/xhtml"`, shared-mime-info detects it as XHTML document, not HTML: https://gitlab.freedesktop.org/xdg/shared-mime-info/-/blob/Release-1-15/freedesktop.org.xml.in#L4000
- WebKitGTK uses shared-mime-info, and if the document is XHTML, tries to parse it with XML parser.
- Because of this, WebKitGTK based browsers fail to render documents generated by Sphinx.

### Detail
Here is how Sphinx' own documentation looks in Epiphany (GNOME browser):

![Sphinx in Epiphany](https://user-images.githubusercontent.com/1381584/78896722-981eac80-7a79-11ea-9c31-ad9455f7a214.png)

Line 45 is inside a `<script>` tag:
```js
        if (sbh < win.innerHeight()) {
```
Parsing fails because XHTML requires `<` to be escaped as `&gt;`.

If I try to open `search.html`, it says: `error on line 27 at column 37: Specification mandates value for attribute defer`.

### Relates
- https://launchpad.net/bugs/1871610