### PR TITLE
Added support for suppressing certain cpp domain warnings.

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6784,7 +6784,11 @@ class CPPObject(ObjectDescription):
             ast = self.parse_definition(parser)
             parser.assert_end()
         except DefinitionError as e:
-            logger.warning(e, location=signode)
+            if 'Error when parsing function declaration.' in str(e):
+                logger.warning(e, location=signode,
+                               type='cpp', subtype='parse_function_declaration')
+            else:
+                logger.warning(e, location=signode)
             # It is easier to assume some phony name than handling the error in
             # the possibly inner declarations.
             name = _make_phony_error_name()
@@ -6806,7 +6810,8 @@ class CPPObject(ObjectDescription):
             # Assume we are actually in the old symbol,
             # instead of the newly created duplicate.
             self.env.temp_data['cpp:last_symbol'] = e.symbol
-            logger.warning("Duplicate declaration, %s", sig, location=signode)
+            logger.warning("Duplicate declaration, %s", sig, location=signode,
+                           type='cpp', subtype='duplicate_declaration')
 
         if ast.objectType == 'enumerator':
             self._add_enumerator_to_parent(ast)


### PR DESCRIPTION
Subject: This pull request adds two tags for the suppression of warnings raised by the cpp domain.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
- Feature

### Purpose
This pull request is intended to continue the expansion of the work implemented in #2346 through the addition of new types for the suppression of warnings. Specifically, this pull request focuses on warnings raised from the cpp domain when declaring C++ functions and variables.
A new type and two subtypes of warning are added.
- `cpp.duplicate_declaration`
- `cpp.parse_function_declaration`

### Detail
- `cpp.duplicate_declaration`: Removes the warnings caused by the duplicate declaration of functions. The purpose of removing this warning is to allow functions with the same name to exist within the same project. 
- `cpp.parse_function_declaration`:  Removes warnings caused by errors in the parsing of function declarations. This warning occurs in function statements such as the following:
`const MyStruct const_struct(0,0)`


