### PR TITLE
basic CSS: avoid unnecessary padding to the left of line numbers

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -680,7 +680,7 @@ table.highlighttable td {
 }
 
 table.highlighttable td.linenos {
-    padding: 0 0.5em;
+    padding-right: 0.5em;
 }
 
 table.highlighttable td.code {


### PR DESCRIPTION
This is a follow-up to #7482.

I think it's very good to have some space between line numbers and the code block, but I don't think there needs to be additional empty space to the *left* of the line numbers.