### PR TITLE
Fix #3673: autodoc: bysource order does not work for a module having __all__

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -100,6 +100,8 @@ Bugs fixed
 * #7676: autodoc: typo in the default value of autodoc_member_order
 * #7676: autodoc: wrong value for :member-order: option is ignored silently
 * #7676: autodoc: member-order="bysource" does not work for C module
+* #3673: autodoc: member-order="bysource" does not work for a module having
+  __all__
 * #7668: autodoc: wrong retann value is passed to a handler of
   autodoc-proccess-signature
 * #7551: autosummary: a nested class is indexed as non-nested class

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -940,6 +940,25 @@ class ModuleDocumenter(Documenter):
                 )
         return False, ret
 
+    def sort_members(self, documenters: List[Tuple["Documenter", bool]],
+                     order: str) -> List[Tuple["Documenter", bool]]:
+        if order == 'bysource' and self.__all__:
+            # Sort alphabetically first (for members not listed on the __all__)
+            documenters.sort(key=lambda e: e[0].name)
+
+            # Sort by __all__
+            def keyfunc(entry: Tuple[Documenter, bool]) -> int:
+                name = entry[0].name.split('::')[1]
+                if name in self.__all__:
+                    return self.__all__.index(name)
+                else:
+                    return len(self.__all__)
+            documenters.sort(key=keyfunc)
+
+            return documenters
+        else:
+            return super().sort_members(documenters, order)
+
 
 class ModuleLevelDocumenter(Documenter):
     """

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -733,10 +733,8 @@ class Documenter:
                 # This is a reasonable assumption in Python 3.6 and up, where
                 # module.__dict__ is insertion-ordered.
                 pass
-        elif member_order == 'alphabetical':
+        else:  # alphabetical
             memberdocumenters.sort(key=lambda e: e[0].name)
-        else:
-            raise ValueError("Illegal member order {}".format(member_order))
 
         for documenter, isattr in memberdocumenters:
             documenter.generate(

--- a/tests/roots/test-ext-autodoc/target/sort_by_all.py
+++ b/tests/roots/test-ext-autodoc/target/sort_by_all.py
@@ -1,0 +1,25 @@
+__all__ = ['baz', 'foo', 'Bar']
+
+
+def foo():
+    pass
+
+
+class Bar:
+    pass
+
+
+def baz():
+    pass
+
+
+def qux():
+    pass
+
+
+class Quux:
+    pass
+
+
+def foobar():
+    pass

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -915,6 +915,40 @@ def test_autodoc_member_order(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_module_member_order(app):
+    # case member-order='bysource'
+    options = {"members": 'foo, Bar, baz, qux, Quux, foobar',
+               'member-order': 'bysource',
+               "undoc-members": True}
+    actual = do_autodoc(app, 'module', 'target.sort_by_all', options)
+    assert list(filter(lambda l: '::' in l, actual)) == [
+        '.. py:module:: target.sort_by_all',
+        '.. py:function:: baz()',
+        '.. py:function:: foo()',
+        '.. py:class:: Bar',
+        '.. py:class:: Quux',
+        '.. py:function:: foobar()',
+        '.. py:function:: qux()',
+    ]
+
+    # case member-order='bysource' and ignore-module-all
+    options = {"members": 'foo, Bar, baz, qux, Quux, foobar',
+               'member-order': 'bysource',
+               "undoc-members": True,
+               "ignore-module-all": True}
+    actual = do_autodoc(app, 'module', 'target.sort_by_all', options)
+    assert list(filter(lambda l: '::' in l, actual)) == [
+        '.. py:module:: target.sort_by_all',
+        '.. py:function:: foo()',
+        '.. py:class:: Bar',
+        '.. py:function:: baz()',
+        '.. py:function:: qux()',
+        '.. py:class:: Quux',
+        '.. py:function:: foobar()',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_module_scope(app):
     app.env.temp_data['autodoc:module'] = 'target'
     actual = do_autodoc(app, 'attribute', 'Class.mdocattr')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #3673 