### PR TITLE
Fix #8143: AttributeError if autodoc_default_options contains False

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #8085: i18n: Add support for having single text domain
+* #8143: autodoc: AttributeError is raised when False value is passed to
+  autodoc_default_options
 * #8093: The highlight warning has wrong location in some builders (LaTeX,
   singlehtml and so on)
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -94,7 +94,10 @@ def members_option(arg: Any) -> Union[object, List[str]]:
     """Used to convert the :members: option to auto directives."""
     if arg is None or arg is True:
         return ALL
-    return [x.strip() for x in arg.split(',') if x.strip()]
+    elif arg is False:
+        return None
+    else:
+        return [x.strip() for x in arg.split(',') if x.strip()]
 
 
 def members_set_option(arg: Any) -> Union[object, Set[str]]:
@@ -172,7 +175,7 @@ def merge_members_option(options: Dict) -> None:
 
     members = options.setdefault('members', [])
     for key in {'private-members', 'special-members'}:
-        if key in options and options[key] is not ALL:
+        if key in options and options[key] not in (ALL, None):
             for member in options[key]:
                 if member not in members:
                     members.append(member)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8143 
- autodoc crahses when autodoc_default_options contains False value
unexpectedly.  After this change, it also accepts False.
