### PR TITLE
Fix #7650: autodoc: undecorated signature is shown for decorated functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -88,6 +88,7 @@ Bugs fixed
   autodoc_typehints='description' mode
 * #7551: autodoc: failed to import nested class
 * #7362: autodoc: does not render correct signatures for built-in functions
+* #7650: autodoc: undecorated signature is shown for decorated functions
 * #7551: autosummary: a nested class is indexed as non-nested class
 * #7535: sphinx-autogen: crashes when custom template uses inheritance
 * #7536: sphinx-autogen: crashes when template uses i18n feature

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -408,13 +408,20 @@ def is_builtin_class_method(obj: Any, attr_name: str) -> bool:
     return getattr(builtins, name, None) is cls
 
 
-def signature(subject: Callable, bound_method: bool = False) -> inspect.Signature:
+def signature(subject: Callable, bound_method: bool = False, follow_wrapped: bool = False
+              ) -> inspect.Signature:
     """Return a Signature object for the given *subject*.
 
     :param bound_method: Specify *subject* is a bound method or not
+    :param follow_wrapped: Same as ``inspect.signature()``.
+                           Defaults to ``False`` (get a signature of *subject*).
     """
     try:
-        signature = inspect.signature(subject)
+        try:
+            signature = inspect.signature(subject, follow_wrapped=follow_wrapped)
+        except ValueError:
+            # follow built-in wrappers up (ex. functools.lru_cache)
+            signature = inspect.signature(subject)
         parameters = list(signature.parameters.values())
         return_annotation = signature.return_annotation
     except IndexError:

--- a/tests/roots/test-ext-autodoc/target/decorator.py
+++ b/tests/roots/test-ext-autodoc/target/decorator.py
@@ -1,5 +1,9 @@
+from functools import wraps
+
+
 def deco1(func):
     """docstring for deco1"""
+    @wraps(func)
     def wrapper():
         return func()
 
@@ -14,3 +18,14 @@ def deco2(condition, message):
 
         return wrapper
     return decorator
+
+
+@deco1
+def foo(name=None, age=None):
+    pass
+
+
+class Bar:
+    @deco1
+    def meth(self, name=None, age=None):
+        pass

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -142,6 +142,7 @@ def test_format_signature(app):
         inst = app.registry.documenters[objtype](directive, name)
         inst.fullname = name
         inst.doc_as_attr = False  # for class objtype
+        inst.parent = object  # dummy
         inst.object = obj
         inst.objpath = [name]
         inst.args = args
@@ -1244,6 +1245,17 @@ def test_autofunction_for_methoddescriptor(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autofunction_for_decorated(app):
+    actual = do_autodoc(app, 'function', 'target.decorator.foo')
+    assert list(actual) == [
+        '',
+        '.. py:function:: foo()',
+        '   :module: target.decorator',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_automethod_for_builtin(app):
     actual = do_autodoc(app, 'method', 'builtins.int.__add__')
     assert list(actual) == [
@@ -1252,6 +1264,17 @@ def test_automethod_for_builtin(app):
         '   :module: builtins',
         '',
         '   Return self+value.',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_automethod_for_decorated(app):
+    actual = do_autodoc(app, 'method', 'target.decorator.Bar.meth')
+    assert list(actual) == [
+        '',
+        '.. py:method:: Bar.meth()',
+        '   :module: target.decorator',
         '',
     ]
 
@@ -1415,7 +1438,7 @@ def test_coroutine(app):
     actual = do_autodoc(app, 'function', 'target.coroutine.sync_func')
     assert list(actual) == [
         '',
-        '.. py:function:: sync_func()',
+        '.. py:function:: sync_func(*args, **kwargs)',
         '   :module: target.coroutine',
         '',
     ]

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -97,7 +97,7 @@ def test_signature_methods():
 
     # wrapped bound method
     sig = inspect.signature(wrapped_bound_method)
-    assert stringify_signature(sig) == '(arg1, **kwargs)'
+    assert stringify_signature(sig) == '(*args, **kwargs)'
 
 
 def test_signature_partialmethod():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7650 