### PR TITLE
[WIP?] C, add compatibility flag for parsing some pre-v3 input

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ Incompatible changes
 Deprecated
 ----------
 
+* C, parsing of pre-v3 style type directives and roles, along with the options
+  :confval:`c_allow_pre_v3` and :confval:`c_warn_on_allowed_pre_v3`.
+
 Features added
 --------------
 
@@ -24,6 +27,12 @@ Features added
 * #7052: add ``:noindexentry:`` to the Python, C, C++, and Javascript domains.
   Update the documentation to better reflect the relationship between this option
   and the ``:noindex:`` option.
+* #7899: C, add possibility of parsing of some pre-v3 style type directives and
+  roles and try to convert them to equivalent v3 directives/roles.
+  Set the new option :confval:`c_allow_pre_v3` to ``True`` to enable this.
+  The warnings printed from this functionality can be suppressed by setting
+  :confval:`c_warn_on_allowed_pre_v3`` to ``True``.
+  The functionality is immediately deprecated.
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2545,6 +2545,23 @@ Options for the C domain
 
    .. versionadded:: 3.0
 
+.. confval:: c_allow_pre_v3
+
+   A boolean (default ``False``) controlling whether to parse and try to
+   convert pre-v3 style type directives and type roles.
+
+   .. versionadded:: 3.2
+   .. deprecated:: 3.2
+      Use the directives and roles added in v3.
+
+.. confval:: c_warn_on_allowed_pre_v3
+
+   A boolean (default ``True``) controlling whether to warn when a pre-v3
+   style type directive/role is parsed and converted.
+
+   .. versionadded:: 3.2
+   .. deprecated:: 3.2
+      Use the directives and roles added in v3.
 
 .. _cpp-config:
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3170,12 +3170,13 @@ class CObject(ObjectDescription):
                 except DefinitionError:
                     raise eOrig
                 self.object_type = ast.objectType  # type: ignore
-                msg = "{}: Pre-v3 C type directive '.. c:type:: {}' converted to " \
-                      "'.. c:{}:: {}'." \
-                      "\nThe original parsing error was:\n{}"
-                msg = msg.format(RemovedInSphinx50Warning.__name__,
-                                 sig, ast.objectType, ast, eOrig)
-                logger.warning(msg, location=signode)
+                if self.env.config['c_warn_on_allowed_pre_v3']:
+                    msg = "{}: Pre-v3 C type directive '.. c:type:: {}' converted to " \
+                          "'.. c:{}:: {}'." \
+                          "\nThe original parsing error was:\n{}"
+                    msg = msg.format(RemovedInSphinx50Warning.__name__,
+                                     sig, ast.objectType, ast, eOrig)
+                    logger.warning(msg, location=signode)
         except DefinitionError as e:
             logger.warning(e, location=signode)
             # It is easier to assume some phony name than handling the error in
@@ -3510,10 +3511,11 @@ class CXRefRole(XRefRole):
             signode = nodes.inline(classes=classes)
             ast.describe_signature(signode, 'markType', self.env, parentSymbol)
 
-            msg = "{}: Pre-v3 C type role ':c:type:`{}`' converted to ':c:expr:`{}`'."
-            msg += "\nThe original parsing error was:\n{}"
-            msg = msg.format(RemovedInSphinx50Warning.__name__, text, text, eOrig)
-            logger.warning(msg, location=self.get_source_info())
+            if self.env.config['c_warn_on_allowed_pre_v3']:
+                msg = "{}: Pre-v3 C type role ':c:type:`{}`' converted to ':c:expr:`{}`'."
+                msg += "\nThe original parsing error was:\n{}"
+                msg = msg.format(RemovedInSphinx50Warning.__name__, text, text, eOrig)
+                logger.warning(msg, location=self.get_source_info())
             return [signode], []
 
 
@@ -3718,6 +3720,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_post_transform(AliasTransform)
 
     app.add_config_value("c_allow_pre_v3", False, 'env')
+    app.add_config_value("c_warn_on_allowed_pre_v3", True, 'env')
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
The C domain got much stricter in its parsing in version 3 and added additional directives and roles to provide better markup. This PR adds the configuration variable ``c_allow_pre_v3``. When set to ``True`` the type directive and role will try to convert some previously recognized input to the v3 equivalent.

### Feature or Bugfix
- Feature

### Detail
- Fixes #7899
