### PR TITLE
refactor: Deprecate AttributeDocumenter.isinstanceattribute()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.ext.autodoc.AttributeDocumenter.isinstanceattribute()``
 * ``sphinx.ext.autodoc.importer.get_module_members()``
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.ext.autodoc.AttributeDocumenter.isinstanceattribute()``
+     - 3.5
+     - 5.0
+     - N/A
+
    * - ``sphinx.ext.autodoc.importer.get_module_members()``
      - 3.5
      - 5.0

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2362,6 +2362,8 @@ class AttributeDocumenter(GenericAliasMixin, NewTypeMixin, SlotsMixin,  # type: 
 
     def isinstanceattribute(self) -> bool:
         """Check the subject is an instance attribute."""
+        warnings.warn('AttributeDocumenter.isinstanceattribute() is deprecated.',
+                      RemovedInSphinx50Warning)
         # uninitialized instance variable (PEP-526)
         with mock(self.config.autodoc_mock_imports):
             try:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
