### PR TITLE
Make linkcheck more robust on HEAD failure

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -20,7 +20,7 @@ from urllib.parse import unquote, urlparse
 
 from docutils import nodes
 from docutils.nodes import Node
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError
 
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
@@ -177,7 +177,7 @@ class CheckExternalLinksBuilder(Builder):
                         response = requests.head(req_url, config=self.app.config,
                                                  auth=auth_info, **kwargs)
                         response.raise_for_status()
-                    except HTTPError:
+                    except (HTTPError, ConnectionError):
                         # retry with GET request if that fails, some servers
                         # don't like HEAD requests.
                         response = requests.get(req_url, stream=True, config=self.app.config,


### PR DESCRIPTION
Subject: Make linkcheck more robust on HEAD failure

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix (sorta)

### Purpose
- Fix linkcheck errors connecting to this [website](https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/north-american-regional-reanalysis-narr). It completely drops the connection when trying to do a HEAD request (due to the default set of headers from requests). The simplest solution was to catch `ConnectionError` as well as `HTTPError`.
