### PR TITLE
Replace modify_env() with pytest monkeypatch.setenv()

### DIFF
--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -24,7 +24,7 @@ import requests
 from sphinx.builders.linkcheck import CheckExternalLinksBuilder, RateLimit
 from sphinx.util.console import strip_colors
 
-from .utils import CERT_FILE, http_server, https_server, modify_env
+from .utils import CERT_FILE, http_server, https_server
 
 ts_re = re.compile(r".*\[(?P<ts>.*)\].*")
 
@@ -361,8 +361,9 @@ def test_connect_to_selfsigned_with_tls_cacerts(app):
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
-def test_connect_to_selfsigned_with_requests_env_var(app):
-    with modify_env(REQUESTS_CA_BUNDLE=CERT_FILE), https_server(OKHandler):
+def test_connect_to_selfsigned_with_requests_env_var(monkeypatch, app):
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", CERT_FILE)
+    with https_server(OKHandler):
         app.builder.build_all()
 
     with open(app.outdir / 'output.json') as fp:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 import contextlib
 import http.server
-import os
 import pathlib
 import ssl
 import threading
@@ -48,18 +47,3 @@ def create_server(thread_class):
 
 http_server = create_server(HttpServerThread)
 https_server = create_server(HttpsServerThread)
-
-
-@contextlib.contextmanager
-def modify_env(**env):
-    original_env = os.environ.copy()
-    for k, v in env.items():
-        os.environ[k] = v
-    try:
-        yield
-    finally:
-        for k in env:
-            try:
-                os.environ[k] = original_env[k]
-            except KeyError:
-                del os.environ[k]


### PR DESCRIPTION
Subject: Replace modify_env() with pytest monkeypatch.setenv()

### Feature or Bugfix

- Refactoring

### Purpose

The same test utility function is built into pytest. Can avoid the duplication.

### Relates

https://docs.pytest.org/en/latest/monkeypatch.html#monkeypatching-environment-variables

