### PR TITLE
Fix #8616: autodoc: AttributeError when non-class is passed to autoclass

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #8164: autodoc: Classes that inherit mocked class are not documented
+* #8616: autodoc: AttributeError is raised on non-class object is passed to
+  autoclass directive
 
 Testing
 --------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1662,7 +1662,11 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
     def add_content(self, more_content: Optional[StringList], no_docstring: bool = False
                     ) -> None:
         if self.doc_as_attr:
-            more_content = StringList([_('alias of %s') % restify(self.object)], source='')
+            try:
+                more_content = StringList([_('alias of %s') % restify(self.object)], source='')
+            except AttributeError:
+                pass  # Invalid class object is passed.
+
             super().add_content(more_content, no_docstring=True)
         else:
             super().add_content(more_content)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 3.4.0, AttributeError is raised when non-class object is passed to
the autoclass directive.  It has built successfully before 3.4.0
release.  So this handles the exception on generating "alias" text.
- refs: #8616
