### PR TITLE
Fix #7466: autosummary: headings in generated documents are not translated

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Features added
 * LaTeX: Make the ``toplevel_sectioning`` setting optional in LaTeX theme
 * #7410: Allow to suppress "circular toctree references detected" warnings using
   :confval:`suppress_warnings`
+* #7466: autosummary: headings in generated documents are not translated
 
 Bugs fixed
 ----------

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -124,6 +124,11 @@ class AutosummaryRenderer:
         self.env.filters['e'] = rst.escape
         self.env.filters['underline'] = _underline
 
+        if builder:
+            if builder.app.translator:
+                self.env.add_extension("jinja2.ext.i18n")
+                self.env.install_gettext_translations(builder.app.translator)  # type: ignore
+
     def exists(self, template_name: str) -> bool:
         """Check if template file exists."""
         try:

--- a/sphinx/ext/autosummary/templates/autosummary/class.rst
+++ b/sphinx/ext/autosummary/templates/autosummary/class.rst
@@ -8,7 +8,7 @@
    .. automethod:: __init__
 
    {% if methods %}
-   .. rubric:: Methods
+   .. rubric:: {{ _('Methods') }}
 
    .. autosummary::
    {% for item in methods %}
@@ -19,7 +19,7 @@
 
    {% block attributes %}
    {% if attributes %}
-   .. rubric:: Attributes
+   .. rubric:: {{ _('Attributes') }}
 
    .. autosummary::
    {% for item in attributes %}

--- a/sphinx/ext/autosummary/templates/autosummary/module.rst
+++ b/sphinx/ext/autosummary/templates/autosummary/module.rst
@@ -4,7 +4,7 @@
 
    {% block functions %}
    {% if functions %}
-   .. rubric:: Functions
+   .. rubric:: {{ _('Functions') }}
 
    .. autosummary::
    {% for item in functions %}
@@ -15,7 +15,7 @@
 
    {% block classes %}
    {% if classes %}
-   .. rubric:: Classes
+   .. rubric:: {{ _('Classes') }}
 
    .. autosummary::
    {% for item in classes %}
@@ -26,7 +26,7 @@
 
    {% block exceptions %}
    {% if exceptions %}
-   .. rubric:: Exceptions
+   .. rubric:: {{ _('Exceptions') }}
 
    .. autosummary::
    {% for item in exceptions %}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7466 