### PR TITLE
Stemmer len3

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -112,7 +112,7 @@ var Stemmer = function() {
             len(word) == 0 or not (
                 ((len(word) < 3) and (12353 < ord(word[0]) < 12436)) or
                 (ord(word[0]) < 256 and (
-                    len(word) < 3 or word in self.stopwords
+                    word in self.stopwords
                 ))))
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -143,6 +143,7 @@ def test_IndexBuilder():
     assert index._titles == {'docname': 'title', 'docname2': 'title2'}
     assert index._filenames == {'docname': 'filename', 'docname2': 'filename2'}
     assert index._mapping == {
+        'ar': {'docname', 'docname2'},
         'fermion': {'docname', 'docname2'},
         'comment': {'docname', 'docname2'},
         'non': {'docname', 'docname2'},
@@ -161,7 +162,8 @@ def test_IndexBuilder():
         'objects': {'': {'objdispname': (0, 0, 1, '#anchor')}},
         'objnames': {0: ('dummy', 'objtype', 'objtype')},
         'objtypes': {0: 'dummy:objtype'},
-        'terms': {'comment': [0, 1],
+        'terms': {'ar': [0, 1],
+                  'comment': [0, 1],
                   'fermion': [0, 1],
                   'index': [0, 1],
                   'non': [0, 1],
@@ -197,6 +199,7 @@ def test_IndexBuilder():
     assert index._titles == {'docname2': 'title2'}
     assert index._filenames == {'docname2': 'filename2'}
     assert index._mapping == {
+        'ar': {'docname2'},
         'fermion': {'docname2'},
         'comment': {'docname2'},
         'non': {'docname2'},
@@ -215,7 +218,8 @@ def test_IndexBuilder():
         'objects': {},
         'objnames': {0: ('dummy', 'objtype', 'objtype')},
         'objtypes': {0: 'dummy:objtype'},
-        'terms': {'comment': 0,
+        'terms': {'ar': 0,
+                  'comment': 0,
                   'fermion': 0,
                   'index': 0,
                   'non': 0,
@@ -261,4 +265,3 @@ def test_nosearch(app):
     assert index['docnames'] == ['index', 'nosearch', 'tocitem']
     assert 'latex' not in index['terms']
     assert 'zfs' in index['terms']
-    assert index['terms']['zfs'] == 0  # zfs on nosearch.rst is not registered to index

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -265,3 +265,4 @@ def test_nosearch(app):
     assert index['docnames'] == ['index', 'nosearch', 'tocitem']
     assert 'latex' not in index['terms']
     assert 'zfs' in index['terms']
+    assert index['terms']['zfs'] == []  # zfs on nosearch.rst is not registered to index


### PR DESCRIPTION
Subject: fix for inconsistent stemmer issue #8069

### Bugfix

### Purpose
We have document titled "1st go live". It can be found with "1st", with "live", with "1st live", but search result is empty for "go live" and "1st go live".

It's due to an inconsistency between javascript stemmer and python one.
Javascript accepts short words like "go" and looks for them in the index file. Python however explicitly removes rejects anything shorter than 3 characters.

### Detail
N/A

### Relates
- #8069

