### PR TITLE
autodoc: fix constructor signatures for classes derived from typing.Generic

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1317,6 +1317,12 @@ _METACLASS_CALL_BLACKLIST = [
 ]
 
 
+# Types whose __new__ signature is a pass-thru.
+_CLASS_NEW_BLACKLIST = [
+    'typing.Generic.__new__',
+]
+
+
 class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: ignore
     """
     Specialized Documenter subclass for classes.
@@ -1385,6 +1391,11 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
 
         # Now we check if the 'obj' class has a '__new__' method
         new = get_user_defined_function_or_method(self.object, '__new__')
+
+        if new is not None:
+            if "{0.__module__}.{0.__qualname__}".format(new) in _CLASS_NEW_BLACKLIST:
+                new = None
+
         if new is not None:
             self.env.app.emit('autodoc-before-process-signature', new, True)
             try:

--- a/tests/roots/test-ext-autodoc/target/generic_class.py
+++ b/tests/roots/test-ext-autodoc/target/generic_class.py
@@ -1,0 +1,12 @@
+from typing import TypeVar, Generic
+
+
+T = TypeVar('T')
+
+
+# Test that typing.Generic's __new__ method does not mask our class'
+# __init__ signature.
+class A(Generic[T]):
+    """docstring for A"""
+    def __init__(self, a, b=None):
+        pass

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -290,6 +290,22 @@ def test_format_signature(app):
         '(b, c=42, *d, **e)'
 
 
+@pytest.mark.skipif(sys.version_info < (3, 5), reason='typing is available since python3.5.')
+@pytest.mark.xfail
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autodoc_process_signature_typing_generic(app):
+    actual = do_autodoc(app, 'class', 'target.generic_class.A', {})
+
+    assert list(actual) == [
+        '',
+        '.. py:class:: A(a, b=None)',
+        '   :module: target.generic_class',
+        '',
+        '   docstring for A',
+        '',
+    ]
+
+
 def test_autodoc_process_signature_typehints(app):
     captured = []
 

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -291,7 +291,6 @@ def test_format_signature(app):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason='typing is available since python3.5.')
-@pytest.mark.xfail
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_process_signature_typing_generic(app):
     actual = do_autodoc(app, 'class', 'target.generic_class.A', {})


### PR DESCRIPTION
Subject: take the constructor signature from __init__ instead of __new__ for classes derived from typing.Generic

### Feature or Bugfix

- Bugfix

### Purpose

When documenting classes derived from `typing.Generic` (essentially all classes in the typing module) the constructor signature would show an unhelpful `(*args, **kwds).`

`typing.Generic.__new__` was being picked up by sphinx.ext.autodoc. With this patch it is skipped and constructor signatures for generic classes are taken from `__init__`.

### Detail

I copied the code that was used to skip callable metaclasses.


