### PR TITLE
Fix #8398: Fix type annotation for "confdir" of Sphinx.__init__()

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -135,7 +135,7 @@ class Sphinx:
     :ivar outdir: Directory for storing build documents.
     """
 
-    def __init__(self, srcdir: str, confdir: str, outdir: str, doctreedir: str,
+    def __init__(self, srcdir: str, confdir: Optional[str], outdir: str, doctreedir: str,
                  buildername: str, confoverrides: Dict = None,
                  status: IO = sys.stdout, warning: IO = sys.stderr,
                  freshenv: bool = False, warningiserror: bool = False, tags: List[str] = None,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- None is allowed to the argument. So it should be "Optional[str]" instead
of "str".
- refs: #8398 