### PR TITLE
Fix #8683: html_last_updated_fmt does not support UTC offset (%z) 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Bugs fixed
 * #8341: C, fix intersphinx lookup types for names in declarations.
 * C, C++: in general fix intersphinx and role lookup types.
 * #8683: :confval:`html_last_updated_fmt` does not support UTC offset (%z)
+* #8683: :confval:`html_last_updated_fmt` generates wrong time zone for %Z
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ Bugs fixed
 * #8671: :confval:`highlight_options` is not working
 * #8341: C, fix intersphinx lookup types for names in declarations.
 * C, C++: in general fix intersphinx and role lookup types.
+* #8683: :confval:`html_last_updated_fmt` does not support UTC offset (%z)
 
 Testing
 --------

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -237,6 +237,8 @@ date_format_mappings = {
     '%y':  'YY',      # Year without century as a zero-padded decimal number.
     '%Y':  'yyyy',    # Year with century as a decimal number.
     '%Z':  'zzzz',    # Time zone name (no characters if no time zone exists).
+    '%z':  'ZZZ',     # UTC offset in the form ±HHMM[SS[.ffffff]]
+                      # (empty string if the object is naive).
     '%%':  '%',
 }
 

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -236,7 +236,7 @@ date_format_mappings = {
     '%X':  'medium',  # Locale’s appropriate time representation.
     '%y':  'YY',      # Year without century as a zero-padded decimal number.
     '%Y':  'yyyy',    # Year with century as a decimal number.
-    '%Z':  'zzzz',    # Time zone name (no characters if no time zone exists).
+    '%Z':  'zzz',     # Time zone name (no characters if no time zone exists).
     '%z':  'ZZZ',     # UTC offset in the form ±HHMM[SS[.ffffff]]
                       # (empty string if the object is naive).
     '%%':  '%',

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -88,6 +88,8 @@ def test_format_date():
     assert i18n.format_date(format, date=date) == 'Feb 7, 2016'
 
     # timezone
+    format = '%Z'
+    assert i18n.format_date(format, date=datet) == 'UTC'
     format = '%z'
     assert i18n.format_date(format, date=datet) == '+0000'
 

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -87,6 +87,10 @@ def test_format_date():
     assert i18n.format_date(format, date=datet) == 'Feb 7, 2016, 5:11:17 AM'
     assert i18n.format_date(format, date=date) == 'Feb 7, 2016'
 
+    # timezone
+    format = '%z'
+    assert i18n.format_date(format, date=datet) == '+0000'
+
 
 @pytest.mark.xfail(os.name != 'posix', reason="Path separators don't match on windows")
 def test_get_filename_for_language(app):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix #8683: html_last_updated_fmt generates wrong time zone for %Z
  -    sphinx.util.i18n:format_date() converts '%Z' to full name of time zone
   unexpectedly.  It should be converted to short name.
- Fix #8683: html_last_updated_fmt does not support UTC offset (%z)
  - sphinx.util.i18n:format_date() does not support %z so far.  This
    adds a mapping for %z to the babel form 'ZZZ'.
- refs: #8683 