### PR TITLE
add item even if it could not be imported

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -303,6 +303,7 @@ class Autosummary(SphinxDirective):
             except ImportError:
                 logger.warning(__('autosummary: failed to import %s'), name,
                                location=self.get_source_info())
+                items.append((display_name, '', '', name))
                 continue
 
             self.bridge.result = StringList()  # initialize for each documenter


### PR DESCRIPTION
partially reverts 1dcfc44ace8f3da33f4ee62448aadee67edd80cc from #7661

Subject: Add an item to the autosummary table, even if it cannot be imported

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Not sure if this was removed by accident in #7661, but the following line has been removed in 1dcfc44ace8f3da33f4ee62448aadee67edd80cc

https://github.com/sphinx-doc/sphinx/blob/1771bbb9277c3b629ac6e708c4c3f355e034c6cd/sphinx/ext/autosummary/__init__.py#L306

I am readding it here and use the `display_name` instead of the `name` (makes more sense, doesn't it?). The reason, why I am interested in is, that otherwise instance attributes are skipped entirely with the `autosummary` directive.

### Relates
- #7661

