### PR TITLE
preprocessing numpy types

### DIFF
--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -278,7 +278,7 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
 .. _Google style:
    https://google.github.io/styleguide/pyguide.html
 .. _NumPy style:
-   https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+   https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 
 .. confval:: napoleon_google_docstring
 

--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -274,6 +274,7 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
     napoleon_use_ivar = False
     napoleon_use_param = True
     napoleon_use_rtype = True
+    napoleon_type_aliases = None
 
 .. _Google style:
    https://google.github.io/styleguide/pyguide.html
@@ -435,7 +436,7 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
        :param arg1: Description of `arg1`
        :type arg1: str
        :param arg2: Description of `arg2`, defaults to 0
-       :type arg2: int, optional
+       :type arg2: :class:`int`, *optional*
 
    **If False**::
 
@@ -480,3 +481,31 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
    **If False**::
 
        :returns: *bool* -- True if successful, False otherwise
+
+.. confval:: napoleon_type_aliases
+
+   A mapping to translate type names to other names or references. Works
+   only when ``napoleon_use_param = True``. *Defaults to None.*
+
+   With::
+
+       napoleon_type_aliases = {
+           "CustomType": "mypackage.CustomType",
+           "dict-like": ":term:`dict-like <mapping>`",
+       }
+
+   This `NumPy style`_ snippet::
+
+       Parameters
+       ----------
+       arg1 : CustomType
+           Description of `arg1`
+       arg2 : dict-like
+           Description of `arg2`
+
+   becomes::
+
+       :param arg1: Description of `arg1`
+       :type arg1: mypackage.CustomType
+       :param arg2: Description of `arg2`
+       :type arg2: :term:`dict-like <mapping>`

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -41,6 +41,7 @@ class Config:
         napoleon_use_param = True
         napoleon_use_rtype = True
         napoleon_use_keyword = True
+        napoleon_numpy_type_aliases = None
         napoleon_custom_sections = None
 
     .. _Google style:
@@ -236,6 +237,9 @@ class Config:
 
             :returns: *bool* -- True if successful, False otherwise
 
+    napoleon_numpy_type_aliases : :obj:`dict` (Defaults to None)
+        Add a mapping of strings to string, translating types.
+
     napoleon_custom_sections : :obj:`list` (Defaults to None)
         Add a list of custom sections to include, expanding the list of parsed sections.
 
@@ -263,6 +267,7 @@ class Config:
         'napoleon_use_param': (True, 'env'),
         'napoleon_use_rtype': (True, 'env'),
         'napoleon_use_keyword': (True, 'env'),
+        'napoleon_numpy_type_aliases': (None, 'env'),
         'napoleon_custom_sections': (None, 'env')
     }
 

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -238,7 +238,8 @@ class Config:
             :returns: *bool* -- True if successful, False otherwise
 
     napoleon_type_aliases : :obj:`dict` (Defaults to None)
-        Add a mapping of strings to string, translating types in numpy style docstrings.
+        Add a mapping of strings to string, translating types in numpy
+        style docstrings. Only works when ``napoleon_use_param = True``.
 
     napoleon_custom_sections : :obj:`list` (Defaults to None)
         Add a list of custom sections to include, expanding the list of parsed sections.

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -41,7 +41,7 @@ class Config:
         napoleon_use_param = True
         napoleon_use_rtype = True
         napoleon_use_keyword = True
-        napoleon_numpy_type_aliases = None
+        napoleon_type_aliases = None
         napoleon_custom_sections = None
 
     .. _Google style:
@@ -237,8 +237,8 @@ class Config:
 
             :returns: *bool* -- True if successful, False otherwise
 
-    napoleon_numpy_type_aliases : :obj:`dict` (Defaults to None)
-        Add a mapping of strings to string, translating types.
+    napoleon_type_aliases : :obj:`dict` (Defaults to None)
+        Add a mapping of strings to string, translating types in numpy style docstrings.
 
     napoleon_custom_sections : :obj:`list` (Defaults to None)
         Add a list of custom sections to include, expanding the list of parsed sections.
@@ -267,7 +267,7 @@ class Config:
         'napoleon_use_param': (True, 'env'),
         'napoleon_use_rtype': (True, 'env'),
         'napoleon_use_keyword': (True, 'env'),
-        'napoleon_numpy_type_aliases': (None, 'env'),
+        'napoleon_type_aliases': (None, 'env'),
         'napoleon_custom_sections': (None, 'env')
     }
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -15,15 +15,15 @@ import re
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
+from docutils import nodes
+from docutils.nodes import Node, system_message
+from docutils.parsers.rst import roles
+
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.locale import _
-
 from sphinx.util.docutils import SphinxRole
-from docutils import nodes
-from docutils.nodes import Node, system_message
-from docutils.parsers.rst import roles
 
 
 class LiteralText(SphinxRole):

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -904,10 +904,10 @@ def _token_type(token):
 def _convert_numpy_type_spec(_type, translations={}):
     def convert_obj(obj, translations, default_translation):
         # use :class: (the default) only if obj is not a standard singleton (None, True, False)
-        if obj in ("None", "True", "False") and default_translation == ":class:`{}`":
-            default_translation = ":obj:`{}`"
+        if obj in ("None", "True", "False") and default_translation == ":class:`%s`":
+            default_translation = ":obj:`%s`"
 
-        return translations.get(obj, default_translation.format(obj))
+        return translations.get(obj, default_translation % obj)
 
     tokens = _tokenize_type_spec(_type)
     combined_tokens = _recombine_sets(tokens)
@@ -918,15 +918,15 @@ def _convert_numpy_type_spec(_type, translations={}):
 
     # don't use the object role if it's not necessary
     default_translation = (
-        ":class:`{}`"
+        ":class:`%s`"
         if not all(type_ == "obj" for _, type_ in types)
-        else "{}"
+        else "%s"
     )
 
     converters = {
-        "literal": lambda x: "``{x}``".format(x=x),
+        "literal": lambda x: "``%s``" % x,
         "obj": lambda x: convert_obj(x, translations, default_translation),
-        "control": lambda x: "*{x}*".format(x=x),
+        "control": lambda x: "*%s*" % x,
         "delimiter": lambda x: x,
         "reference": lambda x: x,
     }

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -858,10 +858,10 @@ def _token_type(token):
     if token.startswith(" ") or token.endswith(" "):
         type_ = "delimiter"
     elif (
-            token.isnumeric()
-            or (token.startswith("{") and token.endswith("}"))
-            or (token.startswith('"') and token.endswith('"'))
-            or (token.startswith("'") and token.endswith("'"))
+            token.isnumeric() or
+            (token.startswith("{") and token.endswith("}")) or
+            (token.startswith('"') and token.endswith('"')) or
+            (token.startswith("'") and token.endswith("'"))
     ):
         type_ = "literal"
     elif token.startswith("{"):

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -845,10 +845,17 @@ def _recombine_set_tokens(tokens: List[str]) -> List[str]:
 
 
 def _tokenize_type_spec(spec: str) -> List[str]:
+    def postprocess(item):
+        if item.startswith("default"):
+            return [item[:7], item[7:]]
+        else:
+            return [item]
+
     tokens = list(
         item
-        for item in _token_regex.split(spec)
-        if item is not None and item.strip()
+        for raw_token in _token_regex.split(spec)
+        for item in postprocess(raw_token)
+        if item
     )
     return tokens
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -845,14 +845,17 @@ def _convert_numpy_type_spec(_type, translations={}):
     def token_type(token):
         if token.startswith(" ") or token.endswith(" "):
             type_ = "delimiter"
-        elif token.startswith("{") and token.endswith("}"):
-            type_ = "value_set"
+        elif (
+                token.isnumeric()
+                or (token.startswith("{") and token.endswith("}"))
+                or (token.startswith('"') and token.endswith('"'))
+                or (token.startswith("'") and token.endswith("'"))
+                ):
+            type_ = "literal"
         elif token in ("optional", "default"):
             type_ = "control"
         elif _xref_regex.match(token):
             type_ = "reference"
-        elif token.isnumeric() or (token.startswith('"') and token.endswith('"')):
-            type_ = "literal"
         else:
             type_ = "obj"
 
@@ -875,7 +878,6 @@ def _convert_numpy_type_spec(_type, translations={}):
     )
 
     converters = {
-        "value_set": lambda x: f"``{x}``",
         "literal": lambda x: f"``{x}``",
         "obj": lambda x: convert_obj(x, translations, default_translation),
         "control": lambda x: f"*{x}*",

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -978,6 +978,7 @@ class NumpyDocstring(GoogleDocstring):
             _name, _type = line, ''
         _name, _type = _name.strip(), _type.strip()
         _name = self._escape_args_and_kwargs(_name)
+        _type = self._convert_type_spec(_type)
 
         if prefer_type and not _type:
             _type, _name = _name, _type

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -840,7 +840,7 @@ def _tokenize_type_spec(spec):
     return _recombine_set_tokens(tokens)
 
 
-def _convert_numpy_type_spec(_type):
+def _convert_numpy_type_spec(_type, translations):
     def token_type(token):
         if token.startswith(" ") or token.endswith(" "):
             type_ = "delimiter"
@@ -865,13 +865,6 @@ def _convert_numpy_type_spec(_type):
         (token, token_type(token))
         for token in tokens
     ]
-
-    # TODO: make this configurable
-    translations = {
-        "sequence": ":term:`sequence`",
-        "mapping": ":term:`mapping`",
-        "dict-like": ":term:`dict-like <mapping>`",
-    }
 
     # don't use the object role if it's not necessary
     default_translation = (
@@ -1002,7 +995,10 @@ class NumpyDocstring(GoogleDocstring):
             _name, _type = line, ''
         _name, _type = _name.strip(), _type.strip()
         _name = self._escape_args_and_kwargs(_name)
-        _type = _convert_numpy_type_spec(_type)
+        _type = _convert_numpy_type_spec(
+            _type,
+            translations=self._config.napoleon_numpy_type_aliases or {},
+        )
 
         if prefer_type and not _type:
             _type, _name = _name, _type

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -15,23 +15,10 @@ import re
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from docutils import nodes
-from docutils.nodes import Node, system_message
-from docutils.parsers.rst import roles
-
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
 from sphinx.ext.napoleon.iterators import modify_iter
-from sphinx.locale import _
-from sphinx.util.docutils import SphinxRole
 
-
-class LiteralText(SphinxRole):
-    def run(self) -> Tuple[List[Node], List[system_message]]:
-        return [nodes.Text(self.text, self.text, **self.options)], []
-
-
-roles.register_local_role("noref", LiteralText())
 
 if False:
     # For type annotation
@@ -874,10 +861,10 @@ def _convert_numpy_type_spec(_type, translations):
     )
 
     converters = {
-        "value_set": lambda x: f":noref:`{x}`",
-        "literal": lambda x: f":noref:`{x}`",
+        "value_set": lambda x: f"``{x}``",
+        "literal": lambda x: f"``{x}``",
         "obj": lambda x: convert_obj(x, translations, default_translation),
-        "control": lambda x: f":noref:`{x}`",
+        "control": lambda x: f"*{x}*",
         "delimiter": lambda x: x,
         "reference": lambda x: x,
     }

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -840,13 +840,7 @@ def _tokenize_type_spec(spec):
     return _recombine_set_tokens(tokens)
 
 
-def _parse_numpy_type_spec(_type):
-    raw_tokens = _tokenize_type_spec(_type)
-    tokens = list(_recombine_set_tokens(raw_tokens))
-    return tokens
-
-
-def _parse_numpy_type_spec2(_type):
+def _convert_numpy_type_spec(_type):
     def token_type(token):
         if token.startswith(" ") or token.endswith(" "):
             type_ = "delimiter"
@@ -866,7 +860,7 @@ def _parse_numpy_type_spec2(_type):
     def convert_obj(obj, translations, default_translation=":obj:`{}`"):
         return translations.get(obj, default_translation.format(obj))
 
-    tokens = tokenize_type_spec(_type)
+    tokens = _tokenize_type_spec(_type)
     types = [
         (token, token_type(token))
         for token in tokens
@@ -895,7 +889,9 @@ def _parse_numpy_type_spec2(_type):
         "reference": lambda x: x,
     }
 
-    return "".join(converters.get(type_)(token) for token, type_ in types)
+    converted = "".join(converters.get(type_)(token) for token, type_ in types)
+
+    return converted
 
 
 class NumpyDocstring(GoogleDocstring):
@@ -1006,7 +1002,7 @@ class NumpyDocstring(GoogleDocstring):
             _name, _type = line, ''
         _name, _type = _name.strip(), _type.strip()
         _name = self._escape_args_and_kwargs(_name)
-        _type = _parse_numpy_type_spec(_type)
+        _type = _convert_numpy_type_spec(_type)
 
         if prefer_type and not _type:
             _type, _name = _name, _type

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -899,6 +899,8 @@ def _token_type(token: str, location: str = None) -> str:
         )
         type_ = "literal"
     elif token in ("optional", "default"):
+        # default is not a official keyword (yet) but supported by the
+        # reference implementation (numpydoc) and widely used
         type_ = "control"
     elif _xref_regex.match(token):
         type_ = "reference"

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -904,7 +904,7 @@ def _token_type(token):
 def _convert_numpy_type_spec(_type, translations={}):
     def convert_obj(obj, translations, default_translation):
         # use :class: (the default) only if obj is not a standard singleton (None, True, False)
-        if obj in (None, True, False) and default_translation == ":class:`{}`":
+        if obj in ("None", "True", "False") and default_translation == ":class:`{}`":
             default_translation = ":obj:`{}`"
 
         return translations.get(obj, default_translation.format(obj))

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -953,7 +953,8 @@ class NumpyDocstring(GoogleDocstring):
         # TODO: make this configurable
         translations = {
             "sequence": ":term:`sequence`",
-            "dict-like": ":term:`mapping`",
+            "mapping": ":term:`mapping`",
+            "dict-like": ":term:`dict-like <mapping>`",
         }
 
         converters = {

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -798,7 +798,6 @@ def _recombine_sets(tokens):
     def takewhile_set(tokens):
         open_braces = 0
         previous_token = None
-        print("combining set:", tokens)
         while True:
             try:
                 token = tokens.popleft()

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1050,12 +1050,11 @@ class NumpyDocstring(GoogleDocstring):
     def _get_location(self) -> str:
         filepath = inspect.getfile(self._obj) if self._obj is not None else ""
         name = self._name
-        line = ""
 
         if filepath is None and name is None:
             return None
 
-        return ":".join([filepath, "docstring of %s" % name, line])
+        return ":".join([filepath, "docstring of %s" % name])
 
     def _consume_field(self, parse_type: bool = True, prefer_type: bool = False
                        ) -> Tuple[str, str, List[str]]:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -848,7 +848,7 @@ def _tokenize_type_spec(spec):
     return _recombine_set_tokens(tokens)
 
 
-def _convert_numpy_type_spec(_type, translations):
+def _convert_numpy_type_spec(_type, translations={}):
     def token_type(token):
         if token.startswith(" ") or token.endswith(" "):
             type_ = "delimiter"

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -932,8 +932,6 @@ class NumpyDocstring(GoogleDocstring):
                 type_ = "value_set"
             elif token in ("optional", "default"):
                 type_ = "control"
-            elif "instance" in token:
-                type_ = "literal"
             elif re.match(":[^:]+:`[^`]+`", token):
                 type_ = "reference"
             elif token.isnumeric() or (token.startswith('"') and token.endswith('"')):

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -910,11 +910,16 @@ def _token_type(token: str, location: str = None) -> str:
 
 def _convert_numpy_type_spec(_type: str, location: str = None, translations: dict = {}) -> str:
     def convert_obj(obj, translations, default_translation):
+        translation = translations.get(obj, obj)
+
         # use :class: (the default) only if obj is not a standard singleton (None, True, False)
-        if obj in ("None", "True", "False") and default_translation == ":class:`%s`":
+        if translation in ("None", "True", "False") and default_translation == ":class:`%s`":
             default_translation = ":obj:`%s`"
 
-        return translations.get(obj, default_translation % obj)
+        if _xref_regex.match(translation) is None:
+            translation = default_translation % translation
+
+        return translation
 
     tokens = _tokenize_type_spec(_type)
     combined_tokens = _recombine_set_tokens(tokens)

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -13,12 +13,15 @@
 import inspect
 import re
 from functools import partial
+import logging
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
 from sphinx.ext.napoleon.iterators import modify_iter
+from sphinx.locale import _, __
 
+logger = logging.Logger(__name__)
 
 if False:
     # For type annotation
@@ -789,7 +792,7 @@ def _recombine_set_tokens(tokens):
                 token = next(iterable)
             except StopIteration:
                 if open_braces != 0:
-                    raise ValueError("invalid value set: {}".format("".join(tokens)))
+                    logger.warning(__("invalid value set: %r"), "".join(tokens))
 
                 break
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -997,7 +997,7 @@ class NumpyDocstring(GoogleDocstring):
         _name = self._escape_args_and_kwargs(_name)
         _type = _convert_numpy_type_spec(
             _type,
-            translations=self._config.napoleon_numpy_type_aliases or {},
+            translations=self._config.napoleon_type_aliases or {},
         )
 
         if prefer_type and not _type:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -13,15 +13,15 @@
 import inspect
 import re
 from functools import partial
-import logging
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.locale import _, __
+from sphinx.util import logging
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 if False:
     # For type annotation
@@ -792,7 +792,12 @@ def _recombine_set_tokens(tokens):
                 token = next(iterable)
             except StopIteration:
                 if open_braces != 0:
-                    logger.warning(__("invalid value set: %r"), "".join(tokens))
+                    location = ("", "")
+                    logger.warning(
+                        __("invalid value set: %r"),
+                        "".join(tokens),
+                        location=location,
+                    )
 
                 break
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -861,7 +861,7 @@ def _convert_numpy_type_spec(_type, translations={}):
 
         return type_
 
-    def convert_obj(obj, translations, default_translation=":obj:`{}`"):
+    def convert_obj(obj, translations, default_translation):
         return translations.get(obj, default_translation.format(obj))
 
     tokens = _tokenize_type_spec(_type)

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -920,9 +920,9 @@ def _convert_numpy_type_spec(_type, translations={}):
     )
 
     converters = {
-        "literal": lambda x: f"``{x}``",
+        "literal": lambda x: "``{x}``".format(x=x),
         "obj": lambda x: convert_obj(x, translations, default_translation),
-        "control": lambda x: f"*{x}*",
+        "control": lambda x: "*{x}*".format(x=x),
         "delimiter": lambda x: x,
         "reference": lambda x: x,
     }

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -825,12 +825,25 @@ def _recombine_set_tokens(tokens):
 
 
 def _tokenize_type_spec(spec):
-    delimiters = r"(\sor\s|\sof\s|:\s|,\s|[{]|[}])"
-
+    delimiters = [
+        r"\sor\s",
+        r"\sof\s",
+        r":\s",
+        r",\s",
+    ]
+    braces = [
+        "[{]",
+        "[}]",
+    ]
+    quoted_strings = [
+        r'"(?:[^"]|\\")*"',
+        r"'(?:[^']|\\')*'",
+    ]
+    tokenization_re = re.compile(f"({'|'.join(delimiters + braces + quoted_strings)})")
     tokens = tuple(
         item
-        for item in re.split(delimiters, spec)
-        if item
+        for item in tokenization_re.split(spec)
+        if item is not None and item.strip()
     )
     return _recombine_set_tokens(tokens)
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -903,6 +903,10 @@ def _token_type(token):
 
 def _convert_numpy_type_spec(_type, translations={}):
     def convert_obj(obj, translations, default_translation):
+        # use :class: (the default) only if obj is not a standard singleton (None, True, False)
+        if obj in (None, True, False) and default_translation == ":class:`{}`":
+            default_translation = ":obj:`{}`"
+
         return translations.get(obj, default_translation.format(obj))
 
     tokens = _tokenize_type_spec(_type)
@@ -914,7 +918,7 @@ def _convert_numpy_type_spec(_type, translations={}):
 
     # don't use the object role if it's not necessary
     default_translation = (
-        ":obj:`{}`"
+        ":class:`{}`"
         if not all(type_ == "obj" for _, type_ in types)
         else "{}"
     )

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1054,11 +1054,12 @@ class NumpyDocstring(GoogleDocstring):
             _name, _type = line, ''
         _name, _type = _name.strip(), _type.strip()
         _name = self._escape_args_and_kwargs(_name)
-        _type = _convert_numpy_type_spec(
-            _type,
-            location=self._get_location(),
-            translations=self._config.napoleon_type_aliases or {},
-        )
+        if self._config.napoleon_use_param:
+            _type = _convert_numpy_type_spec(
+                _type,
+                location=self._get_location(),
+                translations=self._config.napoleon_type_aliases or {},
+            )
 
         if prefer_type and not _type:
             _type, _name = _name, _type

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -852,6 +852,9 @@ def _convert_numpy_type_spec(_type, translations={}):
                 or (token.startswith("'") and token.endswith("'"))
                 ):
             type_ = "literal"
+        elif token.startswith("{"):
+            # invalid value set, make it a literal to avoid further warnings
+            type_ = "literal"
         elif token in ("optional", "default"):
             type_ = "control"
         elif _xref_regex.match(token):

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -842,8 +842,8 @@ def _parse_numpy_type_spec(_type):
 
         return type_
 
-    def convert_obj(obj, translations):
-        return translations.get(obj, ":obj:`{}`".format(obj))
+    def convert_obj(obj, translations, default_translation=":obj:`{}`"):
+        return translations.get(obj, default_translation.format(obj))
 
     tokens = tokenize_type_spec(_type)
     types = [
@@ -858,10 +858,17 @@ def _parse_numpy_type_spec(_type):
         "dict-like": ":term:`dict-like <mapping>`",
     }
 
+    # don't use the object role if it's not necessary
+    default_translation = (
+        ":obj:`{}`"
+        if not all(type_ == "obj" for _, type_ in types)
+        else "{}"
+    )
+
     converters = {
         "value_set": lambda x: f":noref:`{x}`",
         "literal": lambda x: f":noref:`{x}`",
-        "obj": lambda x: convert_obj(x, translations),
+        "obj": lambda x: convert_obj(x, translations, default_translation),
         "control": lambda x: f":noref:`{x}`",
         "delimiter": lambda x: x,
         "reference": lambda x: x,

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1068,7 +1068,7 @@ Methods:
 .. method:: func(i, j)
    :noindex:
 
-
+   
    description
 """
         config = Config()

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2126,8 +2126,8 @@ definition_after_normal_text : int
 
         converted_types = (
             "",
-            ":obj:`str`",
-            ":obj:`int` or :obj:`float` or :obj:`None`",
+            ":class:`str`",
+            ":class:`int` or :class:`float` or :obj:`None`",
             '``{"F", "C", "N"}``',
             "``{'F', 'C', 'N'}``",
         )
@@ -2171,11 +2171,11 @@ definition_after_normal_text : int
             :param param1: the data to work on
             :type param1: DataFrame
             :param param2: a parameter with different types
-            :type param2: :obj:`int` or :obj:`float` or :obj:`None`
+            :type param2: :class:`int` or :class:`float` or :obj:`None`
             :param param3: a optional mapping
             :type param3: :term:`dict-like <mapping>`, *optional*
             :param param4: a optional parameter with different types
-            :type param4: :obj:`int` or :obj:`float` or :obj:`None`, *optional*
+            :type param4: :class:`int` or :class:`float` or :obj:`None`, *optional*
             :param param5: a optional parameter with fixed values
             :type param5: ``{"F", "C", "N"}``, *optional*
         """)

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1999,7 +1999,7 @@ definition_after_normal_text : int
         )
 
         for input_tokens in invalid_tokens:
-            with self.assertRaisesRegex(ValueError, "invalid value set:"):
+            with self.assertWarnsRegex(UserWarning, "invalid value set:"):
                 _recombine_set_tokens(input_tokens)
 
 

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -20,7 +20,7 @@ from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring
 from sphinx.ext.napoleon.docstring import (
     _tokenize_type_spec,
-    _recombine_sets,
+    _recombine_set_tokens,
     _convert_numpy_type_spec,
     _token_type
 )
@@ -2051,7 +2051,7 @@ definition_after_normal_text : int
             actual = _tokenize_type_spec(type_spec)
             self.assertEqual(expected, actual)
 
-    def test_recombine_sets(self):
+    def test_recombine_set_tokens(self):
         type_tokens = (
             ["{", "1", ", ", "2", "}"],
             ["{", '"F"', ", ", '"C"', ", ", '"N"', "}"],
@@ -2075,10 +2075,10 @@ definition_after_normal_text : int
         )
 
         for tokens_, expected in zip(tokens, combined_tokens):
-            actual = _recombine_sets(tokens_)
+            actual = _recombine_set_tokens(tokens_)
             self.assertEqual(expected, actual)
 
-    def test_recombine_sets_invalid(self):
+    def test_recombine_set_tokens_invalid(self):
         type_tokens = (
             ["{", "1", ", ", "2"],
             ['"F"', ", ", '"C"', ", ", '"N"', "}"],
@@ -2102,7 +2102,7 @@ definition_after_normal_text : int
         )
 
         for tokens_, expected in zip(tokens, combined_tokens):
-            actual = _recombine_sets(tokens_)
+            actual = _recombine_set_tokens(tokens_)
             self.assertEqual(expected, actual)
 
     def test_convert_numpy_type_spec(self):

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2008,13 +2008,17 @@ definition_after_normal_text : int
     def test_token_type_invalid(self):
         tokens = (
             "{1, 2",
-            "1, 2}",
+            "}",
             "'abc",
             "def'",
+            '"ghi',
+            'jkl"',
         )
         for token in tokens:
             # TODO: check for the warning
             _token_type(token)
+
+        assert False
 
     def test_tokenize_type_spec(self):
         types = (

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2009,6 +2009,8 @@ definition_after_normal_text : int
             "int or float or None",
             '{"F", "C", "N"}',
             "{'F', 'C', 'N'}",
+            '"ma{icious"',
+            r"'with \'quotes\''",
         )
         modifiers = (
             "optional",
@@ -2020,6 +2022,8 @@ definition_after_normal_text : int
             ["int", " or ", "float", " or ", "None"],
             ['{"F", "C", "N"}'],
             ["{'F', 'C', 'N'}"],
+            ['"ma{icious"'],
+            [r"'with \'quotes\''"],
         )
         modifier_tokens = (
             ["optional"],

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2068,13 +2068,13 @@ definition_after_normal_text : int
         converted_types = (
             ":obj:`str`",
             ":obj:`int` or :obj:`float` or :obj:`None`",
-            ':noref:`{"F", "C", "N"}`',
-            ":noref:`{'F', 'C', 'N'}`",
+            '``{"F", "C", "N"}``',
+            "``{'F', 'C', 'N'}``",
         )
         converted_modifiers = (
             "",
-            ":noref:`optional`",
-            ":noref:`default`: :obj:`None`",
+            "*optional*",
+            "*default*: :obj:`None`",
         )
         converted = tuple(
             ", ".join([converted_type, converted_modifier])
@@ -2114,13 +2114,20 @@ definition_after_normal_text : int
         :param param2: a parameter with different types
         :type param2: :obj:`int` or :obj:`float` or :obj:`None`
         :param param3: a optional mapping
-        :type param3: :term:`dict-like <mapping>`, :noref:`optional`
+        :type param3: :term:`dict-like <mapping>`, *optional*
         :param param4: a optional parameter with different types
-        :type param4: :obj:`int` or :obj:`float` or :obj:`None`, :noref:`optional`
+        :type param4: :obj:`int` or :obj:`float` or :obj:`None`, *optional*
         :param param5: a optional parameter with fixed values
-        :type param5: :noref:`{"F", "C", "N"}`, :noref:`optional`
+        :type param5: ``{"F", "C", "N"}``, *optional*
         """)
-        config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
+        translations = {
+            "dict-like": ":term:`dict-like <mapping>`",
+        }
+        config = Config(
+            napoleon_use_param=True,
+            napoleon_use_rtype=True,
+            napoleon_type_aliases=translations,
+        )
         actual = str(NumpyDocstring(docstring, config))
         self.assertEqual(expected, actual)
 

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2153,8 +2153,7 @@ definition_after_normal_text : int
             self.assertEqual(expected, actual)
 
     def test_parameter_types(self):
-        import textwrap
-        docstring = textwrap.dedent("""\
+        docstring = dedent("""\
             Parameters
             ----------
             param1 : DataFrame
@@ -2168,17 +2167,17 @@ definition_after_normal_text : int
             param5 : {"F", "C", "N"}, optional
                 a optional parameter with fixed values
         """)
-        expected = textwrap.dedent("""\
-        :param param1: the data to work on
-        :type param1: DataFrame
-        :param param2: a parameter with different types
-        :type param2: :obj:`int` or :obj:`float` or :obj:`None`
-        :param param3: a optional mapping
-        :type param3: :term:`dict-like <mapping>`, *optional*
-        :param param4: a optional parameter with different types
-        :type param4: :obj:`int` or :obj:`float` or :obj:`None`, *optional*
-        :param param5: a optional parameter with fixed values
-        :type param5: ``{"F", "C", "N"}``, *optional*
+        expected = dedent("""\
+            :param param1: the data to work on
+            :type param1: DataFrame
+            :param param2: a parameter with different types
+            :type param2: :obj:`int` or :obj:`float` or :obj:`None`
+            :param param3: a optional mapping
+            :type param3: :term:`dict-like <mapping>`, *optional*
+            :param param4: a optional parameter with different types
+            :type param4: :obj:`int` or :obj:`float` or :obj:`None`, *optional*
+            :param param5: a optional parameter with fixed values
+            :type param5: ``{"F", "C", "N"}``, *optional*
         """)
         translations = {
             "dict-like": ":term:`dict-like <mapping>`",

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2066,6 +2066,10 @@ definition_after_normal_text : int
             self.assertEqual(expected, actual)
 
     def test_convert_numpy_type_spec(self):
+        translations = {
+            "DataFrame": "pandas.DataFrame",
+        }
+
         specs = (
             "",
             "optional",
@@ -2073,6 +2077,7 @@ definition_after_normal_text : int
             "int or float or None, default: None",
             '{"F", "C", "N"}',
             "{'F', 'C', 'N'}, default: 'N'",
+            "DataFrame, optional",
         )
 
         converted = (
@@ -2082,10 +2087,11 @@ definition_after_normal_text : int
             ":class:`int` or :class:`float` or :obj:`None`, *default*: :obj:`None`",
             '``{"F", "C", "N"}``',
             "``{'F', 'C', 'N'}``, *default*: ``'N'``",
+            ":class:`pandas.DataFrame`, *optional*",
         )
 
         for spec, expected in zip(specs, converted):
-            actual = _convert_numpy_type_spec(spec)
+            actual = _convert_numpy_type_spec(spec, translations=translations)
             self.assertEqual(expected, actual)
 
     def test_parameter_types(self):

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2128,14 +2128,13 @@ definition_after_normal_text : int
             "default: None",
         )
         type_specs = tuple(
-            ", ".join([type_, modifier])
-            if modifier
-            else type_
+            ", ".join(part for part in (type_, modifier) if part)
             for type_ in types
             for modifier in modifiers
         )
 
         converted_types = (
+            "",
             ":obj:`str`",
             ":obj:`int` or :obj:`float` or :obj:`None`",
             '``{"F", "C", "N"}``',
@@ -2147,7 +2146,7 @@ definition_after_normal_text : int
             "*default*: :obj:`None`",
         )
         converted = tuple(
-            ", ".join([converted_type, converted_modifier])
+            ", ".join(part for part in (converted_type, converted_modifier) if part)
             if converted_modifier
             else (
                 type_

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1976,6 +1976,37 @@ definition_after_normal_text : int
         actual = str(NumpyDocstring(docstring, config))
         self.assertEqual(expected, actual)
 
+    def test_parameter_types(self):
+        docstring = """\
+Parameters
+----------
+param1 : DataFrame
+    the data to work on
+param2 : int or float or None
+    a parameter with different types
+param3 : dict-like, optional
+    a optional mapping
+param4 : int or float or None, optional
+    a optional parameter with different types
+param5 : {"F", "C", "N"}, optional
+    a optional parameter with fixed values
+"""
+        expected = """\
+:param param1: the data to work on
+:type param1: :obj:`DataFrame`
+:param param2: a parameter with different types
+:type param2: :obj:`int` or :obj:`float` or :obj:`None`
+:param param3: a optional mapping
+:type param3: :obj:`dict-like`, optional
+:param param4: a optional parameter with different types
+:type param4: :obj:`int` or :obj:`float` or :obj:`None`, optional
+:param param5: a optional parameter with fixed values
+:type param5: {"F", "C", "N"}, optional
+"""
+        config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
+        actual = str(NumpyDocstring(docstring, config))
+        self.assertEqual(expected, actual)
+
     def test_keywords_with_types(self):
         docstring = """\
 Do as you please

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1070,7 +1070,7 @@ Methods:
 .. method:: func(i, j)
    :noindex:
 
-
+   
    description
 """
         config = Config()

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1977,32 +1977,33 @@ definition_after_normal_text : int
         self.assertEqual(expected, actual)
 
     def test_parameter_types(self):
-        docstring = """\
-Parameters
-----------
-param1 : DataFrame
-    the data to work on
-param2 : int or float or None
-    a parameter with different types
-param3 : dict-like, optional
-    a optional mapping
-param4 : int or float or None, optional
-    a optional parameter with different types
-param5 : {"F", "C", "N"}, optional
-    a optional parameter with fixed values
-"""
-        expected = """\
-:param param1: the data to work on
-:type param1: :obj:`DataFrame`
-:param param2: a parameter with different types
-:type param2: :obj:`int` or :obj:`float` or :obj:`None`
-:param param3: a optional mapping
-:type param3: :obj:`dict-like`, optional
-:param param4: a optional parameter with different types
-:type param4: :obj:`int` or :obj:`float` or :obj:`None`, optional
-:param param5: a optional parameter with fixed values
-:type param5: {"F", "C", "N"}, optional
-"""
+        import textwrap
+        docstring = textwrap.dedent("""\
+            Parameters
+            ----------
+            param1 : DataFrame
+                the data to work on
+            param2 : int or float or None
+                a parameter with different types
+            param3 : dict-like, optional
+                a optional mapping
+            param4 : int or float or None, optional
+                a optional parameter with different types
+            param5 : {"F", "C", "N"}, optional
+                a optional parameter with fixed values
+        """)
+        expected = textwrap.dedent("""\
+        :param param1: the data to work on
+        :type param1: :obj:`DataFrame`
+        :param param2: a parameter with different types
+        :type param2: :obj:`int` or :obj:`float` or :obj:`None`
+        :param param3: a optional mapping
+        :type param3: :obj:`dict-like`, optional
+        :param param4: a optional parameter with different types
+        :type param4: :obj:`int` or :obj:`float` or :obj:`None`, optional
+        :param param5: a optional parameter with fixed values
+        :type param5: {"F", "C", "N"}, optional
+        """)
         config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
         actual = str(NumpyDocstring(docstring, config))
         self.assertEqual(expected, actual)

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2013,6 +2013,7 @@ definition_after_normal_text : int
             "int or float or None, optional",
             '{"F", "C", "N"}',
             "{'F', 'C', 'N'}, default: 'F'",
+            "{'F', 'C', 'N or C'}, default 'F'",
             '"ma{icious"',
             r"'with \'quotes\''",
         )
@@ -2022,6 +2023,7 @@ definition_after_normal_text : int
             ["int", " or ", "float", " or ", "None", ", ", "optional"],
             ["{", '"F"', ", ", '"C"', ", ", '"N"', "}"],
             ["{", "'F'", ", ", "'C'", ", ", "'N'", "}", ", ", "default", ": ", "'F'"],
+            ["{", "'F'", ", ", "'C'", ", ", "'N or C'", "}", ", ", "default", " ", "'F'"],
             ['"ma{icious"'],
             [r"'with \'quotes\''"],
         )

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -2106,15 +2106,15 @@ definition_after_normal_text : int
         """)
         expected = textwrap.dedent("""\
         :param param1: the data to work on
-        :type param1: :obj:`DataFrame`
+        :type param1: DataFrame
         :param param2: a parameter with different types
         :type param2: :obj:`int` or :obj:`float` or :obj:`None`
         :param param3: a optional mapping
-        :type param3: :obj:`dict-like`, optional
+        :type param3: :term:`dict-like <mapping>`, :noref:`optional`
         :param param4: a optional parameter with different types
-        :type param4: :obj:`int` or :obj:`float` or :obj:`None`, optional
+        :type param4: :obj:`int` or :obj:`float` or :obj:`None`, :noref:`optional`
         :param param5: a optional parameter with fixed values
-        :type param5: {"F", "C", "N"}, optional
+        :type param5: :noref:`{"F", "C", "N"}`, :noref:`optional`
         """)
         config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
         actual = str(NumpyDocstring(docstring, config))


### PR DESCRIPTION
Subject: `napoleon` should translate the type fields

### Feature or Bugfix
- Feature
- Bugfix

could be both?

### Purpose
As reported in #6861, `napoleon` simply puts everything after the colon of a `numpy`-style parameter description (e.g. the `int` in `val : int`) into a `:type:` field. This works most of the time, but `numpydoc` also uses certain keywords (`optional`, `default`), value sets (e.g. `{"val1", "val2"}`) and literals (as in `default: "val2"`), among others. Right now, using those will raise nit-picky warnings and possibly also result in incorrect parameter documentation.

This PR adds a new role (named `noref`, but could also be `literal` or `text`; I'm not confident in my ability to come up with good names) that is then used to make the type field ignore the keywords / literals above.

The type preprocessing also allows adding a mapping of terms to other links (see the `translations` dict), so terms like `dict-like` or `array-like` / `array_like` can be mapped to `mapping` using a configuration option. It isn't restricted to terms, though, any kind of role should be possible.

I don't really know if this is the best approach to the problem described in #6861 (in that issue, the suggestion to create a new section for optional parameters came up) but I'm submitting this to start making progress.

### Relates
- #6861

