### PR TITLE
Fix #8255: py domain: number in defarg is changed to decimal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,8 @@ Bugs fixed
 * #8277: sphinx-build: missing and redundant spacing (and etc) for console
   output on building
 * #7973: imgconverter: Check availability of imagemagick many times
+* #8255: py domain: number in default argument value is changed from hexadecimal
+  to decimal
 * #8093: The highlight warning has wrong location in some builders (LaTeX,
   singlehtml and so on)
 * #8239: Failed to refer a token in productionlist if it is indented

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -600,13 +600,14 @@ def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
 
 def signature_from_str(signature: str) -> inspect.Signature:
     """Create a Signature object from string."""
-    module = ast.parse('def func' + signature + ': pass')
+    code = 'def func' + signature + ': pass'
+    module = ast.parse(code)
     function = cast(ast.FunctionDef, module.body[0])  # type: ignore
 
-    return signature_from_ast(function)
+    return signature_from_ast(function, code)
 
 
-def signature_from_ast(node: ast.FunctionDef) -> inspect.Signature:
+def signature_from_ast(node: ast.FunctionDef, code: str = '') -> inspect.Signature:
     """Create a Signature object from AST *node*."""
     args = node.args
     defaults = list(args.defaults)
@@ -626,9 +627,9 @@ def signature_from_ast(node: ast.FunctionDef) -> inspect.Signature:
             if defaults[i] is Parameter.empty:
                 default = Parameter.empty
             else:
-                default = ast_unparse(defaults[i])
+                default = ast_unparse(defaults[i], code)
 
-            annotation = ast_unparse(arg.annotation) or Parameter.empty
+            annotation = ast_unparse(arg.annotation, code) or Parameter.empty
             params.append(Parameter(arg.arg, Parameter.POSITIONAL_ONLY,
                                     default=default, annotation=annotation))
 
@@ -636,29 +637,29 @@ def signature_from_ast(node: ast.FunctionDef) -> inspect.Signature:
         if defaults[i + posonlyargs] is Parameter.empty:
             default = Parameter.empty
         else:
-            default = ast_unparse(defaults[i + posonlyargs])
+            default = ast_unparse(defaults[i + posonlyargs], code)
 
-        annotation = ast_unparse(arg.annotation) or Parameter.empty
+        annotation = ast_unparse(arg.annotation, code) or Parameter.empty
         params.append(Parameter(arg.arg, Parameter.POSITIONAL_OR_KEYWORD,
                                 default=default, annotation=annotation))
 
     if args.vararg:
-        annotation = ast_unparse(args.vararg.annotation) or Parameter.empty
+        annotation = ast_unparse(args.vararg.annotation, code) or Parameter.empty
         params.append(Parameter(args.vararg.arg, Parameter.VAR_POSITIONAL,
                                 annotation=annotation))
 
     for i, arg in enumerate(args.kwonlyargs):
-        default = ast_unparse(args.kw_defaults[i]) or Parameter.empty
-        annotation = ast_unparse(arg.annotation) or Parameter.empty
+        default = ast_unparse(args.kw_defaults[i], code) or Parameter.empty
+        annotation = ast_unparse(arg.annotation, code) or Parameter.empty
         params.append(Parameter(arg.arg, Parameter.KEYWORD_ONLY, default=default,
                                 annotation=annotation))
 
     if args.kwarg:
-        annotation = ast_unparse(args.kwarg.annotation) or Parameter.empty
+        annotation = ast_unparse(args.kwarg.annotation, code) or Parameter.empty
         params.append(Parameter(args.kwarg.arg, Parameter.VAR_KEYWORD,
                                 annotation=annotation))
 
-    return_annotation = ast_unparse(node.returns) or Parameter.empty
+    return_annotation = ast_unparse(node.returns, code) or Parameter.empty
 
     return inspect.Signature(params, return_annotation=return_annotation)
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -386,6 +386,19 @@ def test_pyfunction_signature_full_py38(app):
                                       [desc_parameter, desc_sig_operator, "/"])])
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
+def test_pyfunction_with_number_literals(app):
+    text = ".. py:function:: hello(age=0x10, height=1_6_0)"
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree[1][0][1],
+                [desc_parameterlist, ([desc_parameter, ([desc_sig_name, "age"],
+                                                        [desc_sig_operator, "="],
+                                                        [nodes.inline, "0x10"])],
+                                      [desc_parameter, ([desc_sig_name, "height"],
+                                                        [desc_sig_operator, "="],
+                                                        [nodes.inline, "1_6_0"])])])
+
+
 def test_optional_pyfunction_signature(app):
     text = ".. py:function:: compile(source [, filename [, symbol]]) -> ast object"
     doctree = restructuredtext.parse(app, text)

--- a/tests/test_pycode_ast.py
+++ b/tests/test_pycode_ast.py
@@ -58,7 +58,7 @@ from sphinx.pycode import ast
 ])
 def test_unparse(source, expected):
     module = ast.parse(source)
-    assert ast.unparse(module.body[0].value) == expected
+    assert ast.unparse(module.body[0].value, source) == expected
 
 
 def test_unparse_None():
@@ -66,8 +66,12 @@ def test_unparse_None():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
-def test_unparse_py38():
-    source = "lambda x=0, /, y=1, *args, z, **kwargs: x + y + z"
-    expected = "lambda x=0, /, y=1, *args, z, **kwargs: ..."
+@pytest.mark.parametrize('source,expected', [
+    ("lambda x=0, /, y=1, *args, z, **kwargs: x + y + z",
+     "lambda x=0, /, y=1, *args, z, **kwargs: ..."),    # posonlyargs
+    ("0x1234", "0x1234"),                               # Constant
+    ("1_000_000", "1_000_000"),                         # Constant
+])
+def test_unparse_py38(source, expected):
     module = ast.parse(source)
-    assert ast.unparse(module.body[0].value) == expected
+    assert ast.unparse(module.body[0].value, source) == expected


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8255 
-    Developers can write number literals in several ways. For example,
   decimal (1234), hexadecimal (0x1234), octal decimal (0o1234) and so on.
   But, AST module don't mind how the numbers written in the code. As a
   result, ast.unparse() could not reproduce the original form of number
   literals.
-    This allows to construct number literals as possible using original
   source code.
-   Note: This is only available in Python 3.8+.
-   Note: autodoc is still converting the default argument to decimal form. I'll work on it in another PR (refs: #759).