### PR TITLE
sphinx/themes/basic/layout: Set url_root properly on index, don't use '#'

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -18,7 +18,7 @@
 {%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and
                          (sidebars != []) %}
 {%- set url_root = pathto('', 1) %}
-{# XXX necessary? #}
+{# URL root should never be #, then all links are fragments #}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
 {%- if not embedded and docstitle %}
   {%- set titlesuffix = " &#8212; "|safe + docstitle|e %}
@@ -88,7 +88,7 @@
 {%- endmacro %}
 
 {%- macro script() %}
-    <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+    <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for js in script_files %}
     {{ js_tag(js) }}
     {%- endfor %}


### PR DESCRIPTION
- url_root is set to `#` on the index page, which layout.html tries to
  change back to `''` (the empty string).
- But, this updated url_root wasn't used in the actual location, as an
  argument to `documentation_options.js`.
- Thus, clever enough templates, which tried to use
  `$DOCUMENTATION_OPTIONS.URL_ROOT` inside javascript would fail.
  This was manifested as broken links, which led to this issue:
  https://github.com/executablebooks/sphinx-copybutton/issues/110
- I have eventually traced that back to sphinx itself, and found that
  layout.html tried to fix the problem, but the fixed value wasn't
  used.
- This fix works in my basic test, but I will continue with more tests.
- Review:
  - someone more clever should examine this and make sure it makes
    sense
  - This does not have tests.  Should it?