### PR TITLE
Fix #7968: i18n: process math_block as a literal node

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -242,6 +242,7 @@ def is_translatable(node: Node) -> bool:
 LITERAL_TYPE_NODES = (
     nodes.literal_block,
     nodes.doctest_block,
+    nodes.math_block,
     nodes.raw,
 )
 IMAGE_TYPE_NODES = (


### PR DESCRIPTION
Subject: enable translating math blocks. Before this PR, `\` weren't preserved.

### Feature or Bugfix
- Bugfix

### Purpose
- Without this patch, you can't translate math blocks

### Detail
- #7968
