### PR TITLE
C++ domain: Add support for semicolon in declarations

### DIFF
--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -33,10 +33,8 @@ def parse(name, string):
     return ast
 
 
-def check(name, input, idDict, output=None):
+def _check(name, input, idDict, output):
     # first a simple check of the AST
-    if output is None:
-        output = input
     ast = parse(name, input)
     res = str(ast)
     if res != output:
@@ -81,6 +79,15 @@ def check(name, input, idDict, output=None):
             print("expected: %s" % idExpected[i])
         print(rootSymbol.dump(0))
         raise DefinitionError("")
+
+
+def check(name, input, idDict, output=None):
+    if output is None:
+        output = input
+    # First, check without semicolon
+    _check(name, input, idDict, output)
+    # Second, check with semicolon
+    _check(name, input + ';', idDict, output + ';')
 
 
 def test_fundamental_types():


### PR DESCRIPTION
Subject: Add support for semicolon in declarations

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose

Some people prefer the signatures of commented entities to look like real code, which in C++ means including the semicolon to end a declaration.

This PR enables to add a semicolon to documentation directives in the cpp domain and to obtain appropriate output.

*Examples:*

    cpp:function:: void f();

    cpp:class:: MyClass;

### Detail

The change is simple and backwards compatible. It's entirely the user's decision if he/she adds a semicolon, and only then will it be rendered.

