### PR TITLE
Fix #8099: autodoc: NameError is raised when script uses TYPE_CHECKING

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ Bugs fixed
   class
 * #8091: autodoc: AttributeError is raised on documenting an attribute on Python
   3.5.2
+* #8099: autodoc: NameError is raised when target code uses ``TYPE_CHECKING``
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1608,6 +1608,9 @@ class DataDocumenter(ModuleLevelDocumenter):
             # obtain annotation for this data
             try:
                 annotations = get_type_hints(self.parent)
+            except NameError:
+                # Failed to evaluate ForwardRef (maybe TYPE_CHECKING)
+                annotations = safe_getattr(self.parent, '__annotations__', {})
             except TypeError:
                 annotations = {}
             except KeyError:
@@ -1984,6 +1987,9 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
             # obtain type annotation for this attribute
             try:
                 annotations = get_type_hints(self.parent)
+            except NameError:
+                # Failed to evaluate ForwardRef (maybe TYPE_CHECKING)
+                annotations = safe_getattr(self.parent, '__annotations__', {})
             except TypeError:
                 annotations = {}
             except KeyError:

--- a/tests/roots/test-ext-autodoc/target/TYPE_CHECKING.py
+++ b/tests/roots/test-ext-autodoc/target/TYPE_CHECKING.py
@@ -1,0 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from io import StringIO
+
+
+class Foo:
+    attr1: "StringIO"

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1740,6 +1740,28 @@ def test_autodoc_Annotated(app):
     ]
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason='py36+ is required.')
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_TYPE_CHECKING(app):
+    options = {"members": None,
+               "undoc-members": None}
+    actual = do_autodoc(app, 'module', 'target.TYPE_CHECKING', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.TYPE_CHECKING',
+        '',
+        '',
+        '.. py:class:: Foo()',
+        '   :module: target.TYPE_CHECKING',
+        '',
+        '',
+        '   .. py:attribute:: Foo.attr1',
+        '      :module: target.TYPE_CHECKING',
+        '      :type: StringIO',
+        '',
+    ]
+
+
 @pytest.mark.sphinx('html', testroot='pycode-egg')
 def test_autodoc_for_egged_code(app):
     options = {"members": None,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8099 
- `typing.get_type_hints()` raises NameError when the target object
contains unresolavable type annotation (ex. TYPE_CHECKING).  This
handles the exception and use unresolved annotations for type hints.