### PR TITLE
refactor: namedtuples with PEP 526

### DIFF
--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -54,13 +54,14 @@ class ObjType:
         self.attrs.update(attrs)
 
 
-IndexEntry = NamedTuple('IndexEntry', [('name', str),
-                                       ('subtype', int),
-                                       ('docname', str),
-                                       ('anchor', str),
-                                       ('extra', str),
-                                       ('qualifier', str),
-                                       ('descr', str)])
+class IndexEntry(NamedTuple):
+    name: str
+    subtype: int
+    docname: str
+    anchor: str
+    extra: str
+    qualifier: str
+    descr: str
 
 
 class Index:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -63,15 +63,20 @@ pairindextypes = {
     'builtin':   _('built-in function'),
 }
 
-ObjectEntry = NamedTuple('ObjectEntry', [('docname', str),
-                                         ('node_id', str),
-                                         ('objtype', str),
-                                         ('canonical', bool)])
-ModuleEntry = NamedTuple('ModuleEntry', [('docname', str),
-                                         ('node_id', str),
-                                         ('synopsis', str),
-                                         ('platform', str),
-                                         ('deprecated', bool)])
+
+class ObjectEntry(NamedTuple):
+    docname: str
+    node_id: str
+    objtype: str
+    canonical: bool
+
+
+class ModuleEntry(NamedTuple):
+    docname: str
+    node_id: str
+    synopsis: str
+    platform: str
+    deprecated: bool
 
 
 def type_to_xref(text: str) -> addnodes.pending_xref:

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -25,9 +25,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-EventListener = NamedTuple('EventListener', [('id', int),
-                                             ('handler', Callable),
-                                             ('priority', int)])
+
+class EventListener(NamedTuple):
+    id: int
+    handler: Callable
+    priority: int
 
 
 # List of all known core events. Maps name to arguments description.

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -76,10 +76,11 @@ class DummyApplication:
         pass
 
 
-AutosummaryEntry = NamedTuple('AutosummaryEntry', [('name', str),
-                                                   ('path', str),
-                                                   ('template', str),
-                                                   ('recursive', bool)])
+class AutosummaryEntry(NamedTuple):
+    name: str
+    path: str
+    template: str
+    recursive: bool
 
 
 def setup_documenters(app: Any) -> None:

--- a/sphinx/transforms/post_transforms/code.py
+++ b/sphinx/transforms/post_transforms/code.py
@@ -21,9 +21,10 @@ from sphinx.ext import doctest
 from sphinx.transforms import SphinxTransform
 
 
-HighlightSetting = NamedTuple('HighlightSetting', [('language', str),
-                                                   ('force', bool),
-                                                   ('lineno_threshold', int)])
+class HighlightSetting(NamedTuple):
+    language: str
+    force: bool
+    lineno_threshold: int
 
 
 class HighlightLanguageTransform(SphinxTransform):

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -31,9 +31,11 @@ mime_suffixes = OrderedDict([
     ('.ai', 'application/illustrator'),
 ])
 
-DataURI = NamedTuple('DataURI', [('mimetype', str),
-                                 ('charset', str),
-                                 ('data', bytes)])
+
+class DataURI(NamedTuple):
+    mimetype: str
+    charset: str
+    data: bytes
 
 
 def get_image_size(filename: str) -> Optional[Tuple[int, int]]:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Apply PEP 526 based variable annotation style to namedtuples.  It
is available since python 3.6.
