### PR TITLE
Close #8619: html: kbd role generates customizable HTML tags for compound keys

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Features added
 * #8022: autodoc: autodata and autoattribute directives does not show right-hand
   value of the variable if docstring contains ``:meta hide-value:`` in
   info-field-list
+* #8619: html: kbd role generates customizable HTML tags for compound keys
 * #8132: Add :confval:`project_copyright` as an alias of :confval:`copyright`
 
 Bugs fixed

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -28,7 +28,7 @@ class KeyboardTransform(SphinxPostTransform):
 
     After::
 
-        <literal class="kbd">
+        <literal class="kbd compound">
             <literal class="kbd">
                 Control
             -
@@ -46,6 +46,7 @@ class KeyboardTransform(SphinxPostTransform):
             if len(parts) == 1:
                 continue
 
+            node['classes'].append('compound')
             node.pop()
             while parts:
                 key = parts.pop(0)

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -244,7 +244,7 @@ def get_verifier(verify, verify_re):
         # kbd role
         'verify',
         ':kbd:`Control+X`',
-        ('<p><kbd class="kbd docutils literal notranslate">'
+        ('<p><kbd class="kbd compound docutils literal notranslate">'
          '<kbd class="kbd docutils literal notranslate">Control</kbd>'
          '+'
          '<kbd class="kbd docutils literal notranslate">X</kbd>'
@@ -255,7 +255,7 @@ def get_verifier(verify, verify_re):
         # kbd role
         'verify',
         ':kbd:`M-x  M-s`',
-        ('<p><kbd class="kbd docutils literal notranslate">'
+        ('<p><kbd class="kbd compound docutils literal notranslate">'
          '<kbd class="kbd docutils literal notranslate">M</kbd>'
          '-'
          '<kbd class="kbd docutils literal notranslate">x</kbd>'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #8619 