### PR TITLE
Use restify() to reference alias attributes in autodoc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -68,6 +68,7 @@ Bugs fixed
 * #8131: linkcheck: Use GET when HEAD requests cause Too Many Redirects, to
   accommodate infinite redirect loops on HEAD
 * #8437: Makefile: ``make clean`` with empty BUILDDIR is dangerous
+* #8493: autodoc: references to builtins not working in class aliases
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1654,16 +1654,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
     def add_content(self, more_content: Optional[StringList], no_docstring: bool = False
                     ) -> None:
         if self.doc_as_attr:
-            classname = safe_getattr(self.object, '__qualname__', None)
-            if not classname:
-                classname = safe_getattr(self.object, '__name__', None)
-            if classname:
-                module = safe_getattr(self.object, '__module__', None)
-                parentmodule = safe_getattr(self.parent, '__module__', None)
-                if module and module != parentmodule:
-                    classname = str(module) + '.' + str(classname)
-                content = StringList([_('alias of :class:`%s`') % classname], source='')
-                super().add_content(content, no_docstring=True)
+            content = StringList([_('alias of %s') % restify(self.object)], source='')
+            super().add_content(content, no_docstring=True)
         else:
             super().add_content(more_content)
 

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -806,7 +806,7 @@ def test_autodoc_inner_class(app):
         '   .. py:attribute:: Outer.factory',
         '      :module: target',
         '',
-        '      alias of :class:`builtins.dict`'
+        '      alias of :class:`dict`'
     ]
 
     actual = do_autodoc(app, 'class', 'target.Outer.Inner', options)
@@ -1704,7 +1704,7 @@ def test_autodoc_GenericAlias(app):
             '.. py:attribute:: T',
             '   :module: target.genericalias',
             '',
-            '   alias of :class:`typing.List`',
+            '   alias of :class:`List`\\ [:class:`int`]',
         ]
     else:
         assert list(actual) == [


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix
- Refactoring

### Purpose
- Alias references to builtin classes did not work correctly

### Detail
- Make use of the utility function [restify](https://github.com/sphinx-doc/sphinx/blob/e6e23aa45b9191655fb7790b0b97826ce663119a/sphinx/util/typing.py#L89) to determine the correct module path for the `:class:` reference
- Modify expected outcome of test case


Fix #8493