### PR TITLE
Add docs.mesa3d.org to EXAMPLES

### DIFF
--- a/EXAMPLES
+++ b/EXAMPLES
@@ -223,6 +223,7 @@ Documentation using sphinx_rtd_theme
 * `Mailman <http://docs.list.org/>`__
 * `MathJax <https://docs.mathjax.org/>`__
 * `MDTraj <http://mdtraj.org/latest/>`__ (customized)
+* `Mesa 3D <https://docs.mesa3d.org/>`__
 * `micca - MICrobial Community Analysis <https://micca.readthedocs.io/>`__
 * `MicroPython <https://docs.micropython.org/>`__
 * `Minds <https://www.minds.org/docs/>`__ (customized)


### PR DESCRIPTION
We started using Sphinx for docs.mesa3d.org, thanks for a great product!