### PR TITLE
Close #7768: i18n: figure_language_filename supports {docpath} token

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Features added
 * #7902: html theme: Add a new option :confval:`globaltoc_maxdepth` to control
   the behavior of globaltoc in sidebar
 * #7840: i18n: Optimize the dependencies check on bootstrap
+* #7768: i18n: :confval:`figure_language_filename` supports ``docpath`` token
 * #5208: linkcheck: Support checks for local links
 * #5090: setuptools: Link verbosity to distutils' -v and -q option
 * #7052: add ``:noindexentry:`` to the Python, C, C++, and Javascript domains.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -821,6 +821,8 @@ documentation on :ref:`intl` for details.
      extension, e.g. ``dirname/filename``
    * ``{path}`` - the directory path component of the filename, with a trailing
      slash if non-empty, e.g. ``dirname/``
+   * ``{docpath}`` - the directory path component for the current document, with
+     a trailing slash if non-empty.
    * ``{basename}`` - the filename without the directory path or file extension
      components, e.g. ``filename``
    * ``{ext}`` - the file extension, e.g. ``.png``
@@ -833,6 +835,9 @@ documentation on :ref:`intl` for details.
 
    .. versionchanged:: 1.5
       Added ``{path}`` and ``{basename}`` tokens.
+
+   .. versionchanged:: 3.2
+      Added ``{docpath}`` token.
 
 
 .. _math-options:

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -306,8 +306,12 @@ def get_image_filename_for_language(filename: str, env: "BuildEnvironment") -> s
     dirname = path.dirname(d['root'])
     if dirname and not dirname.endswith(path.sep):
         dirname += path.sep
+    docpath = path.dirname(env.docname)
+    if docpath and not docpath.endswith(path.sep):
+        docpath += path.sep
     d['path'] = dirname
     d['basename'] = path.basename(d['root'])
+    d['docpath'] = docpath
     d['language'] = env.config.language
     try:
         return filename_format.format(**d)

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -90,6 +90,8 @@ def test_format_date():
 
 @pytest.mark.xfail(os.name != 'posix', reason="Path separators don't match on windows")
 def test_get_filename_for_language(app):
+    app.env.temp_data['docname'] = 'index'
+
     # language is None
     app.env.config.language = None
     assert app.env.config.language is None
@@ -144,6 +146,17 @@ def test_get_filename_for_language(app):
     app.env.config.figure_language_filename = '{root}.{invalid}{ext}'
     with pytest.raises(SphinxError):
         i18n.get_image_filename_for_language('foo.png', app.env)
+
+    # docpath (for a document in the top of source directory)
+    app.env.config.language = 'en'
+    app.env.config.figure_language_filename = '/{docpath}{language}/{basename}{ext}'
+    assert (i18n.get_image_filename_for_language('foo.png', app.env) ==
+            '/en/foo.png')
+
+    # docpath (for a document in the sub directory)
+    app.env.temp_data['docname'] = 'subdir/index'
+    assert (i18n.get_image_filename_for_language('foo.png', app.env) ==
+            '/subdir/en/foo.png')
 
 
 def test_CatalogRepository(tempdir):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7768 
- To build structured i18n imaging directory, figure_language_filename
now supports `{docpath}` token that is a dirname of the current
document.
