### PR TITLE
C and C++, don't crash during stringification

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+- #7763: C and C++, don't crash during display stringification of unary
+  expressions and fold expressions.
+
 Testing
 --------
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -424,9 +424,9 @@ class ASTUnaryOpExpr(ASTExpression):
 
     def _stringify(self, transform: StringifyTransform) -> str:
         if self.op[0] in 'cn':
-            return transform(self.op) + " " + transform(self.expr)
+            return self.op + " " + transform(self.expr)
         else:
-            return transform(self.op) + transform(self.expr)
+            return self.op + transform(self.expr)
 
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -906,12 +906,12 @@ class ASTFoldExpr(ASTExpression):
         if self.leftExpr:
             res.append(transform(self.leftExpr))
             res.append(' ')
-            res.append(transform(self.op))
+            res.append(self.op)
             res.append(' ')
         res.append('...')
         if self.rightExpr:
             res.append(' ')
-            res.append(transform(self.op))
+            res.append(self.op)
             res.append(' ')
             res.append(transform(self.rightExpr))
         res.append(')')
@@ -1178,9 +1178,9 @@ class ASTUnaryOpExpr(ASTExpression):
 
     def _stringify(self, transform: StringifyTransform) -> str:
         if self.op[0] in 'cn':
-            return transform(self.op) + " " + transform(self.expr)
+            return self.op + " " + transform(self.expr)
         else:
-            return transform(self.op) + transform(self.expr)
+            return self.op + transform(self.expr)
 
     def get_id(self, version: int) -> str:
         return _id_operator_unary_v2[self.op] + self.expr.get_id(version)

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -96,6 +96,15 @@ def test_expressions():
             print("Result:   ", res)
             print("Expected: ", output)
             raise DefinitionError("")
+        displayString = ast.get_display_string()
+        if res != displayString:
+            # note: if the expression contains an anon name then this will trigger a falsely
+            print("")
+            print("Input:    ", expr)
+            print("Result:   ", res)
+            print("Display:  ", displayString)
+            raise DefinitionError("")
+
     # type expressions
     exprCheck('int*')
     exprCheck('int *const*')

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -125,6 +125,15 @@ def test_expressions():
             print("Input:    ", expr)
             print("Result:   ", res)
             raise DefinitionError("")
+        displayString = ast.get_display_string()
+        if res != displayString:
+            # note: if the expression contains an anon name then this will trigger a falsely
+            print("")
+            print("Input:    ", expr)
+            print("Result:   ", res)
+            print("Display:  ", displayString)
+            raise DefinitionError("")
+
     # primary
     exprCheck('nullptr', 'LDnE')
     exprCheck('true', 'L1E')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
When generating display strings for unary expressions and fold expressions, use the op directly instead of trying to transform it.

### Detail
Fixes #7763