### PR TITLE
C, don't deepcopy as deep on handling enumerators

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* C, don't deepcopy the entire symbol table and make a mess every time an
+  enumerator is handled.
+
 Testing
 --------
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1330,6 +1330,10 @@ class ASTDeclaration(ASTBaseBase):
         # set by CObject._add_enumerator_to_parent
         self.enumeratorScopedSymbol = None  # type: Symbol
 
+    def clone(self) -> "ASTDeclaration":
+        return ASTDeclaration(self.objectType, self.directiveType,
+                              self.declaration.clone(), self.semicolon)
+
     @property
     def name(self) -> ASTNestedName:
         return self.declaration.name
@@ -1418,6 +1422,16 @@ class Symbol:
     debug_indent_string = "  "
     debug_lookup = False
     debug_show_tree = False
+
+    def __copy__(self):
+        assert False  # shouldn't happen
+
+    def __deepcopy__(self, memo):
+        if self.parent:
+            assert False  # shouldn't happen
+        else:
+            # the domain base class makes a copy of the initial data, which is fine
+            return Symbol(None, None, None, None)
 
     @staticmethod
     def debug_print(*args: Any) -> None:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3781,6 +3781,16 @@ class Symbol:
     debug_lookup = False  # overridden by the corresponding config value
     debug_show_tree = False  # overridden by the corresponding config value
 
+    def __copy__(self):
+        assert False  # shouldn't happen
+
+    def __deepcopy__(self, memo):
+        if self.parent:
+            assert False  # shouldn't happen
+        else:
+            # the domain base class makes a copy of the initial data, which is fine
+            return Symbol(None, None, None, None, None, None)
+
     @staticmethod
     def debug_print(*args: Any) -> None:
         print(Symbol.debug_indent_string * Symbol.debug_indent, end="")

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -110,7 +110,6 @@ class ASTBaseBase:
     __hash__ = None  # type: Callable[[], int]
 
     def clone(self) -> Any:
-        """Clone a definition expression node."""
         return deepcopy(self)
 
     def _stringify(self, transform: StringifyTransform) -> str:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
When an enumerator is added it is automatically copied into the scope of the parent as well. The symbol, along with the complete symbol table and all other declarations of the domain, was not supposed to copied.

### Relates
- Fixes michaeljones/breathe#559

