### PR TITLE
Add viewport meta tag for responsive layout

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -120,6 +120,7 @@
     {%- else %}
     <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
     {%- endif %}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{- metatags }}
     {%- block htmltitle %}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>


### PR DESCRIPTION
Subject: add meta viewport tag to start creating responsive layout

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: 3.x

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Viewport meta tag is necessary to make layout responsive. Without it, the layout is rendered for desktop size and then scaled down, making text small and difficult to read. It also makes a site fail Google Lighthouse audits.