### PR TITLE
Fix typo in autodoc docs.

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -229,7 +229,7 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
 
      .. versionchanged:: 3.0
 
-        It takes an anchestor class name as an argument.
+        It takes an ancestor class name as an argument.
 
    * It's possible to override the signature for explicitly documented callable
      objects (functions, methods, classes) with the regular syntax that will


### PR DESCRIPTION
Subject: fixes minor typo in autodoc.rst.

### Bugfix
- Fixes `anchestor` ➡️ `ancestor`.