### PR TITLE
Remove config variable: source_parsers

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -106,7 +106,6 @@ class Config:
         'master_doc': ('index', 'env', []),
         'source_suffix': ({'.rst': 'restructuredtext'}, 'env', Any),
         'source_encoding': ('utf-8-sig', 'env', []),
-        'source_parsers': ({}, 'env', []),
         'exclude_patterns': ([], 'env', []),
         'default_role': (None, 'env', [str]),
         'add_function_parentheses': (True, 'env', []),


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- It was already deprecated at 1.8.0 and removed at 3.0.0.  So the
definition is no longer used.
- refs: dc45877d3cb9f67348d3e2857bc489e16b71f61a
