### PR TITLE
BUG: Allow extensions to pass Sphinx errors during init

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -33,7 +33,7 @@ from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.domains import Domain, Index
 from sphinx.environment import BuildEnvironment
 from sphinx.environment.collectors import EnvironmentCollector
-from sphinx.errors import ApplicationError, ConfigError, VersionRequirementError
+from sphinx.errors import ApplicationError, ConfigError, VersionRequirementError, SphinxError
 from sphinx.events import EventManager
 from sphinx.extension import Extension
 from sphinx.highlighting import lexer_classes, lexers
@@ -330,7 +330,7 @@ class Sphinx:
     def _init_builder(self) -> None:
         self.builder.set_environment(self.env)
         self.builder.init()
-        self.events.emit('builder-inited')
+        self.events.emit('builder-inited', allowed_exceptions=(SphinxError,))
 
     # ---- main "build" method -------------------------------------------------
 


### PR DESCRIPTION
In `sphinx-gallery` #7683 causes some problems for us because we used to check that things like `ValueError` were raised during builder init, but now it's always `ExtensionError` with the message "Handler <function generate_gallery_rst at 0x7f88327f69d0> for event 'builder-inited' threw an exception", and the useful error message higher up.

One solution is that we can switch to emitting `ExtensionError` and `ConfigError` as appropriate (I have tested this and it works). Then Sphinx needs the change here, and things work as expected.

Let me know if there is some other solution. It's possible that there are other events that get emitted that might need similar changes.