### PR TITLE
refactor: autodoc: class processors on autofunction is no longer needed

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1049,23 +1049,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             sig = inspect.signature(unwrapped)
             args = stringify_signature(sig, **kwargs)
         except TypeError:
-            if (inspect.is_builtin_class_method(unwrapped, '__new__') and
-               inspect.is_builtin_class_method(unwrapped, '__init__')):
-                raise TypeError('%r is a builtin class' % unwrapped)
-
-            # if a class should be documented as function (yay duck
-            # typing) we try to use the constructor signature as function
-            # signature without the first argument.
-            try:
-                self.env.app.emit('autodoc-before-process-signature',
-                                  unwrapped.__new__, True)
-                sig = inspect.signature(unwrapped.__new__, bound_method=True)
-                args = stringify_signature(sig, show_return_annotation=False, **kwargs)
-            except TypeError:
-                self.env.app.emit('autodoc-before-process-signature',
-                                  unwrapped.__init__, True)
-                sig = inspect.signature(unwrapped.__init__, bound_method=True)
-                args = stringify_signature(sig, show_return_annotation=False, **kwargs)
+            args = ''
 
         if self.env.config.strip_signature_backslash:
             # escape backslashes for reST

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -402,12 +402,6 @@ def signature(subject: Callable, bound_method: bool = False) -> inspect.Signatur
 
     :param bound_method: Specify *subject* is a bound method or not
     """
-    # check subject is not a built-in class (ex. int, str)
-    if (isinstance(subject, type) and
-            is_builtin_class_method(subject, "__new__") and
-            is_builtin_class_method(subject, "__init__")):
-        raise TypeError("can't compute signature for built-in type {}".format(subject))
-
     try:
         signature = inspect.signature(subject)
         parameters = list(signature.parameters.values())

--- a/tests/roots/test-ext-autodoc/target/classes.py
+++ b/tests/roots/test-ext-autodoc/target/classes.py
@@ -1,0 +1,12 @@
+class Foo:
+    pass
+
+
+class Bar:
+    def __init__(self, x, y):
+        pass
+
+
+class Baz:
+    def __new__(cls, x, y):
+        pass

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1165,6 +1165,33 @@ def test_descriptor_class(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autofunction_for_classes(app):
+    actual = do_autodoc(app, 'function', 'target.classes.Foo')
+    assert list(actual) == [
+        '',
+        '.. py:function:: Foo()',
+        '   :module: target.classes',
+        '',
+    ]
+
+    actual = do_autodoc(app, 'function', 'target.classes.Bar')
+    assert list(actual) == [
+        '',
+        '.. py:function:: Bar(x, y)',
+        '   :module: target.classes',
+        '',
+    ]
+
+    actual = do_autodoc(app, 'function', 'target.classes.Baz')
+    assert list(actual) == [
+        '',
+        '.. py:function:: Baz(x, y)',
+        '   :module: target.classes',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autofunction_for_callable(app):
     actual = do_autodoc(app, 'function', 'target.callable.function')
     assert list(actual) == [

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -30,10 +30,10 @@ def test_signature():
         inspect.signature('')
 
     # builitin classes
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         inspect.signature(int)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         inspect.signature(str)
 
     # normal function


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
