### PR TITLE
domains: c: fix intersphinx anonymous nested names

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3753,6 +3753,7 @@ class CDomain(Domain):
 
     def get_objects(self) -> Iterator[Tuple[str, str, str, str, str, int]]:
         for refname, (docname, node_id, objtype) in list(self.objects.items()):
+            refname = refname.replace('[anonymous].', '')
             yield (refname, refname, objtype, docname, node_id, 1)
 
 


### PR DESCRIPTION
When anonymous enums (and possibly other anonymous elements) exists in a project, the current intersphinx inventory looks something like:

```
$ python3 -m sphinx.ext.intersphinx objects.inv | rg SOME_SYMBOL
[anonymous].SOME_SYMBOL some-long-unique-url
```

When linking external projects through intersphinx one has to write:

```
:c:enumerator:`SOME_SYMBOL <[anonymous].SOME_SYMBOL>`
```

After this commit, the generated intersphinx inventory does remove the "[anonymous]." nested elements, so a symbol can be simply written:

```
:c:enumerator:`SOME_SYMBOL`
```