### PR TITLE
Support testing from read-only filesystems

### DIFF
--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -98,6 +98,15 @@ class path(str):
             pointed to by the symbolic links are copied.
         """
         shutil.copytree(self, destination, symlinks=symlinks)
+        # If source tree is marked read-only (e.g. because it is on a read-only
+        # filesystem), `shutil.copytree` will mark the destination as read-only
+        # as well.  To avoid failures when adding additional files/directories
+        # to the destination tree, ensure destination directories are not marked
+        # read-only.
+        for root, dirs, files in os.walk(destination):
+            os.chmod(root, 0o755)
+            for name in files:
+                os.chmod(os.path.join(root, name), 0o644)
 
     def movetree(self, destination: str) -> None:
         """


### PR DESCRIPTION
Currently, tests fail if run from a read-only filesystem because the temporary directory trees copied from the source tree are marked read-only by shutil.copytree.

This change fixes that by ensuring directories created `sphinx.testing.path.copytree` are always writable.
