### PR TITLE
html: html_codeblock_linenos_style defaults to 'inline' (refs: #7849)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Incompatible changes
   section
 * #7996: manpage: Make a section directory on build manpage by default (see
   :confval:`man_make_section_directory`)
+* #7849: html: Change the default setting of
+  :confval:`html_codeblock_linenos_style` to ``'inline'``
 * #8380: html search: search results are wrapped with ``<p>`` instead of
   ``<div>``
 * html theme: Move a script tag for documentation_options.js in
@@ -38,6 +40,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* :confval:`html_codeblock_linenos_style`
 * ``favicon`` and ``logo`` variable in HTML templates
 * ``sphinx.directives.patches.CSVTable``
 * ``sphinx.directives.patches.ListTable``

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -971,10 +971,15 @@ that use Sphinx's HTMLWriter class.
 
    The style of line numbers for code-blocks.
 
-   * ``'table'`` -- display line numbers using ``<table>`` tag (default)
-   * ``'inline'`` -- display line numbers using ``<span>`` tag
+   * ``'table'`` -- display line numbers using ``<table>`` tag
+   * ``'inline'`` -- display line numbers using ``<span>`` tag (default)
 
    .. versionadded:: 3.2
+   .. versionchanged:: 4.0
+
+      It defaults to ``'inline'``.
+
+   .. deprecated:: 4.0
 
 .. confval:: html_context
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1296,7 +1296,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('html_search_scorer', '', None)
     app.add_config_value('html_scaled_image_link', True, 'html')
     app.add_config_value('html_baseurl', '', 'html')
-    app.add_config_value('html_codeblock_linenos_style', 'table', 'html',
+    app.add_config_value('html_codeblock_linenos_style', 'inline', 'html',  # RemovedInSphinx60Warning  # NOQA
                          ENUM('table', 'inline'))
     app.add_config_value('html_math_renderer', None, 'env')
     app.add_config_value('html4_writer', False, 'html')

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -423,44 +423,16 @@ def test_literal_include_linenos(app, status, warning):
     html = (app.outdir / 'linenos.html').read_text()
 
     # :linenos:
-    assert ('<td class="linenos"><div class="linenodiv"><pre>'
-            ' 1\n'
-            ' 2\n'
-            ' 3\n'
-            ' 4\n'
-            ' 5\n'
-            ' 6\n'
-            ' 7\n'
-            ' 8\n'
-            ' 9\n'
-            '10\n'
-            '11\n'
-            '12\n'
-            '13</pre></div></td>' in html)
+    assert ('<span class="linenos"> 1</span><span class="c1">'
+            '# Literally included file using Python highlighting</span>' in html)
 
     # :lineno-start:
-    assert ('<td class="linenos"><div class="linenodiv"><pre>'
-            '200\n'
-            '201\n'
-            '202\n'
-            '203\n'
-            '204\n'
-            '205\n'
-            '206\n'
-            '207\n'
-            '208\n'
-            '209\n'
-            '210\n'
-            '211\n'
-            '212</pre></div></td>' in html)
+    assert ('<span class="linenos">200</span><span class="c1">'
+            '# Literally included file using Python highlighting</span>' in html)
 
-    # :lineno-match:
-    assert ('<td class="linenos"><div class="linenodiv"><pre>'
-            '5\n'
-            '6\n'
-            '7\n'
-            '8\n'
-            '9</pre></div></td>' in html)
+    # :lines: 5-9
+    assert ('<span class="linenos">5</span><span class="k">class</span> '
+            '<span class="nc">Foo</span><span class="p">:</span>' in html)
 
 
 @pytest.mark.sphinx('latex', testroot='directive-code')
@@ -594,45 +566,17 @@ def test_linenothreshold(app, status, warning):
     app.builder.build(['linenothreshold'])
     html = (app.outdir / 'linenothreshold.html').read_text()
 
-    lineos_head = '<td class="linenos"><div class="linenodiv"><pre>'
-    lineos_tail = '</pre></div></td>'
-
     # code-block using linenothreshold
-    _, matched, html = html.partition(lineos_head +
-                                      '1\n'
-                                      '2\n'
-                                      '3\n'
-                                      '4\n'
-                                      '5\n'
-                                      '6' + lineos_tail)
-    assert matched
+    assert ('<span class="linenos">1</span><span class="k">class</span> '
+            '<span class="nc">Foo</span><span class="p">:</span>' in html)
 
-    # code-block not using linenothreshold
-    html, matched, _ = html.partition(lineos_head +
-                                      '1\n'
-                                      '2' + lineos_tail)
-    assert not matched
+    # code-block not using linenothreshold (no line numbers)
+    assert '<span></span><span class="c1"># comment</span>' in html
 
     # literal include using linenothreshold
-    _, matched, html = html.partition(lineos_head +
-                                      ' 1\n'
-                                      ' 2\n'
-                                      ' 3\n'
-                                      ' 4\n'
-                                      ' 5\n'
-                                      ' 6\n'
-                                      ' 7\n'
-                                      ' 8\n'
-                                      ' 9\n'
-                                      '10\n'
-                                      '11\n'
-                                      '12\n'
-                                      '13' + lineos_tail)
-    assert matched
+    assert ('<span class="linenos"> 1</span><span class="c1">'
+            '# Literally included file using Python highlighting</span>' in html)
 
-    # literal include not using linenothreshold
-    html, matched, _ = html.partition(lineos_head +
-                                      '1\n'
-                                      '2\n'
-                                      '3' + lineos_tail)
-    assert not matched
+    # literal include not using linenothreshold (no line numbers)
+    assert ('<span></span><span class="c1"># Very small literal include '
+            '(linenothreshold check)</span>' in html)


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7849 
- As discussed in #7879, the default style of line numbers for code
blocks in HTML output becomes 'inline' by default.  And 'table' style
is now deprecated and will be removed in Sphinx-6.0.
