### PR TITLE
Allow to suppress "duplicated toc entry" warnings from epub builder

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,8 +26,8 @@ Features added
   just before writing .tex file
 * #7996: manpage: Add :confval:`man_make_section_directory` to make a section
   directory on build man page
-* #8289: epub: Allow to suppress "duplicated ToC entry found" warnings from epub builder
-  using :confval:`suppress_warnings`.
+* #8289: epub: Allow to suppress "duplicated ToC entry found" warnings from epub
+  builder using :confval:`suppress_warnings`.
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -26,7 +26,7 @@ Features added
   just before writing .tex file
 * #7996: manpage: Add :confval:`man_make_section_directory` to make a section
   directory on build man page
-* #8289: Allow to suppress "duplicated ToC entry found" warnings from epub builder
+* #8289: epub: Allow to suppress "duplicated ToC entry found" warnings from epub builder
   using :confval:`suppress_warnings`.
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@ Features added
   just before writing .tex file
 * #7996: manpage: Add :confval:`man_make_section_directory` to make a section
   directory on build man page
+* #8289: Allow to suppress "duplicated ToC entry found" warnings from epub builder
+  using :confval:`suppress_warnings`.
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -341,7 +341,6 @@ General configuration
 
       Added ``autosectionlabel.*``
 
-
    .. versionchanged:: 3.3.0
 
       Added ``epub.duplicated_toc_entry``

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -316,6 +316,7 @@ General configuration
    * ``toc.circular``
    * ``toc.secnum``
    * ``epub.unknown_project_files``
+   * ``epub.duplicated_toc_entry``
    * ``autosectionlabel.*``
 
    You can choose from these types.
@@ -339,6 +340,11 @@ General configuration
    .. versionchanged:: 2.1
 
       Added ``autosectionlabel.*``
+
+
+   .. versionchanged:: 3.3.0
+
+      Added ``epub.duplicated_toc_entry``
 
 .. confval:: needs_sphinx
 

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -208,7 +208,12 @@ class EpubBuilder(StandaloneHTMLBuilder):
         appeared = set()  # type: Set[str]
         for node in nodes:
             if node['refuri'] in appeared:
-                logger.warning(__('duplicated ToC entry found: %s'), node['refuri'])
+                logger.warning(
+                    __('duplicated ToC entry found: %s'),
+                    node['refuri'],
+                    type="epub",
+                    subtype="duplicated_toc_entry",
+                )
             else:
                 appeared.add(node['refuri'])
 


### PR DESCRIPTION
Subject:  Allow to suppress "duplicated toc entry" warnings from epub builder #8289 


### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
I'd like to suppress this warning, while I find time to fix it

### Detail

### Relates
- https://github.com/sphinx-doc/sphinx/commit/6d900c34f12db0d21c581c58a5dd38ab49c8ea35

