### PR TITLE
Fix #8372: autodoc: autoclass directive became slower than Sphinx-3.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Features added
 Bugs fixed
 ----------
 
+* #8372: autodoc: autoclass directive became slower than Sphinx-3.2
 * #8364: C, properly initialize attributes in empty symbols.
 
 Testing

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1503,6 +1503,9 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
                     qualname = '.'.join([cls.__qualname__, self._signature_method_name])
                     if qualname in analyzer.overloads:
                         return analyzer.overloads.get(qualname)
+                    elif qualname in analyzer.tagorder:
+                        # the constructor is defined in the class, but not overrided.
+                        return []
                 except PycodeError:
                     pass
 

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -150,9 +150,13 @@ class ModuleAnalyzer:
         self.overloads = None    # type: Dict[str, List[Signature]]
         self.tagorder = None     # type: Dict[str, int]
         self.tags = None         # type: Dict[str, Tuple[str, int, int]]
+        self._parsed = False
 
     def parse(self) -> None:
         """Parse the source code."""
+        if self._parsed:
+            return None
+
         try:
             parser = Parser(self.code, self._encoding)
             parser.parse()
@@ -169,21 +173,18 @@ class ModuleAnalyzer:
             self.overloads = parser.overloads
             self.tags = parser.definitions
             self.tagorder = parser.deforders
+            self._parsed = True
         except Exception as exc:
             raise PycodeError('parsing %r failed: %r' % (self.srcname, exc)) from exc
 
     def find_attr_docs(self) -> Dict[Tuple[str, str], List[str]]:
         """Find class and module-level attributes and their documentation."""
-        if self.attr_docs is None:
-            self.parse()
-
+        self.parse()
         return self.attr_docs
 
     def find_tags(self) -> Dict[str, Tuple[str, int, int]]:
         """Find class, function and method definitions and their location."""
-        if self.tags is None:
-            self.parse()
-
+        self.parse()
         return self.tags
 
     @property


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
* The result of ModuleAnalyzer.parse() is not cached
* autodoc tries to search overloaded constructor methods to the root
  class even if a definition found