### PR TITLE
Close #7996: manpage: Make a section directory on build manpage by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Incompatible changes
   MathJax configuration may have to set the old MathJax path or update their
   configuration for version 3. See :mod:`sphinx.ext.mathjax`.
 * #7784: i18n: The msgid for alt text of image is changed
+* #7996: manpage: Make a section directory on build manpage by default (see
+  :confval:`man_make_section_directory`)
 
 Deprecated
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2248,10 +2248,12 @@ These options influence manual page output.
 
 .. confval:: man_make_section_directory
 
-   If true, make a section directory on build man page.  Default is False.
+   If true, make a section directory on build man page.  Default is True.
 
    .. versionadded:: 3.3
+   .. versionchanged:: 4.0
 
+      The default is changed to ``False`` from ``True``.
 
 .. _texinfo-options:
 

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -120,7 +120,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value('man_pages', default_man_pages, None)
     app.add_config_value('man_show_urls', False, None)
-    app.add_config_value('man_make_section_directory', False, None)
+    app.add_config_value('man_make_section_directory', True, None)
 
     return {
         'version': 'builtin',

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -17,9 +17,9 @@ from sphinx.config import Config
 @pytest.mark.sphinx('man')
 def test_all(app, status, warning):
     app.builder.build_all()
-    assert (app.outdir / 'sphinxtests.1').exists()
+    assert (app.outdir / '1' / 'sphinxtests.1').exists()
 
-    content = (app.outdir / 'sphinxtests.1').read_text()
+    content = (app.outdir / '1' / 'sphinxtests.1').read_text()
     assert r'\fBprint \fP\fIi\fP\fB\en\fP' in content
     assert r'\fBmanpage\en\fP' in content
 
@@ -31,16 +31,16 @@ def test_all(app, status, warning):
 
 
 @pytest.mark.sphinx('man', testroot='basic',
-                    confoverrides={'man_make_section_directory': True})
+                    confoverrides={'man_make_section_directory': False})
 def test_man_make_section_directory(app, status, warning):
     app.build()
-    assert (app.outdir / '1' / 'python.1').exists()
+    assert (app.outdir / 'python.1').exists()
 
 
 @pytest.mark.sphinx('man', testroot='directive-code')
 def test_captioned_code_block(app, status, warning):
     app.builder.build_all()
-    content = (app.outdir / 'python.1').read_text()
+    content = (app.outdir / '1' / 'python.1').read_text()
 
     assert ('.sp\n'
             'caption \\fItest\\fP rb\n'
@@ -71,5 +71,5 @@ def test_default_man_pages():
 @pytest.mark.sphinx('man', testroot='markup-rubric')
 def test_rubric(app, status, warning):
     app.build()
-    content = (app.outdir / 'python.1').read_text()
+    content = (app.outdir / '1' / 'python.1').read_text()
     assert 'This is a rubric\n' in content

--- a/tests/test_smartquotes.py
+++ b/tests/test_smartquotes.py
@@ -31,7 +31,7 @@ def test_text_builder(app, status, warning):
 def test_man_builder(app, status, warning):
     app.build()
 
-    content = (app.outdir / 'python.1').read_text()
+    content = (app.outdir / '1' / 'python.1').read_text()
     assert '\\-\\- "Sphinx" is a tool that makes it easy ...' in content
 
 
@@ -84,5 +84,5 @@ def test_smartquotes_excludes_language(app, status, warning):
 def test_smartquotes_excludes_builders(app, status, warning):
     app.build()
 
-    content = (app.outdir / 'python.1').read_text()
+    content = (app.outdir / '1' / 'python.1').read_text()
     assert '– “Sphinx” is a tool that makes it easy …' in content


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #7996 
- As I commented at #7996, I enabled `man_make_section_directory` by default since 4.0.