### PR TITLE
Fix #8190: autodoc: parse error for docstring w/o ending blank lines

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Bugs fixed
 * #8085: i18n: Add support for having single text domain
 * #8143: autodoc: AttributeError is raised when False value is passed to
   autodoc_default_options
+* #8190: autodoc: parsing error is raised if some extension replaces docstring
+  by string not ending with blank lines
 * #8093: The highlight warning has wrong location in some builders (LaTeX,
   singlehtml and so on)
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -535,6 +535,11 @@ class Documenter:
                 self.env.app.emit('autodoc-process-docstring',
                                   self.objtype, self.fullname, self.object,
                                   self.options, docstringlines)
+
+                if docstringlines and docstringlines[-1] != '':
+                    # append a blank line to the end of the docstring
+                    docstringlines.append('')
+
             yield from docstringlines
 
     def get_sourcename(self) -> str:

--- a/tests/test_ext_autodoc_events.py
+++ b/tests/test_ext_autodoc_events.py
@@ -28,7 +28,8 @@ def test_process_docstring(app):
         '.. py:function:: func()',
         '   :module: target.process_docstring',
         '',
-        '   my docstring'
+        '   my docstring',
+        '',
     ]
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8190 
- autodoc raises a parsing error if some extension generates a docstring
not having blank lines at the tail.  This appends a blank line if
generated one does not contain it.