### PR TITLE
Fix #7812: autosummary: generates broken stub files (again)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
   the autoclass directive
 * #7850: autodoc: KeyError is raised for invalid mark up when autodoc_typehints
   is 'description'
+* #7812: autosummary: generates broken stub files if the target code contains
+  an attribute and module that are same name
 
 Testing
 --------

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -615,24 +615,11 @@ def split_full_qualified_name(name: str) -> Tuple[str, str]:
               Therefore you need to mock 3rd party modules if needed before
               calling this function.
     """
-    from sphinx.util import inspect
-
     parts = name.split('.')
     for i, part in enumerate(parts, 1):
         try:
             modname = ".".join(parts[:i])
-            module = import_module(modname)
-
-            # check the module has a member named as attrname
-            #
-            # Note: This is needed to detect the attribute having the same name
-            #       as the module.
-            #       ref: https://github.com/sphinx-doc/sphinx/issues/7812
-            attrname = parts[i]
-            if hasattr(module, attrname):
-                value = inspect.safe_getattr(module, attrname)
-                if not inspect.ismodule(value):
-                    return ".".join(parts[:i]), ".".join(parts[i:])
+            import_module(modname)
         except ImportError:
             if parts[:i - 1]:
                 return ".".join(parts[:i - 1]), ".".join(parts[i - 1:])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7812 and #7844 
- Unfortunately, #7815's approach is not good. This reverts it and use the result of `import_by_name()` to detect correct mod name and qualname.