### PR TITLE
Prevent page brake in the middle of a `seealso` 

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -813,7 +813,8 @@ class LaTeXTranslator(SphinxTranslator):
         pass
 
     def visit_seealso(self, node: Element) -> None:
-        self.body.append('\n\n\\sphinxstrong{%s:}\n\\nopagebreak\n\n' % admonitionlabels['seealso'])
+        self.body.append('\n\n\\sphinxstrong{%s:}\n\\nopagebreak\n\n'
+                         % admonitionlabels['seealso'])
 
     def depart_seealso(self, node: Element) -> None:
         self.body.append("\n\n")

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -813,7 +813,7 @@ class LaTeXTranslator(SphinxTranslator):
         pass
 
     def visit_seealso(self, node: Element) -> None:
-        self.body.append('\n\n\\sphinxstrong{%s:}\n\n' % admonitionlabels['seealso'])
+        self.body.append('\n\n\\sphinxstrong{%s:}\n\\nopagebreak\n\n' % admonitionlabels['seealso'])
 
     def depart_seealso(self, node: Element) -> None:
         self.body.append("\n\n")


### PR DESCRIPTION
Subject: Prevent page brake in the middle of a `seealso`

### Feature or Bugfix
- Bugfix

### Purpose
- Minor change to improve the quality of latex output.

### Detail
`seealso` directives usually contain short content. It looks bad when the "See also:" strong text is alone at the end of a page and the associated content is at the top of the next one.

