### PR TITLE
linkchecker: Remove dead code is_ssl_error()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* The ``is_ssl_error()`` function of ``sphinx.util.requests``
 * The ``follow_wrapped`` argument of ``sphinx.util.inspect.signature()``
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -27,6 +27,11 @@ The following is a list of deprecated interfaces.
      - Alternatives
 
 
+   * - ``sphinx.util.requests.is_ssl_error()``
+     - 3.4
+     - 5.0
+     - N/A
+
    * - The ``follow_wrapped`` argument of ``sphinx.util.inspect.signature()``
      - 3.4
      - 5.0

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -28,7 +28,6 @@ from sphinx.locale import __
 from sphinx.util import encode_uri, logging, requests
 from sphinx.util.console import darkgray, darkgreen, purple, red, turquoise  # type: ignore
 from sphinx.util.nodes import get_node_line
-from sphinx.util.requests import is_ssl_error
 
 logger = logging.getLogger(__name__)
 
@@ -189,10 +188,7 @@ class CheckExternalLinksBuilder(Builder):
                 else:
                     return 'broken', str(err), 0
             except Exception as err:
-                if is_ssl_error(err):
-                    return 'ignored', str(err), 0
-                else:
-                    return 'broken', str(err), 0
+                return 'broken', str(err), 0
             if response.url.rstrip('/') == req_url.rstrip('/'):
                 return 'working', '', 0
             else:

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -18,6 +18,7 @@ import requests
 
 import sphinx
 from sphinx.config import Config
+from sphinx.deprecation import RemovedInSphinx50Warning
 
 try:
     from requests.packages.urllib3.exceptions import SSLError
@@ -43,6 +44,10 @@ useragent_header = [('User-Agent',
 
 def is_ssl_error(exc: Exception) -> bool:
     """Check an exception is SSLError."""
+    warnings.warn(
+        "is_ssl_error() is outdated and likely returns incorrect results "
+        "for modern versions of Requests.",
+        RemovedInSphinx50Warning)
     if isinstance(exc, SSLError):
         return True
     else:

--- a/tests/roots/test-linkcheck-localserver-https/conf.py
+++ b/tests/roots/test-linkcheck-localserver-https/conf.py
@@ -1,0 +1,1 @@
+exclude_patterns = ['_build']

--- a/tests/roots/test-linkcheck-localserver-https/index.rst
+++ b/tests/roots/test-linkcheck-localserver-https/index.rst
@@ -1,0 +1,1 @@
+`HTTPS server <https://localhost:7777/>`_


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose

#### Verify invalid SSL handling

Test invalid SSL is reported as broken.

`linkcheck` logic suggests that SSL errors were originally expected to
be ignored.

Blaming the corresponding lines point to issue #3008: linkcheck to
website with self-signed certificates. That issue was fixed by commit
4c7bec6460ae6154705bfd023e363e458f16d1b6, which ignored SSL errors.
Probably because back then, users could not specify a CA bundle.

A broken SSL certificate is a real issue, it should not be ignored.
Users wishing to ignore issues for a specific link can use the
`linkcheck_ignore` option.

The current behavior is to report the site as broken, keep it.

#### Remove `is_ssl_error()`

That function is dead code, it always returns False. The exception
checking stopped working because the Requests library wraps SSL errors
in a `requests.exceptions.SSLError` and no longer throws an
`urllib3.exceptions.SSLError`. The first argument to that exception is
an `urllib3.exceptions.MaxRetryError`.

### Relates
- #3008