### PR TITLE
Fix #7973: imgconverter: Check availability of imagemagick many times

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,7 @@ Bugs fixed
 * #8175: intersphinx: Potential of regex denial of service by broken inventory
 * #8277: sphinx-build: missing and redundant spacing (and etc) for console
   output on building
+* #7973: imgconverter: Check availability of imagemagick many times
 * #8093: The highlight warning has wrong location in some builders (LaTeX,
   singlehtml and so on)
 * #8239: Failed to refer a token in productionlist if it is indented

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -11,7 +11,7 @@
 import os
 import re
 from math import ceil
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from docutils import nodes
 
@@ -175,6 +175,13 @@ class ImageConverter(BaseImageConverter):
     """
     default_priority = 200
 
+    #: The converter is available or not.  Will be filled at the first call of
+    #: the build.  The result is shared in the same process.
+    #:
+    #: .. todo:: This should be refactored not to store the state without class
+    #:           variable.
+    available = None  # type: Optional[bool]
+
     #: A conversion rules the image converter supports.
     #: It is represented as a list of pair of source image format (mimetype) and
     #: destination one::
@@ -187,16 +194,14 @@ class ImageConverter(BaseImageConverter):
     conversion_rules = []  # type: List[Tuple[str, str]]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.available = None   # type: bool
-                                # the converter is available or not.
-                                # Will be checked at first conversion
         super().__init__(*args, **kwargs)
 
     def match(self, node: nodes.image) -> bool:
         if not self.app.builder.supported_image_types:
             return False
         elif self.available is None:
-            self.available = self.is_available()
+            # store the value to the class variable to share it during the build
+            self.__class__.available = self.is_available()
 
         if not self.available:
             return False


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7973 
- To prevent checking the availability of image converters times and times
again, this stores the result to the class variable.  It is not a good
design to have a state globally.  So this should be refactored in the
future.
