### PR TITLE
Fix #8652: autodoc: variable comments are ignored if invalid type comments found

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,8 @@ Bugs fixed
 * #8592: autodoc: ``:meta public:`` does not effect to variables
 * #8594: autodoc: empty __all__ attribute is ignored
 * #8315: autodoc: Failed to resolve struct.Struct type annotation
+* #8652: autodoc: All variable comments in the module are ignored if the module
+  contains invalid type comments
 * #8306: autosummary: mocked modules are documented as empty page when using
   :recursive: option
 * #8618: html: kbd role produces incorrect HTML when compound-key separators (-,

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -52,6 +52,10 @@ def parse(code: str, mode: str = 'exec') -> "ast.AST":
     try:
         # type_comments parameter is available on py38+
         return ast.parse(code, mode=mode, type_comments=True)  # type: ignore
+    except SyntaxError:
+        # Some syntax error found. To ignore invalid type comments, retry parsing without
+        # type_comments parameter (refs: https://github.com/sphinx-doc/sphinx/issues/8652).
+        return ast.parse(code, mode=mode)
     except TypeError:
         # fallback to ast module.
         # typed_ast is used to parse type_comments if installed.


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose-
- To avoid the crash of ModuleAnalyzer from invalid type comments, this
start to retry parsing without type_comments=False when `ast.parse()`
raises SyntaxError.
- refs: #8652 