### PR TITLE
Close #5977: :var: field do not create a cross-reference …

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Incompatible changes
   ``<div>``
 * #8508: LaTeX: uplatex becomes a default setting of latex_engine for Japanese
   documents
+* #5977: py domain: ``:var:``, ``:cvar:`` and ``:ivar:`` fields do not create
+  cross-references
 
 Deprecated
 ----------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -354,7 +354,7 @@ class PyObject(ObjectDescription):
                             'keyword', 'kwarg', 'kwparam'),
                      typerolename='class', typenames=('paramtype', 'type'),
                      can_collapse=True),
-        PyTypedField('variable', label=_('Variables'), rolename='obj',
+        PyTypedField('variable', label=_('Variables'),
                      names=('var', 'ivar', 'cvar'),
                      typerolename='class', typenames=('vartype',),
                      can_collapse=True),

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -852,14 +852,12 @@ def test_info_field_list_var(app):
 
     # :var int attr:
     assert_node(doctree[1][1][0][0][1][0],
-                ([pending_xref, addnodes.literal_strong, "attr"],
+                ([addnodes.literal_strong, "attr"],
                  " (",
                  [pending_xref, addnodes.literal_emphasis, "int"],
                  ")",
                  " -- ",
                  "blah blah"))
-    assert_node(doctree[1][1][0][0][1][0][0], pending_xref,
-                refdomain="py", reftype="obj", reftarget="attr", **{"py:class": "Class"})
     assert_node(doctree[1][1][0][0][1][0][2], pending_xref,
                 refdomain="py", reftype="class", reftarget="int", **{"py:class": "Class"})
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -838,6 +838,32 @@ def test_info_field_list(app):
                 **{"py:module": "example", "py:class": "Class"})
 
 
+def test_info_field_list_var(app):
+    text = (".. py:class:: Class\n"
+            "\n"
+            "   :var int attr: blah blah\n")
+    doctree = restructuredtext.parse(app, text)
+
+    assert_node(doctree, (addnodes.index,
+                          [desc, (desc_signature,
+                                  [desc_content, nodes.field_list, nodes.field])]))
+    assert_node(doctree[1][1][0][0], ([nodes.field_name, "Variables"],
+                                      [nodes.field_body, nodes.paragraph]))
+
+    # :var int attr:
+    assert_node(doctree[1][1][0][0][1][0],
+                ([pending_xref, addnodes.literal_strong, "attr"],
+                 " (",
+                 [pending_xref, addnodes.literal_emphasis, "int"],
+                 ")",
+                 " -- ",
+                 "blah blah"))
+    assert_node(doctree[1][1][0][0][1][0][0], pending_xref,
+                refdomain="py", reftype="obj", reftarget="attr", **{"py:class": "Class"})
+    assert_node(doctree[1][1][0][0][1][0][2], pending_xref,
+                refdomain="py", reftype="class", reftarget="int", **{"py:class": "Class"})
+
+
 @pytest.mark.sphinx(freshenv=True)
 def test_module_index(app):
     text = (".. py:module:: docutils\n"


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Purpose
-  Since its beginning, `:var:` field has created a cross-reference to the
    attribute having the same name.  It is meaningful only if the attribute
    is documented by `py:attribute` directive.  It means the `:var:` field
    and `:attr:` role are almost the same and conflicted.  Additionally, the
    cross-reference points incorrect variable if the target is not
    documented.
-  Thus, the cross-reference feature of `:var:` field is disabled.
- refs: #5977

