### PR TITLE
Skip imgconverter availability check if builder supports the image type

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -197,14 +197,14 @@ class ImageConverter(BaseImageConverter):
     def match(self, node: nodes.image) -> bool:
         if not self.app.builder.supported_image_types:
             return False
+        elif set(node['candidates']) & set(self.app.builder.supported_image_types):
+            # builder supports the image; no need to convert
+            return False
         elif self.available is None:
             # store the value to the class variable to share it during the build
             self.__class__.available = self.is_available()
 
         if not self.available:
-            return False
-        elif set(node['candidates']) & set(self.app.builder.supported_image_types):
-            # builder supports the image; no need to convert
             return False
         else:
             rule = self.get_conversion_rule(node)


### PR DESCRIPTION
Subject: Skip imgconverter availability check if builder supports the image type

### Feature or Bugfix
- Bugfix

### Purpose
Pull request #7978 fixed calling the imgconverter `is_availabality()` function many times; however, the availability is currently still checked even if the builder supports the image type.

### Relates
- #7973: ImgConverter runs is_available in HTML builder
- missinglinkelectronics/sphinxcontrib-svg2pdfconverter#8: Extension should only run on LaTeX builder