### PR TITLE
Preserve exception info in raised SphinxWarning objects

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -412,9 +412,13 @@ class WarningIsErrorFilter(logging.Filter):
                 message = record.msg  # use record.msg itself
 
             if location:
-                raise SphinxWarning(location + ":" + str(message))
+                exc = SphinxWarning(location + ":" + str(message))
             else:
-                raise SphinxWarning(message)
+                exc = SphinxWarning(message)
+            if record.exc_info is not None:
+                raise exc from record.exc_info[1]
+            else:
+                raise exc
         else:
             return True
 


### PR DESCRIPTION
This perhaps isn't enough to do anything useful yet, as `sphinx/command/build.py` discards this information