### PR TITLE
Match linkcheck deprecation warning version with deprecated.rst

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -29,7 +29,7 @@ from requests.exceptions import HTTPError, TooManyRedirects
 
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
-from sphinx.deprecation import RemovedInSphinx40Warning
+from sphinx.deprecation import RemovedInSphinx50Warning
 from sphinx.locale import __
 from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import encode_uri, logging, requests
@@ -60,7 +60,7 @@ def node_line_or_0(node: Element) -> int:
     tuple used by the PriorityQueue, keep an homogeneous type for comparison.
     """
     warnings.warn('node_line_or_0() is deprecated.',
-                  RemovedInSphinx40Warning, stacklevel=2)
+                  RemovedInSphinx50Warning, stacklevel=2)
     return get_node_line(node) or 0
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Deprecated.rst states the node_line_or_0 helper will be removed in
Sphinx 5.0, use a RemovedInSphinx50Warning.