### PR TITLE
Use chain.from_iterable in text.py

### DIFF
--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -223,7 +223,7 @@ class Table:
                 for left, right in zip(out, out[1:])
             ]
             glue.append(tail)
-            return head + "".join(chain(*zip(out, glue)))
+            return head + "".join(chain.from_iterable(zip(out, glue)))
 
         for lineno, line in enumerate(self.lines):
             if self.separator and lineno == self.separator:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.