### PR TITLE
Fix #4550: The align attribute of figure nodes becomes None by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,8 @@ Incompatible changes
   documents
 * #5977: py domain: ``:var:``, ``:cvar:`` and ``:ivar:`` fields do not create
   cross-references
+* #4550: The ``align`` attribute of ``figure`` and ``table`` nodes becomes
+  ``None`` by default instead of ``'default'``
 
 Deprecated
 ----------
@@ -32,6 +34,7 @@ Deprecated
 * ``sphinx.directives.patches.CSVTable``
 * ``sphinx.directives.patches.ListTable``
 * ``sphinx.directives.patches.RSTTable``
+* ``sphinx.transforms.FigureAligner``
 * ``sphinx.util.pycompat.convert_with_2to3()``
 * ``sphinx.util.pycompat.execfile_()``
 * ``sphinx.util.smartypants``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -41,6 +41,11 @@ The following is a list of deprecated interfaces.
      - 6.0
      - ``docutils.parsers.rst.diretives.tables.RSTTable``
 
+   * - ``sphinx.transforms.FigureAligner``
+     - 4.0
+     - 6.0
+     - N/A
+
    * - ``sphinx.util.pycompat.convert_with_2to3()``
      - 4.0
      - 6.0

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -9,6 +9,7 @@
 """
 
 import re
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Tuple
 
 from docutils import nodes
@@ -21,6 +22,7 @@ from docutils.utils.smartquotes import smartchars
 
 from sphinx import addnodes
 from sphinx.config import Config
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.locale import _, __
 from sphinx.util import docutils, logging
 from sphinx.util.docutils import new_document
@@ -284,6 +286,11 @@ class FigureAligner(SphinxTransform):
     """
     default_priority = 700
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn('FigureAilgner is deprecated.',
+                      RemovedInSphinx60Warning)
+        super().__init__(*args, **kwargs)
+
     def apply(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.table, nodes.figure)
         for node in self.document.traverse(matcher):  # type: Element
@@ -406,7 +413,6 @@ def setup(app: "Sphinx") -> Dict[str, Any]:
     app.add_transform(HandleCodeBlocks)
     app.add_transform(SortIds)
     app.add_transform(DoctestTransform)
-    app.add_transform(FigureAligner)
     app.add_transform(AutoNumbering)
     app.add_transform(AutoIndexUpgrader)
     app.add_transform(FilterSystemMessages)

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -574,6 +574,13 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.body.append(self.context.pop())
 
     # overwritten
+    def visit_figure(self, node: Element) -> None:
+        # set align=default if align not specified to give a default style
+        node.setdefault('align', 'default')
+
+        return super().visit_figure(node)
+
+    # overwritten
     def visit_image(self, node: Element) -> None:
         olduri = node['uri']
         # rewrite the URI if the environment knows about it
@@ -774,6 +781,10 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
 
     def visit_table(self, node: Element) -> None:
         self._table_row_index = 0
+
+        # set align=default if align not specified to give a default style
+        node.setdefault('align', 'default')
+
         return super().visit_table(node)
 
     def visit_row(self, node: Element) -> None:

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -516,6 +516,13 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.body.append(self.context.pop())
 
     # overwritten
+    def visit_figure(self, node: Element) -> None:
+        # set align=default if align not specified to give a default style
+        node.setdefault('align', 'default')
+
+        return super().visit_figure(node)
+
+    # overwritten
     def visit_image(self, node: Element) -> None:
         olduri = node['uri']
         # rewrite the URI if the environment knows about it
@@ -716,8 +723,10 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         atts = {}
         classes = [cls.strip(' \t\n') for cls in self.settings.table_style.split(',')]
         classes.insert(0, "docutils")  # compat
-        if 'align' in node:
-            classes.append('align-%s' % node['align'])
+
+        # set align-default if align not specified to give a default style
+        classes.append('align-%s' % node.get('align', 'default'))
+
         if 'width' in node:
             atts['style'] = 'width: %s' % node['width']
         tag = self.starttag(node, 'table', CLASS=' '.join(classes), **atts)

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -106,7 +106,7 @@ class Table:
     def __init__(self, node: Element) -> None:
         self.header = []                        # type: List[str]
         self.body = []                          # type: List[str]
-        self.align = node.get('align')
+        self.align = node.get('align', 'default')
         self.colcount = 0
         self.colspec = None                     # type: str
         self.colwidths = []                     # type: List[int]
@@ -1240,7 +1240,6 @@ class LaTeXTranslator(SphinxTranslator):
                 (1, 'middle'): ('\\raisebox{-0.5\\height}{', '}'),
                 (1, 'bottom'): ('\\raisebox{-\\height}{', '}'),
                 (0, 'center'): ('{\\hspace*{\\fill}', '\\hspace*{\\fill}}'),
-                (0, 'default'): ('{\\hspace*{\\fill}', '\\hspace*{\\fill}}'),
                 # These 2 don't exactly do the right thing.  The image should
                 # be floated alongside the paragraph.  See
                 # https://www.w3.org/TR/html4/struct/objects.html#adef-align-IMG


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To keep compatibility with the standard doctree model of docutils,
this stops to use 'default' value as a default value of the align
attribute for figure and table nodes.
- refs: #4550 