### PR TITLE
Feature fancy favicons

### DIFF
--- a/doc/_static/conf.py.txt
+++ b/doc/_static/conf.py.txt
@@ -148,6 +148,12 @@ html_theme = 'alabaster'
 #
 # html_favicon = None
 
+# The name of an image file (relative to this directory) to use as touch icon
+# for a home screen link in iOS. This file should be a PNG file (.png) being
+# 180x180 pixels large without transparency.
+#
+# html_apple_touch_icon = None
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/doc/templating.rst
+++ b/doc/templating.rst
@@ -276,6 +276,10 @@ in the future.
 
    The path to the HTML favicon in the static path, or ``''``.
 
+.. data:: apple_touch_icon
+
+   The path to the iOS home screen icon in the static path, or ``''``.
+
 .. data:: file_suffix
 
    The value of the builder's :attr:`~.SerializingHTMLBuilder.out_suffix`

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -977,6 +977,15 @@ that use Sphinx's HTMLWriter class.
       The image file will be copied to the ``_static`` directory of the output
       HTML, but only if the file does not already exist there.
 
+.. confval:: html_apple_touch_icon
+
+   If given, this must be the name of an image file (path relative to the
+   :term:`configuration directory`). iOS uses it as the home screen icon when
+   the page is bookmarked to the screen. It should be a PNG of
+   180x180 pixels. Default: ``None``.
+
+   .. versionadded:: 3.3
+
 .. confval:: html_css_files
 
    A list of CSS files.  The entry must be a *filename* string or a tuple

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -447,7 +447,8 @@ class StandaloneHTMLBuilder(Builder):
 
         logo = path.basename(self.config.html_logo) if self.config.html_logo else ''
         favicon = path.basename(self.config.html_favicon) if self.config.html_favicon else ''
-
+        apple_touch_icon = path.basename(self.config.html_apple_touch_icon) \
+            if self.config.html_apple_touch_icon else ''
         if not isinstance(self.config.html_use_opensearch, str):
             logger.warning(__('html_use_opensearch config value must now be a string'))
 
@@ -497,6 +498,7 @@ class StandaloneHTMLBuilder(Builder):
             'parents': [],
             'logo': logo,
             'favicon': favicon,
+            'apple_touch_icon': apple_touch_icon,
             'html5_doctype': html5_ready and not self.config.html4_writer,
         }
         if self.theme:
@@ -783,6 +785,12 @@ class StandaloneHTMLBuilder(Builder):
             copy_asset(path.join(self.confdir, self.config.html_favicon),
                        path.join(self.outdir, '_static'))
 
+    def copy_html_apple_touch_icon(self) -> None:
+        if self.config.html_apple_touch_icon:
+            copy_asset(path.join(self.confdir,
+                                 self.config.html_apple_touch_icon),
+                       path.join(self.outdir, '_static'))
+
     def copy_static_files(self) -> None:
         try:
             with progress_message(__('copying static files... ')):
@@ -800,6 +808,7 @@ class StandaloneHTMLBuilder(Builder):
                 self.copy_html_static_files(context)
                 self.copy_html_logo()
                 self.copy_html_favicon()
+                self.copy_html_apple_touch_icon()
         except OSError as err:
             logger.warning(__('cannot copy static file %r'), err)
 
@@ -1188,6 +1197,13 @@ def validate_html_favicon(app: Sphinx, config: Config) -> None:
         logger.warning(__('favicon file %r does not exist'), config.html_favicon)
         config.html_favicon = None  # type: ignore
 
+def validate_html_apple_touch_icon(app: Sphinx, config: Config) -> None:
+    """Check html_apple_touch_icon setting."""
+    if config.html_apple_touch_icon and \
+       not path.isfile(path.join(app.confdir, config.html_apple_touch_icon)):
+        logger.warning(__('apple touch icon file %r does not exist'),
+                       config.html_apple_touch_icon)
+        config.html_apple_touch_icon = None  # type: ignore
 
 # for compatibility
 import sphinx.builders.dirhtml  # NOQA
@@ -1210,6 +1226,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('html_style', None, 'html', [str])
     app.add_config_value('html_logo', None, 'html', [str])
     app.add_config_value('html_favicon', None, 'html', [str])
+    app.add_config_value('html_apple_touch_icon', None, 'html', [str])
     app.add_config_value('html_css_files', [], 'html')
     app.add_config_value('html_js_files', [], 'html')
     app.add_config_value('html_static_path', [], 'html')
@@ -1250,6 +1267,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect('config-inited', validate_html_static_path, priority=800)
     app.connect('config-inited', validate_html_logo, priority=800)
     app.connect('config-inited', validate_html_favicon, priority=800)
+    app.connect('config-inited', validate_html_apple_touch_icon, priority=800)
     app.connect('builder-inited', validate_math_renderer)
     app.connect('html-page-context', setup_js_tag_helper)
 

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -143,6 +143,9 @@
     {%- if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1)|e }}"/>
     {%- endif %}
+    {%- if apple_touch_icon %}
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ pathto('_static/' + apple_touch_icon, 1)|e }}">
+    {%- endif%}
     {%- endif %}
 {%- block linktags %}
     {%- if hasdoc('about') %}


### PR DESCRIPTION
Subject: Allow Sphinx to handle Apple touch icons

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
Introduces a new HTML builder variable `html_apple_touch_icon` that gets the path to an image file and causes this file being copied to `_static/apple-touch-icon.png`. With that, if an iPhone creates a link to the HTML page on the home screen, this image will be used as icon.

Missing: Translation of the message from the validator. I tried to get this in, but with the commands given on https://www.sphinx-doc.org/en/master/internals/contributing.html#translations, more files than I expect get changed plus I see changes I don't understand.

To be considered: Apple suggests icons in multiple dimensions for different devices. There are 4-5 sizes mentioned at https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/. Those could all be introduced and i would suggest to name suffix the builder variables with `_<size>`. If this is favourable, this pull request can be skipped and I add the various sizes to create a new pull request. However, I would also like to have some more "favicon variables" for the new style 32x32/ 16x16 icons, MS Windows Tiles and Safari pinned tab icons... not sure if that is desirable for Sphinx and how to proceed with that.

### Relates
- #7600

