### PR TITLE
Don't require typed_ast in [test] with Python 3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         'pytest',
         'pytest-cov',
         'html5lib',
-        'typed_ast',  # for py35-37
+        "typed_ast; python_version < '3.8'",
         'cython',
     ],
 }


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

Neither?

### Purpose

To avoid a dependency.



