### PR TITLE
Fix #8084: autodoc: KeyError is raised on documenting a broken attribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,9 @@ Features added
 Bugs fixed
 ----------
 
+* #8084: autodoc: KeyError is raised on documenting an attribute of the broken
+  class
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1610,6 +1610,9 @@ class DataDocumenter(ModuleLevelDocumenter):
                 annotations = get_type_hints(self.parent)
             except TypeError:
                 annotations = {}
+            except KeyError:
+                # a broken class found (refs: https://github.com/sphinx-doc/sphinx/issues/8084)
+                annotations = {}
 
             if self.objpath[-1] in annotations:
                 objrepr = stringify_typehint(annotations.get(self.objpath[-1]))
@@ -1979,6 +1982,9 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
             try:
                 annotations = get_type_hints(self.parent)
             except TypeError:
+                annotations = {}
+            except KeyError:
+                # a broken class found (refs: https://github.com/sphinx-doc/sphinx/issues/8084)
                 annotations = {}
 
             if self.objpath[-1] in annotations:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8084 
- ``typing.get_type_hints()`` raises KeyError when a class having invalid
__module__ was given.  This handles the exception not to crash on build
documents.
