### PR TITLE
Fix #7983: autodoc: Generator type annotation is wrongly rendered in py36

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -46,6 +46,7 @@ Bugs fixed
 * #7901: autodoc: type annotations for overloaded functions are not resolved
 * #904: autodoc: An instance attribute cause a crash of autofunction directive
 * #1362: autodoc: ``private-members`` option does not work for class attributes
+* #7983: autodoc: Generator type annotation is wrongly rendered in py36
 * #7839: autosummary: cannot handle umlauts in function names
 * #7865: autosummary: Failed to extract summary line when abbreviations found
 * #7866: autosummary: Failed to extract correct summary line when docstring

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -10,7 +10,7 @@
 
 import sys
 import typing
-from typing import Any, Callable, Dict, List, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Generator, List, Tuple, TypeVar, Union
 
 from docutils import nodes
 from docutils.parsers.rst.states import Inliner
@@ -163,6 +163,8 @@ def _stringify_py36(annotation: Any) -> str:
         if hasattr(annotation, '__args__'):
             # for Python 3.5.2+
             if annotation.__args__ is None or len(annotation.__args__) <= 2:  # type: ignore  # NOQA
+                params = annotation.__args__  # type: ignore
+            elif annotation.__origin__ == Generator:  # type: ignore
                 params = annotation.__args__  # type: ignore
             else:  # typing.Callable
                 args = ', '.join(stringify(arg) for arg

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -10,7 +10,9 @@
 
 import sys
 from numbers import Integral
-from typing import Any, Dict, List, TypeVar, Union, Callable, Tuple, Optional, Generic
+from typing import (
+    Any, Dict, Generator, List, TypeVar, Union, Callable, Tuple, Optional, Generic
+)
 
 import pytest
 
@@ -48,6 +50,7 @@ def test_stringify_type_hints_containers():
     assert stringify(Tuple[str, ...]) == "Tuple[str, ...]"
     assert stringify(List[Dict[str, Tuple]]) == "List[Dict[str, Tuple]]"
     assert stringify(MyList[Tuple[int, int]]) == "test_util_typing.MyList[Tuple[int, int]]"
+    assert stringify(Generator[None, None, None]) == "Generator[None, None, None]"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason='python 3.9+ is required.')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7983 
- This adds a special handler (if-branch) for Generator type to stringify
them correctly.  So far, they have been considered as a kind of Callable.

