### PR TITLE
autodoc: Support type union operator (PEP-604) (refs: #8775)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,7 @@ Features added
   info-field-list
 * #8514: autodoc: Default values of overloaded functions are taken from actual
   implementation if they're ellipsis
+* #8775: autodoc: Support type union operator (PEP-604) in Python 3.10 or above
 * #8619: html: kbd role generates customizable HTML tags for compound keys
 * #8634: html: Allow to change the order of JS/CSS via ``priority`` parameter
   for :meth:`Sphinx.add_js_file()` and :meth:`Sphinx.add_css_file()`

--- a/tests/roots/test-ext-autodoc/target/pep604.py
+++ b/tests/roots/test-ext-autodoc/target/pep604.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+attr: int | str  #: docstring
+
+
+def sum(x: int | str, y: int | str) -> int | str:
+    """docstring"""
+
+
+class Foo:
+    """docstring"""
+
+    attr: int | str  #: docstring
+
+    def meth(self, x: int | str, y: int | str) -> int | str:
+        """docstring"""

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -2237,6 +2237,50 @@ def test_name_mangling(app):
     ]
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_type_union_operator(app):
+    options = {'members': None}
+    actual = do_autodoc(app, 'module', 'target.pep604', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.pep604',
+        '',
+        '',
+        '.. py:class:: Foo()',
+        '   :module: target.pep604',
+        '',
+        '   docstring',
+        '',
+        '',
+        '   .. py:attribute:: Foo.attr',
+        '      :module: target.pep604',
+        '      :type: int | str',
+        '',
+        '      docstring',
+        '',
+        '',
+        '   .. py:method:: Foo.meth(x: int | str, y: int | str) -> int | str',
+        '      :module: target.pep604',
+        '',
+        '      docstring',
+        '',
+        '',
+        '.. py:data:: attr',
+        '   :module: target.pep604',
+        '   :type: int | str',
+        '',
+        '   docstring',
+        '',
+        '',
+        '.. py:function:: sum(x: int | str, y: int | str) -> int | str',
+        '   :module: target.pep604',
+        '',
+        '   docstring',
+        '',
+    ]
+
+
 @pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_hide_value(app):

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -117,6 +117,13 @@ def test_restify_type_ForwardRef():
     assert restify(ForwardRef("myint")) == ":class:`myint`"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
+def test_restify_type_union_operator():
+    assert restify(int | None) == "Optional[:class:`int`]"  # type: ignore
+    assert restify(int | str) == ":class:`int` | :class:`str`"  # type: ignore
+    assert restify(int | str | None) == "Optional[:class:`int` | :class:`str`]"  # type: ignore
+
+
 def test_restify_broken_type_hints():
     assert restify(BrokenType) == ':class:`tests.test_util_typing.BrokenType`'
 
@@ -204,6 +211,13 @@ def test_stringify_type_hints_alias():
     MyTuple = Tuple[str, str]
     assert stringify(MyStr) == "str"
     assert stringify(MyTuple) == "Tuple[str, str]"  # type: ignore
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
+def test_stringify_type_union_operator():
+    assert stringify(int | None) == "Optional[int]"  # type: ignore
+    assert stringify(int | str) == "int | str"  # type: ignore
+    assert stringify(int | str | None) == "Optional[int | str]"  # type: ignore
 
 
 def test_stringify_broken_type_hints():


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Upgrade autodoc to support type union operator introduced in
PEP-604. It's available only with python 3.10+.
- refs: #8775 