### PR TITLE
Closes: #8339

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,7 @@ Bugs fixed
 * #8683: :confval:`html_last_updated_fmt` generates wrong time zone for %Z
 * #1112: ``download`` role creates duplicated copies when relative path is
   specified
+* #8339: make latexpdf fails when using literal-blocks and fancybox package
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -72,7 +72,6 @@ Bugs fixed
 * #8683: :confval:`html_last_updated_fmt` generates wrong time zone for %Z
 * #1112: ``download`` role creates duplicated copies when relative path is
   specified
-* #8339: make latexpdf fails when using literal-blocks and fancybox package
 
 Testing
 --------

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -95,6 +95,12 @@ Keys that you may want to override include:
    A string which will be positioned early in the preamble, designed to
    contain ``\\PassOptionsToPackage{options}{foo}`` commands.
 
+   .. hint::
+
+      It may be also used for loading LaTeX packages very early in the
+      preamble.  For example package ``fancybox`` is incompatible with
+      being loaded via the ``'preamble'`` key, it must be loaded earlier.
+
    Default: ``''``
 
    .. versionadded:: 1.4

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -966,9 +966,9 @@
 % - with possibly of a top caption, non-separable by pagebreak.
 % - and usable inside tables or footnotes ("footnotehyper-sphinx").
 
-% For extensions which use \OriginalVerbatim and compatibility with Sphinx <
-% 1.5, we define and use these when (unmodified) Verbatim will be needed. But
-% Sphinx >= 1.5 does not modify the \Verbatim macro anymore.
+% Prior to Sphinx 1.5, \Verbatim and \endVerbatim were modified by Sphinx.
+% The aliases defined here are used in sphinxVerbatim environment and can
+% serve as hook-points with no need to modify \Verbatim itself.
 \let\OriginalVerbatim   \Verbatim
 \let\endOriginalVerbatim\endVerbatim
 


### PR DESCRIPTION
Handled as only a documentation issue.

Closes #8339.

I decided against the 
```
\def\OriginalVerbatim{\Verbatim}
\def\endOriginalVerbatim{\endVerbatim}
```
I had mentioned at https://github.com/sphinx-doc/sphinx/issues/8339#issuecomment-764840325 because in fact this did not solve #8339.

fancybox and fancyvrb define the same things with distinct macro names, Sphinx hooks into fancyvrb, in the past it was also loading fancybox, if this is added by user it must be executed before sphinx.sty loads fancyvrb anyway, because fancybox changes too many macro names.

This PR changes only documentation.