### PR TITLE
Fix #8566: autodoc-process-docstring is emitted to the alias classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Bugs fixed
   annotations
 * #8568: autodoc: TypeError is raised on checking slots attribute
 * #8567: autodoc: Instance attributes are incorrectly added to Parent class
+* #8566: autodoc: The ``autodoc-process-docstring`` event is emitted to the
+  alias classes unexpectedly
 * #8565: linkcheck: Fix PriorityQueue crash when link tuples are not
   comparable
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -587,10 +587,12 @@ class Documenter:
     def add_content(self, more_content: Optional[StringList], no_docstring: bool = False
                     ) -> None:
         """Add content from docstrings, attribute documentation and user."""
-        if no_docstring:
-            warnings.warn("The 'no_docstring' argument to %s.add_content() is deprecated."
-                          % self.__class__.__name__,
-                          RemovedInSphinx50Warning, stacklevel=2)
+        # Suspended temporarily (see https://github.com/sphinx-doc/sphinx/pull/8533)
+        #
+        # if no_docstring:
+        #     warnings.warn("The 'no_docstring' argument to %s.add_content() is deprecated."
+        #                   % self.__class__.__name__,
+        #                   RemovedInSphinx50Warning, stacklevel=2)
 
         # set sourcename and add content from attribute documentation
         sourcename = self.get_sourcename()
@@ -1661,8 +1663,9 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
                     ) -> None:
         if self.doc_as_attr:
             more_content = StringList([_('alias of %s') % restify(self.object)], source='')
-
-        super().add_content(more_content)
+            super().add_content(more_content, no_docstring=True)
+        else:
+            super().add_content(more_content)
 
     def document_members(self, all_members: bool = False) -> None:
         if self.doc_as_attr:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- On the refactoring of Documenter.add_content() method, the
autodoc-process-docstring event is emitted to the alias classes (called
as doc_as_attr in our code) unexpectedly.  Before the change, it has
never been emitted.
- The event causes that extensions (ex. numpydoc) confused.  So this
reverts the change temporarily (during 3.4.x).
- refs: https://github.com/sphinx-doc/sphinx/pull/8533, #8566