### PR TITLE
basic CSS: fix "highlight-" selector

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -86,6 +86,7 @@ Bugs fixed
 * #7619: Duplicated node IDs are generated if node has multiple IDs
 * #2050: Symbols sections are appeared twice in the index page
 * #8017: Fix circular import in sphinx.addnodes
+* #7986: CSS: make "highlight" selector more robust
 
 Testing
 --------

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -693,7 +693,7 @@ pre {
     overflow-y: hidden;  /* fixes display issues on Chrome browsers */
 }
 
-pre, div[class|="highlight"] {
+pre, div[class*="highlight-"] {
     clear: both;
 }
 
@@ -704,7 +704,7 @@ span.pre {
     hyphens: none;
 }
 
-div[class^="highlight-"] {
+div[class*="highlight-"] {
     margin: 1em 0;
 }
 


### PR DESCRIPTION
In 0dc6e3ac458dd6c10ed2c7bd03ca95bd694d7ec6 I've added

```css
div[class^="highlight-"] {
    margin: 1em 0;
}
```

and in 03be040ca8f5aa6c52b19cf3bf3ab10e284159f6 I've added

```css
div[class|="highlight"] {
    clear: both;
}
```

In the first case I wanted to select `highlight-*` but not `highlight`.
In the second case I didn't care whether `highlight` was selected or not.

The problem is that both selectors only work if they are at the beginning of the `class` attribute.
If they are not (which happens e.g. in a `compound` directive), the selectors don't work as expected.

In this PR, I'm suggesting to change both cases to `div[class*="highlight-"]` which should work in both cases as expected.

This also selects classes which have `highlight-` somewhere in the middle or at the end, but I hope such class names are not used in practice.

### Feature or Bugfix

- Bugfix

### Relates

#7540
#7657