### PR TITLE
Align equation numbers at the right margin

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -779,8 +779,7 @@ span.eqno {
 }
 
 span.eqno a.headerlink {
-    position: relative;
-    left: 0px;
+    position: absolute;
     z-index: 1;
 }
 


### PR DESCRIPTION
Closes #2785.

Example (with `html_theme = 'basic'`):

```rst
----

.. math:: x
    :label: x

----
```

Before:

![image](https://user-images.githubusercontent.com/705404/80399336-52efdc80-88b9-11ea-8d6a-49baa73eef1a.png)

After:

![image](https://user-images.githubusercontent.com/705404/80399239-2d62d300-88b9-11ea-9e13-90f55b3f6534.png)