### PR TITLE
refactor: pretty change for isproperty()

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -355,7 +355,7 @@ def iscoroutinefunction(obj: Any) -> bool:
 
 def isproperty(obj: Any) -> bool:
     """Check if the object is property."""
-    if sys.version_info > (3, 8):
+    if sys.version_info >= (3, 8):
         from functools import cached_property  # cached_property is available since py3.8
         if isinstance(obj, cached_property):
             return True


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- It is more readable to use `>=` to compare versions.
- refs: https://github.com/sphinx-doc/sphinx/commit/088b04917033f142b9e9830a2dca86f8d3bc95f1#r44691513