### PR TITLE
Fix #7786: autodoc: can't detect overloaded methods defined in other file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
 * #8157: autodoc: TypeError is raised when annotation has invalid __args__
 * #7964: autodoc: Tuple in default value is wrongly rendered
 * #8200: autodoc: type aliases break type formatting of autoattribute
+* #7786: autodoc: can't detect overloaded methods defined in other file
 * #8192: napoleon: description is disappeared when it contains inline literals
 * #8142: napoleon: Potential of regex denial of service in google style docs
 * #8169: LaTeX: pxjahyper loaded even when latex_engine is not platex

--- a/tests/roots/test-ext-autodoc/target/overload2.py
+++ b/tests/roots/test-ext-autodoc/target/overload2.py
@@ -1,0 +1,5 @@
+from target.overload import Bar
+
+
+class Baz(Bar):
+    pass

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -2003,6 +2003,22 @@ def test_overload(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_overload2(app):
+    options = {"members": None}
+    actual = do_autodoc(app, 'module', 'target.overload2', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.overload2',
+        '',
+        '',
+        '.. py:class:: Baz(x: int, y: int)',
+        '              Baz(x: str, y: str)',
+        '   :module: target.overload2',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_pymodule_for_ModuleLevelDocumenter(app):
     app.env.ref_context['py:module'] = 'target.classes'
     actual = do_autodoc(app, 'class', 'Foo')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #7786 