### PR TITLE
Do not log 'Unparseable C++' warning if reference is of type 'any'

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7345,9 +7345,8 @@ class CPPDomain(Domain):
                 # strange, that we don't get the error now, use the original
                 return target, e
             t, ex = findWarning(e)
-            if typ != 'any':
-                logger.warning('Unparseable C++ cross-reference: %r\n%s', t, ex,
-                               location=node)
+            logger.warning('Unparseable C++ cross-reference: %r\n%s', t, ex,
+                           location=node)
             return None, None
         parentKey = node.get("cpp:parent_key", None)  # type: LookupKey
         rootSymbol = self.data['root_symbol']

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7345,8 +7345,9 @@ class CPPDomain(Domain):
                 # strange, that we don't get the error now, use the original
                 return target, e
             t, ex = findWarning(e)
-            logger.warning('Unparseable C++ cross-reference: %r\n%s', t, ex,
-                           location=node)
+            if typ != 'any':
+                logger.warning('Unparseable C++ cross-reference: %r\n%s', t, ex,
+                               location=node)
             return None, None
         parentKey = node.get("cpp:parent_key", None)  # type: LookupKey
         rootSymbol = self.data['root_symbol']

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -234,8 +234,10 @@ def suppress_logging() -> Generator[MemoryHandler, None, None]:
             handlers.append(handler)
 
         logger.addHandler(memhandler)
+        logger.propagate = False
         yield memhandler
     finally:
+        logger.propagate = True
         logger.removeHandler(memhandler)
 
         for handler in handlers:

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -229,6 +229,7 @@ def suppress_logging() -> Generator[MemoryHandler, None, None]:
 
     try:
         handlers = []
+        propagation = logger.propagate
         for handler in logger.handlers[:]:
             logger.removeHandler(handler)
             handlers.append(handler)
@@ -237,7 +238,7 @@ def suppress_logging() -> Generator[MemoryHandler, None, None]:
         logger.propagate = False
         yield memhandler
     finally:
-        logger.propagate = True
+        logger.propagate = propagation
         logger.removeHandler(memhandler)
 
         for handler in handlers:


### PR DESCRIPTION
Subject: Do not log 'Unparseable C++' warning if reference is of type 'any'

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

If `` :any:`index.md` `` is used, you now (as of sphinx 3) get the warning: "WARNING  Unparseable C++ cross-reference: 'index.md'"

It is highly unlikely that an `any` cross-reference is intended to be C++ related, and obviously breaks any builds using `sphinx-build -W`
