### PR TITLE
Fix #7865: autosummary: Failed to extract summary line when abbr. found

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Bugs fixed
 ----------
 
 * #7839: autosummary: cannot handle umlauts in function names
+* #7865: autosummary: Failed to extract summary line when abbreviations found
+
 * #7715: LaTeX: ``numfig_secnum_depth > 1`` leads to wrong figure links
 * #7846: html theme: XML-invalid files were generated
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -99,6 +99,8 @@ logger = logging.getLogger(__name__)
 periods_re = re.compile(r'\.(?:\s+)')
 literal_re = re.compile(r'::\s*$')
 
+WELL_KNOWN_ABBREVIATIONS = (' i.e.',)
+
 
 # -- autosummary_toc node ------------------------------------------------------
 
@@ -529,11 +531,13 @@ def extract_summary(doc: List[str], document: Any) -> str:
             summary = sentences[0].strip()
         else:
             summary = ''
-            while sentences:
-                summary += sentences.pop(0) + '.'
+            for i in range(len(sentences)):
+                summary = ". ".join(sentences[:i + 1]).rstrip(".") + "."
                 node[:] = []
                 state_machine.run([summary], node)
-                if not node.traverse(nodes.system_message):
+                if summary.endswith(WELL_KNOWN_ABBREVIATIONS):
+                    pass
+                elif not node.traverse(nodes.system_message):
                     # considered as that splitting by period does not break inline markups
                     break
 

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -97,7 +97,7 @@ def test_extract_summary(capsys):
 
     # abbreviations
     doc = ['Blabla, i.e. bla.']
-    assert extract_summary(doc, document) == 'Blabla, i.e.'
+    assert extract_summary(doc, document) == ' '.join(doc)
 
     # literal
     doc = ['blah blah::']


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7865 