### PR TITLE
Latex url as footnotes in signatures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -118,6 +118,8 @@ Bugs fixed
   :confval:`numfig` is not True
 * #8442: LaTeX: some indexed terms are ignored when using xelatex engine
   (or pdflatex and :confval:`latex_use_xindy` set to True) with memoir class
+* #8750: LaTeX: URLs as footnotes fail to show in PDF if originating from
+  inside function type signatures
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
   bracketed, not braced (and is anyhow not needed) 

--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -1,9 +1,9 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{footnotehyper-sphinx}%
- [2021/01/26 v1.1b hyperref aware footnote.sty for sphinx (JFB)]
+ [2021/01/29 v1.1c hyperref aware footnote.sty for sphinx (JFB)]
 %%
 %% Package: footnotehyper-sphinx
-%% Version: based on footnotehyper.sty 2021/01/26 v1.1b
+%% Version: based on footnotehyper.sty 2021/01/29 v1.1c
 %% as available at https://www.ctan.org/pkg/footnotehyper
 %% License: the one applying to Sphinx
 %%
@@ -20,6 +20,7 @@
 \DeclareOption*{\PackageWarning{footnotehyper-sphinx}{Option `\CurrentOption' is unknown}}%
 \ProcessOptions\relax
 \newbox\FNH@notes
+\newtoks\FNH@toks % 1.1c
 \newdimen\FNH@width
 \let\FNH@colwidth\columnwidth
 \newif\ifFNH@savingnotes
@@ -27,6 +28,7 @@
     \let\FNH@latex@footnote    \footnote
     \let\FNH@latex@footnotetext\footnotetext
     \let\FNH@H@@footnotetext   \@footnotetext
+    \let\FNH@H@@mpfootnotetext \@mpfootnotetext
     \newenvironment{savenotes}
         {\FNH@savenotes\ignorespaces}{\FNH@spewnotes\ignorespacesafterend}%
     \let\spewnotes      \FNH@spewnotes
@@ -37,6 +39,7 @@
     \@ifpackageloaded{hyperref}
      {\ifHy@hyperfootnotes
          \let\FNH@H@@footnotetext\H@@footnotetext
+         \let\FNH@H@@mpfootnotetext\H@@mpfootnotetext
       \else
          \let\FNH@hyper@fntext\FNH@nohyp@fntext
       \fi}%
@@ -111,14 +114,33 @@
   \fi
 }%
 \def\FNH@spewnotes {%
-  \endgroup
+  \if@endpe\ifx\par\@@par\FNH@toks{}\else
+     \FNH@toks\expandafter{\expandafter
+              \def\expandafter\par\expandafter{\par}\@endpetrue}%
+     \expandafter\expandafter\expandafter
+     \FNH@toks
+     \expandafter\expandafter\expandafter
+     {\expandafter\the\expandafter\FNH@toks
+      \expandafter\def\expandafter\@par\expandafter{\@par}}%
+     \expandafter\expandafter\expandafter
+     \FNH@toks
+     \expandafter\expandafter\expandafter
+     {\expandafter\the\expandafter\FNH@toks
+      \expandafter\everypar\expandafter{\the\everypar}}\fi
+  \else\FNH@toks{}\fi
+  \expandafter
+  \endgroup\the\FNH@toks
   \ifFNH@savingnotes\else
    \ifvoid\FNH@notes\else
     \begingroup
      \let\@makefntext\@empty
      \let\@finalstrut\@gobble
      \let\rule\@gobbletwo
-     \FNH@H@@footnotetext{\unvbox\FNH@notes}%
+     \ifx\@footnotetext\@mpfootnotetext
+        \expandafter\FNH@H@@mpfootnotetext
+     \else
+        \expandafter\FNH@H@@footnotetext
+     \fi{\unvbox\FNH@notes}%
     \endgroup
    \fi
   \fi

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -704,12 +704,18 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.append(self.context.pop())
 
     def visit_desc(self, node: Element) -> None:
-        self.body.append('\n\n\\begin{fulllineitems}\n')
+        if self.config.latex_show_urls == 'footnote':
+            self.body.append('\n\n\\begin{savenotes}\\begin{fulllineitems}\n')
+        else:
+            self.body.append('\n\n\\begin{fulllineitems}\n')
         if self.table:
             self.table.has_problematic = True
 
     def depart_desc(self, node: Element) -> None:
-        self.body.append('\n\\end{fulllineitems}\n\n')
+        if self.config.latex_show_urls == 'footnote':
+            self.body.append('\n\\end{fulllineitems}\\end{savenotes}\n\n')
+        else:
+            self.body.append('\n\\end{fulllineitems}\n\n')
 
     def _visit_signature_line(self, node: Element) -> None:
         for child in node:

--- a/tests/roots/test-footnotes/index.rst
+++ b/tests/roots/test-footnotes/index.rst
@@ -169,3 +169,9 @@ Footnote in term [#]_
 
           def bar(x,y):
               return x+y
+
+The section with an object description
+======================================
+
+.. py:function:: dummy(N)
+   :noindex:

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -829,6 +829,7 @@ def test_latex_show_urls_is_inline(app, status, warning):
     assert '\\sphinxurl{https://github.com/sphinx-doc/sphinx}\n' in result
     assert ('\\sphinxhref{mailto:sphinx-dev@googlegroups.com}'
             '{sphinx\\sphinxhyphen{}dev@googlegroups.com}') in result
+    assert '\\begin{savenotes}\\begin{fulllineitems}' not in result
 
 
 @pytest.mark.sphinx(
@@ -883,6 +884,7 @@ def test_latex_show_urls_is_footnote(app, status, warning):
     assert ('\\sphinxurl{https://github.com/sphinx-doc/sphinx}\n' in result)
     assert ('\\sphinxhref{mailto:sphinx-dev@googlegroups.com}'
             '{sphinx\\sphinxhyphen{}dev@googlegroups.com}\n') in result
+    assert '\\begin{savenotes}\\begin{fulllineitems}' in result
 
 
 @pytest.mark.sphinx(
@@ -926,6 +928,7 @@ def test_latex_show_urls_is_no(app, status, warning):
     assert ('\\sphinxurl{https://github.com/sphinx-doc/sphinx}\n' in result)
     assert ('\\sphinxhref{mailto:sphinx-dev@googlegroups.com}'
             '{sphinx\\sphinxhyphen{}dev@googlegroups.com}\n') in result
+    assert '\\begin{savenotes}\\begin{fulllineitems}' not in result
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
Closes: #8750 

### Feature or Bugfix
<!-- please choose -->
- Bugfix

Only solution I found so far is to wrap entire `fulllineitems` in `savenotes`. The footnotes will appear at bottom of page where the object description ends.

I take this opportunity to sync with upstream footnotehyper 1.1c and also a patch from 1.1 which was not incorporated so far.