### PR TITLE
Make man writer default month format the same as documented

### DIFF
--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -109,7 +109,7 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
         if self.config.today:
             self._docinfo['date'] = self.config.today
         else:
-            self._docinfo['date'] = format_date(self.config.today_fmt or _('%b %d, %Y'),
+            self._docinfo['date'] = format_date(self.config.today_fmt or _('%B %d, %Y'),
                                                 language=self.config.language)
         self._docinfo['copyright'] = self.config.copyright
         self._docinfo['version'] = self.config.version


### PR DESCRIPTION
Subject:

Current default is the abbreviated month name, change to full month name as today_fmt in documentation

### Feature or Bugfix
- Bugfix

### Detail
Documented as today_fmt in doc/usage/configuration.rst.

This also matches the format to be used for the last modification date
in the BSD mdoc guide:
https://manpages.bsd.lv/mdoc.html
