### PR TITLE
Fix #8023: evaluate_signature() does not work properly in python3.9

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -499,7 +499,7 @@ def evaluate_signature(sig: inspect.Signature, globalns: Dict = None, localns: D
     """Evaluate unresolved type annotations in a signature object."""
     def evaluate_forwardref(ref: ForwardRef, globalns: Dict, localns: Dict) -> Any:
         """Evaluate a forward reference."""
-        if sys.version_info > (3, 10):
+        if sys.version_info > (3, 9):
             return ref._evaluate(globalns, localns, frozenset())
         else:
             return ref._evaluate(globalns, localns)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8023
- Since 3.9b5, ForwardRef._evalute() also takes an additional argument
`recursive_guard`.  As a result, sphinx.util.inspect:evaluate_signature()
does not work properly.  This adds a simple wrapper evalute_forwardref()
to allow evaluating ForwardRefs in py3.9.