### PR TITLE
refactor: Clean up filterwarnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ filterwarnings =
     all
     ignore::DeprecationWarning:docutils.io
     ignore::DeprecationWarning:pyximport.pyximport
-    ignore::PendingDeprecationWarning:sphinx.util.pycompat
 markers =
     sphinx
     apidoc


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
Since 4.0, Sphinx does not use lib2to3.  Therefore a filterwarnings
entry for lib2to3 is no longer needed.
