### PR TITLE
refactor: Deprecate DocumenterBrdige.reporter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Deprecated
 ----------
 
 * ``sphinx.ext.autodoc.AttributeDocumenter.isinstanceattribute()``
+* ``sphinx.ext.autodoc.directive.DocumenterBridge.reporter``
 * ``sphinx.ext.autodoc.importer.get_module_members()``
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -77,6 +77,11 @@ The following is a list of deprecated interfaces.
      - 5.0
      - ``sphinx.ext.autodoc.DataDocumenter``
 
+   * - ``sphinx.ext.autodoc.directive.DocumenterBridge.reporter``
+     - 3.5
+     - 5.0
+     - ``sphinx.util.logging``
+
    * - ``sphinx.ext.autodoc.importer._getannotations()``
      - 3.4
      - 4.0

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -16,7 +16,7 @@ from docutils.statemachine import StringList
 from docutils.utils import Reporter, assemble_option_dict
 
 from sphinx.config import Config
-from sphinx.deprecation import RemovedInSphinx40Warning
+from sphinx.deprecation import RemovedInSphinx40Warning, RemovedInSphinx50Warning
 from sphinx.environment import BuildEnvironment
 from sphinx.ext.autodoc import Documenter, Options
 from sphinx.util import logging
@@ -55,7 +55,7 @@ class DocumenterBridge:
     def __init__(self, env: BuildEnvironment, reporter: Reporter, options: Options,
                  lineno: int, state: Any = None) -> None:
         self.env = env
-        self.reporter = reporter
+        self._reporter = reporter
         self.genopt = options
         self.lineno = lineno
         self.filename_set = set()  # type: Set[str]
@@ -73,6 +73,12 @@ class DocumenterBridge:
 
     def warn(self, msg: str) -> None:
         logger.warning(msg, location=(self.env.docname, self.lineno))
+
+    @property
+    def reporter(self) -> Reporter:
+        warnings.warn('DocumenterBridge.reporter is deprecated.',
+                      RemovedInSphinx50Warning, stacklevel=2)
+        return self._reporter
 
 
 def process_documenter_options(documenter: "Type[Documenter]", config: Config, options: Dict


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The logging system of Sphinx was migrated to sphinx.util.logging now.
So it's time to deprecate reporter interface for Documenters.
