### PR TITLE
refactor: autodoc: if-block for callable object is no longer needed

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1045,18 +1045,8 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             # cannot introspect arguments of a C function or method
             return None
         try:
-            if (not inspect.isfunction(unwrapped) and
-                    not inspect.ismethod(unwrapped) and
-                    not inspect.isbuiltin(unwrapped) and
-                    not inspect.is_cython_function_or_method(unwrapped) and
-                    not inspect.isclass(unwrapped) and
-                    hasattr(unwrapped, '__call__')):
-                self.env.app.emit('autodoc-before-process-signature',
-                                  unwrapped.__call__, False)
-                sig = inspect.signature(unwrapped.__call__)
-            else:
-                self.env.app.emit('autodoc-before-process-signature', unwrapped, False)
-                sig = inspect.signature(unwrapped)
+            self.env.app.emit('autodoc-before-process-signature', unwrapped, False)
+            sig = inspect.signature(unwrapped)
             args = stringify_signature(sig, **kwargs)
         except TypeError:
             if (inspect.is_builtin_class_method(unwrapped, '__new__') and


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
The if-block for callable object was added to FunctionDocumenter at
5c3a0e4e40 (see #5447).  At that time, it helps to introspect
the function signature for a callable object because
``sphinx.util.inspect:Signature`` emits a warning when a callable
object is given.

For now, ``sphinx.util.inspect:signature()` does not emit a warning
even if a callable object is given.  So this if-block is no longer
needed.