### PR TITLE
Fix #8655: autodoc: Crashes when object raises an exception on hasattr()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #8655: autodoc: Failed to generate document if target module contains an
+  object that raises an exception on ``hasattr()``
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -153,7 +153,10 @@ def mock(modnames: List[str]) -> Generator[None, None, None]:
 def ismock(subject: Any) -> bool:
     """Check if the object is mocked."""
     # check the object has '__sphinx_mock__' attribute
-    if not hasattr(subject, '__sphinx_mock__'):
+    try:
+        if safe_getattr(subject, '__sphinx_mock__', None) is None:
+            return False
+    except AttributeError:
         return False
 
     # check the object is mocked module


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- autodoc crashes when the target object raises an exception on
`hasattr()`.  The `hasattr()` function internally calls the
`obj.__getattr__()` or `obj.__getattribute__()` of the target object.
Hence the reaction can be changed on the target object.
- This starts to use `safe_getattr()` to check the object is mocked or not
and to prevent an unexpected error.
- refs: #8655 