### PR TITLE
classic theme: default codetextcolor/codebgcolor doesn't override Pygments

### DIFF
--- a/sphinx/themes/classic/theme.conf
+++ b/sphinx/themes/classic/theme.conf
@@ -25,8 +25,8 @@ headtextcolor    = #20435c
 headlinkcolor    = #c60f0f
 linkcolor        = #355f7c
 visitedlinkcolor = #355f7c
-codebgcolor      = #eeffcc
-codetextcolor    = #333333
+codebgcolor      = unset
+codetextcolor    = unset
 
 bodyfont = sans-serif
 headfont = 'Trebuchet MS', sans-serif


### PR DESCRIPTION
A much better alternative to #7720.

With this PR, the Pygments colors (including background and text for `'none'` language) are used by default for code blocks.

However, `codetextcolor`/`codebgcolor` can still be used to override the colors.

Therefore, I wouldn't call this a "breaking" change (but this is debatable).