### PR TITLE
C++, also hyperlink operators in expr and alias

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Features added
 * #207: Now :confval:`highlight_language` supports multiple languages
 * #2030: :rst:dir:`code-block` and :rst:dir:`literalinclude` supports automatic
   dedent via no-argument ``:dedent:`` option
+* C++, also hyperlink operator overloads in expressions and alias declarations.
 
 Bugs fixed
 ----------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -1592,6 +1592,15 @@ class ASTOperator(ASTBase):
         identifier = str(self)
         if mode == 'lastIsName':
             signode += addnodes.desc_name(identifier, identifier)
+        elif mode == 'markType':
+            targetText = prefix + identifier + templateArgs
+            pnode = addnodes.pending_xref('', refdomain='cpp',
+                                          reftype='identifier',
+                                          reftarget=targetText, modname=None,
+                                          classname=None)
+            pnode['cpp:parent_key'] = symbol.get_lookup_key()
+            pnode += nodes.Text(identifier)
+            signode += pnode
         else:
             signode += addnodes.desc_addname(identifier, identifier)
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature(/Bugfix)

### Purpose
Make the two ``operator+`` in the following into cross-references.
```rst
.. default-domain:: cpp

.. function:: void operator+(int)

:expr:`operator+`

.. alias:: operator+
```