### PR TITLE
basic theme: Make admonition/topic/sidebar scrollable

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -321,6 +321,7 @@ div.sidebar {
     width: 40%;
     float: right;
     clear: right;
+    overflow-x: auto;
 }
 
 p.sidebar-title {
@@ -337,6 +338,7 @@ div.topic {
     border: 1px solid #ccc;
     padding: 7px 7px 0 7px;
     margin: 10px 0 10px 0;
+    overflow-x: auto;
 }
 
 p.topic-title {
@@ -351,6 +353,7 @@ div.admonition {
     margin-top: 10px;
     margin-bottom: 10px;
     padding: 7px;
+    overflow-x: auto;
 }
 
 div.admonition dt {


### PR DESCRIPTION
Most of the time this isn't a problem because content isn't that wide and un-breakable.
But one important use case are overly wide tables.

For example, using `html_theme = 'classic'` and this source text:

```rst
.. note::

    = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
    x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
    = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

```

Before:

![image](https://user-images.githubusercontent.com/705404/80105049-5103e180-8578-11ea-9b6b-5ad11c8ccd0c.png)

After:

![image](https://user-images.githubusercontent.com/705404/80105158-74c72780-8578-11ea-8ce2-b2494f1de6f6.png)
