### PR TITLE
Fix comment end string in LaTeXRenderer

### DIFF
--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -85,7 +85,7 @@ class LaTeXRenderer(SphinxRenderer):
         self.env.block_start_string = '<%'
         self.env.block_end_string = '%>'
         self.env.comment_start_string = '<#'
-        self.env.comment_end_string = '<#'
+        self.env.comment_end_string = '#>'
 
 
 class ReSTRenderer(SphinxRenderer):


### PR DESCRIPTION
Fix bug introduced by commit 5f82825e27 in `self.env.comment_end_string`

### Feature or Bugfix

- Bugfix

### Detail
- Changed the comment end string to `#>`