### PR TITLE
basic theme: Avoid whitespace at the beginning of genindex.html

### DIFF
--- a/sphinx/themes/basic/genindex.html
+++ b/sphinx/themes/basic/genindex.html
@@ -7,6 +7,9 @@
     :copyright: Copyright 2007-2020 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
+{%- extends "layout.html" %}
+{% set title = _('Index') %}
+
 {% macro indexentries(firstname, links) %}
   {%- if links -%}
     <a href="{{ links[0][1] }}">
@@ -26,8 +29,6 @@
   {%- endif %}
 {% endmacro %}
 
-{%- extends "layout.html" %}
-{% set title = _('Index') %}
 {% block body %}
 
 <h1 id="index">{{ _('Index') }}</h1>


### PR DESCRIPTION
This is picking up where 4370896aea063b9abb539d4861c25aee3deb8b9e left off 7 years ago ...

So what's going on here?

Let's say you create (e.g. for testing purposes) your own template called `layout.html` with this content:

    nothing

That's it. Only one word, nothing else. Especially no `{% extends ... %}` clause.

In this case, you should expect *all* generated HTML files to only consist the word "nothing", nothing else.

This works, except for the file `genindex.html` which will contain:

```

nothing
```

I.e., it contains a blank line at the top.
This PR fixes that.