### PR TITLE
Fix #8454: graphviz: The layout option for graph and digraph don't work

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ Bugs fixed
   is decorated
 * #8434: autodoc: :confval:`autodoc_type_aliases` does not effect to variables
   and attributes
+* #8454: graphviz: The layout option for graph and digraph directives don't work
 
 Testing
 --------

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -182,7 +182,8 @@ class GraphvizSimple(SphinxDirective):
         'alt': directives.unchanged,
         'align': align_spec,
         'caption': directives.unchanged,
-        'graphviz_dot': directives.unchanged,
+        'layout': directives.unchanged,
+        'graphviz_dot': directives.unchanged,  # an old alias of `layout` option
         'name': directives.unchanged,
         'class': directives.class_option,
     }
@@ -194,6 +195,8 @@ class GraphvizSimple(SphinxDirective):
         node['options'] = {'docname': self.env.docname}
         if 'graphviz_dot' in self.options:
             node['options']['graphviz_dot'] = self.options['graphviz_dot']
+        if 'layout' in self.options:
+            node['options']['graphviz_dot'] = self.options['layout']
         if 'alt' in self.options:
             node['alt'] = self.options['alt']
         if 'align' in self.options:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8454 