### PR TITLE
Fix #7745: html: inventory is broken if the docname contains a space

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Features added
 * #7888: napoleon: Add aliases Warn and Raise.
 * C, added :rst:dir:`c:alias` directive for inserting copies
   of existing declarations.
+* #7745: html: inventory is broken if the docname contains a space
 * #7902: html theme: Add a new option :confval:`globaltoc_maxdepth` to control
   the behavior of globaltoc in sidebar
 * #7052: add ``:noindexentry:`` to the Python, C, C++, and Javascript domains.

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -15,6 +15,7 @@ import sys
 import warnings
 from os import path
 from typing import Any, Dict, IO, Iterable, Iterator, List, Set, Tuple
+from urllib.parse import quote
 
 from docutils import nodes
 from docutils.core import publish_parts
@@ -947,7 +948,7 @@ class StandaloneHTMLBuilder(Builder):
     # --------- these are overwritten by the serialization builder
 
     def get_target_uri(self, docname: str, typ: str = None) -> str:
-        return docname + self.link_suffix
+        return quote(docname) + self.link_suffix
 
     def handle_page(self, pagename: str, addctx: Dict, templatename: str = 'page.html',
                     outfilename: str = None, event_arg: Any = None) -> None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7745 
- The format of inventory file expects that URIs do not contain spaces.
Not to generate a URL containing spaces, HTMLBuilder.get_target_uri()
should do URL-escaping to the docname.