### PR TITLE
Override Pygments CSS with theme CSS

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -95,8 +95,8 @@
 {%- endmacro %}
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1)|e }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1)|e }}" type="text/css" />
     {%- for css in css_files %}
       {%- if css|attr("filename") %}
     {{ css_tag(css) }}


### PR DESCRIPTION
Before this PR, the Pygments colors for line numbers have overridden the colors selected by Sphinx.

This problem has only become visible with the upgrade to Pygments 2.7.0.

This PR fixes the color problem visible in #8254, but not the alignment problem.

The alignment problem has been fixed by https://github.com/pygments/pygments/pull/1583, which will become available soon in Pygments 2.7.2 [UPDATE: this has already been released in the meantime!].