### PR TITLE
Run lint tools on GH Actions

### DIFF
--- a/.github/workflows/docslint.yml
+++ b/.github/workflows/docslint.yml
@@ -1,0 +1,16 @@
+name: Lint the format of document
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run:  pip install -U tox
+    - name: Run Tox
+      run:  tox -e docslint

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,18 @@
+name: Lint source code (flake8)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run:  pip install -U tox
+    - name: Run Tox
+      run:  tox -e flake8

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,16 @@
+name: Lint source code (mypy)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run:  pip install -U tox
+    - name: Run Tox
+      run:  tox -e mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,6 @@ jobs:
         - TOXENV=du16
     - python: '3.6'
       env: TOXENV=docs
-    - python: '3.6'
-      env: TOXENV=docslint
-    - python: '3.6'
-      env: TOXENV=mypy
-    - python: '3.6'
-      env: TOXENV=flake8
 
     - language: node_js
       node_js: '10.7'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- GHA allows us to invoke 20 jobs at the same time. It improves the speed of our CI process.
  https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
- As a first step, this PR moves linting to GHA from Travis CI. I'll work for other CI processes in the next step.