### PR TITLE
Fix #8651: cross-reference for a rubric having inline item is broken

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Features added
 * #8649: imgconverter: Skip availability check if builder supports the image
   type
 * #6241: mathjax: Include mathjax.js only on the document using equations
+* #8651: std domain: cross-reference for a rubric having inline item is broken
 * #8132: Add :confval:`project_copyright` as an alias of :confval:`copyright`
 
 Bugs fixed

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -745,9 +745,11 @@ class StandardDomain(Domain):
                                name, env.doc2path(self.labels[name][0]),
                                location=node)
             self.anonlabels[name] = docname, labelid
-            if node.tagname in ('section', 'rubric'):
+            if node.tagname == 'section':
                 title = cast(nodes.title, node[0])
                 sectname = clean_astext(title)
+            elif node.tagname == 'rubric':
+                sectname = clean_astext(node)
             elif self.is_enumerable_node(node):
                 sectname = self.get_numfig_title(node)
                 if not sectname:

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -412,3 +412,13 @@ def test_disabled_docref(app):
     assert_node(doctree, ([nodes.paragraph, ([pending_xref, nodes.inline, "index"],
                                              "\n",
                                              [nodes.inline, "index"])],))
+
+
+def test_labeled_rubric(app):
+    text = (".. _label:\n"
+            ".. rubric:: blah *blah* blah\n")
+    restructuredtext.parse(app, text)
+
+    domain = app.env.get_domain("std")
+    assert 'label' in domain.labels
+    assert domain.labels['label'] == ('index', 'label', 'blah blah blah')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The implementation of the standard domain so far has considered the
first child of the rubric node is the title of the rubric.  But it can
may multiple nodes when the rubric title is marked up.
- This extracts the title of the rubric from the whole of the children
of it.
- refs: #8651 