### PR TITLE
refactor: test: Do not use deprecated function: execfile_()

### DIFF
--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -16,7 +16,6 @@ import pytest
 from sphinx import application
 from sphinx.cmd import quickstart as qs
 from sphinx.util.console import coloron, nocolor
-from sphinx.util.pycompat import execfile_
 
 warnfile = StringIO()
 
@@ -108,7 +107,7 @@ def test_quickstart_defaults(tempdir):
     conffile = tempdir / 'conf.py'
     assert conffile.isfile()
     ns = {}
-    execfile_(conffile, ns)
+    exec(conffile.read_text(), ns)
     assert ns['extensions'] == []
     assert ns['templates_path'] == ['_templates']
     assert ns['project'] == 'Sphinx Test'
@@ -158,7 +157,7 @@ def test_quickstart_all_answers(tempdir):
     conffile = tempdir / 'source' / 'conf.py'
     assert conffile.isfile()
     ns = {}
-    execfile_(conffile, ns)
+    exec(conffile.read_text(), ns)
     assert ns['extensions'] == [
         'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo'
     ]
@@ -239,7 +238,7 @@ def test_default_filename(tempdir):
     conffile = tempdir / 'conf.py'
     assert conffile.isfile()
     ns = {}
-    execfile_(conffile, ns)
+    exec(conffile.read_text(), ns)
 
 
 def test_extensions(tempdir):
@@ -249,5 +248,5 @@ def test_extensions(tempdir):
     conffile = tempdir / 'conf.py'
     assert conffile.isfile()
     ns = {}
-    execfile_(conffile, ns)
+    exec(conffile.read_text(), ns)
     assert ns['extensions'] == ['foo', 'bar', 'baz']


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
