### PR TITLE
Re-allow NoUri from missing-reference handlers

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -230,11 +230,15 @@ connect handlers to the events.  Example:
 
 .. event:: missing-reference (app, env, node, contnode)
 
-   Emitted when a cross-reference to a Python module or object cannot be
-   resolved.  If the event handler can resolve the reference, it should return a
+   Emitted when a cross-reference to an object cannot be resolved.
+   If the event handler can resolve the reference, it should return a
    new docutils node to be inserted in the document tree in place of the node
    *node*.  Usually this node is a :class:`reference` node containing *contnode*
    as a child.
+   If the handler can not resolve the cross-reference,
+   it can either return ``None`` to let other handlers try,
+   or raise :class:`NoUri` to prevent other handlers in trying and suppress
+   a warning about this cross-reference being unresolved.
 
    :param env: The build environment (``app.builder.env``).
    :param node: The :class:`pending_xref` node to be resolved.  Its attributes

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -116,7 +116,8 @@ class PycodeError(Exception):
 
 
 class NoUri(Exception):
-    """Raised by builder.get_relative_uri() if there is no URI available."""
+    """Raised by builder.get_relative_uri() or from missing-reference handlers
+    if there is no URI available."""
     pass
 
 

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -93,7 +93,7 @@ class ReferencesResolver(SphinxPostTransform):
                 if newnode is None:
                     newnode = self.app.emit_firstresult('missing-reference', self.env,
                                                         node, contnode,
-                                                        allowed_exceptions=(NoUri))
+                                                        allowed_exceptions=(NoUri,))
                     # still not found? warn if node wishes to be warned about or
                     # we are in nit-picky mode
                     if newnode is None:

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -92,7 +92,8 @@ class ReferencesResolver(SphinxPostTransform):
                 # no new node found? try the missing-reference event
                 if newnode is None:
                     newnode = self.app.emit_firstresult('missing-reference', self.env,
-                                                        node, contnode)
+                                                        node, contnode,
+                                                        allowed_exceptions=(NoUri))
                     # still not found? warn if node wishes to be warned about or
                     # we are in nit-picky mode
                     if newnode is None:


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix (for change only in the 3.x branch)

### Purpose
In b9793e5519a3e974886f8316fa1e74339075a1d2 (on the 3.x branch) some nice error handling is introduced for when event handlers raise exceptions. However, previously is was possible to have an extension handling ``missing-reference`` raise ``NoUri`` to silence warnings for specific references. This exception no longer reaches https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/transforms/post_transforms/__init__.py#L100.
I'm not sure this usage was documented before, but I believe something similar is needed. That is, a handler for ``missing-reference`` must be able to produce 3 results:
- Resolving the reference: return a node.
- Not able to resolve the reference: return ``None``.
- Able to resolve, but has no target: ? (previously raise ``NoUri``)

Use #7684 to explicitly allow ``NoUri`` from ``missing-reference`` handlers.