### PR TITLE
refactor: some domain base classes become subclasses of abc.ABC

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* domain: The ``Index`` class becomes subclasses of ``abc.ABC`` to indicate
+  methods that must be overrided in the concrete classes
 * #4826: py domain: The structure of python objects is changed.  A boolean value
   is added to indicate that the python object is canonical one
 * #7425: MathJax: The MathJax was changed from 2 to 3. Users using a custom

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -10,6 +10,7 @@
 """
 
 import copy
+from abc import ABC, abstractmethod
 from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List, NamedTuple, Tuple,
                     Type, Union, cast)
 
@@ -64,7 +65,7 @@ class IndexEntry(NamedTuple):
     descr: str
 
 
-class Index:
+class Index(ABC):
     """
     An Index is the description for a domain-specific index.  To add an index to
     a domain, subclass Index, overriding the three name attributes:
@@ -97,6 +98,7 @@ class Index:
                               % self.__class__.__name__)
         self.domain = domain
 
+    @abstractmethod
     def generate(self, docnames: Iterable[str] = None
                  ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         """Get entries for the index.


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- `ObjectDescription`, `Index` and `Domain` classes become subclasses of
`abc.ABC` to indicate methods that must be overrided in the concrete
classes.