### PR TITLE
Fix #8091: autodoc: AttributeError is raised on documenting an attribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,8 @@ Bugs fixed
 * #8074: napoleon: Crashes during processing C-ext module
 * #8084: autodoc: KeyError is raised on documenting an attribute of the broken
   class
+* #8091: autodoc: AttributeError is raised on documenting an attribute on Python
+  3.5.2
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1613,6 +1613,9 @@ class DataDocumenter(ModuleLevelDocumenter):
             except KeyError:
                 # a broken class found (refs: https://github.com/sphinx-doc/sphinx/issues/8084)
                 annotations = {}
+            except AttributeError:
+                # AttributeError is raised on 3.5.2 (fixed by 3.5.3)
+                annotations = {}
 
             if self.objpath[-1] in annotations:
                 objrepr = stringify_typehint(annotations.get(self.objpath[-1]))
@@ -1985,6 +1988,9 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
                 annotations = {}
             except KeyError:
                 # a broken class found (refs: https://github.com/sphinx-doc/sphinx/issues/8084)
+                annotations = {}
+            except AttributeError:
+                # AttributeError is raised on 3.5.2 (fixed by 3.5.3)
                 annotations = {}
 
             if self.objpath[-1] in annotations:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8091
- Until Python 3.5.2, typing.get_type_hints() raises AttributeError if
given object does not have `__code__` attribute.  This handles the
exception not to crash building documents.
- refs: https://github.com/python/cpython/commit/991d14fee1805e17647940a2a8cbf4f62f0f09ea