### PR TITLE
Fix #7676: autodoc: wrong value for :member-order: option is ignored silently

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -93,6 +93,7 @@ Bugs fixed
 * #7629: autodoc: autofunction emits an unfriendly warning if an invalid object
   specified
 * #7650: autodoc: undecorated signature is shown for decorated functions
+* #7676: autodoc: wrong value for :member-order: option is ignored silently
 * #7551: autosummary: a nested class is indexed as non-nested class
 * #7661: autosummary: autosummary directive emits warnings twices if failed to
   import the target module

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -15,7 +15,9 @@ import re
 import warnings
 from inspect import Parameter
 from types import ModuleType
-from typing import Any, Callable, Dict, Iterator, List, Sequence, Set, Tuple, Type, Union
+from typing import (
+    Any, Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Type, Union
+)
 
 from docutils.statemachine import StringList
 
@@ -90,6 +92,16 @@ def inherited_members_option(arg: Any) -> Union[object, Set[str]]:
         return 'object'
     else:
         return arg
+
+
+def member_order_option(arg: Any) -> Optional[str]:
+    """Used to convert the :members: option to auto directives."""
+    if arg is None:
+        return None
+    elif arg in ('alphabetical', 'bysource', 'groupwise'):
+        return arg
+    else:
+        raise ValueError(__('invalid value for member-order option: %s') % arg)
 
 
 SUPPRESS = object()
@@ -817,7 +829,7 @@ class ModuleDocumenter(Documenter):
         'noindex': bool_option, 'inherited-members': inherited_members_option,
         'show-inheritance': bool_option, 'synopsis': identity,
         'platform': identity, 'deprecated': bool_option,
-        'member-order': identity, 'exclude-members': members_set_option,
+        'member-order': member_order_option, 'exclude-members': members_set_option,
         'private-members': bool_option, 'special-members': members_option,
         'imported-members': bool_option, 'ignore-module-all': bool_option
     }  # type: Dict[str, Callable]
@@ -1150,7 +1162,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
     option_spec = {
         'members': members_option, 'undoc-members': bool_option,
         'noindex': bool_option, 'inherited-members': inherited_members_option,
-        'show-inheritance': bool_option, 'member-order': identity,
+        'show-inheritance': bool_option, 'member-order': member_order_option,
         'exclude-members': members_set_option,
         'private-members': bool_option, 'special-members': members_option,
     }  # type: Dict[str, Callable]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/pull/7676#discussion_r426164955