### PR TITLE
Fix #8567: autodoc: Instance attributes are incorrectly added to Parent class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Bugs fixed
 * #8559: autodoc: AttributeError is raised when using forward-reference type
   annotations
 * #8568: autodoc: TypeError is raised on checking slots attribute
+* #8567: autodoc: Instance attributes are incorrectly added to Parent class
 
 Testing
 --------

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -690,6 +690,7 @@ def test_autodoc_special_members(app):
     actual = do_autodoc(app, 'class', 'target.Class', options)
     assert list(filter(lambda l: '::' in l, actual)) == [
         '.. py:class:: Class(arg)',
+        '   .. py:attribute:: Class.__annotations__',
         '   .. py:attribute:: Class.__dict__',
         '   .. py:method:: Class.__init__(arg)',
         '   .. py:attribute:: Class.__module__',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The instance attributes on subclasses are shown on the document of
parent class unexpectedly because of autodoc modifies `__annotations__`
in place.  This fix creates a copy of `__annotations__` attribute and
attach it to the subclass.
- refs: #8567 