### PR TITLE
C, C++: remove noindex option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ Bugs fixed
 * #7846: html theme: XML-invalid files were generated
 * #7869: :rst:role:`abbr` role without an explanation will show the explanation
   from the previous abbr role
+* C and C++, removed ``noindex`` directive option as it did
+  nothing.
 
 Testing
 --------

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1038,7 +1038,6 @@ Options
 
 Some directives support options:
 
-- ``:noindex:``, see :ref:`basic-domain-markup`.
 - ``:tparam-line-spec:``, for templated declarations.
   If specified, each template parameter will be rendered on a separate line.
 


### PR DESCRIPTION
The option did nothing, so better let the parser warn about the extraneous option instead. Also, improve error messages on duplicates.

### Feature or Bugfix
- Bugfix
- Refactoring

### Relates
See also the discussion in #7052.

