### PR TITLE
Close #7849: html: Add html_codeblock_linenos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Deprecated
 Features added
 --------------
 
+* #7849: html: Add :confval:`html_codeblock_linenos_style` to change the style
+  of line numbers for code-blocks
 * #7853: C and C++, support parameterized GNU style attributes.
 * #7888: napoleon: Add aliases Warn and Raise.
 * C, added :rst:dir:`c:alias` directive for inserting copies

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -926,6 +926,15 @@ that use Sphinx's HTMLWriter class.
 
    .. versionadded:: 1.8
 
+.. confval:: html_codeblock_linenos_style
+
+   The style of line numbers for code-blocks.
+
+   * ``'table'`` -- display line numbers using ``<table>`` tag (default)
+   * ``'inline'`` -- display line numbers using ``<span>`` tag
+
+   .. versionadded:: 3.2
+
 .. confval:: html_context
 
    A dictionary of values to pass into the template engine's context for all

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -26,7 +26,7 @@ from docutils.utils import relative_path
 from sphinx import package_dir, __display_version__
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
-from sphinx.config import Config
+from sphinx.config import Config, ENUM
 from sphinx.deprecation import RemovedInSphinx40Warning
 from sphinx.domains import Domain, Index, IndexEntry
 from sphinx.environment.adapters.asset import ImageAdapter
@@ -1226,6 +1226,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('html_search_scorer', '', None)
     app.add_config_value('html_scaled_image_link', True, 'html')
     app.add_config_value('html_baseurl', '', 'html')
+    app.add_config_value('html_codeblock_linenos_style', 'table', 'html',
+                         ENUM('table', 'inline'))
     app.add_config_value('html_math_renderer', None, 'env')
     app.add_config_value('html4_writer', False, 'html')
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -445,6 +445,9 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         else:
             opts = {}
 
+        if linenos and self.builder.config.html_codeblock_linenos_style:
+            linenos = self.builder.config.html_codeblock_linenos_style
+
         highlighted = self.highlighter.highlight_block(
             node.rawsource, lang, opts=opts, linenos=linenos,
             location=(self.builder.current_docname, node.line), **highlight_args

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -397,6 +397,9 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         else:
             opts = {}
 
+        if linenos and self.builder.config.html_codeblock_linenos_style:
+            linenos = self.builder.config.html_codeblock_linenos_style
+
         highlighted = self.highlighter.highlight_block(
             node.rawsource, lang, opts=opts, linenos=linenos,
             location=(self.builder.current_docname, node.line), **highlight_args

--- a/tests/roots/test-reST-code-block/index.rst
+++ b/tests/roots/test-reST-code-block/index.rst
@@ -1,0 +1,7 @@
+.. code-block::
+   :linenos:
+
+   def hello(name)
+       print("hello", name)
+
+   hello("Sphinx")

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1575,3 +1575,21 @@ def test_html_scaled_image_link(app):
     assert re.search('\n<img alt="_images/img.png" class="no-scaled-link"'
                      ' src="_images/img.png" style="[^"]+" />',
                      context)
+
+
+@pytest.mark.sphinx('html', testroot='reST-code-block',
+                    confoverrides={'html_codeblock_linenos_style': 'table'})
+def test_html_codeblock_linenos_style_table(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    assert '<div class="linenodiv"><pre>1\n2\n3\n4</pre></div>' in content
+
+
+@pytest.mark.sphinx('html', testroot='reST-code-block',
+                    confoverrides={'html_codeblock_linenos_style': 'inline'})
+def test_html_codeblock_linenos_style_inline(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    assert '<span class="lineno">1 </span>' in content


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7849 
- This adds `html_codeblock_linenos` option to control the style of line numbers for code-blocks.

### Reamining tasks:

- [x] determine the name of the configuration
- [x] add testcases
- [x] documents