### PR TITLE
Fix #7534: docs: Big vertical whitespace rendered in official doc

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -127,6 +127,7 @@ div.sphinxsidebar {
     float: right;
     font-size: 1em;
     text-align: left;
+    max-height: 0px;
 }
 
 div.sphinxsidebar .logo {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7534 
