### PR TITLE
FIX Unwrap user-defined functions or methods to get correct signature

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1370,7 +1370,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             attr = self.get_attr(obj, attr, None)
             if not (inspect.ismethod(attr) or inspect.isfunction(attr)):
                 return None
-            # Unwrap the user defined function or method
+            # Unwrap the user-defined function or method
             # to avoid that the signature of a decorator
             # is obtained
             return inspect.unwrap(attr)

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1370,14 +1370,17 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             attr = self.get_attr(obj, attr, None)
             if not (inspect.ismethod(attr) or inspect.isfunction(attr)):
                 return None
-            return attr
+            # Unwrap the user defined function or method
+            # to avoid that the signature of a decorator
+            # is obtained
+            return inspect.unwrap(attr)
 
         # This sequence is copied from inspect._signature_from_callable.
         # ValueError means that no signature could be found, so we keep going.
 
         # First, let's see if it has an overloaded __call__ defined
         # in its metaclass
-        call = get_user_defined_function_or_method(type(self.object), '__call__')
+        call =  get_user_defined_function_or_method(type(self.object), '__call__')
 
         if call is not None:
             if "{0.__module__}.{0.__qualname__}".format(call) in _METACLASS_CALL_BLACKLIST:

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1380,7 +1380,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
 
         # First, let's see if it has an overloaded __call__ defined
         # in its metaclass
-        call =  get_user_defined_function_or_method(type(self.object), '__call__')
+        call = get_user_defined_function_or_method(type(self.object), '__call__')
 
         if call is not None:
             if "{0.__module__}.{0.__qualname__}".format(call) in _METACLASS_CALL_BLACKLIST:


### PR DESCRIPTION
Subject: This PR fixes the signature of user-defined functions or methods that are wrapped by a decorator.  

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Unwrap the user-defined functions or methods to obtain the correct signature instead of the decorator signature.

### Relates
- scikit-learn/scikit-learn#18434

