### PR TITLE
Makefiles: Include clean in help message

### DIFF
--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -51,6 +51,7 @@ BUILDERS = [
     ("",      "doctest",     "to run all doctests embedded in the documentation "
                              "(if enabled)"),
     ("",      "coverage",    "to run coverage check of the documentation (if enabled)"),
+    ("",      "clean",       "to remove everything in the build directory"),
 ]
 
 

--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -95,3 +95,4 @@ gettext:
 .PHONY: Makefile
 %: Makefile
 	$(SPHINXBUILD) -b "$@" $(ALLSPHINXOPTS) "$(BUILDDIR)/$@"
+

--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -46,6 +46,7 @@ help:
 	@echo "  doctest     to run all doctests embedded in the documentation (if enabled)"
 	@echo "  coverage    to run coverage check of the documentation (if enabled)"
 	@echo "  dummy       to check syntax errors of document sources"
+	@echo "  clean       to remove everything in the build directory"
 
 .PHONY: clean
 clean:
@@ -94,4 +95,3 @@ gettext:
 .PHONY: Makefile
 %: Makefile
 	$(SPHINXBUILD) -b "$@" $(ALLSPHINXOPTS) "$(BUILDDIR)/$@"
-

--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -46,6 +46,7 @@ help:
 	@echo "  doctest     to run all doctests embedded in the documentation (if enabled)"
 	@echo "  coverage    to run coverage check of the documentation (if enabled)"
 	@echo "  dummy       to check syntax errors of document sources"
+	@echo "  clean       to remove everything in the build directory"
 
 .PHONY: clean
 clean:

--- a/sphinx/templates/quickstart/make.bat_t
+++ b/sphinx/templates/quickstart/make.bat_t
@@ -107,3 +107,4 @@ goto end
 
 :end
 popd
+

--- a/sphinx/templates/quickstart/make.bat_t
+++ b/sphinx/templates/quickstart/make.bat_t
@@ -43,6 +43,7 @@ if "%1" == "help" (
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
 	echo.  coverage   to run coverage check of the documentation if enabled
 	echo.  dummy      to check syntax errors of document sources
+	echo.  clean      to remove everything in the build directory
 	goto end
 )
 

--- a/sphinx/templates/quickstart/make.bat_t
+++ b/sphinx/templates/quickstart/make.bat_t
@@ -43,6 +43,7 @@ if "%1" == "help" (
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
 	echo.  coverage   to run coverage check of the documentation if enabled
 	echo.  dummy      to check syntax errors of document sources
+	echo.  clean      to remove everything in the build directory
 	goto end
 )
 
@@ -106,4 +107,3 @@ goto end
 
 :end
 popd
-


### PR DESCRIPTION
Subject: The make clean help command was missing from all make files.
