### PR TITLE
DOC: Use html_baseurl

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -13,11 +13,6 @@
 {% block sidebar1 %}{{ sidebar() }}{% endblock %}
 {% block sidebar2 %}{% endblock %}
 
-{% block linktags %}
-{{ super() }}
-    <link rel="canonical" href="http://www.sphinx-doc.org/en/master/{{ pagename }}{{ file_suffix }}" />
-{% endblock %}
-
 {% block extrahead %}
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,700'
           rel='stylesheet' type='text/css' />

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,7 @@ html_static_path = ['_static']
 html_sidebars = {'index': ['indexsidebar.html', 'searchbox.html']}
 html_additional_pages = {'index': 'index.html'}
 html_use_opensearch = 'http://sphinx-doc.org'
+html_baseurl = 'https://www.sphinx-doc.org/en/master/'
 
 htmlhelp_basename = 'Sphinxdoc'
 


### PR DESCRIPTION
The `canonical` URL has been added in #4764.

But afterwards, in #5049, the config value `html_baseurl` has been introduced to simplify that.

This PR shouldn't really change anything in the resulting HTML pages, except that I used `https` instead of `http`.