### PR TITLE
basic CSS: allow more "floating"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
   an attribute and module that are same name
 * #7806: viewcode: Failed to resolve viewcode references on 3rd party builders
 * #7838: html theme: List items have extra vertical space
+* #7878: html theme: Undesired interaction between "overflow" and "float"
 
 Testing
 --------

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -328,8 +328,8 @@ p.sidebar-title {
     font-weight: bold;
 }
 
-div.admonition, div.topic, pre, div[class|="highlight"] {
-    clear: both;
+div.admonition, div.topic, blockquote {
+    clear: left;
 }
 
 /* -- topics ---------------------------------------------------------------- */
@@ -338,7 +338,6 @@ div.topic {
     border: 1px solid #ccc;
     padding: 7px;
     margin: 10px 0 10px 0;
-    overflow-x: auto;
 }
 
 p.topic-title {
@@ -353,7 +352,6 @@ div.admonition {
     margin-top: 10px;
     margin-bottom: 10px;
     padding: 7px;
-    overflow-x: auto;
 }
 
 div.admonition dt {
@@ -678,6 +676,10 @@ abbr, acronym {
 pre {
     overflow: auto;
     overflow-y: hidden;  /* fixes display issues on Chrome browsers */
+}
+
+pre, div[class|="highlight"] {
+    clear: both;
 }
 
 span.pre {

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -15,6 +15,12 @@ div.clearer {
     clear: both;
 }
 
+div.section::after {
+    display: block;
+    content: '';
+    clear: left;
+}
+
 /* -- relbar ---------------------------------------------------------------- */
 
 div.related {
@@ -374,6 +380,15 @@ div.sidebar > :last-child,
 div.topic > :last-child,
 div.admonition > :last-child {
     margin-bottom: 0;
+}
+
+div.sidebar::after,
+div.topic::after,
+div.admonition::after,
+blockquote::after {
+    display: block;
+    content: '';
+    clear: both;
 }
 
 /* -- tables ---------------------------------------------------------------- */


### PR DESCRIPTION
I wasn't aware of an IMHO very un-intuitive interaction between `overflow` and `float`: If an element has an `overflow` setting, preceding elements cannot "float" into it.

That's why I'm suggesting to remove the `overflow` setting from `admonition` and `topic`.

This partially reverts my previous PR #7542. I'm only keeping the `overflow` setting on `sidebar`, where "floating into it" is not desired anyway.

For the other elements, it looks like we cannot have perfect "overflow" and perfect "float" behavior at the same time.
Derived themes can still add their `overflow` settings if they want.

This also partially reverts my previous PR #7484. It allows "right floats" to float into `admonition` and `topic` elements (as was possible before #7484). It still doesn't allow floating into code blocks, because this would interact badly with their `overflow` behavior (which is more important).

### Feature or Bugfix

- Bugfix