### PR TITLE
linkcheck: The docname of hyperlink is not displayed (refs: #8791)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -91,6 +91,7 @@ Bugs fixed
   footnote reference
 * #4304: linkcheck: Fix race condition that could lead to checking the
   availability of the same URL twice
+* #8791: linkcheck: The docname for each hyperlink is not displayed
 * #7118: sphinx-quickstart: questionare got Mojibake if libreadline unavailable
 * #8094: texinfo: image files on the different directory with document are not
   copied

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -390,7 +390,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
             self.write_linkstat(linkstat)
             return
         if lineno:
-            logger.info('(line %4d) ', lineno, nonl=True)
+            logger.info('(%16s: line %4d) ', docname, lineno, nonl=True)
         if status == 'ignored':
             if info:
                 logger.info(darkgray('-ignored- ') + uri + ': ' + info)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Currently, linkcheck displays the status of hyperlinks.  But it is hard
to search where the hyperlink is written because only line numbers are
shown as the location for the link.
- This displays the docname of the link too.
- refs: #8791 