### PR TITLE
Check autodoc's exclude_members before mock.

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -739,12 +739,12 @@ class Documenter:
                 isprivate = membername.startswith('_')
 
             keep = False
-            if ismock(member):
-                # mocked module or object
-                pass
-            elif self.options.exclude_members and membername in self.options.exclude_members:
+            if self.options.exclude_members and membername in self.options.exclude_members:
                 # remove members given by exclude-members
                 keep = False
+            elif ismock(member):
+                # mocked module or object
+                pass
             elif want_all and special_member_re.match(membername):
                 # special __methods__
                 if self.options.special_members and membername in self.options.special_members:


### PR DESCRIPTION
This prevents accidently checking for the __sphinx_mock__ attribute on objects that may be proxies or other lazily evaluated objects that shouldn't be documented and are included in exclude_members.

Subject: Check autodoc's exclude_members before mock.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- The purpose is to make sure that laziliy evaluated objects aren't accidently triggering side-effects in this code path, such as Flask objects `g`, `request`, `current_app` etc when they are module globals.

### Detail
- Changes the order of evaluation when considering the members to document, evaluating exclude_members first.

### Relates
- #8164

