### PR TITLE
refactor: Remove meaningless variable: attrs

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1205,7 +1205,6 @@ class LaTeXTranslator(SphinxTranslator):
         return isinstance(node.parent, nodes.TextElement)
 
     def visit_image(self, node: Element) -> None:
-        attrs = node.attributes
         pre = []    # type: List[str]
                     # in reverse order
         post = []   # type: List[str]
@@ -1215,27 +1214,27 @@ class LaTeXTranslator(SphinxTranslator):
             is_inline = self.is_inline(node.parent)
         else:
             is_inline = self.is_inline(node)
-        if 'width' in attrs:
-            if 'scale' in attrs:
-                w = self.latex_image_length(attrs['width'], attrs['scale'])
+        if 'width' in node:
+            if 'scale' in node:
+                w = self.latex_image_length(node['width'], node['scale'])
             else:
-                w = self.latex_image_length(attrs['width'])
+                w = self.latex_image_length(node['width'])
             if w:
                 include_graphics_options.append('width=%s' % w)
-        if 'height' in attrs:
-            if 'scale' in attrs:
-                h = self.latex_image_length(attrs['height'], attrs['scale'])
+        if 'height' in node:
+            if 'scale' in node:
+                h = self.latex_image_length(node['height'], node['scale'])
             else:
-                h = self.latex_image_length(attrs['height'])
+                h = self.latex_image_length(node['height'])
             if h:
                 include_graphics_options.append('height=%s' % h)
-        if 'scale' in attrs:
+        if 'scale' in node:
             if not include_graphics_options:
                 # if no "width" nor "height", \sphinxincludegraphics will fit
                 # to the available text width if oversized after rescaling.
                 include_graphics_options.append('scale=%s'
-                                                % (float(attrs['scale']) / 100.0))
-        if 'align' in attrs:
+                                                % (float(node['scale']) / 100.0))
+        if 'align' in node:
             align_prepost = {
                 # By default latex aligns the top of an image.
                 (1, 'top'): ('', ''),
@@ -1250,8 +1249,8 @@ class LaTeXTranslator(SphinxTranslator):
                 (0, 'right'): ('{\\hspace*{\\fill}', '}'),
             }
             try:
-                pre.append(align_prepost[is_inline, attrs['align']][0])
-                post.append(align_prepost[is_inline, attrs['align']][1])
+                pre.append(align_prepost[is_inline, node['align']][0])
+                post.append(align_prepost[is_inline, node['align']][1])
             except KeyError:
                 pass
         if self.in_parsed_literal:

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1206,11 +1206,10 @@ class TexinfoTranslator(SphinxTranslator):
             # ignore remote images
             return
         name, ext = path.splitext(uri)
-        attrs = node.attributes
         # width and height ignored in non-tex output
-        width = self.tex_image_length(attrs.get('width', ''))
-        height = self.tex_image_length(attrs.get('height', ''))
-        alt = self.escape_arg(attrs.get('alt', ''))
+        width = self.tex_image_length(node.get('width', ''))
+        height = self.tex_image_length(node.get('height', ''))
+        alt = self.escape_arg(node.get('alt', ''))
         filename = "%s-figures/%s" % (self.elements['filename'][:-5], name)  # type: ignore
         self.body.append('\n@image{%s,%s,%s,%s,%s}\n' %
                          (filename, width, height, alt, ext[1:]))


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- It would be better to use `name in node` and `node[name]` to check and
access an attribute of the node instead of `node.attributes`.
