### PR TITLE
linkcheck: take source directory into account for local files

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -210,7 +210,7 @@ class CheckExternalLinksBuilder(Builder):
                 else:
                     return 'redirected', new_url, 0
 
-        def check() -> Tuple[str, str, int]:
+        def check(srcdir: str) -> Tuple[str, str, int]:
             # check for various conditions without bothering the network
             if len(uri) == 0 or uri.startswith(('#', 'mailto:')):
                 return 'unchecked', '', 0
@@ -219,7 +219,7 @@ class CheckExternalLinksBuilder(Builder):
                     # non supported URI schemes (ex. ftp)
                     return 'unchecked', '', 0
                 else:
-                    if path.exists(path.join(self.srcdir, uri)):
+                    if path.exists(path.join(srcdir, uri)):
                         return 'working', '', 0
                     else:
                         for rex in self.to_ignore:
@@ -256,7 +256,8 @@ class CheckExternalLinksBuilder(Builder):
             uri, docname, lineno = self.wqueue.get()
             if uri is None:
                 break
-            status, info, code = check()
+            srcdir = path.dirname(self.env.doc2path(docname))
+            status, info, code = check(srcdir)
             self.rqueue.put((uri, docname, lineno, status, info, code))
 
     def process_result(self, result: Tuple[str, str, int, str, str, int]) -> None:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -210,7 +210,7 @@ class CheckExternalLinksBuilder(Builder):
                 else:
                     return 'redirected', new_url, 0
 
-        def check(srcdir: str) -> Tuple[str, str, int]:
+        def check(docname: str) -> Tuple[str, str, int]:
             # check for various conditions without bothering the network
             if len(uri) == 0 or uri.startswith(('#', 'mailto:')):
                 return 'unchecked', '', 0
@@ -219,6 +219,7 @@ class CheckExternalLinksBuilder(Builder):
                     # non supported URI schemes (ex. ftp)
                     return 'unchecked', '', 0
                 else:
+                    srcdir = path.dirname(self.env.doc2path(docname))
                     if path.exists(path.join(srcdir, uri)):
                         return 'working', '', 0
                     else:
@@ -256,8 +257,7 @@ class CheckExternalLinksBuilder(Builder):
             uri, docname, lineno = self.wqueue.get()
             if uri is None:
                 break
-            srcdir = path.dirname(self.env.doc2path(docname))
-            status, info, code = check(srcdir)
+            status, info, code = check(docname)
             self.rqueue.put((uri, docname, lineno, status, info, code))
 
     def process_result(self, result: Tuple[str, str, int, str, str, int]) -> None:


### PR DESCRIPTION
In  #7985, the `linkcheck` builder has been extended to also check local links.

However, the local file URIs are checked relative to the global source directory.
If a relative path is used in a source file in a sub-directory, the file is not found and a linkcheck error is reported.

This PR uses the actual source directory of the current source file.

### Feature or Bugfix

- Bugfix

### Relates
- #7985

