### PR TITLE
Add .pre-commit-hooks.yaml configurations

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: sphinx
+  name: sphinx
+  description: Python Documentation Generator
+  entry: sphinx-build
+  language: python
+  language_version: python3


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
This change allows to easily configure sphinx as a git hook over the [pre-commit](https://pre-commit.com/)  framework, so as to:
- Ensure the documentation is building for each commit
- Automatically keep the local documentation up to date

### Detail
To use sphinx as a git hook over pre-commit with this change, you may follow the steps below:

1. Install `pre-commit` in you project 
```
pip install pre-commit
pre-commit install
```
2. Create an appropriate `.pre-commit-config.yaml` file at your project root. Example:
```yaml
repos:
  - repo: https://github.com/sphinx-doc/sphinx
    rev: 3.x
    hooks:
      - id: docs
        args: [-W, ./docs/source, ./docs/build]
        additional_dependencies:
          - sphinx_rtd_theme
        always_run: true
        files: ".^"
```
**NB 1**: The `files` and `always_run` keys are set so that the build runs exactly once without matching any files.
**NB 2**: My fork can be used for testing by setting `repo: https://github.com/OliverSieweke/sphinx`

3. Commit and see the hook running

Below are examples of passing and failing documentation builds:

![sphinx-valid-commit](https://user-images.githubusercontent.com/30631513/80303469-cf4ac880-87b0-11ea-8550-c120d2478a92.gif)
![sphinx-invalid-commit](https://user-images.githubusercontent.com/30631513/80303473-d1ad2280-87b0-11ea-927b-89bfc69721b0.gif)

#### References:
- https://pre-commit.com/
- https://pre-commit.com/#new-hooks
