### PR TITLE
Fix #7469: autodoc: The change of autodoc-process-docstring is cached

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,8 @@ Bugs fixed
 * #6703: autodoc: incremental build does not work for imported objects
 * #7564: autodoc: annotations not to be shown for descriptors
 * #6588: autodoc: Decorated inherited method has no documentation
+* #7469: autodoc: The change of autodoc-process-docstring for variables is
+  cached unexpectedly
 * #7535: sphinx-autogen: crashes when custom template uses inheritance
 * #7536: sphinx-autogen: crashes when template uses i18n feature
 * #2785: html: Bad alignment of equation links

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -468,7 +468,10 @@ class Documenter:
                 key = ('.'.join(self.objpath[:-1]), self.objpath[-1])
                 if key in attr_docs:
                     no_docstring = True
-                    docstrings = [attr_docs[key]]
+                    # make a copy of docstring for attributes to avoid cache
+                    # the change of autodoc-process-docstring event.
+                    docstrings = [list(attr_docs[key])]
+
                     for i, line in enumerate(self.process_doc(docstrings)):
                         self.add_line(line, sourcename, i)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7469
- The change of event-handlers was cached unexpectedly.