### PR TITLE
Fix #7567: autodoc: parametrized types are shown twice for generic types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,7 @@ Bugs fixed
 
 * #6703: autodoc: incremental build does not work for imported objects
 * #7564: autodoc: annotations not to be shown for descriptors
+* #7567: autodoc: parametrized types are shown twice for generic types
 
 Testing
 --------

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -10,7 +10,7 @@
 
 import sys
 import typing
-from typing import Any, Callable, Dict, List, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Tuple, TypeVar, Union
 
 from docutils import nodes
 from docutils.parsers.rst.states import Inliner
@@ -92,6 +92,9 @@ def _stringify_py37(annotation: Any) -> str:
         elif str(annotation).startswith('typing.Annotated'):  # for py39+
             return stringify(annotation.__args__[0])
         elif annotation._special:
+            return qualname
+        elif issubclass(annotation.__origin__, Generic):  # type: ignore
+            # subclasses of Generic already contains the types for elements in its name
             return qualname
         else:
             args = ', '.join(stringify(a) for a in annotation.__args__)

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -10,7 +10,7 @@
 
 import sys
 from numbers import Integral
-from typing import Any, Dict, List, TypeVar, Union, Callable, Tuple, Optional
+from typing import Any, Dict, Generic, List, TypeVar, Union, Callable, Tuple, Optional
 
 import pytest
 
@@ -92,6 +92,16 @@ def test_stringify_type_hints_typevars():
     assert stringify(T_co) == "T_co"
     assert stringify(T_contra) == "T_contra"
     assert stringify(List[T]) == "List[T]"
+
+
+def test_stringify_type_hints_Generic():
+    T = TypeVar('T')
+
+    class Foo(Generic[T]):
+        pass
+
+    expected = "test_util_typing.test_stringify_type_hints_Generic.<locals>.Foo[int]"
+    assert stringify(Foo[int]) == expected
 
 
 def test_stringify_type_hints_custom_class():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7567 