### PR TITLE
Fix #8756: viewcode: highlighted code is generated even if not referenced

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -84,6 +84,7 @@ Bugs fixed
   copied
 * #8720: viewcode: module pages are generated for epub on incremental build
 * #8704: viewcode: anchors are generated in incremental build after singlehtml
+* #8756: viewcode: highlighted code is generated even if not referenced
 * #8671: :confval:`highlight_options` is not working
 * #8341: C, fix intersphinx lookup types for names in declarations.
 * C, C++: in general fix intersphinx and role lookup types.

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -149,6 +149,18 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: Iterable[str],
     env._viewcode_modules.update(other._viewcode_modules)  # type: ignore
 
 
+def env_purge_doc(app: Sphinx, env: BuildEnvironment, docname: str) -> None:
+    modules = getattr(env, '_viewcode_modules', {})
+
+    for modname, (code, tags, used, refname) in list(modules.items()):
+        for fullname in list(used):
+            if used[fullname] == docname:
+                used.pop(fullname)
+
+        if len(used) == 0:
+            modules.pop(modname)
+
+
 class ViewcodeAnchorTransform(SphinxPostTransform):
     """Convert or remove viewcode_anchor nodes depends on builder."""
     default_priority = 100
@@ -323,6 +335,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('viewcode_follow_imported_members', True, False)
     app.connect('doctree-read', doctree_read)
     app.connect('env-merge-info', env_merge_info)
+    app.connect('env-purge-doc', env_purge_doc)
     app.connect('html-collect-pages', collect_pages)
     app.connect('missing-reference', missing_reference)
     # app.add_config_value('viewcode_include_modules', [], 'env')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- viewcode does not purge unreferenced modules on incremental build.  This
adds env-purge-doc handler to clean them.
- refs: #8756 