### PR TITLE
Propagate original extension errors

### DIFF
--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -115,7 +115,7 @@ class EventManager:
                 raise
             except Exception as exc:
                 raise ExtensionError(__("Handler %r for event %r threw an exception") %
-                                     (listener.handler, name)) from exc
+                                     (listener.handler, name), exc) from exc
         return results
 
     def emit_firstresult(self, name: str, *args: Any,


### PR DESCRIPTION
Subject: Previously the `exc` error did not get propagated through to the constructor of `ExtensionError`. This fixes that so that the text of the original error gets printed.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- Fixes https://github.com/sphinx-doc/sphinx/issues/7868

