### PR TITLE
Linkcheck: Use Thread daemon argument

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -106,8 +106,7 @@ class CheckExternalLinksBuilder(Builder):
         self.rqueue = queue.Queue()  # type: queue.Queue
         self.workers = []  # type: List[threading.Thread]
         for i in range(self.app.config.linkcheck_workers):
-            thread = threading.Thread(target=self.check_thread)
-            thread.setDaemon(True)
+            thread = threading.Thread(target=self.check_thread, daemon=True)
             thread.start()
             self.workers.append(thread)
 


### PR DESCRIPTION
Instead of using a separate call.

Argument introduced in Python 3.3. https://docs.python.org/3.5/library/threading.html#threading.Thread

### Feature or Bugfix
- Refactoring