### PR TITLE
Support testing from read-only filesystems

### DIFF
--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -18,6 +18,17 @@ from sphinx.deprecation import RemovedInSphinx50Warning
 FILESYSTEMENCODING = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
 
+def getumask() -> int:
+    """Get current umask value"""
+    umask = os.umask(0)  # Note: Change umask value temporarily to obtain it
+    os.umask(umask)
+
+    return umask
+
+
+UMASK = getumask()
+
+
 class path(str):
     """
     Represents a path which behaves like a string.
@@ -104,9 +115,9 @@ class path(str):
         # to the destination tree, ensure destination directories are not marked
         # read-only.
         for root, dirs, files in os.walk(destination):
-            os.chmod(root, 0o755)
+            os.chmod(root, 0o755 & ~UMASK)
             for name in files:
-                os.chmod(os.path.join(root, name), 0o644)
+                os.chmod(os.path.join(root, name), 0o644 & ~UMASK)
 
     def movetree(self, destination: str) -> None:
         """

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -109,15 +109,16 @@ class path(str):
             pointed to by the symbolic links are copied.
         """
         shutil.copytree(self, destination, symlinks=symlinks)
-        # If source tree is marked read-only (e.g. because it is on a read-only
-        # filesystem), `shutil.copytree` will mark the destination as read-only
-        # as well.  To avoid failures when adding additional files/directories
-        # to the destination tree, ensure destination directories are not marked
-        # read-only.
-        for root, dirs, files in os.walk(destination):
-            os.chmod(root, 0o755 & ~UMASK)
-            for name in files:
-                os.chmod(os.path.join(root, name), 0o644 & ~UMASK)
+        if os.environ.get('SPHINX_READONLY_TESTDIR'):
+            # If source tree is marked read-only (e.g. because it is on a read-only
+            # filesystem), `shutil.copytree` will mark the destination as read-only
+            # as well.  To avoid failures when adding additional files/directories
+            # to the destination tree, ensure destination directories are not marked
+            # read-only.
+            for root, dirs, files in os.walk(destination):
+                os.chmod(root, 0o755 & ~UMASK)
+                for name in files:
+                    os.chmod(os.path.join(root, name), 0o644 & ~UMASK)
 
     def movetree(self, destination: str) -> None:
         """

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -98,6 +98,15 @@ class path(str):
             pointed to by the symbolic links are copied.
         """
         shutil.copytree(self, destination, symlinks=symlinks)
+        # If source tree is marked read-only (e.g. because it is on a read-only
+        # filesystem), `shutil.copytree` will mark the destination as read-only
+        # as well.  To avoid failures when adding additional files/directories
+        # to the destination tree, ensure destination directories are not marked
+        # read-only.
+        for root, dirs, files in os.walk(destination):
+            os.chmod(root, 0o755)
+            for name in files:
+                os.chmod(os.path.join(root, name), 0o644)
 
     def movetree(self, destination: str) -> None:
         """


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- This is a refined version of #8511 
- Refer umask on changing permissions
- Change permissions only if `SPHINX_READONLY_TESTDIR` is set.