### PR TITLE
Basic theme: cast globaltoc_maxdepth to int

### DIFF
--- a/sphinx/themes/basic/globaltoc.html
+++ b/sphinx/themes/basic/globaltoc.html
@@ -8,4 +8,4 @@
     :license: BSD, see LICENSE for details.
 #}
 <h3><a href="{{ pathto(master_doc)|e }}">{{ _('Table of Contents') }}</a></h3>
-{{ toctree(includehidden=theme_globaltoc_includehidden, collapse=theme_globaltoc_collapse, maxdepth=theme_globaltoc_maxdepth) }}
+{{ toctree(includehidden=theme_globaltoc_includehidden, collapse=theme_globaltoc_collapse, maxdepth=theme_globaltoc_maxdepth|int) }}


### PR DESCRIPTION
Subject: In the basic html theme, when specifying the max-depth in `theme.conf` that isn't automatically cast to int, causing a hard to locate error.


### Feature or Bugfix
- Bugfix


### Purpose
Cast maxdepth to int in the basic template.

### Detail
The globaltoc uses ``theme_globaltoc_maxdepth`` without casting it to `int`, causing errors when this is set in `theme.conf`


