### PR TITLE
Fix double trailing newline apidoc

### DIFF
--- a/sphinx/templates/apidoc/package.rst_t
+++ b/sphinx/templates/apidoc/package.rst_t
@@ -35,14 +35,15 @@ Submodules
 ----------
 {% if separatemodules %}
 {{ toctree(submodules) }}
-{%- else %}
+{% endif %}
+{%- if not separatemodules %}
 {%- for submodule in submodules %}
 {% if show_headings %}
 {{- [submodule, "module"] | join(" ") | e | heading(2) }}
 {% endif %}
 {{ automodule(submodule, automodule_options) }}
 {% endfor %}
-{%- endif %}
+{%- endif -%}
 {% endif %}
 
 {%- if not modulefirst and not is_namespace %}

--- a/sphinx/templates/apidoc/package.rst_t
+++ b/sphinx/templates/apidoc/package.rst_t
@@ -35,16 +35,15 @@ Submodules
 ----------
 {% if separatemodules %}
 {{ toctree(submodules) }}
-{% endif %}
-{%- if not separatemodules %}
+{% else %}
 {%- for submodule in submodules %}
 {% if show_headings %}
 {{- [submodule, "module"] | join(" ") | e | heading(2) }}
 {% endif %}
 {{ automodule(submodule, automodule_options) }}
 {% endfor %}
-{%- endif -%}
-{% endif %}
+{%- endif %}
+{%- endif %}
 
 {%- if not modulefirst and not is_namespace %}
 Module contents

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -121,7 +121,6 @@ def test_pep_0420_enabled_separate(make_app, apidoc):
 
     with open(outdir / 'a.b.c.rst') as f:
         rst = f.read()
-
         assert ".. toctree::\n   :maxdepth: 4\n\n   a.b.c.d\n" in rst
 
     with open(outdir / 'a.b.e.rst') as f:

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -509,7 +509,6 @@ def test_package_file(tempdir):
                        "   :undoc-members:\n"
                        "   :show-inheritance:\n"
                        "\n"
-                       "\n"
                        "Module contents\n"
                        "---------------\n"
                        "\n"
@@ -595,8 +594,7 @@ def test_package_file_module_first(tempdir):
                        ".. automodule:: testpkg.example\n"
                        "   :members:\n"
                        "   :undoc-members:\n"
-                       "   :show-inheritance:\n"
-                       "\n")
+                       "   :show-inheritance:\n")
 
 
 def test_package_file_without_submodules(tempdir):
@@ -639,5 +637,4 @@ def test_namespace_package_file(tempdir):
                        ".. automodule:: testpkg.example\n"
                        "   :members:\n"
                        "   :undoc-members:\n"
-                       "   :show-inheritance:\n"
-                       "\n")
+                       "   :show-inheritance:\n")


### PR DESCRIPTION
Subject: Fix apidoc generating two newlines at the end of the package rst file if it contains submodules and `--module-first` is used.

### Feature or Bugfix
- Bugfix

### Purpose
- Fix #7890 