### PR TITLE
Use alt text as short caption

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1330,7 +1330,7 @@ class LaTeXTranslator(SphinxTranslator):
     def depart_figure(self, node: Element) -> None:
         self.body.append(self.context.pop())
 
-    def visit_caption(self, node: Element) -> None:
+    def visit_caption(self, node):
         self.in_caption += 1
         if isinstance(node.parent, captioned_literal_block):
             self.body.append('\\sphinxSetupCaptionForVerbatim{')
@@ -1339,7 +1339,14 @@ class LaTeXTranslator(SphinxTranslator):
         elif self.table and node.parent.tagname == 'figure':
             self.body.append('\\sphinxfigcaption{')
         else:
-            self.body.append('\\caption{')
+            # Use alt text as short caption for the \listoffigures
+            short = ''
+            if isinstance(node.parent, nodes.figure):
+                if isinstance(node.parent.children[0], nodes.image):
+                    alt = node.parent.children[0].get('alt')
+                    if alt:
+                        short = '[' + texescape.escape(alt) + ']'
+            self.body.append('\\caption%s{' % short)
 
     def depart_caption(self, node: Element) -> None:
         self.body.append('}')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1338,8 +1338,8 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(r'\captionof{figure}{')
         elif self.table and node.parent.tagname == 'figure':
             self.body.append(r'\sphinxfigcaption{')
-        elif (isinstance(node.parent, node.figure) and
-              isinstance(node.parent.children[0], node.image) and
+        elif (isinstance(node.parent, nodes.figure) and
+              isinstance(node.parent.children[0], nodes.image) and
               'alt' in node.parent.children[0]):
             alt = node.parent.children[0]['alt']
             self.body.append(r'\caption[%s]{' % texescape.escape(alt))

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1330,23 +1330,21 @@ class LaTeXTranslator(SphinxTranslator):
     def depart_figure(self, node: Element) -> None:
         self.body.append(self.context.pop())
 
-    def visit_caption(self, node):
+    def visit_caption(self, node: Element) -> None:
         self.in_caption += 1
         if isinstance(node.parent, captioned_literal_block):
-            self.body.append('\\sphinxSetupCaptionForVerbatim{')
+            self.body.append(r'\sphinxSetupCaptionForVerbatim{')
         elif self.in_minipage and isinstance(node.parent, nodes.figure):
-            self.body.append('\\captionof{figure}{')
+            self.body.append(r'\captionof{figure}{')
         elif self.table and node.parent.tagname == 'figure':
-            self.body.append('\\sphinxfigcaption{')
+            self.body.append(r'\sphinxfigcaption{')
+        elif (isinstance(node.parent, node.figure) and
+              isinstance(node.parent.children[0], node.image) and
+              'alt' in node.parent.children[0]):
+            alt = node.parent.children[0]['alt']
+            self.body.append(r'\caption[%s]{' % texescape.escape(alt))
         else:
-            # Use alt text as short caption for the \listoffigures
-            short = ''
-            if isinstance(node.parent, nodes.figure):
-                if isinstance(node.parent.children[0], nodes.image):
-                    alt = node.parent.children[0].get('alt')
-                    if alt:
-                        short = '[' + texescape.escape(alt) + ']'
-            self.body.append('\\caption%s{' % short)
+            self.body.append(r'\caption{')
 
     def depart_caption(self, node: Element) -> None:
         self.body.append('}')


### PR DESCRIPTION
In LaTeX figures captions can be written as: 

    \caption[Short description]{Long description}

Having long descriptions for figures will compromise the `\listoffigures`. It is therefore useful to have short description for figures, but Sphinx does not support this out of the box. 

One solution is to use the `alt` text used in HTML `<img alt="text" src="..."/>` for the LaTeX short description. 

There are too many `if` in my patch. Feel free to propose something better.