### PR TITLE
Relbar breadcrumb should contain current page

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -42,6 +42,7 @@
         {%- for parent in parents %}
           <li class="nav-item nav-item-{{ loop.index }}"><a href="{{ parent.link|e }}" {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>{{ reldelim1 }}</li>
         {%- endfor %}
+        <li class="nav-item nav-item-this"><a href="{{ link|e }}">{{ title }}</a></li>
         {%- block relbaritems %} {% endblock %}
       </ul>
     </div>


### PR DESCRIPTION
The relbar at the top contains the sequence of parents, which looks like [breadcrumb navigation](https://en.wikipedia.org/wiki/Breadcrumb_navigation):
![grafik](https://user-images.githubusercontent.com/2836374/79143595-caa01080-7dbd-11ea-9d23-2e6e9a033d8c.png)

However, breadcrumbs also contain the current page itself (see linked wikipedia article above). This makes sense as it's a self-contained display of the current location. Having the current page missing always confuses me.

This PR adds the current page as well:

![grafik](https://user-images.githubusercontent.com/2836374/79143568-c07e1200-7dbd-11ea-9c93-d8ff35fdd93b.png)

This is a change of the layout. If you have concerns about backward-compatibility, we could make it configurable via an option. (But IMHO it's generally the right thing to do, so not sure if we can just regard this as bug fix).