### PR TITLE
Fix typos

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1004,7 +1004,7 @@ class Sphinx:
         logger.debug('[app] adding lexer: %r', (alias, lexer))
         if isinstance(lexer, Lexer):
             warnings.warn('app.add_lexer() API changed; '
-                          'Please give lexer class instead instance',
+                          'Please give lexer class instead of instance',
                           RemovedInSphinx40Warning, stacklevel=2)
             lexers[alias] = lexer
         else:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -401,7 +401,7 @@ class SphinxComponentRegistry:
 
     def load_extension(self, app: "Sphinx", extname: str) -> None:
         """Load a Sphinx extension."""
-        if extname in app.extensions:  # alread loaded
+        if extname in app.extensions:  # already loaded
             return
         if extname in EXTENSION_BLACKLIST:
             logger.warning(__('the extension %r was already merged with Sphinx since '


### PR DESCRIPTION
Subject: Fix two typos in the code. 

### Feature or Bugfix
- Bugfix

### Detail
- One type is in the warning emitted by Sphinx.add_lexer() when passing an instance rather than a class. There was a missing 'of'; without it the sentence doesn't make sense. 
- The other is a comment that should say `# already loaded` but actually says `# alread loaded`.

There doesn't appear to be a test for the warning, so I don't think any changes will be required elsewhere.

