### PR TITLE
[bugfix] SubstitutionDefinitionsRemove: only run for LaTeX builder

### DIFF
--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -44,7 +44,7 @@ class SubstitutionDefinitionsRemover(SphinxPostTransform):
     default_priority = Substitutions.default_priority + 1
     builders = ('latex',)
 
-    def apply(self, **kwargs: Any) -> None:
+    def run(self, **kwargs: Any) -> None:
         for node in self.document.traverse(nodes.substitution_definition):
             node.parent.remove(node)
 


### PR DESCRIPTION
My PR #8183 includes an oversight that makes it have no effect. The post-transform was still applied when using builders other than the LaTeX builder. This fixes it.

I noticed that also _IndexInSectionTitleTransform_ is being applied for all builders. Perhaps that should be limited to the LaTeX builder as well?