### PR TITLE
LaTeX: optionally apply a second forceful wrapping of long code lines

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -131,6 +131,7 @@ Bugs fixed
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
   bracketed, not braced (and is anyhow not needed) 
+* #8849: LaTex: code-block printed out of margin
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -131,7 +131,9 @@ Bugs fixed
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
   bracketed, not braced (and is anyhow not needed) 
-* #8849: LaTex: code-block printed out of margin
+* #8849: LaTex: code-block printed out of margin (see the opt-in LaTeX syntax
+  boolean :ref:`verbatimforcewraps <latexsphinxsetupforcewraps>` for use via
+  the :ref:`'sphinxsetup' <latexsphinxsetup>` key of ``latex_elements``)
 
 Testing
 --------

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -638,6 +638,18 @@ macros may be significant.
 
     Default: ``true``
 
+``verbatimforcewraps``
+    Boolean to specify if long lines in :rst:dir:`code-block`\ 's contents
+    which the wrapping algorithm could not reduce to at most an excess of 3
+    characters on a line will be cut forcefully to achieve this maximal excess
+    of 3 characters on each line. (*this is possibly fragile, so by default is
+    not done; please try it out and report issues to the maintainers to help
+    improve and decide whether to make this default*)
+
+    Default: ``false``
+
+    .. versionadded:: 3.5.0
+
 ``literalblockcappos``
     Decides the caption position: either ``b`` ("bottom") or ``t`` ("top").
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -650,7 +650,7 @@ macros may be significant.
     Boolean to specify if long lines in :rst:dir:`code-block`\ 's contents
     should be forcefully wrapped to never overflow due to long strings.
 
-    .. notice::
+    .. note::
 
        It is assumed that the Pygments_ LaTeXFormatter has not been used with
        its ``texcomments`` or similar options which allow additional

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -642,9 +642,13 @@ macros may be significant.
     Boolean to specify if long lines in :rst:dir:`code-block`\ 's contents
     which the wrapping algorithm could not reduce to at most an excess of 3
     characters on a line will be cut forcefully to achieve this maximal excess
-    of 3 characters on each line. (*this is possibly fragile, so by default is
-    not done; please try it out and report issues to the maintainers to help
-    improve and decide whether to make this default*)
+    of 3 characters on each line. (*this is possibly fragile, and in
+    particular will break with* ``'pdflatex'``, *if the code-block contains
+    Unicode input, so by default is not activated; however it will not have
+    this problem with Unicode engines. Please try it out and report further
+    issues to the maintainers; injecting* ``\sphinxsetup{verbatimforcewraps}``
+    *and* ``\sphinxsetup{verbatimforcewraps=false}`` *via* ``.. raw:: latex``
+    *directives will localize usage to only certain code-blocks*)
 
     Default: ``false``
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -585,7 +585,7 @@ The below is included at the end of the chapter::
 
      \endgroup
 
-LaTeX syntax for boolean keys require *lowercase* ``true`` or ``false``
+LaTeX syntax for boolean keys requires *lowercase* ``true`` or ``false``
 e.g ``'sphinxsetup': "verbatimwrapslines=false"``.  If setting the
 boolean key to ``true``, ``=true`` is optional.
 Spaces around the commas and equal signs are ignored, spaces inside LaTeX

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -585,7 +585,9 @@ The below is included at the end of the chapter::
 
      \endgroup
 
-LaTeX boolean keys require *lowercase* ``true`` or ``false`` values.
+LaTeX syntax for boolean keys require *lowercase* ``true`` or ``false``
+e.g ``'sphinxsetup': "verbatimwrapslines=false"``.  If setting the
+boolean key to ``true``, ``=true`` is optional.
 Spaces around the commas and equal signs are ignored, spaces inside LaTeX
 macros may be significant.
 
@@ -636,30 +638,63 @@ macros may be significant.
     Boolean to specify if long lines in :rst:dir:`code-block`\ 's contents are
     wrapped.
 
+    If ``true``, line breaks may happen at spaces (the last space before the
+    line break will be rendered using a special symbol), and at ascii
+    punctuation characters (i.e. not at letters or digits). Whenever a long
+    string has no break points, it is moved to next line. If its length is
+    longer than the line width it will overflow.
+
     Default: ``true``
 
 ``verbatimforcewraps``
     Boolean to specify if long lines in :rst:dir:`code-block`\ 's contents
-    which the wrapping algorithm could not reduce to at most an excess of 3
-    characters on a line will be cut forcefully to achieve this maximal excess
-    of 3 characters on each line. (*this is possibly fragile, and in
-    particular will break with* ``'pdflatex'``, *if the code-block contains
-    Unicode input, so by default is not activated; however it will not have
-    this problem with Unicode engines. Please try it out and report further
-    issues to the maintainers; injecting* ``\sphinxsetup{verbatimforcewraps}``
-    *and* ``\sphinxsetup{verbatimforcewraps=false}`` *via* ``.. raw:: latex``
-    *directives will localize usage to only certain code-blocks*)
+    should be forcefully wrapped to never overflow due to long strings.
+
+    .. notice::
+
+       It is assumed that the Pygments_ LaTeXFormatter has not been used with
+       its ``texcomments`` or similar options which allow additional
+       (arbitrary) LaTeX mark-up.
+
+       Also, in case of :confval:`latex_engine` set to ``'pdflatex'``, only
+       the default LaTeX handling of Unicode code points, i.e. ``utf8`` not
+       ``utf8x`` is allowed.
 
     Default: ``false``
 
     .. versionadded:: 3.5.0
 
-``literalblockcappos``
-    Decides the caption position: either ``b`` ("bottom") or ``t`` ("top").
+``verbatimmaxoverfull``
+    A number. If an unbreakable long string has length larger than the total
+    linewidth plus this number of characters, and if ``verbatimforcewraps``
+    mode is on, the input line will be reset using the forceful algorithm
+    which applies breakpoints at each character.
 
-    Default: ``t``
+    Default: ``3``
 
-    .. versionadded:: 1.7
+    .. versionadded:: 3.5.0
+
+``verbatimmaxunderfull``
+    A number. If ``verbatimforcewraps`` mode applies, and if after applying
+    the line wrapping at spaces and punctuation, the first part of the split
+    line is lacking at least that number of characters to fill the available
+    width, then the input line will be reset using the forceful algorithm.
+
+    As the default is set to a high value, the forceful algorithm is triggered
+    only in overfull case, i.e. in presence of a string longer than full
+    linewidth. Set this to ``0`` to force all input lines to be hard wrapped
+    at the current avaiable linewidth::
+
+      latex_elements = {
+          'sphinxsetup': "verbatimforcewraps, verbatimmaxunderfull=0",
+      }
+
+    This can be done locally for a given code-block via the use of raw latex
+    directives to insert suitable ``\sphinxsetup`` into the latex file.
+
+    Default: ``100``
+
+    .. versionadded:: 3.5.0
 
 ``verbatimhintsturnover``
     Boolean to specify if code-blocks display "continued on next page" and

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -646,6 +646,8 @@ macros may be significant.
 
     Default: ``true``
 
+.. _latexsphinxsetupforcewraps:
+
 ``verbatimforcewraps``
     Boolean to specify if long lines in :rst:dir:`code-block`\ 's contents
     should be forcefully wrapped to never overflow due to long strings.
@@ -692,7 +694,8 @@ macros may be significant.
       }
 
     This can be done locally for a given code-block via the use of raw latex
-    directives to insert suitable ``\sphinxsetup`` into the latex file.
+    directives to insert suitable ``\sphinxsetup`` (before and after) into the
+    latex file.
 
     Default: ``100``
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -660,6 +660,8 @@ macros may be significant.
        the default LaTeX handling of Unicode code points, i.e. ``utf8`` not
        ``utf8x`` is allowed.
 
+    .. _Pygments: https://pygments.org/
+
     Default: ``false``
 
     .. versionadded:: 3.5.0

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1185,27 +1185,46 @@
           \doublehyphendemerits\z@\finalhyphendemerits\z@
           \strut #1\strut}%
 }%
-% We implement an alternative to wrapping long code lines. This
-% alternative works only if the contents are in the expected
-% Pygments mark-up: i.e. some character escapes such as \PYGZdl{}
-% and the highlighting \PYG macro with always 2 arguments, and no
-% other macros. This means:
-% - the command prefix *must* be PYG
-% - the texcomments Pygments option *must* be set to False (it could
-% work by luck if True)
-% For non-highlighted tokens a break point is installed at each of them.
-% For highlighted tokens (i.e. in 2nd argument of \PYG) every four such
-% characters. \PYGZdl{} etc will count for 2, although corresponding to
-% only one. The result is that no line should be more than 3 characters
-% overfull.
-% First a measurement step is done of what would our standard wrapping
-% approach give. This is a bit tricky, cf TeX by Topic for the basic
-% dissecting technique, because TeX unfortunately when building a
-% vertical box does not store in an accessible way what was the maximal
-% line-width: the width of the box will be the set \hsize.
-% Anyway, if the max width exceed the linewidth by at least 4 character
-% widths, then we apply the "force wrapping" of previous paragraph,
-% else we apply our "standard wrapping".
+%
+% The normal line wrapping allows breaks at spaces and ascii non
+% letters, non digits. The \raggedright above means there will be
+% an overfilled line only if some non-breakable "word" was
+% encountered, which is longer than a line (it is moved always to
+% be on its own on a new line).
+% 
+% The "forced" line wrapping will parse the tokens to add potential
+% breakpoints at each character. As some strings are highlighted,
+% we have to apply the highlighting character per character, which
+% requires to manipulate the output of the Pygments LaTeXFormatter.
+%
+% Doing this at latex level is complicated. The contents should
+% be as expected: i.e. some active characters from
+% \sphinxbreaksviaactive, some Pygments character escapes such as
+% \PYGZdl{}, and the highlighting \PYG macro with always 2
+% arguments. No other macros should be there, except perhaps
+% zero-parameter macros. In particular:
+% - the texcomments Pygments option must be set to False
+%
+% With pdflatex, Unicode input gives multi-bytes characters
+% where the first byte is active. We support the "utf8" macros
+% only. "utf8x" is not supported.
+%
+% The highlighting macro \PYG will be applied character per
+% character. Highlighting via a colored background gives thus a
+% chain of small colored boxes which may cause some artefact in
+% some pdf viewers. Can't do anything here if we do want the line
+% break to be possible.
+%
+% First a measurement step is done of what would the standard line
+% wrapping give (i.e line breaks only at spaces and non-letter,
+% non-digit ascii characters), cf TeX by Topic for the basic
+% dissecting technique: TeX unfortunately when building a vertical
+% box does not store in an accessible way what was the maximal
+% line-width during paragraph building.
+%
+% If the max width exceed the linewidth by at least 4 character
+% widths, then we apply the "force wrapping" with potential line
+% break at each character, else we don't.
 \long\def\spx@verb@FormatLineForceWrap#1{%
     % \spx@image@box is a scratch box register that we can use here
     \global\let\spx@verb@maxwidth\z@
@@ -1215,58 +1234,115 @@
           \strut #1\strut\@@par
           \spx@verb@getmaxwidth}%
     \ifdim\spx@verb@maxwidth>\dimexpr\linewidth+3\fontcharwd\font`X\relax
-      \spx@verb@FormatLineWrap{\spx@forcewrapPYG #1\spx@forcewrapPYG}%
+      \spx@verb@FormatLineWrap{\spx@verb@wrapPYG #1\spx@verb@wrapPYG}%
     \else
       \spx@verb@FormatLineWrap{#1}%
     \fi
 }%
 % auxiliary paragraph dissector to get max width
-\newbox\spx@line@box
+\newbox\spx@scratchbox
 \def\spx@verb@getmaxwidth {%
     \unskip\unpenalty
-    \setbox\spx@line@box\lastbox
-    \ifvoid\spx@line@box
+    \setbox\spx@scratchbox\lastbox
+    \ifvoid\spx@scratchbox
     \else
-       \setbox\spx@line@box\hbox{\unhbox\spx@line@box}%
-       \ifdim\spx@verb@maxwidth<\wd\spx@line@box
-          \xdef\spx@verb@maxwidth{\number\wd\spx@line@box sp}%
+       \setbox\spx@scratchbox\hbox{\unhbox\spx@scratchbox}%
+       \ifdim\spx@verb@maxwidth<\wd\spx@scratchbox
+          \xdef\spx@verb@maxwidth{\number\wd\spx@scratchbox sp}%
        \fi
        \expandafter\spx@verb@getmaxwidth
     \fi
 }%
 % auxiliary macros to implement "cut long line even in middle of word"
-\def\spx@forcewrapPYG{%
-    \futurelet\spx@nexttoken\spx@forcewrapPYG@i
+\catcode`Z=3 % safe delimiter
+\def\spx@verb@wrapPYG{%
+    \futurelet\spx@nexttoken\spx@verb@wrapPYG@i
 }%
-\def\spx@forcewrapPYG@i{%
-    \ifx\spx@nexttoken\spx@forcewrapPYG\let\next=\@gobble\else
-    \ifx\spx@nexttoken\PYG\let\next=\spx@forcewrapPYG@PYG\else
+\def\spx@verb@wrapPYG@i{%
+    \ifx\spx@nexttoken\spx@verb@wrapPYG\let\next=\@gobble\else
+    \ifx\spx@nexttoken\PYG\let\next=\spx@verb@wrapPYG@PYG@onebyone\else
       \discretionary{}{\sphinxafterbreak}{}%
-      \let\next=\spx@forcewrapPYG@ii
+      \let\next\spx@verb@wrapPYG@ii
     \fi\fi
     \next
 }%
-\def\spx@forcewrapPYG@ii#1{#1\futurelet\spx@nexttoken\spx@forcewrapPYG@i}%
-% Replace \PYG by itself applied to short strings of 4 characters at a time
-% and insert breakpoints in-between
-\def\spx@forcewrapPYG@PYG\PYG#1#2{%
-    \def\spx@PYGspec{{#1}}%
-    \spx@PYG#2\@empty\@empty\@empty\@empty\relax
+% Let's recognize active characters. We don't support utf8x only utf8.
+% And here #1 should not have picked up (non empty) braced contents
+\long\def\spx@verb@wrapPYG@ii#1{%
+    \ifcat\noexpand~\noexpand#1\relax% active character
+      \expandafter\spx@verb@wrapPYG@active
+    \else % non-active character, control sequence such as \PYGZdl, or empty
+      \expandafter\spx@verb@wrapPYG@one
+    \fi {#1}%
 }%
-\def\spx@PYG#1#2#3#4{%
-    \discretionary{}{\sphinxafterbreak}{}%
-    \expandafter\PYG\spx@PYGspec{#1#2#3#4}%
-% I assume here contents never contain \@empty. If #4={} originally then
-% it is empty here and the \ifx will compare \@empty to \relax and choose
-% the else branch, i.e. to continue applying \PYG repeatedly
-    \ifx#4\@empty\relax
-      \expandafter\spx@PYG@done
-    \else
-      \expandafter\spx@PYG
+\long\def\spx@verb@wrapPYG@active#1{%
+% Let's hope expansion of active character does not really require arguments,
+% as we certainly don't want to go into expanding upfront token stream anyway.
+    \expandafter\spx@verb@wrapPYG@iii#1{}{}{}{}{}{}{}{}{}Z#1%
+}%
+\long\def\spx@verb@wrapPYG@iii#1#2Z{%
+    \ifx\UTFviii@four@octets#1\let\next=\spx@verb@wrapPYG@four\else
+    \ifx\UTFviii@three@octets#1\let\next=\spx@verb@wrapPYG@three\else
+    \ifx\UTFviii@two@octets#1\let\next=\spx@verb@wrapPYG@two\else
+    \let\next=\spx@verb@wrapPYG@one
+    \fi\fi\fi
+    \next
+}%
+\long\def\spx@verb@wrapPYG@one   #1{#1\futurelet\spx@nexttoken\spx@verb@wrapPYG@i}%
+\long\def\spx@verb@wrapPYG@two   #1#2{#1#2\futurelet\spx@nexttoken\spx@verb@wrapPYG@i}%
+\long\def\spx@verb@wrapPYG@three #1#2#3{#1#2#3\futurelet\spx@nexttoken\spx@verb@wrapPYG@i}%
+\long\def\spx@verb@wrapPYG@four  #1#2#3#4{#1#2#3#4\futurelet\spx@nexttoken\spx@verb@wrapPYG@i}%
+% Replace \PYG by itself applied one character at a time! This way breakpoints
+% can be inserted.
+\def\spx@verb@wrapPYG@PYG@onebyone#1#2#3{% #1 = \PYG, #2 = highlight spec, #3 = tokens
+    \def\spx@verb@wrapPYG@PYG@spec{{#2}}%
+    \futurelet\spx@nexttoken\spx@verb@wrapPYG@PYG@i#3Z%
+}%
+\def\spx@verb@wrapPYG@PYG@i{%
+    \ifx\spx@nexttokenZ\let\next=\spx@verb@wrapPYG@PYG@done\else
+      \discretionary{}{\sphinxafterbreak}{}%
+      \let\next\spx@verb@wrapPYG@PYG@ii
     \fi
+    \next
 }%
-% Once \PYG is handled we get back to our forward scan token by token
-\def\spx@PYG@done#1\relax{\futurelet\spx@nexttoken\spx@forcewrapPYG@i}%
+\def\spx@verb@wrapPYG@PYG@doneZ{\futurelet\spx@nexttoken\spx@verb@wrapPYG@i}%
+\long\def\spx@verb@wrapPYG@PYG@ii#1{%
+    \ifcat\noexpand~\noexpand#1\relax% active character
+      \expandafter\spx@verb@wrapPYG@PYG@active
+    \else % non-active character, control sequence such as \PYGZdl, or empty
+      \expandafter\spx@verb@wrapPYG@PYG@one
+    \fi {#1}%
+}%
+\long\def\spx@verb@wrapPYG@PYG@active#1{%
+% Let's hope expansion of active character does not really require arguments,
+% as we certainly don't want to go into expanding upfront token stream anyway.
+    \expandafter\spx@verb@wrapPYG@PYG@iii#1{}{}{}{}{}{}{}{}{}Z#1%
+}%
+\long\def\spx@verb@wrapPYG@PYG@iii#1#2Z{%
+    \ifx\UTFviii@four@octets#1\let\next=\spx@verb@wrapPYG@PYG@four\else
+    \ifx\UTFviii@three@octets#1\let\next=\spx@verb@wrapPYG@PYG@three\else
+    \ifx\UTFviii@two@octets#1\let\next=\spx@verb@wrapPYG@PYG@two\else
+    \let\next=\spx@verb@wrapPYG@PYG@one
+    \fi\fi\fi
+    \next
+}%
+\long\def\spx@verb@wrapPYG@PYG@one#1{%
+    \expandafter\PYG\spx@verb@wrapPYG@PYG@spec{#1}%
+    \futurelet\spx@nexttoken\spx@verb@wrapPYG@PYG@i
+}%
+\long\def\spx@verb@wrapPYG@PYG@two#1#2{%
+    \expandafter\PYG\spx@verb@wrapPYG@PYG@spec{#1#2}%
+    \futurelet\spx@nexttoken\spx@verb@wrapPYG@PYG@i
+}%
+\long\def\spx@verb@wrapPYG@PYG@three#1#2#3{%
+    \expandafter\PYG\spx@verb@wrapPYG@PYG@spec{#1#2#3}%
+    \futurelet\spx@nexttoken\spx@verb@wrapPYG@PYG@i
+}%
+\long\def\spx@verb@wrapPYG@PYG@four#1#2#3#4{%
+    \expandafter\PYG\spx@verb@wrapPYG@PYG@spec{#1#2#3#4}%
+    \futurelet\spx@nexttoken\spx@verb@wrapPYG@PYG@i
+}%
+\catcode`Z 11%
 %
 \g@addto@macro\FV@SetupFont{%
     \sbox\sphinxcontinuationbox {\spx@opt@verbatimcontinued}%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1230,25 +1230,26 @@
 \long\def\spx@verb@FormatLineForceWrap#1{%
     % \spx@image@box is a scratch box register that we can use here
     \global\let\spx@verb@maxwidth\z@
+    \global\let\spx@verb@minwidth\linewidth
     \setbox\spx@image@box
     \vtop{\raggedright\hyphenpenalty\z@\exhyphenpenalty\z@
           \doublehyphendemerits\z@\finalhyphendemerits\z@
           \strut #1\strut\@@par
-          \spx@verb@getmaxwidth}%
+          \spx@verb@getwidths}%
     \ifdim\spx@verb@maxwidth>
           \dimexpr\linewidth+\spx@opt@verbatimmaxoverfull\fontcharwd\font`X \relax
       \spx@verb@FormatLineWrap{\spx@verb@wrapPYG #1\spx@verb@wrapPYG}%
     \else
-      \ifdim\spx@verb@maxwidth<
+      \ifdim\spx@verb@minwidth<
             \dimexpr\linewidth-\spx@opt@verbatimmaxunderfull\fontcharwd\font`X \relax
         \spx@verb@FormatLineWrap{\spx@verb@wrapPYG #1\spx@verb@wrapPYG}%
       \else
         \spx@verb@FormatLineWrap{#1}%
     \fi\fi
 }%
-% auxiliary paragraph dissector to get max width
+% auxiliary paragraph dissector to get max and min widths
 \newbox\spx@scratchbox
-\def\spx@verb@getmaxwidth {%
+\def\spx@verb@getwidths {%
     \unskip\unpenalty
     \setbox\spx@scratchbox\lastbox
     \ifvoid\spx@scratchbox
@@ -1257,7 +1258,10 @@
        \ifdim\spx@verb@maxwidth<\wd\spx@scratchbox
           \xdef\spx@verb@maxwidth{\number\wd\spx@scratchbox sp}%
        \fi
-       \expandafter\spx@verb@getmaxwidth
+       \ifdim\spx@verb@minwidth>\wd\spx@scratchbox
+          \xdef\spx@verb@minwidth{\number\wd\spx@scratchbox sp}%
+       \fi
+       \expandafter\spx@verb@getwidths
     \fi
 }%
 % auxiliary macros to implement "cut long line even in middle of word"

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -334,6 +334,7 @@
 % verbatim
 \DeclareBoolOption[true]{verbatimwithframe}
 \DeclareBoolOption[true]{verbatimwrapslines}
+\DeclareBoolOption[false]{verbatimforcewraps}
 \DeclareBoolOption[true]{verbatimhintsturnover}
 \DeclareBoolOption[true]{inlineliteralwraps}
 \DeclareStringOption[t]{literalblockcappos}
@@ -1171,13 +1172,102 @@
   % no need to restore \fboxsep here, as this ends up in a \hbox from fancyvrb
 }%
 % \sphinxVerbatimFormatLine will be set locally to one of those two:
-\newcommand\sphinxVerbatimFormatLineWrap[1]{%
-    \hsize\linewidth
+\newcommand\sphinxVerbatimFormatLineWrap{%
+  \hsize\linewidth
+  \ifspx@opt@verbatimforcewraps
+       \expandafter\spx@verb@FormatLineForceWrap
+  \else\expandafter\spx@verb@FormatLineWrap
+  \fi
+}%
+\newcommand\sphinxVerbatimFormatLineNoWrap[1]{\hb@xt@\linewidth{\strut #1\hss}}%
+\long\def\spx@verb@FormatLineWrap#1{%
     \vtop{\raggedright\hyphenpenalty\z@\exhyphenpenalty\z@
           \doublehyphendemerits\z@\finalhyphendemerits\z@
           \strut #1\strut}%
 }%
-\newcommand\sphinxVerbatimFormatLineNoWrap[1]{\hb@xt@\linewidth{\strut #1\hss}}%
+% We implement an alternative to wrapping long code lines. This
+% alternative works only if the contents are in the expected
+% Pygments mark-up: i.e. some character escapes such as \PYGZdl{}
+% and the highlighting \PYG macro with always 2 arguments, and no
+% other macros. This means:
+% - the command prefix *must* be PYG
+% - the texcomments Pygments option *must* be set to False (it could
+% work by luck if True)
+% For non-highlighted tokens a break point is installed at each of them.
+% For highlighted tokens (i.e. in 2nd argument of \PYG) every four such
+% characters. \PYGZdl{} etc will count for 2, although corresponding to
+% only one. The result is that no line should be more than 3 characters
+% overfull.
+% First a measurement step is done of what would our standard wrapping
+% approach give. This is a bit tricky, cf TeX by Topic for the basic
+% dissecting technique, because TeX unfortunately when building a
+% vertical box does not store in an accessible way what was the maximal
+% line-width: the width of the box will be the set \hsize.
+% Anyway, if the max width exceed the linewidth by at least 4 character
+% widths, then we apply the "force wrapping" of previous paragraph,
+% else we apply our "standard wrapping".
+\long\def\spx@verb@FormatLineForceWrap#1{%
+    % \spx@image@box is a scratch box register that we can use here
+    \global\let\spx@verb@maxwidth\z@
+    \setbox\spx@image@box
+    \vtop{\raggedright\hyphenpenalty\z@\exhyphenpenalty\z@
+          \doublehyphendemerits\z@\finalhyphendemerits\z@
+          \strut #1\strut\@@par
+          \spx@verb@getmaxwidth}%
+    \ifdim\spx@verb@maxwidth>\dimexpr\linewidth+3\fontcharwd\font`X\relax
+      \spx@verb@FormatLineWrap{\spx@forcewrapPYG #1\spx@forcewrapPYG}%
+    \else
+      \spx@verb@FormatLineWrap{#1}%
+    \fi
+}%
+% auxiliary paragraph dissector to get max width
+\newbox\spx@line@box
+\def\spx@verb@getmaxwidth {%
+    \unskip\unpenalty
+    \setbox\spx@line@box\lastbox
+    \ifvoid\spx@line@box
+    \else
+       \setbox\spx@line@box\hbox{\unhbox\spx@line@box}%
+       \ifdim\spx@verb@maxwidth<\wd\spx@line@box
+          \xdef\spx@verb@maxwidth{\number\wd\spx@line@box sp}%
+       \fi
+       \expandafter\spx@verb@getmaxwidth
+    \fi
+}%
+% auxiliary macros to implement "cut long line even in middle of word"
+\def\spx@forcewrapPYG{%
+    \futurelet\spx@nexttoken\spx@forcewrapPYG@i
+}%
+\def\spx@forcewrapPYG@i{%
+    \ifx\spx@nexttoken\spx@forcewrapPYG\let\next=\@gobble\else
+    \ifx\spx@nexttoken\PYG\let\next=\spx@forcewrapPYG@PYG\else
+      \discretionary{}{\sphinxafterbreak}{}%
+      \let\next=\spx@forcewrapPYG@ii
+    \fi\fi
+    \next
+}%
+\def\spx@forcewrapPYG@ii#1{#1\futurelet\spx@nexttoken\spx@forcewrapPYG@i}%
+% Replace \PYG by itself applied to short strings of 4 characters at a time
+% and insert breakpoints in-between
+\def\spx@forcewrapPYG@PYG\PYG#1#2{%
+    \def\spx@PYGspec{{#1}}%
+    \spx@PYG#2\@empty\@empty\@empty\@empty\relax
+}%
+\def\spx@PYG#1#2#3#4{%
+    \discretionary{}{\sphinxafterbreak}{}%
+    \expandafter\PYG\spx@PYGspec{#1#2#3#4}%
+% I assume here contents never contain \@empty. If #4={} originally then
+% it is empty here and the \ifx will compare \@empty to \relax and choose
+% the else branch, i.e. to continue applying \PYG repeatedly
+    \ifx#4\@empty\relax
+      \expandafter\spx@PYG@done
+    \else
+      \expandafter\spx@PYG
+    \fi
+}%
+% Once \PYG is handled we get back to our forward scan token by token
+\def\spx@PYG@done#1\relax{\futurelet\spx@nexttoken\spx@forcewrapPYG@i}%
+%
 \g@addto@macro\FV@SetupFont{%
     \sbox\sphinxcontinuationbox {\spx@opt@verbatimcontinued}%
     \sbox\sphinxvisiblespacebox {\spx@opt@verbatimvisiblespace}%

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -1224,9 +1224,10 @@
 % box does not store in an accessible way what was the maximal
 % line-width during paragraph building.
 %
-% If the max width exceed the linewidth by at least 4 character
-% widths, then we apply the "force wrapping" with potential line
-% break at each character, else we don't.
+% If the max width exceeds the linewidth by more than verbatimmaxoverfull
+% character widths, or if the min width plus verbatimmaxunderfull character
+% widths is inferior to linewidth, then we apply the "force wrapping" with
+% potential line break at each character, else we don't.
 \long\def\spx@verb@FormatLineForceWrap#1{%
     % \spx@image@box is a scratch box register that we can use here
     \global\let\spx@verb@maxwidth\z@

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -335,6 +335,8 @@
 \DeclareBoolOption[true]{verbatimwithframe}
 \DeclareBoolOption[true]{verbatimwrapslines}
 \DeclareBoolOption[false]{verbatimforcewraps}
+\DeclareStringOption[3]{verbatimmaxoverfull}
+\DeclareStringOption[100]{verbatimmaxunderfull}
 \DeclareBoolOption[true]{verbatimhintsturnover}
 \DeclareBoolOption[true]{inlineliteralwraps}
 \DeclareStringOption[t]{literalblockcappos}
@@ -1233,11 +1235,16 @@
           \doublehyphendemerits\z@\finalhyphendemerits\z@
           \strut #1\strut\@@par
           \spx@verb@getmaxwidth}%
-    \ifdim\spx@verb@maxwidth>\dimexpr\linewidth+3\fontcharwd\font`X\relax
+    \ifdim\spx@verb@maxwidth>
+          \dimexpr\linewidth+\spx@opt@verbatimmaxoverfull\fontcharwd\font`X \relax
       \spx@verb@FormatLineWrap{\spx@verb@wrapPYG #1\spx@verb@wrapPYG}%
     \else
-      \spx@verb@FormatLineWrap{#1}%
-    \fi
+      \ifdim\spx@verb@maxwidth<
+            \dimexpr\linewidth-\spx@opt@verbatimmaxunderfull\fontcharwd\font`X \relax
+        \spx@verb@FormatLineWrap{\spx@verb@wrapPYG #1\spx@verb@wrapPYG}%
+      \else
+        \spx@verb@FormatLineWrap{#1}%
+    \fi\fi
 }%
 % auxiliary paragraph dissector to get max width
 \newbox\spx@scratchbox


### PR DESCRIPTION
Closes #8849

To try it out:

```
latex_elements = {
    'sphinxsetup': "verbatimforcewraps",
}
```

This is a bit experimental as I need to confirm that Pygments LaTeXFormatter output, as we use it, always comply with the pre-conceptions which are summarized in the latex code comments.

For this input:

```
DryGASCON128k56:

.. code-block:: shell

   $ python3 -m drysponge.drygascon128_aead e 000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031323334353637 000102030405060708090A0B0C0D0E0F "" ""
   28830FE67DE9772201D254ABE4C9788D

.. code-block:: shell

   $ python3 -m drysponge.drygascon128_aead e "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031323334353637" 000102030405060708090A0B0C0D0E0F "" ""
   28830FE67DE9772201D254ABE4C9788D
```

the following output is obtained in PDF:

![Capture d’écran 2021-02-08 à 23 15 03](https://user-images.githubusercontent.com/2589111/107288649-12d2a280-6a64-11eb-913b-e4e8a280fe49.png)

Non highlighted strings like in first example can break at each character. Highlighted strings only every four characters. That here it breaks without one or two characters going in margin or one or two spaces at end is luck. Here is with removing one character before on same line, we see now it breaks one character short of ending line.

![Capture d’écran 2021-02-08 à 23 20 53](https://user-images.githubusercontent.com/2589111/107288863-78269380-6a64-11eb-8060-42043d00ed9e.png)


Actually I could make even highlighted strings have breakpoints at each character. But it makes me pain to let the computer suffer with lots of extra work.
