### PR TITLE
Fix #7445: a return annotation ``None`` is not converted to a hyperlink

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Bugs fixed
 ----------
 
 * #7428: py domain: a reference to class ``None`` emits a nitpicky warning
+* #7445: py domain: a return annotation ``None`` in the function signature is
+  not converted to a hyperlink when using intersphinx
 * #7418: std domain: duplication warning for glossary terms is case insensitive
 * #7438: C++, fix merging overloaded functions in parallel builds.
 * #7422: autodoc: fails with ValueError when using autodoc_mock_imports

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -71,8 +71,13 @@ pairindextypes = {
 def _parse_annotation(annotation: str) -> List[Node]:
     """Parse type annotation."""
     def make_xref(text: str) -> addnodes.pending_xref:
+        if text == 'None':
+            reftype = 'obj'
+        else:
+            reftype = 'class'
+
         return pending_xref('', nodes.Text(text),
-                            refdomain='py', reftype='class', reftarget=text)
+                            refdomain='py', reftype=reftype, reftarget=text)
 
     def unparse(node: ast.AST) -> List[Node]:
         if isinstance(node, ast.Attribute):

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -239,6 +239,7 @@ def test_get_full_qualified_name():
 def test_parse_annotation():
     doctree = _parse_annotation("int")
     assert_node(doctree, ([pending_xref, "int"],))
+    assert_node(doctree[0], pending_xref, refdomain="py", reftype="class", reftarget="int")
 
     doctree = _parse_annotation("List[int]")
     assert_node(doctree, ([pending_xref, "List"],
@@ -265,6 +266,12 @@ def test_parse_annotation():
                           [desc_sig_punctuation, ", "],
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
+
+    # None type makes an object-reference (not a class reference)
+    doctree = _parse_annotation("None")
+    assert_node(doctree, ([pending_xref, "None"],))
+    assert_node(doctree[0], pending_xref, refdomain="py", reftype="obj", reftarget="None")
+
 
 
 def test_pyfunction_signature(app):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7445 