### PR TITLE
test: Add a docstring to avoid an error on py39a5+

### DIFF
--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -145,6 +145,8 @@ First line of docstring
 
 
 class StrRepr(str):
+    """docstring"""
+
     def __repr__(self):
         return self
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
