### PR TITLE
Check for __display_version__ in package_dir

### DIFF
--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -56,6 +56,7 @@ if __version__.endswith('+'):
     __version__ = __version__[:-1]  # remove '+' for PEP-440 version spec.
     try:
         ret = subprocess.run(['git', 'show', '-s', '--pretty=format:%h'],
+                             cwd=package_dir,
                              stdout=PIPE, stderr=PIPE)
         if ret.stdout:
             __display_version__ += '/' + ret.stdout.decode('ascii').strip()


### PR DESCRIPTION
Since #5352, the `__display_version__` (and therefore the context variable `sphinx_version`) has been wrong in Sphinx development builds for all Sphinx projects except the Sphinx docs themselves.

The problem is that `git` has been called without specifying a working directory, so it was running in the directory from wherever Sphinx was started.

Therefore, the Git hash was not representing the Sphinx version, but the version of the currently built docs!

### Feature or Bugfix

- Bugfix

### Relates
- #5352

