### PR TITLE
Fix #8350: autosummary_mock_imports causes slow down builds

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #8372: autodoc: autoclass directive became slower than Sphinx-3.2
 * #7727: autosummary: raise PycodeError when documenting python package
   without __init__.py
+* #8350: autosummary: autosummary_mock_imports causes slow down builds
 * #8364: C, properly initialize attributes in empty symbols.
 * #8399: i18n: Put system locale path after the paths specified by configuration
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -122,7 +122,11 @@ def getargspec(func: Callable) -> Any:
 def unwrap(obj: Any) -> Any:
     """Get an original object from wrapped object (wrapped functions)."""
     try:
-        return inspect.unwrap(obj)
+        if hasattr(obj, '__sphinx_mock__'):
+            # Skip unwrapping mock object to avoid RecursionError
+            return obj
+        else:
+            return inspect.unwrap(obj)
     except ValueError:
         # might be a mock object
         return obj


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8350  
- The mock objects set up via `autosummary_mock_imports` causes slow down
of autosummary stub generation because AttributeDocumenter falls into
infinite recursion call to unwrap decorators of mocked objects.
- To avoid the trouble, this blocks unwrapping decorators of mocked
objects.