### PR TITLE
Fix typo in make.bat_t, https:// link

### DIFF
--- a/sphinx/templates/quickstart/make.bat_t
+++ b/sphinx/templates/quickstart/make.bat_t
@@ -27,9 +27,9 @@ if "%1" == "help" (
 	echo.  pickle     to make pickle files
 	echo.  json       to make JSON files
 	echo.  htmlhelp   to make HTML files and an HTML help project
-	echo.  qthelp     to make HTML files and a qthelp project
+	echo.  qthelp     to make HTML files and a Qt help project
 	echo.  devhelp    to make HTML files and a Devhelp project
-	echo.  epub       to make an epub
+	echo.  epub       to make an EPUB
 	echo.  latex      to make LaTeX files (you can set PAPER=a4 or PAPER=letter)
 	echo.  latexpdf   to make LaTeX files and then PDFs out of them
 	echo.  text       to make text files
@@ -69,7 +69,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 


### PR DESCRIPTION
As per
https://en.wikipedia.org/wiki/EPUB
https://doc.qt.io/archives/qt-4.8/qthelp-framework.html
https://doc.qt.io/qt-5/qthelp-index.html
Spelling differs between the latter two


Subject: <Correct spelling of EPUB and Qt help, better to use HTTPS>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

### Purpose
- <Correct spelling of EPUB and Qt help, better to use HTTPS>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

