### PR TITLE
autoclass-content new options for more flexibility   

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1540,7 +1540,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
 
         # for classes, what the "docstring" is can be controlled via a
         # config value; the default is only the class docstring
-        if content in ('both', 'init'):
+        if content in ('both', 'init', 'class-priority', 'init-priority'):
             __init__ = self.get_attr(self.object, '__init__', None)
             initdocstring = getdoc(__init__, self.get_attr,
                                    self.env.config.autodoc_inherit_docstrings,
@@ -1564,6 +1564,12 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             if initdocstring:
                 if content == 'init':
                     docstrings = [initdocstring]
+                elif content == 'class-priority':
+                    if not docstrings:
+                        docstrings = [initdocstring]
+                elif content == 'init-priority':
+                    if initdocstring:
+                        docstrings = [initdocstring]
                 else:
                     docstrings.append(initdocstring)
 


### PR DESCRIPTION
Subject: Add new options for autodoc autoclass-content to be more flexible about choosing docsting 


### Feature or Bugfix
- Feature

### Purpose
- More flexibility for auto generated class documentation. Improvement solves the issue when there is an abstract class with init docstring and child class with class docstring. Thanks to 'class-priority' only class docstring will be visible in final class documentation while in abstract class init docstring is still presented. 
