### PR TITLE
Fix #8508: LaTeX: uplatex becomes a default setting of latex_engine for Japanese

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Incompatible changes
   :confval:`man_make_section_directory`)
 * #8380: html search: search results are wrapped with ``<p>`` instead of
   ``<div>``
+* #8508: LaTeX: uplatex becomes a default setting of latex_engine for Japanese
+  documents
 
 Deprecated
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1903,8 +1903,8 @@ These options influence LaTeX output.
    * ``'pdflatex'`` -- PDFLaTeX (default)
    * ``'xelatex'`` -- XeLaTeX
    * ``'lualatex'`` -- LuaLaTeX
-   * ``'platex'`` -- pLaTeX (default if :confval:`language` is ``'ja'``)
-   * ``'uplatex'`` -- upLaTeX (experimental)
+   * ``'platex'`` -- pLaTeX
+   * ``'uplatex'`` -- upLaTeX (default if :confval:`language` is ``'ja'``)
 
    ``'pdflatex'``\ 's support for Unicode characters is limited.
 
@@ -1933,6 +1933,10 @@ These options influence LaTeX output.
    .. versionchanged:: 2.3
 
       Add ``uplatex`` support.
+
+   .. versionchanged:: 4.0
+
+      ``uplatex`` becomes the default setting of Japanese documents.
 
    Contrarily to :ref:`MathJaX math rendering in HTML output <math-support>`,
    LaTeX requires some extra configuration to support Unicode literals in

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -482,7 +482,7 @@ def install_packages_for_ja(app: Sphinx) -> None:
 def default_latex_engine(config: Config) -> str:
     """ Better default latex_engine settings for specific languages. """
     if config.language == 'ja':
-        return 'platex'
+        return 'uplatex'
     elif (config.language or '').startswith('zh'):
         return 'xelatex'
     elif config.language == 'el':

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -197,7 +197,7 @@ def test_latex_basic_manual_ja(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').read_text(encoding='utf8')
     print(result)
-    assert r'\def\sphinxdocclass{jsbook}' in result
+    assert r'\def\sphinxdocclass{ujbook}' in result
     assert r'\documentclass[letterpaper,10pt,dvipdfmx]{sphinxmanual}' in result
 
 
@@ -210,7 +210,7 @@ def test_latex_basic_howto_ja(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').read_text(encoding='utf8')
     print(result)
-    assert r'\def\sphinxdocclass{jreport}' in result
+    assert r'\def\sphinxdocclass{ujreport}' in result
     assert r'\documentclass[letterpaper,10pt,dvipdfmx]{sphinxhowto}' in result
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Since v2.3, Sphinx supports uplatex as an alternative of latex_engine for Japanese
docs (refs: #4186, #6841). uplatex is able to build a document without conversion
character encoding internally. It allows using unicode characters in documents.
Additionally, uplatex is compatible with platex (current default latex_engine for
Japanese docs).
- This changes the default latex_engine for Japanese document to uplatex.
- refs: #8508 