### PR TITLE
Fix #7451: autodoc: failed with non-string __doc__ member

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@ Bugs fixed
 * #7422: autodoc: fails with ValueError when using autodoc_mock_imports
 * #7435: autodoc: ``autodoc_typehints='description'`` doesn't suppress typehints
   in signature for classes/methods
+* #7451: autodoc: fails with AttributeError when an object returns non-string
+  object as a ``__doc__`` member
 * #7423: crashed when giving a non-string object to logger
 * #7479: html theme: Do not include xmlns attribute with HTML 5 doctype
 * #7426: html theme: Escape some links in HTML templates

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -557,6 +557,9 @@ class Documenter:
                 isattr = False
 
             doc = getdoc(member, self.get_attr, self.env.config.autodoc_inherit_docstrings)
+            if not isinstance(doc, str):
+                # Ignore non-string __doc__
+                doc = None
 
             # if the member __doc__ is the same as self's __doc__, it's just
             # inherited and therefore not the member's doc


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7451 