### PR TITLE
osutil FileAvoidWrite support non-ascii content

### DIFF
--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -222,14 +222,14 @@ class FileAvoidWrite:
         self._io.close()
 
         try:
-            with open(self._path) as old_f:
+            with open(self._path, encoding=fs_encoding) as old_f:
                 old_content = old_f.read()
                 if old_content == buf:
                     return
         except OSError:
             pass
 
-        with open(self._path, 'w') as f:
+        with open(self._path, 'w', encoding=fs_encoding) as f:
             f.write(buf)
 
     def __enter__(self) -> "FileAvoidWrite":


### PR DESCRIPTION
Subject: make FileAvoidWrite support non-ascii content

branch: 3.x

### Feature or Bugfix
- Bugfix

### Purpose

I created a custom `package.rst_t` and add some non-ascii words, but the encoding was wrong.

With my fix, it works well.

![image](https://user-images.githubusercontent.com/23495987/99884877-43c4e780-2c6c-11eb-99df-ad98c09910b2.png)

![image](https://user-images.githubusercontent.com/23495987/99884936-7969d080-2c6c-11eb-9afc-185387812185.png)


