### PR TITLE
Add missing French translation

### DIFF
--- a/sphinx/locale/fr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fr/LC_MESSAGES/sphinx.po
@@ -3173,7 +3173,7 @@ msgstr "Veuillez activer le JavaScript pour que la recherche fonctionne."
 msgid ""
 "Searching for multiple words only shows matches that contain\n"
 "    all words."
-msgstr ""
+msgstr "Une recherche sur plusieurs mots affiche uniquement les résultats qui contiennent tous les mots."
 
 #: sphinx/themes/basic/search.html:32
 msgid "search"


### PR DESCRIPTION
Subject: Add missing French translation for the sentence "Searching for multiple words only shows matches that contain all words."

### Feature or Bugfix
- Bugfix

### Purpose
The purpose is to add a missing French translation for "Searching for multiple words only shows matches that contain all words."
Currently, an English sentence appears on the search results page.


