### PR TITLE
Add prefer-class autodoc-content option

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1546,7 +1546,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
 
         # for classes, what the "docstring" is can be controlled via a
         # config value; the default is only the class docstring
-        if content in ('both', 'init'):
+        if content in ('both', 'init', 'prefer-class'):
             __init__ = self.get_attr(self.object, '__init__', None)
             initdocstring = getdoc(__init__, self.get_attr,
                                    self.env.config.autodoc_inherit_docstrings,
@@ -1570,6 +1570,9 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             if initdocstring:
                 if content == 'init':
                     docstrings = [initdocstring]
+                elif content == 'prefer-class':
+                    if not docstrings:
+                        docstrings = [initdocstring]
                 else:
                     docstrings.append(initdocstring)
 

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -488,6 +488,40 @@ def test_autoclass_content_and_docstring_signature_both(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autoclass_content_and_docstring_signature_prefer_class(app):
+    app.config.autoclass_content = 'prefer-class'
+    options = {"members": None,
+               "undoc-members": None}
+    actual = do_autodoc(app, 'module', 'target.docstring_signature', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.docstring_signature',
+        '',
+        '',
+        '.. py:class:: A(foo, bar)',
+        '   :module: target.docstring_signature',
+        '',
+        '',
+        '.. py:class:: B(foo, bar)',
+        '   :module: target.docstring_signature',
+        '',
+        '',
+        '.. py:class:: C(foo, bar)',
+        '   :module: target.docstring_signature',
+        '',
+        '',
+        '.. py:class:: D(foo, bar, baz)',
+        '   :module: target.docstring_signature',
+        '',
+        '',
+        '.. py:class:: E(foo: int, bar: int, baz: int) -> None',
+        '              E(foo: str, bar: str, baz: str) -> None',
+        '   :module: target.docstring_signature',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_mocked_module_imports(app, warning):
     # no autodoc_mock_imports
     options = {"members": 'TestAutodoc,decoratedFunction,func'}

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -209,6 +209,65 @@ def test_autoclass_content_both(app):
         '',
     ]
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_autoclass_content_prefer_class(app):
+    app.config.autoclass_content = 'prefer-class'
+    options = {"members": None}
+    actual = do_autodoc(app, 'module', 'target.autoclass_content', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.autoclass_content',
+        '',
+        '',
+        '.. py:class:: A()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class having no __init__, no __new__',
+        '',
+        '',
+        '.. py:class:: B()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class having __init__(no docstring), no __new__',
+        '',
+        '',
+        '.. py:class:: C()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class having __init__, no __new__',
+        '',
+        '',
+        '.. py:class:: D()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class having no __init__, __new__(no docstring)',
+        '',
+        '',
+        '.. py:class:: E()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class having no __init__, __new__',
+        '',
+        '',
+        '.. py:class:: F()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class having both __init__ and __new__',
+        '',
+        '',
+        '.. py:class:: G()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class inherits __init__ without docstring.',
+        '',
+        '',
+        '.. py:class:: H()',
+        '   :module: target.autoclass_content',
+        '',
+        '   A class inherits __new__ without docstring.',
+        '',
+    ]
+
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_inherit_docstrings(app):


### PR DESCRIPTION
Subject: Autodoc-content prefer-class options takes class' docstring if exists otherwise selects __init__ docstring

### Feature or Bugfix
- Feature

### Purpose
- To avoid merging docstrings when __init__was inherited and describes superclass but not the subclass. In such case one would like to have only one of docstrings in the generated documentation. This option allows to show only subclass' class' docstring without merging superclass __init__ docstring
