### PR TITLE
Fix #7628: imgconverter: runs imagemagick unnecessary

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -92,6 +92,8 @@ Bugs fixed
 * #7536: sphinx-autogen: crashes when template uses i18n feature
 * #2785: html: Bad alignment of equation links
 * #7581: napoleon: bad parsing of inline code in attribute docstrings
+* #7628: imgconverter: runs imagemagick once unnecessary for builders not
+  supporting images
 * #7610: incorrectly renders consecutive backslashes for docutils-0.16
 
 Testing

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -193,7 +193,9 @@ class ImageConverter(BaseImageConverter):
         super().__init__(*args, **kwargs)
 
     def match(self, node: nodes.image) -> bool:
-        if self.available is None:
+        if not self.app.builder.supported_image_types:
+            return False
+        elif self.available is None:
             self.available = self.is_available()
 
         if not self.available:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: #7628 