### PR TITLE
Fix #8072: Directive hlist not implemented in LaTeX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ Release 3.5.0 (in development)
 Dependencies
 ------------
 
+* LaTeX: ``multicol`` (it is anyhow a required part of the official latex2e
+  base distribution)
+
 Incompatible changes
 --------------------
 
@@ -103,6 +106,7 @@ Bugs fixed
   specified
 * #7576: LaTeX with French babel and memoir crash: "Illegal parameter number
   in definition of ``\FNH@prefntext``"
+* #8072: LaTeX: Directive :rst:dir:`hlist` not implemented in LaTeX
 * #8214: LaTeX: The :rst:role:`index` role and the glossary generate duplicate
   entries in the LaTeX index (if both used for same term)
 * #8735: LaTeX: wrong internal links in pdf to captioned code-blocks when

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -394,6 +394,8 @@ units as well as normal text.
 
    .. versionadded:: 0.6
 
+   .. versionchanged:: 3.5.0
+      support by the latex builder.
 
 .. _code-examples:
 

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -394,8 +394,6 @@ units as well as normal text.
 
    .. versionadded:: 0.6
 
-   .. versionchanged:: 3.5.0
-      support by the latex builder.
 
 .. _code-examples:
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -276,6 +276,7 @@ class HList(SphinxDirective):
         npercol, nmore = divmod(len(fulllist), ncolumns)
         index = 0
         newnode = addnodes.hlist()
+        newnode['ncolumns'] = str(ncolumns)
         for column in range(ncolumns):
             endindex = index + ((npercol + 1) if column < nmore else npercol)
             bullet_list = nodes.bullet_list()

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -239,6 +239,8 @@
 \ltx@ifundefined{@removefromreset}
     {\RequirePackage{remreset}}
     {}% avoid warning
+% To support hlist directive
+\RequirePackage{multicol}
 % to make pdf with correct encoded bookmarks in Japanese
 % this should precede the hyperref package
 \ifx\kanjiskip\@undefined

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1175,9 +1175,11 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.append('\n\\end{center}')
 
     def visit_hlist(self, node: Element) -> None:
-        # for now, we don't support a more compact list format
-        # don't add individual itemize environments, but one for all columns
         self.compact_list += 1
+        ncolumns = node['ncolumns']
+        if self.compact_list > 1:
+            self.body.append('\\setlength{\\multicolsep}{0pt}\n')
+        self.body.append('\\begin{multicols}{' + ncolumns + '}\\raggedright\n')
         self.body.append('\\begin{itemize}\\setlength{\\itemsep}{0pt}'
                          '\\setlength{\\parskip}{0pt}\n')
         if self.table:
@@ -1185,12 +1187,17 @@ class LaTeXTranslator(SphinxTranslator):
 
     def depart_hlist(self, node: Element) -> None:
         self.compact_list -= 1
-        self.body.append('\\end{itemize}\n')
+        self.body.append('\\end{itemize}\\raggedcolumns\\end{multicols}\n')
 
     def visit_hlistcol(self, node: Element) -> None:
         pass
 
     def depart_hlistcol(self, node: Element) -> None:
+        # \columnbreak would guarantee same columns as in html ouput.  But
+        # some testing with long items showed that columns may be too uneven.
+        # And in case only of short items, the automatic column breaks should
+        # match the ones pre-computed by the hlist() directive.
+        # self.body.append('\\columnbreak\n')
         pass
 
     def latex_image_length(self, width_str: str, scale: int = 100) -> str:


### PR DESCRIPTION
Adds ``multicol`` LaTeX package requirement, but it is a required
part of any latex distribution.

(hence I make the PR on 3.x branch)

I think this is bugfix as #8072 was tagged as "bug" :)

I used following test file 
[index.rst.txt](https://github.com/sphinx-doc/sphinx/files/5889808/index.rst.txt)
to check it was possible to use `hlist` inside a table, or inside another list (I checked only a `hlist`, but this is only more stringent).

In the test output one sees some phenomenon related to the fact that LaTeX does not hyphenate the first word of a paragraph. This shows here with the word "horizontally" in narrow columns. The non-hyphenated word gets then shifted down...

But this has nothing to do with this PR and I will make another one to address the issue. The bullets in the output may look random but they do match the input which I constructed by random copy paste and adding and suppressing item separators.

![Capture d’écran 2021-01-28 à 21 24 38](https://user-images.githubusercontent.com/2589111/106195222-25212680-61b0-11eb-8b95-202ec83d0da2.png)


### Relates
- #8072

