### PR TITLE
Fix AliasNode.copy()

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3452,7 +3452,8 @@ class AliasNode(nodes.Element):
             self.parentKey = parentKey
 
     def copy(self: T) -> T:
-        return self.__class__(self.sig, env=None, parentKey=self.parentKey)  # type: ignore
+        return self.__class__(self.sig, self.maxdepth, self.document,
+                              env=None, parentKey=self.parentKey)  # type: ignore
 
 
 class AliasTransform(SphinxTransform):

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3451,9 +3451,9 @@ class AliasNode(nodes.Element):
             assert parentKey is not None
             self.parentKey = parentKey
 
-    def copy(self: T) -> T:
+    def copy(self) -> 'AliasNode':
         return self.__class__(self.sig, self.maxdepth, self.document,
-                              env=None, parentKey=self.parentKey)  # type: ignore
+                              env=None, parentKey=self.parentKey)
 
 
 class AliasTransform(SphinxTransform):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
The changed args in the constructor are not reflected in the copy function.

In the openSUSE build this manifests when building Sphinx' own docs as manpages with the very unspecific error message:

```
[  208s] writing... sphinx-all.1 { usage/index usage/quickstart usage/installation usage/restructuredtext/index usage/restructuredtext/basics usage/restructuredtext/roles usage/restructuredtext/directives usage/restructuredtext/field-lists usage/restructuredtext/domains failed
[  208s] 
[  208s] Warning, treated as error:
[  208s] /home/abuild/rpmbuild/BUILD/Sphinx-3.3.1/doc/contents.rst:toctree contains ref to nonexisting file 'usage/index'
```

With `-vvv` I managed to observe the relevant backtrace:

```
[   30s] looking for now-outdated files... [app] emitting event: 'env-get-updated'(<sphinx.environment.BuildEnvironment object at 0x7f99ab401b00>,)
[   30s] none found
[   31s] writing... sphinx-all.1 { usage/index usage/quickstart usage/installation usage/restructuredtext/index usage/restructuredtext/basics usage/restructuredtext/roles usage/restructuredtext/directives usage/restructuredtext/field-lists usage/restructuredtext/domains failed
[   31s] [app] emitting event: 'build-finished'(SphinxWarning("/home/abuild/rpmbuild/BUILD/Sphinx-3.3.1/doc/contents.rst:toctree contains ref to no
[   31s] 
[   31s] Traceback (most recent call last):
[   31s]   File "/home/abuild/rpmbuild/BUILD/Sphinx-3.3.1/sphinx/util/nodes.py", line 426, in inline_all_toctrees
[   31s]     colorfunc, traversed)
[   31s]   File "/home/abuild/rpmbuild/BUILD/Sphinx-3.3.1/sphinx/util/nodes.py", line 415, in inline_all_toctrees
[   31s]     tree = cast(nodes.document, tree.deepcopy())
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in deepcopy
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1074, in <listcomp>
[   31s]     copy.extend([child.deepcopy() for child in self.children])
[   31s]   File "/usr/lib/python3.6/site-packages/docutils/nodes.py", line 1073, in deepcopy
[   31s]     copy = self.copy()
[   31s]   File "/home/abuild/rpmbuild/BUILD/Sphinx-3.3.1/sphinx/domains/c.py", line 3460, in copy
[   31s]     return self.__class__(self.sig, env=None, parentKey=self.parentKey)  # type: ignore
[   31s] TypeError: __init__() missing 2 required positional arguments: 'maxdepth' and 'document'
[   31s] 
```