### PR TITLE
Fix #7679: autodoc: Pass priority option to the config-inited handler

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1791,7 +1791,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_event('autodoc-process-signature')
     app.add_event('autodoc-skip-member')
 
-    app.connect('config-inited', migrate_autodoc_member_order)
+    app.connect('config-inited', migrate_autodoc_member_order, priority=800)
 
     app.setup_extension('sphinx.ext.autodoc.type_comment')
     app.setup_extension('sphinx.ext.autodoc.typehints')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It is better to invoke `migrate_autodoc_member_order` handler after other hooks to support extensions that modifies `autodoc_member_order` in their handler.