### PR TITLE
refactor: linkcheck: Deprecate attributes of linkcheck builders

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,9 +18,12 @@ Deprecated
 ----------
 
 * pending_xref node for viewcode extension
+* ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.anchors_ignore``
+* ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.auth``
 * ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.broken``
 * ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.good``
 * ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.redirected``
+* ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.to_ignore``
 * ``sphinx.builders.linkcheck.node_line_or_0()``
 * ``sphinx.ext.autodoc.AttributeDocumenter.isinstanceattribute()``
 * ``sphinx.ext.autodoc.directive.DocumenterBridge.reporter``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -27,6 +27,16 @@ The following is a list of deprecated interfaces.
      - 5.0
      - ``sphinx.ext.viewcode.viewcode_anchor``
 
+   * - ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.anchors_ignore``
+     - 3.5
+     - 5.0
+     - N/A
+
+   * - ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.auth``
+     - 3.5
+     - 5.0
+     - N/A
+
    * - ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.broken``
      - 3.5
      - 5.0
@@ -38,6 +48,11 @@ The following is a list of deprecated interfaces.
      - N/A
 
    * - ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.redirected``
+     - 3.5
+     - 5.0
+     - N/A
+
+   * - ``sphinx.builders.linkcheck.CheckExternalLinksBuilder.to_ignore``
      - 3.5
      - 5.0
      - N/A


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Move anchors_ignore, auth and to_ignore to
HyperlinkAvailabilityCheckWorker and become deprecated.
- refs: https://github.com/sphinx-doc/sphinx/pull/8806