### PR TITLE
use the obj role for all See Also items

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1131,7 +1131,11 @@ class NumpyDocstring(GoogleDocstring):
         func_name1, func_name2, :meth:`func_name`, func_name3
 
         """
-        inventory = getattr(self._app.builder.env, "intersphinx_inventory", {})
+        try:
+            inventory = self._app.builder.env.intersphinx_inventory
+        except AttributeError:
+            inventory = {}
+
         items = []
 
         def parse_item_name(text: str) -> Tuple[str, str]:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1132,7 +1132,7 @@ class NumpyDocstring(GoogleDocstring):
 
         """
         try:
-            inventory = self._app.builder.env.intersphinx_inventory
+            inventory = self._app.builder.env.intersphinx_inventory  # type: ignore
         except AttributeError:
             inventory = {}
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1175,6 +1175,22 @@ class NumpyDocstring(GoogleDocstring):
 
             return None
 
+        def translate(func, description, role):
+            translations = self._config.napoleon_type_aliases
+            if role is not None or not translations:
+                return func, description, role
+
+            translated = translations.get(func, func)
+            match = self._name_rgx.match(translated)
+            if not match:
+                return translated, description, role
+
+            groups = match.groupdict()
+            role = groups["role"]
+            new_func = groups["name"] or groups["name2"]
+
+            return new_func, description, role
+
         current_func = None
         rest = []  # type: List[str]
 
@@ -1204,6 +1220,12 @@ class NumpyDocstring(GoogleDocstring):
 
         if not items:
             return []
+
+        # apply type aliases
+        items = [
+            translate(func, description, role)
+            for func, description, role in items
+        ]
 
         roles = {
             'method': 'meth',

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1131,11 +1131,6 @@ class NumpyDocstring(GoogleDocstring):
         func_name1, func_name2, :meth:`func_name`, func_name3
 
         """
-        try:
-            inventory = self._app.builder.env.intersphinx_inventory  # type: ignore
-        except AttributeError:
-            inventory = {}
-
         items = []
 
         def parse_item_name(text: str) -> Tuple[str, str]:
@@ -1227,41 +1222,14 @@ class NumpyDocstring(GoogleDocstring):
             for func, description, role in items
         ]
 
-        roles = {
-            'method': 'meth',
-            'meth': 'meth',
-            'function': 'func',
-            'func': 'func',
-            'class': 'class',
-            'exception': 'exc',
-            'exc': 'exc',
-            'object': 'obj',
-            'obj': 'obj',
-            'module': 'mod',
-            'mod': 'mod',
-            'data': 'data',
-            'constant': 'const',
-            'const': 'const',
-            'attribute': 'attr',
-            'attr': 'attr'
-        }
-        if self._what is None:
-            func_role = 'obj'
-        else:
-            func_role = roles.get(self._what, '')
+        func_role = 'obj'
         lines = []  # type: List[str]
         last_had_desc = True
         for func, desc, role in items:
-            if not role:
-                raw_role = search_inventory(inventory, func, hint=func_role)
-                role = roles.get(raw_role, raw_role)
-
             if role:
                 link = ':%s:`%s`' % (role, func)
-            elif func_role:
-                link = ':%s:`%s`' % (func_role, func)
             else:
-                link = "`%s`_" % func
+                link = ':%s:`%s`' % (func_role, func)
             if desc or last_had_desc:
                 lines += ['']
                 lines += [link]

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1400,6 +1400,38 @@ numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 """
         self.assertEqual(expected, actual)
 
+        docstring = """\
+numpy.multivariate_normal(mean, cov, shape=None, spam=None)
+
+See Also
+--------
+some, other, :func:`funcs`
+otherfunc : relationship
+
+"""
+        translations = {
+            "other": "MyClass.other",
+            "otherfunc": ":func:`~my_package.otherfunc`",
+        }
+        config = Config(napoleon_type_aliases=translations)
+        app = mock.Mock()
+        app.builder.env.intersphinx_inventory = {
+            "py:func": {"funcs": (), "otherfunc": ()},
+            "py:meth": {"some": (), "MyClass.other": ()},
+        }
+        actual = str(NumpyDocstring(docstring, config, app, "method"))
+
+        expected = """\
+numpy.multivariate_normal(mean, cov, shape=None, spam=None)
+
+.. seealso::
+
+   :meth:`some`, :meth:`MyClass.other`, :func:`funcs`
+   \n\
+   :func:`~my_package.otherfunc`
+       relationship
+"""
+        self.assertEqual(expected, actual)
 
     def test_colon_in_return_type(self):
         docstring = """

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1365,7 +1365,6 @@ otherfunc : relationship
 
         config = Config()
         app = mock.Mock()
-        app.builder.env = None
         actual = str(NumpyDocstring(docstring, config, app, "method"))
 
         expected = """\
@@ -1373,29 +1372,9 @@ numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
 .. seealso::
 
-   :meth:`some`, :meth:`other`, :meth:`funcs`
+   :obj:`some`, :obj:`other`, :obj:`funcs`
    \n\
-   :meth:`otherfunc`
-       relationship
-"""
-        self.assertEqual(expected, actual)
-
-        config = Config()
-        app = mock.Mock()
-        app.builder.env.intersphinx_inventory = {
-            "py:func": {"funcs": (), "otherfunc": ()},
-            "py:meth": {"some": (), "other": ()},
-        }
-        actual = str(NumpyDocstring(docstring, config, app, "method"))
-
-        expected = """\
-numpy.multivariate_normal(mean, cov, shape=None, spam=None)
-
-.. seealso::
-
-   :meth:`some`, :meth:`other`, :func:`funcs`
-   \n\
-   :func:`otherfunc`
+   :obj:`otherfunc`
        relationship
 """
         self.assertEqual(expected, actual)
@@ -1415,10 +1394,6 @@ otherfunc : relationship
         }
         config = Config(napoleon_type_aliases=translations)
         app = mock.Mock()
-        app.builder.env.intersphinx_inventory = {
-            "py:func": {"funcs": (), "otherfunc": ()},
-            "py:meth": {"some": (), "MyClass.other": ()},
-        }
         actual = str(NumpyDocstring(docstring, config, app, "method"))
 
         expected = """\
@@ -1426,7 +1401,7 @@ numpy.multivariate_normal(mean, cov, shape=None, spam=None)
 
 .. seealso::
 
-   :meth:`some`, :meth:`MyClass.other`, :func:`funcs`
+   :obj:`some`, :obj:`MyClass.other`, :func:`funcs`
    \n\
    :func:`~my_package.otherfunc`
        relationship

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1365,6 +1365,7 @@ otherfunc : relationship
 
         config = Config()
         app = mock.Mock()
+        app.builder.env = None
         actual = str(NumpyDocstring(docstring, config, app, "method"))
 
         expected = """\
@@ -1378,6 +1379,27 @@ numpy.multivariate_normal(mean, cov, shape=None, spam=None)
        relationship
 """
         self.assertEqual(expected, actual)
+
+        config = Config()
+        app = mock.Mock()
+        app.builder.env.intersphinx_inventory = {
+            "py:func": {"funcs": (), "otherfunc": ()},
+            "py:meth": {"some": (), "other": ()},
+        }
+        actual = str(NumpyDocstring(docstring, config, app, "method"))
+
+        expected = """\
+numpy.multivariate_normal(mean, cov, shape=None, spam=None)
+
+.. seealso::
+
+   :meth:`some`, :meth:`other`, :func:`funcs`
+   \n\
+   :func:`otherfunc`
+       relationship
+"""
+        self.assertEqual(expected, actual)
+
 
     def test_colon_in_return_type(self):
         docstring = """


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Before this change, `napoleon` would look for `See Also` items using the same role as the documented object. This breaks once one tries to link to other kinds of objects, e.g. from a function to a method.

With the proposed changes, the code parsing `See Also` sections will try to find the correct role for a referenced object from the intersphinx inventory.

### Relates
- #7690, #8050

