### PR TITLE
LaTeX: remove last argument of \titleformat in sphinx.sty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -114,6 +114,8 @@ Bugs fixed
 * #8442: LaTeX: some indexed terms are ignored when using xelatex engine
   (or pdflatex and :confval:`latex_use_xindy` set to True) with memoir class
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
+* #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
+  bracketed, not braced (and is anyhow not needed) 
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -716,17 +716,17 @@
 % Augment the sectioning commands used to get our own font family in place,
 % and reset some internal data items (\titleformat from titlesec package)
 \titleformat{\section}{\Large\py@HeaderFamily}%
-            {\py@TitleColor\thesection}{0.5em}{\py@TitleColor}{\py@NormalColor}
+            {\py@TitleColor\thesection}{0.5em}{\py@TitleColor}
 \titleformat{\subsection}{\large\py@HeaderFamily}%
-            {\py@TitleColor\thesubsection}{0.5em}{\py@TitleColor}{\py@NormalColor}
+            {\py@TitleColor\thesubsection}{0.5em}{\py@TitleColor}
 \titleformat{\subsubsection}{\py@HeaderFamily}%
-            {\py@TitleColor\thesubsubsection}{0.5em}{\py@TitleColor}{\py@NormalColor}
+            {\py@TitleColor\thesubsubsection}{0.5em}{\py@TitleColor}
 % By default paragraphs (and subsubsections) will not be numbered because
 % sphinxmanual.cls and sphinxhowto.cls set secnumdepth to 2
 \titleformat{\paragraph}{\py@HeaderFamily}%
-            {\py@TitleColor\theparagraph}{0.5em}{\py@TitleColor}{\py@NormalColor}
+            {\py@TitleColor\theparagraph}{0.5em}{\py@TitleColor}
 \titleformat{\subparagraph}{\py@HeaderFamily}%
-            {\py@TitleColor\thesubparagraph}{0.5em}{\py@TitleColor}{\py@NormalColor}
+            {\py@TitleColor\thesubparagraph}{0.5em}{\py@TitleColor}
 
 
 %% GRAPHICS


### PR DESCRIPTION
The ``{\py@NormalColor}`` was wrong it should have been ``[\py@NormalColor]``.

It got executed by latex during document preamble and never got
integrated as part of the heading...

Closes: #8788

I will merge after testing completes. The argument is not needed as it was actually never correctly used...