### PR TITLE
ext.napoleon: Emit type annotations at the start of `.. attribute::`

### DIFF
--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -168,10 +168,9 @@ class Config:
         **If False**::
 
             .. attribute:: attr1
+               :type: int
 
                Description of `attr1`
-
-               :type: int
 
     napoleon_use_param : :obj:`bool` (Defaults to True)
         True to use a ``:param:`` role for each function parameter. False to

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -586,13 +586,12 @@ class GoogleDocstring:
                 lines.append('.. attribute:: ' + _name)
                 if self._opt and 'noindex' in self._opt:
                     lines.append('   :noindex:')
+                if _type:
+                    lines.extend(self._indent([':type: %s' % _type], 3))
                 lines.append('')
 
                 fields = self._format_field('', '', _desc)
                 lines.extend(self._indent(fields, 3))
-                if _type:
-                    lines.append('')
-                    lines.extend(self._indent([':type: %s' % _type], 3))
                 lines.append('')
         if self._config.napoleon_use_ivar:
             lines.append('')

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -53,22 +53,19 @@ class NamedtupleSubclassTest(BaseDocstringTest):
 Sample namedtuple subclass
 
 .. attribute:: attr1
+   :type: Arbitrary type
 
    Quick description of attr1
 
-   :type: Arbitrary type
-
 .. attribute:: attr2
+   :type: Another arbitrary type
 
    Quick description of attr2
 
-   :type: Another arbitrary type
-
 .. attribute:: attr3
+   :type: Type
 
    Adds a newline after the type
-
-   :type: Type
 """
 
         self.assertEqual(expected, actual)
@@ -390,10 +387,9 @@ Attributes:
         actual = str(GoogleDocstring(docstring))
         expected = """\
 .. attribute:: in_attr
+   :type: :class:`numpy.ndarray`
 
    super-dooper attribute
-
-   :type: :class:`numpy.ndarray`
 """
         self.assertEqual(expected, actual)
 
@@ -405,10 +401,9 @@ Attributes:
         actual = str(GoogleDocstring(docstring))
         expected = """\
 .. attribute:: in_attr
+   :type: numpy.ndarray
 
    super-dooper attribute
-
-   :type: numpy.ndarray
 """
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
A partial fix for #7582. This is the easy half, which handles `Attribute` sections within docstrings.

The hard part is handling inline attribute docstrings like
```
x = 1 #: int: some docs
```

I'll leave that till a future PR, or a more competent developer :)