### PR TITLE
Glob names for output assets directories

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -84,6 +84,10 @@ class Builder:
     #: The builder supports data URIs or not.
     supported_data_uri_images = False
 
+    # basename of output assets directories
+    imagedir = ""
+    sourcesdir = ""
+
     def __init__(self, app: "Sphinx") -> None:
         self.srcdir = app.srcdir
         self.confdir = app.confdir
@@ -103,8 +107,7 @@ class Builder:
 
         # images that need to be copied over (source -> dest)
         self.images = {}  # type: Dict[str, str]
-        # basename of images directory
-        self.imagedir = ""
+
         # relative path to image directory from current docname (used at writing docs)
         self.imgpath = ""
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -85,7 +85,7 @@ class Builder:
     supported_data_uri_images = False
 
     # basename of output assets directories
-    imagedir = ""
+    assets_images_directory = ""
     sourcesdir = ""
 
     def __init__(self, app: "Sphinx") -> None:

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -392,7 +392,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         The method tries to read and write the files with Pillow, converting
         the format and resizing the image if necessary/possible.
         """
-        ensuredir(path.join(self.outdir, self.imagedir))
+        ensuredir(path.join(self.outdir, self.assets_images_directory))
         for src in status_iterator(self.images, __('copying images... '), "brown",
                                    len(self.images), self.app.verbosity):
             dest = self.images[src]
@@ -404,7 +404,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                                    path.join(self.srcdir, src))
                 try:
                     copyfile(path.join(self.srcdir, src),
-                             path.join(self.outdir, self.imagedir, dest))
+                             path.join(self.outdir, self.assets_images_directory, dest))
                 except OSError as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
@@ -421,7 +421,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                     nh = (height * nw) / width
                     img = img.resize((nw, nh), Image.BICUBIC)
             try:
-                img.save(path.join(self.outdir, self.imagedir, dest))
+                img.save(path.join(self.outdir, self.assets_images_directory, dest))
             except OSError as err:
                 logger.warning(__('cannot write image file %r: %s'),
                                path.join(self.srcdir, src), err)

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -181,6 +181,11 @@ class StandaloneHTMLBuilder(Builder):
     link_suffix = '.html'  # defaults to matching out_suffix
     indexer_format = js_index  # type: Any
     indexer_dumps_unicode = True
+
+    # basename of output directories
+    imagedir = '_images'
+    sourcedir = '_sources'
+
     # create links to original images from images [True/False]
     html_scaled_image_link = True
     supported_image_types = ['image/svg+xml', 'image/png',
@@ -209,8 +214,7 @@ class StandaloneHTMLBuilder(Builder):
 
     def init(self) -> None:
         self.build_info = self.create_build_info()
-        # basename of images directory
-        self.imagedir = '_images'
+
         # section numbers for headings in the currently visited document
         self.secnumbers = {}  # type: Dict[str, Tuple[int, ...]]
         # currently written docname
@@ -1032,7 +1036,7 @@ class StandaloneHTMLBuilder(Builder):
             logger.warning(__("error writing file %s: %s"), outfilename, err)
         if self.copysource and ctx.get('sourcename'):
             # copy the source file for the "show source" link
-            source_name = path.join(self.outdir, '_sources',
+            source_name = path.join(self.outdir, self.sourcedir,
                                     os_path(ctx['sourcename']))
             ensuredir(path.dirname(source_name))
             copyfile(self.env.doc2path(pagename), source_name)

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -183,8 +183,8 @@ class StandaloneHTMLBuilder(Builder):
     indexer_dumps_unicode = True
 
     # basename of output assets directories
-    imagedir = '_images'
-    sourcedir = '_sources'
+    assets_images_directory = '_images'
+    assets_sources_directory = '_sources'
 
     # create links to original images from images [True/False]
     html_scaled_image_link = True
@@ -501,6 +501,10 @@ class StandaloneHTMLBuilder(Builder):
             'parents': [],
             'logo': logo,
             'favicon': favicon,
+            'assets_dirs': {
+                'images': self.assets_images_directory,
+                'sources': self.assets_sources_directory
+            },
             'html5_doctype': html5_ready and not self.config.html4_writer,
         }
         if self.theme:
@@ -607,7 +611,7 @@ class StandaloneHTMLBuilder(Builder):
         self.handle_page(docname, ctx, event_arg=doctree)
 
     def write_doc_serialized(self, docname: str, doctree: nodes.document) -> None:
-        self.imgpath = relative_uri(self.get_target_uri(docname), self.imagedir)
+        self.imgpath = relative_uri(self.get_target_uri(docname), self.assets_images_directory)
         self.post_process_images(doctree)
         title_node = self.env.longtitles.get(docname)
         title = self.render_partial(title_node)['title'] if title_node else ''
@@ -701,14 +705,14 @@ class StandaloneHTMLBuilder(Builder):
     def copy_image_files(self) -> None:
         if self.images:
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
-            ensuredir(path.join(self.outdir, self.imagedir))
+            ensuredir(path.join(self.outdir, self.assets_images_directory))
             for src in status_iterator(self.images, __('copying images... '), "brown",
                                        len(self.images), self.app.verbosity,
                                        stringify_func=stringify_func):
                 dest = self.images[src]
                 try:
                     copyfile(path.join(self.srcdir, src),
-                             path.join(self.outdir, self.imagedir, dest))
+                             path.join(self.outdir, self.assets_images_directory, dest))
                 except Exception as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
@@ -1036,7 +1040,7 @@ class StandaloneHTMLBuilder(Builder):
             logger.warning(__("error writing file %s: %s"), outfilename, err)
         if self.copysource and ctx.get('sourcename'):
             # copy the source file for the "show source" link
-            source_name = path.join(self.outdir, self.sourcedir,
+            source_name = path.join(self.outdir, self.assets_sources_directory,
                                     os_path(ctx['sourcename']))
             ensuredir(path.dirname(source_name))
             copyfile(self.env.doc2path(pagename), source_name)

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -182,7 +182,7 @@ class StandaloneHTMLBuilder(Builder):
     indexer_format = js_index  # type: Any
     indexer_dumps_unicode = True
 
-    # basename of output directories
+    # basename of output assets directories
     imagedir = '_images'
     sourcedir = '_sources'
 

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -180,9 +180,9 @@ class TexinfoBuilder(Builder):
                                        stringify_func=stringify_func):
                 dest = self.images[src]
                 try:
-                    imagedir = path.join(self.outdir, targetname + '-figures')
-                    ensuredir(imagedir)
-                    copy_asset_file(path.join(self.srcdir, dest), imagedir)
+                    assets_images_directory = path.join(self.outdir, targetname + '-figures')
+                    ensuredir(assets_images_directory)
+                    copy_asset_file(path.join(self.srcdir, dest), assets_images_directory)
                 except Exception as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -219,7 +219,7 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict,
 
     fname = '%s-%s.%s' % (prefix, sha1(hashkey).hexdigest(), format)
     relfn = posixpath.join(self.builder.imgpath, fname)
-    outfn = path.join(self.builder.outdir, self.builder.imagedir, fname)
+    outfn = path.join(self.builder.outdir, self.builder.assets_images_directory, fname)
 
     if path.isfile(outfn):
         return relfn, outfn

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -263,7 +263,7 @@ def render_math(self: HTMLTranslator, math: str) -> Tuple[str, int]:
 
     filename = "%s.%s" % (sha1(latex.encode()).hexdigest(), image_format)
     relfn = posixpath.join(self.builder.imgpath, 'math', filename)
-    outfn = path.join(self.builder.outdir, self.builder.imagedir, 'math', filename)
+    outfn = path.join(self.builder.outdir, self.builder.assets_images_directory, 'math', filename)
     if path.isfile(outfn):
         if image_format == 'png':
             depth = read_png_depth(outfn)

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -86,7 +86,7 @@
           <div role="note" aria-label="source link">
             {%- if show_source and has_source and sourcename %}
               <br/>
-              <a href="{{ pathto('_sources/' + sourcename, true)|e }}"
+              <a href="{{ pathto(assets_dirs['sources'] + '/' + sourcename, true)|e }}"
                 rel="nofollow">{{ _('Show Source') }}</a>
             {%- endif %}
           </div>

--- a/sphinx/themes/basic/sourcelink.html
+++ b/sphinx/themes/basic/sourcelink.html
@@ -11,7 +11,7 @@
   <div role="note" aria-label="source link">
     <h3>{{ _('This Page') }}</h3>
     <ul class="this-page-menu">
-      <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
+      <li><a href="{{ pathto(assets_dirs['sources'] + '/' + sourcename, true)|e }}"
             rel="nofollow">{{ _('Show Source') }}</a></li>
     </ul>
    </div>

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -43,7 +43,7 @@ class BaseImageConverter(SphinxTransform):
         pass
 
     @property
-    def imagedir(self) -> str:
+    def assets_images_directory(self) -> str:
         return os.path.join(self.app.doctreedir, 'images')
 
 
@@ -72,8 +72,8 @@ class ImageDownloader(BaseImageConverter):
                                                                  ord("&"): "/"})
             if len(dirname) > MAX_FILENAME_LEN:
                 dirname = sha1(dirname.encode()).hexdigest()
-            ensuredir(os.path.join(self.imagedir, dirname))
-            path = os.path.join(self.imagedir, dirname, basename)
+            ensuredir(os.path.join(self.assets_images_directory, dirname))
+            path = os.path.join(self.assets_images_directory, dirname, basename)
 
             headers = {}
             if os.path.exists(path):
@@ -100,7 +100,7 @@ class ImageDownloader(BaseImageConverter):
                 if mimetype != '*' and os.path.splitext(basename)[1] == '':
                     # append a suffix if URI does not contain suffix
                     ext = get_image_extension(mimetype)
-                    newpath = os.path.join(self.imagedir, dirname, basename + ext)
+                    newpath = os.path.join(self.assets_images_directory, dirname, basename + ext)
                     movefile(path, newpath)
                     self.app.env.original_image_uri.pop(path)
                     self.app.env.original_image_uri[newpath] = node['uri']
@@ -132,9 +132,9 @@ class DataURIExtractor(BaseImageConverter):
                            location=node)
             return
 
-        ensuredir(os.path.join(self.imagedir, 'embeded'))
+        ensuredir(os.path.join(self.assets_images_directory, 'embeded'))
         digest = sha1(image.data).hexdigest()
-        path = os.path.join(self.imagedir, 'embeded', digest + ext)
+        path = os.path.join(self.assets_images_directory, 'embeded', digest + ext)
         self.app.env.original_image_uri[path] = node['uri']
 
         with open(path, 'wb') as f:
@@ -240,8 +240,8 @@ class ImageConverter(BaseImageConverter):
             srcpath = node['candidates']['*']
 
         filename = get_filename_for(srcpath, _to)
-        ensuredir(self.imagedir)
-        destpath = os.path.join(self.imagedir, filename)
+        ensuredir(self.assets_images_directory)
+        destpath = os.path.join(self.assets_images_directory, filename)
 
         abs_srcpath = os.path.join(self.app.srcdir, srcpath)
         if self.convert(abs_srcpath, destpath):

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1225,25 +1225,25 @@ def test_html_assets(app):
 @pytest.mark.sphinx('html', testroot='basic', confoverrides={'html_copy_source': False})
 def test_html_copy_source(app):
     app.builder.build_all()
-    assert not (app.outdir / '_sources' / 'index.rst.txt').exists()
+    assert not (app.outdir / app.builder.assets_sources_directory / 'index.rst.txt').exists()
 
 
 @pytest.mark.sphinx('html', testroot='basic', confoverrides={'html_sourcelink_suffix': '.txt'})
 def test_html_sourcelink_suffix(app):
     app.builder.build_all()
-    assert (app.outdir / '_sources' / 'index.rst.txt').exists()
+    assert (app.outdir / app.builder.assets_sources_directory / 'index.rst.txt').exists()
 
 
 @pytest.mark.sphinx('html', testroot='basic', confoverrides={'html_sourcelink_suffix': '.rst'})
 def test_html_sourcelink_suffix_same(app):
     app.builder.build_all()
-    assert (app.outdir / '_sources' / 'index.rst').exists()
+    assert (app.outdir / app.builder.assets_sources_directory / 'index.rst').exists()
 
 
 @pytest.mark.sphinx('html', testroot='basic', confoverrides={'html_sourcelink_suffix': ''})
 def test_html_sourcelink_suffix_empty(app):
     app.builder.build_all()
-    assert (app.outdir / '_sources' / 'index.rst').exists()
+    assert (app.outdir / app.builder.assets_sources_directory / 'index.rst').exists()
 
 
 @pytest.mark.sphinx('html', testroot='html_entity')


### PR DESCRIPTION
Currently in the builders, the values of `_images` and `_sources` hard kind of hard-coded. Only the `_images` is initialized on the `__init__` which makes it cumbersome to modify this value in a new builder: 

```python
class MyNewBuilder(StandaloneHTMLBuilder):
    name = 'mybuilder'
    def __init__(*args, **kwargs):
        super().__init__(*args, **kwargs)
        self.imagedir = 'assets/images' # override
```

With the change made, it is easier:

```python
class MyNewBuilder(StandaloneHTMLBuilder):
    name = 'mybuilder'
    imagedir = 'assets/images'
```