### PR TITLE
[RFC] Revisit/improve generating of ids (`_make_id`)

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -447,16 +447,15 @@ def _make_id(string: str) -> str:
     id = string.translate(_non_id_translate_digraphs)
     id = id.translate(_non_id_translate)
     # get rid of non-ascii characters.
-    # 'ascii' lowercase to prevent problems with turkish locale.
-    id = unicodedata.normalize('NFKD', id).encode('ascii', 'ignore').decode('ascii')
-    # shrink runs of whitespace and replace by hyphen
+    id = unicodedata.normalize('NFKD', id).encode('ascii', 'backslashreplace').decode('ascii')
+    # shrink runs of whitespace and replace by single hyphen.
+    id = '-'.join(id.split())
+    # replace non-id chars with hyphens.
     id = _non_id_chars.sub('-', ' '.join(id.split()))
-    id = _non_id_at_ends.sub('', id)
-    return str(id)
+    return id
 
 
-_non_id_chars = re.compile('[^a-zA-Z0-9._]+')
-_non_id_at_ends = re.compile('^[-0-9._]+|-+$')
+_non_id_chars = re.compile('[^a-zA-Z0-9._]')
 _non_id_translate = {
     0x00f8: u'o',       # o with stroke
     0x0111: u'd',       # d with stroke

--- a/tests/test_util_nodes.py
+++ b/tests/test_util_nodes.py
@@ -191,13 +191,19 @@ def test_clean_astext():
         ('term', 'Sphinx', 'term-Sphinx'),
         ('', 'io.StringIO', 'io.StringIO'),   # contains a dot
         ('', 'sphinx.setup_command', 'sphinx.setup_command'),  # contains a dot & underscore
-        ('', '_io.StringIO', 'io.StringIO'),  # starts with underscore
+        ('', '_io.StringIO', '_io.StringIO'),  # starts with underscore
+        ('', 'term_', 'term_'),  # ends with underscore
+        ('', '.surrounded.with.dots.', '.surrounded.with.dots.'),
+        ('', '  with  whitespace  ', 'with-whitespace'),
         ('', 'ｓｐｈｉｎｘ', 'sphinx'),  # alphabets in unicode fullwidth characters
-        ('', '悠好', 'id0'),  # multibytes text (in Chinese)
-        ('', 'Hello=悠好=こんにちは', 'Hello'),  # alphabets and multibytes text
-        ('', 'fünf', 'funf'),  # latin1 (umlaut)
-        ('', '0sphinx', 'sphinx'),  # starts with number
-        ('', 'sphinx-', 'sphinx'),  # ends with hyphen
+        ('', '悠好', '-u60a0-u597d'),  # multibytes text (in Chinese)
+        ('', 'Hello=悠好=こんにちは', 'Hello--u60a0-u597d--u3053-u3093-u306b-u3061-u306f'),  # alphabets and multibytes text
+        ('', 'fünf', 'fu-u0308nf'),  # latin1 (umlaut)
+        ('', 'foo::bar', 'foo--bar'),  # two non-id (but ascii) chars
+        ('', '0sphinx', '0sphinx'),  # starts with number
+        ('', 'sphinx0', 'sphinx0'),  # ends with number
+        ('', '-sphinx', '-sphinx'),  # starts with hyphen
+        ('', 'sphinx-', 'sphinx-'),  # ends with hyphen
     ])
 def test_make_id(app, prefix, term, expected):
     document = create_new_document()


### PR DESCRIPTION
This started by looking into keeping leading underscores (since
`_foo.bar` is different than `foo.bar`).

From the commit message:

- use "backslashreplace" to not ignore non-ascii characters in general
  ("fünf" will get another id than "fnf")
- keep dots and underscores at the beginning also
- use a separate hyphen for replacement of each non-id (ascii) character
  ("foo::bar" becomes "foo--bar" instead of "foo-bar") - runs of
  whitespace are still replaced by a single hypehn

Ref: https://github.com/sphinx-doc/sphinx/issues/7301 (/cc @mgeier @jakobandersen)