### PR TITLE
fix for #7516

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -578,9 +578,13 @@ class Documenter:
                 isprivate = membername.startswith('_')
 
             keep = False
-            if getattr(member, '__sphinx_mock__', False):
+            try:
+                is_mock = getattr(member, '__sphinx_mock__', False)
+            except Exception:
+                is_mock = False
+            if is_mock:
                 # mocked module or object
-                keep = False
+                pass
             elif want_all and membername.startswith('__') and \
                     membername.endswith('__') and len(membername) > 4:
                 # special __methods__


### PR DESCRIPTION
### Bugfix

Subject: Enable secure object inspection in autodoc'd modules.

### Purpose
Inspecting objects in user modules can be risky if they raise errors in their `__getattr__` implementations. One such case is the `flask.request` proxy which will complain about not being in a valid context if is accessed in any way and throws a `RuntimeError`.

### Detail
I just wrapped the access in a catchall, since users can raise whatever Exception they want. Maybe `BaseException`/a bare `except` would be even better, but it seemed risky to include `SystemExit`.

### Relates
#7516 

