### PR TITLE
Fix #8200: autodoc: type aliases break type formatting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
   by string not ending with blank lines
 * #8142: autodoc: Wrong constructor signature for the class derived from
   typing.Generic
+* #8200: autodoc: type aliases break type formatting of autoattribute
 * #8192: napoleon: description is disappeared when it contains inline literals
 * #8142: napoleon: Potential of regex denial of service in google style docs
 * #8169: LaTeX: pxjahyper loaded even when latex_engine is not platex

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1731,7 +1731,8 @@ class GenericAliasDocumenter(DataDocumenter):
         return inspect.isgenericalias(member)
 
     def add_directive_header(self, sig: str) -> None:
-        self.options.annotation = SUPPRESS  # type: ignore
+        self.options = Options(self.options)
+        self.options['annotation'] = SUPPRESS
         super().add_directive_header(sig)
 
     def add_content(self, more_content: Any, no_docstring: bool = False) -> None:
@@ -1755,7 +1756,8 @@ class TypeVarDocumenter(DataDocumenter):
         return isinstance(member, TypeVar) and isattr  # type: ignore
 
     def add_directive_header(self, sig: str) -> None:
-        self.options.annotation = SUPPRESS  # type: ignore
+        self.options = Options(self.options)
+        self.options['annotation'] = SUPPRESS
         super().add_directive_header(sig)
 
     def get_doc(self, encoding: str = None, ignore: int = None) -> List[List[str]]:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8200 
- The annotation option is shared between auto directives unexpectedly.
It causes supression of type annotations for objects after
GenericAlias definition.
