### PR TITLE
Revert "Add \nobreak inside \sphinxAtStartPar"

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -414,7 +414,7 @@
 \DisableKeyvalOption{sphinx}{mathnumfig}
 % To allow hyphenation of first word in narrow contexts; no option,
 % customization to be done via 'preamble' key
-\newcommand*\sphinxAtStartPar{\nobreak\hskip\z@skip}
+\newcommand*\sphinxAtStartPar{\hskip\z@skip}
 % No need for the \hspace{0pt} trick (\hskip\z@skip) with luatex
 \ifdefined\directlua\let\sphinxAtStartPar\@empty\fi
 % user interface: options can be changed midway in a document!


### PR DESCRIPTION
This reverts commit 17642a5e6bbcccc5616da381c10a068c9e09b6d7.

Fixes #8838. For some reason the \nobreak causes breakage in table
vertical spacing for merge cells in tabular and longtable, and regarding
tabulary for all cells...

Reverting this will cause as described in the reverted commit message
some much less annoying problem in certain circumstances when a long
word has no hyphenation point.

Relates #8781