### PR TITLE
domains: c: add missing intersphinx object types

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3607,6 +3607,10 @@ class CDomain(Domain):
         'macro': ObjType(_('macro'), 'macro'),
         'type': ObjType(_('type'), 'type'),
         'var': ObjType(_('variable'), 'data'),
+        'enum': ObjType(_('enum'), 'enum'),
+        'enumerator': ObjType(_('enumerator'), 'enumerator'),
+        'struct': ObjType(_('struct'), 'struct'),
+        'union': ObjType(_('union'), 'union'),
     }
 
     directives = {


### PR DESCRIPTION
For intersphinx to be able to resolve references to C-Domain objects, it needs to have them declared in the obj_types dict. This is currently missing enum, enumerator, struct and union so those can't be referenced by an external project. This commit fixes the issue by adding them.