### PR TITLE
Fix typo in prepare_docstring() warning

### DIFF
--- a/sphinx/util/docstrings.py
+++ b/sphinx/util/docstrings.py
@@ -57,7 +57,7 @@ def prepare_docstring(s: str, ignore: int = None, tabsize: int = 8) -> List[str]
     if ignore is None:
         ignore = 1
     else:
-        warnings.warn("The 'ignore' argument to parepare_docstring() is deprecated.",
+        warnings.warn("The 'ignore' argument to prepare_docstring() is deprecated.",
                       RemovedInSphinx50Warning, stacklevel=2)
 
     lines = s.expandtabs(tabsize).splitlines()


### PR DESCRIPTION
Subject: Fix typo in prepare_docstring() warning

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Detail
Fix warning from mentioning "parepare_docstring" to "prepare_docstring".

