### PR TITLE
test: Pass ACTIONS_ALLOW_UNSECURE_COMMANDS to deadsnake/action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
       if: endsWith(matrix.python, '-dev')
       with:
         python-version: ${{ matrix.python }}
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Check Python version
       run: python --version
     - name: Install graphviz


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The `add-path` command that deadsnake/action internally uses is
disabled by default now [*1].  But the action is still does not
support new style environment files commands [*2].  So this enables
the deprecated command via `ACTIONS_ALLOW_UNSECURE_COMMANDS` envvar.

[*1]: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
[*2]: https://github.com/deadsnakes/issues/issues/135