### PR TITLE
Fix #8004: napoleon_preprocess_types for Google style docstrings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,8 @@ Features added
   type
 * #8573: napoleon: Allow to change the style of custom sections using
   :confval:`napoleon_custom_styles`
+* #8004: napoleon: Type definitions in Google style docstrings are rendered as
+  references when :confval:`napoleon_preprocess_types` enabled
 * #6241: mathjax: Include mathjax.js only on the document using equations
 * #8651: std domain: cross-reference for a rubric having inline item is broken
 * #8681: viewcode: Support incremental build

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -59,6 +59,19 @@ _default_regex = re.compile(
 _SINGLETONS = ("None", "True", "False", "Ellipsis")
 
 
+def _convert_type_spec(_type: str, translations: Dict[str, str] = {}) -> str:
+    """Convert type specification to reference in reST."""
+    if _type in translations:
+        return translations[_type]
+    else:
+        if _type == 'None':
+            return ':obj:`None`'
+        else:
+            return ':class:`%s`' % _type
+
+    return _type
+
+
 class GoogleDocstring:
     """Convert Google style docstrings to reStructuredText.
 
@@ -265,6 +278,10 @@ class GoogleDocstring:
 
         if prefer_type and not _type:
             _type, _name = _name, _type
+
+        if _type and self._config.napoleon_preprocess_types:
+            _type = _convert_type_spec(_type, self._config.napoleon_type_aliases or {})
+
         indent = self._get_indent(line) + 1
         _descs = [_desc] + self._dedent(self._consume_indented_block(indent))
         _descs = self.__class__(_descs, self._config).lines()
@@ -293,7 +310,8 @@ class GoogleDocstring:
         _descs = self.__class__(_descs, self._config).lines()
         return _type, _descs
 
-    def _consume_returns_section(self) -> List[Tuple[str, str, List[str]]]:
+    def _consume_returns_section(self, preprocess_types: bool = False
+                                 ) -> List[Tuple[str, str, List[str]]]:
         lines = self._dedent(self._consume_to_next_section())
         if lines:
             before, colon, after = self._partition_field_on_colon(lines[0])
@@ -306,6 +324,10 @@ class GoogleDocstring:
                     _desc = lines[1:]
 
                 _type = before
+
+            if (_type and preprocess_types and
+                    self._config.napoleon_preprocess_types):
+                _type = _convert_type_spec(_type, self._config.napoleon_type_aliases or {})
 
             _desc = self.__class__(_desc, self._config).lines()
             return [(_name, _type, _desc,)]
@@ -652,7 +674,7 @@ class GoogleDocstring:
         return self._format_fields(section, self._consume_fields())
 
     def _parse_custom_returns_style_section(self, section: str) -> List[str]:
-        fields = self._consume_returns_section()
+        fields = self._consume_returns_section(preprocess_types=True)
         return self._format_fields(section, fields)
 
     def _parse_usage_section(self, section: str) -> List[str]:
@@ -778,7 +800,7 @@ class GoogleDocstring:
         return self._format_fields(_('Warns'), self._consume_fields())
 
     def _parse_yields_section(self, section: str) -> List[str]:
-        fields = self._consume_returns_section()
+        fields = self._consume_returns_section(preprocess_types=True)
         return self._format_fields(_('Yields'), fields)
 
     def _partition_field_on_colon(self, line: str) -> Tuple[str, str, str]:
@@ -1170,7 +1192,8 @@ class NumpyDocstring(GoogleDocstring):
         _desc = self.__class__(_desc, self._config).lines()
         return _name, _type, _desc
 
-    def _consume_returns_section(self) -> List[Tuple[str, str, List[str]]]:
+    def _consume_returns_section(self, preprocess_types: bool = False
+                                 ) -> List[Tuple[str, str, List[str]]]:
         return self._consume_fields(prefer_type=True)
 
     def _consume_section_header(self) -> str:

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1167,6 +1167,30 @@ Sample class with PEP 526 annotations and google docstring
 """
             self.assertEqual(expected, actual)
 
+    def test_preprocess_types(self):
+        docstring = """\
+Do as you please
+
+Yield:
+   str:Extended
+"""
+        actual = str(GoogleDocstring(docstring))
+        expected = """\
+Do as you please
+
+:Yields: *str* -- Extended
+"""
+        self.assertEqual(expected, actual)
+
+        config = Config(napoleon_preprocess_types=True)
+        actual = str(GoogleDocstring(docstring, config))
+        expected = """\
+Do as you please
+
+:Yields: :class:`str` -- Extended
+"""
+        self.assertEqual(expected, actual)
+
 
 class NumpyDocstringTest(BaseDocstringTest):
     docstrings = [(


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Type definitions in Google style docstrings are rendered as references
when :confval:`napoleon_preprocess_types` enabled.
- refs: #8004 