### PR TITLE
Fix #7805: autodoc: an object which descriptors returns is documented

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 * #7808: autodoc: Warnings raised on variable and attribute type annotations
 * #7802: autodoc: EOFError is raised on parallel build
 * #7821: autodoc: TypeError is raised for overloaded C-ext function
+* #7805: autodoc: an object which descriptors returns is unexpectedly documented
 * #7812: autosummary: generates broken stub files if the target code contains
   an attribute and module that are same name
 * #7808: napoleon: Warnings raised on variable and attribute type annotations

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1929,6 +1929,17 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
         else:
             self.add_line('   :annotation: %s' % self.options.annotation, sourcename)
 
+    def get_doc(self, encoding: str = None, ignore: int = None) -> List[List[str]]:
+        try:
+            # Disable `autodoc_inherit_docstring` temporarily to avoid to obtain
+            # a docstring from the value which descriptor returns unexpectedly.
+            # ref: https://github.com/sphinx-doc/sphinx/issues/7805
+            orig = self.env.config.autodoc_inherit_docstrings
+            self.env.config.autodoc_inherit_docstrings = False  # type: ignore
+            return super().get_doc(encoding, ignore)
+        finally:
+            self.env.config.autodoc_inherit_docstrings = orig  # type: ignore
+
     def add_content(self, more_content: Any, no_docstring: bool = False) -> None:
         if not self._datadescriptor:
             # if it's not a data descriptor, its docstring is very probably the


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7805 