### PR TITLE
Outdated comment in docs config for intersphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,8 +110,6 @@ texinfo_documents = [
      1),
 ]
 
-# We're not using intersphinx right now, but if we did, this would be part of
-# the mapping:
 intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}
 
 # Sphinx document translation with sphinx gettext feature uses these settings:


### PR DESCRIPTION
Subject: Remove outdated comment in Sphinx docs config for intersphinx

### Feature or Bugfix
- Docfix

### Purpose
- Intersphinx is in use in the documentation since 6a396c7.