### PR TITLE
Fix #8030: autodoc: An annotated instance variable is not documented

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,8 @@ Bugs fixed
 * #904: autodoc: An instance attribute cause a crash of autofunction directive
 * #1362: autodoc: ``private-members`` option does not work for class attributes
 * #7983: autodoc: Generator type annotation is wrongly rendered in py36
+* #8030: autodoc: An uninitialized annotated instance variable is not documented
+  when ``:inherited-members:`` option given
 * #7839: autosummary: cannot handle umlauts in function names
 * #7865: autosummary: Failed to extract summary line when abbreviations found
 * #7866: autosummary: Failed to extract correct summary line when docstring

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -579,6 +579,8 @@ class Documenter:
                         return True
                     elif name in cls.__dict__:
                         return False
+                    elif name in self.get_attr(cls, '__annotations__', {}):
+                        return False
 
             return False
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8030 
- Documenter.filter_members() have wrongly considered that an instance
variable not having a docstring should be skipped when
`:inherited-members:` option given.
- This fixes the behavior when the instance variable has annotated.
- Note: This doest not still detect well for not annotated instance
variables.

