### PR TITLE
Fix multiple directory creation on quickstart script with nested relpath.

### DIFF
--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -358,7 +358,7 @@ def generate(d: Dict, overwrite: bool = True, silent: bool = False, templatedir:
     d.setdefault('extensions', [])
     d['copyright'] = time.strftime('%Y') + ', ' + d['author']
 
-    d["path"] = pathlib.Path(d['path']).resolve()
+    d["path"] = str(pathlib.Path(d['path']).resolve())
     ensuredir(d['path'])
 
     srcdir = path.join(d['path'], 'source') if d['sep'] else d['path']

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -11,7 +11,6 @@
 import argparse
 import locale
 import os
-import pathlib
 import re
 import sys
 import time
@@ -358,7 +357,7 @@ def generate(d: Dict, overwrite: bool = True, silent: bool = False, templatedir:
     d.setdefault('extensions', [])
     d['copyright'] = time.strftime('%Y') + ', ' + d['author']
 
-    d["path"] = str(pathlib.Path(d['path']).resolve())
+    d["path"] = os.path.abspath(d['path'])
     ensuredir(d['path'])
 
     srcdir = path.join(d['path'], 'source') if d['sep'] else d['path']

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -11,6 +11,7 @@
 import argparse
 import locale
 import os
+import pathlib
 import re
 import sys
 import time
@@ -357,6 +358,7 @@ def generate(d: Dict, overwrite: bool = True, silent: bool = False, templatedir:
     d.setdefault('extensions', [])
     d['copyright'] = time.strftime('%Y') + ', ' + d['author']
 
+    d["path"] = pathlib.Path(d['path']).resolve()
     ensuredir(d['path'])
 
     srcdir = path.join(d['path'], 'source') if d['sep'] else d['path']


### PR DESCRIPTION
Avoid multiple directory creation with quickstart script called with nested relative path.

### Feature or Bugfix
- Bugfix

### Purpose
Call the `sphinx/cmd/quickstart.py` script using next command:
```
python sphinx/cmd/quickstart.py ./foo/bar/../baz --quiet --project hello --author bye
```
You will see that the directories `foo/bar` and `foo/baz` are created, the new project is created inside `foo/baz` and the directory `foo/bar` is empty.

To fix this I've ensured that the project directory path is resolved with [`pathlib.Path.resolve`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve) before create it, so the empty directory is not created.
