### PR TITLE
Expand autodoc's `_METACLASS_CALL_BLACKLIST` for Hypothesis

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1322,6 +1322,7 @@ class DecoratorDocumenter(FunctionDocumenter):
 # needing to import the modules.
 _METACLASS_CALL_BLACKLIST = [
     'enum.EnumMeta.__call__',
+    'hypothesis.database._EDMeta.__call__',
 ]
 
 


### PR DESCRIPTION
Subject: supporting Hypothesis metaclass in autodoc

### Feature or Bugfix
- Feature (a very small one)

### Purpose

Hypothesis provides an abstract base class `ExampleDatabase`, whose metaclass defines a custom `__call__` method.  Unfortunately, at present this takes priority over the actual `__init__` signature of concrete subclasses ([see the current docs here](https://hypothesis.readthedocs.io/en/latest/database.html#hypothesis.database.DirectoryBasedExampleDatabase) and compare to the signature behind `[source]` link).

While I have investigated various ways to fix this for both our own docs and those of downstream providers of concrete database classes, the cleanest by far appears to be adding it to this list upstream.

### Relates
- Investigated as part of https://github.com/HypothesisWorks/hypothesis/pull/2622
- Similar in spirit to https://github.com/PyCQA/astroid/pull/820