### PR TITLE
UML inheritance diagram

### DIFF
--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -101,6 +101,10 @@ It adds this directive:
    It supports two different values: ``default``, which generates a diagram
    with normal arrows; and ``uml`` which generates UML-like arrows.
 
+   The direction of the diagram can be specified with the directive
+   ``direction``. It can be one of the values: ``left-right`` (the default),
+   or ``top-bottom``.
+
 
 Examples
 --------
@@ -134,6 +138,14 @@ part (``sphinx``) from all names::
 .. inheritance-diagram:: sphinx.ext.inheritance_diagram.InheritanceDiagram
    :top-classes: sphinx.util.docutils.SphinxDirective
    :parts: -1
+
+Using a diagram with vertical orientation::
+
+   .. inheritance-diagram:: sphinx.ext.inheritance_diagram.InheritanceDiagram
+      :direction: top-bottom
+
+.. inheritance-diagram:: sphinx.ext.inheritance_diagram.InheritanceDiagram
+   :direction: top-bottom
 
 Using UML-like diagram::
 

--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -97,6 +97,10 @@ It adds this directive:
    .. versionchanged:: 1.7
       Added ``top-classes`` option to limit the scope of inheritance graphs.
 
+   One of the predefined style can be selected with the directive ``style``.
+   It supports two different values: ``default``, which generates a diagram
+   with normal arrows; and ``uml`` which generates UML-like arrows.
+
 
 Examples
 --------
@@ -131,6 +135,13 @@ part (``sphinx``) from all names::
    :top-classes: sphinx.util.docutils.SphinxDirective
    :parts: -1
 
+Using UML-like diagram::
+
+   .. inheritance-diagram:: sphinx.ext.inheritance_diagram.InheritanceDiagram
+      :style: uml
+
+.. inheritance-diagram:: sphinx.ext.inheritance_diagram.InheritanceDiagram
+   :style: uml
 
 
 Configuration

--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -16,11 +16,11 @@ It adds this directive:
 .. rst:directive:: inheritance-diagram
 
    This directive has one or more arguments, each giving a module or class
-   name.  Class names can be unqualified; in that case they are taken to exist
+   name. Class names can be unqualified; in that case they are taken to exist
    in the currently described module (see :rst:dir:`py:module`).
 
    For each given class, and each class in each given module, the base classes
-   are determined.  Then, from all classes and their base classes, a graph is
+   are determined. Then, from all classes and their base classes, a graph is
    generated which is then rendered via the graphviz extension to a directed
    graph.
 
@@ -49,8 +49,10 @@ It adds this directive:
       Added ``caption`` option
 
    It also supports a ``top-classes`` option which requires one or more class
-   names separated by comma. If specified inheritance traversal will stop at the
-   specified class names. Given the following Python module::
+   names separated by space (or comma). If specified, the known classes,
+   as selected by other directives will be filtered in order to remove classes
+   which are not of the inheritance from one of the ``top-classes``
+   classes. Given the following Python module::
 
         """
                A
@@ -59,8 +61,10 @@ It adds this directive:
             / \ / \
            E   D   F
         """
+        class NotIncluded:
+            pass
 
-        class A:
+        class A(NotIncluded):
             pass
 
         class B(A):
@@ -78,26 +82,10 @@ It adds this directive:
         class F(C):
             pass
 
-   If you have specified a module in the inheritance diagram like this::
-
-        .. inheritance-diagram:: dummy.test
-           :top-classes: dummy.test.B, dummy.test.C
-
-   any base classes which are ancestors to ``top-classes`` and are also defined
-   in the same module will be rendered as stand alone nodes. In this example
-   class A will be rendered as stand alone node in the graph. This is a known
-   issue due to how this extension works internally.
-
-   If you don't want class A (or any other ancestors) to be visible then specify
-   only the classes you would like to generate the diagram for like this::
-
-        .. inheritance-diagram:: dummy.test.D dummy.test.E dummy.test.F
-           :top-classes: dummy.test.B, dummy.test.C
-
    .. versionchanged:: 1.7
       Added ``top-classes`` option to limit the scope of inheritance graphs.
 
-   One of the predefined style can be selected with the directive ``style``.
+   The way the diagram is rendered can be selected with the directive ``style``.
    It supports two different values: ``default``, which generates a diagram
    with normal arrows; and ``uml`` which generates UML-like arrows.
 

--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -101,6 +101,9 @@ It adds this directive:
    It supports two different values: ``default``, which generates a diagram
    with normal arrows; and ``uml`` which generates UML-like arrows.
 
+   .. versionadded:: 3.3.0
+      Added ``style`` option to use predefined style.
+
    The direction of the diagram can be specified with the directive
    ``direction``. It can be one of the values: ``left-right`` (the default),
    or ``top-bottom``.

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -67,12 +67,7 @@ module_sig_re = re.compile(r'''^(?:([\w.]*)\.)?  # module names
 
 
 def try_import(objname: str) -> Any:
-    """Import a object or module using *name* and *currentmodule*.
-    *name* should be a relative name from *currentmodule* or
-    a fully-qualified name.
-
-    Returns imported object or module.  If failed, returns None value.
-    """
+    """Import a module or an object using its fully-qualified *objname*."""
     try:
         return import_module(objname)
     except TypeError:
@@ -95,15 +90,23 @@ def try_import(objname: str) -> Any:
             return None
 
 
-def import_classes(name: str, currmodule: str) -> Any:
-    """Import a class using its fully-qualified *name*."""
+def import_classes(name: str, module_name: str) -> List[Any]:
+    """Import classes from it's *name* and it's *module_name*.
+
+    *name* should be a relative name from *module_name* or
+    a fully-qualified name.
+
+    If the input identify a class, a list of this single class is returned.
+    If the input identify a module, the list of the whole classes contained is
+    returned. Else raises *InheritanceException*.
+    """
     target = None
 
-    # import class or module using currmodule
-    if currmodule:
-        target = try_import(currmodule + '.' + name)
+    # import class or module using module_name
+    if module_name:
+        target = try_import(module_name + '.' + name)
 
-    # import class or module without currmodule
+    # import class or module without module_name
     if target is None:
         target = try_import(name)
 
@@ -127,6 +130,7 @@ def import_classes(name: str, currmodule: str) -> Any:
 
 
 class InheritanceException(Exception):
+    """Exception raised if the extension as configured can't be used."""
     pass
 
 
@@ -394,7 +398,7 @@ class InheritanceDiagram(SphinxDirective):
         # references to real URLs later.  These nodes will eventually be
         # removed from the doctree after we're done with them.
         for name in graph.get_all_class_names():
-            refnodes, x = class_role(  # type: ignore
+            refnodes, _x = class_role(  # type: ignore
                 'class', ':class:`%s`' % name, name, 0, self.state)  # type: ignore
             node.extend(refnodes)
         # Store the graph object so we can use it to generate the
@@ -417,7 +421,7 @@ def get_graph_hash(node: inheritance_diagram) -> str:
 
 def html_visit_inheritance_diagram(self: HTMLTranslator, node: inheritance_diagram) -> None:
     """
-    Output the graph for HTML.  This will insert a PNG with clickable
+    Output the graph for HTML. This will insert a PNG with clickable
     image map.
     """
     graph = node['graph']

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -145,8 +145,8 @@ class InheritanceGraph:
         """Hold a class and it's relations with the other classes"""
         def __init__(self, cls):
             self.cls = cls
-            self.based = set([])  # type: Set[Any]
-            self.derived = set([])  # type: Set[Any]
+            self.based = set()  # type: Set[Any]
+            self.derived = set()  # type: Set[Any]
             self.used = False
 
     def __init__(self, class_names: List[str], currmodule: str, show_builtins: bool = False,

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -177,13 +177,18 @@ class InheritanceGraph:
         self.diagram_direction = direction
         self.show_builtins = show_builtins
         self.private_bases = private_bases
-        self.classes = self._import_classes(class_names, currmodule)
         self.top_classes = self._import_classes(top_classes, currmodule)
 
         # Create the whole relationships
+        self.classes = []
         self.class_dag = {}  # type: Dict[Any, InheritanceGraph.Node]
-        for c in self.classes:
-            self._add_class(c)
+        for target in class_names:
+            classes = self._import_classes([target], currmodule)
+            self.classes.extend(classes)
+            # If length is 1, guess the target is not a module
+            force = len(classes) == 1
+            for c in classes:
+                self._add_class(c, force=force)
 
         # Flag the classes to finally use
         if not self.top_classes:

--- a/tests/roots/test-ext-inheritance_diagram/index.rst
+++ b/tests/roots/test-ext-inheritance_diagram/index.rst
@@ -8,3 +8,6 @@ test-ext-inheritance_diagram
    :caption: Test Foo!
 
 .. inheritance-diagram:: test.Baz
+
+.. inheritance-diagram:: test.Baz
+   :style: uml

--- a/tests/roots/test-inheritance/diagram_class.rst
+++ b/tests/roots/test-inheritance/diagram_class.rst
@@ -1,0 +1,6 @@
+Inheritance diagram of a specific class
+=======================================
+
+.. inheritance-diagram::
+    dummy.test.D
+

--- a/tests/roots/test-inheritance/diagram_module_w_top_and_private.rst
+++ b/tests/roots/test-inheritance/diagram_module_w_top_and_private.rst
@@ -1,0 +1,8 @@
+Inheritance diagram of a specific class
+=======================================
+
+.. inheritance-diagram::
+    dummy.test_module
+    :top-classes: dummy.test_module.G
+    :private-bases:
+

--- a/tests/roots/test-inheritance/diagram_w_direction.rst
+++ b/tests/roots/test-inheritance/diagram_w_direction.rst
@@ -1,0 +1,7 @@
+Diagram using the direction option
+==================================
+
+.. inheritance-diagram::
+    dummy.test
+    :direction: top-bottom
+

--- a/tests/roots/test-inheritance/diagram_w_explicit_private_class.rst
+++ b/tests/roots/test-inheritance/diagram_w_explicit_private_class.rst
@@ -1,0 +1,6 @@
+Inheritance diagram of explicit private class
+=============================================
+
+.. inheritance-diagram::
+    dummy.test_module._H
+

--- a/tests/roots/test-inheritance/diagram_w_homonyms.rst
+++ b/tests/roots/test-inheritance/diagram_w_homonyms.rst
@@ -1,0 +1,7 @@
+Diagram containing homonymous classes
+=====================================
+
+.. inheritance-diagram::
+    dummy.test_homonyms dummy.test_homonyms.B.A
+    :parts: 1
+

--- a/tests/roots/test-inheritance/diagram_w_nested_classes.rst
+++ b/tests/roots/test-inheritance/diagram_w_nested_classes.rst
@@ -1,4 +1,4 @@
-Diagram with Nested Classes
+Diagram with nested classes
 ===========================
 
 .. inheritance-diagram::

--- a/tests/roots/test-inheritance/diagram_w_uml.rst
+++ b/tests/roots/test-inheritance/diagram_w_uml.rst
@@ -1,0 +1,7 @@
+Diagram using the style option with UML
+=======================================
+
+.. inheritance-diagram::
+    dummy.test
+    :style: uml
+

--- a/tests/roots/test-inheritance/dummy/test_homonyms.py
+++ b/tests/roots/test-inheritance/dummy/test_homonyms.py
@@ -1,0 +1,14 @@
+"""
+    Two homonymous class
+
+    Could be in 2 different modules
+    But it is easier to implement it with nested classes
+"""
+
+class A:
+    pass
+
+class B:
+    class A(A):
+        pass
+

--- a/tests/roots/test-inheritance/dummy/test_module.py
+++ b/tests/roots/test-inheritance/dummy/test_module.py
@@ -1,0 +1,57 @@
+r"""
+
+    Test with a class diagram like this::
+
+          _A
+           |
+           A       G
+          / \     / \
+         B   C  _H   I
+        / \ / \ /
+       E   D   F
+           |
+           J
+"""
+
+class _A(object):
+    pass
+
+
+class A(_A):
+    pass
+
+
+class B(A):
+    pass
+
+
+class C(A):
+    pass
+
+
+class D(B, C):
+    pass
+
+
+class E(B):
+    pass
+
+
+class G(object):
+    pass
+
+
+class _H(G):
+    pass
+
+
+class I(G):
+    pass
+
+
+class F(C, _H):
+    pass
+
+
+class J(D):
+    pass

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -133,20 +133,16 @@ def test_diagram_w_1_top_class(status, build_context):
     """Inheritance diagram with 1 top class"""
     # :top-classes: dummy.test.B
     # rendering should be
-    #       A
-    #        \
-    #     B   C
-    #    / \ / \
-    #   E   D   F
+    #
+    #     B
+    #    / \
+    #   E   D
     #
     dot = build_context.dots['diagram_w_1_top_class']
-    assert dot.count("->") == 5
-    assert dot.count("label=") == 6
-    assert edge("dummy.test.A", "dummy.test.C") in dot
+    assert dot.count("->") == 2
+    assert dot.count("label=") == 3
     assert edge("dummy.test.B", "dummy.test.D") in dot
     assert edge("dummy.test.B", "dummy.test.E") in dot
-    assert edge("dummy.test.C", "dummy.test.D") in dot
-    assert edge("dummy.test.C", "dummy.test.F") in dot
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -173,23 +169,17 @@ def test_diagram_w_2_top_classes(status, build_context):
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_diagram_module_w_2_top_classes(status, build_context):
-    """inheritance diagram with 2 top classes and specifying the entire
+    """Inheritance diagram with 2 top classes and specifying the entire
     module"""
     # rendering should be
     #
-    #       A
     #     B   C
     #    / \ / \
     #   E   D   F
     #
-    # Note: dummy.test.A is included in the graph before its descendants are even processed
-    # b/c we've specified to load the entire module. The way InheritanceGraph works it is very
-    # hard to exclude parent classes once after they have been included in the graph.
-    # If you'd like to not show class A in the graph don't specify the entire module.
-    # this is a known issue.
     dot = build_context.dots['diagram_module_w_2_top_classes']
     assert dot.count("->") == 4
-    assert dot.count("label=") == 6
+    assert dot.count("label=") == 5
     assert edge("dummy.test.B", "dummy.test.D") in dot
     assert edge("dummy.test.C", "dummy.test.D") in dot
     assert edge("dummy.test.B", "dummy.test.E") in dot

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -199,6 +199,30 @@ def test_diagram_w_nested_classes(status, build_context):
 
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
+def test_diagram_classe(status, build_context):
+    """Inheritance diagram from a complex module
+    where a specific class is designed
+
+    Private classes are not displayed.
+    """
+    #
+    #       A
+    #      / \
+    #     B   C
+    #      \ /
+    #       D
+    #
+    dot = build_context.dots['diagram_class']
+    assert dot.count("->") == 4
+    assert dot.count("label=") == 4
+    assert edge("dummy.test.B", "dummy.test.D") in dot
+    assert edge("dummy.test.C", "dummy.test.D") in dot
+    assert edge("dummy.test.A", "dummy.test.B") in dot
+    assert edge("dummy.test.A", "dummy.test.C") in dot
+
+
+@pytest.mark.usefixtures('if_graphviz_found')
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_diagram_w_uml(status, build_context):
     """Check that the empty arrow is part of the UML diagram
     """

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -194,6 +194,15 @@ def test_diagram_w_nested_classes(status, build_context):
         ]
 
 
+@pytest.mark.usefixtures('if_graphviz_found')
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
+def test_diagram_w_uml(status, build_context):
+    """Check that the empty arrow is part of the UML diagram
+    """
+    dot = build_context['diagram_w_uml'].dot
+    assert 'arrowtail="empty"' in dot
+
+
 @pytest.mark.sphinx('html', testroot='ext-inheritance_diagram')
 @pytest.mark.usefixtures('if_graphviz_found')
 def test_inheritance_diagram_png_html(app, status, warning):

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -216,6 +216,19 @@ def test_diagram_w_uml(status, build_context):
     assert 'arrowtail="empty"' in dot
 
 
+@pytest.mark.usefixtures('if_graphviz_found')
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
+def test_diagram_w_homonyms(status, build_context):
+    """Test that homonymous classes are not merged together
+    """
+    dot = build_context.dots['diagram_w_homonyms']
+    assert dot.count("->") == 1
+    assert dot.count("label=") == 3
+    assert edge("dummy.test_homonyms.A", "dummy.test_homonyms.B.A") in dot
+    assert get_label("dummy.test_homonyms.A", dot) == "A"
+    assert get_label("dummy.test_homonyms.B.A", dot) == "A"
+
+
 @pytest.mark.sphinx('html', testroot='ext-inheritance_diagram')
 @pytest.mark.usefixtures('if_graphviz_found')
 def test_inheritance_diagram_png_html(app, status, warning):

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -11,19 +11,57 @@
 import re
 import os
 import sys
-import collections
-
 import pytest
 
-from sphinx.ext.inheritance_diagram import (
-    InheritanceDiagram, InheritanceGraph, InheritanceException, import_classes
-)
+from sphinx.ext import inheritance_diagram as ext
+
 
 CACHE = None
 
 
 @pytest.fixture
-def build_context(make_app, app_params, warning):
+def diagram_lookup():
+    """Monkey-patch InheritaceDiagram.run() and InheritanceGraph.generate_dot()
+    so we can get access to generated dot content.
+    """
+    class Lookup():
+        def __init__(self):
+            self.dots = {}  # type: Dict[str, str]
+            """Store each dot result per graph name which was generate"""
+
+    lookup = Lookup()
+    
+    orig_run = ext.InheritanceDiagram.run
+    orig_generate_dot = ext.InheritanceGraph.generate_dot
+
+    def new_run(self):
+        result = orig_run(self)
+        node = result[0]
+        if not isinstance(node, ext.inheritance_diagram):
+            node = node[0]
+        if not isinstance(node, ext.inheritance_diagram):
+            node = None
+        if node is not None:            
+            source = os.path.basename(node.document.current_source).replace(".rst", "")
+            node['graph']._source = source
+        return result
+
+    def new_generate_dot(self, *args, **kwargs):
+        result = orig_generate_dot(self, *args, **kwargs)
+        lookup.dots[self._source] = result
+        return result
+
+    ext.InheritanceDiagram.run = new_run
+    ext.InheritanceGraph.generate_dot = new_generate_dot
+    try:
+        yield lookup
+    finally:
+        ext.InheritanceDiagram.run = orig_run
+        ext.InheritanceGraph.generate_dot = orig_generate_dot
+
+
+@pytest.fixture
+def build_context(make_app, diagram_lookup, app_params, warning):
     """Build the whole sphinx rst for this extension a single time.
 
     It's a kind of module scope fixture but it uses function scope fixture.
@@ -32,80 +70,61 @@ def build_context(make_app, app_params, warning):
     if CACHE is not None:
         return CACHE
 
-    # monkey-patch InheritaceDiagram.run() and InheritanceGraph.generate_dot()
-    # so we can get access to its results.
-    orig_run = InheritanceDiagram.run
-    orig_generate_dot = InheritanceGraph.generate_dot
-    graphs = {}
-    dots = {}
-
-    def new_run(self):
-        result = orig_run(self)
-        node = result[0]
-        source = os.path.basename(node.document.current_source).replace(".rst", "")
-        graphs[source] = node['graph']
-        node['graph']._source = source
-        return result
-
-    def new_generate_dot(self, *args, **kwargs):
-        result = orig_generate_dot(self, *args, **kwargs)
-        dots[self._source] = result
-        return result
-
-    InheritanceDiagram.run = new_run
-    InheritanceGraph.generate_dot = new_generate_dot
-
-    try:
-        args, kwargs = app_params
-        app = make_app(*args, **kwargs)
-        app.builder.build_all()
-    finally:
-        InheritanceDiagram.run = orig_run
-        InheritanceGraph.generate_dot = orig_generate_dot
+    args, kwargs = app_params
+    app = make_app(*args, **kwargs)
+    app.builder.build_all()
 
     assert app.statuscode == 0
 
     html_warnings = warning.getvalue()
     assert html_warnings == ""
-    
-    results = {}
-    Result = collections.namedtuple("Result", ["graph", "dot"])
-    for k in graphs:
-        r = Result(graphs[k], dots[k])
-        results[k] = r
 
-    CACHE = results
-    return results
+    CACHE = diagram_lookup
+    return diagram_lookup
+
+
+def get_label(class_name, dot):
+    """Returns the label from a class name of a dot format"""
+    try:
+        template = r"^\s*\"%s\"\s*\[.*label=\"((?:\w|\.)+)\"" % re.escape(class_name)
+        return re.search(template, dot, re.MULTILINE).groups()[0]
+    except:
+        raise RuntimeError("Classname label not found for %s" % class_name)
+
+
+def edge(classname1, classname2):
+    return '"%s" -> "%s"' % (classname1, classname2)
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_basic_diagram(status, build_context):
     """Basic inheritance diagram showing all classes"""
-    for cls in build_context['basic_diagram'].graph.class_info:
-        # use in b/c traversing order is different sometimes
-        assert cls in [
-            ('dummy.test.A', 'dummy.test.A', [], None),
-            ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
-            ('dummy.test.C', 'dummy.test.C', ['dummy.test.A'], None),
-            ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
-            ('dummy.test.D', 'dummy.test.D', ['dummy.test.B', 'dummy.test.C'], None),
-            ('dummy.test.B', 'dummy.test.B', ['dummy.test.A'], None)
-        ]
+    dot = build_context.dots['basic_diagram']
+    assert dot.count("->") == 6
+    assert dot.count("label=") == 6
+    assert edge("dummy.test.A", "dummy.test.B") in dot
+    assert edge("dummy.test.A", "dummy.test.C") in dot
+    assert edge("dummy.test.B", "dummy.test.D") in dot
+    assert edge("dummy.test.B", "dummy.test.E") in dot
+    assert edge("dummy.test.C", "dummy.test.D") in dot
+    assert edge("dummy.test.C", "dummy.test.F") in dot
+    assert get_label("dummy.test.A", dot) == "dummy.test.A"
+
 
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_diagram_w_parts(status, build_context):
     """Inheritance diagram using :parts: 1 option"""
-    for cls in build_context['diagram_w_parts'].graph.class_info:
-        assert cls in [
-            ('A', 'dummy.test.A', [], None),
-            ('F', 'dummy.test.F', ['C'], None),
-            ('C', 'dummy.test.C', ['A'], None),
-            ('E', 'dummy.test.E', ['B'], None),
-            ('D', 'dummy.test.D', ['B', 'C'], None),
-            ('B', 'dummy.test.B', ['A'], None)
-        ]
+    dot = build_context.dots['diagram_w_parts']
+    assert dot.count("->") == 6
+    assert dot.count("label=") == 6
+    assert get_label("dummy.test.A", dot) == "A"
+    assert get_label("dummy.test.B", dot) == "B"
+    assert get_label("dummy.test.C", dot) == "C"
+    assert get_label("dummy.test.D", dot) == "D"
+    assert get_label("dummy.test.E", dot) == "E"
+    assert get_label("dummy.test.F", dot) == "F"
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -120,15 +139,14 @@ def test_diagram_w_1_top_class(status, build_context):
     #    / \ / \
     #   E   D   F
     #
-    for cls in build_context['diagram_w_1_top_class'].graph.class_info:
-        assert cls in [
-            ('dummy.test.A', 'dummy.test.A', [], None),
-            ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
-            ('dummy.test.C', 'dummy.test.C', ['dummy.test.A'], None),
-            ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
-            ('dummy.test.D', 'dummy.test.D', ['dummy.test.B', 'dummy.test.C'], None),
-            ('dummy.test.B', 'dummy.test.B', [], None)
-        ]
+    dot = build_context.dots['diagram_w_1_top_class']
+    assert dot.count("->") == 5
+    assert dot.count("label=") == 6
+    assert edge("dummy.test.A", "dummy.test.C") in dot
+    assert edge("dummy.test.B", "dummy.test.D") in dot
+    assert edge("dummy.test.B", "dummy.test.E") in dot
+    assert edge("dummy.test.C", "dummy.test.D") in dot
+    assert edge("dummy.test.C", "dummy.test.F") in dot
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -143,14 +161,13 @@ def test_diagram_w_2_top_classes(status, build_context):
     #    / \ / \
     #   E   D   F
     #
-    for cls in build_context['diagram_w_2_top_classes'].graph.class_info:
-        assert cls in [
-            ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
-            ('dummy.test.C', 'dummy.test.C', [], None),
-            ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
-            ('dummy.test.D', 'dummy.test.D', ['dummy.test.B', 'dummy.test.C'], None),
-            ('dummy.test.B', 'dummy.test.B', [], None)
-        ]
+    dot = build_context.dots['diagram_w_2_top_classes']
+    assert dot.count("->") == 4
+    assert dot.count("label=") == 5
+    assert edge("dummy.test.B", "dummy.test.D") in dot
+    assert edge("dummy.test.C", "dummy.test.D") in dot
+    assert edge("dummy.test.B", "dummy.test.E") in dot
+    assert edge("dummy.test.C", "dummy.test.F") in dot
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -170,15 +187,13 @@ def test_diagram_module_w_2_top_classes(status, build_context):
     # hard to exclude parent classes once after they have been included in the graph.
     # If you'd like to not show class A in the graph don't specify the entire module.
     # this is a known issue.
-    for cls in build_context['diagram_module_w_2_top_classes'].graph.class_info:
-        assert cls in [
-            ('dummy.test.F', 'dummy.test.F', ['dummy.test.C'], None),
-            ('dummy.test.C', 'dummy.test.C', [], None),
-            ('dummy.test.E', 'dummy.test.E', ['dummy.test.B'], None),
-            ('dummy.test.D', 'dummy.test.D', ['dummy.test.B', 'dummy.test.C'], None),
-            ('dummy.test.B', 'dummy.test.B', [], None),
-            ('dummy.test.A', 'dummy.test.A', [], None),
-        ]
+    dot = build_context.dots['diagram_module_w_2_top_classes']
+    assert dot.count("->") == 4
+    assert dot.count("label=") == 6
+    assert edge("dummy.test.B", "dummy.test.D") in dot
+    assert edge("dummy.test.C", "dummy.test.D") in dot
+    assert edge("dummy.test.B", "dummy.test.E") in dot
+    assert edge("dummy.test.C", "dummy.test.F") in dot
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -186,12 +201,10 @@ def test_diagram_module_w_2_top_classes(status, build_context):
 def test_diagram_w_nested_classes(status, build_context):
     """Inheritance diagram involving a base class nested within another class
     """
-    for cls in build_context['diagram_w_nested_classes'].graph.class_info:
-        assert cls in [
-            ('dummy.test_nested.A', 'dummy.test_nested.A', [], None),
-            ('dummy.test_nested.C', 'dummy.test_nested.C', ['dummy.test_nested.A.B'], None),
-            ('dummy.test_nested.A.B', 'dummy.test_nested.A.B', [], None)
-        ]
+    dot = build_context.dots['diagram_w_nested_classes']
+    assert dot.count("->") == 1
+    assert dot.count("label=") == 3
+    assert edge("dummy.test_nested.A.B", "dummy.test_nested.C") in dot
 
 
 @pytest.mark.usefixtures('if_graphviz_found')
@@ -199,7 +212,7 @@ def test_diagram_w_nested_classes(status, build_context):
 def test_diagram_w_uml(status, build_context):
     """Check that the empty arrow is part of the UML diagram
     """
-    dot = build_context['diagram_w_uml'].dot
+    dot = build_context.dots['diagram_w_uml']
     assert 'arrowtail="empty"' in dot
 
 
@@ -254,19 +267,20 @@ def test_inheritance_diagram_latex(app, status, warning):
 @pytest.mark.sphinx('html', testroot='ext-inheritance_diagram',
                     srcdir='ext-inheritance_diagram-alias')
 @pytest.mark.usefixtures('if_graphviz_found')
-def test_inheritance_diagram_latex_alias(app, status, warning):
+def test_inheritance_diagram_html_alias(app, diagram_lookup, status, warning):
     app.config.inheritance_alias = {'test.Foo': 'alias.Foo'}
     app.builder.build_all()
 
-    doc = app.env.get_and_resolve_doctree('index', app)
-    aliased_graph = doc.children[0].children[3]['graph'].class_info
-    assert len(aliased_graph) == 3
-    assert ('test.Baz', 'test.Baz', ['test.Bar'], None) in aliased_graph
-    assert ('test.Bar', 'test.Bar', ['alias.Foo'], None) in aliased_graph
-    assert ('alias.Foo', 'alias.Foo', [], None) in aliased_graph
+    dot = diagram_lookup.dots["index"]
+    assert dot.count("->") == 2
+    assert dot.count("label=") == 3
+    assert edge("test.Foo", "test.Bar") in dot
+    assert edge("test.Bar", "test.Baz") in dot
+    assert get_label("test.Foo", dot) == "alias.Foo"
+    assert get_label("test.Baz", dot) == "test.Baz"
+    assert get_label("test.Bar", dot) == "test.Bar"
 
     content = (app.outdir / 'index.html').read_text()
-
     pattern = ('<div class="figure align-default" id="id1">\n'
                '<div class="graphviz">'
                '<img src="_images/inheritance-\\w+.png" alt="Inheritance diagram of test.Foo" '
@@ -285,49 +299,49 @@ def test_import_classes(rootdir):
         from example.sphinx import DummyClass
 
         # got exception for unknown class or module
-        with pytest.raises(InheritanceException):
-            import_classes('unknown', None)
-        with pytest.raises(InheritanceException):
-            import_classes('unknown.Unknown', None)
+        with pytest.raises(ext.InheritanceException):
+            ext.import_classes('unknown', None)
+        with pytest.raises(ext.InheritanceException):
+            ext.import_classes('unknown.Unknown', None)
 
         # got exception InheritanceException for wrong class or module
         # not AttributeError (refs: #4019)
-        with pytest.raises(InheritanceException):
-            import_classes('unknown', '.')
-        with pytest.raises(InheritanceException):
-            import_classes('unknown.Unknown', '.')
-        with pytest.raises(InheritanceException):
-            import_classes('.', None)
+        with pytest.raises(ext.InheritanceException):
+            ext.import_classes('unknown', '.')
+        with pytest.raises(ext.InheritanceException):
+            ext.import_classes('unknown.Unknown', '.')
+        with pytest.raises(ext.InheritanceException):
+            ext.import_classes('.', None)
 
         # a module having no classes
-        classes = import_classes('sphinx', None)
+        classes = ext.import_classes('sphinx', None)
         assert classes == []
 
-        classes = import_classes('sphinx', 'foo')
+        classes = ext.import_classes('sphinx', 'foo')
         assert classes == []
 
         # all of classes in the module
-        classes = import_classes('sphinx.parsers', None)
+        classes = ext.import_classes('sphinx.parsers', None)
         assert set(classes) == {Parser, RSTParser}
 
         # specified class in the module
-        classes = import_classes('sphinx.parsers.Parser', None)
+        classes = ext.import_classes('sphinx.parsers.Parser', None)
         assert classes == [Parser]
 
         # specified class in current module
-        classes = import_classes('Parser', 'sphinx.parsers')
+        classes = ext.import_classes('Parser', 'sphinx.parsers')
         assert classes == [Parser]
 
         # relative module name to current module
-        classes = import_classes('i18n.CatalogInfo', 'sphinx.util')
+        classes = ext.import_classes('i18n.CatalogInfo', 'sphinx.util')
         assert classes == [CatalogInfo]
 
         # got exception for functions
-        with pytest.raises(InheritanceException):
-            import_classes('encode_uri', 'sphinx.util')
+        with pytest.raises(ext.InheritanceException):
+            ext.import_classes('encode_uri', 'sphinx.util')
 
         # import submodule on current module (refs: #3164)
-        classes = import_classes('sphinx', 'example')
+        classes = ext.import_classes('sphinx', 'example')
         assert classes == [DummyClass]
     finally:
         sys.path.pop()

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -223,6 +223,27 @@ def test_diagram_classe(status, build_context):
 
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
+def test_diagram_module_w_top_and_private(status, build_context):
+    """Inheritance diagram from a complex module
+    where a top class is specified and private classes displayed.
+    """
+    #
+    #       G
+    #      / \
+    #    _H   I
+    #    /
+    #   F
+    #
+    dot = build_context.dots['diagram_module_w_top_and_private']
+    assert dot.count("->") == 3
+    assert dot.count("label=") == 4
+    assert edge("dummy.test_module.G", "dummy.test_module._H") in dot
+    assert edge("dummy.test_module._H", "dummy.test_module.F") in dot
+    assert edge("dummy.test_module.G", "dummy.test_module.I") in dot
+
+
+@pytest.mark.usefixtures('if_graphviz_found')
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_diagram_w_uml(status, build_context):
     """Check that the empty arrow is part of the UML diagram
     """

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -244,6 +244,25 @@ def test_diagram_module_w_top_and_private(status, build_context):
 
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
+def test_diagram_w_explicit_private_class(status, build_context):
+    """Inheritance diagram from a complex module
+    where the requested class is private.
+
+    Here the private flag is not used.
+    """
+    #
+    #     G
+    #    /
+    #  _H
+    #
+    dot = build_context.dots['diagram_w_explicit_private_class']
+    assert dot.count("->") == 1
+    assert dot.count("label=") == 2
+    assert edge("dummy.test_module.G", "dummy.test_module._H") in dot
+
+
+@pytest.mark.usefixtures('if_graphviz_found')
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_diagram_w_uml(status, build_context):
     """Check that the empty arrow is part of the UML diagram
     """

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -253,6 +253,15 @@ def test_diagram_w_uml(status, build_context):
 
 @pytest.mark.usefixtures('if_graphviz_found')
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
+def test_diagram_w_direction(status, build_context):
+    """Check that the empty arrow is part of the UML diagram
+    """
+    dot = build_context.dots['diagram_w_direction']
+    assert 'rankdir=TB' in dot
+
+
+@pytest.mark.usefixtures('if_graphviz_found')
+@pytest.mark.sphinx(buildername="html", testroot="inheritance")
 def test_diagram_w_homonyms(status, build_context):
     """Test that homonymous classes are not merged together
     """


### PR DESCRIPTION
Hi. Here is a first attempt to allow to display inheritance diagram with UML-like notation.

### Feature
- Feature
- Refactoring

### Purpose
The aim was to allow to use UML-like diagram, without leaning graphvis language.

### Detail
- A `:style:` was added
   - It supports `default` for the current look
   - And `uml` which generates edges in the reversed direction and with the right arrow symbol (as specified in the issue) 
- Unittests was refactored in order to:
   - Split a big test (as it was called in a comment in the source code)
   - If you have an example with a module-scope fixture to build stuff, it could be much cleaner (i tried, i failed)
   - Allow to introspect the dot syntax

### Example
Picked from the unittests
```
class Foo(object): pass
class Bar(Foo): pass
class Baz(Bar): pass
```
On side note, this unittest uses a special directive to alias the `Foo` class, but nothing related to this PR.

#### With `:style: uml`
Picked from the unittest.
![inheritance-f707c1c85be7bf38531ec0591e8842b3856a1d4f](https://user-images.githubusercontent.com/7579321/82123624-9e035e00-979a-11ea-9a4e-a58c2a5a0607.png)

#### Without `:style: uml` (the default)

![inheritance-c4c48c632b4eeb835502bead236b4432c35d88e1](https://user-images.githubusercontent.com/7579321/82123631-abb8e380-979a-11ea-8cb7-cb5ddcfb0fad.png)

### Relates
- Closes #2969
