### PR TITLE
Put system locale path after the paths specified by configuration

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -294,8 +294,8 @@ class Sphinx:
                 if catalog.domain == 'sphinx' and catalog.is_outdated():
                     catalog.write_mo(self.config.language)
 
-            locale_dirs = [None]  # type: List[Optional[str]]
-            locale_dirs += list(repo.locale_dirs)
+            locale_dirs = list(repo.locale_dirs)  # type: List[Optional[str]]
+            locale_dirs += [None]
             locale_dirs += [path.join(package_dir, 'locale')]
 
             self.translator, has_translation = locale.init(locale_dirs, self.config.language)


### PR DESCRIPTION
Subject: Put system locale path after the paths specified by configuration

### Feature or Bugfix
- Bugfix

### Purpose
In Debian, we ship the translation data for Sphinx in the gettext's default search path, `/usr/share/locale/` (support for that was added in c0e848f0db52e242). When a `.mo` file is present there, it takes priority over the translation files specified by the configuration, so overriding does not work. This makes the (recently added) `test_customize_system_message` test fail.

This amends 37235c71e04aff3b and makes sure `list(repo.locale_dirs)` is taken into account first.