### PR TITLE
basic CSS: disable "user-select" on span.linenos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,7 @@ Bugs fixed
 * #8268: linkcheck: Report HTTP errors when ``linkcheck_anchors`` is ``True``
 * #8245: linkcheck: take source directory into account for local files
 * #6914: figure numbers are unexpectedly assigned to uncaptioned items
+* #8320: make "inline" line numbers un-selectable
 
 Testing
 --------

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -764,6 +764,7 @@ div.code-block-caption code {
 }
 
 table.highlighttable td.linenos,
+span.linenos,
 div.doctest > div.highlight span.gp {  /* gp: Generic.Prompt */
     user-select: none;
 }


### PR DESCRIPTION
This is an addition to #7482.

This disables mouse selection of line numbers if `html_codeblock_linenos_style = 'inline'` is used.