### PR TITLE
Escape "canonical" URL

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -132,7 +132,7 @@
     {{- script() }}
     {%- endblock %}
     {%- if pageurl %}
-    <link rel="canonical" href="{{ pageurl }}" />
+    <link rel="canonical" href="{{ pageurl|e }}" />
     {%- endif %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"


### PR DESCRIPTION
If the URL happens to have `"` in it, the URL becomes invalid.

### Feature or Bugfix

- Bugfix

### Relates
- https://github.com/readthedocs/readthedocs-sphinx-ext/issues/82

