### PR TITLE
basic theme: Avoid clashes between sidebar and other blocks

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -320,13 +320,14 @@ div.sidebar {
     background-color: #ffe;
     width: 40%;
     float: right;
+    clear: right
 }
 
 p.sidebar-title {
     font-weight: bold;
 }
 
-div.admonition, div.topic, div.sidebar, pre {
+div.admonition, div.topic, pre {
     clear: both;
 }
 

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -326,6 +326,10 @@ p.sidebar-title {
     font-weight: bold;
 }
 
+div.admonition, div.topic, div.sidebar, pre {
+    clear: both;
+}
+
 /* -- topics ---------------------------------------------------------------- */
 
 div.topic {

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -320,7 +320,7 @@ div.sidebar {
     background-color: #ffe;
     width: 40%;
     float: right;
-    clear: right
+    clear: right;
 }
 
 p.sidebar-title {


### PR DESCRIPTION
When following a `sidebar`, these blocks should not be squished next to the sidebar, but they should start *after* the end of the sidebar in their full width:

* admonitions
* topics
* code blocks
* further sidebars