### PR TITLE
Add permalink to rubric

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -256,6 +256,7 @@ h6:hover > a.headerlink,
 dt:hover > a.headerlink,
 caption:hover > a.headerlink,
 p.caption:hover > a.headerlink,
+p.rubric:hover > a.headerlink,
 div.code-block-caption:hover > a.headerlink {
     visibility: visible;
 }

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -430,6 +430,11 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         super().depart_title(node)
 
     # overwritten
+    def depart_rubric(self, node: Element) -> None:
+        self.body.append('</p>\n')
+        self.add_permalink_ref(node.parent, _('Permalink to this headline'))
+
+    # overwritten
     def visit_literal_block(self, node: Element) -> None:
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -382,6 +382,11 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         super().depart_title(node)
 
     # overwritten
+    def depart_rubric(self, node: Element) -> None:
+        self.add_permalink_ref(node.parent, _('Permalink to this headline'))
+        self.body.append('</p>\n')
+
+    # overwritten
     def visit_literal_block(self, node: Element) -> None:
         if node.rawsource != node.astext():
             # most probably a parsed-literal block -- don't highlight

--- a/tests/roots/test-rubric/conf.py
+++ b/tests/roots/test-rubric/conf.py
@@ -1,0 +1,15 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+
+class TestRubric(SphinxDirective):
+    def run(self):
+        return [nodes.section('',
+            nodes.rubric('Rubric Title', 'Rubric Title'),
+            nodes.Text('Lorem ipsum.'),
+            ids=['rubric-permalink-name']
+        )]
+
+
+def setup(app):
+    app.add_directive('test_rubric', TestRubric)

--- a/tests/roots/test-rubric/index.rst
+++ b/tests/roots/test-rubric/index.rst
@@ -1,0 +1,1 @@
+.. test_rubric::

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1297,6 +1297,13 @@ def test_html_anchor_for_figure(app):
             '<a class="headerlink" href="#id1" title="Permalink to this image">¶</a></p>'
             in content)
 
+@pytest.mark.sphinx('html', testroot='rubric')
+def test_html_rubric_permalink(app):
+    app.builder.build_all()
+    content = (app.outdir / 'index.html').read_text()
+    assert('<p class="rubric">Rubric Title<a class="headerlink" '
+           'href="#rubric-permalink-name" title="Permalink to this headline">¶</a>'
+           in content)
 
 @pytest.mark.sphinx('html', testroot='directives-raw')
 def test_html_raw_directive(app, status, warning):


### PR DESCRIPTION
According to docutils a rubric is: 

> rubric n. 1. a title, heading, or the like, in a manuscript, book, statute, etc., written or printed in red or otherwise distinguished from the rest of the text. ...

I think it deserves to have a permalink like other titles or headings. A rubric with a headlink can be added as follow: 

```python
class TestRubric(SphinxDirective):
    def run(self):
        node = nodes.section('',
            nodes.rubric('Rubric Title', 'Rubric Title'),
            nodes.Text('Lorem ipsum.'),
            ids=['rubric-permalink-name']
        )
        return [node]

def setup(app):
    app.add_directive('test_rubric', TestRubric)
```

