### PR TITLE
Add support for :meta public:

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -154,6 +154,21 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
 
      .. versionadded:: 3.0
 
+   * autodoc considers a member public if its docstring contains
+     ``:meta public:`` in its :ref:`info-field-lists`, even if it starts with
+     an underscore.
+     For example:
+
+     .. code-block:: rst
+
+        def _my_function(my_arg, my_other_arg):
+            """blah blah blah
+
+            :meta public:
+            """
+
+     .. versionadded:: 3.1
+
    * Python "special" members (that is, those named like ``__special__``) will
      be included if the ``special-members`` flag option is given::
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -574,6 +574,9 @@ class Documenter:
             if 'private' in metadata:
                 # consider a member private if docstring has "private" metadata
                 isprivate = True
+            elif 'public' in metadata:
+                # consider a member public if docstring has "public" metadata
+                isprivate = False
             else:
                 isprivate = membername.startswith('_')
 

--- a/tests/roots/test-ext-autodoc/target/private.py
+++ b/tests/roots/test-ext-autodoc/target/private.py
@@ -3,3 +3,9 @@ def private_function(name):
 
     :meta private:
     """
+
+def _public_function(name):
+    """public_function is a docstring().
+
+    :meta public:
+    """

--- a/tests/test_ext_autodoc_private_members.py
+++ b/tests/test_ext_autodoc_private_members.py
@@ -22,6 +22,14 @@ def test_private_field(app):
         '',
         '.. py:module:: target.private',
         '',
+        '',
+        '.. py:function:: _public_function(name)',
+        '   :module: target.private',
+        '',
+        '   public_function is a docstring().',
+        '',
+        '   :meta public:',
+        '',
     ]
 
 
@@ -34,6 +42,14 @@ def test_private_field_and_private_members(app):
     assert list(actual) == [
         '',
         '.. py:module:: target.private',
+        '',
+        '',
+        '.. py:function:: _public_function(name)',
+        '   :module: target.private',
+        '',
+        '   public_function is a docstring().',
+        '',
+        '   :meta public:',
         '',
         '',
         '.. py:function:: private_function(name)',


### PR DESCRIPTION
A common use case for this is a class like `namedtuple`, which has a public `_replace` method that is so-named in order not to conflict with arbitrary user-provided attributes.

Other spellings I considered include:
* `:meta not-private:`
* `:meta private: False`

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
As a concrete example of why I want this:

```python
class AttrDict:
    def __init__(self, d):
        self.__dict__.update(d)

    def _update_helper(self, kwargs):
        """ private, please don't show me in the docs """
        self.__dict__.update(kwargs)

    def _replace(**kwargs):
        """
        Get a copy with an attribute replaced

        :meta public:
        """
        r = AttrDict(self.__dict__)
        r.__update_helper(kwargs)
        return r
```

Here I want the `_replace` member to be documented, but I don't want `_update_helper` to be.

