### PR TITLE
Fix nonascii_srcdir to work when non-ascii directories aren't supported

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -37,6 +37,8 @@ def nonascii_srcdir(request, rootdir, sphinx_test_tempdir):
             (rootdir / 'test-root').copytree(srcdir)
     except UnicodeEncodeError:
         srcdir = basedir / 'all'
+        if not srcdir.exists():
+            (rootdir / 'test-root').copytree(srcdir)
     else:
         # add a doc with a non-ASCII file name to the source dir
         (srcdir / (test_name + '.txt')).write_text(dedent("""


### PR DESCRIPTION
Previously, the nonascii_srcdir in tests/test_build.py contained some
logic to attempt to handle the case where non-ascii directories aren't
supported, but it did not actually work because it fails to copy the
test sources to the temporary directory.

With this commit, the following test invocation, which previously
failed, now pases:

LANG=en_US.iso8859-1 python -m pytest test_build.py
