### PR TITLE
Fix bug in mathjax: newest 2.x version not being loaded by latest.js

### DIFF
--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -96,7 +96,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # more information for mathjax secure url is here:
     # https://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn
     app.add_config_value('mathjax_path',
-                         'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?'
+                         'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?'
                          'config=TeX-AMS-MML_HTMLorMML', 'html')
     app.add_config_value('mathjax_options', {}, 'html')
     app.add_config_value('mathjax_inline', [r'\(', r'\)'], 'html')

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -71,7 +71,7 @@ def test_mathjax_options(app, status, warning):
 
     content = (app.outdir / 'index.html').read_text()
     assert ('<script async="async" integrity="sha384-0123456789" '
-            'src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?'
+            'src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?'
             'config=TeX-AMS-MML_HTMLorMML"></script>' in content)
 
 


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
There is a bug in `latest.js` in versions 2.7.5 and below; when the current version on the CDN is 3.0 or higher, `latest.js` will not use the highest version of 2.x, but instead will use the version from which `latest.js` has been taken. As such, the sphinx-mathjax extension is stuck loading MathJax 2.7.5 from the CDN, whereas `latest.js` _should_ be loading the newest 2.x version.

See the warning section on this page:  http://docs.mathjax.org/en/latest/upgrading/v2.html

This PR fixes that by pointing to 2.7.7, the latest 2.X version available on the CDN.
