### PR TITLE
autodoc: Remove autodoc_default_flags (no longer used)

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1757,7 +1757,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value('autoclass_content', 'class', True)
     app.add_config_value('autodoc_member_order', 'alphabetic', True)
-    app.add_config_value('autodoc_default_flags', [], True)
     app.add_config_value('autodoc_default_options', {}, True)
     app.add_config_value('autodoc_docstring_signature', True, True)
     app.add_config_value('autodoc_mock_imports', [], True)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
