### PR TITLE
refactor with pyupgrade

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1582,13 +1582,11 @@ class Symbol:
     def get_all_symbols(self) -> Iterator["Symbol"]:
         yield self
         for sChild in self._children:
-            for s in sChild.get_all_symbols():
-                yield s
+            yield from sChild.get_all_symbols()
 
     @property
     def children(self) -> Iterator["Symbol"]:
-        for c in self._children:
-            yield c
+        yield from self._children
 
     @property
     def children_recurse_anon(self) -> Iterator["Symbol"]:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -3927,8 +3927,7 @@ class Symbol:
     def get_all_symbols(self) -> Iterator[Any]:
         yield self
         for sChild in self._children:
-            for s in sChild.get_all_symbols():
-                yield s
+            yield from sChild.get_all_symbols()
 
     @property
     def children_recurse_anon(self) -> Generator["Symbol", None, None]:

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -93,7 +93,7 @@ depthsvgcomment_re = re.compile(r'<!-- DEPTH=(-?\d+) -->')
 def read_svg_depth(filename: str) -> int:
     """Read the depth from comment at last line of SVG file
     """
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         for line in f:
             pass
         # Only last line is checked

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -469,46 +469,46 @@ def _make_id(string: str) -> str:
 _non_id_chars = re.compile('[^a-zA-Z0-9._]+')
 _non_id_at_ends = re.compile('^[-0-9._]+|-+$')
 _non_id_translate = {
-    0x00f8: u'o',       # o with stroke
-    0x0111: u'd',       # d with stroke
-    0x0127: u'h',       # h with stroke
-    0x0131: u'i',       # dotless i
-    0x0142: u'l',       # l with stroke
-    0x0167: u't',       # t with stroke
-    0x0180: u'b',       # b with stroke
-    0x0183: u'b',       # b with topbar
-    0x0188: u'c',       # c with hook
-    0x018c: u'd',       # d with topbar
-    0x0192: u'f',       # f with hook
-    0x0199: u'k',       # k with hook
-    0x019a: u'l',       # l with bar
-    0x019e: u'n',       # n with long right leg
-    0x01a5: u'p',       # p with hook
-    0x01ab: u't',       # t with palatal hook
-    0x01ad: u't',       # t with hook
-    0x01b4: u'y',       # y with hook
-    0x01b6: u'z',       # z with stroke
-    0x01e5: u'g',       # g with stroke
-    0x0225: u'z',       # z with hook
-    0x0234: u'l',       # l with curl
-    0x0235: u'n',       # n with curl
-    0x0236: u't',       # t with curl
-    0x0237: u'j',       # dotless j
-    0x023c: u'c',       # c with stroke
-    0x023f: u's',       # s with swash tail
-    0x0240: u'z',       # z with swash tail
-    0x0247: u'e',       # e with stroke
-    0x0249: u'j',       # j with stroke
-    0x024b: u'q',       # q with hook tail
-    0x024d: u'r',       # r with stroke
-    0x024f: u'y',       # y with stroke
+    0x00f8: 'o',       # o with stroke
+    0x0111: 'd',       # d with stroke
+    0x0127: 'h',       # h with stroke
+    0x0131: 'i',       # dotless i
+    0x0142: 'l',       # l with stroke
+    0x0167: 't',       # t with stroke
+    0x0180: 'b',       # b with stroke
+    0x0183: 'b',       # b with topbar
+    0x0188: 'c',       # c with hook
+    0x018c: 'd',       # d with topbar
+    0x0192: 'f',       # f with hook
+    0x0199: 'k',       # k with hook
+    0x019a: 'l',       # l with bar
+    0x019e: 'n',       # n with long right leg
+    0x01a5: 'p',       # p with hook
+    0x01ab: 't',       # t with palatal hook
+    0x01ad: 't',       # t with hook
+    0x01b4: 'y',       # y with hook
+    0x01b6: 'z',       # z with stroke
+    0x01e5: 'g',       # g with stroke
+    0x0225: 'z',       # z with hook
+    0x0234: 'l',       # l with curl
+    0x0235: 'n',       # n with curl
+    0x0236: 't',       # t with curl
+    0x0237: 'j',       # dotless j
+    0x023c: 'c',       # c with stroke
+    0x023f: 's',       # s with swash tail
+    0x0240: 'z',       # z with swash tail
+    0x0247: 'e',       # e with stroke
+    0x0249: 'j',       # j with stroke
+    0x024b: 'q',       # q with hook tail
+    0x024d: 'r',       # r with stroke
+    0x024f: 'y',       # y with stroke
 }
 _non_id_translate_digraphs = {
-    0x00df: u'sz',      # ligature sz
-    0x00e6: u'ae',      # ae
-    0x0153: u'oe',      # ligature oe
-    0x0238: u'db',      # db digraph
-    0x0239: u'qp',      # qp digraph
+    0x00df: 'sz',      # ligature sz
+    0x00e6: 'ae',      # ae
+    0x0153: 'oe',      # ligature oe
+    0x0238: 'db',      # db digraph
+    0x0239: 'qp',      # qp digraph
 }
 
 

--- a/tests/test_build_changes.py
+++ b/tests/test_build_changes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     test_build_changes
     ~~~~~~~~~~~~~~~~~~

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -46,7 +46,7 @@ def reference_check(app, *args, **kwds):
 @mock.patch('sphinx.ext.intersphinx._read_from_url')
 def test_fetch_inventory_redirection(_read_from_url, InventoryFile, app, status, warning):
     intersphinx_setup(app)
-    _read_from_url().readline.return_value = '# Sphinx inventory version 2'.encode()
+    _read_from_url().readline.return_value = b'# Sphinx inventory version 2'
 
     # same uri and inv, not redirected
     _read_from_url().url = 'http://hostname/' + INVENTORY_FILENAME

--- a/tests/test_util_inventory.py
+++ b/tests/test_util_inventory.py
@@ -14,20 +14,20 @@ from io import BytesIO
 
 from sphinx.ext.intersphinx import InventoryFile
 
-inventory_v1 = '''\
+inventory_v1 = b'''\
 # Sphinx inventory version 1
 # Project: foo
 # Version: 1.0
 module mod foo.html
 module.cls class foo.html
-'''.encode()
+'''
 
-inventory_v2 = '''\
+inventory_v2 = b'''\
 # Sphinx inventory version 2
 # Project: foo
 # Version: 2.0
 # The remainder of this file is compressed with zlib.
-'''.encode() + zlib.compress('''\
+''' + zlib.compress(b'''\
 module1 py:module 0 foo.html#module-module1 Long Module desc
 module2 py:module 0 foo.html#module-$ -
 module1.func py:function 1 sub/foo.html#$ -
@@ -47,16 +47,16 @@ foo.bar js:class 1 index.html#foo.bar -
 foo.bar.baz js:method 1 index.html#foo.bar.baz -
 foo.bar.qux js:data 1 index.html#foo.bar.qux -
 a term including:colon std:term -1 glossary.html#term-a-term-including-colon -
-'''.encode())
+''')
 
-inventory_v2_not_having_version = '''\
+inventory_v2_not_having_version = b'''\
 # Sphinx inventory version 2
 # Project: foo
 # Version:
 # The remainder of this file is compressed with zlib.
-'''.encode() + zlib.compress('''\
+''' + zlib.compress(b'''\
 module1 py:module 0 foo.html#module-module1 Long Module desc
-'''.encode())
+''')
 
 
 def test_read_inventory_v1():


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Run `pyupgrade --py3-only --keep-percent-format` to refine our code.
- Note:  --keep-percent-format is required to keep translations available.
