### PR TITLE
Fix #7806: viewcode: Failed to resolve viewcode references on 3rd party builders

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
   the autoclass directive
 * #7850: autodoc: KeyError is raised for invalid mark up when autodoc_typehints
   is 'description'
+* #7806: viewcode: Failed to resolve viewcode references on 3rd party builders
 
 Testing
 --------

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -131,10 +131,8 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: Iterable[str],
 
 def missing_reference(app: Sphinx, env: BuildEnvironment, node: Element, contnode: Node
                       ) -> Node:
-    if app.builder.format != 'html':
-        return None
-    elif node['reftype'] == 'viewcode':
-        # resolve our "viewcode" reference nodes -- they need special treatment
+    # resolve our "viewcode" reference nodes -- they need special treatment
+    if node['reftype'] == 'viewcode':
         return make_refnode(app.builder, node['refdoc'], node['reftarget'],
                             node['refid'], contnode)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7806
- This reverts #7682 because the original error was completely resolved by #7683. So the change is no longer needed.