### PR TITLE
Fix #904: autodoc: An instance attribute cause a crash of autofunction

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ Bugs fixed
 * #7935: autodoc: function signature is not shown when the function has a
   parameter having ``inspect._empty`` as its default value
 * #7901: autodoc: type annotations for overloaded functions are not resolved
+* #904: autodoc: An instance attribute cause a crash of autofunction directive
 * #7839: autosummary: cannot handle umlauts in function names
 * #7865: autosummary: Failed to extract summary line when abbreviations found
 * #7866: autosummary: Failed to extract correct summary line when docstring

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1047,7 +1047,7 @@ def test_class_attributes(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_instance_attributes(app):
+def test_autoclass_instance_attributes(app):
     options = {"members": None}
     actual = do_autodoc(app, 'class', 'target.InstAttCls', options)
     assert list(actual) == [
@@ -1116,6 +1116,19 @@ def test_instance_attributes(app):
         '      :module: target',
         '',
         '      Doc comment for instance attribute InstAttCls.ia1',
+        ''
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autoattribute_instance_attributes(app):
+    actual = do_autodoc(app, 'attribute', 'target.InstAttCls.ia1')
+    assert list(actual) == [
+        '',
+        '.. py:attribute:: InstAttCls.ia1',
+        '   :module: target',
+        '',
+        '   Doc comment for instance attribute InstAttCls.ia1',
         ''
     ]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #904 
- So far, autofunction only checks the existence of the class variable.
   As a result, it crashes with AttributeError if an instance variable is
   specified.

   This adds an exisitence for instance attributes via ModuleAnalyzer
   before getattr-check.
