### PR TITLE
autodoc: an imported TypeVar is not resolved (refs: #8415)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,8 @@ Bugs fixed
 ----------
 
 * #8917: autodoc: Raises a warning if function has wrong __globals__ value
+* #8415: autodoc: a TypeVar imported from other module is not resolved (in
+  Python 3.7 or above)
 * #8380: html search: Paragraphs in search results are not identified as ``<p>``
 * #8915: html theme: The translation of sphinx_rtd_theme does not work
 * #8342: Emit a warning if a unknown domain is given for directive or role (ex.

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -263,7 +263,10 @@ def stringify(annotation: Any) -> str:
         else:
             return annotation
     elif isinstance(annotation, TypeVar):
-        return annotation.__name__
+        if annotation.__module__ == 'typing':
+            return annotation.__name__
+        else:
+            return '.'.join([annotation.__module__, annotation.__name__])
     elif inspect.isNewType(annotation):
         # Could not get the module where it defiend
         return annotation.__name__

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -142,7 +142,13 @@ def test_signature_annotations():
 
     # TypeVars and generic types with TypeVars
     sig = inspect.signature(f2)
-    assert stringify_signature(sig) == '(x: List[T], y: List[T_co], z: T) -> List[T_contra]'
+    if sys.version_info < (3, 7):
+        assert stringify_signature(sig) == '(x: List[T], y: List[T_co], z: T) -> List[T_contra]'
+    else:
+        assert stringify_signature(sig) == ('(x: List[tests.typing_test_data.T],'
+                                            ' y: List[tests.typing_test_data.T_co],'
+                                            ' z: tests.typing_test_data.T'
+                                            ') -> List[tests.typing_test_data.T_contra]')
 
     # Union types
     sig = inspect.signature(f3)

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -194,10 +194,17 @@ def test_stringify_type_hints_typevars():
     T_co = TypeVar('T_co', covariant=True)
     T_contra = TypeVar('T_contra', contravariant=True)
 
-    assert stringify(T) == "T"
-    assert stringify(T_co) == "T_co"
-    assert stringify(T_contra) == "T_contra"
-    assert stringify(List[T]) == "List[T]"
+    if sys.version_info < (3, 7):
+        assert stringify(T) == "T"
+        assert stringify(T_co) == "T_co"
+        assert stringify(T_contra) == "T_contra"
+        assert stringify(List[T]) == "List[T]"
+    else:
+        assert stringify(T) == "tests.test_util_typing.T"
+        assert stringify(T_co) == "tests.test_util_typing.T_co"
+        assert stringify(T_contra) == "tests.test_util_typing.T_contra"
+        assert stringify(List[T]) == "List[tests.test_util_typing.T]"
+
     assert stringify(MyInt) == "MyInt"
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- So far, a TypeVar is rendered without module name. As a result, it
could not be resolved if it is imported from other modules.  This
prepends its module name and make it resolvable.
- This is available only in ~Python 3.6 or above~ Python 3.7 or above.
- As a side effect, all of TypeVars are displayed with module name. It
should be fixed in latter step (refs: #7119)
- refs: #8415 
