### PR TITLE
LaTeX: sync pdftex engine default imageresolution with pxunit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -68,6 +68,8 @@ Bugs fixed
   ``:unknown:doc:``)
 * #8711: LaTeX: backticks in code-blocks trigger latexpdf build warning (and font
   change) with late TeXLive 2019
+* #8253: LaTeX: Figures with no size defined get overscaled (compared to images
+  with size explicitly set in pixels) (fixed for ``'pdflatex'/'lualatex'`` only)
 
 Testing
 --------

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -13,6 +13,9 @@
 \ifdefined\pdfpxdimen
    \let\sphinxpxdimen\pdfpxdimen\else\newdimen\sphinxpxdimen
 \fi \sphinxpxdimen=<%= pxunit %>\relax
+\ifdefined\pdfimageresolution
+    \pdfimageresolution= \numexpr \dimexpr1in\relax/\sphinxpxdimen\relax
+\fi
 <% if use_xindy -%>
 %% turn off hyperref patch of \index as sphinx.xdy xindy module takes care of
 %% suitable \hyperpage mark-up, working around hyperref-xindy incompatibility


### PR DESCRIPTION
Closes: #8253

The 'pxunit' key from latex_elements instructs how to handle image
dimensions specified in px units.

But pdftex has \pdfimageresolution which is used when an image file does
not provide readable or legit values for the x and/or y resolution.

This commit syncs them: from 'pxunit' the default image resolution in
pixels per inch (an integer) is computed.

This way an image will behave the same if:

- it is loaded with no explicit size set, _and_ no readable image
  resolution data is readable from the file (or that data matches the
  'pxunit' setting)

- or a size is set in figure directive using px units and equal to the
  natural pixel size of the image,

This also with 'lualatex' but is ignored by with 'xelatex' and
'uplatex'.

### Bugfix

### Relates
- #8253 

It is hard to provide unit test, because one would have to examine logs of a latex build, and the data inthere might change according to latex upgrades.

This will change the size of images loaded with no explicit dimension set, if the graphics file has no x-resolution or no such resolution understood by pdftex. For this reason I make this PR for merge into master.


