### PR TITLE
C, add c:alias directive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Features added
 
 * #7853: C and C++, support parameterized GNU style attributes.
 * #7888: napoleon: Add aliases Warn and Raise.
+* C, added :rst:dir:`c:alias` directive for inserting copies
+  of existing declarations.
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -699,6 +699,41 @@ Explicit ref: :c:var:`Data.@data.a`. Short-hand ref: :c:var:`Data.a`.
 .. versionadded:: 3.0
 
 
+Aliasing Declarations
+~~~~~~~~~~~~~~~~~~~~~
+
+.. c:namespace-push:: @alias
+
+Sometimes it may be helpful list declarations elsewhere than their main
+documentation, e.g., when creating a synopsis of an interface.
+The following directive can be used for this purpose.
+
+.. rst:directive:: .. c:alias:: name
+
+   Insert one or more alias declarations. Each entity can be specified
+   as they can in the :rst:role:`c:any` role.
+
+   For example::
+
+       .. c:var:: int data
+       .. c:function:: int f(double k)
+
+       .. c:alias:: data
+                    f
+
+   becomes
+
+   .. c:var:: int data
+   .. c:function:: int f(double k)
+
+   .. c:alias:: data
+                f
+
+   .. versionadded:: 3.2
+
+.. c:namespace-pop::
+
+
 Inline Expressions and Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add ``c:alias`` directive, similar to the C++ version, for inserting a copy of an existing declaration.

### Feature or Bugfix
- Feature

### Purpose
Sometimes it is convenient to show a declaration in another place than where it is really documented. E.g, in examples or in a synopsis of an interface.
The alias directive does this, and make a cross reference to the real declaration.

### Relates
michaeljones/breathe#549