### PR TITLE
Fix #8618: html: incorrect HTML for single compound-kdb separators

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ Bugs fixed
 * #8594: autodoc: empty __all__ attribute is ignored
 * #8306: autosummary: mocked modules are documented as empty page when using
   :recursive: option
+* #8618: html: kbd role produces incorrect HTML when compound-key separators (-,
+  + or ^) are used as keystrokes
 * #8094: texinfo: image files on the different directory with document are not
   copied
 

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -37,7 +37,7 @@ class KeyboardTransform(SphinxPostTransform):
     """
     default_priority = 400
     builders = ('html',)
-    pattern = re.compile(r'(-|\+|\^|\s+)')
+    pattern = re.compile(r'(?<=.)(-|\+|\^|\s+)(?=.)')
 
     def run(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -254,6 +254,17 @@ def get_verifier(verify, verify_re):
     (
         # kbd role
         'verify',
+        ':kbd:`Alt+^`',
+        ('<p><kbd class="kbd docutils literal notranslate">'
+         '<kbd class="kbd docutils literal notranslate">Alt</kbd>'
+         '+'
+         '<kbd class="kbd docutils literal notranslate">^</kbd>'
+         '</kbd></p>'),
+        '\\sphinxkeyboard{\\sphinxupquote{Alt+\\textasciicircum{}}}',
+    ),
+    (
+        # kbd role
+        'verify',
         ':kbd:`M-x  M-s`',
         ('<p><kbd class="kbd docutils literal notranslate">'
          '<kbd class="kbd docutils literal notranslate">M</kbd>'
@@ -265,6 +276,13 @@ def get_verifier(verify, verify_re):
          '<kbd class="kbd docutils literal notranslate">s</kbd>'
          '</kbd></p>'),
         '\\sphinxkeyboard{\\sphinxupquote{M\\sphinxhyphen{}x  M\\sphinxhyphen{}s}}',
+    ),
+    (
+        # kbd role
+        'verify',
+        ':kbd:`-`',
+        '<p><kbd class="kbd docutils literal notranslate">-</kbd></p>',
+        '\\sphinxkeyboard{\\sphinxupquote{\\sphinxhyphen{}}}',
     ),
     (
         # non-interpolation of dashes in option role


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8618 