### PR TITLE
Fix #8380: html search: search results are wrapped with <p> instead of <div>

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Incompatible changes
 * #7784: i18n: The msgid for alt text of image is changed
 * #7996: manpage: Make a section directory on build manpage by default (see
   :confval:`man_make_section_directory`)
+* #8380: html search: search results are wrapped with ``<p>`` instead of
+  ``<div>``
 
 Deprecated
 ----------
@@ -43,6 +45,7 @@ Features added
 Bugs fixed
 ----------
 
+* #8380: html search: Paragraphs in search results are not identified as ``<p>``
 * #8342: Emit a warning if a unknown domain is given for directive or role (ex.
   ``:unknown:doc:``)
 

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -130,7 +130,7 @@ ul.search li a {
     font-weight: bold;
 }
 
-ul.search li div.context {
+ul.search li p.context {
     color: #888;
     margin: 2px 0 0 30px;
     text-align: left;

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -501,7 +501,7 @@ var Search = {
     var excerpt = ((start > 0) ? '...' : '') +
       $.trim(text.substr(start, 240)) +
       ((start + 240 - text.length) ? '...' : '');
-    var rv = $('<div class="context"></div>').text(excerpt);
+    var rv = $('<p class="context"></div>').text(excerpt);
     $.each(hlwords, function() {
       rv = rv.highlightText(this, 'highlighted');
     });


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8380 