### PR TITLE
test: do not use "object" for the type annotation

### DIFF
--- a/tests/roots/test-ext-autodoc/target/typehints.py
+++ b/tests/roots/test-ext-autodoc/target/typehints.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 
 
 def incr(a: int, b: int = 1) -> int:
@@ -11,7 +11,7 @@ def decr(a, b = 1):
 
 
 class Math:
-    def __init__(self, s: str, o: object = None) -> None:
+    def __init__(self, s: str, o: Any = None) -> None:
         pass
 
     def incr(self, a: int, b: int = 1) -> int:

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -490,7 +490,7 @@ def test_autodoc_typehints_signature(app):
         '.. py:module:: target.typehints',
         '',
         '',
-        '.. py:class:: Math(s: str, o: object = None)',
+        '.. py:class:: Math(s: str, o: Any = None)',
         '   :module: target.typehints',
         '',
         '',


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Usually we use "Any" type for the type annotation which takes any kinds
of types, instead of "object" class.  So this replaces "object" to "Any"
in our example.
