### PR TITLE
fix for #8491

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -1106,7 +1106,7 @@ class StandardDomain(Domain):
 
 
 def warn_missing_reference(app: "Sphinx", domain: Domain, node: pending_xref) -> bool:
-    if domain.name != 'std' or node['reftype'] != 'ref':
+    if (domain and domain.name != 'std') or node['reftype'] != 'ref':
         return None
     else:
         target = node['reftarget']


### PR DESCRIPTION
Subject: fix #8491 

### Feature or Bugfix
- Bugfix

### Purpose
- Subject: fix #8491 by checking that the `domain` argument is defined before accessing its attributes

### Detail
- #8491 is fixed by the proposed check. I am not familiar enough with sphinx to know if `domain` should never be `None`, but at least this prevent a crash.