### PR TITLE
Fix #7869: abbr role wrongly copies an explanation from the previous one

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
 * #7839: autosummary: cannot handle umlauts in function names
 * #7715: LaTeX: ``numfig_secnum_depth > 1`` leads to wrong figure links
 * #7846: html theme: XML-invalid files were generated
+* #7869: :rst:role:`abbr` role without an explanation will show the explanation
+  from the previous abbr role
 
 Testing
 --------

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -530,14 +530,15 @@ class Abbreviation(SphinxRole):
     abbr_re = re.compile(r'\((.*)\)$', re.S)
 
     def run(self) -> Tuple[List[Node], List[system_message]]:
+        options = self.options.copy()
         matched = self.abbr_re.search(self.text)
         if matched:
             text = self.text[:matched.start()].strip()
-            self.options['explanation'] = matched.group(1)
+            options['explanation'] = matched.group(1)
         else:
             text = self.text
 
-        return [nodes.abbreviation(self.rawtext, text, **self.options)], []
+        return [nodes.abbreviation(self.rawtext, text, **options)], []
 
 
 def index_role(typ: str, rawtext: str, text: str, lineno: int, inliner: Inliner,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7869 