### PR TITLE
refactor: Remove rst_epilog from test-root/conf.py

### DIFF
--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -32,8 +32,6 @@ pygments_style = 'sphinx'
 show_authors = True
 numfig = True
 
-rst_epilog = '.. |subst| replace:: global substitution'
-
 html_sidebars = {'**': ['localtoc.html', 'relations.html', 'sourcelink.html',
                         'customsb.html', 'searchbox.html'],
                  'index': ['contentssb.html', 'localtoc.html', 'globaltoc.html']}

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -22,7 +22,9 @@ Meta markup
 Generic reST
 ------------
 
-A |subst| (the definition is in rst_epilog).
+A |subst|!
+
+.. |subst| replace:: global substitution
 
 .. highlight:: none
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -258,7 +258,7 @@ def test_html4_output(app, status, warning):
         (".//pre/strong", 'try_stmt'),
         (".//pre/a[@href='#grammar-token-try1_stmt']/code/span", 'try1_stmt'),
         # tests for ``only`` directive
-        (".//p", 'A global substitution.'),
+        (".//p", 'A global substitution!'),
         (".//p", 'In HTML.'),
         (".//p", 'In both.'),
         (".//p", 'Always present'),


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/pull/8183#discussion_r499733345
- I found test-root defines rst_epilog in its conf.py.  It causes
side-effects to many test cases in Sphinx's testing because test-root
is widely used.  This removes the configuration from test-root not to
cause side-effects to our testings.
- Note: We already have test cases for rst_epilog in test_util_rst.