### PR TITLE
Fix #7807: autodoc: wrong signature is shown for the function using contextmanager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* #7807: autodoc: Show detailed warning when type_comment is mismatched with its
+  signature
+
 Bugs fixed
 ----------
 

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 
 * #7808: autodoc: Warnings raised on variable and attribute type annotations
 * #7802: autodoc: EOFError is raised on parallel build
+* #7807: autodoc: wrong signature is shown for the function using contextmanager
 * #7812: autosummary: generates broken stub files if the target code contains
   an attribute and module that are same name
 * #7811: sphinx.util.inspect causes circular import problem

--- a/sphinx/ext/autodoc/type_comment.py
+++ b/sphinx/ext/autodoc/type_comment.py
@@ -128,6 +128,9 @@ def update_annotations_using_type_comments(app: Sphinx, obj: Any, bound_method: 
 
             if 'return' not in obj.__annotations__:
                 obj.__annotations__['return'] = type_sig.return_annotation
+    except KeyError as exc:
+        logger.warning(__("Failed to update signature for %r: parameter not found: %s"),
+                       obj, exc)
     except NotImplementedError as exc:  # failed to ast.unparse()
         logger.warning(__("Failed to parse type_comment for %r: %s"), obj, exc)
 

--- a/tests/roots/test-ext-autodoc/target/wrappedfunction.py
+++ b/tests/roots/test-ext-autodoc/target/wrappedfunction.py
@@ -1,8 +1,15 @@
-# for py32 or above
+from contextlib import contextmanager
 from functools import lru_cache
+from typing import Generator
 
 
 @lru_cache(maxsize=None)
 def slow_function(message, timeout):
     """This function is slow."""
     print(message)
+
+
+@contextmanager
+def feeling_good(x: int, y: int) -> Generator:
+    """You'll feel better in this context!"""
+    yield

--- a/tests/test_ext_autodoc_autofunction.py
+++ b/tests/test_ext_autodoc_autofunction.py
@@ -146,3 +146,16 @@ def test_wrapped_function(app):
         '   This function is slow.',
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_wrapped_function_contextmanager(app):
+    actual = do_autodoc(app, 'function', 'target.wrappedfunction.feeling_good')
+    assert list(actual) == [
+        '',
+        '.. py:function:: feeling_good(x: int, y: int) -> Generator',
+        '   :module: target.wrappedfunction',
+        '',
+        "   You'll feel better in this context!",
+        '',
+    ]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix autodoc: wrong signature is shown for the function using contextmanager
- Fix autodoc: Show detailed warning when type_comment is mismatched
- refs: #7807