### PR TITLE
Address #7491 - Configuration of pointer/ref placement in C++ decls

### DIFF
--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -50,7 +50,7 @@ def check(name, input, idDict, output=None):
     parentNode = addnodes.desc()
     signode = addnodes.desc_signature(input, '')
     parentNode += signode
-    ast.describe_signature(signode, 'lastIsName', symbol, options={})
+    ast.describe_signature(signode, 'lastIsName', None, options={})
 
     idExpected = [None]
     for i in range(1, _max_id + 1):


### PR DESCRIPTION
Subject: Allow configuration of the placement of the reference and pointer tokens in C++ declarations in the rendered output.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature - 2 additional configuration options, no changes for existing projects 

### Purpose
- This change adds options `cpp_ptr_placement` and `cpp_ref_placement`, which determine where the rendered output will attach the reference `&` or pointer `*` declaration token relative to the main type and the declared name. "right" (the current behavior and default) will attach towards the right on the declared name, whereas "left" will attach towrads the left, closer to the pointed-to/referred type.

### Relates
- #7491 

