### PR TITLE
Fix our test failed with pygments-2.7.0

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -10,8 +10,10 @@
 
 import os
 import re
+from distutils.version import LooseVersion
 from itertools import cycle, chain
 
+import pygments
 import pytest
 from html5lib import HTMLParser
 
@@ -1591,4 +1593,8 @@ def test_html_codeblock_linenos_style_inline(app):
     app.build()
     content = (app.outdir / 'index.html').read_text()
 
-    assert '<span class="lineno">1 </span>' in content
+    pygments_version = tuple(LooseVersion(pygments.__version__).version)
+    if pygments_version > (2, 7):
+        assert '<span class="linenos">1</span>' in content
+    else:
+        assert '<span class="lineno">1 </span>' in content


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since pygments-2.7.0, it has changed the style of output HTML.
That makes our test broken.  This fixes it to pass with new pygments.
This also fixes the version of the pygments for testing to latest one.