### PR TITLE
CSS: Respect Pygments background color

### DIFF
--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -207,7 +207,6 @@ div.document .section:first-child {
 
 div.document div.highlight {
   padding: 3px;
-  background-color: #eeeeec;
   border-top: 2px solid #dddddd;
   border-bottom: 2px solid #dddddd;
   margin-top: .8em;

--- a/sphinx/themes/haiku/static/haiku.css_t
+++ b/sphinx/themes/haiku/static/haiku.css_t
@@ -319,7 +319,6 @@ pre {
     border-width: thin;
     margin: 0 0 12px 0;
     padding: 0.8em;
-    background-color: #f0f0f0;
 }
 
 hr {

--- a/sphinx/themes/nature/static/nature.css_t
+++ b/sphinx/themes/nature/static/nature.css_t
@@ -184,10 +184,6 @@ div.admonition p.admonition-title + p {
     display: inline;
 }
 
-div.highlight{
-    background-color: white;
-}
-
 div.note {
     background-color: #eee;
     border: 1px solid #ccc;
@@ -217,8 +213,6 @@ p.admonition-title:after {
  
 pre {
     padding: 10px;
-    background-color: White;
-    color: #222;
     line-height: 1.2em;
     border: 1px solid #C6C9CB;
     font-size: 1.1em;

--- a/sphinx/themes/pyramid/static/pyramid.css_t
+++ b/sphinx/themes/pyramid/static/pyramid.css_t
@@ -229,10 +229,6 @@ div.admonition {
     padding: 10px 20px 10px 60px;
 }
 
-div.highlight{
-    background-color: white;
-}
-
 div.note {
     border: 2px solid #7a9eec;
     border-right-style: none;
@@ -286,8 +282,6 @@ p.admonition-title:after {
  
 pre {
     padding: 10px;
-    background-color: #fafafa;
-    color: #222;
     line-height: 1.2em;
     border: 2px solid #C6C9CB;
     font-size: 1.1em;

--- a/sphinx/themes/scrolls/static/scrolls.css_t
+++ b/sphinx/themes/scrolls/static/scrolls.css_t
@@ -188,7 +188,7 @@ a:hover {
 }
 
 pre {
-    background: #ededed url(metal.png);
+    background-image: url(metal.png);
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
     padding: 5px;

--- a/sphinx/themes/sphinxdoc/static/sphinxdoc.css_t
+++ b/sphinx/themes/sphinxdoc/static/sphinxdoc.css_t
@@ -247,7 +247,6 @@ pre {
     line-height: 120%;
     padding: 0.5em;
     border: 1px solid #ccc;
-    background-color: #f8f8f8;
 }
 
 pre a {

--- a/sphinx/themes/traditional/static/traditional.css_t
+++ b/sphinx/themes/traditional/static/traditional.css_t
@@ -632,7 +632,6 @@ th {
 pre {
     font-family: monospace;
     padding: 5px;
-    color: #00008b;
     border-left: none;
     border-right: none;
 }


### PR DESCRIPTION
Most built-in themes set the background color of code blocks in some way, overriding the background color provided by Pygments. This means that Pygments styles with bright text colors will not be readable on the (typically bright) hard-coded background.

This PR removes the background color from all built-in themes except:

* `classic`, where there are custom theme options for code text and background colors [see ~#7720~ #7721]
* `scrolls`, which has a custom image as background