### PR TITLE
BUG: Fix check for meth

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -726,7 +726,7 @@ def getdoc(obj: Any, attrgetter: Callable = safe_getattr,
             # This tries to obtain the docstring from super classes.
             for basecls in getattr(cls, '__mro__', []):
                 meth = safe_getattr(basecls, name, None)
-                if meth:
+                if meth is not None:
                     doc = inspect.getdoc(meth)
                     if doc:
                         break


### PR DESCRIPTION
https://github.com/sphinx-doc/sphinx/pull/7557/files#diff-84bfd2ad46b7c8e97e5a06abb886c065R714 causes a problem when building the SciPy docs because `meth` ends up being an `ndarray` which leads to:
```
  File "/home/larsoner/python/sphinx/sphinx/util/inspect.py", line 564, in getdoc
    if meth:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
This allows the build to avoid this error. Not sure if it's the correct approach or not...