### PR TITLE
Linkcheck: Fix broken url not reporting error

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -226,6 +226,7 @@ class CheckExternalLinksBuilder(Builder):
                             if rex.match(uri):
                                 return 'ignored', '', 0
                         else:
+                            self.broken[uri] = ''
                             return 'broken', '', 0
             elif uri in self.good:
                 return 'working', 'old', 0


### PR DESCRIPTION
Subject: Linkcheck: Fix broken url not reporting error

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
Some links are printed as broken but do not error out the build.
This issue appeared when we include `tel:` links in our build.

### Relates
- #8321 

