### PR TITLE
refactor: Deprecate InstanceAttributeDocumenter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Deprecated
 * The ``follow_wrapped`` argument of ``sphinx.util.inspect.signature()``
 * ``sphinx.ext.autodoc.Documenter.get_object_members()``
 * ``sphinx.ext.autodoc.DataDeclarationDocumenter``
+* ``sphinx.ext.autodoc.InstanceAttributeDocumenter``
 * ``sphinx.ext.autodoc.SlotsAttributeDocumenter``
 * ``sphinx.ext.autodoc.TypeVarDocumenter``
 * ``sphinx.ext.autodoc.importer._getannotations()``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -41,6 +41,11 @@ The following is a list of deprecated interfaces.
      - 5.0
      - ``sphinx.ext.autodoc.DataDocumenter``
 
+   * - ``sphinx.ext.autodoc.InstanceAttributeDocumenter``
+     - 3.4
+     - 5.0
+     - ``sphinx.ext.autodoc.AttributeDocumenter``
+
    * - ``sphinx.ext.autodoc.SlotsAttributeDocumenter``
      - 3.4
      - 5.0

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2337,37 +2337,10 @@ class InstanceAttributeDocumenter(AttributeDocumenter):
     # must be higher than AttributeDocumenter
     priority = 11
 
-    @classmethod
-    def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any
-                            ) -> bool:
-        """This documents only INSTANCEATTR members."""
-        return (not isinstance(parent, ModuleDocumenter) and
-                isattr and
-                member is INSTANCEATTR)
-
-    def import_parent(self) -> Any:
-        try:
-            parent = importlib.import_module(self.modname)
-            for name in self.objpath[:-1]:
-                parent = self.get_attr(parent, name)
-
-            return parent
-        except (ImportError, AttributeError):
-            return None
-
-    def import_object(self, raiseerror: bool = False) -> bool:
-        """Never import anything."""
-        # disguise as an attribute
-        self.objtype = 'attribute'
-        self.object = INSTANCEATTR
-        self.parent = self.import_parent()
-        self._datadescriptor = False
-        return True
-
-    def add_content(self, more_content: Optional[StringList], no_docstring: bool = False
-                    ) -> None:
-        """Never try to get a docstring from the object."""
-        super().add_content(more_content, no_docstring=True)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn("%s is deprecated." % self.__class__.__name__,
+                      RemovedInSphinx50Warning, stacklevel=2)
+        super().__init__(*args, **kwargs)
 
 
 class SlotsAttributeDocumenter(AttributeDocumenter):
@@ -2441,7 +2414,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_autodocumenter(MethodDocumenter)
     app.add_autodocumenter(AttributeDocumenter)
     app.add_autodocumenter(PropertyDocumenter)
-    app.add_autodocumenter(InstanceAttributeDocumenter)
     app.add_autodocumenter(NewTypeAttributeDocumenter)
 
     app.add_config_value('autoclass_content', 'class', True, ENUM('both', 'class', 'init'))

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -88,16 +88,14 @@ def setup_documenters(app: Any) -> None:
     from sphinx.ext.autodoc import (AttributeDocumenter, ClassDocumenter, DataDocumenter,
                                     DecoratorDocumenter, ExceptionDocumenter,
                                     FunctionDocumenter, GenericAliasDocumenter,
-                                    InstanceAttributeDocumenter, MethodDocumenter,
-                                    ModuleDocumenter, NewTypeAttributeDocumenter,
-                                    NewTypeDataDocumenter, PropertyDocumenter,
-                                    SingledispatchFunctionDocumenter)
+                                    MethodDocumenter, ModuleDocumenter,
+                                    NewTypeAttributeDocumenter, NewTypeDataDocumenter,
+                                    PropertyDocumenter, SingledispatchFunctionDocumenter)
     documenters = [
         ModuleDocumenter, ClassDocumenter, ExceptionDocumenter, DataDocumenter,
         FunctionDocumenter, MethodDocumenter, NewTypeAttributeDocumenter,
-        NewTypeDataDocumenter, AttributeDocumenter, InstanceAttributeDocumenter,
-        DecoratorDocumenter, PropertyDocumenter, GenericAliasDocumenter,
-        SingledispatchFunctionDocumenter,
+        NewTypeDataDocumenter, AttributeDocumenter, DecoratorDocumenter, PropertyDocumenter,
+        GenericAliasDocumenter, SingledispatchFunctionDocumenter,
     ]  # type: List[Type[Documenter]]
     for documenter in documenters:
         app.registry.add_documenter(documenter.objtype, documenter)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
-  InstanceAttributeDocumenter is merged into AttributeDocumenter in #7946
    and #8444. So it is no longer needed now.