### PR TITLE
fix for #7516

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -578,9 +578,9 @@ class Documenter:
                 isprivate = membername.startswith('_')
 
             keep = False
-            if getattr(member, '__sphinx_mock__', False):
+            if safe_getattr(member, '__sphinx_mock__', False):
                 # mocked module or object
-                keep = False
+                pass
             elif want_all and membername.startswith('__') and \
                     membername.endswith('__') and len(membername) > 4:
                 # special __methods__


### PR DESCRIPTION
### Bugfix

Subject: Enable secure object inspection in autodoc'd modules.

### Purpose
Inspecting objects in user modules can be risky if they raise errors in their `__getattr__` implementations. One such case is the `flask.request` proxy which will complain about not being in a valid context if is accessed in any way and throws a `RuntimeError`.

### Detail
I replaced the `getattr` call with the existing `safe_getattr`.

### Relates
#7516 

------

Same as https://github.com/sphinx-doc/sphinx/pull/7518 based from a different branch, because I was not clever enough to rebase between branches that can't be fast-forwarded.