### PR TITLE
Fix #7866: autosummary: Failed to extract correct summary line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Bugs fixed
 ----------
 
 * #7839: autosummary: cannot handle umlauts in function names
+* #7866: autosummary: Failed to extract correct summary line when docstring
+  contains a hyperlink target
 * #7715: LaTeX: ``numfig_secnum_depth > 1`` leads to wrong figure links
 * #7846: html theme: XML-invalid files were generated
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -497,6 +497,13 @@ def mangle_signature(sig: str, max_chars: int = 30) -> str:
 
 def extract_summary(doc: List[str], document: Any) -> str:
     """Extract summary from docstring."""
+    def parse(doc: List[str], settings: Any) -> nodes.document:
+        state_machine = RSTStateMachine(state_classes, 'Body')
+        node = new_document('', settings)
+        node.reporter = NullReporter()
+        state_machine.run(doc, node)
+
+        return node
 
     # Skip a blank lines at the top
     while doc and not doc[0].strip():
@@ -514,11 +521,7 @@ def extract_summary(doc: List[str], document: Any) -> str:
         return ''
 
     # parse the docstring
-    state_machine = RSTStateMachine(state_classes, 'Body')
-    node = new_document('', document.settings)
-    node.reporter = NullReporter()
-    state_machine.run(doc, node)
-
+    node = parse(doc, document.settings)
     if not isinstance(node[0], nodes.paragraph):
         # document starts with non-paragraph: pick up the first line
         summary = doc[0].strip()
@@ -532,7 +535,7 @@ def extract_summary(doc: List[str], document: Any) -> str:
             while sentences:
                 summary += sentences.pop(0) + '.'
                 node[:] = []
-                state_machine.run([summary], node)
+                node = parse(doc, document.settings)
                 if not node.traverse(nodes.system_message):
                     # considered as that splitting by period does not break inline markups
                     break

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -108,6 +108,12 @@ def test_extract_summary(capsys):
            '=========']
     assert extract_summary(doc, document) == 'blah blah'
 
+    # hyperlink target
+    doc = ['Do `this <https://www.sphinx-doc.org/>`_ and that. '
+           'blah blah blah.']
+    assert (extract_summary(doc, document) ==
+            'Do `this <https://www.sphinx-doc.org/>`_ and that.')
+
     _, err = capsys.readouterr()
     assert err == ''
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7866 
- A hyperlink target in the docstring causes a system_error because
node_ids are cached expectedly during extracting a summary.
