### PR TITLE
Slightly modify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,11 @@ Subject: <short purpose of this pull request>
   For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
 -->
 
-### Feature or Bugfix
-<!-- please choose -->
-- Feature
-- Bugfix
-- Refactoring
+### Type
+<!-- change [ ] to [x] for those that apply -->
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Refactoring
 
 ### Purpose
 - <long purpose of this pull request>


### PR DESCRIPTION
### Type
- Github

### Purpose
Adjust the PR template regarding the type of change. Most PRs should be a single type, but sometimes more than one category apply. Use checkboxes to better signal how this section should be used.