### PR TITLE
refactor: Do not pass builder paramater to generate_autosummary_docs()

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -752,8 +752,7 @@ def process_generate_options(app: Sphinx) -> None:
 
     imported_members = app.config.autosummary_imported_members
     with mock(app.config.autosummary_mock_imports):
-        generate_autosummary_docs(genfiles, builder=app.builder,
-                                  suffix=suffix, base_path=app.srcdir,
+        generate_autosummary_docs(genfiles, suffix=suffix, base_path=app.srcdir,
                                   app=app, imported_members=imported_members,
                                   overwrite=app.config.autosummary_generate_overwrite)
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- It has been deprecated!