### PR TITLE
change from apt to pip for debian and ubuntu

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -31,7 +31,8 @@ Install either ``python3-sphinx`` using :command:`apt-get`:
 
 ::
 
-   $ apt-get install python3-sphinx
+   $ apt-get install python3-pip
+   $ pip3 install sphinx
 
 If it not already present, this will install Python for you.
 


### PR DESCRIPTION
sphinx in apt is old
````bash
apt search python3-sphinx
Sorting... Done
Full Text Search... Done
 
python3-sphinx/focal 1.8.5-7ubuntu3 all
  documentation generator for Python projects (implemented in Python 3)

```` 
