### PR TITLE
minor typing fix

### DIFF
--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from typing import Any, Dict, List, Tuple, Type, cast
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
 
 from docutils import nodes
 from docutils.nodes import Element
@@ -150,7 +150,7 @@ class ReferencesResolver(SphinxPostTransform):
         return newnode
 
     def warn_missing_reference(self, refdoc: str, typ: str, target: str,
-                               node: pending_xref, domain: Domain) -> None:
+                               node: pending_xref, domain: Optional[Domain]) -> None:
         warn = node.get('refwarn')
         if self.config.nitpicky:
             warn = True


### PR DESCRIPTION
Subject: `domain` is allowed to be `None` in `warn_missing_reference` method

### Feature or Bugfix
<!-- please choose -->
- Bugfix

