### PR TITLE
Fix #8419: html search: Do not load language_data.js in non-search pages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
   is decorated
 * #8434: autodoc: :confval:`autodoc_type_aliases` does not effect to variables
   and attributes
+* #8419: html search: Do not load ``language_data.js`` in non-search pages
 
 Testing
 --------

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -301,7 +301,6 @@ class StandaloneHTMLBuilder(Builder):
         self.add_js_file('jquery.js')
         self.add_js_file('underscore.js')
         self.add_js_file('doctools.js')
-        self.add_js_file('language_data.js')
 
         for filename, attrs in self.app.registry.js_files:
             self.add_js_file(filename, **attrs)

--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -12,6 +12,7 @@
 {%- block scripts %}
     {{ super() }}
     <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
   <script src="{{ pathto('searchindex.js', 1) }}" defer></script>


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8419 
- The ``language_data.js`` is only used on search page.  But it is always
loaded meaninglessly.  This fixes not to load it on all non-search pages.