### PR TITLE
autodoc: deprecate SingledispatchFunctionDocumenter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Deprecated
 
 * ``sphinx.builders.latex.LaTeXBuilder.usepackages``
 * ``sphinx.builders.latex.LaTeXBuilder.usepackages_afger_hyperref``
+* ``sphinx.ext.autodoc.SingledispatchFunctionDocumenter``
+* ``sphinx.ext.autodoc.SingledispatchMethodDocumenter``
 
 Features added
 --------------

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -36,6 +36,16 @@ The following is a list of deprecated interfaces.
      - 5.0
      - N/A
 
+   * - ``sphinx.ext.autodoc.SingledispatchFunctionDocumenter``
+     - 3.3
+     - 5.0
+     - ``sphinx.ext.autodoc.FunctionDocumenter``
+
+   * - ``sphinx.ext.autodoc.SingledispatchMethodDocumenter``
+     - 3.3
+     - 5.0
+     - ``sphinx.ext.autodoc.MethodDocumenter``
+
    * - ``sphinx.ext.autodoc.members_set_option()``
      - 3.2
      - 5.0

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1302,6 +1302,11 @@ class SingledispatchFunctionDocumenter(FunctionDocumenter):
     Retained for backwards compatibility, now does the same as the FunctionDocumenter
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn("%s is deprecated." % self.__class__.__name__,
+                      RemovedInSphinx50Warning, stacklevel=2)
+        super().__init__(*args, **kwargs)
+
 
 class DecoratorDocumenter(FunctionDocumenter):
     """
@@ -1935,6 +1940,11 @@ class SingledispatchMethodDocumenter(MethodDocumenter):
 
     Retained for backwards compatibility, now does the same as the MethodDocumenter
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn("%s is deprecated." % self.__class__.__name__,
+                      RemovedInSphinx50Warning, stacklevel=2)
+        super().__init__(*args, **kwargs)
 
 
 class AttributeDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  # type: ignore


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- In #7487, SingledispatchFunctionDocumenter is merged into
FunctionDocumenter.  SingledispatchMethodDocumenter is also.  As a result,
They are no longer needed.  So this deprecates them.
