### PR TITLE
Autodoc: Allow overriding of exclude-members in skip-member function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Deprecated
 Features added
 --------------
 
+* #2076: autodoc: Allow overriding of exclude-members in skip-member function
 * #7849: html: Add :confval:`html_codeblock_linenos_style` to change the style
   of line numbers for code-blocks
 * #7853: C and C++, support parameterized GNU style attributes.

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -626,6 +626,10 @@ class Documenter:
             if safe_getattr(member, '__sphinx_mock__', False):
                 # mocked module or object
                 pass
+            elif (self.options.exclude_members not in (None, ALL) and
+                  membername in self.options.exclude_members):
+                # remove members given by exclude-members
+                keep = False
             elif want_all and membername.startswith('__') and \
                     membername.endswith('__') and len(membername) > 4:
                 # special __methods__
@@ -694,16 +698,6 @@ class Documenter:
             self.options.members is ALL
         # find out which members are documentable
         members_check_module, members = self.get_object_members(want_all)
-
-        # remove members given by exclude-members
-        if self.options.exclude_members:
-            members = [
-                (membername, member) for (membername, member) in members
-                if (
-                    self.options.exclude_members is ALL or
-                    membername not in self.options.exclude_members
-                )
-            ]
 
         # document non-skipped members
         memberdocumenters = []  # type: List[Tuple[Documenter, bool]]


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #2076 
- I cherry-pick'ed a commit from #2076 to 3.x branch.