### PR TITLE
adds ability for users to provide a custom pygments Style object

### DIFF
--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -10,7 +10,7 @@
 
 from functools import partial
 from importlib import import_module
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from pygments import highlight
 from pygments.filters import ErrorToken
@@ -60,7 +60,7 @@ class PygmentsBridge:
     html_formatter = HtmlFormatter
     latex_formatter = LatexFormatter
 
-    def __init__(self, dest: str = 'html', stylename: str = 'sphinx',
+    def __init__(self, dest: str = 'html', stylename: Union[str,Style] = 'sphinx',
                  latex_engine: str = None) -> None:
         self.dest = dest
         self.latex_engine = latex_engine
@@ -73,7 +73,7 @@ class PygmentsBridge:
             self.formatter = self.latex_formatter
             self.formatter_args['commandprefix'] = 'PYG'
 
-    def get_style(self, stylename: str) -> Style:
+    def get_style(self, stylename: Union[str,Style] ) -> Style:
         if stylename is None or stylename == 'sphinx':
             return SphinxStyle
         elif stylename == 'none':
@@ -81,6 +81,10 @@ class PygmentsBridge:
         elif '.' in stylename:
             module, stylename = stylename.rsplit('.', 1)
             return getattr(import_module(module), stylename)
+        # check if a custom Style object is provided by the user
+        # (this way they can just define one in their conf.py)
+        elif isinstance(stylename, Style):
+            return stylename
         else:
             return get_style_by_name(stylename)
 

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -60,7 +60,7 @@ class PygmentsBridge:
     html_formatter = HtmlFormatter
     latex_formatter = LatexFormatter
 
-    def __init__(self, dest: str = 'html', stylename: Union[str,Style] = 'sphinx',
+    def __init__(self, dest: str = 'html', stylename: Union[str, Style] = 'sphinx',
                  latex_engine: str = None) -> None:
         self.dest = dest
         self.latex_engine = latex_engine
@@ -73,7 +73,7 @@ class PygmentsBridge:
             self.formatter = self.latex_formatter
             self.formatter_args['commandprefix'] = 'PYG'
 
-    def get_style(self, stylename: Union[str,Style] ) -> Style:
+    def get_style(self, stylename: Union[str, Style]) -> Style:
         if stylename is None or stylename == 'sphinx':
             return SphinxStyle
         elif stylename == 'none':


### PR DESCRIPTION
Subject: adds ability for users to provide a custom pygments Style object

### Feature or Bugfix
- Feature


### Purpose
Allows users to pass in a pygments Style or a string for the conf.py _pygments_style_ parameter 

This would save them the trouble of adding the Style to their module, making a separate plugin, or monkey patching in a change to pygments directly (as is the in the link below). This was an annoying problem for our project when we wanted to implement custom syntax highlighting, but couldn't figure out the `fully-qualified name of a custom Pygments style class` (link to docs below)

### Relates
docs for  _pygments_style_ parameter: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-pygments_style

monkey patching example: https://stackoverflow.com/questions/48615629/how-to-include-pygments-styles-in-a-sphinx-project)


