### PR TITLE
Fix #7812: autodoc: crashed when given name is conflicted

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
   the autoclass directive
 * #7850: autodoc: KeyError is raised for invalid mark up when autodoc_typehints
   is 'description'
+* #7812: autodoc: crashed if the target name matches to both an attribute and
+  module that are same name
 * #7812: autosummary: generates broken stub files if the target code contains
   an attribute and module that are same name
 * #7806: viewcode: Failed to resolve viewcode references on 3rd party builders

--- a/tests/roots/test-ext-autodoc/target/name_conflict/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/name_conflict/__init__.py
@@ -1,0 +1,5 @@
+from .foo import bar
+
+class foo:
+    """docstring of target.name_conflict::foo."""
+    pass

--- a/tests/roots/test-ext-autodoc/target/name_conflict/foo.py
+++ b/tests/roots/test-ext-autodoc/target/name_conflict/foo.py
@@ -1,0 +1,2 @@
+class bar:
+    """docstring of target.name_conflict.foo::bar."""

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -121,8 +121,8 @@ def test_parse_name(app):
     verify('class', 'Base', ('test_ext_autodoc', ['Base'], None, None))
 
     # for members
-    directive.env.ref_context['py:module'] = 'sphinx.testing'
-    verify('method', 'util.SphinxTestApp.cleanup',
+    directive.env.ref_context['py:module'] = 'sphinx.testing.util'
+    verify('method', 'SphinxTestApp.cleanup',
            ('sphinx.testing.util', ['SphinxTestApp', 'cleanup'], None, None))
     directive.env.ref_context['py:module'] = 'sphinx.testing.util'
     directive.env.ref_context['py:class'] = 'Foo'
@@ -801,14 +801,14 @@ def test_autodoc_inner_class(app):
     actual = do_autodoc(app, 'class', 'target.Outer.Inner', options)
     assert list(actual) == [
         '',
-        '.. py:class:: Outer.Inner()',
-        '   :module: target',
+        '.. py:class:: Inner()',
+        '   :module: target.Outer',
         '',
         '   Foo',
         '',
         '',
-        '   .. py:method:: Outer.Inner.meth()',
-        '      :module: target',
+        '   .. py:method:: Inner.meth()',
+        '      :module: target.Outer',
         '',
         '      Foo',
         '',
@@ -1884,8 +1884,8 @@ def test_overload(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_pymodule_for_ModuleLevelDocumenter(app):
-    app.env.ref_context['py:module'] = 'target'
-    actual = do_autodoc(app, 'class', 'classes.Foo')
+    app.env.ref_context['py:module'] = 'target.classes'
+    actual = do_autodoc(app, 'class', 'Foo')
     assert list(actual) == [
         '',
         '.. py:class:: Foo()',
@@ -1896,8 +1896,8 @@ def test_pymodule_for_ModuleLevelDocumenter(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_pymodule_for_ClassLevelDocumenter(app):
-    app.env.ref_context['py:module'] = 'target'
-    actual = do_autodoc(app, 'method', 'methods.Base.meth')
+    app.env.ref_context['py:module'] = 'target.methods'
+    actual = do_autodoc(app, 'method', 'Base.meth')
     assert list(actual) == [
         '',
         '.. py:method:: Base.meth()',
@@ -1937,3 +1937,26 @@ my_name
 
 alias of bug2437.autodoc_dummy_foo.Foo"""
     assert warning.getvalue() == ''
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_name_conflict(app):
+    actual = do_autodoc(app, 'class', 'target.name_conflict.foo')
+    assert list(actual) == [
+        '',
+        '.. py:class:: foo()',
+        '   :module: target.name_conflict',
+        '',
+        '   docstring of target.name_conflict::foo.',
+        '',
+    ]
+
+    actual = do_autodoc(app, 'class', 'target.name_conflict.foo.bar')
+    assert list(actual) == [
+        '',
+        '.. py:class:: bar()',
+        '   :module: target.name_conflict.foo',
+        '',
+        '   docstring of target.name_conflict.foo::bar.',
+        '',
+    ]

--- a/tests/test_ext_autodoc_autofunction.py
+++ b/tests/test_ext_autodoc_autofunction.py
@@ -85,8 +85,8 @@ def test_methoddescriptor(app):
     actual = do_autodoc(app, 'function', 'builtins.int.__add__')
     assert list(actual) == [
         '',
-        '.. py:function:: int.__add__(self, value, /)',
-        '   :module: builtins',
+        '.. py:function:: __add__(self, value, /)',
+        '   :module: builtins.int',
         '',
         '   Return self+value.',
         '',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7812
- Note: this partially reverts #7594 to avoid errors.