### PR TITLE
Don't remove substitution_reference nodes (fix #7953)

### DIFF
--- a/sphinx/transforms/references.py
+++ b/sphinx/transforms/references.py
@@ -10,25 +10,13 @@
 
 from typing import Any, Dict
 
-from docutils import nodes
-from docutils.transforms.references import DanglingReferences, Substitutions
+from docutils.transforms.references import DanglingReferences
 
 from sphinx.transforms import SphinxTransform
 
 if False:
     # For type annotation
     from sphinx.application import Sphinx
-
-
-class SubstitutionDefinitionsRemover(SphinxTransform):
-    """Remove ``substitution_definition node from doctrees."""
-
-    # should be invoked after Substitutions process
-    default_priority = Substitutions.default_priority + 1
-
-    def apply(self, **kwargs: Any) -> None:
-        for node in self.document.traverse(nodes.substitution_definition):
-            node.parent.remove(node)
 
 
 class SphinxDanglingReferences(DanglingReferences):
@@ -56,7 +44,6 @@ class SphinxDomains(SphinxTransform):
 
 
 def setup(app: "Sphinx") -> Dict[str, Any]:
-    app.add_transform(SubstitutionDefinitionsRemover)
     app.add_transform(SphinxDanglingReferences)
     app.add_transform(SphinxDomains)
 

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1242,6 +1242,15 @@ class TexinfoTranslator(SphinxTranslator):
     def depart_legend(self, node: Element) -> None:
         pass
 
+    def visit_substitution_reference(self, node: Element) -> None:
+        pass
+
+    def depart_substitution_reference(self, node: Element) -> None:
+        pass
+
+    def visit_substitution_definition(self, node: Element) -> None:
+        raise nodes.SkipNode
+
     def visit_system_message(self, node: Element) -> None:
         self.body.append('\n@verbatim\n'
                          '<SYSTEM MESSAGE: %s>\n'

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -1013,6 +1013,9 @@ class TextTranslator(SphinxTranslator):
     def visit_toctree(self, node: Element) -> None:
         raise nodes.SkipNode
 
+    def visit_substitution_definition(self, node: Element) -> None:
+        raise nodes.SkipNode
+
     def visit_pending_xref(self, node: Element) -> None:
         pass
 

--- a/tests/test_directive_patch.py
+++ b/tests/test_directive_patch.py
@@ -21,7 +21,8 @@ def test_code_directive(app):
             '   print("hello world")\n')
 
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, nodes.literal_block, 'print("hello world")'])
+    assert_node(doctree, ([nodes.literal_block, 'print("hello world")'],
+                          nodes.substitution_definition))
     assert_node(doctree[0], language="default", highlight_args={})
 
     # with language
@@ -30,7 +31,8 @@ def test_code_directive(app):
             '   print("hello world")\n')
 
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, nodes.literal_block, 'print("hello world")'])
+    assert_node(doctree, ([nodes.literal_block, 'print("hello world")'],
+                          nodes.substitution_definition))
     assert_node(doctree[0], language="python", highlight_args={})
 
     # :number-lines: option
@@ -40,7 +42,8 @@ def test_code_directive(app):
             '   print("hello world")\n')
 
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, nodes.literal_block, 'print("hello world")'])
+    assert_node(doctree, ([nodes.literal_block, 'print("hello world")'],
+                          nodes.substitution_definition))
     assert_node(doctree[0], language="python", linenos=True, highlight_args={})
 
     # :number-lines: option
@@ -50,7 +53,8 @@ def test_code_directive(app):
             '   print("hello world")\n')
 
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, nodes.literal_block, 'print("hello world")'])
+    assert_node(doctree, ([nodes.literal_block, 'print("hello world")'],
+                          nodes.substitution_definition))
     assert_node(doctree[0], language="python", linenos=True, highlight_args={'linenostart': 5})
 
 
@@ -58,29 +62,33 @@ def test_math_directive(app):
     # normal case
     text = '.. math:: E = mc^2'
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, nodes.math_block, 'E = mc^2\n\n'])
+    assert_node(doctree, ([nodes.math_block, "E = mc^2\n\n"],
+                          nodes.substitution_definition))
 
     # :name: option
     text = ('.. math:: E = mc^2\n'
             '   :name: eq1\n')
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, (nodes.target,
-                                           [nodes.math_block, "E = mc^2\n\n"])])
+    assert_node(doctree, (nodes.target,
+                          [nodes.math_block, "E = mc^2\n\n"],
+                          nodes.substitution_definition))
     assert_node(doctree[1], nodes.math_block, docname='index', label="eq1", number=1)
 
     # :label: option
     text = ('.. math:: E = mc^2\n'
             '   :label: eq2\n')
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, (nodes.target,
-                                           [nodes.math_block, 'E = mc^2\n\n'])])
+    assert_node(doctree, (nodes.target,
+                          [nodes.math_block, "E = mc^2\n\n"],
+                          nodes.substitution_definition))
     assert_node(doctree[1], nodes.math_block, docname='index', label="eq2", number=2)
 
     # :label: option without value
     text = ('.. math:: E = mc^2\n'
             '   :label:\n')
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, [nodes.document, (nodes.target,
-                                           [nodes.math_block, 'E = mc^2\n\n'])])
+    assert_node(doctree, (nodes.target,
+                          [nodes.math_block, "E = mc^2\n\n"],
+                          nodes.substitution_definition))
     assert_node(doctree[1], nodes.math_block, ids=['equation-index-0'],
                 docname='index', label="index:0", number=3)

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -8,6 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 import pytest
+from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.addnodes import desc
@@ -601,6 +602,7 @@ def test_noindexentry(app):
             ".. c:function:: void g()\n"
             "   :noindexentry:\n")
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc,
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C function)', 'c.f', '', None)])
     assert_node(doctree[2], addnodes.index, entries=[])

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -11,6 +11,7 @@
 import re
 
 import pytest
+from docutils import nodes
 
 import sphinx.domains.cpp as cppDomain
 from sphinx import addnodes
@@ -1233,6 +1234,7 @@ def test_noindexentry(app):
             ".. cpp:function:: void g()\n"
             "   :noindexentry:\n")
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc,
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C++ function)', '_CPPv41fv', '', None)])
     assert_node(doctree[2], addnodes.index, entries=[])

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -176,7 +176,8 @@ def test_js_module(app):
     text = ".. js:module:: sphinx"
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (nodes.target,
-                          addnodes.index))
+                          addnodes.index,
+                          nodes.substitution_definition))
     assert_node(doctree[0], nodes.target, ids=["module-sphinx"])
     assert_node(doctree[1], addnodes.index,
                 entries=[("single", "sphinx (module)", "module-sphinx", "", None)])
@@ -188,7 +189,8 @@ def test_js_function(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, "sum"],
                                                     desc_parameterlist)],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[1][0][1], [desc_parameterlist, ([desc_parameter, "a"],
                                                         [desc_parameter, "b"])])
     assert_node(doctree[0], addnodes.index,
@@ -203,7 +205,8 @@ def test_js_class(app):
                           [desc, ([desc_signature, ([desc_annotation, "class "],
                                                     [desc_name, "Application"],
                                                     [desc_parameterlist, ()])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index,
                 entries=[("single", "Application() (class)", "Application", "", None)])
     assert_node(doctree[1], addnodes.desc, domain="js", objtype="class", noindex=False)
@@ -214,7 +217,8 @@ def test_js_data(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, desc_name, "name"],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index,
                 entries=[("single", "name (global variable or constant)", "name", "", None)])
     assert_node(doctree[1], addnodes.desc, domain="js", objtype="data", noindex=False)
@@ -225,6 +229,7 @@ def test_noindexentry(app):
             ".. js:function:: g()\n"
             "   :noindexentry:\n")
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc,
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f() (built-in function)', 'f', '', None)])
     assert_node(doctree[2], addnodes.index, entries=[])

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -301,7 +301,8 @@ def test_pyfunction_signature(app):
                           [desc, ([desc_signature, ([desc_name, "hello"],
                                                     desc_parameterlist,
                                                     [desc_returns, pending_xref, "str"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="function",
                 domain="py", objtype="function", noindex=False)
     assert_node(doctree[1][0][1],
@@ -319,7 +320,8 @@ def test_pyfunction_signature_full(app):
                           [desc, ([desc_signature, ([desc_name, "hello"],
                                                     desc_parameterlist,
                                                     [desc_returns, pending_xref, "str"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="function",
                 domain="py", objtype="function", noindex=False)
     assert_node(doctree[1][0][1],
@@ -393,7 +395,8 @@ def test_optional_pyfunction_signature(app):
                           [desc, ([desc_signature, ([desc_name, "compile"],
                                                     desc_parameterlist,
                                                     [desc_returns, pending_xref, "ast object"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="function",
                 domain="py", objtype="function", noindex=False)
     assert_node(doctree[1][0][1],
@@ -409,7 +412,8 @@ def test_pyexception_signature(app):
                           [desc, ([desc_signature, ([desc_annotation, "exception "],
                                                     [desc_addname, "exceptions."],
                                                     [desc_name, "IOError"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], desc, desctype="exception",
                 domain="py", objtype="exception", noindex=False)
 
@@ -421,7 +425,8 @@ def test_exceptions_module_is_ignored(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_annotation, "exception "],
                                                     [desc_name, "IOError"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], desc, desctype="exception",
                 domain="py", objtype="exception", noindex=False)
 
@@ -436,7 +441,8 @@ def test_pydata_signature(app):
                                                     [desc_annotation, (": ",
                                                                        [pending_xref, "int"])],
                                                     [desc_annotation, " = 1"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="data",
                 domain="py", objtype="data", noindex=False)
 
@@ -448,7 +454,8 @@ def test_pydata_signature_old(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, "version"],
                                                     [desc_annotation, " = 1"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="data",
                 domain="py", objtype="data", noindex=False)
 
@@ -465,7 +472,8 @@ def test_pyobject_prefix(app):
                                   [desc_content, (addnodes.index,
                                                   desc,
                                                   addnodes.index,
-                                                  desc)])]))
+                                                  desc)])],
+                          nodes.substitution_definition))
     assert doctree[1][1][1].astext().strip() == 'say()'           # prefix is stripped
     assert doctree[1][1][3].astext().strip() == 'FooBar.say()'    # not stripped
 
@@ -483,7 +491,8 @@ def test_pydata(app):
                                                     [desc_name, "var"],
                                                     [desc_annotation, (": ",
                                                                        [pending_xref, "int"])])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[3][0][2][1], pending_xref, **{"py:module": "example"})
     assert 'example.var' in domain.objects
     assert domain.objects['example.var'] == ('index', 'example.var', 'data')
@@ -507,7 +516,8 @@ def test_pyfunction(app):
                                                     [desc_addname, "example."],
                                                     [desc_name, "func2"],
                                                     [desc_parameterlist, ()])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index,
                 entries=[('pair', 'built-in function; func1()', 'func1', '', None)])
     assert_node(doctree[3], addnodes.index,
@@ -534,7 +544,8 @@ def test_pyclass_options(app):
                           addnodes.index,
                           [desc, ([desc_signature, ([desc_annotation, "final class "],
                                                     [desc_name, "Class2"])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
 
     # class
     assert_node(doctree[0], addnodes.index,
@@ -583,7 +594,8 @@ def test_pymethod_options(app):
                                                   addnodes.index,
                                                   desc,
                                                   addnodes.index,
-                                                  desc)])]))
+                                                  desc)])],
+                          nodes.substitution_definition))
 
     # method
     assert_node(doctree[1][1][0], addnodes.index,
@@ -664,7 +676,8 @@ def test_pyclassmethod(app):
                           [desc, ([desc_signature, ([desc_annotation, "class "],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
-                                                  desc)])]))
+                                                  desc)])],
+                          nodes.substitution_definition))
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'meth() (Class class method)', 'Class.meth', '', None)])
     assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, "classmethod "],
@@ -685,7 +698,8 @@ def test_pystaticmethod(app):
                           [desc, ([desc_signature, ([desc_annotation, "class "],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
-                                                  desc)])]))
+                                                  desc)])],
+                          nodes.substitution_definition))
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'meth() (Class static method)', 'Class.meth', '', None)])
     assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, "static "],
@@ -708,7 +722,8 @@ def test_pyattribute(app):
                           [desc, ([desc_signature, ([desc_annotation, "class "],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
-                                                  desc)])]))
+                                                  desc)])],
+                          nodes.substitution_definition))
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'attr (Class attribute)', 'Class.attr', '', None)])
     assert_node(doctree[1][1][1], ([desc_signature, ([desc_name, "attr"],
@@ -732,7 +747,8 @@ def test_pydecorator_signature(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_addname, "@"],
                                                     [desc_name, "deco"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="function",
                 domain="py", objtype="function", noindex=False)
 
@@ -747,7 +763,8 @@ def test_pydecoratormethod_signature(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_addname, "@"],
                                                     [desc_name, "deco"])],
-                                  desc_content)]))
+                                  desc_content)],
+                          nodes.substitution_definition))
     assert_node(doctree[1], addnodes.desc, desctype="method",
                 domain="py", objtype="method", noindex=False)
 
@@ -827,7 +844,8 @@ def test_noindexentry(app):
             ".. py:function:: g()\n"
             "   :noindexentry:\n")
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc,
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index, entries=[('pair', 'built-in function; f()', 'f', '', None)])
     assert_node(doctree[2], addnodes.index, entries=[])
 
@@ -835,6 +853,7 @@ def test_noindexentry(app):
             ".. py:class:: g\n"
             "   :noindexentry:\n")
     doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc,
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f (built-in class)', 'f', '', None)])
     assert_node(doctree[2], addnodes.index, entries=[])

--- a/tests/test_domain_rst.py
+++ b/tests/test_domain_rst.py
@@ -8,6 +8,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from docutils import nodes
+
 from sphinx import addnodes
 from sphinx.addnodes import (
     desc, desc_addname, desc_annotation, desc_content, desc_name, desc_signature
@@ -37,7 +39,8 @@ def test_rst_directive(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, desc_name, ".. toctree::"],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="directive",
@@ -48,7 +51,8 @@ def test_rst_directive(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, desc_name, ".. toctree::"],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="directive",
@@ -61,7 +65,8 @@ def test_rst_directive_with_argument(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, ".. toctree::"],
                                                     [desc_addname, " foo bar baz"])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="directive",
@@ -73,7 +78,8 @@ def test_rst_directive_option(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, desc_name, ":foo:"],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", ":foo: (directive option)",
                           "directive-option-foo", "", "F")])
@@ -87,7 +93,8 @@ def test_rst_directive_option_with_argument(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, ":foo:"],
                                                     [desc_annotation, " bar baz"])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", ":foo: (directive option)",
                           "directive-option-foo", "", "F")])
@@ -102,7 +109,8 @@ def test_rst_directive_option_type(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, ":foo:"],
                                                     [desc_annotation, " (directives.flags)"])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", ":foo: (directive option)",
                           "directive-option-foo", "", "F")])
@@ -118,7 +126,8 @@ def test_rst_directive_and_directive_option(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, desc_name, ".. foo::"],
                                   [desc_content, (addnodes.index,
-                                                  desc)])]))
+                                                  desc)])],
+                          nodes.substitution_definition))
     assert_node(doctree[1][1][0],
                 entries=[("pair", "foo (directive); :bar: (directive option)",
                           "directive-option-foo-bar", "", "B")])
@@ -133,7 +142,8 @@ def test_rst_role(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, desc_name, ":ref:"],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0],
                 entries=[("single", "ref (role)", "role-ref", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="role",

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -123,6 +123,7 @@ def test_glossary(app):
                                      [definition_list_item, ([term, ("term4",
                                                                      index)],
                                                              definition)])],
+        nodes.substitution_definition
     ))
     assert_node(doctree[0][0][0][0][1],
                 entries=[("single", "term1", "term-term1", "main", None)])
@@ -212,6 +213,7 @@ def test_glossary_comment(app):
         [glossary, definition_list, definition_list_item, ([term, ("term1",
                                                                    index)],
                                                            definition)],
+        nodes.substitution_definition
     ))
     assert_node(doctree[0][0][0][1],
                 [nodes.definition, nodes.paragraph, "description"])
@@ -235,6 +237,7 @@ def test_glossary_comment2(app):
                                      [definition_list_item, ([term, ("term3",
                                                                      index)],
                                                              definition)])],
+        nodes.substitution_definition
     ))
     assert_node(doctree[0][0][0][1],
                 [nodes.definition, nodes.paragraph, "description"])
@@ -263,6 +266,7 @@ def test_glossary_sorted(app):
                                      [definition_list_item, ([term, ("term3",
                                                                      index)],
                                                              definition)])],
+        nodes.substitution_definition
     ))
     assert_node(doctree[0][0][0][2],
                 [nodes.definition, nodes.paragraph, "description"])
@@ -300,7 +304,8 @@ def test_cmdoption(app):
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, "-l"],
                                                     [desc_addname, ()])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index,
                 entries=[('pair', 'ls command line option; -l', 'cmdoption-ls-l', '', None)])
     assert ('ls', '-l') in domain.progoptions
@@ -319,7 +324,8 @@ def test_multiple_cmdoptions(app):
                                                     [desc_addname, ", "],
                                                     [desc_name, "--output"],
                                                     [desc_addname, " directory"])],
-                                  [desc_content, ()])]))
+                                  [desc_content, ()])],
+                          nodes.substitution_definition))
     assert_node(doctree[0], addnodes.index,
                 entries=[('pair', 'cmd command line option; -o directory',
                           'cmdoption-cmd-o', '', None),
@@ -393,4 +399,5 @@ def test_disabled_docref(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, ([nodes.paragraph, ([pending_xref, nodes.inline, "index"],
                                              "\n",
-                                             [nodes.inline, "index"])],))
+                                             [nodes.inline, "index"])],
+                          nodes.substitution_definition))


### PR DESCRIPTION
SubstitutionDefinitionsRemover is now a SphinxPostTransform, only
applied in the Sphinx builder, as was originally the case (see #4827).

