### PR TITLE
Fix #8315: autodoc: Failed to resolve struct.Struct type annotation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Bugs fixed
   class
 * #8592: autodoc: ``:meta public:`` does not effect to variables
 * #8594: autodoc: empty __all__ attribute is ignored
+* #8315: autodoc: Failed to resolve struct.Struct type annotation
 * #8306: autosummary: mocked modules are documented as empty page when using
   :recursive: option
 * #8094: texinfo: image files on the different directory with document are not

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -10,6 +10,7 @@
 
 import sys
 import typing
+from struct import Struct
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, TypeVar, Union
 
 from docutils import nodes
@@ -94,6 +95,9 @@ def restify(cls: Optional["Type"]) -> str:
         return ':obj:`None`'
     elif cls is Ellipsis:
         return '...'
+    elif cls is Struct:
+        # Before Python 3.9, struct.Struct class has incorrect __module__.
+        return ':class:`struct.Struct`'
     elif inspect.isNewType(cls):
         return ':class:`%s`' % cls.__name__
     elif cls.__module__ in ('__builtin__', 'builtins'):
@@ -305,6 +309,9 @@ def stringify(annotation: Any) -> str:
         return annotation.__qualname__
     elif annotation is Ellipsis:
         return '...'
+    elif annotation is Struct:
+        # Before Python 3.9, struct.Struct class has incorrect __module__.
+        return 'struct.Struct'
 
     if sys.version_info >= (3, 7):  # py37+
         return _stringify_py37(annotation)

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -10,6 +10,7 @@
 
 import sys
 from numbers import Integral
+from struct import Struct
 from typing import (Any, Callable, Dict, Generator, List, NewType, Optional, Tuple, TypeVar,
                     Union)
 
@@ -43,6 +44,7 @@ def test_restify():
     assert restify(str) == ":class:`str`"
     assert restify(None) == ":obj:`None`"
     assert restify(Integral) == ":class:`numbers.Integral`"
+    assert restify(Struct) == ":class:`struct.Struct`"
     assert restify(Any) == ":obj:`Any`"
 
 
@@ -124,6 +126,7 @@ def test_stringify():
     assert stringify(str) == "str"
     assert stringify(None) == "None"
     assert stringify(Integral) == "numbers.Integral"
+    assert restify(Struct) == ":class:`struct.Struct`"
     assert stringify(Any) == "Any"
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The builtin module, ``struct.Struct`` does not have correct module
name since Python 3.8.  This allows to refer it automatically.
- refs: #8315 