### PR TITLE
Fix #8074: napoleon: Crashes during processing C-ext module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,8 @@ Features added
 Bugs fixed
 ----------
 
+* #8074: napoleon: Crashes during processing C-ext module
+
 Testing
 --------
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1074,7 +1074,10 @@ class NumpyDocstring(GoogleDocstring):
         super().__init__(docstring, config, app, what, name, obj, options)
 
     def _get_location(self) -> str:
-        filepath = inspect.getfile(self._obj) if self._obj is not None else None
+        try:
+            filepath = inspect.getfile(self._obj) if self._obj is not None else None
+        except TypeError:
+            filepath = None
         name = self._name
 
         if filepath is None and name is None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8074 
- inspect.getfile() raises TypeError if given object is a C-extension.
This handles the exception not to be crashed.