### PR TITLE
show docs for decorated special functions

### DIFF
--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -438,7 +438,11 @@ def _skip_member(app: Sphinx, what: str, name: str, obj: Any,
                         mod_path = cls_path.split('.')
                         cls = functools.reduce(getattr, mod_path, mod)
                     else:
-                        cls = obj.__globals__[cls_path]
+                        if hasattr(obj, '__wrapped__'):
+                            # handle functions decorated by @functools.wrap
+                            cls = obj.__wrapped__.__globals__[cls_path]
+                        else:
+                            cls = obj.__globals__[cls_path]
                 except Exception:
                     cls_is_owner = False
                 else:

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 from sphinx import __display_version__ as __version__
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon.docstring import GoogleDocstring, NumpyDocstring
+from sphinx.util import inspect
 
 
 class Config:
@@ -438,11 +439,7 @@ def _skip_member(app: Sphinx, what: str, name: str, obj: Any,
                         mod_path = cls_path.split('.')
                         cls = functools.reduce(getattr, mod_path, mod)
                     else:
-                        if hasattr(obj, '__wrapped__'):
-                            # handle functions decorated by @functools.wrap
-                            cls = obj.__wrapped__.__globals__[cls_path]
-                        else:
-                            cls = obj.__globals__[cls_path]
+                        cls = inspect.unwrap(obj).__globals__[cls_path]
                 except Exception:
                     cls_is_owner = False
                 else:

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -14,6 +14,7 @@ import warnings
 from io import StringIO
 from typing import Any, Dict, Generator, IO, List, Pattern
 from xml.etree import ElementTree
+import functools
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -195,3 +196,15 @@ def find_files(root: str, suffix: bool = None) -> Generator[str, None, None]:
 
 def strip_escseq(text: str) -> str:
     return re.sub('\x1b.*?m', '', text)
+
+
+def simple_decorator(f):
+    """
+    A simple decorator that does nothing, for tests to use.
+    """
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wrapper
+
+

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -7,6 +7,7 @@
     :copyright: Copyright 2007-2020 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import functools
 import os
 import re
 import sys
@@ -14,7 +15,6 @@ import warnings
 from io import StringIO
 from typing import Any, Dict, Generator, IO, List, Pattern
 from xml.etree import ElementTree
-import functools
 
 from docutils import nodes
 from docutils.nodes import Node
@@ -206,5 +206,3 @@ def simple_decorator(f):
     def wrapper(*args, **kwargs):
         return f(*args, **kwargs)
     return wrapper
-
-

--- a/tests/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 from unittest import TestCase, mock
 
 from sphinx.application import Sphinx
+from sphinx.testing.util import simple_decorator
 from sphinx.ext.napoleon import _process_docstring, _skip_member, Config, setup
 
 
@@ -48,6 +49,11 @@ class SampleClass:
         pass
 
     def __special_undoc__(self):
+        pass
+
+    @simple_decorator
+    def __decorated_func__(self):
+        """doc"""
         pass
 
 
@@ -130,8 +136,8 @@ class SkipMemberTest(TestCase):
             self.assertEqual(None, _skip_member(app, what, member, obj, skip,
                                                 mock.Mock()))
         else:
-            self.assertFalse(_skip_member(app, what, member, obj, skip,
-                                          mock.Mock()))
+            self.assertIs(_skip_member(app, what, member, obj, skip,
+                                       mock.Mock()), False)
         setattr(app.config, config_name, False)
         self.assertEqual(None, _skip_member(app, what, member, obj, skip,
                                             mock.Mock()))
@@ -168,6 +174,11 @@ class SkipMemberTest(TestCase):
     def test_class_special_undoc(self):
         self.assertSkip('class', '__special_undoc__',
                         SampleClass.__special_undoc__, True,
+                        'napoleon_include_special_with_doc')
+
+    def test_class_decorated_doc(self):
+        self.assertSkip('class', '__decorated_func__',
+                        SampleClass.__decorated_func__, False,
                         'napoleon_include_special_with_doc')
 
     def test_exception_private_doc(self):


### PR DESCRIPTION
Subject: show docs for decorated special functions. Fix https://github.com/sphinx-doc/sphinx/issues/4258


### Feature or Bugfix
- Bugfix

### Purpose
1. fix #4258, as explained in the original issue
2. fix a bug about the existing testing framework 

### Detail
1. by checking `hasattr(obj, '__wrapped__')`, napoleon is now able to correctly handle functions decorated by `functools.wraps`. This is verified by a new unittest which would fail without this PR.
2. The unittest code had a bug: it uses `assertFalse` which cannot distinguish `False` and `None`. It is now fixed.