### PR TITLE
linkcheck: Prevent REQUESTS_CA_BUNDLE leak in tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import http.server
+import os
 import pathlib
 import ssl
 import threading
@@ -46,3 +47,16 @@ def create_server(thread_class):
 
 http_server = create_server(HttpServerThread)
 https_server = create_server(HttpsServerThread)
+
+
+@contextlib.contextmanager
+def modify_env(**env):
+    original_env = os.environ.copy()
+    for k, v in env.items():
+        os.environ[k] = v
+    yield
+    for k in env:
+        try:
+            os.environ[k] = original_env[k]
+        except KeyError:
+            os.unsetenv(k)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Test `test_connect_to_selfsigned_nonexistent_cert_file` serves two
purposes:
- verify the behavior when the CA bundle file path is incorrect
- flag a leak of REQUESTS_CA_BUNDLE

Assumes that test runs after
`test_connect_to_selfsigned_with_requests_env_var`. Not great, but
better than no testing.