### PR TITLE
test: Use released html5lib package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ description =
     py{35,36,37,38,39}: Run unit tests against {envname}.
     du{12,13,14}: Run unit tests with the given version of docutils.
 deps =
-    git+https://github.com/html5lib/html5lib-python  # refs: https://github.com/html5lib/html5lib-python/issues/419
     du12: docutils==0.12
     du13: docutils==0.13.1
     du14: docutils==0.14


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Recently, html5lib-1.1 was released. So it is no longer to install it from repository.
