### PR TITLE
Ensure linkcheck items are comparable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Bugs fixed
   annotations
 * #8568: autodoc: TypeError is raised on checking slots attribute
 * #8567: autodoc: Instance attributes are incorrectly added to Parent class
+* #8565: linkcheck: Fix PriorityQueue crash when link tuples are not
+  comparable
 
 Testing
 --------

--- a/tests/roots/test-linkcheck-localserver-two-links/conf.py
+++ b/tests/roots/test-linkcheck-localserver-two-links/conf.py
@@ -1,0 +1,1 @@
+exclude_patterns = ['_build']

--- a/tests/roots/test-linkcheck-localserver-two-links/index.rst
+++ b/tests/roots/test-linkcheck-localserver-two-links/index.rst
@@ -1,0 +1,6 @@
+.. image:: http://localhost:7777/
+   :target: http://localhost:7777/
+
+`weblate.org`_
+
+.. _weblate.org: http://localhost:7777/

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -573,3 +573,40 @@ def test_limit_rate_bails_out_after_waiting_max_time(app):
     checker.rate_limits = {"localhost": RateLimit(90.0, 0.0)}
     next_check = checker.limit_rate(FakeResponse())
     assert next_check is None
+
+
+@pytest.mark.sphinx(
+    'linkcheck', testroot='linkcheck-localserver-two-links', freshenv=True,
+)
+def test_priorityqueue_items_are_comparable(app):
+    with http_server(OKHandler):
+        app.builder.build_all()
+    content = (app.outdir / 'output.json').read_text()
+    rows = [json.loads(x) for x in sorted(content.splitlines())]
+    assert rows == [
+        {
+            'filename': 'index.rst',
+            # Should not be None.
+            'lineno': 0,
+            'status': 'working',
+            'code': 0,
+            'uri': 'http://localhost:7777/',
+            'info': '',
+        },
+        {
+            'filename': 'index.rst',
+            'lineno': 0,
+            'status': 'working',
+            'code': 0,
+            'uri': 'http://localhost:7777/',
+            'info': '',
+        },
+        {
+            'filename': 'index.rst',
+            'lineno': 4,
+            'status': 'working',
+            'code': 0,
+            'uri': 'http://localhost:7777/',
+            'info': '',
+        }
+    ]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Fixes an issue when a document contains two links to the same URL, one with
an int line number and the other without line number metadata (such as an
image :target: attribute).

### Details
Linkcheck organizes the URLs to checks in a PriorityQueue. The items are
tuples (priority, url, docname, lineno).

Tuples where the lineno is `None` are not comparable with tuples that have
an integer lineno, and PriorityQueue items must be comparable (see
https://bugs.python.org/issue31145).

Using 0 instead of None to represent no line number should not lead to
observable changes, the result logger only logs the line number when it is
truthy.

### Relates
Close #8565