### PR TITLE
Updates for TexLive 2020

### DIFF
--- a/sphinx/builders/latex/constants.py
+++ b/sphinx/builders/latex/constants.py
@@ -91,6 +91,7 @@ DEFAULT_SETTINGS = {
     'fontpkg':         PDFLATEX_DEFAULT_FONTPKG,
     'substitutefont':  '',
     'textcyrillic':    '',
+    'grffile':         '\\usepackage{grffile}[=v1]',
     'textgreek':       '\\usepackage{textalpha}',
     'fncychap':        '\\usepackage[Bjarne]{fncychap}',
     'hyperref':        ('% Include hyperref last.\n'
@@ -140,7 +141,7 @@ ADDITIONAL_SETTINGS = {
         'latex_engine': 'xelatex',
         'polyglossia':  '\\usepackage{polyglossia}',
         'babel':        '',
-        'fontenc':     ('\\usepackage{fontspec}\n'
+        'fontenc':     ('\\usepackage[no-math]{fontspec}\n'
                         '\\defaultfontfeatures[\\rmfamily,\\sffamily,\\ttfamily]{}'),
         'fontpkg':      XELATEX_DEFAULT_FONTPKG,
         'textgreek':    '',
@@ -151,7 +152,7 @@ ADDITIONAL_SETTINGS = {
         'latex_engine': 'lualatex',
         'polyglossia':  '\\usepackage{polyglossia}',
         'babel':        '',
-        'fontenc':     ('\\usepackage{fontspec}\n'
+        'fontenc':     ('\\usepackage[no-math]{fontspec}\n'
                         '\\defaultfontfeatures[\\rmfamily,\\sffamily,\\ttfamily]{}'),
         'fontpkg':      LUALATEX_DEFAULT_FONTPKG,
         'textgreek':    '',

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -31,6 +31,7 @@
 <%= fontpkg %>
 <%= textgreek %>
 <%= fncychap %>
+<%= grffile %>
 \usepackage<%= sphinxpkgoptions %>{sphinx}
 <%= sphinxsetup %>
 <%= fvset %>


### PR DESCRIPTION
Subject: Updates for TexLive 2020

### Feature or Bugfix

- Bugfix

### Purpose

In Fedora, we just updated to TexLive 2020 and we got some troubles. @spotrh was awesome and figured out patches needed to make it work. I am proposing them to you with his description.


### Detail

There were 2 errors:

    ...
    Chapter 1.
    [3] [4]
    Chapter 2.
    (/usr/share/texlive/texmf-dist/tex/latex/psnfss/t1pcr.fd) [5 <./img.png (PNG co
    py)> <./img1.png (PNG copy)> <./img.pdf>]

    ! LaTeX Error: Unknown graphics extension: .foo.png.

    See the LaTeX manual or LaTeX Companion for explanation.
    Type  H <return>  for immediate help.
     ...

    l.111 ...dent\sphinxincludegraphics{{img.foo}.png}

    !  ==> Fatal error occurred, no output PDF file produced!

And:

    ...
    (/usr/share/texlive/texmf-dist/tex/latex/oberdiek/hypcap.sty)
    (./sphinxmessages.sty)
    Writing index file sphinxtests.idx
    No file sphinxtests.aux.
    (/usr/share/texlive/texmf-dist/tex/latex/base/ts1cmr.fd)

    ! LaTeX Error: Command `\acute' already defined.

    See the LaTeX manual or LaTeX Companion for explanation.
    Type  H <return>  for immediate help.
     ...

    l.79 \begin{document}

     573 words of node memory still in use:
       3 hlist, 1 rule, 1 dir, 3 kern, 1 glyph, 16 attribute, 65 glue_spec, 16 attr
    ibute_list, 4 if_stack, 1 write, 11 pdf_colorstack nodes
       avail lists: 2:16,3:1,4:1,5:3,7:5,8:2,9:2
    !  ==> Fatal error occurred, no output PDF file produced!

There were two problems:

 1. fontspec, when loaded without the [no-math] option, conflicts with the font
    handling of math symbols (which sphinx uses). I think this may have always
    been true, but we weren't hitting it before for some reason.
    Forcing fontspec to load with no-math in the xetex and luatex cases
    resolves the test failures.

 2. Something is broken in the "new" \includegraphics parsing logic.
    Before, you could get past the "two dot" problem by doing:

        \includegraphics{{img.foo}.png}

    And tex wouldn't try to pass the whole file name to the parser.
    The parser used to live in grffile.sty, which was being used behind the
    scenes.
    Now, the upstream for grffile (https://ctan.org/pkg/grffile) says this:

    > The original package extended the file name processing of package
    > graphics to support a larger range of file names.
    > The base LATEX code now supports multiple dots and spaces, and this
    > package by default is a stub that just loads graphic.
    > However, \usepackage{grffile}[=v1] may be used to access version 1(.18)
    > of the package if that is needed.

It seems clear that the base LATEX code isn't working everywhere. :/
So, we always do a \usepackage{grffile}[=v1] call in the tex generation logic,
and this works as expected.

