### PR TITLE
Fix #8704: viewcode: anchors are generated in incremental build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* pending_xref node for viewcode extension
 * ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.broken``
 * ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.good``
 * ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.redirected``
@@ -69,6 +70,7 @@ Bugs fixed
 * #8094: texinfo: image files on the different directory with document are not
   copied
 * #8720: viewcode: module pages are generated for epub on incremental build
+* #8704: viewcode: anchors are generated in incremental build after singlehtml
 * #8671: :confval:`highlight_options` is not working
 * #8341: C, fix intersphinx lookup types for names in declarations.
 * C, C++: in general fix intersphinx and role lookup types.

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -26,6 +26,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - pending_xref node for viewcode extension
+     - 3.5
+     - 5.0
+     - ``sphinx.ext.viewcode.viewcode_anchor``
+
    * - ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.broken``
      - 3.5
      - 5.0

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -55,6 +55,9 @@ def test_viewcode_epub_default(app, status, warning):
 
     assert not (app.outdir / '_modules/spam/mod1.xhtml').exists()
 
+    result = (app.outdir / 'index.xhtml').read_text()
+    assert result.count('href="_modules/spam/mod1.xhtml#func1"') == 0
+
 
 @pytest.mark.sphinx('epub', testroot='ext-viewcode',
                     confoverrides={'viewcode_enable_epub': True})
@@ -62,6 +65,9 @@ def test_viewcode_epub_enabled(app, status, warning):
     app.builder.build_all()
 
     assert (app.outdir / '_modules/spam/mod1.xhtml').exists()
+
+    result = (app.outdir / 'index.xhtml').read_text()
+    assert result.count('href="_modules/spam/mod1.xhtml#func1"') == 2
 
 
 @pytest.mark.sphinx(testroot='ext-viewcode', tags=['test_linkcode'])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The anchors for viewcode was generated in the reading phase only if
supported builder is used.  It causes anchors are missing on the
incremental build after the build for non supported builder.
- This introduces `viewcode_anchor` node to insert the anchor even if non
supported builders.  They will be converted to the anchor tag in the
resolving phase for supported builders.  Or, they will be removed for
non supported builders.