### PR TITLE
[doc] Modify branch policy (again! :))

### DIFF
--- a/doc/internals/release-process.rst
+++ b/doc/internals/release-process.rst
@@ -5,22 +5,19 @@ Sphinx's release process
 Branch Model
 ------------
 
-Sphinx project uses following branches for developing that conforms to Semantic
-Versioning 2.0.0 (refs: https://semver.org/ ).
+Sphinx project uses following branches for developing that conforms to
+`Semantic Versioning 2.0.0`__.
+
+.. __: https://semver.org/
 
 ``master``
-    Development for MAJOR version.
-    All changes including incompatible behaviors and public API updates are
-    allowed.
+    Development for next release. Typically this is a MINOR release. New
+    features are allowed but must be backwards-compatible, preserving API
+    compatibility.
 
-``A.x`` (ex. ``2.x``)
-    Where ``A.x`` is the ``MAJOR.MINOR`` release.  Used to maintain current
-    MINOR release. All changes are allowed if the change preserves
-    backwards-compatibility of API and features.
-
-    Only the most recent ``MAJOR.MINOR`` branch is currently retained. When a
-    new MAJOR version is released, the old ``MAJOR.MINOR`` branch will be
-    deleted and replaced by an equivalent tag.
+``devel``
+    Development for the next MAJOR release. All changes including incompatible
+    behaviors and public API updates are allowed.
 
 ``A.B.x`` (ex. ``2.4.x``)
     Where ``A.B.x`` is the ``MAJOR.MINOR.PATCH`` release.  Only
@@ -28,9 +25,18 @@ Versioning 2.0.0 (refs: https://semver.org/ ).
     version is used for urgent bug fix.
 
     ``MAJOR.MINOR.PATCH`` branch will be branched from the ``v`` prefixed
-    release tag (ex. make 2.3.1 that branched from v2.3.0) when a urgent
-    release is needed. When new PATCH version is released, the branch will be
-    deleted and replaced by an equivalent tag (ex. v2.3.1).
+    release tag (for example, make ``2.3.1`` that branched from ``v2.3.0``)
+    when a urgent release is needed. When new PATCH version is released, the
+    branch will be deleted and replaced by an equivalent tag (ex. v2.3.1).
+
+
+Release schedule
+----------------
+
+Sphinx uses a time-based release schedule with releases roughly every three
+months. Every fourth release is a major version, in which it is possible to
+make :ref:`breaking changes <deprecation-policy>`. Future releases are listed
+on `GitHub <https://github.com/sphinx-doc/sphinx/milestones>`.
 
 
 Deprecating a feature


### PR DESCRIPTION
Once again, I'm discussing branching policy. Yes, I am a broken record :smile: Sorry!

I am still finding the branching policy extremely confusing. There are a couple of reasons for this:

1. While Git allows you to configure a different default branch to master, tradition dictates that master is the branch where most action should occur. While we do document our branch policy very well, you have to think about the fact you're doing things differently to most projects.
2. Most tooling expects people to be using master by default. For example, the `hub` tool I use defaults to `master`, as do many aliases I have configured. Ditto for CI tools.
3. No other projects seem to use this model, which means you *have* to read the docs to understand why things are done they way they are.

While I still disagree with the idea that a *next major version* branch is needed (Django is much bigger and they don't have one, to take but one example), I do realize this is something that is wanted. This change suggests changing from using `master` for the next major version and `3.x` for the next minor version, to using `master` for the next version (minor or major, depending on what the next release is expected to be) and `devel` for the next MAJOR version. A snapshot of this is described below.

+----------------+-----------------------+----------------------+
| Latest release | `master` next release | `devel` next release |
+----------------+-----------------------+----------------------+
| 3.0.x          | 3.1.0                 | 4.0.0                |
+----------------+-----------------------+----------------------+
| 3.1.x          | 3.2.0                 | 4.0.0                |
+----------------+-----------------------+----------------------+
| 3.3.x          | 4.0.0                 | 5.0.0                |
+----------------+-----------------------+----------------------+

(this assumes 3.3.0 would be the last MINOR release in the 3.x series)

I think this would encourage people to focus on backwards-compatible changes, it would benefit those with lots of CLI tooling and it would make Sphinx's release process a little more normal.

What do you think?