### PR TITLE
fix #8522: sphinx could lead to `__bool__` method call, what can lead to side effect or direct failure in case it generate an error bug 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -97,8 +97,8 @@ Features added
 
 Bugs fixed
 ----------
-* #8522: ``__bool__`` method isn't called now by autodoc module, so it won't lead to
-side effect or direct failure in case it generate an error.
+* #8522: ``__bool__`` method isn't called now by autodoc module, so it won't
+    lead to side effect or direct failure in case it generate an error.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -98,7 +98,7 @@ Features added
 Bugs fixed
 ----------
 * #8522: ``__bool__`` method isn't called now by autodoc module, so it won't
-    lead to side effect or direct failure in case it generate an error.
+    lead to side effect or direct failure in case it generates an error.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,5 @@
 Release 3.4.0 (in development)
 ==============================
-
 Dependencies
 ------------
 
@@ -98,6 +97,8 @@ Features added
 
 Bugs fixed
 ----------
+* #8522: ``__bool__`` method isn't called now by autodoc module, so it won't lead to
+side effect or direct failure in case it generate an error.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Release 3.4.0 (in development)
 ==============================
+
 Dependencies
 ------------
 
@@ -76,6 +77,7 @@ Bugs fixed
   accommodate infinite redirect loops on HEAD
 * #8437: Makefile: ``make clean`` with empty BUILDDIR is dangerous
 * #8352: std domain: Failed to parse an option that starts with bracket
+* #8522: fix ``__bool__`` method could be called by autodoc module.
 
 Testing
 --------
@@ -97,8 +99,6 @@ Features added
 
 Bugs fixed
 ----------
-* #8522: ``__bool__`` method isn't called now by autodoc module, so it won't
-    lead to side effect or direct failure in case it generates an error.
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -716,7 +716,7 @@ class Documenter:
                 isprivate = membername.startswith('_')
 
             keep = False
-            if safe_getattr(member, '__sphinx_mock__', False):
+            if safe_getattr(member, '__sphinx_mock__', None) is not None:
                 # mocked module or object
                 pass
             elif self.options.exclude_members and membername in self.options.exclude_members:


### PR DESCRIPTION
Subject: fix #8522.

### Feature or Bugfix
- Bugfix

### Purpose
Prevent user code execution, see examples in #8522.
