### PR TITLE
basic CSS: Take "simple" lists into account, resuscitating the "html_compact_lists" config option

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -537,6 +537,14 @@ ul ul > li:last-child > :last-child {
     margin-bottom: revert;
 }
 
+ol.simple > li > p,
+ul.simple > li > p,
+ol.compact > li > p,
+ul.compact > li > p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
 dl.footnote > dt,
 dl.citation > dt {
     float: left;

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -538,9 +538,7 @@ ul ul > li:last-child > :last-child {
 }
 
 ol.simple > li > p,
-ul.simple > li > p,
-ol.compact > li > p,
-ul.compact > li > p {
+ul.simple > li > p {
     margin-top: 0;
     margin-bottom: 0;
 }

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -513,33 +513,30 @@ ol.upperroman {
     list-style: upper-roman;
 }
 
-ol > li:first-child > :first-child,
-ul > li:first-child > :first-child {
+:not(li) > ol > li:first-child > :first-child,
+:not(li) > ul > li:first-child > :first-child {
     margin-top: 0px;
 }
 
-ol ol > li:first-child > :first-child,
-ol ul > li:first-child > :first-child,
-ul ol > li:first-child > :first-child,
-ul ul > li:first-child > :first-child {
-    margin-top: revert;
-}
-
-ol > li:last-child > :last-child,
-ul > li:last-child > :last-child {
+:not(li) > ol > li:last-child > :last-child,
+:not(li) > ul > li:last-child > :last-child {
     margin-bottom: 0px;
 }
 
-ol ol > li:last-child > :last-child,
-ol ul > li:last-child > :last-child,
-ul ol > li:last-child > :last-child,
-ul ul > li:last-child > :last-child {
-    margin-bottom: revert;
+ol.simple ol p,
+ol.simple ul p,
+ul.simple ol p,
+ul.simple ul p {
+    margin-top: 0;
 }
 
-ol.simple > li > p,
-ul.simple > li > p {
+ol.simple > li:not(:first-child) > p,
+ul.simple > li:not(:first-child) > p {
     margin-top: 0;
+}
+
+ol.simple p,
+ul.simple p {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
See #7838, where the CSS classes `compact` and `simple` have been mentioned.

I'm not sure if that's the best solution, but it should definitely be a basis for further discussion.

This is how it looks with the docutils demo https://github.com/docutils/docutils/blob/master/docutils/docs/user/rst/demo.txt, using the `sphinxdoc` theme:

**Before:**

![image](https://user-images.githubusercontent.com/705404/85075344-51a6a600-b1be-11ea-8ff9-311b72d4e299.png)


**Between (Sphinx 3.1):**

![image](https://user-images.githubusercontent.com/705404/85075210-17d59f80-b1be-11ea-8555-a6cf82c755c8.png)


**After:**

![image](https://user-images.githubusercontent.com/705404/85074968-b44b7200-b1bd-11ea-81fa-a4b68eb28e51.png)

----

There is still something strange happening in the last case: ~The list containing "Third level." and "Item 2." doesn't get the `simple` class, but the one containing it does.~
~I think those two cases should be reversed, right?~
~I guess that's a bug?~