### PR TITLE
Customize jinja comment-tag

### DIFF
--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -84,6 +84,8 @@ class LaTeXRenderer(SphinxRenderer):
         self.env.variable_end_string = '%>'
         self.env.block_start_string = '<%'
         self.env.block_end_string = '%>'
+        self.env.comment_start_string = '<#'
+        self.env.comment_end_string = '<#'
 
 
 class ReSTRenderer(SphinxRenderer):


### PR DESCRIPTION
In LaTeX templates you could have something like this:

    \par\noindent\textbf{Exercice \thechapter.\theexercise} {#1}

where `{#` acts as a jinja comment. In this case you will get an error: 

    jinja2.exceptions.TemplateSyntaxError: Missing end of comment tag

The solution is to also override the comment tags for LaTeX.
