### PR TITLE
Test with python 3.10 (in master)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,12 @@ jobs:
       env:
         - TOXENV=du16
         - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
-    - python: 'nightly'
+    - python: '3.9-dev'
       env:
         - TOXENV=py39
+    - python: 'nightly'
+      env:
+        - TOXENV=py310
     - python: '3.6'
       env: TOXENV=docs
     - python: '3.6'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
It seems "nightly" python in Travis CI has been changed to 3.10.0a0.
This starts to test with 3.10!
