### PR TITLE
Fix incorrect Greek translation of dates

### DIFF
--- a/sphinx/locale/el/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/el/LC_MESSAGES/sphinx.po
@@ -889,7 +889,7 @@ msgstr "Αδυναμία ανάγνωσης αρχείου πληροφοριώ�
 #: sphinx/writers/texinfo.py:237
 #, python-format
 msgid "%b %d, %Y"
-msgstr "%d de %B de %Y"
+msgstr "%d %B, %Y"
 
 #: sphinx/builders/html/__init__.py:439
 msgid "html_use_opensearch config value must now be a string"


### PR DESCRIPTION
There is no `de` in Greek. `02 Ιανουαρίου, 2021` would be OK for today's date