### PR TITLE
test: Upgrade deadsnake/action to v2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Set up Python ${{ matrix.python }} (deadsnakes)
-      uses: deadsnakes/action@v1.0.0
+      uses: deadsnakes/action@v2.0.0
       if: endsWith(matrix.python, '-dev')
       with:
         python-version: ${{ matrix.python }}


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- deadsnake/action@v1.0.0 uses `add-path` command internally. But it
has been disabled by default.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
