### PR TITLE
Linkcheck: Avoid duplicate download of page to check anchors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Deprecated
 Features added
 --------------
 
+* #4303: linkcheck: Avoid duplicate download of page to check multiple anchors
 * #8022: autodoc: autodata and autoattribute directives does not show right-hand
   value of the variable if docstring contains ``:meta hide-value:`` in
   info-field-list

--- a/tests/roots/test-linkcheck-localserver-multiple-anchors/conf.py
+++ b/tests/roots/test-linkcheck-localserver-multiple-anchors/conf.py
@@ -1,0 +1,2 @@
+exclude_patterns = ['_build']
+linkcheck_anchors = True

--- a/tests/roots/test-linkcheck-localserver-multiple-anchors/index.rst
+++ b/tests/roots/test-linkcheck-localserver-multiple-anchors/index.rst
@@ -1,0 +1,3 @@
+`local server <http://localhost:7777/#ants>`_
+`local server <http://localhost:7777/#behavior-and-ecology>`_
+`local server <http://localhost:7777/#content-from-other-site>`_


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
Avoid unnecessary round-trips to web servers, speeding up the linkcheck
process when multiple anchors need to be checked on the same page.

### Detail
Anchors (named fragments in the spec) indicate a secondary resource
relative to the primary resource. The page can be fetched once, and all
anchors checked on the retrieved page.

The distinction between anchors and the web page location has been made
more explicit in the work queue. A single page now has a set of anchors
to check.
Previously, the anchor was considered part of the link, such that
http://a.example/#id-1 and http://a.example/#id-2 would be considered
two different links. After this change, the link becomes
http://a.example/ and has two anchors: {'id-1', 'id-2'}.

Errors occurring when the web page is downloaded no longer show the
anchor, the anchor existence is conditioned by the existence of the page
at URI.

### Relates

- #4303