### PR TITLE
viewcode: Fix viewcode raises NoUri error on resolving phase except on HTML builders

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -131,8 +131,10 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: Iterable[str],
 
 def missing_reference(app: Sphinx, env: BuildEnvironment, node: Element, contnode: Node
                       ) -> Node:
-    # resolve our "viewcode" reference nodes -- they need special treatment
-    if node['reftype'] == 'viewcode':
+    if app.builder.format != 'html':
+        return None
+    elif node['reftype'] == 'viewcode':
+        # resolve our "viewcode" reference nodes -- they need special treatment
         return make_refnode(app.builder, node['refdoc'], node['reftarget'],
                             node['refid'], contnode)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- After #7658, viewcode causes a crash on building PDF.
- refs: https://readthedocs.org/projects/sphinx/builds/11054708/