### PR TITLE
Fix #741: autodoc: inherited-members doesn't support instance attributes on super class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #741: autodoc: inherited-members doesn't work for instance attributes on super
+  class
+
 Testing
 --------
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It was fixed once, but it does not work expectedly on running Sphinx
from command line.  It only works fine on test script because
:inherited-members: option is recognized as expected.
- This fixes the option_spec handler and autodoc itself.
- refs: #8548
