### PR TITLE
Latex sphinxsafeincludegraphics corebug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Bugs fixed
 * #8655: autodoc: Failed to generate document if target module contains an
   object that raises an exception on ``hasattr()``
 * C, ``expr`` role should start symbol lookup in the current scope.
+* #8796: LaTeX: potentially critical low level TeX coding mistake has gone
+  unnoticed so far
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -737,7 +737,7 @@
 \AtBeginDocument{\spx@image@maxheight\textheight}
 
 % box scratch register
-\newdimen\spx@image@box
+\newbox\spx@image@box
 \newcommand*{\sphinxsafeincludegraphics}[2][]{%
     % #1 contains possibly width=, height=, but no scale= since 1.8.4
     \setbox\spx@image@box\hbox{\includegraphics[#1,draft]{#2}}%


### PR DESCRIPTION
This bug was introduced at 2.0 (commit 669f9c3a) (sorry)

This core bug seems not to cause harm, so it is no reason to hurry 3.4.4, it can be delayed to 3.5

