### PR TITLE
C, fix namespace lookup for expr role

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,10 @@ Features added
 Bugs fixed
 ----------
 
+* #8655: autodoc: Failed to generate document if target module contains an
+  object that raises an exception on ``hasattr()``
+* C, ``expr`` role should start symbol lookup in the current scope.
+
 Testing
 --------
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -137,8 +137,7 @@ class ASTIdentifier(ASTBaseBase):
                                           reftype='identifier',
                                           reftarget=targetText, modname=None,
                                           classname=None)
-            key = symbol.get_lookup_key()
-            pnode['c:parent_key'] = key
+            pnode['c:parent_key'] = symbol.get_lookup_key()
             if self.is_anon():
                 pnode += nodes.strong(text="[anonymous]")
             else:
@@ -3204,7 +3203,8 @@ class CObject(ObjectDescription):
     def parse_pre_v3_type_definition(self, parser: DefinitionParser) -> ASTDeclaration:
         return parser.parse_pre_v3_type_definition()
 
-    def describe_signature(self, signode: TextElement, ast: Any, options: Dict) -> None:
+    def describe_signature(self, signode: TextElement, ast: ASTDeclaration,
+                           options: Dict) -> None:
         ast.describe_signature(signode, 'lastIsName', self.env, options)
 
     def run(self) -> List[Node]:
@@ -3642,7 +3642,7 @@ class CExprRole(SphinxRole):
                            location=self.get_source_info())
             # see below
             return [self.node_type(text, text, classes=classes)], []
-        parentSymbol = self.env.temp_data.get('cpp:parent_symbol', None)
+        parentSymbol = self.env.temp_data.get('c:parent_symbol', None)
         if parentSymbol is None:
             parentSymbol = self.env.domaindata['c']['root_symbol']
         # ...most if not all of these classes should really apply to the individual references,

--- a/tests/roots/test-domain-c/ns_lookup.rst
+++ b/tests/roots/test-domain-c/ns_lookup.rst
@@ -1,0 +1,13 @@
+.. c:namespace:: ns_lookup
+
+.. c:var:: int i
+
+.. c:function:: void f(int j)
+
+	- :c:var:`i`
+	- :c:var:`j`
+	- :c:expr:`i`
+	- :c:expr:`j`
+
+- :c:var:`i`
+- :c:expr:`i`

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -595,6 +595,13 @@ def test_build_function_param_target(app, warning):
     ]
 
 
+@pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
+def test_build_ns_lookup(app, warning):
+    app.builder.build_all()
+    ws = filter_warnings(warning, "ns_lookup")
+    assert len(ws) == 0
+
+
 def _get_obj(app, queryName):
     domain = app.env.get_domain('c')
     for name, dispname, objectType, docname, anchor, prio in domain.get_objects():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Fix typo in C domain which messes up lookup of symbols in ``expr`` roles.
