### PR TITLE
Fix #8549: i18n: ``-D gettext_compact=0`` is no longer working

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -87,6 +87,7 @@ Bugs fixed
 * #8501: autosummary: summary extraction splits text after "el at." unexpectedly
 * #8524: html: Wrong url_root has been generated on a document named "index"
 * #8419: html search: Do not load ``language_data.js`` in non-search pages
+* #8549: i18n: ``-D gettext_compact=0`` is no longer working
 * #8454: graphviz: The layout option for graph and digraph directives don't work
 * #8131: linkcheck: Use GET when HEAD requests cause Too Many Redirects, to
   accommodate infinite redirect loops on HEAD

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -315,7 +315,7 @@ class MessageCatalogBuilder(I18nBuilder):
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_builder(MessageCatalogBuilder)
 
-    app.add_config_value('gettext_compact', True, 'gettext', Any)
+    app.add_config_value('gettext_compact', True, 'gettext', {bool, str})
     app.add_config_value('gettext_location', True, 'gettext')
     app.add_config_value('gettext_uuid', False, 'gettext')
     app.add_config_value('gettext_auto_build', True, 'env')

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -180,6 +180,14 @@ class Config:
             defvalue = self.values[name][0]
             if self.values[name][2] == Any:
                 return value
+            elif self.values[name][2] == {bool, str}:
+                if value == '0':
+                    # given falsy string from command line option
+                    return False
+                elif value == '1':
+                    return True
+                else:
+                    return value
             elif type(defvalue) is bool or self.values[name][2] == [bool]:
                 if value == '0':
                     # given falsy string from command line option


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 1bf7fe424, ``-D gettext_compact=0`` is not treated as disabling
the feature.  It is recognized as creating ``0.pot`` because its type is
Any.  This changes it to `[bool, str]`.
- refs: #8549 