### PR TITLE
Fix #8720: viewcode: module pages are generated for epub on incremental build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,7 @@ Bugs fixed
   availability of the same URL twice
 * #8094: texinfo: image files on the different directory with document are not
   copied
+* #8720: viewcode: module pages are generated for epub on incremental build
 * #8671: :confval:`highlight_options` is not working
 * #8341: C, fix intersphinx lookup types for names in declarations.
 * C, C++: in general fix intersphinx and role lookup types.

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -182,6 +182,10 @@ def collect_pages(app: Sphinx) -> Generator[Tuple[str, Dict[str, Any], str], Non
     env = app.builder.env
     if not hasattr(env, '_viewcode_modules'):
         return
+    if app.builder.name == "singlehtml":
+        return
+    if app.builder.name.startswith("epub") and not env.config.viewcode_enable_epub:
+        return
     highlighter = app.builder.highlighter  # type: ignore
     urito = app.builder.get_relative_uri
 

--- a/tests/test_ext_viewcode.py
+++ b/tests/test_ext_viewcode.py
@@ -49,6 +49,21 @@ def test_viewcode(app, status, warning):
             '<span>    &quot;&quot;&quot;</span></div>\n') in result
 
 
+@pytest.mark.sphinx('epub', testroot='ext-viewcode')
+def test_viewcode_epub_default(app, status, warning):
+    app.builder.build_all()
+
+    assert not (app.outdir / '_modules/spam/mod1.xhtml').exists()
+
+
+@pytest.mark.sphinx('epub', testroot='ext-viewcode',
+                    confoverrides={'viewcode_enable_epub': True})
+def test_viewcode_epub_enabled(app, status, warning):
+    app.builder.build_all()
+
+    assert (app.outdir / '_modules/spam/mod1.xhtml').exists()
+
+
 @pytest.mark.sphinx(testroot='ext-viewcode', tags=['test_linkcode'])
 def test_linkcode(app, status, warning):
     app.builder.build(['objects'])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The module pages should be generated for epub only if enabled via
configuration.  But they are generated after the build for other
viewcode-supported builders.  This checks the current builder on
generating module pages.
- refs: #8720 