### PR TITLE
Fixes #8568. Ignore TypeError from getslots in isslotsattribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #8559: autodoc: AttributeError is raised when using forward-reference type
   annotations
+* #8568: autodoc: TypeError is raised on checking slots attribute
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2114,7 +2114,7 @@ class SlotsMixin(DataDocumenterMixinBase):
                 return True
             else:
                 return False
-        except (AttributeError, ValueError):
+        except (AttributeError, ValueError, TypeError):
             return False
 
     def import_object(self, raiseerror: bool = False) -> bool:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -187,6 +187,7 @@ def getslots(obj: Any) -> Optional[Dict]:
 
     Return None if gienv *obj* does not have __slots__.
     Raises AttributeError if given *obj* raises an error on accessing __slots__.
+    Raises TypeError if given *obj* is not a class.
     Raises ValueError if given *obj* have invalid __slots__.
     """
     if not inspect.isclass(obj):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Same as #8569 
- A cherry-picked version toward 3.4.x branch