### PR TITLE
add parallel to SphinxTestApp

### DIFF
--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -108,7 +108,7 @@ class SphinxTestApp(application.Sphinx):
 
     def __init__(self, buildername: str = 'html', srcdir: path = None, freshenv: bool = False,
                  confoverrides: Dict = None, status: IO = None, warning: IO = None,
-                 tags: List[str] = None, docutilsconf: str = None) -> None:
+                 tags: List[str] = None, docutilsconf: str = None, parallel: int = 0) -> None:
 
         if docutilsconf is not None:
             (srcdir / 'docutils.conf').write_text(docutilsconf)
@@ -133,7 +133,7 @@ class SphinxTestApp(application.Sphinx):
         try:
             super().__init__(srcdir, confdir, outdir, doctreedir,
                              buildername, confoverrides, status, warning,
-                             freshenv, warningiserror, tags)
+                             freshenv, warningiserror, tags, parallel=parallel)
         except Exception:
             self.cleanup()
             raise

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -421,11 +421,10 @@ def test_html5_output(app, cached_etree_parse, fname, expect):
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
 
 
-@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
-                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html', parallel=2)
 def test_html_parallel(app):
     app.build()
+
 
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
                     reason='docutils-0.13 or above is required')

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -423,6 +423,12 @@ def test_html5_output(app, cached_etree_parse, fname, expect):
 
 @pytest.mark.skipif(docutils.__version_info__ < (0, 13),
                     reason='docutils-0.13 or above is required')
+@pytest.mark.sphinx('html', parallel=2)
+def test_html_parallel(app):
+    app.build()
+
+@pytest.mark.skipif(docutils.__version_info__ < (0, 13),
+                    reason='docutils-0.13 or above is required')
 @pytest.mark.sphinx('html')
 @pytest.mark.test_params(shared_result='test_build_html_output')
 def test_html_download(app):


### PR DESCRIPTION
Subject: allow parallel with SphinxTestApp

### Feature or Bugfix
- Feature


### Purpose
- Make it easier to test extensions with parallel build. I am trying to get all the extensions I use to support parallel read. Some are using SphinxTestApp, so supporting parallel makes it easier to add tests.




