### PR TITLE
Fix #7894: gettext: Wrong source info is shown when using rst_epilog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Bugs fixed
 * #4258: napoleon: decorated special methods are not shown
 * #7715: LaTeX: ``numfig_secnum_depth > 1`` leads to wrong figure links
 * #7846: html theme: XML-invalid files were generated
+* #7894: gettext: Wrong source info is shown when using rst_epilog
 * #7869: :rst:role:`abbr` role without an explanation will show the explanation
   from the previous abbr role
 * C and C++, removed ``noindex`` directive option as it did

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -103,6 +103,11 @@ def prepend_prolog(content: StringList, prolog: str) -> None:
 def append_epilog(content: StringList, epilog: str) -> None:
     """Append a string to content body as epilog."""
     if epilog:
-        content.append('', '<generated>', 0)
+        if 0 < len(content):
+            source, lineno = content.info(-1)
+        else:
+            source = '<generated>'
+            lineno = 0
+        content.append('', source, lineno + 1)
         for lineno, line in enumerate(epilog.splitlines()):
             content.append(line, '<rst_epilog>', lineno)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -50,7 +50,7 @@ def test_RSTParser_prolog_epilog(RSTStateMachine, app):
     (content, _), _ = RSTStateMachine().run.call_args
     assert list(content.xitems()) == [('dummy.rst', 0, 'hello Sphinx world'),
                                       ('dummy.rst', 1, 'Sphinx is a document generator'),
-                                      ('<generated>', 0, ''),
+                                      ('dummy.rst', 2, ''),
                                       ('<rst_epilog>', 0, 'this is rst_epilog'),
                                       ('<rst_epilog>', 1, 'good-bye reST!')]
 

--- a/tests/test_util_rst.py
+++ b/tests/test_util_rst.py
@@ -32,7 +32,7 @@ def test_append_epilog(app):
 
     assert list(content.xitems()) == [('dummy.rst', 0, 'hello Sphinx world'),
                                       ('dummy.rst', 1, 'Sphinx is a document generator'),
-                                      ('<generated>', 0, ''),
+                                      ('dummy.rst', 2, ''),
                                       ('<rst_epilog>', 0, 'this is rst_epilog'),
                                       ('<rst_epilog>', 1, 'good-bye reST!')]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7894 