### PR TITLE
always use separate fields for param and type in ext.autodoc.typehints

### DIFF
--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -104,24 +104,16 @@ def modify_field_list(node: nodes.field_list, annotations: Dict[str, str]) -> No
             continue
 
         arg = arguments.get(name, {})
-        field = nodes.field()
-        if arg.get('param') and arg.get('type'):
-            # both param and type are already filled manually
-            continue
-        elif arg.get('param'):
-            # only param: fill type field
+        if not arg.get('type'):
+            field = nodes.field()
             field += nodes.field_name('', 'type ' + name)
             field += nodes.field_body('', nodes.paragraph('', annotation))
-        elif arg.get('type'):
-            # only type: It's odd...
+            node += field
+        if not arg.get('param'):
+            field = nodes.field()
             field += nodes.field_name('', 'param ' + name)
             field += nodes.field_body('', nodes.paragraph('', ''))
-        else:
-            # both param and type are not found
-            field += nodes.field_name('', 'param ' + annotation + ' ' + name)
-            field += nodes.field_body('', nodes.paragraph('', ''))
-
-        node += field
+            node += field
 
     if 'return' in annotations and 'return' not in arguments:
         field = nodes.field()

--- a/tests/roots/test-ext-autodoc/index.rst
+++ b/tests/roots/test-ext-autodoc/index.rst
@@ -9,3 +9,5 @@
    :members:
 
 .. autofunction:: target.typehints.incr
+
+.. autofunction:: target.typehints.tuple_args

--- a/tests/roots/test-ext-autodoc/target/typehints.py
+++ b/tests/roots/test-ext-autodoc/target/typehints.py
@@ -1,3 +1,6 @@
+from typing import Tuple, Union
+
+
 def incr(a: int, b: int = 1) -> int:
     return a + b
 
@@ -28,6 +31,10 @@ class Math:
               ):
         # type: (...) -> None
         return
+
+
+def tuple_args(x: Tuple[int, Union[int, str]]) -> Tuple[int, int]:
+    pass
 
 
 def complex_func(arg1, arg2, arg3=None, *args, **kwargs):

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -508,7 +508,11 @@ def test_autodoc_typehints_signature(app):
         '',
         '.. py:function:: missing_attr(c, a: str, b: Optional[str] = None) -> str',
         '   :module: target.typehints',
-        ''
+        '',
+        '',
+        '.. py:function:: tuple_args(x: Tuple[int, Union[int, str]]) -> Tuple[int, int]',
+        '   :module: target.typehints',
+        '',
     ]
 
 
@@ -557,7 +561,11 @@ def test_autodoc_typehints_none(app):
         '',
         '.. py:function:: missing_attr(c, a, b=None)',
         '   :module: target.typehints',
-        ''
+        '',
+        '',
+        '.. py:function:: tuple_args(x)',
+        '   :module: target.typehints',
+        '',
     ]
 
 
@@ -576,6 +584,15 @@ def test_autodoc_typehints_description(app):
             '   Return type:\n'
             '      int\n'
             in context)
+    assert ('target.typehints.tuple_args(x)\n'
+            '\n'
+            '   Parameters:\n'
+            '      **x** (*Tuple**[**int**, **Union**[**int**, **str**]**]*) --\n'
+            '\n'
+            '   Return type:\n'
+            '      Tuple[int, int]\n'
+            in context)
+
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')


### PR DESCRIPTION
this fixes issues where annotations such as `x: typing.Tuple[int, int]`
will be transformed to `:field typing.Tuple[int, int] x:`, which renders
as `*int] x* (**typing.Tuple[int,**) -- `

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Minimum example:
```
mkdir -p sphinx_signature_type_hints
cd sphinx_signature_type_hints

cat <<'EOF' >type_hint_test.py
import typing
def test(x: typing.Tuple[int, int] = ()) -> int:
    return 1
EOF

mkdir -p docs

cat <<'EOF' >docs/conf.py
extensions = ["sphinx.ext.autodoc", "sphinx.ext.autodoc.typehints"]
autodoc_typehints = 'description'
EOF

cat <<'EOF' >docs/index.rst
.. automodule:: type_hint_test
    :members:
    :undoc-members:
EOF

mkdir -p html
python3.8 -m sphinx -vvv -W -b html --keep-going docs html
```

Unfortunately, I didn't find a testsuite for `sphinx.ext.autodoc.typehints`, so I can't promise that this doesn't have any weird side effects.