### PR TITLE
Add a config item to place figure captions on top in LaTeX

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2196,6 +2196,12 @@ These options influence LaTeX output.
 
    .. versionadded:: 3.0
 
+.. confval:: latex_figure_captions_top
+
+   If ``True``, captions for figures are placed above the figure. Defaults to ``False``.
+   
+   .. versionadded:: 3.5
+
 
 .. _text-options:
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2198,8 +2198,9 @@ These options influence LaTeX output.
 
 .. confval:: latex_figure_captions_top
 
-   If ``True``, captions for figures are placed above the figure. Defaults to ``False``.
-   
+   If ``True``, captions for figures are placed above the figure.
+   Defaults to ``False``.
+
    .. versionadded:: 3.5
 
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -588,6 +588,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('latex_theme', 'manual', None, [str])
     app.add_config_value('latex_theme_options', {}, None)
     app.add_config_value('latex_theme_path', [], None, [list])
+    app.add_config_value('latex_figure_captions_top', False, None)
 
     app.add_config_value('latex_docclass', default_latex_docclass, None)
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1320,8 +1320,13 @@ class LaTeXTranslator(SphinxTranslator):
             self.context.append('\\end{center}\n')
         else:
             self.body.append('\n\\begin{figure}[%s]\n\\centering\n' % align)
-            if any(isinstance(child, nodes.caption) for child in node):
-                self.body.append('\\capstart\n')
+            for child in node:
+                if isinstance(child, nodes.caption):
+                    self.body.append('\\capstart\n')
+                    if self.builder.config.latex_figure_captions_top:
+                        caption = node.pop(node.index(child))
+                        node.insert(0, caption)
+                    break
             self.context.append('\\end{figure}\n')
 
     def depart_figure(self, node: Element) -> None:


### PR DESCRIPTION
For code/literal blocks and tables, the default caption placement is above the content. For figures, this is below the figure.
There are ways that captions in LaTeX output can be moved for code blocks (through a config item) and tables (by changing templates), but not for figures.

This PR exposes an option to move the figure caption to the top. It does not contain any tests (yet). Comments on the approach are appreciated. A [previous comment suggested this would be better to add to docutils](https://github.com/sphinx-doc/sphinx/issues/1723#issuecomment-239059458), which currently places the caption node after the image node in the doctree. I find it hard to make changes to docutils, so I've opted to do this in Sphinx, by moving the caption node above the image node in the doctree.

### Feature or Bugfix
- Feature, implements #1723

### Relates
- #161, #3686 
- #3872
