### PR TITLE
Fix #7768: i18n: Wrong root element is passed to figure_language_filename

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,8 @@ Bugs fixed
 * #7928: py domain: failed to resolve a type annotation for the attribute
 * #7968: i18n: The content of ``math`` directive is interpreted as reST on
   translation
+* #7768: i18n: The ``root`` element for :confval:`figure_language_filename` is
+  not a path that user specifies in the document
 * #7869: :rst:role:`abbr` role without an explanation will show the explanation
   from the previous abbr role
 * C and C++, removed ``noindex`` directive option as it did

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -58,17 +58,13 @@ class ImageCollector(EnvironmentCollector):
             elif imguri.find('://') != -1:
                 candidates['?'] = imguri
                 continue
-            rel_imgpath, full_imgpath = app.env.relfn2path(imguri, docname)
-            if app.config.language:
-                # substitute figures (ex. foo.png -> foo.en.png)
-                i18n_full_imgpath = search_image_for_language(full_imgpath, app.env)
-                if i18n_full_imgpath != full_imgpath:
-                    full_imgpath = i18n_full_imgpath
-                    rel_imgpath = relative_path(path.join(app.srcdir, 'dummy'),
-                                                i18n_full_imgpath)
-            # set imgpath as default URI
-            node['uri'] = rel_imgpath
-            if rel_imgpath.endswith(os.extsep + '*'):
+
+            if imguri.endswith(os.extsep + '*'):
+                # Update `node['uri']` to a relative path from srcdir
+                # from a relative path from current document.
+                rel_imgpath, full_imgpath = app.env.relfn2path(imguri, docname)
+                node['uri'] = rel_imgpath
+
                 if app.config.language:
                     # Search language-specific figures at first
                     i18n_imguri = get_image_filename_for_language(imguri, app.env)
@@ -77,7 +73,15 @@ class ImageCollector(EnvironmentCollector):
 
                 self.collect_candidates(app.env, full_imgpath, candidates, node)
             else:
-                candidates['*'] = rel_imgpath
+                if app.config.language:
+                    # substitute imguri by figure_language_filename
+                    # (ex. foo.png -> foo.en.png)
+                    imguri = search_image_for_language(imguri, app.env)
+
+                # Update `node['uri']` to a relative path from srcdir
+                # from a relative path from current document.
+                node['uri'], _ = app.env.relfn2path(imguri, docname)
+                candidates['*'] = node['uri']
 
             # map image paths to unique image names (so that they can be put
             # into a single directory)

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -320,8 +320,8 @@ def search_image_for_language(filename: str, env: "BuildEnvironment") -> str:
         return filename
 
     translated = get_image_filename_for_language(filename, env)
-    dirname = path.dirname(env.docname)
-    if path.exists(path.join(env.srcdir, dirname, translated)):
+    _, abspath = env.relfn2path(translated)
+    if path.exists(abspath):
         return translated
     else:
         return filename


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7768 
- The root element should be a user specified path; a relative path from
current document or absolute path based on source directory.  But an
absolute path is passed instead.
