### PR TITLE
Close #8011: autosummary: Support instance attributes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Features added
 * #2076: autodoc: Allow overriding of exclude-members in skip-member function
 * #2024: autosummary: Add :confval:`autosummary_filename_map` to avoid conflict
   of filenames between two object with different case
+* #8011: autosummary: Support instance attributes as a target of autosummary
+  directive
 * #7849: html: Add :confval:`html_codeblock_linenos_style` to change the style
   of line numbers for code-blocks
 * #7853: C and C++, support parameterized GNU style attributes.

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -41,7 +41,7 @@ from sphinx.builders import Builder
 from sphinx.config import Config
 from sphinx.deprecation import RemovedInSphinx40Warning, RemovedInSphinx50Warning
 from sphinx.ext.autodoc import Documenter
-from sphinx.ext.autosummary import import_by_name, get_documenter
+from sphinx.ext.autosummary import import_by_name, import_ivar_by_name, get_documenter
 from sphinx.locale import __
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.registry import SphinxComponentRegistry
@@ -413,8 +413,13 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
             name, obj, parent, modname = import_by_name(entry.name)
             qualname = name.replace(modname + ".", "")
         except ImportError as e:
-            _warn(__('[autosummary] failed to import %r: %s') % (entry.name, e))
-            continue
+            try:
+                # try to importl as an instance attribute
+                name, obj, parent, modname = import_ivar_by_name(entry.name)
+                qualname = name.replace(modname + ".", "")
+            except ImportError:
+                _warn(__('[autosummary] failed to import %r: %s') % (entry.name, e))
+                continue
 
         context = {}
         if app:

--- a/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
@@ -16,7 +16,8 @@ class Foo:
         pass
 
     def __init__(self):
-        pass
+        #: docstring
+        self.value = 1
 
     def bar(self):
         pass

--- a/tests/roots/test-ext-autosummary/index.rst
+++ b/tests/roots/test-ext-autosummary/index.rst
@@ -10,6 +10,7 @@
    autosummary_dummy_module
    autosummary_dummy_module.Foo
    autosummary_dummy_module.Foo.Bar
+   autosummary_dummy_module.Foo.value
    autosummary_dummy_module.bar
    autosummary_dummy_module.qux
    autosummary_importfail

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -293,15 +293,17 @@ def test_autosummary_generate(app, status, warning):
                                                                                nodes.row,
                                                                                nodes.row,
                                                                                nodes.row,
+                                                                               nodes.row,
                                                                                nodes.row)])])
     assert_node(doctree[4][0], addnodes.toctree, caption="An autosummary")
 
-    assert len(doctree[3][0][0][2]) == 5
+    assert len(doctree[3][0][0][2]) == 6
     assert doctree[3][0][0][2][0].astext() == 'autosummary_dummy_module\n\n'
     assert doctree[3][0][0][2][1].astext() == 'autosummary_dummy_module.Foo()\n\n'
     assert doctree[3][0][0][2][2].astext() == 'autosummary_dummy_module.Foo.Bar()\n\n'
-    assert doctree[3][0][0][2][3].astext() == 'autosummary_dummy_module.bar(x[, y])\n\n'
-    assert doctree[3][0][0][2][4].astext() == 'autosummary_dummy_module.qux\n\na module-level attribute'
+    assert doctree[3][0][0][2][3].astext() == 'autosummary_dummy_module.Foo.value\n\ndocstring'
+    assert doctree[3][0][0][2][4].astext() == 'autosummary_dummy_module.bar(x[, y])\n\n'
+    assert doctree[3][0][0][2][5].astext() == 'autosummary_dummy_module.qux\n\na module-level attribute'
 
     module = (app.srcdir / 'generated' / 'autosummary_dummy_module.rst').read_text()
     assert ('   .. autosummary::\n'
@@ -332,6 +334,11 @@ def test_autosummary_generate(app, status, warning):
     assert ('.. currentmodule:: autosummary_dummy_module\n'
             '\n'
             '.. autoclass:: Foo.Bar\n' in FooBar)
+
+    Foo_value = (app.srcdir / 'generated' / 'autosummary_dummy_module.Foo.value.rst').read_text()
+    assert ('.. currentmodule:: autosummary_dummy_module\n'
+            '\n'
+            '.. autoattribute:: Foo.value' in Foo_value)
 
     qux = (app.srcdir / 'generated' / 'autosummary_dummy_module.qux.rst').read_text()
     assert ('.. currentmodule:: autosummary_dummy_module\n'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #8011 
- This allows the autosummary directive to take instance attributes to
build documents for them.
