### PR TITLE
Close #2645: html: Support the Open Graph Protocol (OGP)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,9 @@ Features added
 * C, added :rst:dir:`c:alias` directive for inserting copies
   of existing declarations.
 * #7745: html: inventory is broken if the docname contains a space
+* #2645: html: Support the Open Graph Protocol (OGP).  It can be controlled via
+  :confval:`html_ogp`, :confval:`html_ogp_meta` and document :ref:`metadata`
+  (a.k.a.  docinfo)
 * #7902: html theme: Add a new option :confval:`globaltoc_maxdepth` to control
   the behavior of globaltoc in sidebar
 * #7840: i18n: Optimize the dependencies check on bootstrap

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -966,6 +966,32 @@ that use Sphinx's HTMLWriter class.
       The image file will be copied to the ``_static`` directory of the output
       HTML, but only if the file does not already exist there.
 
+.. confval:: html_ogp
+
+   If ``True``, HTML builder generates metadata for `The Open Graph protocol`__
+   (OGP) from the content and configurations.  Default is ``True``.
+
+   By setting :confval:`html_baseurl`, the ``og:url`` can be added
+   automatically.
+
+   .. versionadded:: 3.2
+   .. __: https://ogp.me/
+
+.. confval:: html_ogp_meta
+
+   A dictionary for the Open Graph Protocol (OGP).  It is used to the default
+   value of the metadata.  It can be overridden by the :ref:`metadata` in
+   each document.
+
+   Example::
+
+       html_ogp_meta = {
+           "twitter:card": "summary",
+           "twitter:site": "@sphinxdoc"
+       }
+
+   .. versionadded:: 3.2
+
 .. confval:: html_css_files
 
    A list of CSS files.  The entry must be a *filename* string or a tuple

--- a/doc/usage/restructuredtext/field-lists.rst
+++ b/doc/usage/restructuredtext/field-lists.rst
@@ -60,3 +60,13 @@ At the moment, these metadata fields are recognized:
    .. note:: object search is still available even if `nosearch` option is set.
 
    .. versionadded:: 3.0
+
+``og:*`` (ex. ``og:site_name``, ``og:description`` and so on)
+   If set, the metadata for `The Open Graph protocol`__ is applied to the
+   document.  The metadata is used in the HTML builders.  See
+   :confval:`html_ogp` for detail.
+
+   .. versionadded:: 3.2
+   .. __: https://ogp.me/
+
+   .. note:: OGP metadata is available since docutils-0.16.

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -563,7 +563,7 @@ class StandaloneHTMLBuilder(Builder):
             sourcename = ''
 
         # metadata for the document
-        meta = self.env.metadata.get(docname)
+        meta = self.env.metadata.get(docname, {})
 
         # local TOC and global TOC tree
         self_toc = TocTree(self.env).get_toc_for(docname, self)
@@ -1247,7 +1247,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # load default math renderer
     app.setup_extension('sphinx.ext.mathjax')
 
-    # load transforms for HTML builder
+    # load sub-extensions for HTML builders
+    app.setup_extension('sphinx.builders.html.ogp')
     app.setup_extension('sphinx.builders.html.transforms')
 
     return {

--- a/sphinx/builders/html/ogp.py
+++ b/sphinx/builders/html/ogp.py
@@ -1,0 +1,164 @@
+"""
+    sphinx.builders.html.ogp
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    OGP tag plug-in for HTML builders.
+
+    :copyright: Copyright 2007-2020 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import posixpath
+from typing import Any, Dict, Generator, List
+
+from docutils import nodes
+from docutils.nodes import Element
+
+from sphinx.application import Sphinx
+from sphinx.util.osutil import canon_path
+
+
+class OGDescriptionCollector(nodes.SparseNodeVisitor):
+    """A description collector module for OGP metadata."""
+
+    def __init__(self, document: nodes.document) -> None:
+        super().__init__(document)
+        self.descriptions = []  # type: List[str]
+        self.sections = 0       # type: int
+
+    def visit_compact_paragraph(self, node: Element) -> None:
+        if node.get('toctree'):
+            # ignore toctree
+            raise nodes.SkipChildren
+
+    def visit_section(self, node: Element) -> None:
+        self.sections += 1
+        if self.sections >= 3:
+            # stop processing when the 3rd section found
+            raise nodes.StopTraversal
+
+    def visit_paragraph(self, node: Element) -> None:
+        # collect paragraph as a part of descriptions
+        self.descriptions.append(node.astext())
+
+
+class OGImageCollector(nodes.SparseNodeVisitor):
+    """An image collector module for OGP metadata.
+
+    .. note:: This will be removed on dropping docutils-0.15 support.
+              Since 0.16, this class will be replaced by
+              ``Element.traverse()``.
+    """
+    def __init__(self, document: nodes.document) -> None:
+        super().__init__(document)
+        self.image = None  # type: nodes.image
+
+    def visit_image(self, node: nodes.image) -> None:
+        self.image = node
+        raise nodes.StopTraversal
+
+
+def get_ogpmeta_from_context(context: Dict) -> Dict:
+    """Pick OGP metadata up from the metadata of the document."""
+    htmlmeta = context.get('meta') or {}
+    return {k: v for k, v in htmlmeta.items() if k.startswith('og:')}
+
+
+def apply_html_ogp_meta(app: Sphinx, ogpmeta: Dict) -> None:
+    """Apply :confval:`html_ogp_meta` to document specific OGP metadata."""
+    for key, value in app.config.html_ogp_meta.items():
+        ogpmeta.setdefault(key, value)
+
+
+def extract_ogpmeta_from_content(app: Sphinx, docname: str, context: Dict,
+                                 ogpmeta: Dict, doctree: nodes.document) -> None:
+    """Extract OGP metadata from contents."""
+    # fill system-default OGP metadata
+    ogpmeta.setdefault('og:type', 'website')
+    ogpmeta.setdefault('og:title', app.env.titles[docname].astext())
+
+    if app.config.html_baseurl:
+        url = posixpath.join(app.config.html_baseurl,
+                             docname + app.builder.out_suffix)  # type: ignore
+        ogpmeta.setdefault('og:url', url)
+    if app.config.project:
+        ogpmeta.setdefault('og:site_name', app.config.project)
+
+    # collect og:description from doctree
+    if 'og:description' not in ogpmeta:
+        dcollector = OGDescriptionCollector(doctree)
+        doctree.walkabout(dcollector)
+
+        if dcollector.descriptions:
+            description = ' '.join(dcollector.descriptions)
+            if len(description) > 200:
+                description = description[:197] + "..."
+
+            ogpmeta['og:description'] = description
+
+    # collect og:image from doctree
+    if 'og:image' not in ogpmeta:
+        icollector = OGImageCollector(doctree)
+        doctree.walkabout(icollector)
+
+        if icollector.image:
+            if app.config.html_baseurl:
+                ogpmeta['og:image'] = posixpath.join(app.config.html_baseurl,
+                                                     icollector.image['uri'])
+            else:
+                ogpmeta['og:image'] = icollector.image['uri']
+
+
+def _generate_ogp_tags(context: Dict, ogpmeta: Dict) -> Generator[str, None, None]:
+    """Generate OGP tags from given *ogpmeta*."""
+    pathto = context['pathto']
+    for key, value in ogpmeta.items():
+        if key == 'og:image':
+            # convert og:image to a relative URI from current document.
+            try:
+                value = pathto(value, True)
+            except Exception:
+                pass
+
+        yield '<meta property="%s" content="%s" />' % (key, value)
+
+
+def generate_ogp_tags(app: Sphinx, pagename: str, templatename: str,
+                      context: Dict, doctree: nodes.document) -> None:
+    """Generate OGP tags for current document."""
+    if doctree is None:
+        # ignore static pages
+        return
+    if app.config.html_ogp is False:
+        # OGP feature is disabled
+        return
+
+    ogpmeta = get_ogpmeta_from_context(context)
+    apply_html_ogp_meta(app, ogpmeta)
+
+    if 'og:image' in ogpmeta:
+        # convert document specific og:image to a relative path from current document
+        ogimage = ogpmeta['og:image']
+        relpath, abspath = app.env.relfn2path(ogimage, pagename)
+        relpath = canon_path(relpath)
+        if app.config.html_baseurl:
+            relpath = posixpath.join(app.config.html_baseurl, relpath)
+        ogpmeta['og:image'] = relpath
+
+    extract_ogpmeta_from_content(app, pagename, context, ogpmeta, doctree)
+
+    if ogpmeta:
+        context['metatags'] += '\n    '
+        context['metatags'] += '\n    '.join(_generate_ogp_tags(context, ogpmeta))
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_config_value('html_ogp', True, 'html')
+    app.add_config_value('html_ogp_meta', {}, 'html')
+    app.connect('html-page-context', generate_ogp_tags)
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/tests/roots/test-ext-viewcode-find/conf.py
+++ b/tests/roots/test-ext-viewcode-find/conf.py
@@ -1,3 +1,4 @@
 extensions = ['sphinx.ext.viewcode']
 exclude_patterns = ['_build']
 viewcode_follow_imported_members = False
+html_ogp = False

--- a/tests/roots/test-ext-viewcode/conf.py
+++ b/tests/roots/test-ext-viewcode/conf.py
@@ -6,6 +6,7 @@ if source_dir not in sys.path:
     sys.path.insert(0, source_dir)
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
 exclude_patterns = ['_build']
+html_ogp = False
 
 
 if 'test_linkcode' in tags:  # NOQA

--- a/tests/roots/test-html-ogp/conf.py
+++ b/tests/roots/test-html-ogp/conf.py
@@ -1,0 +1,1 @@
+html_baseurl = 'https://example.com/'

--- a/tests/roots/test-html-ogp/image.rst
+++ b/tests/roots/test-html-ogp/image.rst
@@ -1,0 +1,4 @@
+image
+=====
+
+.. image:: path/to/image.png

--- a/tests/roots/test-html-ogp/index.rst
+++ b/tests/roots/test-html-ogp/index.rst
@@ -1,0 +1,6 @@
+html-ogp
+========
+
+blah blah
+
+blah blah

--- a/tests/roots/test-html-ogp/metadata.rst
+++ b/tests/roots/test-html-ogp/metadata.rst
@@ -1,0 +1,11 @@
+:og:url: https://www.sphinx-doc.org/
+:og:site_name: Sphinx
+:og:image: /image.png
+:og:description: User defined description
+
+metadata
+========
+
+blah blah
+
+blah blah

--- a/tests/roots/test-html-ogp/subdir/image.rst
+++ b/tests/roots/test-html-ogp/subdir/image.rst
@@ -1,0 +1,4 @@
+subdir/image
+============
+
+.. image:: /image.png

--- a/tests/roots/test-html-ogp/subdir/metadata.rst
+++ b/tests/roots/test-html-ogp/subdir/metadata.rst
@@ -1,0 +1,4 @@
+:og:image: image.png
+
+subdir/metadata
+===============

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1592,3 +1592,115 @@ def test_html_codeblock_linenos_style_inline(app):
     content = (app.outdir / 'index.html').read_text()
 
     assert '<span class="lineno">1 </span>' in content
+
+
+@pytest.mark.skipif(docutils.__version_info__ < (0, 16),
+                    reason='docutils-0.16 or above is required')
+@pytest.mark.sphinx('html', testroot='html-ogp')
+def test_html_ogp(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    # basic
+    assert '<meta property="og:type" content="website" />' in content
+    assert '<meta property="og:url" content="https://example.com/index.html" />' in content
+    assert '<meta property="og:site_name" content="Python" />' in content
+    assert '<meta property="og:title" content="html-ogp" />' in content
+    assert '<meta property="og:description" content="blah blah blah blah" />' in content
+    assert '<meta property="og:image" ' not in content
+
+    # og:image
+    content = (app.outdir / 'image.html').read_text()
+    assert '<meta property="og:type" content="website" />' in content
+    assert '<meta property="og:title" content="image" />' in content
+    assert '<meta property="og:description" ' not in content
+    assert '<meta property="og:image" content="https://example.com/path/to/image.png" />' in content
+
+    # og:image (absolute-like path)
+    content = (app.outdir / 'subdir' / 'image.html').read_text()
+    assert '<meta property="og:type" content="website" />' in content
+    assert '<meta property="og:title" content="subdir/image" />' in content
+    assert '<meta property="og:description" ' not in content
+    assert '<meta property="og:image" content="https://example.com/image.png" />' in content
+
+    # document specific metadata
+    content = (app.outdir / 'metadata.html').read_text()
+    assert '<meta property="og:type" content="website" />' in content
+    assert '<meta property="og:url" content="https://www.sphinx-doc.org/" />' in content
+    assert '<meta property="og:site_name" content="Sphinx" />' in content
+    assert '<meta property="og:title" content="metadata" />' in content
+    assert '<meta property="og:description" content="User defined description" />' in content
+    assert '<meta property="og:image" content="https://example.com/image.png" />' in content
+
+    # document specific metadata (relative og:image)
+    content = (app.outdir / 'subdir' / 'metadata.html').read_text()
+    assert '<meta property="og:type" content="website" />' in content
+    assert '<meta property="og:title" content="subdir/metadata" />' in content
+    assert '<meta property="og:image" content="https://example.com/subdir/image.png" />' in content
+
+
+@pytest.mark.skipif(docutils.__version_info__ < (0, 16),
+                    reason='docutils-0.16 or above is required')
+@pytest.mark.sphinx('html', testroot='html-ogp', confoverrides={'html_ogp': False})
+def test_html_ogp_disabled(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    # basic
+    assert '<meta property="og:type" content="website" />' not in content
+    assert '<meta property="og:url" content="https://example.com/index.html" />' not in content
+    assert '<meta property="og:site_name" content="Python" />' not in content
+    assert '<meta property="og:title" content="html-ogp" />' not in content
+    assert '<meta property="og:description" content="blah blah blah blah" />' not in content
+    assert '<meta property="og:image" ' not in content
+
+    # og:image
+    content = (app.outdir / 'image.html').read_text()
+    assert '<meta property="og:type" content="website" />' not in content
+    assert '<meta property="og:title" content="html-ogp" />' not in content
+    assert '<meta property="og:description" ' not in content
+    assert '<meta property="og:image" content="https://example.com/path/to/image.png" />' not in content
+
+    # og:image (absolute-like path)
+    content = (app.outdir / 'subdir' / 'image.html').read_text()
+    assert '<meta property="og:type" content="website" />' not in content
+    assert '<meta property="og:title" content="html-ogp" />' not in content
+    assert '<meta property="og:description" ' not in content
+    assert '<meta property="og:image" content="https://example.com/image.png" />' not in content
+
+    # document specific metadata are also not shown
+    content = (app.outdir / 'metadata.html').read_text()
+    assert '<meta property="og:type" content="website" />' not in content
+    assert '<meta property="og:url" content="https://www.sphinx-doc.org/" />' not in content
+    assert '<meta property="og:site_name" content="Sphinx" />' not in content
+    assert '<meta property="og:title" content="html-ogp" />' not in content
+    assert '<meta property="og:description" content="User defined description" />' not in content
+    assert '<meta property="og:image" content="https://example.com/image.png" />' not in content
+
+    # document specific metadata (relative og:image) are also not shown
+    content = (app.outdir / 'subdir' / 'metadata.html').read_text()
+    assert '<meta property="og:type" content="website" />' not in content
+    assert '<meta property="og:title" content="html-ogp" />' not in content
+    assert '<meta property="og:image" content="https://example.com/subdir/image.png" />' not in content
+
+
+@pytest.mark.skipif(docutils.__version_info__ < (0, 16),
+                    reason='docutils-0.16 or above is required')
+@pytest.mark.sphinx('html', testroot='html-ogp',
+                    confoverrides={'html_ogp_meta': {'og:site_name': 'SPHINX',
+                                                     'twitter:card': 'summary',
+                                                     'twitter:site': '@sphinxdoc'}})
+def test_html_ogp_meta(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    # basic
+    assert '<meta property="og:site_name" content="SPHINX" />' in content
+    assert '<meta property="twitter:card" content="summary" />' in content
+    assert '<meta property="twitter:site" content="@sphinxdoc" />' in content
+
+    # document specific metadata
+    content = (app.outdir / 'metadata.html').read_text()
+    assert '<meta property="og:site_name" content="Sphinx" />' in content
+    assert '<meta property="twitter:card" content="summary" />' in content
+    assert '<meta property="twitter:site" content="@sphinxdoc" />' in content


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #2645 
- This adds a OGP feature to HTML builders.

  * Enable or disable whole of OGP feature via :confval:`html_ogp`
  * Set the default OGP metadata of the document via :confval:
    `html_ogp_meta`
  * Generate OGP metadata automatically from its contents
  * Specify document-specific OGP metadata via docinfo

-  This is based on @shimizukawa's implementation:
    https://github.com/sphinx-contrib/ogp