### PR TITLE
Fix #7479: autodoc: Sphinx builds has been slower since 3.0.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,7 @@ Bugs fixed
 
 * #7461: py domain: fails with IndexError for empty tuple in type annotation
 * #7461: autodoc: empty tuple in type annotation is not shown correctly
+* #7479: autodoc: Sphinx builds has been slower since 3.0.0 on mocking
 * C++, fix spacing issue in east-const declarations.
 
 Testing

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -578,7 +578,10 @@ class Documenter:
                 isprivate = membername.startswith('_')
 
             keep = False
-            if want_all and membername.startswith('__') and \
+            if getattr(member, '__sphinx_mock__', False):
+                # mocked module or object
+                keep = False
+            elif want_all and membername.startswith('__') and \
                     membername.endswith('__') and len(membername) > 4:
                 # special __methods__
                 if self.options.special_members is ALL:

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -25,6 +25,7 @@ class _MockObject:
     """Used by autodoc_mock_imports."""
 
     __display_name__ = '_MockObject'
+    __sphinx_mock__ = True
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         if len(args) == 3 and isinstance(args[1], tuple):
@@ -78,6 +79,7 @@ def _make_subclass(name: str, module: str, superclass: Any = _MockObject,
 class _MockModule(ModuleType):
     """Used by autodoc_mock_imports."""
     __file__ = os.devnull
+    __sphinx_mock__ = True
 
     def __init__(self, name: str) -> None:
         super().__init__(name)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Call ``inspect.unwrap()`` for Mocked objects and modules causes
deep recurrsion calls. As a result, it causes slow builds.  This
skips to try documenting mocked objects on filtering members.

refs: #7479 