### PR TITLE
Fix unnecessary load of images when parsing the document text for search function.

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -59,10 +59,10 @@ var Search = {
   _pulse_status : -1,
 
   htmlToText : function(htmlString) {
-      var htmlElement = document.createElement('span');
-      htmlElement.innerHTML = htmlString;
-      $(htmlElement).find('.headerlink').remove();
-      docContent = $(htmlElement).find('[role=main]')[0];
+      var virtualDocument = document.implementation.createHTMLDocument('virtual');
+      var htmlElement = $(htmlString, virtualDocument);
+      htmlElement.find('.headerlink').remove();
+      docContent = htmlElement.find('[role=main]')[0];
       if(docContent === undefined) {
           console.warn("Content block not found. Sphinx search tries to obtain it " +
                        "via '[role=main]'. Could you check your theme or template.");


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Avoid unnecessary traffic caused by loading many (or all) documentation images unnecessarily. In some cases, avoid unnecessary 404 errors.

### Detail
The issue was, that when searching, new element with all the HTML content
was created. This caused loading of all images in the background. However, in
the end, these images are stripped from search result anyway, so there is no
point in loading them.

In cases where images were included in HTML files in a different directory from
search.html, this behaviour was even causing 404 errors because of wrong relative URLs.

This commit fixes the issue by creating virtual document and using that as the owner
document of temporary meta-element used for searching and parsing purposes.
The virtual owner document causes browser to not load the images.


