### PR TITLE
coverage ext - config to log missing coverage

### DIFF
--- a/doc/usage/extensions/coverage.rst
+++ b/doc/usage/extensions/coverage.rst
@@ -51,4 +51,11 @@ should check:
 
    .. versionadded:: 1.1
 
+.. conval:: coverage_show_missing_items 
+
+   Print objects that are missing to standard output also.
+   ``False`` by default.
+
+   .. versionadded:: 3.1
+
 .. _Python regular expressions: https://docs.python.org/library/re

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -22,9 +22,7 @@ from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.locale import __
 from sphinx.util import logging
-from sphinx.util.console import (  # type: ignore
-    blue, darkblue, darkgreen, green, red, teal, turquoise
-)
+from sphinx.util.console import red  # type: ignore
 from sphinx.util.inspect import safe_getattr
 
 logger = logging.getLogger(__name__)

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -22,6 +22,9 @@ from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.locale import __
 from sphinx.util import logging
+from sphinx.util.console import (  # type: ignore
+    blue, darkblue, darkgreen, green, red, teal, turquoise
+)
 from sphinx.util.inspect import safe_getattr
 
 logger = logging.getLogger(__name__)
@@ -121,6 +124,14 @@ class CoverageBuilder(Builder):
                 write_header(op, filename)
                 for typ, name in sorted(undoc):
                     op.write(' * %-50s [%9s]\n' % (name, typ))
+                    if self.config.coverage_print_missing_c_items:
+                        if self.app.quiet or self.app.warningiserror:
+                            logger.warning(__('undocumented c api: %s [%s] in file %s'),
+                                           name, typ, filename)
+                        else:
+                            logger.info(red('undocumented  ') + darkgreen('c   ') +
+                                        darkblue('api       ') + '%-30s' % (name + " [%9s]" % typ) +
+                                        red(' - in file ') + filename)
                 op.write('\n')
 
     def ignore_pyobj(self, full_name: str) -> bool:
@@ -239,16 +250,46 @@ class CoverageBuilder(Builder):
                     if undoc['funcs']:
                         op.write('Functions:\n')
                         op.writelines(' * %s\n' % x for x in undoc['funcs'])
+                        if self.config.coverage_print_missing_py_items:
+                            if self.app.quiet or self.app.warningiserror:
+                                for func in undoc['funcs']:
+                                    logger.warning(__('undocumented python function: %s :: %s'),
+                                                   name, func)
+                            else:
+                                for func in undoc['funcs']:
+                                    logger.info(red('undocumented  ') + green('py  ') +
+                                                teal('function  ') + '%-30s' % func +
+                                                red(' - in module ') + name)
                         op.write('\n')
                     if undoc['classes']:
                         op.write('Classes:\n')
-                        for name, methods in sorted(
+                        for class_name, methods in sorted(
                                 undoc['classes'].items()):
                             if not methods:
-                                op.write(' * %s\n' % name)
+                                op.write(' * %s\n' % class_name)
+                                if self.config.coverage_print_missing_py_items:
+                                    if self.app.quiet or self.app.warningiserror:
+                                        logger.warning(__('undocumented python class: %s :: %s'),
+                                                       name, class_name)
+                                    else:
+                                        logger.info(red('undocumented  ') + green('py  ') +
+                                                    blue('class     ') + '%-30s' % class_name +
+                                                    red(' - in module ') + name)
                             else:
-                                op.write(' * %s -- missing methods:\n\n' % name)
+                                op.write(' * %s -- missing methods:\n\n' % class_name)
                                 op.writelines('   - %s\n' % x for x in methods)
+                                if self.config.coverage_print_missing_py_items:
+                                    if self.app.quiet or self.app.warningiserror:
+                                        for meth in methods:
+                                            logger.warning(
+                                                __('undocumented python method: %s :: %s :: %s'),
+                                                name, class_name, meth)
+                                    else:
+                                        for meth in methods:
+                                            logger.info(red('undocumented  ') + green('py  ') +
+                                                        turquoise('method    ') + '%-30s' %
+                                                        (class_name + '.' + meth) +
+                                                        red(' - in module ') + name)
                         op.write('\n')
 
             if failed:
@@ -273,4 +314,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('coverage_ignore_c_items', {}, False)
     app.add_config_value('coverage_write_headline', True, False)
     app.add_config_value('coverage_skip_undoc_in_source', False, False)
+    app.add_config_value('coverage_print_missing_c_items', False, False)
+    app.add_config_value('coverage_print_missing_py_items', False, False)
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -129,8 +129,7 @@ class CoverageBuilder(Builder):
                             logger.warning(__('undocumented c api: %s [%s] in file %s'),
                                            name, typ, filename)
                         else:
-                            logger.info(red('undocumented  ') + darkgreen('c   ') +
-                                        darkblue('api       ') +
+                            logger.info(red('undocumented  ') + 'c   ' + 'api       ' +
                                         '%-30s' % (name + " [%9s]" % typ) +
                                         red(' - in file ') + filename)
                 op.write('\n')
@@ -259,9 +258,8 @@ class CoverageBuilder(Builder):
                                         name, func)
                             else:
                                 for func in undoc['funcs']:
-                                    logger.info(red('undocumented  ') + green('py  ') +
-                                                teal('function  ') + '%-30s' % func +
-                                                red(' - in module ') + name)
+                                    logger.info(red('undocumented  ') + 'py  ' + 'function  ' +
+                                                '%-30s' % func + red(' - in module ') + name)
                         op.write('\n')
                     if undoc['classes']:
                         op.write('Classes:\n')
@@ -275,8 +273,8 @@ class CoverageBuilder(Builder):
                                             __('undocumented python class: %s :: %s'),
                                             name, class_name)
                                     else:
-                                        logger.info(red('undocumented  ') + green('py  ') +
-                                                    blue('class     ') + '%-30s' % class_name +
+                                        logger.info(red('undocumented  ') + 'py  ' +
+                                                    'class     ' + '%-30s' % class_name +
                                                     red(' - in module ') + name)
                             else:
                                 op.write(' * %s -- missing methods:\n\n' % class_name)
@@ -290,8 +288,8 @@ class CoverageBuilder(Builder):
                                                 name, class_name, meth)
                                     else:
                                         for meth in methods:
-                                            logger.info(red('undocumented  ') + green('py  ') +
-                                                        turquoise('method    ') + '%-30s' %
+                                            logger.info(red('undocumented  ') + 'py  ' +
+                                                        'method    ' + '%-30s' %
                                                         (class_name + '.' + meth) +
                                                         red(' - in module ') + name)
                         op.write('\n')

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -124,7 +124,7 @@ class CoverageBuilder(Builder):
                 write_header(op, filename)
                 for typ, name in sorted(undoc):
                     op.write(' * %-50s [%9s]\n' % (name, typ))
-                    if self.config.coverage_print_missing_c_items:
+                    if self.config.coverage_show_missing_items:
                         if self.app.quiet or self.app.warningiserror:
                             logger.warning(__('undocumented c api: %s [%s] in file %s'),
                                            name, typ, filename)
@@ -250,7 +250,7 @@ class CoverageBuilder(Builder):
                     if undoc['funcs']:
                         op.write('Functions:\n')
                         op.writelines(' * %s\n' % x for x in undoc['funcs'])
-                        if self.config.coverage_print_missing_py_items:
+                        if self.config.coverage_show_missing_items:
                             if self.app.quiet or self.app.warningiserror:
                                 for func in undoc['funcs']:
                                     logger.warning(__('undocumented python function: %s :: %s'),
@@ -267,7 +267,7 @@ class CoverageBuilder(Builder):
                                 undoc['classes'].items()):
                             if not methods:
                                 op.write(' * %s\n' % class_name)
-                                if self.config.coverage_print_missing_py_items:
+                                if self.config.coverage_show_missing_items:
                                     if self.app.quiet or self.app.warningiserror:
                                         logger.warning(__('undocumented python class: %s :: %s'),
                                                        name, class_name)
@@ -278,7 +278,7 @@ class CoverageBuilder(Builder):
                             else:
                                 op.write(' * %s -- missing methods:\n\n' % class_name)
                                 op.writelines('   - %s\n' % x for x in methods)
-                                if self.config.coverage_print_missing_py_items:
+                                if self.config.coverage_show_missing_items:
                                     if self.app.quiet or self.app.warningiserror:
                                         for meth in methods:
                                             logger.warning(
@@ -314,6 +314,5 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('coverage_ignore_c_items', {}, False)
     app.add_config_value('coverage_write_headline', True, False)
     app.add_config_value('coverage_skip_undoc_in_source', False, False)
-    app.add_config_value('coverage_print_missing_c_items', False, False)
-    app.add_config_value('coverage_print_missing_py_items', False, False)
+    app.add_config_value('coverage_show_missing_items', False, False)
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -130,7 +130,8 @@ class CoverageBuilder(Builder):
                                            name, typ, filename)
                         else:
                             logger.info(red('undocumented  ') + darkgreen('c   ') +
-                                        darkblue('api       ') + '%-30s' % (name + " [%9s]" % typ) +
+                                        darkblue('api       ') +
+                                        '%-30s' % (name + " [%9s]" % typ) +
                                         red(' - in file ') + filename)
                 op.write('\n')
 
@@ -253,8 +254,9 @@ class CoverageBuilder(Builder):
                         if self.config.coverage_show_missing_items:
                             if self.app.quiet or self.app.warningiserror:
                                 for func in undoc['funcs']:
-                                    logger.warning(__('undocumented python function: %s :: %s'),
-                                                   name, func)
+                                    logger.warning(
+                                        __('undocumented python function: %s :: %s'),
+                                        name, func)
                             else:
                                 for func in undoc['funcs']:
                                     logger.info(red('undocumented  ') + green('py  ') +
@@ -269,8 +271,9 @@ class CoverageBuilder(Builder):
                                 op.write(' * %s\n' % class_name)
                                 if self.config.coverage_show_missing_items:
                                     if self.app.quiet or self.app.warningiserror:
-                                        logger.warning(__('undocumented python class: %s :: %s'),
-                                                       name, class_name)
+                                        logger.warning(
+                                            __('undocumented python class: %s :: %s'),
+                                            name, class_name)
                                     else:
                                         logger.info(red('undocumented  ') + green('py  ') +
                                                     blue('class     ') + '%-30s' % class_name +
@@ -282,7 +285,8 @@ class CoverageBuilder(Builder):
                                     if self.app.quiet or self.app.warningiserror:
                                         for meth in methods:
                                             logger.warning(
-                                                __('undocumented python method: %s :: %s :: %s'),
+                                                __('undocumented python method:' +
+                                                   ' %s :: %s :: %s'),
                                                 name, class_name, meth)
                                     else:
                                         for meth in methods:

--- a/tests/test_ext_coverage.py
+++ b/tests/test_ext_coverage.py
@@ -28,6 +28,8 @@ def test_build(app, status, warning):
 
     assert ' * mod -- No module named mod'  # in the "failed import" section
 
+    assert "undocumented  py" not in status.getvalue()
+
     c_undoc = (app.outdir / 'c.txt').read_text()
     assert c_undoc.startswith('Undocumented C API elements\n'
                               '===========================\n')
@@ -45,6 +47,8 @@ def test_build(app, status, warning):
     assert 'classes' in undoc_py['autodoc_target']
     assert 'Class' in undoc_py['autodoc_target']['classes']
     assert 'undocmeth' in undoc_py['autodoc_target']['classes']['Class']
+
+    assert "undocumented  c" not in status.getvalue()
 
 
 @pytest.mark.sphinx('coverage', testroot='ext-coverage')
@@ -64,3 +68,16 @@ Classes:
 
 '''
     assert actual == expected
+
+
+@pytest.mark.sphinx('coverage', confoverrides={'coverage_show_missing_items': True})
+def test_show_missing_items(app, status, warning):
+    app.builder.build_all()
+
+    assert "undocumented" in status.getvalue()
+
+    assert "py  function  raises" in status.getvalue()
+    assert "py  class     Base" in status.getvalue()
+    assert "py  method    Class.roger" in status.getvalue()
+
+    assert "c   api       Py_SphinxTest [ function]" in status.getvalue()

--- a/tests/test_ext_coverage.py
+++ b/tests/test_ext_coverage.py
@@ -81,3 +81,15 @@ def test_show_missing_items(app, status, warning):
     assert "py  method    Class.roger" in status.getvalue()
 
     assert "c   api       Py_SphinxTest [ function]" in status.getvalue()
+
+
+@pytest.mark.sphinx('coverage', confoverrides={'coverage_show_missing_items': True})
+def test_show_missing_items_quiet(app, status, warning):
+    app.quiet = True
+    app.builder.build_all()
+
+    assert "undocumented python function: autodoc_target :: raises" in warning.getvalue()
+    assert "undocumented python class: autodoc_target :: Base" in warning.getvalue()
+    assert "undocumented python method: autodoc_target :: Class :: roger" in warning.getvalue()
+
+    assert "undocumented c api: Py_SphinxTest [function]" in warning.getvalue()


### PR DESCRIPTION
Subject: coverage ext - config to log missing coverage


### Feature or Bugfix
<!-- please choose -->
- Feature


### Purpose
When running the `coverage` builder the output is written to files only. This feature let the output also be printed to console.

One can then also use the `coverage` builder in CI pipelines as a check with `-W` flag.


### Detail
- Added `coverage_print_missing_c_items` config var (default: `False`)
  When set to `True` undocumented c api elements are logged on `info` level.
  When a `quiet` or `warning is error` flag is set undocumented c api elements are logged on `warning` level (like `linkcheck` builder does)
- Added `coverage_print_missing_py_items` config var (default: `False`)
  When set to `True` undocumented python objects are logged on `info` level.
  When a `quiet` or `warning is error` flag is set undocumented python objects are logged on `warning` level (like `linkcheck` builder does)

### Relates
- Fixes #7758 

