### PR TITLE
Close #7996: manpage: Add man_make_section_directory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Features added
   nested declarations.
 * #8081: LaTeX: Allow to add LaTeX package via ``app.add_latex_package()`` until
   just before writing .tex file
+* #7996: manpage: Add :confval:`man_make_section_directory` to make a section
+  directory on build man page
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2245,6 +2245,12 @@ These options influence manual page output.
 
    .. versionadded:: 1.1
 
+.. confval:: man_make_section_directory
+
+   If true, make a section directory on build man page.  Default is False.
+
+   .. versionadded:: 3.3
+
 
 .. _texinfo-options:
 

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -24,7 +24,7 @@ from sphinx.util import logging
 from sphinx.util import progress_message
 from sphinx.util.console import darkgreen  # type: ignore
 from sphinx.util.nodes import inline_all_toctrees
-from sphinx.util.osutil import make_filename_from_project
+from sphinx.util.osutil import ensuredir, make_filename_from_project
 from sphinx.writers.manpage import ManualPageWriter, ManualPageTranslator
 
 
@@ -80,7 +80,12 @@ class ManualPageBuilder(Builder):
             docsettings.authors = authors
             docsettings.section = section
 
-            targetname = '%s.%s' % (name, section)
+            if self.config.man_make_section_directory:
+                ensuredir(path.join(self.outdir, str(section)))
+                targetname = '%s/%s.%s' % (section, name, section)
+            else:
+                targetname = '%s.%s' % (name, section)
+
             logger.info(darkgreen(targetname) + ' { ', nonl=True)
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
@@ -115,6 +120,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value('man_pages', default_man_pages, None)
     app.add_config_value('man_show_urls', False, None)
+    app.add_config_value('man_make_section_directory', False, None)
 
     return {
         'version': 'builtin',

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -30,6 +30,13 @@ def test_all(app, status, warning):
     assert 'Footnotes' not in content
 
 
+@pytest.mark.sphinx('man', testroot='basic',
+                    confoverrides={'man_make_section_directory': True})
+def test_man_make_section_directory(app, status, warning):
+    app.build()
+    assert (app.outdir / '1' / 'python.1').exists()
+
+
 @pytest.mark.sphinx('man', testroot='directive-code')
 def test_captioned_code_block(app, status, warning):
     app.builder.build_all()


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7996 
- Add a new config variable; man_make_section_directory to make a
section directory on build man page.  During 3.x, it defaults to
False and will be changed to True on 4.0 release.