### PR TITLE
basic theme: CSS margin overhaul

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -316,7 +316,7 @@ img.align-default, .figure.align-default {
 div.sidebar {
     margin: 0 0 0.5em 1em;
     border: 1px solid #ddb;
-    padding: 7px 7px 0 7px;
+    padding: 7px;
     background-color: #ffe;
     width: 40%;
     float: right;
@@ -336,7 +336,7 @@ div.admonition, div.topic, pre, div[class|="highlight"] {
 
 div.topic {
     border: 1px solid #ccc;
-    padding: 7px 7px 0 7px;
+    padding: 7px;
     margin: 10px 0 10px 0;
     overflow-x: auto;
 }

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -482,6 +482,10 @@ table.field-list td, table.field-list th {
 
 /* -- hlist styles ---------------------------------------------------------- */
 
+table.hlist {
+    margin: 1em 0;
+}
+
 table.hlist td {
     vertical-align: top;
 }

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -426,13 +426,13 @@ table.citation td {
     border-bottom: none;
 }
 
-th > p:first-child,
-td > p:first-child {
+th > :first-child,
+td > :first-child {
     margin-top: 0px;
 }
 
-th > p:last-child,
-td > p:last-child {
+th > :last-child,
+td > :last-child {
     margin-bottom: 0px;
 }
 
@@ -505,11 +505,11 @@ ol.upperroman {
     list-style: upper-roman;
 }
 
-li > p:first-child {
+li > :first-child {
     margin-top: 0px;
 }
 
-li > p:last-child {
+li > :last-child {
     margin-bottom: 0px;
 }
 
@@ -557,7 +557,7 @@ dl {
     margin-bottom: 15px;
 }
 
-dd > p:first-child {
+dd > :first-child {
     margin-top: 0px;
 }
 

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -509,12 +509,28 @@ ol.upperroman {
     list-style: upper-roman;
 }
 
-li > :first-child {
+ol > li:first-child > :first-child,
+ul > li:first-child > :first-child {
     margin-top: 0px;
 }
 
-li > :last-child {
+ol ol > li:first-child > :first-child,
+ol ul > li:first-child > :first-child,
+ul ol > li:first-child > :first-child,
+ul ul > li:first-child > :first-child {
+    margin-top: revert;
+}
+
+ol > li:last-child > :last-child,
+ul > li:last-child > :last-child {
     margin-bottom: 0px;
+}
+
+ol ol > li:last-child > :last-child,
+ol ul > li:last-child > :last-child,
+ul ol > li:last-child > :last-child,
+ul ul > li:last-child > :last-child {
+    margin-bottom: revert;
 }
 
 dl.footnote > dt,

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -360,10 +360,6 @@ div.admonition dt {
     font-weight: bold;
 }
 
-div.admonition dl {
-    margin-bottom: 0;
-}
-
 p.admonition-title {
     margin: 0px 10px 5px 0px;
     font-weight: bold;
@@ -372,6 +368,14 @@ p.admonition-title {
 div.body p.centered {
     text-align: center;
     margin-top: 25px;
+}
+
+/* -- content of sidebars/topics/admonitions -------------------------------- */
+
+div.sidebar > :last-child,
+div.topic > :last-child,
+div.admonition > :last-child {
+    margin-bottom: 0;
 }
 
 /* -- tables ---------------------------------------------------------------- */

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -575,6 +575,11 @@ dd {
     margin-left: 30px;
 }
 
+dl > dd:last-child,
+dl > dd:last-child > :last-child {
+    margin-bottom: 0;
+}
+
 dt:target, span.highlighted {
     background-color: #fbe54e;
 }

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -680,6 +680,10 @@ span.pre {
     hyphens: none;
 }
 
+div[class^="highlight-"] {
+    margin: 1em 0;
+}
+
 td.linenos pre {
     border: 0;
     background-color: transparent;
@@ -688,7 +692,6 @@ td.linenos pre {
 
 table.highlighttable {
     display: block;
-    margin: 1em 0;
 }
 
 table.highlighttable tbody {
@@ -717,11 +720,12 @@ table.highlighttable td.code {
     display: block;
 }
 
+div.highlight pre,
 table.highlighttable pre {
     margin: 0;
 }
 
-div.code-block-caption + div > table.highlighttable {
+div.code-block-caption + div {
     margin-top: 0;
 }
 
@@ -733,10 +737,6 @@ div.code-block-caption {
 
 div.code-block-caption code {
     background-color: transparent;
-}
-
-div.code-block-caption + div > div.highlight > pre {
-    margin-top: 0;
 }
 
 table.highlighttable td.linenos,


### PR DESCRIPTION
Fixes #7544.

Some details might still be missing, but I think this is at least a step in the right direction.

As mentioned in https://github.com/sphinx-doc/sphinx/issues/7544#issuecomment-624096608:

> I think the "right" solution would be to remove the `margin-bottom` from the `:last-child` and add a consistent `padding: 7px` on all sides.
> The problem is that this would be quite a big change in multiple themes, and people might consider it a "breaking change".

It turned out that I had only to change the `basic` theme, but it's still quite a big change, and some might consider it "breaking".

Any suggestions for improvements?