### PR TITLE
LaTeX: sync with upstream footnotehyper

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -98,6 +98,8 @@ Bugs fixed
 * #8683: :confval:`html_last_updated_fmt` generates wrong time zone for %Z
 * #1112: ``download`` role creates duplicated copies when relative path is
   specified
+* #7576: LaTeX with French babel and memoir crash: "Illegal parameter number
+  in definition of ``\FNH@prefntext``"
 * #8735: LaTeX: wrong internal links in pdf to captioned code-blocks when
   :confval:`numfig` is not True
 

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -1,9 +1,9 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{footnotehyper-sphinx}%
- [2017/10/27 v1.7 hyperref aware footnote.sty for sphinx (JFB)]
+ [2021/01/26 v1.1b hyperref aware footnote.sty for sphinx (JFB)]
 %%
 %% Package: footnotehyper-sphinx
-%% Version: based on footnotehyper.sty 2017/03/07 v1.0
+%% Version: based on footnotehyper.sty 2021/01/26 v1.1b
 %% as available at https://www.ctan.org/pkg/footnotehyper
 %% License: the one applying to Sphinx
 %%
@@ -16,7 +16,7 @@
 %% 3. use of \sphinxunactivateextrasandspace from sphinx.sty,
 %% 4. macro definition \sphinxfootnotemark,
 %% 5. macro definition \sphinxlongtablepatch
-%% 6. replaced an \undefined by \@undefined
+%% 6. replaced some \undefined by \@undefined
 \DeclareOption*{\PackageWarning{footnotehyper-sphinx}{Option `\CurrentOption' is unknown}}%
 \ProcessOptions\relax
 \newbox\FNH@notes
@@ -206,9 +206,20 @@
                \FNH@@@1.2!3?4,\FNH@@@\relax
 }%
 \long\def\FNH@check@a #11.2!3?4,#2\FNH@@@#3{%
-    \ifx\relax#3\expandafter\@firstoftwo\else\expandafter\@secondoftwo\fi
-    \FNH@bad@makefntext@alert
-    {\def\FNH@prefntext{#1}\def\FNH@postfntext{#2}\FNH@check@b}%
+    \ifx\relax#3\FNH@bad@makefntext@alert
+    \else
+      \edef\FNH@restore@{\catcode`\noexpand\@\the\catcode`\@\relax}%
+      \makeatletter
+      \ifx\@makefntextFB\@undefined
+      \expandafter\@gobble\else\expandafter\@firstofone\fi
+      {\@ifclassloaded{memoir}%
+           {\ifFBFrenchFootnotes\expandafter\@gobble\fi}%
+           {}}%
+      \@secondoftwo
+      \scantokens{\def\FNH@prefntext{#1}\def\FNH@postfntext{#2}}%
+      \FNH@restore@
+      \expandafter\FNH@check@b
+    \fi
 }%
 \def\FNH@check@b #1\relax{%
     \expandafter\expandafter\expandafter\FNH@check@c


### PR DESCRIPTION
This fixes #7576

### Feature or Bugfix
- Bugfix

Hard to provide a test as it would have to make a latexpdf compilation only to test an exotic document class (memoir). Not worth it. Besides it is only syncing with upstream Latex code of footnotehyper, let's leave the burden there of testing.

