### PR TITLE
Fix #8583: autodoc: Unnecessary object comparision via ``__eq__`` method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Bugs fixed
 * #8567: autodoc: Instance attributes are incorrectly added to Parent class
 * #8566: autodoc: The ``autodoc-process-docstring`` event is emitted to the
   alias classes unexpectedly
+* #8583: autodoc: Unnecessary object comparision via ``__eq__`` method
 * #8565: linkcheck: Fix PriorityQueue crash when link tuples are not
   comparable
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1829,7 +1829,7 @@ class UninitializedGlobalVariableMixin(DataDocumenterMixinBase):
                 return False
 
     def should_suppress_value_header(self) -> bool:
-        return (self.object == UNINITIALIZED_ATTR or
+        return (self.object is UNINITIALIZED_ATTR or
                 super().should_suppress_value_header())
 
     def get_doc(self, encoding: str = None, ignore: int = None) -> List[List[str]]:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It should be compared by `is` keyword instead.
- refs: #8583 