### PR TITLE
basic theme: Add a "clearer" at the end of the "body".

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -181,6 +181,7 @@
       {%- endif %}
           <div class="body" role="main">
             {% block body %} {% endblock %}
+            <div class="clearer"></div>
           </div>
       {%- if render_sidebar %}
         </div>


### PR DESCRIPTION
You can see the problem when e.g. using `html_theme = 'classic'` and adding a `sidebar` at the very end of the page. It will reach into the footer.
Same for floating figures.

I'm not sure if this is the best solution, but it's simple and unobtrusive, so IMHO it's at least a step into the right direction.