### PR TITLE
Fix #8321: linkcheck: ``tel:`` schema hyperlinks are detected as errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,7 @@ Bugs fixed
 * #8239: Failed to refer a token in productionlist if it is indented
 * #8268: linkcheck: Report HTTP errors when ``linkcheck_anchors`` is ``True``
 * #8245: linkcheck: take source directory into account for local files
+* #8321: linkcheck: ``tel:`` schema hyperlinks are detected as errors
 * #6914: figure numbers are unexpectedly assigned to uncaptioned items
 
 Testing

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -213,7 +213,7 @@ class CheckExternalLinksBuilder(Builder):
 
         def check(docname: str) -> Tuple[str, str, int]:
             # check for various conditions without bothering the network
-            if len(uri) == 0 or uri.startswith(('#', 'mailto:')):
+            if len(uri) == 0 or uri.startswith(('#', 'mailto:', 'tel:')):
                 return 'unchecked', '', 0
             elif not uri.startswith(('http:', 'https:')):
                 if uri_re.match(uri):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8321 
-  The linkcheck builder should ignore hyperlinks having ``tel:`` schema
  because it can't ensure the links are healthy or not.