### PR TITLE
Fix #8745: i18n: KeyError if a new auto footnote_ref in translations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -78,6 +78,8 @@ Bugs fixed
 * #8629: html: A type warning for html_use_opensearch is shown twice
 * #8714: html: kbd role with "Caps Lock" rendered incorrectly
 * #8665: html theme: Could not override globaltoc_maxdepth in theme.conf
+* #8745: i18n: crashes with KeyError when translation message adds a new auto
+  footnote reference
 * #4304: linkcheck: Fix race condition that could lead to checking the
   availability of the same URL twice
 * #8094: texinfo: image files on the different directory with document are not

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -311,6 +311,7 @@ class Locale(SphinxTransform):
                 refname = newf.get('refname')
                 refs = old_foot_namerefs.get(refname, [])
                 if not refs:
+                    newf.parent.remove(newf)
                     continue
 
                 oldf = refs.pop(0)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Some writers will be crashed by KeyError because of lack of the refid if
a new auto footnote reference is added to the message catalog by
translation misses.
- This detects the invalid footnote references and removes them on
the translation phase.
- refs: #8745 