### PR TITLE
Prevent arrow keys changing page when button elements are focused

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -285,9 +285,10 @@ var Documentation = {
   initOnKeyListeners: function() {
     $(document).keydown(function(event) {
       var activeElementType = document.activeElement.tagName;
-      // don't navigate when in search box or textarea
+      // don't navigate when in search box, textarea, dropdown or button
       if (activeElementType !== 'TEXTAREA' && activeElementType !== 'INPUT' && activeElementType !== 'SELECT'
-          && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+          && activeElementType !== 'BUTTON' && !event.altKey && !event.ctrlKey && !event.metaKey
+          && !event.shiftKey) {
         switch (event.keyCode) {
           case 37: // left
             var prevHref = $('link[rel="prev"]').prop('href');


### PR DESCRIPTION
Subject: Change document event listener, so that arrow keys can be used to access tabbed content

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Purpose
- Left and right arrow key presses trigger sphinx docs to switch the previous or next page, respectively. Left and right arrow keys may be required for keyboard-only users to access content within a page. For example, [where button elements are used to switch between tabbed content](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role). This minor change prevents the arrow keys from triggering a page change when the active element is a button, as in the case of accessible tabs. This allows users to switch accessible tabbed content using only a keyboard.

### Detail
- Bug - [accessible tabs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role) cannot be accessed by keyboard-only users.

### Relates
- Supports [accessibility improvements to tabbed content](https://github.com/executablebooks/sphinx-tabs/pull/94) in sphinx extensions.
