### PR TITLE
Support dynamically added attribute ordering in autodoc

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -722,7 +722,7 @@ class Documenter:
             memberdocumenters.sort(key=keyfunc)
         elif member_order == 'byobject':
             # sort in order of addition to parents' namespace
-            def keyfunc(entry: Tuple[Documenter, bool], cache = {}) -> int:
+            def keyfunc(entry: Tuple[Documenter, bool]) -> int:
                 fullname = entry[0].name.split('::')[1]
                 child_obj = self.module
                 for name in fullname.split('.'):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Attributes set during runtime are not detected by `ModuleAnalyzer` and do not have an entry in `tagorder`, leading to alphabetic sorting even if `member_order='bysource'`. This PR adds another option which also looks at the parent's `__dict__` to determine order.

### Detail
- Adds a static `Documenter.get_attrs` function that joins `__dict__.keys` and `__dir__` results to obtain a comprehensive list of objects' attributes while best preserving the order in which they were added.
- Adds a `byobject` ordering option which utilizes the aforementioned function to sort objects according to when they were added to their parent's namespace.