### PR TITLE
C, fix AliasNode.copy

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #8520: C, fix copying of AliasNode.
+
 Testing
 --------
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3456,9 +3456,9 @@ class AliasNode(nodes.Element):
             assert parentKey is not None
             self.parentKey = parentKey
 
-    def copy(self: T) -> T:
+    def copy(self) -> 'AliasNode':
         return self.__class__(self.sig, self.maxdepth, self.document,
-                              env=None, parentKey=self.parentKey)  # type: ignore
+                              env=None, parentKey=self.parentKey)
 
 
 class AliasTransform(SphinxTransform):

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3457,7 +3457,8 @@ class AliasNode(nodes.Element):
             self.parentKey = parentKey
 
     def copy(self: T) -> T:
-        return self.__class__(self.sig, env=None, parentKey=self.parentKey)  # type: ignore
+        return self.__class__(self.sig, self.maxdepth, self.document,
+                              env=None, parentKey=self.parentKey)  # type: ignore
 
 
 class AliasTransform(SphinxTransform):

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7055,8 +7055,8 @@ class AliasNode(nodes.Element):
             assert parentKey is not None
             self.parentKey = parentKey
 
-    def copy(self: T) -> T:
-        return self.__class__(self.sig, env=None, parentKey=self.parentKey)  # type: ignore
+    def copy(self) -> 'AliasNode':
+        return self.__class__(self.sig, env=None, parentKey=self.parentKey)
 
 
 class AliasTransform(SphinxTransform):


### PR DESCRIPTION
PR #8520 rebased to 3.3.x, and with type fix in the C++ equivalent.