### PR TITLE
C++, fix spacing issue in east-const notation

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -2062,13 +2062,16 @@ class ASTDeclSpecs(ASTBase):
         if self.trailingTypeSpec:
             if addSpace:
                 signode += nodes.Text(' ')
+            numChildren = len(signode)
             self.trailingTypeSpec.describe_signature(signode, mode, env,
                                                      symbol=symbol)
-            numChildren = len(signode)
-            self.rightSpecs.describe_signature(signode)
-            if len(signode) != numChildren:
-                signode += nodes.Text(' ')
+            addSpace = len(signode) != numChildren
 
+            if len(str(self.rightSpecs)) > 0:
+                if addSpace:
+                    signode += nodes.Text(' ')
+                self.rightSpecs.describe_signature(signode)
+ 
 
 # Declarator
 ################################################################################

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -2071,7 +2071,7 @@ class ASTDeclSpecs(ASTBase):
                 if addSpace:
                     signode += nodes.Text(' ')
                 self.rightSpecs.describe_signature(signode)
- 
+
 
 # Declarator
 ################################################################################


### PR DESCRIPTION
Subject: Fix a spacing issue which occurs when using east-const notation

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Documenting a function in this way

    cpp:function:: int foo(Type const& param)

renders output like this

int **foo**(**Type**_const_ &_param_)

That is, a space between **Type** and the following _const_ is missing.

This PR fixes this bug.

### Detail

The bugfix is a modification of the `ASTDeclSpecs.describe_signature` method, which did not properly insert a space between `trailingTypeSpec` and `rightSpecs`.

Note that the  `ASTDeclSpecs._stringify` method does not have the same problem, it behaves correctly. Therefore the problem is not observable in the unit tests in `test_domain_cpp.py`.

The problem was observed and the fix tested with HTML output.