### PR TITLE
Fix #8157: autodoc: TypeError is raised when annotation has invalid __args__

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
   by string not ending with blank lines
 * #8142: autodoc: Wrong constructor signature for the class derived from
   typing.Generic
+* #8157: autodoc: TypeError is raised when annotation has invalid __args__
 * #8192: napoleon: description is disappeared when it contains inline literals
 * #8142: napoleon: Potential of regex denial of service in google style docs
 * #8169: LaTeX: pxjahyper loaded even when latex_engine is not platex

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -109,7 +109,10 @@ def _stringify_py37(annotation: Any) -> str:
         return repr(annotation)
 
     if getattr(annotation, '__args__', None):
-        if qualname == 'Union':
+        if not isinstance(annotation.__args__, (list, tuple)):
+            # broken __args__ found
+            pass
+        elif qualname == 'Union':
             if len(annotation.__args__) > 1 and annotation.__args__[-1] is NoneType:
                 if len(annotation.__args__) > 2:
                     args = ', '.join(stringify(a) for a in annotation.__args__[:-1])

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -32,6 +32,10 @@ class MyList(List[T]):
     pass
 
 
+class BrokenType:
+    __args__ = int
+
+
 def test_stringify():
     assert stringify(int) == "int"
     assert stringify(str) == "str"
@@ -113,3 +117,7 @@ def test_stringify_type_hints_alias():
     MyTuple = Tuple[str, str]
     assert stringify(MyStr) == "str"
     assert stringify(MyTuple) == "Tuple[str, str]"  # type: ignore
+
+
+def test_stringify_broken_type_hints():
+    assert stringify(BrokenType) == 'test_util_typing.BrokenType'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8157 
- Typically, the __args__ attribute of type annotations is a tuple
containing arguments for the types (ex. The __args__ of `List[int]` is
`(int,)`).  But some kind of types has non tuple __args__ attribute.
For example, `nptyping.NDArray` is one of them.

- This fixes the TypeError when the invalid __args__ attribute found.
