### PR TITLE
Cast maxdepth to int in toctree

### DIFF
--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -320,7 +320,7 @@ class TocTree:
         toctrees = []  # type: List[Element]
         if 'includehidden' not in kwargs:
             kwargs['includehidden'] = True
-        if 'maxdepth' not in kwargs:
+        if 'maxdepth' not in kwargs or not kwargs['maxdepth']:
             kwargs['maxdepth'] = 0
         else:
             kwargs['maxdepth'] = int(kwargs['maxdepth'])

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -322,6 +322,8 @@ class TocTree:
             kwargs['includehidden'] = True
         if 'maxdepth' not in kwargs:
             kwargs['maxdepth'] = 0
+        else:
+            kwargs['maxdepth'] = int(kwargs['maxdepth'])
         kwargs['collapse'] = collapse
         for toctreenode in doctree.traverse(addnodes.toctree):
             toctree = self.resolve(docname, builder, toctreenode, prune=True, **kwargs)


### PR DESCRIPTION
Subject: When specifying the toc's max-depth in theme.conf that isn't automatically cast to int, causing a hard to locate error.

### Feature or Bugfix
- Bugfix

### Relates
-  Replaces #8663

