### PR TITLE
basic theme: set "clear: both" on "highlight*" divs

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -327,7 +327,7 @@ p.sidebar-title {
     font-weight: bold;
 }
 
-div.admonition, div.topic, pre {
+div.admonition, div.topic, pre, div[class|="highlight"] {
     clear: both;
 }
 


### PR DESCRIPTION
This is a refinement of my PR #7484.

For, example, when using `html_theme = 'classic'` and this source text:

```rst
.. sidebar:: Sidebar

    Sidebar content.

::

    code
```

Before:

![image](https://user-images.githubusercontent.com/705404/80099921-86580180-856f-11ea-8ccf-0224c8ddab0d.png)

After:

![image](https://user-images.githubusercontent.com/705404/80099836-64f71580-856f-11ea-89b7-e962f4d348f1.png)
