### PR TITLE
Use current node location in case of error (related to #8093)

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -450,7 +450,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
 
         highlighted = self.highlighter.highlight_block(
             node.rawsource, lang, opts=opts, linenos=linenos,
-            location=(self.builder.current_docname, node.line), **highlight_args
+            location=node, **highlight_args
         )
         starttag = self.starttag(node, 'div', suffix='',
                                  CLASS='highlight-%s notranslate' % lang)

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -402,7 +402,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
         highlighted = self.highlighter.highlight_block(
             node.rawsource, lang, opts=opts, linenos=linenos,
-            location=(self.builder.current_docname, node.line), **highlight_args
+            location=node, **highlight_args
         )
         starttag = self.starttag(node, 'div', suffix='',
                                  CLASS='highlight-%s notranslate' % lang)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -651,7 +651,7 @@ class LaTeXTranslator(SphinxTranslator):
                 if len(node.children) != 1 and not isinstance(node.children[0],
                                                               nodes.Text):
                     logger.warning(__('document title is not a single Text node'),
-                                   location=(self.curfilestack[-1], node.line))
+                                   location=node)
                 if not self.elements['title']:
                     # text needs to be escaped since it is inserted into
                     # the output literally
@@ -684,7 +684,7 @@ class LaTeXTranslator(SphinxTranslator):
         else:
             logger.warning(__('encountered title node not in section, topic, table, '
                               'admonition or sidebar'),
-                           location=(self.curfilestack[-1], node.line or ''))
+                           location=node)
             self.body.append('\\sphinxstyleothertitle{')
             self.context.append('}\n')
         self.in_title = 1
@@ -1762,7 +1762,7 @@ class LaTeXTranslator(SphinxTranslator):
 
             hlcode = self.highlighter.highlight_block(
                 node.rawsource, lang, opts=opts, linenos=linenos,
-                location=(self.curfilestack[-1], node.line), **highlight_args
+                location=node, **highlight_args
             )
             if self.in_footnote:
                 self.body.append('\n\\sphinxSetupCodeBlockInFootnote')

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -628,7 +628,7 @@ class TexinfoTranslator(SphinxTranslator):
         elif not isinstance(parent, nodes.section):
             logger.warning(__('encountered title node not in section, topic, table, '
                               'admonition or sidebar'),
-                           location=(self.curfilestack[-1], node.line))
+                           location=node)
             self.visit_rubric(node)
         else:
             try:
@@ -1186,7 +1186,7 @@ class TexinfoTranslator(SphinxTranslator):
             self.body.append('\n@caption{')
         else:
             logger.warning(__('caption not inside a figure.'),
-                           location=(self.curfilestack[-1], node.line))
+                           location=node)
 
     def depart_caption(self, node: Element) -> None:
         if (isinstance(node.parent, nodes.figure) or
@@ -1262,11 +1262,11 @@ class TexinfoTranslator(SphinxTranslator):
 
     def unimplemented_visit(self, node: Element) -> None:
         logger.warning(__("unimplemented node type: %r"), node,
-                       location=(self.curfilestack[-1], node.line))
+                       location=node)
 
     def unknown_visit(self, node: Node) -> None:
         logger.warning(__("unknown node type: %r"), node,
-                       location=(self.curfilestack[-1], node.line))
+                       location=node)
 
     def unknown_departure(self, node: Node) -> None:
         pass


### PR DESCRIPTION
In `writer/html5.py/visit_literal_block` we find this:

        highlighted = self.highlighter.highlight_block(
            node.rawsource, lang, opts=opts, linenos=linenos,
            location=(self.builder.current_docname, node.line), **highlight_args
        )

The good news is that it works in most cases. However if a node is moved during the build process, you'll get an error with the wrong document name as we use the `node.line`, but the current docname.

Wouldn't be better to use `node.source` and `node.line`?
