### PR TITLE
Improve Sphinx own pdf docs

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,4 +8,9 @@
 Changelog
 =========
 
+.. raw:: latex
+
+   \hypersetup{bookmarksdepth=1}% pdf bookmarks
+   \addtocontents{toc}{\protect\setcounter{tocdepth}{1}}%
+
 .. include:: ../CHANGES

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,8 +69,15 @@ latex_elements = {
 \substitutefont{X2}{\sfdefault}{cmss}
 \substitutefont{X2}{\ttdefault}{cmtt}
 ''',
-    'passoptionstopackages': '\\PassOptionsToPackage{svgnames}{xcolor}',
-    'preamble': '\\DeclareUnicodeCharacter{229E}{\\ensuremath{\\boxplus}}',
+    'passoptionstopackages': r'''
+\PassOptionsToPackage{svgnames}{xcolor}
+\PassOptionsToPackage{bookmarksdepth=3}{hyperref}% depth of pdf bookmarks
+''',
+    'preamble': r'''
+\DeclareUnicodeCharacter{229E}{\ensuremath{\boxplus}}
+\setcounter{tocdepth}{3}%    depth of what is kept from toc file
+\setcounter{secnumdepth}{1}% depth of section numbering
+''',
     'fvset': '\\fvset{fontsize=auto}',
     # fix missing index entry due to RTD doing only once pdflatex after makeindex
     'printindex': r'''


### PR DESCRIPTION
Prior to this the depth of the bookmarks is too low, one does not even
get to see for example what are the built-in extensions offered by
Sphinx.

Similarly the LaTeX created table of contents has not enough depth.
Dozens of contiguous pages from our documentation get only a single
link, it is very hard for newcomer to get some feeling of the scope of
Sphinx.  With a more detailed table of contents (be it inside the PDF or
via the collapsable bookmark panel of PDF viewer) learning Sphinx is
easier.

### Feature or Bugfix
<!-- please choose -->
- Better own docs



