### PR TITLE
Sync with footnotehyper 1.1d

### DIFF
--- a/sphinx/texinputs/footnotehyper-sphinx.sty
+++ b/sphinx/texinputs/footnotehyper-sphinx.sty
@@ -1,9 +1,9 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{footnotehyper-sphinx}%
- [2021/01/29 v1.1c hyperref aware footnote.sty for sphinx (JFB)]
+ [2021/02/04 v1.1d hyperref aware footnote.sty for sphinx (JFB)]
 %%
 %% Package: footnotehyper-sphinx
-%% Version: based on footnotehyper.sty 2021/01/29 v1.1c
+%% Version: based on footnotehyper.sty 2021/02/04 v1.1d
 %% as available at https://www.ctan.org/pkg/footnotehyper
 %% License: the one applying to Sphinx
 %%
@@ -17,6 +17,7 @@
 %% 4. macro definition \sphinxfootnotemark,
 %% 5. macro definition \sphinxlongtablepatch
 %% 6. replaced some \undefined by \@undefined
+\newif\iffootnotehyperparse\footnotehyperparsetrue
 \DeclareOption*{\PackageWarning{footnotehyper-sphinx}{Option `\CurrentOption' is unknown}}%
 \ProcessOptions\relax
 \newbox\FNH@notes
@@ -218,29 +219,67 @@
     \FNH@endfntext@fntext {\unvbox\z@}%
   \endgroup
 }%
-\AtBeginDocument{%
-   \let\FNH@@makefntext\@makefntext
-   \ifx\@makefntextFB\@undefined
-   \expandafter\@gobble\else\expandafter\@firstofone\fi
-   {\ifFBFrenchFootnotes \let\FNH@@makefntext\@makefntextFB \else
-                         \let\FNH@@makefntext\@makefntextORI\fi}%
-   \expandafter\FNH@check@a\FNH@@makefntext{1.2!3?4,}%
-               \FNH@@@1.2!3?4,\FNH@@@\relax
+\let\FNH@prefntext\@empty
+\let\FNH@postfntext\@empty
+\AtBeginDocument{\iffootnotehyperparse\expandafter\FNH@check\fi}%
+\def\FNH@safeif#1{%
+   \iftrue\csname if#1\endcsname\csname fi\endcsname\expandafter\@firstoftwo
+   \else\csname fi\endcsname\expandafter\@secondoftwo
+   \fi
+}%
+\def\FNH@check{%
+   \ifx\@makefntextFB\@undefined\expandafter\FNH@check@
+                           \else\expandafter\FNH@frenchb@
+   \fi
+}%
+\def\FNH@frenchb@{%
+   \def\FNH@prefntext{%
+     \localleftbox{}%
+     \let\FBeverypar@save\FBeverypar@quote
+     \let\FBeverypar@quote\relax
+     \FNH@safeif{FB@koma}%
+       {\FNH@safeif{FBFrenchFootnotes}%
+          {\ifx\footnote\thanks
+             \let\@@makefnmark\@@makefnmarkTH
+             \@makefntextTH{} % space as in french.ldf
+           \else
+             \let\@@makefnmark\@@makefnmarkFB
+             \@makefntextFB{} % space as in french.ldf
+             \fi
+          }{\let\@@makefnmark\@@makefnmarkORI
+             \@makefntextORI{}% no space as in french.ldf
+          }%
+       }%
+       {\FNH@safeif{FBFrenchFootnotes}%
+          {\@makefntextFB{}}%
+          {\@makefntextORI{}}%
+       }%
+   }%
+   \def\FNH@postfntext{%
+     \let\FBeverypar@quote\FBeverypar@save
+     \localleftbox{\FBeveryline@quote}%
+   }%
+}%
+\def\FNH@check@{%
+    \expandafter\FNH@check@a\@makefntext{1.2!3?4,}%
+                \FNH@@@1.2!3?4,\FNH@@@\relax
 }%
 \long\def\FNH@check@a #11.2!3?4,#2\FNH@@@#3{%
-    \ifx\relax#3\FNH@bad@makefntext@alert
+    \ifx\relax#3\expandafter\FNH@checkagain@
     \else
-      \edef\FNH@restore@{\catcode`\noexpand\@\the\catcode`\@\relax}%
-      \makeatletter
-      \ifx\@makefntextFB\@undefined
-      \expandafter\@gobble\else\expandafter\@firstofone\fi
-      {\@ifclassloaded{memoir}%
-           {\ifFBFrenchFootnotes\expandafter\@gobble\fi}%
-           {}}%
-      \@secondoftwo
-      \scantokens{\def\FNH@prefntext{#1}\def\FNH@postfntext{#2}}%
-      \FNH@restore@
+      \def\FNH@prefntext{#1}\def\FNH@postfntext{#2}%
       \expandafter\FNH@check@b
+    \fi
+}%
+\def\FNH@checkagain@{%
+    \expandafter\FNH@checkagain@a
+    \detokenize\expandafter{\@makefntext{1.2!3?4,}}\relax\FNH@@@
+}%
+\edef\FNH@temp{\noexpand\FNH@checkagain@a ##1\string{1.2!3?4,\string}}%
+\expandafter\def\FNH@temp#2#3\FNH@@@{%
+    \ifx\relax#2%
+      \def\FNH@prefntext{\@makefntext{}}%
+    \else\FNH@bad@makefntext@alert
     \fi
 }%
 \def\FNH@check@b #1\relax{%
@@ -249,7 +288,7 @@
     \meaning\FNH@postfntext1.2!3?4,\FNH@check@c\relax
 }%
 \def\FNH@check@c #11.2!3?4,#2#3\relax{%
-    \ifx\FNH@check@c#2\expandafter\@gobble\fi\FNH@bad@makefntext@alert
+    \ifx\FNH@check@c#2\else\FNH@bad@makefntext@alert\fi
 }%
 % slight reformulation for Sphinx
 \def\FNH@bad@makefntext@alert{%
@@ -283,7 +322,6 @@
     \noexpand\if@endpe\noexpand\@endpetrue\noexpand\fi
   }%
 }%
-% end of footnotehyper 2017/02/16 v0.99
 % some extras for Sphinx :
 % \sphinxfootnotemark: usable in section titles and silently removed from TOCs.
 \def\sphinxfootnotemark [#1]%


### PR DESCRIPTION
This fixes a problem (upstream) introduced at 1.1b (which was already merged in 3.x) which could cause latex build
crash in case of extra user (latex) packages.

It also improves compatibility with babel + french.

