### PR TITLE
Fix 'Values object has no attribute tab_width' crash when processing markdown

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -57,6 +57,7 @@ default_settings = {
     'halt_level': 5,
     'file_insertion_enabled': True,
     'smartquotes_locales': [],
+    'tab_width': 8,
 }  # type: Dict[str, Any]
 
 # This is increased every time an environment attribute is added


### PR DESCRIPTION
I'm processing some markdown and get this crash (I've only shown the last bit of the traceback):

```
  File "/Users/william/Development/python-virtualenv/lib/python3.6/site-packages/sphinx_markdown_parser/transform.py", line 309, in find_replace
    newnode = self.auto_code_block(node)
  File "/Users/william/Development/python-virtualenv/lib/python3.6/site-packages/sphinx_markdown_parser/transform.py", line 283, in auto_code_block
    parser.parse(newsource, new_doc)
  File "/Users/william/Development/python-virtualenv/lib/python3.6/site-packages/docutils/parsers/rst/__init__.py", line 189, in parse
    inputstring, tab_width=document.settings.tab_width,
AttributeError: 'Values' object has no attribute 'tab_width'
```

On the face of it the fix is obvious, but I may be missing the big picture.
