### PR TITLE
linkcheck: Remove unused arguments from test_invalid_ssl

### DIFF
--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -271,7 +271,7 @@ def test_follows_redirects_on_GET(app, capsys):
     )
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
-def test_invalid_ssl(app, status, warning):
+def test_invalid_ssl(app):
     # Link indicates SSL should be used (https) but the server does not handle it.
     class OKHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
Not updated after c90eef1f674daac9b51b73662d0d6969f8ad31f7.