### PR TITLE
[Feature] Check if LaTeX package already added

### DIFF
--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -367,7 +367,14 @@ class SphinxComponentRegistry:
         logger.debug('[app] adding js_file: %r, %r', filename, attributes)
         self.js_files.append((filename, attributes))
 
+    def has_latex_package(self, name: str) -> bool:
+        packages = self.latex_packages + self.latex_packages_after_hyperref
+        return bool([x for x in packages if x[0] == name])
+
     def add_latex_package(self, name: str, options: str, after_hyperref: bool = False) -> None:
+        if self.has_latex_package(name):
+            logger.warn("latex package '%s' already included" % name)
+
         logger.debug('[app] adding latex package: %r', name)
         if after_hyperref:
             self.latex_packages_after_hyperref.append((name, options))


### PR DESCRIPTION
When writing an extension, the `app.add_latex_package` does not check if the same package was already added by another extension. This should be checked at some point a warning should occur. 

We could later add different options what would not emit any warning such as:

- `override` to override the already included package options
- `merge` to merge the options from the already included package
