### PR TITLE
Fix #8501: autosummary: summary extraction splits text after "el at."

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,7 @@ Bugs fixed
   information of TypeVars
 * #8477: autosummary: non utf-8 reST files are generated when template contains
   multibyte characters
+* #8501: autosummary: summary extraction splits text after "el at." unexpectedly
 * #8419: html search: Do not load ``language_data.js`` in non-search pages
 * #8454: graphviz: The layout option for graph and digraph directives don't work
 * #8131: linkcheck: Use GET when HEAD requests cause Too Many Redirects, to

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -98,7 +98,7 @@ logger = logging.getLogger(__name__)
 periods_re = re.compile(r'\.(?:\s+)')
 literal_re = re.compile(r'::\s*$')
 
-WELL_KNOWN_ABBREVIATIONS = (' i.e.',)
+WELL_KNOWN_ABBREVIATIONS = ('et al.', ' i.e.',)
 
 
 # -- autosummary_toc node ------------------------------------------------------

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -97,6 +97,9 @@ def test_extract_summary(capsys):
     doc = ['Blabla, i.e. bla.']
     assert extract_summary(doc, document) == ' '.join(doc)
 
+    doc = ['Blabla, et al. bla.']
+    assert extract_summary(doc, document) == ' '.join(doc)
+
     # literal
     doc = ['blah blah::']
     assert extract_summary(doc, document) == 'blah blah.'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Add "el at." to the list of abbreviations.
- refs: #8501 