### PR TITLE
refactor: Deprecate `no_docstring` argument for Documenter.add_content()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Deprecated
 ----------
 
 * The ``follow_wrapped`` argument of ``sphinx.util.inspect.signature()``
+* The ``no_docstring`` argument of
+  ``sphinx.ext.autodoc.Documenter.add_content()``
 * ``sphinx.ext.autodoc.Documenter.get_object_members()``
 * ``sphinx.ext.autodoc.DataDeclarationDocumenter``
 * ``sphinx.ext.autodoc.GenericAliasDocumenter``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -31,6 +31,12 @@ The following is a list of deprecated interfaces.
      - 5.0
      - N/A
 
+   * - The ``no_docstring`` argument of
+       ``sphinx.ext.autodoc.Documenter.add_content()``
+     - 3.4
+     - 5.0
+     - ``sphinx.ext.autodoc.Documenter.get_doc()``
+
    * - ``sphinx.ext.autodoc.Documenter.get_object_members()``
      - 3.4
      - 6.0


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- This deprecates `no_docstring` argument for Documenter.add_content().
After this change, please use Documenter.get_doc() to control (suppress)
the content of the python object.
