### PR TITLE
i18n: Add support for having single text domain

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -756,8 +756,14 @@ documentation on :ref:`intl` for details.
    If true, a document's text domain is its docname if it is a top-level
    project file and its very base directory otherwise.
 
+   If set to string, all document's text domain is this string, making all
+   documents use single text domain.
+
    By default, the document ``markup/code.rst`` ends up in the ``markup`` text
    domain.  With this option set to ``False``, it is ``markup/code``.
+
+   .. versionchanged:: 3.3
+      The string value is now accepted.
 
 .. confval:: gettext_uuid
 

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -316,7 +316,7 @@ class MessageCatalogBuilder(I18nBuilder):
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_builder(MessageCatalogBuilder)
 
-    app.add_config_value('gettext_compact', True, 'gettext')
+    app.add_config_value('gettext_compact', True, 'gettext', Any)
     app.add_config_value('gettext_location', True, 'gettext')
     app.add_config_value('gettext_uuid', False, 'gettext')
     app.add_config_value('gettext_auto_build', True, 'env')

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -14,7 +14,7 @@ import warnings
 from collections import namedtuple
 from datetime import datetime, timezone
 from os import path
-from typing import Callable, Generator, List, Set, Tuple
+from typing import Callable, Generator, List, Set, Tuple, Union
 
 import babel.dates
 from babel.messages.mofile import write_mo
@@ -128,8 +128,10 @@ def find_catalog(docname: str, compaction: bool) -> str:
     return ret
 
 
-def docname_to_domain(docname: str, compation: bool) -> str:
+def docname_to_domain(docname: str, compation: Union[bool, str]) -> str:
     """Convert docname to domain for catalogs."""
+    if isinstance(compation, str):
+        return compation
     if compation:
         return docname.split(SEP, 1)[0]
     else:

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -174,3 +174,21 @@ def test_gettext_template_msgid_order_in_sphinxpot(app):
          'msgid "This is Template 2\\.".*'),
         result,
         flags=re.S)
+
+
+@pytest.mark.sphinx(
+    'gettext', srcdir='root-gettext',
+    confoverrides={'gettext_compact': 'documentation'})
+def test_build_single_pot(app):
+    app.builder.build_all()
+
+    assert (app.outdir / 'documentation.pot').isfile()
+
+    result = (app.outdir / 'documentation.pot').read_text()
+    assert re.search(
+        ('msgid "Todo".*'
+         'msgid "Like footnotes.".*'
+         'msgid "The minute.".*'
+         'msgid "Generated section".*'),
+        result,
+        flags=re.S)


### PR DESCRIPTION
The gettext_compact can now be a string which is then a single domain
for all documents.

Fixes #784

Subject: Add support for having single text domain

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
In many cases it is more useful to have single text domain for all translations. It is now possible to configure that.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/784

