### PR TITLE
Fix #7626: release package does not contain ``CODE_OF_CONDUCT``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #7567: autodoc: parametrized types are shown twice for generic types
 * #7611: md5 fails when OpenSSL FIPS is enabled
+* #7626: release package does not contain ``CODE_OF_CONDUCT``
 
 Testing
 --------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include AUTHORS
 include CHANGES
 include CHANGES.old
+include CODE_OF_CONDUCT
 include CONTRIBUTING.rst
 include EXAMPLES
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7626 