### PR TITLE
Fix #7461: py domain: fails with IndexError for empty tuple in type annotation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #7461: py domain: fails with IndexError for empty tuple in type annotation
+
 Testing
 --------
 

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #7461: py domain: fails with IndexError for empty tuple in type annotation
+* #7461: autodoc: empty tuple in type annotation is not shown correctly
 
 Testing
 --------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -105,11 +105,16 @@ def _parse_annotation(annotation: str) -> List[Node]:
             result.append(addnodes.desc_sig_punctuation('', ']'))
             return result
         elif isinstance(node, ast.Tuple):
-            result = []
-            for elem in node.elts:
-                result.extend(unparse(elem))
-                result.append(addnodes.desc_sig_punctuation('', ', '))
-            result.pop()
+            if node.elts:
+                result = []
+                for elem in node.elts:
+                    result.extend(unparse(elem))
+                    result.append(addnodes.desc_sig_punctuation('', ', '))
+                result.pop()
+            else:
+                result = [addnodes.desc_sig_punctuation('', '('),
+                          addnodes.desc_sig_punctuation('', ')')]
+
             return result
         else:
             raise SyntaxError  # unsupported syntax

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -114,7 +114,10 @@ def unparse(node: ast.AST) -> str:
     elif isinstance(node, ast.UnaryOp):
         return "%s %s" % (unparse(node.op), unparse(node.operand))
     elif isinstance(node, ast.Tuple):
-        return ", ".join(unparse(e) for e in node.elts)
+        if node.elts:
+            return ", ".join(unparse(e) for e in node.elts)
+        else:
+            return "()"
     elif sys.version_info > (3, 6) and isinstance(node, ast.Constant):
         # this branch should be placed at last
         return repr(node.value)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -255,6 +255,13 @@ def test_parse_annotation():
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
 
+    doctree = _parse_annotation("Tuple[()]")
+    assert_node(doctree, ([pending_xref, "Tuple"],
+                          [desc_sig_punctuation, "["],
+                          [desc_sig_punctuation, "("],
+                          [desc_sig_punctuation, ")"],
+                          [desc_sig_punctuation, "]"]))
+
     doctree = _parse_annotation("Callable[[int, int], int]")
     assert_node(doctree, ([pending_xref, "Callable"],
                           [desc_sig_punctuation, "["],

--- a/tests/test_pycode_ast.py
+++ b/tests/test_pycode_ast.py
@@ -54,6 +54,7 @@ from sphinx.pycode import ast
     ("- 1", "- 1"),                             # UnaryOp
     ("- a", "- a"),                             # USub
     ("(1, 2, 3)", "1, 2, 3"),                   # Tuple
+    ("()", "()"),                               # Tuple (empty)
 ])
 def test_unparse(source, expected):
     module = ast.parse(source)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- #7461: py domain: fails with IndexError for empty tuple in type annotation
- This also fixes autodoc; empty tuple in type annotation is not shown correctly
