### PR TITLE
Fix #8342: Emit a warning if a unknown domain is given for directive or role

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,9 @@ Features added
 Bugs fixed
 ----------
 
+* #8342: Emit a warning if a unknown domain is given for directive or role (ex.
+  ``:unknown:doc:``)
+
 Testing
 --------
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -28,6 +28,7 @@ from docutils.statemachine import StateMachine, State, StringList
 from docutils.utils import Reporter, unescape
 
 from sphinx.errors import SphinxError
+from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.typing import RoleFunction
 
@@ -208,6 +209,8 @@ class sphinx_domains:
                 element = getattr(domain, type)(name)
                 if element is not None:
                     return element, []
+            else:
+                logger.warning(_('unknown directive or role name: %s:%s'), domain_name, name)
         # else look in the default domain
         else:
             def_domain = self.env.temp_data.get('default_domain')


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Currently, Sphinx mention nothing if users use unknown domain in their
documents (ex. `.. unknown:directive::`, `:unknown:role` and so on).
This starts to warn them to be clear non acceptable mark-ups.
- refs: #8342
