### PR TITLE
Fix #8268: make linkcheck report HTTP errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ Bugs fixed
 * #8093: The highlight warning has wrong location in some builders (LaTeX,
   singlehtml and so on)
 * #8239: Failed to refer a token in productionlist if it is indented
+* #8268: linkcheck: Report HTTP errors when ``linkcheck_anchors`` is ``True``
 
 Testing
 --------

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -166,6 +166,7 @@ class CheckExternalLinksBuilder(Builder):
                     # Read the whole document and see if #anchor exists
                     response = requests.get(req_url, stream=True, config=self.app.config,
                                             auth=auth_info, **kwargs)
+                    response.raise_for_status()
                     found = check_anchor(response, unquote(anchor))
 
                     if not found:

--- a/tests/roots/test-linkcheck-localserver/conf.py
+++ b/tests/roots/test-linkcheck-localserver/conf.py
@@ -1,0 +1,2 @@
+exclude_patterns = ['_build']
+linkcheck_anchors = True

--- a/tests/roots/test-linkcheck-localserver/index.rst
+++ b/tests/roots/test-linkcheck-localserver/index.rst
@@ -1,0 +1,1 @@
+`local server <http://localhost:7777/#anchor>`_

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -8,8 +8,10 @@
     :license: BSD, see LICENSE for details.
 """
 
+import http.server
 import json
 import re
+import threading
 from unittest import mock
 import pytest
 
@@ -106,6 +108,21 @@ def test_anchors_ignored(app, status, warning):
     # expect all ok when excluding #top
     assert not content
 
+@pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver', freshenv=True)
+def test_raises_for_invalid_status(app, status, warning):
+    server_thread = HttpServerThread(InternalServerErrorHandler, daemon=True)
+    server_thread.start()
+    try:
+        app.builder.build_all()
+    finally:
+        server_thread.terminate()
+    content = (app.outdir / 'output.txt').read_text()
+    assert content == (
+        "index.rst:1: [broken] http://localhost:7777/#anchor: "
+        "500 Server Error: Internal Server Error "
+        "for url: http://localhost:7777/\n"
+    )
+
 
 @pytest.mark.sphinx(
     'linkcheck', testroot='linkcheck', freshenv=True,
@@ -160,3 +177,22 @@ def test_linkcheck_request_headers(app, status, warning):
                 assert headers["X-Secret"] == "open sesami"
             else:
                 assert headers["Accept"] == "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8"
+
+
+class HttpServerThread(threading.Thread):
+    def __init__(self, handler, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.server = http.server.HTTPServer(("localhost", 7777), handler)
+
+    def run(self):
+        self.server.serve_forever(poll_interval=0.01)
+
+    def terminate(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.join()
+
+
+class InternalServerErrorHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_error(500, "Internal Server Error")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- When `linkcheck_anchors` is `True` (the default), HTTP errors for links with anchors are not reported, instead Sphinx reports that the anchor was not found. Make it reveal the HTTP error. 
- Fix #8268