### PR TITLE
Fix autosummary directive wrong processing for invalid modules.

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -302,8 +302,7 @@ class Autosummary(SphinxDirective):
                 with mock(self.config.autosummary_mock_imports):
                     real_name, obj, parent, modname = import_by_name(name, prefixes=prefixes)
             except ImportError:
-                logger.warning(__('failed to import %s'), name)
-                items.append((name, '', '', name))
+                logger.warning(__('autosummary: failed to import %s'), name)
                 continue
 
             self.bridge.result = StringList()  # initialize for each documenter

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -205,15 +205,14 @@ def test_autosummary_generate(app, status, warning):
                                                                 [nodes.tbody, (nodes.row,
                                                                                nodes.row,
                                                                                nodes.row,
-                                                                               nodes.row,
                                                                                nodes.row)])])
     assert_node(doctree[4][0], addnodes.toctree, caption="An autosummary")
 
+    assert len(doctree[3][0][0][2]) == 4
     assert doctree[3][0][0][2][0].astext() == 'autosummary_dummy_module\n\n'
     assert doctree[3][0][0][2][1].astext() == 'autosummary_dummy_module.Foo()\n\n'
     assert doctree[3][0][0][2][2].astext() == 'autosummary_dummy_module.Foo.Bar\n\n'
     assert doctree[3][0][0][2][3].astext() == 'autosummary_dummy_module.bar(x[, y])\n\n'
-    assert doctree[3][0][0][2][4].astext() == 'autosummary_importfail\n\n'
 
     module = (app.srcdir / 'generated' / 'autosummary_dummy_module.rst').read_text()
     assert ('   .. autosummary::\n'

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -397,7 +397,7 @@ def test_autosummary_template(app):
                     confoverrides={'autosummary_generate': []})
 def test_empty_autosummary_generate(app, status, warning):
     app.build()
-    assert ("WARNING: autosummary: stub file not found 'autosummary_importfail'"
+    assert ("WARNING: autosummary: failed to import autosummary_importfail"
             in warning.getvalue())
 
 


### PR DESCRIPTION
Make the extension `autosummary` not process invalid modules that raises an `ImportError`.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
- Bugfix

