### PR TITLE
Don't copy graphviz.css when building man pages

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -385,7 +385,7 @@ def man_visit_graphviz(self: ManualPageTranslator, node: graphviz) -> None:
 
 
 def on_build_finished(app: Sphinx, exc: Exception) -> None:
-    if exc is None:
+    if exc is None and app.builder.format == 'html':
         src = path.join(sphinx.package_dir, 'templates', 'graphviz', 'graphviz.css')
         dst = path.join(app.outdir, '_static')
         copy_asset(src, dst)


### PR DESCRIPTION
_static/graphviz.css is being created alongside the man pages.

-----

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Don't need the CSS file with man pages. Being copied even the source file using Graphviz was not one of those being used for the man pages
- sphinx.ext.graphviz extension
