### PR TITLE
Fix reported dir when throwing ApplicationError

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -165,7 +165,7 @@ class Sphinx:
 
         if path.exists(self.outdir) and not path.isdir(self.outdir):
             raise ApplicationError(__('Output directory (%s) is not a directory') %
-                                   self.srcdir)
+                                   self.outdir)
 
         if self.srcdir == self.outdir:
             raise ApplicationError(__('Source directory and destination '


### PR DESCRIPTION
if path.exists(self.outdir) and not path.isdir(self.outdir), error reported self.srcdir which should be self.outdir

Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- fix error message regarding output directory

### Detail
-  


