### PR TITLE
Fix #7619: Duplicated node IDs are generated if node has multiple IDs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,7 @@ Bugs fixed
   from the previous abbr role
 * C and C++, removed ``noindex`` directive option as it did
   nothing.
+* #7619: Duplicated node IDs are generated if node has multiple IDs
 
 Testing
 --------

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -15,10 +15,37 @@ from docutils import nodes
 from docutils.nodes import Element, Node
 
 from sphinx.deprecation import RemovedInSphinx40Warning
+from sphinx.util import docutils
 
 if False:
     # For type annotation
     from sphinx.application import Sphinx
+
+
+class document(nodes.document):
+    """The document root element patched by Sphinx.
+
+    This fixes that document.set_id() does not support a node having multiple node Ids.
+    see https://sourceforge.net/p/docutils/patches/167/
+
+    .. important:: This is only for Sphinx internal use.  Please don't use this
+                   in your extensions.  It will be removed without deprecation period.
+    """
+
+    def set_id(self, node: Element, msgnode: Element = None,
+               suggested_prefix: str = '') -> str:
+        if docutils.__version_info__ >= (0, 16):
+            ret = super().set_id(node, msgnode, suggested_prefix)  # type: ignore
+        else:
+            ret = super().set_id(node, msgnode)
+
+        if docutils.__version_info__ < (0, 17):
+            # register other node IDs forcedly
+            for node_id in node['ids']:
+                if node_id not in self.ids:
+                    self.ids[node_id] = node
+
+        return ret
 
 
 class translatable(nodes.Node):

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -22,6 +22,7 @@ from docutils.transforms import Transform
 from docutils.transforms.references import DanglingReferences
 from docutils.writers import UnfilteredWriter
 
+from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx40Warning, deprecated_alias
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import FiletypeNotFoundError
@@ -96,6 +97,7 @@ class SphinxBaseReader(standalone.Reader):
         for logging.
         """
         document = super().new_document()
+        document.__class__ = addnodes.document  # replace the class with patched version
 
         # substitute transformer
         document.transformer = SphinxTransformer(document)

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -509,6 +509,7 @@ def new_document(source_path: str, settings: Any = None) -> nodes.document:
         settings = copy(__document_cache__.settings)
 
     # Create a new instance of nodes.document using cached reporter
-    document = nodes.document(settings, __document_cache__.reporter, source=source_path)
+    from sphinx import addnodes
+    document = addnodes.document(settings, __document_cache__.reporter, source=source_path)
     document.note_source(source_path, -1)
     return document


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7619 
- I'll merge this after https://sourceforge.net/p/docutils/patches/167/ is merged.