### PR TITLE
Fix #7477: imgconverter: Invoke "magick convert" command on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #7477: imgconverter: Invoke "magick convert" command by default on Windows
+
 Deprecated
 ----------
 

--- a/doc/usage/extensions/imgconverter.rst
+++ b/doc/usage/extensions/imgconverter.rst
@@ -34,7 +34,19 @@ Configuration
    A path to :command:`convert` command.  By default, the imgconverter uses
    the command from search paths.
 
+   On windows platform, :command:`magick` command is used by default.
+
+   .. versionchanged:: 3.1
+
+      Use :command:`magick` command by default on windows
+
 .. confval:: image_converter_args
 
    Additional command-line arguments to give to :command:`convert`, as a list.
    The default is an empty list ``[]``.
+
+   On windows platform, it defaults to ``["convert"]``.
+
+   .. versionchanged:: 3.1
+
+      Use ``["convert"]`` by default on windows

--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -9,6 +9,7 @@
 """
 
 import subprocess
+import sys
 from subprocess import CalledProcessError, PIPE
 from typing import Any, Dict
 
@@ -74,8 +75,17 @@ class ImagemagickConverter(ImageConverter):
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_post_transform(ImagemagickConverter)
-    app.add_config_value('image_converter', 'convert', 'env')
-    app.add_config_value('image_converter_args', [], 'env')
+    if sys.platform == 'win32':
+        # On Windows, we use Imagemagik v7 by default to avoid the trouble for
+        # convert.exe bundled with Windows.
+        app.add_config_value('image_converter', 'magick', 'env')
+        app.add_config_value('image_converter_args', ['convert'], 'env')
+    else:
+        # On other platform, we use Imagemagick v6 by default.  Especially,
+        # Debian/Ubuntu are still based of v6.  So we can't use "magick" command
+        # for these platforms.
+        app.add_config_value('image_converter', 'convert', 'env')
+        app.add_config_value('image_converter_args', [], 'env')
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7477 