### PR TITLE
Fixes minor typo in quickstart.rst

### DIFF
--- a/doc/usage/quickstart.rst
+++ b/doc/usage/quickstart.rst
@@ -15,7 +15,7 @@ Much of Sphinx's power comes from the richness of its default plain-text markup
 format, :doc:`reStructuredText </usage/restructuredtext/index>`, along with
 it's :doc:`significant extensibility capabilities </development/index>`.
 
-The goal of this document is to give you a quick taste of what Sphinx it is and
+The goal of this document is to give you a quick taste of what Sphinx is and
 how you might use it. When you're done here, you can check out the
 :doc:`installation guide </usage/installation>` followed by the intro to the
 default markup format used by Sphinx, :doc:`reStucturedText


### PR DESCRIPTION
Subject: Fixes minor typo in quickstart.rst

### Bugfix
- Removes superfluous "it" from sentence (right after "Sphinx")