### PR TITLE
Fix #6914: figure numbers are unexpectedly assigned to uncaptioned items

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ Bugs fixed
   singlehtml and so on)
 * #8239: Failed to refer a token in productionlist if it is indented
 * #8268: linkcheck: Report HTTP errors when ``linkcheck_anchors`` is ``True``
+* #6914: figure numbers are unexpectedly assigned to uncaptioned items
 
 Testing
 --------

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -224,6 +224,10 @@ class TocTreeCollector(EnvironmentCollector):
         def get_figtype(node: Node) -> str:
             for domain in env.domains.values():
                 figtype = domain.get_enumerable_node_type(node)
+                if domain.name == 'std' and not domain.get_numfig_title(node):  # type: ignore
+                    # Skip if uncaptioned node
+                    continue
+
                 if figtype:
                     return figtype
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #6914 
- The figure numbers should be assigned to items only having captions or
titles.  This uses `get_numfig_title()` to ensures it on assign numbers.
