### PR TITLE
Fix #8214: duplicate entries in latex index if term also in glossary

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -98,6 +98,8 @@ Bugs fixed
 * #8683: :confval:`html_last_updated_fmt` generates wrong time zone for %Z
 * #1112: ``download`` role creates duplicated copies when relative path is
   specified
+* #8214: LaTeX: The :rst:role:`index` role and the glossary generate duplicate
+  entries in the LaTeX index (if both used for same term)
 * #8735: LaTeX: wrong internal links in pdf to captioned code-blocks when
   :confval:`numfig` is not True
 * #8442: LaTeX: some indexed terms are ignored when using xelatex engine

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1859,8 +1859,8 @@
 \def\sphinxstyleindexextra   #1{ (\emph{#1})}
 \def\sphinxstyleindexpageref #1{, \pageref{#1}}
 \def\sphinxstyleindexpagemain#1{\textbf{#1}}
-\protected\def\spxentry#1{#1}% will get \let to \sphinxstyleindexentry in index
-\protected\def\spxextra#1{#1}% will get \let to \sphinxstyleindexextra in index
+\def\spxentry{\@backslashchar spxentry}% let to \sphinxstyleindexentry in index
+\def\spxextra{\@backslashchar spxextra}% let to \sphinxstyleindexextra in index
 \def\sphinxstyleindexlettergroup #1%
     {{\Large\sffamily#1}\nopagebreak\vspace{1mm}}
 \def\sphinxstyleindexlettergroupDefault #1%


### PR DESCRIPTION
This makes .idx files contain \spxentry{..} with no space, whether or
not the \index latex command is encountered in main text or e.g. in a
label of a description list (like happens for terms from a glossary).

Xindy does not care about spaces, but Makeindex doesn't merge entries
whose typesetting is to be done via \spxentry{..} or \spxentry {..}.

An alternative work-around would be for Sphinx LaTeX writer to use some
wrapper, say, \sphinxindexwrap, only to fetch the argument and force TeX
tokenization and then hand over it to \index command.

But we choose to let \spxentry expand to its own name, with no trailing
space (it gets its final definition only from the python.ist file in
case of Makeindex).

In case both the :index: role and the glossary are on same page, Xindy
and Makeindex behave differently: the former gives only once the page
number, the latter issues them twice (but the indexed term only once),
and there is warning in the .ilg file. But this is unrelated and we
can't do here anything about it.


### Feature or Bugfix
- Bugfix

Closes: #8214
