### PR TITLE
Add override to add_directive

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -628,7 +628,9 @@ class Sphinx:
                def run(self):
                    ...
 
-           add_directive('literalinclude', LiteralIncludeDirective)
+           def setup(app):
+               app.add_directive('literalinclude', LiteralIncludeDirective, override=True)
+               ...
 
         .. versionchanged:: 0.6
            Docutils 0.5-style directive classes are now supported.


### PR DESCRIPTION
Subject: Documentation says to override LiteralIncludeDirective, one should use the override keyword, but the example doesn't reflect that.

Also, the `add_directive` was at the root level which wasn't correct.

### Feature or Bugfix
- Bugfix

### Detail
- Just fix the docstring

