### PR TITLE
Fix autosummary: "Module attributes" header is not translatable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,7 @@ Bugs fixed
 * #7865: autosummary: Failed to extract summary line when abbreviations found
 * #7866: autosummary: Failed to extract correct summary line when docstring
   contains a hyperlink target
+* #7469: autosummary: "Module attributes" header is not translatable
 * #7940: apidoc: An extra newline is generated at the end of the rst file if a
   module has submodules 
 * #4258: napoleon: decorated special methods are not shown

--- a/sphinx/ext/autosummary/templates/autosummary/module.rst
+++ b/sphinx/ext/autosummary/templates/autosummary/module.rst
@@ -4,7 +4,7 @@
 
    {% block attributes %}
    {% if attributes %}
-   .. rubric:: Module Attributes
+   .. rubric:: {{ _('Module Attributes') }}
 
    .. autosummary::
    {% for item in attributes %}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7469