### PR TITLE
doc: Link to detailed extension documentation

### DIFF
--- a/doc/development/index.rst
+++ b/doc/development/index.rst
@@ -2,10 +2,12 @@
 Extending Sphinx
 ================
 
-This guide is aimed at those wishing to develop their own extensions for
-Sphinx. Sphinx possesses significant extensibility capabilities including the
-ability to hook into almost every point of the build process.  If you simply
-wish to use Sphinx with existing extensions, refer to :doc:`/usage/index`.
+This guide is aimed at giving a quick introduction for those wishing to 
+develop their own extensions for Sphinx. Sphinx possesses significant 
+extensibility capabilities including the ability to hook into almost every
+point of the build process.  If you simply wish to use Sphinx with existing 
+extensions, refer to :doc:`/usage/index`. For a more detailed discussion of
+the extension interface see :doc:`/extdev/index`.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Subject: doc: Link to detailed extension documentation

### Feature or Bugfix
- Bugfix

### Purpose
I missed that there are actually two sections explaining extensions in the docs and just saw the examples based one. This lead to me thinking "kind of lousy documentation, but that's probably par for the course". Would there have been a pointer to the detailed extension API description it would have saved me hours of guesswork.