### PR TITLE
Fix #7802: autodoc: EOFError is raised on parallel build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Features added
 Bugs fixed
 ----------
 
+* #7802: autodoc: EOFError is raised on parallel build
 * #7811: sphinx.util.inspect causes circular import problem
 
 Testing

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -422,9 +422,9 @@ class Documenter:
                     if matched:
                         args = matched.group(1)
                         retann = matched.group(2)
-            except Exception:
-                logger.warning(__('error while formatting arguments for %s:') %
-                               self.fullname, type='autodoc', exc_info=True)
+            except Exception as exc:
+                logger.warning(__('error while formatting arguments for %s: %s'),
+                               self.fullname, exc, type='autodoc')
                 args = None
 
         result = self.env.events.emit_firstresult('autodoc-process-signature',
@@ -795,8 +795,8 @@ class Documenter:
             # parse right now, to get PycodeErrors on parsing (results will
             # be cached anyway)
             self.analyzer.find_attr_docs()
-        except PycodeError:
-            logger.debug('[autodoc] module analyzer failed:', exc_info=True)
+        except PycodeError as exc:
+            logger.debug('[autodoc] module analyzer failed: %s', exc)
             # no source file -- e.g. for builtin and C modules
             self.analyzer = None
             # at least add the module.__file__ as a dependency


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
sphinx-build has crashed with EOFError when autodoc raises a warning
having exc_info under parallel mode.  In parallel mode, all messages
are pickled to transfer logs to parent process.  But the warning is
not picklable because it contains a traceback object.

This removes exc_info from warning messages to prevent crashes.

cc: @eric-wieser 

refs: #7802 