### PR TITLE
classic theme: remove codetextcolor/codebgcolor theme options

### DIFF
--- a/doc/usage/theming.rst
+++ b/doc/usage/theming.rst
@@ -219,9 +219,6 @@ These themes are:
   - **headbgcolor** (CSS color): Background color for headings.
   - **headtextcolor** (CSS color): Text color for headings.
   - **headlinkcolor** (CSS color): Link color for headings.
-  - **codebgcolor** (CSS color): Background color for code blocks.
-  - **codetextcolor** (CSS color): Default text color for code blocks, if not
-    set differently by the highlighting style.
 
   - **bodyfont** (CSS font-family): Font for normal text.
   - **headfont** (CSS font-family): Font for headings.

--- a/sphinx/themes/classic/static/classic.css_t
+++ b/sphinx/themes/classic/static/classic.css_t
@@ -278,8 +278,6 @@ p.admonition-title:after {
 
 pre {
     padding: 5px;
-    background-color: {{ theme_codebgcolor }};
-    color: {{ theme_codetextcolor }};
     line-height: 120%;
     border: 1px solid #ac9;
     border-left: none;

--- a/sphinx/themes/classic/theme.conf
+++ b/sphinx/themes/classic/theme.conf
@@ -25,8 +25,6 @@ headtextcolor    = #20435c
 headlinkcolor    = #c60f0f
 linkcolor        = #355f7c
 visitedlinkcolor = #355f7c
-codebgcolor      = #eeffcc
-codetextcolor    = #333333
 
 bodyfont = sans-serif
 headfont = 'Trebuchet MS', sans-serif

--- a/sphinx/themes/pyramid/static/epub.css
+++ b/sphinx/themes/pyramid/static/epub.css
@@ -273,8 +273,6 @@ p.admonition-title:after {
 
 pre {
     padding: 5px;
-    background-color: {{ theme_codebgcolor }};
-    color: {{ theme_codetextcolor }};
     line-height: 120%;
     border: 1px solid #ac9;
     border-left: none;


### PR DESCRIPTION
Since the config option `pygments_style` is supposed to take care of the code text and background colors, it doesn't make much sense to have those options a theme options.

However, removing them would be a breaking change for everyone who customizes those settings in their own `html_theme_options`.

Therefore, you probably don't want to merge this PR.