### PR TITLE
Fix #8559: AttributeError is raised when using ForwardRef

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #8559: autodoc: AttributeError is raised when using forward-reference type
+  annotations
+
 Testing
 --------
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -153,6 +153,8 @@ def _restify_py37(cls: Optional["Type"]) -> str:
             return ':obj:`%s`' % cls._name
         else:
             return ':obj:`%s.%s`' % (cls.__module__, cls._name)
+    elif isinstance(cls, ForwardRef):
+        return ':class:`%s`' % cls.__forward_arg__
     else:
         # not a class (ex. TypeVar)
         return ':obj:`%s.%s`' % (cls.__module__, cls.__name__)

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -109,6 +109,12 @@ def test_restify_type_hints_alias():
     assert restify(MyTuple) == ":class:`Tuple`\\ [:class:`str`, :class:`str`]"  # type: ignore
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='python 3.7+ is required.')
+def test_restify_type_ForwardRef():
+    from typing import ForwardRef  # type: ignore
+    assert restify(ForwardRef("myint")) == ":class:`myint`"
+
+
 def test_restify_broken_type_hints():
     assert restify(BrokenType) == ':class:`tests.test_util_typing.BrokenType`'
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The restify() helper crashes when ForwardRef is passed.
- refs: #8559 