### PR TITLE
Register public markers in sphinx.testing.fixtures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,10 +57,8 @@ filterwarnings =
     ignore::DeprecationWarning:pyximport.pyximport
     ignore::PendingDeprecationWarning:sphinx.util.pycompat
 markers =
-    sphinx
     apidoc
     setup_command
-    test_params
 testpaths = tests
 
 [coverage:run]

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -22,7 +22,7 @@ from sphinx.testing import util
 from sphinx.testing.util import SphinxTestApp, SphinxTestAppWrapperForSkipBuilding
 
 
-PUBLIC_MARKERS = [
+DEFAULT_MARKERS = [
     (
         'sphinx(builder, testroot=None, freshenv=False, confoverrides=None, tags=None,'
         ' docutilsconf=None, parallel=0): arguments to initialize the sphinx test application.'
@@ -33,7 +33,7 @@ PUBLIC_MARKERS = [
 
 def pytest_configure(config):
     # register custom markers
-    for marker in PUBLIC_MARKERS:
+    for marker in DEFAULT_MARKERS:
         config.addinivalue_line('markers', marker)
 
 

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -22,7 +22,7 @@ from sphinx.testing import util
 from sphinx.testing.util import SphinxTestApp, SphinxTestAppWrapperForSkipBuilding
 
 
-markers = [
+PUBLIC_MARKERS = [
     (
         'sphinx(builder, testroot=None, freshenv=False, confoverrides=None, tags=None,'
         ' docutilsconf=None, parallel=0): arguments to initialize the sphinx test application.'
@@ -33,7 +33,7 @@ markers = [
 
 def pytest_configure(config):
     # register custom markers
-    for marker in markers:
+    for marker in PUBLIC_MARKERS:
         config.addinivalue_line('markers', marker)
 
 

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -22,7 +22,7 @@ from sphinx.testing import util
 from sphinx.testing.util import SphinxTestApp, SphinxTestAppWrapperForSkipBuilding
 
 
-DEFAULT_MARKERS = [
+DEFAULT_ENABLED_MARKERS = [
     (
         'sphinx(builder, testroot=None, freshenv=False, confoverrides=None, tags=None,'
         ' docutilsconf=None, parallel=0): arguments to initialize the sphinx test application.'
@@ -33,7 +33,7 @@ DEFAULT_MARKERS = [
 
 def pytest_configure(config):
     # register custom markers
-    for marker in DEFAULT_MARKERS:
+    for marker in DEFAULT_ENABLED_MARKERS:
         config.addinivalue_line('markers', marker)
 
 

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -22,6 +22,21 @@ from sphinx.testing import util
 from sphinx.testing.util import SphinxTestApp, SphinxTestAppWrapperForSkipBuilding
 
 
+markers = [
+    (
+        'sphinx(builder, testroot=None, freshenv=False, confoverrides=None, tags=None,'
+        ' docutilsconf=None, parallel=0): arguments to initialize the sphinx test application.'
+    ),
+    'test_params(shared_result=...): test parameters.',
+]
+
+
+def pytest_configure(config):
+    # register custom markers
+    for marker in markers:
+        config.addinivalue_line('markers', marker)
+
+
 @pytest.fixture(scope='session')
 def rootdir() -> str:
     return None


### PR DESCRIPTION
Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>

Subject: Register public markers in sphinx.testing.fixtures

### Feature or Bugfix
- Feature

### Purpose
When writing tests for a Sphinx extension, the usage of `sphinx` or `test_params` markers raises a `PytestUnknownMarkWarning`:

```
  test_spam.py:0: PytestUnknownMarkWarning: Unknown pytest.mark.sphinx - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.sphinx("html", testroot="spam")
```
The workaround is to register the markers in `pytest.ini`:

```ini
[pytest]
markers =
  sphinx
  test_params
```

To avoid this and offer the markers automatically, this PR moves registration of `sphinx` and `test_params` markers to `sphinx.testing.fixtures` plugin. Only two markers are exposed by the public plugin, so the remaining markers (`apidoc` and `setup_command`) are left in `setup.cfg`.