### PR TITLE
Fix #8437: Do `make clean` in more safe way

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
   is decorated
 * #8434: autodoc: :confval:`autodoc_type_aliases` does not effect to variables
   and attributes
+* #8437: Makefile: ``make clean`` with empty BUILDDIR is dangerous
 
 Testing
 --------

--- a/sphinx/templates/quickstart/Makefile_t
+++ b/sphinx/templates/quickstart/Makefile_t
@@ -49,7 +49,7 @@ help:
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)
 
 .PHONY: latexpdf
 latexpdf:


### PR DESCRIPTION
### Feature or Bugfix
- Feature?
- Bugfix?
- Refactoring?

### Purpose
- When users gives empty BUILDDIR to the `make clean` command on non-make
mode, our Makefile will remove all of files of systems via `rm -rf /*`.
To prevent the catastrophic operation, this makes the `make clean`
command safety.
- refs: #8437 