### PR TITLE
Let option directive support args in the form of foo[=bar]

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 # RE for option descriptions
-option_desc_re = re.compile(r'((?:/|--|-|\+)?[^\s=]+)(=?\s*.*)')
+option_desc_re = re.compile(r'((?:/|--|-|\+)?[^\s=[]+)(=?\s*.*)')
 # RE for grammar tokens
 token_re = re.compile(r'`(\w+)`', re.U)
 

--- a/tests/roots/test-root/objects.txt
+++ b/tests/roots/test-root/objects.txt
@@ -180,7 +180,9 @@ Others
 
 .. option:: arg
 
-Link to :option:`perl +p`, :option:`--ObjC++`, :option:`--plugin.option`, :option:`create-auth-token` and :option:`arg`
+.. option:: -j[=N]
+
+Link to :option:`perl +p`, :option:`--ObjC++`, :option:`--plugin.option`, :option:`create-auth-token`, :option:`arg` and :option:`-j`
 
 .. program:: hg
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -331,6 +331,8 @@ def test_html4_output(app, status, warning):
          'create-auth-token'),
         (".//a[@class='reference internal'][@href='#cmdoption-perl-arg-arg']/code/span",
          'arg'),
+        (".//a[@class='reference internal'][@href='#cmdoption-perl-j']/code/span",
+         '-j'),
         (".//a[@class='reference internal'][@href='#cmdoption-hg-arg-commit']/code/span",
          'hg'),
         (".//a[@class='reference internal'][@href='#cmdoption-hg-arg-commit']/code/span",


### PR DESCRIPTION
Subject: Let `.. option` directive support args in the form of foo[=bar]

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- 50% bugfix 50% feature?

### Purpose
In the [Cabal](https://github.com/haskell/cabal) documentation, there are a lot of flags that can work like `--foo` or `--foo[=N]`. These are all documented with the `.. option` directive but because of the way they were parsed, we couldn't refer to the options as ":option:`-j`", since they were parsed as `--foo[` being the option name and `=N]` being an argument.

### Detail
- This tweaks the regex so that `[` is treated in the same manner as `=` when it comes to splitting up the name and the arguments

### Relates
https://github.com/haskell/cabal/pull/6754

