### PR TITLE
Fix references to production names.

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -500,7 +500,8 @@ class ProductionList(SphinxDirective):
             except ValueError:
                 break
             subnode = addnodes.production(rule)
-            subnode['tokenname'] = name.strip()
+            name = name.strip()
+            subnode['tokenname'] = name
             if subnode['tokenname']:
                 prefix = 'grammar-token-%s' % productionGroup
                 node_id = make_id(self.env, self.state.document, prefix, name)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

When the user tries to align production rules, Sphinx gets confused by spaces around leading tokens. In the following, references to `mygroup:bad1` and `mygroup:bad2` are missing, while the one to `mygroup:correct` is present.

    .. productionlist:: mygroup
       correct: `correct` | `bad1` | `bad2`
       bad1   : `correct` | `bad1` | `bad2`
          bad2: `correct` | `bad1` | `bad2`

Since it is useful to be able to align colons in a production list, this commit systematically strips leading and trailing whitespaces from the production name.
