### PR TITLE
autodoc: the signature of base function will be shown for decorated functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #7650: autodoc: the signature of base function will be shown for decorated
+  functions, not a signature of decorator
+
 Deprecated
 ----------
 
@@ -23,6 +26,8 @@ Bugs fixed
   is 'description'
 * #7812: autodoc: crashed if the target name matches to both an attribute and
   module that are same name
+* #7650: autodoc: function signature becomes ``(*args, **kwargs)`` if the
+  function is decorated by generic decorator
 * #7812: autosummary: generates broken stub files if the target code contains
   an attribute and module that are same name
 * #7806: viewcode: Failed to resolve viewcode references on 3rd party builders

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1157,10 +1157,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
 
         try:
             self.env.app.emit('autodoc-before-process-signature', self.object, False)
-            if inspect.is_singledispatch_function(self.object):
-                sig = inspect.signature(self.object, follow_wrapped=True)
-            else:
-                sig = inspect.signature(self.object)
+            sig = inspect.signature(self.object, follow_wrapped=True)
             args = stringify_signature(sig, **kwargs)
         except TypeError as exc:
             logger.warning(__("Failed to get a function signature for %s: %s"),
@@ -1740,13 +1737,8 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
                     sig = inspect.signature(self.object, bound_method=False)
                 else:
                     self.env.app.emit('autodoc-before-process-signature', self.object, True)
-
-                    meth = self.parent.__dict__.get(self.objpath[-1], None)
-                    if meth and inspect.is_singledispatch_method(meth):
-                        sig = inspect.signature(self.object, bound_method=True,
-                                                follow_wrapped=True)
-                    else:
-                        sig = inspect.signature(self.object, bound_method=True)
+                    sig = inspect.signature(self.object, bound_method=True,
+                                            follow_wrapped=True)
                 args = stringify_signature(sig, **kwargs)
         except TypeError as exc:
             logger.warning(__("Failed to get a method signature for %s: %s"),

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1267,7 +1267,7 @@ def test_automethod_for_decorated(app):
     actual = do_autodoc(app, 'method', 'target.decorator.Bar.meth')
     assert list(actual) == [
         '',
-        '.. py:method:: Bar.meth()',
+        '.. py:method:: Bar.meth(name=None, age=None)',
         '   :module: target.decorator',
         '',
     ]
@@ -1432,7 +1432,7 @@ def test_coroutine(app):
     actual = do_autodoc(app, 'function', 'target.coroutine.sync_func')
     assert list(actual) == [
         '',
-        '.. py:function:: sync_func(*args, **kwargs)',
+        '.. py:function:: sync_func()',
         '   :module: target.coroutine',
         '',
     ]

--- a/tests/test_ext_autodoc_autofunction.py
+++ b/tests/test_ext_autodoc_autofunction.py
@@ -98,7 +98,7 @@ def test_decorated(app):
     actual = do_autodoc(app, 'function', 'target.decorator.foo')
     assert list(actual) == [
         '',
-        '.. py:function:: foo()',
+        '.. py:function:: foo(name=None, age=None)',
         '   :module: target.decorator',
         '',
     ]


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/issues/7650#issuecomment-653700393
- This reverts #7651 (partially)