### PR TITLE
Fix sphinx crashes with ImportError on python3.5.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
 * #7479: autodoc: Sphinx builds has been slower since 3.0.0 on mocking
 * C++, fix spacing issue in east-const declarations.
 * #7414: LaTeX: Xindy language options were incorrect
+* sphinx crashes with ImportError on python3.5.1
 
 Testing
 --------

--- a/sphinx/deprecation.py
+++ b/sphinx/deprecation.py
@@ -12,7 +12,10 @@ import sys
 import warnings
 from importlib import import_module
 from typing import Any, Dict
-from typing import Type  # for python3.5.1
+
+if False:
+    # For type annotation
+    from typing import Type  # for python3.5.1
 
 
 class RemovedInSphinx40Warning(DeprecationWarning):
@@ -26,13 +29,13 @@ class RemovedInSphinx50Warning(PendingDeprecationWarning):
 RemovedInNextVersionWarning = RemovedInSphinx40Warning
 
 
-def deprecated_alias(modname: str, objects: Dict, warning: Type[Warning]) -> None:
+def deprecated_alias(modname: str, objects: Dict, warning: "Type[Warning]") -> None:
     module = import_module(modname)
     sys.modules[modname] = _ModuleWrapper(module, modname, objects, warning)  # type: ignore
 
 
 class _ModuleWrapper:
-    def __init__(self, module: Any, modname: str, objects: Dict, warning: Type[Warning]
+    def __init__(self, module: Any, modname: str, objects: Dict, warning: "Type[Warning]"
                  ) -> None:
         self._module = module
         self._modname = modname
@@ -52,7 +55,7 @@ class _ModuleWrapper:
 class DeprecatedDict(dict):
     """A deprecated dict which warns on each access."""
 
-    def __init__(self, data: Dict, message: str, warning: Type[Warning]) -> None:
+    def __init__(self, data: Dict, message: str, warning: "Type[Warning]") -> None:
         self.message = message
         self.warning = warning
         super().__init__(data)

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -10,7 +10,6 @@
 import codecs
 import warnings
 from typing import Any, List
-from typing import Type  # for python3.5.1
 
 from docutils import nodes
 from docutils.core import Publisher
@@ -40,6 +39,7 @@ from sphinx.versioning import UIDTransform
 
 if False:
     # For type annotation
+    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
 
 
@@ -80,7 +80,7 @@ class SphinxBaseReader(standalone.Reader):
         self._app = app      # hold application object only for compatibility
         self._env = app.env
 
-    def get_transforms(self) -> List[Type[Transform]]:
+    def get_transforms(self) -> List["Type[Transform]"]:
         transforms = super().get_transforms() + self.transforms
 
         # remove transforms which is not needed for Sphinx

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -11,7 +11,6 @@
 import re
 import warnings
 from typing import Any, Dict, List, Tuple
-from typing import Type  # for python3.5.1
 
 from docutils import nodes, utils
 from docutils.nodes import Element, Node, TextElement, system_message
@@ -29,6 +28,7 @@ from sphinx.util.typing import RoleFunction
 
 if False:
     # For type annotation
+    from typing import Type  # for python3.5.1
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
 
@@ -77,7 +77,7 @@ class XRefRole(ReferenceRole):
     innernodeclass = nodes.literal      # type: Type[TextElement]
 
     def __init__(self, fix_parens: bool = False, lowercase: bool = False,
-                 nodeclass: Type[Element] = None, innernodeclass: Type[TextElement] = None,
+                 nodeclass: "Type[Element]" = None, innernodeclass: "Type[TextElement]" = None,
                  warn_dangling: bool = False) -> None:
         self.fix_parens = fix_parens
         self.lowercase = lowercase


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
typing.Type was added since python 3.5.2. So it should be imported only on type checking.
