### PR TITLE
Add new options for moving the toctree

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -162,7 +162,7 @@ tables of contents.  The ``toctree`` directive is the central element.
 
          recipe/*
 
-   You can also give a "hidden" option to the directive, like this::
+   You can also give a ``hidden`` option to the directive, like this::
 
       .. toctree::
          :hidden:
@@ -185,7 +185,71 @@ tables of contents.  The ``toctree`` directive is the central element.
          doc_1
          doc_2
 
-   All other toctree entries can then be eliminated by the "hidden" option.
+   All other toctree entries can then be eliminated by the ``hidden`` option.
+
+   When a ``toctree`` directive is encountered in a reST document, Sphinx will
+   add the listed entries as children of the current nesting level. This is
+   sometimes undesired. For example, placing a ``toctree`` at the end of a
+   document will make make the listed entries subsections of the last section of
+   the document. The default behavior can be changed with the ``raise_level``
+   option. Consider the following::
+
+       ====
+       Main
+       ====
+
+       -----
+       Sub 1
+       -----
+
+       .. toctree::
+          :raise_level: 1
+
+          sub_2
+          sub_3
+
+   The structure without the ``raise_level`` option would be:
+
+   * Main
+
+     * Sub 1
+
+       * Sub 2
+       * Sub 3
+
+   With ``:raise_level: 1`` it becomes:
+
+   * Main
+
+     * Sub 1
+     * Sub 2
+     * Sub 3
+
+   Sometimes, the nesting depth at the end of the document varies and
+   the ``raise_level`` option would need to be changed accordingly. In
+   these cases the ``toctree`` directive can be placed on an
+   appropriate level and moved using the ``index`` option, which
+   determines the (zero-based) index of the first entry of the
+   ``toctree`` among its siblings. Negative indices are counted from
+   the end. For example, the following document produces the same
+   structure as the previous one::
+
+       ====
+       Main
+       ====
+
+       .. toctree::
+          :index: -1
+
+          sub_2
+          sub_3
+
+       -----
+       Sub 1
+       -----
+
+   The ``index`` option is usually used with ``hidden`` to put subsections
+   defined in other files after the sections in the current document.
 
    In the end, all documents in the :term:`source directory` (or subdirectories)
    must occur in some ``toctree`` directive; Sphinx will emit a warning if it

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -58,6 +58,8 @@ class TocTree(SphinxDirective):
         'numbered': int_or_nothing,
         'titlesonly': directives.flag,
         'reversed': directives.flag,
+        'raise_level': int,
+        'index': int,
     }
 
     def run(self) -> List[Node]:
@@ -75,6 +77,9 @@ class TocTree(SphinxDirective):
         subnode['includehidden'] = 'includehidden' in self.options
         subnode['numbered'] = self.options.get('numbered', 0)
         subnode['titlesonly'] = 'titlesonly' in self.options
+        subnode['raise_level'] = self.options.get('raise_level', 0)
+        if 'index' in self.options:
+            subnode['index'] = self.options.get('index')
         self.set_source_info(subnode)
         wrappernode = nodes.compound(classes=['toctree-wrapper'])
         wrappernode.append(subnode)

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -41,6 +41,8 @@ def register_sections_as_label(app: Sphinx, document: Node) -> None:
         docname = app.env.docname
         title = cast(nodes.title, node[0])
         ref_name = getattr(title, 'rawsource', title.astext())
+        if app.config.autosectionlabel_word_separator != ' ':
+            ref_name = app.config.autosectionlabel_word_separator.join(ref_name.split())
         if app.config.autosectionlabel_prefix_document:
             name = nodes.fully_normalize_name(docname + ':' + ref_name)
         else:
@@ -58,6 +60,7 @@ def register_sections_as_label(app: Sphinx, document: Node) -> None:
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('autosectionlabel_prefix_document', False, 'env')
+    app.add_config_value('autosectionlabel_word_separator', ' ', 'env')
     app.add_config_value('autosectionlabel_maxdepth', None, 'env')
     app.connect('doctree-read', register_sections_as_label)
 


### PR DESCRIPTION
Subject: Add `raise_level` and `index` options to `toctree`

Sphinx currently places toctrees as children of the current nesting level. This is not always the desired behaviour especially with the `hidden` option. The `ralse_level` option lets one to move the toctree up. The `index` option lets one to adjust the position of the toctree e.g. by moving it last.

This fixes the problems reported in the links below but does not change the semantics of `hidden`.

https://github.com/sphinx-doc/sphinx/pull/3622
http://stackoverflow.com/q/25276415/102441
http://stackoverflow.com/q/39110429/102441

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix

- Feature
- Bugfix (the fact that hidden toctrees are always *children* of the current level sometimes looks like a bug)
