### PR TITLE
C and C++, allow semicolons in the end of declarations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -54,6 +54,7 @@ Features added
 * #7533: html theme: Avoid whitespace at the beginning of genindex.html
 * #7541: html theme: Add a "clearer" at the end of the "body"
 * #7542: html theme: Make admonition/topic/sidebar scrollable
+* C and C++: allow semicolon in the end of declarations.
 
 Bugs fixed
 ----------

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -338,10 +338,14 @@ class BaseParser:
         self.pos = self.end
         return rv
 
-    def assert_end(self) -> None:
+    def assert_end(self, *, allowSemicolon: bool = False) -> None:
         self.skip_ws()
-        if not self.eof:
-            self.fail('Expected end of definition.')
+        if allowSemicolon:
+            if not self.eof and self.definition[self.pos:] != ';':
+                self.fail('Expected end of definition or ;.')
+        else:
+            if not self.eof:
+                self.fail('Expected end of definition.')
 
     ################################################################################
 

--- a/tests/roots/test-domain-c/semicolon.rst
+++ b/tests/roots/test-domain-c/semicolon.rst
@@ -1,0 +1,10 @@
+.. c:member:: int member;
+.. c:var:: int var;
+.. c:function:: void f();
+.. .. c:macro:: NO_SEMICOLON;
+.. c:struct:: Struct;
+.. c:union:: Union;
+.. c:enum:: Enum;
+.. c:enumerator:: Enumerator;
+.. c:type:: Type;
+.. c:type:: int TypeDef;

--- a/tests/roots/test-domain-cpp/semicolon.rst
+++ b/tests/roots/test-domain-cpp/semicolon.rst
@@ -1,0 +1,14 @@
+.. cpp:class:: Class;
+.. cpp:struct:: Struct;
+.. cpp:union:: Union;
+.. cpp:function:: void f();
+.. cpp:member:: int member;
+.. cpp:var:: int var;
+.. cpp:type:: Type;
+.. cpp:type:: int TypeDef;
+.. cpp:type:: Alias = int;
+.. cpp:concept:: template<typename T> Concept;
+.. cpp:enum:: Enum;
+.. cpp:enum-struct:: EnumStruct;
+.. cpp:enum-class:: EnumClass;
+.. cpp:enumerator:: Enumerator;

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -33,10 +33,8 @@ def parse(name, string):
     return ast
 
 
-def check(name, input, idDict, output=None):
+def _check(name, input, idDict, output):
     # first a simple check of the AST
-    if output is None:
-        output = input
     ast = parse(name, input)
     res = str(ast)
     if res != output:
@@ -81,6 +79,15 @@ def check(name, input, idDict, output=None):
             print("expected: %s" % idExpected[i])
         print(rootSymbol.dump(0))
         raise DefinitionError("")
+
+
+def check(name, input, idDict, output=None):
+    if output is None:
+        output = input
+    # First, check without semicolon
+    _check(name, input, idDict, output)
+    # Second, check with semicolon
+    _check(name, input + ';', idDict, output + ';')
 
 
 def test_fundamental_types():

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -87,7 +87,7 @@ def check(name, input, idDict, output=None):
     # First, check without semicolon
     _check(name, input, idDict, output)
     # Second, check with semicolon
-    _check(name, input + ';', idDict, output + ';')
+    _check(name, input + ' ;', idDict, output + ';')
 
 
 def test_fundamental_types():
@@ -907,6 +907,13 @@ def test_build_domain_cpp_warn_template_param_qualified_name(app, status, warnin
 def test_build_domain_cpp_backslash_ok(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "backslash")
+    assert len(ws) == 0
+
+
+@pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
+def test_build_domain_cpp_semicolon(app, status, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "semicolon")
     assert len(ws) == 0
 
 


### PR DESCRIPTION
An updated version of #7517, which also implements the functionality in the C domain.