### PR TITLE
Fix #7118: quickstart: got Mojibake if libreadline unavailable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -83,6 +83,7 @@ Bugs fixed
 * #8665: html theme: Could not override globaltoc_maxdepth in theme.conf
 * #4304: linkcheck: Fix race condition that could lead to checking the
   availability of the same URL twice
+* #7118: sphinx-quickstart: questionare got Mojibake if libreadline unavailable
 * #8094: texinfo: image files on the different directory with document are not
   copied
 * #8720: viewcode: module pages are generated for epub on incremental build

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -29,6 +29,7 @@ try:
         readline.parse_and_bind("tab: complete")
         USE_LIBEDIT = False
 except ImportError:
+    readline = None
     USE_LIBEDIT = False
 
 from docutils.utils import column_width
@@ -169,8 +170,11 @@ def do_prompt(text: str, default: str = None, validator: Callable[[str], Any] = 
             # sequence (see #5335).  To avoid the problem, all prompts are not colored
             # on libedit.
             pass
-        else:
+        elif readline:
+            # pass input_mode=True if readline available
             prompt = colorize(COLOR_QUESTION, prompt, input_mode=True)
+        else:
+            prompt = colorize(COLOR_QUESTION, prompt, input_mode=False)
         x = term_input(prompt).strip()
         if default and not x:
             x = default


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Do not output escape sequence for libreadline (\1 and \2) when
libreadline is unavailable.
- I've not tested this because I can't create a reproducible environment for this bug.
- refs: #7118 