### PR TITLE
Fix #7410: Allow to suppress "circular toctree references detected" warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* #7410: Allow to suppress "circular toctree references detected" warnings using
+  :confval:`suppress_warnings`
+
 Bugs fixed
 ----------
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -313,6 +313,7 @@ General configuration
    * ``ref.doc``
    * ``ref.python``
    * ``misc.highlighting_failure``
+   * ``toc.circular``
    * ``toc.secnum``
    * ``epub.unknown_project_files``
    * ``autosectionlabel.*``

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -153,7 +153,7 @@ class TocTree:
                             logger.warning(__('circular toctree references '
                                               'detected, ignoring: %s <- %s'),
                                            ref, ' <- '.join(parents),
-                                           location=ref)
+                                           location=ref, type='toc', subtype='circular')
                             continue
                         refdoc = ref
                         toc = self.env.tocs[ref].deepcopy()


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7410 