### PR TITLE
Fix broken "Extend" link in site header

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -67,7 +67,7 @@
     <li><a href="{{ pathto('index') }}">Home</a></li>
     <li><a href="{{ pathto('usage/installation') }}">Get it</a></li>
     <li><a href="{{ pathto('contents') }}">Docs</a></li>
-    <li><a href="{{ pathto('development') }}">Extend</a></li>
+    <li><a href="{{ pathto('development/index') }}">Extend</a></li>
   </ul>
   <div>
     <a href="{{ pathto('index') }}">


### PR DESCRIPTION
This fixes the "Extend" link in the site header pointing to a 404 (https://www.sphinx-doc.org/en/master/development.html). Spotted while navigating on https://www.sphinx-doc.org/en/master/.

### Feature or Bugfix

Bugfix

### Purpose

### Detail

I didn’t actually check whether the new link is correct, just based it on the documentation’s folder structure. There might also be a need to set up a redirect, if the page path changed unintentionally?

Edit: looking at the [RTD preview build](https://sphinx--8827.org.readthedocs.build/en/8827/), new link seems to be working as expected.

### Relates

I searched for "broken link" and "Extend" but couldn’t find anything related to this.