### PR TITLE
Fix #8837: doc: Remove version info from html_title

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,7 @@ html_theme_path = ['_themes']
 modindex_common_prefix = ['sphinx.']
 html_static_path = ['_static']
 html_sidebars = {'index': ['indexsidebar.html', 'searchbox.html']}
+html_title = 'Sphinx documentation'
 html_additional_pages = {'index': 'index.html'}
 html_use_opensearch = 'https://www.sphinx-doc.org/en/master'
 html_baseurl = 'https://www.sphinx-doc.org/en/master/'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8837