### PR TITLE
Fix #8671: highlight_options is not working

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -46,6 +46,7 @@ Bugs fixed
 * #8665: html theme: Could not override globaltoc_maxdepth in theme.conf
 * #8094: texinfo: image files on the different directory with document are not
   copied
+* #8671: :confval:`highlight_options` is not working
 
 Testing
 --------

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -439,7 +439,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         linenos = node.get('linenos', False)
         highlight_args = node.get('highlight_args', {})
         highlight_args['force'] = node.get('force', False)
-        if lang is self.config.highlight_language:
+        if lang == self.config.highlight_language:
             # only pass highlighter options for original language
             opts = self.config.highlight_options
         else:

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -390,7 +390,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         linenos = node.get('linenos', False)
         highlight_args = node.get('highlight_args', {})
         highlight_args['force'] = node.get('force', False)
-        if lang is self.config.highlight_language:
+        if lang == self.config.highlight_language:
             # only pass highlighter options for original language
             opts = self.config.highlight_options
         else:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1751,7 +1751,7 @@ class LaTeXTranslator(SphinxTranslator):
             linenos = node.get('linenos', False)
             highlight_args = node.get('highlight_args', {})
             highlight_args['force'] = node.get('force', False)
-            if lang is self.config.highlight_language:
+            if lang == self.config.highlight_language:
                 # only pass highlighter options for original language
                 opts = self.config.highlight_options
             else:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Sadly HTML and LaTeX writers compares the highlight languages using
`is` operator.  As a result, it has not worked even if languages are
same.  This replaces the comparison operator by `==`.
- refs: #8671 