### PR TITLE
basic theme: CSS spacing for code blocks with captions and line numbers

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -673,7 +673,12 @@ table.highlighttable td.linenos {
 }
 
 table.highlighttable td.code {
+    flex: 1;
     overflow: hidden;
+}
+
+.highlight .hll {
+    display: block;
 }
 
 table.highlighttable pre {

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -645,21 +645,47 @@ span.pre {
 }
 
 td.linenos pre {
-    padding: 5px 0px;
     border: 0;
     background-color: transparent;
     color: #aaa;
 }
 
 table.highlighttable {
-    margin-left: 0.5em;
+    display: block;
+    margin: 1em 0;
+}
+
+table.highlighttable tbody {
+    display: block;
+}
+
+table.highlighttable tr {
+    display: flex;
 }
 
 table.highlighttable td {
-    padding: 0 0.5em 0 0.5em;
+    margin: 0;
+    padding: 0;
+}
+
+table.highlighttable td.linenos {
+    padding: 0 0.5em;
+}
+
+table.highlighttable td.code {
+    overflow: hidden;
+}
+
+table.highlighttable pre {
+    margin: 0;
+}
+
+div.code-block-caption + div > table.highlighttable {
+    margin-top: 0;
 }
 
 div.code-block-caption {
+    margin-top: 1em;
     padding: 2px 5px;
     font-size: small;
 }
@@ -672,6 +698,7 @@ div.code-block-caption + div > div.highlight > pre {
     margin-top: 0;
 }
 
+table.highlighttable td.linenos,
 div.doctest > div.highlight span.gp {  /* gp: Generic.Prompt */
     user-select: none;
 }
@@ -685,11 +712,7 @@ div.code-block-caption span.caption-text {
 }
 
 div.literal-block-wrapper {
-    padding: 1em 1em 0;
-}
-
-div.literal-block-wrapper div.highlight {
-    margin: 0;
+    margin: 1em 0;
 }
 
 code.descname {


### PR DESCRIPTION
I'm not sure whether I got all the details right, but I think it's definitely an improvement.

Example document:

```rest
Normal code block:

.. code-block:: python

    print('Hello, wooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooorld!')

With line numbers:

.. code-block:: python
    :linenos:

    print('Hello, wooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooorld!')

With caption:

.. code-block:: python
    :caption: Caption

    print('Hello, wooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooorld!')

With caption and line numbers:

.. code-block:: python
    :caption: Caption
    :linenos:

    print('Hello, wooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooorld!')
```

With `html_theme = 'basic'`, this previously looked like:

![image](https://user-images.githubusercontent.com/705404/79252339-be7d8700-7e81-11ea-9807-dcd592bd0f8d.png)

After this PR, it looks like:

![image](https://user-images.githubusercontent.com/705404/79252546-1a481000-7e82-11ea-89e9-19b33fe48caa.png)
