### PR TITLE
autodoc: add :novalue: option

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -326,6 +326,15 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
    By default, without ``annotation`` option, Sphinx tries to obtain the value of
    the variable and print it after the name.
 
+   The ``novalue`` option can be used instead of a blank ``annotation`` to show the
+   type hint but not the value::
+
+      .. autodata:: CD_DRIVE
+         :novalue:
+
+   If both the ``annotation`` and ``novalue`` options are used, ``novalue`` has no
+   effect.
+
    For module data members and class attributes, documentation can either be put
    into a comment with special formatting (using a ``#:`` to start the comment
    instead of just ``#``), or in a docstring *after* the definition.  Comments
@@ -365,6 +374,9 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
       option.
    .. versionchanged:: 2.0
       :rst:dir:`autodecorator` added.
+   .. versionchanged:: 3.3
+      :rst:dir:`autodata` and :rst:dir:`autoattribute` now have a ``novalue``
+      option.
 
    .. note::
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1598,6 +1598,7 @@ class DataDocumenter(ModuleLevelDocumenter):
     priority = -10
     option_spec = dict(ModuleLevelDocumenter.option_spec)
     option_spec["annotation"] = annotation_option
+    option_spec["novalue"] = bool_option
 
     @classmethod
     def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any
@@ -1633,7 +1634,7 @@ class DataDocumenter(ModuleLevelDocumenter):
                                   sourcename)
 
             try:
-                if self.object is UNINITIALIZED_ATTR:
+                if self.object is UNINITIALIZED_ATTR or self.options.novalue:
                     pass
                 else:
                     objrepr = object_description(self.object)
@@ -1917,6 +1918,7 @@ class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  
     member_order = 60
     option_spec = dict(ModuleLevelDocumenter.option_spec)
     option_spec["annotation"] = annotation_option
+    option_spec["novalue"] = bool_option
 
     # must be higher than the MethodDocumenter, else it will recognize
     # some non-data descriptors as methods

--- a/tests/roots/test-ext-autodoc/index.rst
+++ b/tests/roots/test-ext-autodoc/index.rst
@@ -11,3 +11,16 @@
 .. autofunction:: target.typehints.incr
 
 .. autofunction:: target.typehints.tuple_args
+
+.. autodata:: target.typed_vars_py35.attr1
+
+.. autodata:: target.typed_vars_py35.attr2
+   :annotation:
+   :novalue:
+
+.. autodata:: target.typed_vars_py35.attr3
+   :annotation: = some integer
+   :novalue:
+
+.. autodata:: target.typed_vars_py35.attr4
+   :novalue:

--- a/tests/roots/test-ext-autodoc/target/typed_vars_py35.py
+++ b/tests/roots/test-ext-autodoc/target/typed_vars_py35.py
@@ -1,0 +1,11 @@
+#: attr1
+attr1 = None # type: str
+
+attr2 = None  # type: List[str]
+"""A list of strings."""
+
+attr3 = None  # type: int
+"""An integer."""
+
+attr4 = None  # type: Dict[str, Union[bool, str]]
+"""A dictionary whose values are a boolean or a string."""


### PR DESCRIPTION
Subject: Add **:novalue:** option to display type hint but remove value

### Feature or Bugfix
- Feature

### Purpose
When documenting using the `.. autodata::` directive, the **:annotation:** option only allows displaying nothing or replacing the annotation manually.
This adds the **:novalue:** option which will display the type hint but not the value. 

### Detail
When the **:annotation:** option is used, the current behavior is preserved, and **:novalue:** option does nothing.
When **:novalue:** is used by itself, the value will not be displayed but any type hint will.

### Relates
#8209 

