### PR TITLE
LaTeX: add support for named destinations (without prefix) in PDFs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -117,8 +117,6 @@ Bugs fixed
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
   bracketed, not braced (and is anyhow not needed)
-* #8807: LaTeX: todo directive inserts ``\label`` without a proper anchor point
-  (from ``\phantomsection`` or a counter stepping)
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -117,6 +117,8 @@ Bugs fixed
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
   bracketed, not braced (and is anyhow not needed)
+* #8807: LaTeX: todo directive inserts ``\label`` without a proper anchor point
+  (from ``\phantomsection`` or a counter stepping)
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,7 @@ Features added
 * #2030: :rst:dir:`code-block` and :rst:dir:`literalinclude` supports automatic
   dedent via no-argument ``:dedent:`` option
 * C++, also hyperlink operator overloads in expressions and alias declarations.
+* #6276: LaTeX: Support external hyperlinking to a named destination within a PDF
 * #8247: Allow production lists to refer to tokens from other production groups
 
 Bugs fixed
@@ -115,7 +116,7 @@ Bugs fixed
   (or pdflatex and :confval:`latex_use_xindy` set to True) with memoir class
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
-  bracketed, not braced (and is anyhow not needed) 
+  bracketed, not braced (and is anyhow not needed)
 
 Testing
 --------

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1686,8 +1686,11 @@
                      \csname\@backslashchar color@#2\endcsname }
 
 % the main dispatch for all types of notices
+% work around a problem with todo extension triggering usage of \label
+% without a proper anchor set-up via ref-stepping a counter (or \phantomsection)
 \newcounter{sphinxadmonition}
 \newenvironment{sphinxadmonition}[2]{% #1=type, #2=heading
+  \refstepcounter{sphinxadmonition}% in case extension triggers \label usage
   % can't use #1 directly in definition of end part
   \def\spx@noticetype {#1}%
   % set parameters of heavybox/lightbox

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1686,11 +1686,8 @@
                      \csname\@backslashchar color@#2\endcsname }
 
 % the main dispatch for all types of notices
-% work around a problem with todo extension triggering usage of \label
-% without a proper anchor set-up via ref-stepping a counter (or \phantomsection)
 \newcounter{sphinxadmonition}
 \newenvironment{sphinxadmonition}[2]{% #1=type, #2=heading
-  \refstepcounter{sphinxadmonition}% in case extension triggers \label usage
   % can't use #1 directly in definition of end part
   \def\spx@noticetype {#1}%
   % set parameters of heavybox/lightbox

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -419,7 +419,66 @@
 \ifdefined\directlua\let\sphinxAtStartPar\@empty\fi
 % user interface: options can be changed midway in a document!
 \newcommand\sphinxsetup[1]{\setkeys{sphinx}{#1}}
-
+% Support for absolute destination label, for example:
+%     http://example.com/doc.pdf#nameddest=my-target
+%
+% This goes via \sphinxnameddest mark-up, which can be used multiple times for
+% same anchor. Achieving this requires hack into \hyper@anchorstart. Here and
+% in \sphinxnameddest, we assume that \@currentHref has benign expansion (i.e.
+% default is somecountername.number or section*.number from \phantomsection)
+% and I see no circumstance why it would be configured otherwise in a Sphinx
+% project.
+\AtBeginDocument{%
+   \let\spx@hyper@anchorstart@ORI\hyper@anchorstart
+   \def\hyper@anchorstart#1{% #1=\@currentHref
+       % in Sphinx context \@currentHref should have benign expansion
+       \ltx@ifundefined{spxDL@#1}%
+         {\spx@hyper@anchorstart@ORI{#1}}%
+         % When \spxDL@#1 expands, it executes for each given name the original
+         % \hyper@anchorstart, creating anchors at same spot in document.
+         {\@nameuse{spxDL@#1}}%
+   }%
+   %\PackageInfo{sphinx}{redefining \string\hyper@anchorstart}%
+}%
+% \spx@DLadd expands when the aux file is loaded and stores all given names
+% sharing a common location for later multiple anchor creations at same spot.
+% this will happen via patched as above \hyper@anchorstart
+\def\spx@DLadd#1#2{%
+  \ltx@ifundefined{spxDL@#1}%
+  % the original \detokenize from Sphinx mark-up now consumed, we add it again
+       {\global\@namedef{spxDL@#1}{%
+           % create anchor with hyperref assigned name else internal links fail!
+           \spx@hyper@anchorstart@ORI{\@currentHref}\hyper@anchorend
+           % add a name from \sphinxnameddest, others may follow
+           \spx@hyper@anchorstart@ORI{\detokenize{#2}}}%
+       }% end of branch for first name to a given location
+       {% add a second, third, etc..., name for anchor creation
+        \expandafter\g@addto@macro\csname spxDL@#1\endcsname
+           {\hyper@anchorend\spx@hyper@anchorstart@ORI{\detokenize{#2}}}%
+       }% end of branch for second, third, etc... additional names
+}%
+% this adds to the aux file, for next latex run, the various \spx@DLadd
+% it can recognize if an attempt is made to use same name multiple times but
+% as this is already filtered out at DocUtils/Sphinx level, simply do nothing
+\protected\def\sphinxnameddest#1{%
+  % \protected to prevent premature expansion, e.g. via \sphinxLiteralBlockLabel
+  % #1 from Sphinx LaTeX writer is always wrapped in \detokenize
+  % the \detokenize will get consumed from writing it out to aux file
+  \ltx@ifundefined{spxDL!#1}{%
+    % it is assumed \@currentHref expands nicely (see remark above)
+    \expandafter\xdef\csname spxDL!#1\endcsname{\@currentHref}%
+    \if@filesw % not really needed in Sphinx automated context
+    \begingroup
+    \edef\x{\endgroup%
+    % this will write to aux file the expanded \@currentHref in association
+    % to the given destination name #1
+    \noexpand\write\@auxout{\string\spx@DLadd{\@currentHref}{#1}}%
+    }\x%
+    \if@nobreak\ifvmode\nobreak\fi\fi
+    \fi}%
+    {% non-document prefixed section titles are likely to generate duplicates
+    }% simply we leave each such name have target its first occurrence location
+}%
 
 %% ALPHANUMERIC LIST ITEMS
 \newcommand\sphinxsetlistlabels[5]
@@ -1627,6 +1686,7 @@
                      \csname\@backslashchar color@#2\endcsname }
 
 % the main dispatch for all types of notices
+\newcounter{sphinxadmonition}
 \newenvironment{sphinxadmonition}[2]{% #1=type, #2=heading
   % can't use #1 directly in definition of end part
   \def\spx@noticetype {#1}%

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -470,12 +470,17 @@ class LaTeXTranslator(SphinxTranslator):
         return ('\\phantomsection' if anchor else '') + \
             '\\label{%s}' % self.idescape(id)
 
+    def hypernameddest(self, name: str) -> str:
+        return '\\sphinxnameddest{%s}' % self.idescape(name)
+
     def hypertarget_to(self, node: Element, anchor: bool = False) -> str:
         labels = ''.join(self.hypertarget(node_id, anchor=False) for node_id in node['ids'])
+        nameddests = ''.join(self.hypernameddest(nodes.make_id(node_name))
+                             for node_name in node['names'])
         if anchor:
-            return r'\phantomsection' + labels
+            return r'\phantomsection' + labels + nameddests
         else:
-            return labels
+            return labels + nameddests
 
     def hyperlink(self, id: str) -> str:
         return '{\\hyperref[%s]{' % self.idescape(id)

--- a/tests/roots/test-latex-table/expects/complex_spanning_cell.tex
+++ b/tests/roots/test-latex-table/expects/complex_spanning_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{complex:complex-spanning-cell}}
+\label{\detokenize{complex:complex-spanning-cell}}\sphinxnameddest{\detokenize{complex-spanning-cell}}
 \sphinxAtStartPar
 table having …
 \begin{itemize}

--- a/tests/roots/test-latex-table/expects/gridtable.tex
+++ b/tests/roots/test-latex-table/expects/gridtable.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{complex:grid-table}}
+\label{\detokenize{complex:grid-table}}\sphinxnameddest{\detokenize{grid-table}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/longtable.tex
+++ b/tests/roots/test-latex-table/expects/longtable.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable}}
+\label{\detokenize{longtable:longtable}}\sphinxnameddest{\detokenize{longtable}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|l|l|}
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_align.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_align.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-having-align-option}}
+\label{\detokenize{longtable:longtable-having-align-option}}\sphinxnameddest{\detokenize{longtable-having-align-option}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[r]{|l|l|}
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-having-caption}}
+\label{\detokenize{longtable:longtable-having-caption}}\sphinxnameddest{\detokenize{longtable-having-caption}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|l|l|}
 \sphinxthelongtablecaptionisattop

--- a/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-having-problematic-cell}}
+\label{\detokenize{longtable:longtable-having-problematic-cell}}\sphinxnameddest{\detokenize{longtable-having-problematic-cell}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|*{2}{\X{1}{2}|}}
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-having-both-stub-columns-and-problematic-cell}}
+\label{\detokenize{longtable:longtable-having-both-stub-columns-and-problematic-cell}}\sphinxnameddest{\detokenize{longtable-having-both-stub-columns-and-problematic-cell}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|*{3}{\X{1}{3}|}}
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-having-verbatim}}
+\label{\detokenize{longtable:longtable-having-verbatim}}\sphinxnameddest{\detokenize{longtable-having-verbatim}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|*{2}{\X{1}{2}|}}
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -1,7 +1,7 @@
-\label{\detokenize{longtable:longtable-having-widths-option}}
+\label{\detokenize{longtable:longtable-having-widths-option}}\sphinxnameddest{\detokenize{longtable-having-widths-option}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|\X{30}{100}|\X{70}{100}|}
-\hline\noalign{\phantomsection\label{\detokenize{longtable:namedlongtable}}\label{\detokenize{longtable:mylongtable}}}%
+\hline\noalign{\phantomsection\label{\detokenize{longtable:namedlongtable}}\label{\detokenize{longtable:mylongtable}}\sphinxnameddest{\detokenize{namedlongtable}}\sphinxnameddest{\detokenize{mylongtable}}}%
 \sphinxstyletheadfamily 
 \sphinxAtStartPar
 header1

--- a/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-having-both-widths-and-problematic-cell}}
+\label{\detokenize{longtable:longtable-having-both-widths-and-problematic-cell}}\sphinxnameddest{\detokenize{longtable-having-both-widths-and-problematic-cell}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|\X{30}{100}|\X{70}{100}|}
 \hline

--- a/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{longtable:longtable-with-tabularcolumn}}
+\label{\detokenize{longtable:longtable-with-tabularcolumn}}\sphinxnameddest{\detokenize{longtable-with-tabularcolumn}}
 
 \begin{savenotes}\sphinxatlongtablestart\begin{longtable}[c]{|c|c|}
 \hline

--- a/tests/roots/test-latex-table/expects/simple_table.tex
+++ b/tests/roots/test-latex-table/expects/simple_table.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:simple-table}}
+\label{\detokenize{tabular:simple-table}}\sphinxnameddest{\detokenize{simple-table}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/table_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/table_having_caption.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-caption}}
+\label{\detokenize{tabular:table-having-caption}}\sphinxnameddest{\detokenize{table-having-caption}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/table_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_problematic_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-problematic-cell}}
+\label{\detokenize{tabular:table-having-problematic-cell}}\sphinxnameddest{\detokenize{table-having-problematic-cell}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/table_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_stub_columns_and_problematic_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-both-stub-columns-and-problematic-cell}}
+\label{\detokenize{tabular:table-having-both-stub-columns-and-problematic-cell}}\sphinxnameddest{\detokenize{table-having-both-stub-columns-and-problematic-cell}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/table_having_threeparagraphs_cell_in_first_col.tex
+++ b/tests/roots/test-latex-table/expects/table_having_threeparagraphs_cell_in_first_col.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-with-cell-in-first-column-having-three-paragraphs}}
+\label{\detokenize{tabular:table-with-cell-in-first-column-having-three-paragraphs}}\sphinxnameddest{\detokenize{table-with-cell-in-first-column-having-three-paragraphs}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/table_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/table_having_verbatim.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-verbatim}}
+\label{\detokenize{tabular:table-having-verbatim}}\sphinxnameddest{\detokenize{table-having-verbatim}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/table_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths.tex
@@ -1,8 +1,8 @@
-\label{\detokenize{tabular:table-having-widths-option}}
+\label{\detokenize{tabular:table-having-widths-option}}\sphinxnameddest{\detokenize{table-having-widths-option}}
 
 \begin{savenotes}\sphinxattablestart
 \centering
-\phantomsection\label{\detokenize{tabular:namedtabular}}\label{\detokenize{tabular:mytabular}}\nobreak
+\phantomsection\label{\detokenize{tabular:namedtabular}}\label{\detokenize{tabular:mytabular}}\sphinxnameddest{\detokenize{namedtabular}}\sphinxnameddest{\detokenize{mytabular}}\nobreak
 \begin{tabular}[t]{|\X{30}{100}|\X{70}{100}|}
 \hline
 \sphinxstyletheadfamily 

--- a/tests/roots/test-latex-table/expects/table_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths_and_problematic_cell.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-both-widths-and-problematic-cell}}
+\label{\detokenize{tabular:table-having-both-widths-and-problematic-cell}}\sphinxnameddest{\detokenize{table-having-both-widths-and-problematic-cell}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/tabular_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/tabular_having_widths.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-align-option-tabular}}
+\label{\detokenize{tabular:table-having-align-option-tabular}}\sphinxnameddest{\detokenize{table-having-align-option-tabular}}
 
 \begin{savenotes}\sphinxattablestart
 \raggedright

--- a/tests/roots/test-latex-table/expects/tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/tabularcolumn.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-with-tabularcolumn}}
+\label{\detokenize{tabular:table-with-tabularcolumn}}\sphinxnameddest{\detokenize{table-with-tabularcolumn}}
 
 \begin{savenotes}\sphinxattablestart
 \centering

--- a/tests/roots/test-latex-table/expects/tabulary_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/tabulary_having_widths.tex
@@ -1,4 +1,4 @@
-\label{\detokenize{tabular:table-having-align-option-tabulary}}
+\label{\detokenize{tabular:table-having-align-option-tabulary}}\sphinxnameddest{\detokenize{table-having-align-option-tabulary}}
 
 \begin{savenotes}\sphinxattablestart
 \raggedleft

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -760,6 +760,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app, status, warning):
     assert '\\subsubsection*{The rubric title with a reference to {[}AuthorYear{]}}' in result
     assert ('\\chapter{The section with a reference to \\sphinxfootnotemark[5]}\n'
             '\\label{\\detokenize{index:the-section-with-a-reference-to}}'
+            '\\sphinxnameddest{\\detokenize{the-section-with-a-reference-to}}'
             '%\n\\begin{footnotetext}[5]\\sphinxAtStartFootnote\n'
             'Footnote in section\n%\n\\end{footnotetext}') in result
     assert ('\\caption{This is the figure caption with a footnote to '
@@ -1447,9 +1448,12 @@ def test_latex_labels(app, status, warning):
             r'\label{\detokenize{index:id1}}'
             r'\label{\detokenize{index:figure2}}'
             r'\label{\detokenize{index:figure1}}'
+            r'\sphinxnameddest{\detokenize{figure2}}'
+            r'\sphinxnameddest{\detokenize{figure1}}'
             r'\end{figure}' in result)
     assert (r'\caption{labeled figure}'
-            '\\label{\\detokenize{index:figure3}}\n'
+            '\\label{\\detokenize{index:figure3}}'
+            '\\sphinxnameddest{\\detokenize{figure3}}\n'
             '\\begin{sphinxlegend}\n\\sphinxAtStartPar\n'
             'with a legend\n\\end{sphinxlegend}\n'
             r'\end{figure}' in result)
@@ -1457,29 +1461,41 @@ def test_latex_labels(app, status, warning):
     # code-blocks
     assert (r'\def\sphinxLiteralBlockLabel{'
             r'\label{\detokenize{index:codeblock2}}'
-            r'\label{\detokenize{index:codeblock1}}}' in result)
+            r'\label{\detokenize{index:codeblock1}}'
+            r'\sphinxnameddest{\detokenize{codeblock2}}'
+            r'\sphinxnameddest{\detokenize{codeblock1}}' in result)
     assert (r'\def\sphinxLiteralBlockLabel{'
-            r'\label{\detokenize{index:codeblock3}}}' in result)
+            r'\label{\detokenize{index:codeblock3}}'
+            r'\sphinxnameddest{\detokenize{codeblock3}}' in result)
 
     # tables
     assert (r'\sphinxcaption{table caption}'
             r'\label{\detokenize{index:id2}}'
             r'\label{\detokenize{index:table2}}'
-            r'\label{\detokenize{index:table1}}' in result)
+            r'\label{\detokenize{index:table1}}'
+            r'\sphinxnameddest{\detokenize{table2}}'
+            r'\sphinxnameddest{\detokenize{table1}}' in result)
     assert (r'\sphinxcaption{table caption}'
-            r'\label{\detokenize{index:table3}}' in result)
+            r'\label{\detokenize{index:table3}}'
+            r'\sphinxnameddest{\detokenize{table3}}' in result)
 
     # sections
     assert ('\\chapter{subsection}\n'
             r'\label{\detokenize{index:subsection}}'
             r'\label{\detokenize{index:section2}}'
-            r'\label{\detokenize{index:section1}}' in result)
+            r'\label{\detokenize{index:section1}}'
+            r'\sphinxnameddest{\detokenize{subsection}}'
+            r'\sphinxnameddest{\detokenize{section2}}'
+            r'\sphinxnameddest{\detokenize{section1}}' in result)
     assert ('\\section{subsubsection}\n'
             r'\label{\detokenize{index:subsubsection}}'
-            r'\label{\detokenize{index:section3}}' in result)
+            r'\label{\detokenize{index:section3}}'
+            r'\sphinxnameddest{\detokenize{subsubsection}}'
+            r'\sphinxnameddest{\detokenize{section3}}' in result)
     assert ('\\subsection{otherdoc}\n'
             r'\label{\detokenize{otherdoc:otherdoc}}'
-            r'\label{\detokenize{otherdoc::doc}}' in result)
+            r'\label{\detokenize{otherdoc::doc}}'
+            r'\sphinxnameddest{\detokenize{otherdoc}}' in result)
 
     # Embedded standalone hyperlink reference (refs: #5948)
     assert result.count(r'\label{\detokenize{index:section1}}') == 1
@@ -1522,6 +1538,7 @@ def test_index_on_title(app, status, warning):
     result = (app.outdir / 'python.tex').read_text()
     assert ('\\chapter{Test for index in top level title}\n'
             '\\label{\\detokenize{contents:test-for-index-in-top-level-title}}'
+            '\\sphinxnameddest{\\detokenize{test-for-index-in-top-level-title}}'
             '\\index{index@\\spxentry{index}}\n'
             in result)
 

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -358,11 +358,13 @@ def test_code_block_caption_latex(app, status, warning):
 def test_code_block_namedlink_latex(app, status, warning):
     app.builder.build_all()
     latex = (app.outdir / 'python.tex').read_text()
-    label1 = '\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:name-test-rb}}}'
+    label1 = ('\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:name-test-rb}}'
+              '\\sphinxnameddest{\\detokenize{name-test-rb}}}')
     link1 = '\\hyperref[\\detokenize{caption:name-test-rb}]'\
             '{\\sphinxcrossref{\\DUrole{std,std-ref}{Ruby}}'
     label2 = ('\\def\\sphinxLiteralBlockLabel'
-              '{\\label{\\detokenize{namedblocks:some-ruby-code}}}')
+              '{\\label{\\detokenize{namedblocks:some-ruby-code}}'
+              '\\sphinxnameddest{\\detokenize{some-ruby-code}}}')
     link2 = '\\hyperref[\\detokenize{namedblocks:some-ruby-code}]'\
             '{\\sphinxcrossref{\\DUrole{std,std-ref}{the ruby code}}}'
     assert label1 in latex
@@ -506,11 +508,13 @@ def test_literalinclude_caption_latex(app, status, warning):
 def test_literalinclude_namedlink_latex(app, status, warning):
     app.builder.build('index')
     latex = (app.outdir / 'python.tex').read_text()
-    label1 = '\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:name-test-py}}}'
+    label1 = ('\\def\\sphinxLiteralBlockLabel{\\label{\\detokenize{caption:name-test-py}}'
+              '\\sphinxnameddest{\\detokenize{name-test-py}}}')
     link1 = '\\hyperref[\\detokenize{caption:name-test-py}]'\
             '{\\sphinxcrossref{\\DUrole{std,std-ref}{Python}}'
     label2 = ('\\def\\sphinxLiteralBlockLabel'
-              '{\\label{\\detokenize{namedblocks:some-python-code}}}')
+              '{\\label{\\detokenize{namedblocks:some-python-code}}'
+              '\\sphinxnameddest{\\detokenize{some-python-code}}}')
     link2 = '\\hyperref[\\detokenize{namedblocks:some-python-code}]'\
             '{\\sphinxcrossref{\\DUrole{std,std-ref}{the python code}}}'
     assert label1 in latex


### PR DESCRIPTION
Allow to link externally to some permanent PDF ids, like this

    http://example.com/doc.pdf#nameddest=my-target

where my-target is chosen label in source (i.e. the document name is not
added as prefix). This allows external linking in a way stable against
renaming of sections or moving documentation from one document to the
other in the same project.

(The "nameddest=" part is even optional in some viewer)

Closes: #6276

<strike>Closes issue #8807</strike>

This adds a feature <strike>(and closes bug #8807 but using  a workaround).</strike>

As per why I don't use `\hypertarget` as proposed in original ticket #6276, it has to do with the fact that it would have to be located before the labeled title or caption.

There is a functionality in hyperref to name destinations. But its option `destlabel` makes it so that it is the first `\label` which decides of the name. In my testing, a user added label in rst source ends up rather as last `\label`. So the approach taken here is to append to last `\label` a dedicated macro. Notice that this avoids any LaTeX hack into `\label`. There is `\label@hook` which hyperref uses under option `destlabel` to insert `\HyperDestRename`. However this is no way to use because we want only the last `\label` to prevail not the first. For simplicity though, the code rather than extending the pre-existing `\HyperDestNameFilter` overwrites it completely with our own version, so if there exists any package influencing naming of destination anchors, and using `\HyperDestNameFilter` as per hyperref doc, their effect will be suppressed. (but a priori if any such thing exists it is for hand-written latex sources, so it is not of Sphinx concern). In particular, our code is stable against passing option `destlabel` to hyperref, which should not change anything. I know that the latex code is hard to understand because one has to read `hyperref` documentation and the relevant part of its source code. We are using its hook `\HyperDestNameFilter` as per its documentation, setting it up as an expandable macro which will convert the internally generated hyperref label into the user provided name.  We imitate `hyperref` way of doing that with option `destlabel` but we have to change things and can not use this option ourselves.

I did not see without more changes to latex.py how to add the mark-up extension *only*  in case of user added labels in source, so I had to allow this extended mark-up for each usages of `hypertarget_to()`. This means that the LaTeX code has to eliminate all duplicates, which will a priori be numerous if the project contains multiple source files, from automated things, many files can have a section "options" for example. Everything is eliminated silently, it is up to user now however to make sure user-added labels are unique across all documentation to avoid pdftex warnings about distinct destinations receiving the same name.

Edit: it may be that some of the above is slightly obsolete because I may have found a way (possibly not natural one) to restrict, so it seems, to only handle hypertargets from explicitly set labels in project source.