### PR TITLE
Fix name of the Hebrew language in test_create_single_index

### DIFF
--- a/tests/test_environment_indexentries.py
+++ b/tests/test_environment_indexentries.py
@@ -23,7 +23,7 @@ def test_create_single_index(app):
             ".. index:: Sphinx\n"
             ".. index:: Ель\n"
             ".. index:: ёлка\n"
-            ".. index:: ‏תירבע‎\n"
+            ".. index:: ‏עברית‎\n"
             ".. index:: 9-symbol\n"
             ".. index:: &-symbol\n"
             ".. index:: £100\n")
@@ -41,7 +41,9 @@ def test_create_single_index(app):
     assert index[4] == ('Е',
                         [('ёлка', [[('', '#index-6')], [], None]),
                          ('Ель', [[('', '#index-5')], [], None])])
-    assert index[5] == ('ת', [('‏תירבע‎', [[('', '#index-7')], [], None])])
+    # Here the word starts with U+200F RIGHT-TO-LEFT MARK, which should be
+    # ignored when getting the first letter.
+    assert index[5] == ('ע', [('‏עברית‎', [[('', '#index-7')], [], None])])
 
 
 @pytest.mark.sphinx('dummy', freshenv=True)


### PR DESCRIPTION
I was the author of that test back in 2017 (see commit 73cd4b038a95271d). However, somehow I got the name of Hebrew language reversed. Maybe my editor did not support RTL languages properly at that time. Since then I learnt the Hebrew alphabet so I noticed this mistake :)

The correct name is `עברית`, where `ע` is the first letter (on the right) and `ת` is the last letter (on the left).

The test is testing the logic in `sphinx.environment.adapters.indexentries module` that skips the first character in the index key if it is U+200F RIGHT-TO-LEFT MARK. So the key here is, character by character:

Position | Unicode symbol            | Letter
-------- | --------------            | ------
0        | U+200F RIGHT-TO-LEFT MARK |
1        | U+05E2 HEBREW LETTER AYIN | `    ע`
2        | U+05D1 HEBREW LETTER BET  | `   ב `
3        | U+05E8 HEBREW LETTER RESH | `  ר  `
4        | U+05D9 HEBREW LETTER YOD  | ` י   `
5        | U+05EA HEBREW LETTER TAV  | `ת    `
6        | U+200E LEFT-TO-RIGHT MARK |

The LEFT-TO-RIGHT MARK is put here just in case, to prevent potential rendering issues of the test file in various editors.

Now I have verified using hexdump that the bytes really match the above table.