### PR TITLE
Unset env variables in tests by del os.environ

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,4 +62,4 @@ def modify_env(**env):
             try:
                 os.environ[k] = original_env[k]
             except KeyError:
-                os.unsetenv(k)
+                del os.environ[k]


### PR DESCRIPTION
The `unsetenv()` operation does not update `os.environ`.
https://docs.python.org/3/library/os.html#os.unsetenv


### Feature or Bugfix
- Refactoring