### PR TITLE
Fix #7723: LaTeX: pdflatex crashed when URL contains a single quote

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -130,6 +130,7 @@ Bugs fixed
 * #7646: handle errors on event handlers
 * #4187: LaTeX: EN DASH disappears from PDF bookmarks in Japanese documents
 * #7701: LaTeX: Anonymous indirect hyperlink target causes duplicated labels
+* #7723: LaTeX: pdflatex crashed when URL contains a single quote
 * #7756: py domain: The default value for positional only argument is not shown
 * C++, fix rendering and xrefs in nested names explicitly starting
   in global scope, e.g., ``::A::B``.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1977,7 +1977,8 @@ class LaTeXTranslator(SphinxTranslator):
         #       mainly, %, #, {, } and \ need escaping via a \ escape
         # in \href, the tilde is allowed and must be represented literally
         return self.encode(text).replace('\\textasciitilde{}', '~').\
-            replace('\\sphinxhyphen{}', '-')
+            replace('\\sphinxhyphen{}', '-').\
+            replace('\\textquotesingle{}', "'")
 
     def visit_Text(self, node: Text) -> None:
         text = self.encode(node.astext())


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7723 