### PR TITLE
basic theme: Add right margin to footnote/citation labels

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -506,6 +506,7 @@ li > p:last-child {
 dl.footnote > dt,
 dl.citation > dt {
     float: left;
+    margin-right: 0.5em;
 }
 
 dl.footnote > dd,


### PR DESCRIPTION
The problem is not visible with single-digit footnote labels.

But with longer labels (e.g. when using multiple back-links, or with citations), there is no space between the label and the description text.

### Feature or Bugfix

- Bugfix