### PR TITLE
Fix #7856: autodoc: AttributeError is raised for non-class object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #7844: autodoc: Failed to detect module when relative module name given
+* #7856: autodoc: AttributeError is raised when non-class object is given to
+  the autoclass directive
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -826,7 +826,12 @@ class Documenter:
         self.add_line('', sourcename)
 
         # format the object's signature, if any
-        sig = self.format_signature()
+        try:
+            sig = self.format_signature()
+        except Exception as exc:
+            logger.warning(__('error while formatting signature for %s: %s'),
+                           self.fullname, exc, type='autodoc')
+            return
 
         # generate the directive header and options, if applicable
         self.add_directive_header(sig)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7856 
- this does not mean the autoclass directive supports non-class objects. this only prevents a crash even if an invalid object is passed.