### PR TITLE
napoleon: Adjust test expectation for namedtuple in py37+

### DIFF
--- a/tests/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import sys
 from collections import namedtuple
 from unittest import TestCase, mock
 
@@ -136,9 +137,18 @@ class SkipMemberTest(TestCase):
                                             mock.Mock()))
 
     def test_namedtuple(self):
-        self.assertSkip('class', '_asdict',
-                        SampleNamedTuple._asdict, False,
-                        'napoleon_include_private_with_doc')
+        if sys.version_info < (3, 7):
+            self.assertSkip('class', '_asdict',
+                            SampleNamedTuple._asdict, False,
+                            'napoleon_include_private_with_doc')
+        else:
+            # Since python 3.7, namedtuple._asdict() has not been documented
+            # because there is no way to check the method is a member of the
+            # namedtuple class.  This testcase confirms only it does not
+            # raise an error on building document (refs: #1455)
+            self.assertSkip('class', '_asdict',
+                            SampleNamedTuple._asdict, True,
+                            'napoleon_include_private_with_doc')
 
     def test_class_private_doc(self):
         self.assertSkip('class', '_private_doc',


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- https://github.com/sphinx-doc/sphinx/pull/7910#discussion_r449853639
- Since python 3.7, namedtuple._asdict() has not been documented because there is no way to check the method is a member of the namedtuple class.
  According to #1455, this testcase confirms napoleon does not raise an error on building document (refs: #1455)