### PR TITLE
Allow user to use url to reference html logo & favicon

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -962,7 +962,7 @@ class StandaloneHTMLBuilder(Builder):
         if parse_result.scheme:
             ref = uri
         elif parse_result.path:
-            ref = path.basename(parse_result.path)
+            ref = path.join('_static', path.basename(parse_result.path))
         return ref
 
     # --------- these are overwritten by the serialization builder
@@ -1188,14 +1188,14 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
 
 def validate_html_logo(app: Sphinx, config: Config) -> None:
     """Check html_logo setting."""
-    if config.html_logo and not path.isfile(path.join(app.confdir, config.html_logo)):
+    if config.html_logo and not path.isfile(path.join(app.confdir, config.html_logo)) and not urlparse(config.html_logo).scheme:
         logger.warning(__('logo file %r does not exist'), config.html_logo)
         config.html_logo = None  # type: ignore
 
 
 def validate_html_favicon(app: Sphinx, config: Config) -> None:
     """Check html_favicon setting."""
-    if config.html_favicon and not path.isfile(path.join(app.confdir, config.html_favicon)):
+    if config.html_favicon and not path.isfile(path.join(app.confdir, config.html_favicon)) and not urlparse(config.html_favicon).scheme:
         logger.warning(__('favicon file %r does not exist'), config.html_favicon)
         config.html_favicon = None  # type: ignore
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1188,14 +1188,16 @@ def validate_html_static_path(app: Sphinx, config: Config) -> None:
 
 def validate_html_logo(app: Sphinx, config: Config) -> None:
     """Check html_logo setting."""
-    if config.html_logo and not path.isfile(path.join(app.confdir, config.html_logo)) and not urlparse(config.html_logo).scheme:
+    if config.html_logo and not path.isfile(path.join(app.confdir, config.html_logo)) \
+            and not urlparse(config.html_logo).scheme:
         logger.warning(__('logo file %r does not exist'), config.html_logo)
         config.html_logo = None  # type: ignore
 
 
 def validate_html_favicon(app: Sphinx, config: Config) -> None:
     """Check html_favicon setting."""
-    if config.html_favicon and not path.isfile(path.join(app.confdir, config.html_favicon)) and not urlparse(config.html_favicon).scheme:
+    if config.html_favicon and not path.isfile(path.join(app.confdir, config.html_favicon)) \
+            and not urlparse(config.html_favicon).scheme:
         logger.warning(__('favicon file %r does not exist'), config.html_favicon)
         config.html_favicon = None  # type: ignore
 

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -15,7 +15,7 @@
       <div class="header">
         {%- if logo %}
           <p class="logo"><a href="{{ pathto(master_doc)|e }}">
-            <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
+            <img class="logo" src="{{ pathto(logo, 1)|e }}" alt="Logo"/>
           </a></p>
         {%- endif %}
         {%- block headertitle %}

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -55,7 +55,7 @@
           {%- block sidebarlogo %}
           {%- if logo %}
             <p class="logo"><a href="{{ pathto(master_doc)|e }}">
-              <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
+              <img class="logo" src="{{ pathto(logo, 1)|e }}" alt="Logo"/>
             </a></p>
           {%- endif %}
           {%- endblock %}
@@ -141,7 +141,7 @@
           href="{{ pathto('_static/opensearch.xml', 1) }}"/>
     {%- endif %}
     {%- if favicon %}
-    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1)|e }}"/>
+    <link rel="shortcut icon" href="{{ pathto(favicon, 1)|e }}"/>
     {%- endif %}
     {%- endif %}
 {%- block linktags %}

--- a/sphinx/themes/basic/opensearch.xml
+++ b/sphinx/themes/basic/opensearch.xml
@@ -7,7 +7,7 @@
        template="{{ use_opensearch }}/{{ pathto('search') }}?q={searchTerms}"/>
   <LongName>{{ docstitle|e }}</LongName>
 {%- if favicon %}
-  <Image height="16" width="16" type="image/x-icon">{{ use_opensearch }}/{{ pathto('_static/' + favicon, 1)|e }}</Image>
+  <Image height="16" width="16" type="image/x-icon">{{ use_opensearch }}/{{ pathto(favicon, 1)|e }}</Image>
 {%- endif %}
 {% block extra %} {# Put e.g. an <Image> element here. #} {% endblock %}
 </OpenSearchDescription>

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -36,11 +36,11 @@
         {%- block haikuheader %}
         {%- if theme_full_logo != "false" %}
         <a href="{{ pathto('index') }}">
-          <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
+          <img class="logo" src="{{ pathto(logo, 1)|e }}" alt="Logo"/>
         </a>
         {%- else %}
         {%- if logo -%}
-          <img class="rightlogo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
+          <img class="rightlogo" src="{{ pathto(logo, 1)|e }}" alt="Logo"/>
         {%- endif -%}
         <h1 class="heading"><a href="{{ pathto('index') }}">
           <span>{{ shorttitle|e }}</span></a></h1>

--- a/sphinx/themes/pyramid/layout.html
+++ b/sphinx/themes/pyramid/layout.html
@@ -13,7 +13,7 @@
 <div class="header" role="banner">
   <div class="logo">
     <a href="{{ pathto(master_doc)|e }}">
-      <img class="logo" src="{{ pathto('_static/' + logo, 1)|e }}" alt="Logo"/>
+      <img class="logo" src="{{ pathto(logo, 1)|e }}" alt="Logo"/>
     </a>
   </div>
 </div>


### PR DESCRIPTION
Subject: Allow user to use url to reference html logo & favicon

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/devguide.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- To give user the possibility to use url to reference html logo and favicon. If a scheme is specified in the configuration file, the resource isn't copied as a a static file but simply referenced by its url.

### Detail
- html logo & favicon reference attributes are now determined when config values are processed. In html layouts, the directory `_static/` does no longer prefix the html logo & favicon reference. Instead, when checking config values, the builder add the `_static/` prefix is added if the scheme is empty. Otherwise, the config value is taken as the reference. 
- It could impact users who use custom html layouts

### Relates
- Closes #2018

This is my first contribution, so don't hesitate to tell me if I'm doing it wrong
