### PR TITLE
Make the toc.circular suppress_warnings flag apply to self referenced toctrees

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -594,7 +594,9 @@ class BuildEnvironment:
 
         def traverse_toctree(parent: str, docname: str) -> Iterator[Tuple[str, str]]:
             if parent == docname:
-                logger.warning(__('self referenced toctree found. Ignored.'), location=docname)
+                logger.warning(__('self referenced toctree found. Ignored.'),
+                               location=docname, type='toc',
+                               subtype='circular')
                 return
 
             # traverse toctree by pre-order


### PR DESCRIPTION
Fixes https://github.com/sphinx-doc/sphinx/issues/7410#issuecomment-670678193.

Not sure if this should be tested, and if so, where that test would go. It isn't clear to me what the difference is between this warning and the other warning that was already matched by toc.circular. 

Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Relates
- https://github.com/sphinx-doc/sphinx/issues/7410#issuecomment-670678193

