### PR TITLE
Fix #7901: autodoc: annotations for overloaded functions are not resolved

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
 ----------
 
 * #7886: autodoc: TypeError is raised on mocking generic-typed classes
+* #7901: autodoc: type annotations for overloaded functions are not resolved
 * #7839: autosummary: cannot handle umlauts in function names
 * #7865: autosummary: Failed to extract summary line when abbreviations found
 * #7866: autosummary: Failed to extract correct summary line when docstring

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -16,6 +16,21 @@ from docutils import nodes
 from docutils.parsers.rst.states import Inliner
 
 
+if sys.version_info > (3, 7):
+    from typing import ForwardRef
+else:
+    from typing import _ForwardRef  # type: ignore
+
+    class ForwardRef:
+        """A pseudo ForwardRef class for py35 and py36."""
+        def __init__(self, arg: Any, is_argument: bool = True) -> None:
+            self.arg = arg
+
+        def _evaluate(self, globalns: Dict, localns: Dict) -> Any:
+            ref = _ForwardRef(self.arg)
+            return ref._eval_type(globalns, localns)
+
+
 # An entry of Directive.option_spec
 DirectiveOption = Callable[[str], Any]
 

--- a/tests/roots/test-ext-autodoc/target/overload.py
+++ b/tests/roots/test-ext-autodoc/target/overload.py
@@ -7,7 +7,7 @@ def sum(x: int, y: int) -> int:
 
 
 @overload
-def sum(x: float, y: float) -> float:
+def sum(x: "float", y: "float") -> "float":
     ...
 
 
@@ -29,7 +29,7 @@ class Math:
         ...
 
     @overload
-    def sum(self, x: float, y: float) -> float:
+    def sum(self, x: "float", y: "float") -> "float":
         ...
 
     @overload
@@ -49,7 +49,7 @@ class Foo:
         ...
 
     @overload
-    def __new__(cls, x: str, y: str) -> "Foo":
+    def __new__(cls, x: "str", y: "str") -> "Foo":
         ...
 
     def __new__(cls, x, y):
@@ -64,7 +64,7 @@ class Bar:
         ...
 
     @overload
-    def __init__(cls, x: str, y: str) -> None:
+    def __init__(cls, x: "str", y: "str") -> "None":
         ...
 
     def __init__(cls, x, y):
@@ -77,7 +77,7 @@ class Meta(type):
         ...
 
     @overload
-    def __call__(cls, x: str, y: str) -> Any:
+    def __call__(cls, x: "str", y: "str") -> "Any":
         ...
 
     def __call__(cls, x, y):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7901 
- So far, type annotations for overloaded functions are not resolved
because they are obtained from AST directly.  This tries to evaluate
them using a context of its function or method.
