### PR TITLE
Allow to build docs in readthedocs.org

### DIFF
--- a/sphinx/builders/dirhtml.py
+++ b/sphinx/builders/dirhtml.py
@@ -13,6 +13,7 @@ from typing import Any, Dict
 
 from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.deprecation import RemovedInSphinx40Warning, deprecated_alias
 from sphinx.util import logging
 from sphinx.util.osutil import SEP, os_path
 
@@ -43,6 +44,14 @@ class DirectoryHTMLBuilder(StandaloneHTMLBuilder):
                                     'index' + self.out_suffix)
 
         return outfilename
+
+
+# for compatibility
+deprecated_alias('sphinx.builders.html',
+                 {
+                     'DirectoryHTMLBuilder': DirectoryHTMLBuilder,
+                 },
+                 RemovedInSphinx40Warning)
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1162,7 +1162,7 @@ def validate_html_favicon(app: Sphinx, config: Config) -> None:
         config.html_favicon = None  # type: ignore
 
 
-# for compatibility
+# for compatibility; RemovedInSphinx40Warning
 import sphinx.builders.dirhtml  # NOQA
 import sphinx.builders.singlehtml  # NOQA
 import sphinxcontrib.serializinghtml  # NOQA

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -16,6 +16,7 @@ from docutils.nodes import Node
 
 from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.deprecation import RemovedInSphinx40Warning, deprecated_alias
 from sphinx.environment.adapters.toctree import TocTree
 from sphinx.locale import __
 from sphinx.util import logging
@@ -185,6 +186,14 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
             logger.info(' opensearch', nonl=True)
             fn = path.join(self.outdir, '_static', 'opensearch.xml')
             self.handle_page('opensearch', {}, 'opensearch.xml', outfilename=fn)
+
+
+# for compatibility
+deprecated_alias('sphinx.builders.html',
+                 {
+                     'SingleFileHTMLBuilder': SingleFileHTMLBuilder,
+                 },
+                 RemovedInSphinx40Warning)
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
At present, readthedocs_ext expects that DirectoryHTMLBuilder and
SingleFileHTMLBuilder are placed at sphinx.builders.html module.
But they were deprecated since Sphinx-2.0 and will be removed at
Sphinx-4.0.

This revives them temporarily to build our document successfully on
RTD until readthedocs_ext supports the new structure of Sphinx
components.

refs: https://github.com/readthedocs/readthedocs-sphinx-ext/pull/86
