### PR TITLE
Add debug logs for change detection of sources and templates

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -12,6 +12,7 @@ import html
 import posixpath
 import re
 import sys
+from datetime import datetime
 from os import path
 from typing import Any, Dict, IO, Iterable, Iterator, List, Set, Tuple, Type
 
@@ -344,6 +345,7 @@ class StandaloneHTMLBuilder(Builder):
                 buildinfo = BuildInfo.load(fp)
 
             if self.build_info != buildinfo:
+                logger.debug('[build target] did not match: build_info ')
                 yield from self.env.found_docs
                 return
         except ValueError as exc:
@@ -358,6 +360,7 @@ class StandaloneHTMLBuilder(Builder):
             template_mtime = 0
         for docname in self.env.found_docs:
             if docname not in self.env.all_docs:
+                logger.debug('[build target] did not in env: %r', docname)
                 yield docname
                 continue
             targetname = self.get_outfilename(docname)
@@ -369,6 +372,14 @@ class StandaloneHTMLBuilder(Builder):
                 srcmtime = max(path.getmtime(self.env.doc2path(docname)),
                                template_mtime)
                 if srcmtime > targetmtime:
+                    logger.debug(
+                        '[build target] targetname %r(%s), template(%s), docname %r(%s)',
+                        targetname,
+                        datetime.utcfromtimestamp(targetmtime),
+                        datetime.utcfromtimestamp(template_mtime),
+                        docname,
+                        datetime.utcfromtimestamp(path.getmtime(self.env.doc2path(docname))),
+                    )
                     yield docname
             except OSError:
                 # source doesn't exist anymore

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -12,6 +12,7 @@ import os
 import pickle
 from collections import defaultdict
 from copy import copy
+from datetime import datetime
 from os import path
 from typing import Any, Callable, Dict, Generator, Iterator, List, Set, Tuple, Union
 from typing import TYPE_CHECKING
@@ -391,21 +392,28 @@ class BuildEnvironment:
         else:
             for docname in self.found_docs:
                 if docname not in self.all_docs:
+                    logger.debug('[build target] added %r', docname)
                     added.add(docname)
                     continue
                 # if the doctree file is not there, rebuild
                 filename = path.join(self.doctreedir, docname + '.doctree')
                 if not path.isfile(filename):
+                    logger.debug('[build target] changed %r', docname)
                     changed.add(docname)
                     continue
                 # check the "reread always" list
                 if docname in self.reread_always:
+                    logger.debug('[build target] changed %r', docname)
                     changed.add(docname)
                     continue
                 # check the mtime of the document
                 mtime = self.all_docs[docname]
                 newmtime = path.getmtime(self.doc2path(docname))
                 if newmtime > mtime:
+                    logger.debug('[build target] outdated %r: %s -> %s',
+                                 docname,
+                                 datetime.utcfromtimestamp(mtime),
+                                 datetime.utcfromtimestamp(newmtime))
                     changed.add(docname)
                     continue
                 # finally, check the mtime of dependencies


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
Timestamp of the files are used by Sphinx to identify the source code to be built. The timestamps are compared between the source code, html templates, and build outputs. When a source is detected as a re-building target, the user has no way to know why it's a target.

### Detail
output debug logs as

```
[app] emitting event: 'builder-inited'()
building [mo]: targets for 0 po files that are out of date
[build target] targetname '/home/runner/work/sphinx-users.jp/sphinx-users.jp/build/html/reverse-dict/writing/vocabulary.html'(2020-05-30 21:04:37), template(2020-05-30 21:05:27.800090), docname 'reverse-dict/writing/vocabulary'(2016-01-13 01:39:05)
[build target] targetname '/home/runner/work/sphinx-users.jp/sphinx-users.jp/build/html/index.html'(2020-05-30 21:04:31), template(2020-05-30 21:05:27.800090), docname 'index'(2019-12-10 03:58:58)
[build target] targetname '/home/runner/work/sphinx-users.jp/sphinx-users.jp/build/html/cookbook/ogp/index.html'(2020-05-30 21:04:20), template(2020-05-30 21:05:27.800090), docname 'cookbook/ogp/index'(2017-07-18 02:58:58)
[build target] targetname '/home/runner/work/sphinx-users.jp/sphinx-users.jp/build/html/reverse-dict/writing/comment.html'(2020-05-30 21:04:35), template(2020-05-30 21:05:27.800090), docname 'reverse-dict/writing/comment'(2013-10-05 04:22:51)
```
