### PR TITLE
Fixes #8146: When identifying bases, only use classes from builtins

### DIFF
--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -66,6 +66,10 @@ module_sig_re = re.compile(r'''^(?:([\w.]*)\.)?  # module names
                            ''', re.VERBOSE)
 
 
+py_builtins = [obj for obj in vars(builtins).values()
+               if inspect.isclass(obj)]
+
+
 def try_import(objname: str) -> Any:
     """Import a object or module using *name* and *currentmodule*.
     *name* should be a relative name from *currentmodule* or
@@ -178,7 +182,6 @@ class InheritanceGraph:
         traverse to. Multiple names can be specified separated by comma.
         """
         all_classes = {}
-        py_builtins = vars(builtins).values()
 
         def recurse(cls: Any) -> None:
             if not show_builtins and cls in py_builtins:


### PR DESCRIPTION
Subject: When identifying bases, only use class objects from `builtins`

### Feature or Bugfix
- Feature
- Minor refactoring

### Purpose
In inheritance_diagram extension, while iterating over bases,
we verify if the base class is one of the Python built-in
class or not.
As of now, we simply check for its presence in all `builtins`
objects. Please note, `builtins` not only has built-in classes,
but also functions (like `open`) and other built-in objects.

To avoid any sort of future problem, it seems better to only
use classes (and of course exception classes).

### Relates
- Issue #8146 