### PR TITLE
linkcheck: Fix a protocol relative URL is considered as a local file

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -35,7 +35,7 @@ from sphinx.util.requests import is_ssl_error
 
 logger = logging.getLogger(__name__)
 
-uri_re = re.compile('[a-z]+://')
+uri_re = re.compile('([a-z]+:)?//')  # matches to foo:// and // (a protocol relative URL)
 
 
 DEFAULT_REQUEST_HEADERS = {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since #7985, a protocol relative URL (URL starts with "//") is considered
as a local file incorrectly.  This makes it to a "unchecked" URL.
- refs: #7985

