### PR TITLE
domains: c: fix use of unitialized variable

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1533,6 +1533,7 @@ class Symbol:
         self.declaration = declaration
         self.declaration.symbol = self
         self.docname = docname
+        self.line = line
         self._assert_invariants()
         # and symbol addition should be done as well
         self._add_function_params()


### PR DESCRIPTION
`_fill_empty` was not updating the state with the value of line, so in recursive calls it would fail the assert checking for its own initialization.

/cc @jakobandersen 