### PR TITLE
Add an include directive that allows one filetype to be included in another

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -708,6 +708,21 @@ __ http://pygments.org/docs/lexers
    .. versionchanged:: 2.1
       Added the ``force`` option.
 
+
+.. rst:directive:: .. docinclude:: filename
+
+   Includes another document in this one. Unlike :directive:`include`, this
+   allows inclusion of documents that use different parsers to their parent
+   document, such as including a markdown file in an rst file.
+
+   .. rst:directive:option:: start-line
+                             end-line
+                             start-after
+                             end-after
+                             encoding
+
+      Options treated the same way as the :rst:dir:`include` directive.
+
 .. _glossary-directive:
 
 Glossary

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -711,7 +711,7 @@ __ http://pygments.org/docs/lexers
 
 .. rst:directive:: .. docinclude:: filename
 
-   Includes another document in this one. Unlike :directive:`include`, this
+   Includes another document in this one. Unlike :rst:dir:`include`, this
    allows inclusion of documents that use different parsers to their parent
    document, such as including a markdown file in an rst file.
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -393,7 +393,6 @@ class IncludeDocument(SphinxDirective):
             path = os.path.join(self.standard_include_path, path[1:-1])
         path = os.path.normpath(os.path.join(source_dir, path))
         path = relative_path(None, path)
-        path = nodes.reprunicode(path)
         encoding = self.options.get(
             'encoding', self.state.document.settings.input_encoding)
         e_handler = self.state.document.settings.input_encoding_error_handler


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Primarily to allow markdown files to be included within rst files (like `m2r`'s `.. mdinclude`
- Works for all other input parsers too

Upstreaming from https://github.com/pygae/galgebra/pull/413, where this was very useful