### PR TITLE
Fix #7629: autodoc: autofunction emits an unfriendly warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -90,6 +90,8 @@ Bugs fixed
 * #7362: autodoc: does not render correct signatures for built-in functions
 * #7654: autodoc: ``Optional[Union[foo, bar]]`` is presented as
   ``Union[foo, bar, None]``
+* #7629: autodoc: autofunction emits an unfriendly warning if an invalid object
+  specified
 * #7551: autosummary: a nested class is indexed as non-nested class
 * #7535: sphinx-autogen: crashes when custom template uses inheritance
 * #7536: sphinx-autogen: crashes when template uses i18n feature

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1056,7 +1056,11 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             self.env.app.emit('autodoc-before-process-signature', unwrapped, False)
             sig = inspect.signature(unwrapped)
             args = stringify_signature(sig, **kwargs)
-        except TypeError:
+        except TypeError as exc:
+            logger.warning(__("Failed to get a function signature for %s: %s"),
+                           self.fullname, exc)
+            return None
+        except ValueError:
             args = ''
 
         if self.env.config.strip_signature_backslash:

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -942,7 +942,7 @@ class ClassLevelDocumenter(Documenter):
 
             try:
                 modname, qualname = split_full_qualified_name(mod_cls)
-                parents = qualname.split(".")
+                parents = qualname.split(".") if qualname else []
             except ImportError:
                 parents = mod_cls.split(".")
 
@@ -1467,6 +1467,10 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
                     self.env.app.emit('autodoc-before-process-signature', unwrapped, True)
                     sig = inspect.signature(unwrapped, bound_method=True)
                 args = stringify_signature(sig, **kwargs)
+        except TypeError as exc:
+            logger.warning(__("Failed to get a method signature for %s: %s"),
+                           self.fullname, exc)
+            return None
         except ValueError:
             args = ''
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7629 
- This also fixes the same problem of automethod.
- I did not resolve a problem for location of the warnings. I'll work on it as another issue.