### PR TITLE
searchtools: Don't use slideDown to show search results.

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -248,7 +248,7 @@ var Search = {
       // results left, load the summary and display it
       if (results.length) {
         var item = results.pop();
-        var listItem = $('<li style="display:none"></li>');
+        var listItem = $('<li></li>');
         var requestUrl = "";
         var linkUrl = "";
         if (DOCUMENTATION_OPTIONS.BUILDER === 'dirhtml') {
@@ -273,9 +273,9 @@ var Search = {
         if (item[3]) {
           listItem.append($('<span> (' + item[3] + ')</span>'));
           Search.output.append(listItem);
-          listItem.slideDown(5, function() {
+          setTimeout(function() {
             displayNextItem();
-          });
+          }, 5);
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
           $.ajax({url: requestUrl,
                   dataType: "text",
@@ -285,16 +285,16 @@ var Search = {
                       listItem.append(Search.makeSearchSummary(data, searchterms, hlterms));
                     }
                     Search.output.append(listItem);
-                    listItem.slideDown(5, function() {
+                    setTimeout(function() {
                       displayNextItem();
-                    });
+                    }, 5);
                   }});
         } else {
           // no source available, just display title
           Search.output.append(listItem);
-          listItem.slideDown(5, function() {
+          setTimeout(function() {
             displayNextItem();
-          });
+          }, 5);
         }
       }
       // search finished, update title and status message


### PR DESCRIPTION
Subject: Don't use slideDown to show search results.

### Feature or Bugfix

- Bugfix

### Purpose

- Fix #8562.

### Detail

Fixes a performance issue with massive lists like #8562.

jQuery.slideDown is pretty bad perf-wise since it thrashes layout
multiple times on all browsers. This is specially bad on slow machines.

The 5ms animation is unnoticeable (it last less than an animation
frame!) and just burns CPU cycles unnecessarily in all browsers.

On Firefox this is specially bad because it hits a performance cliff
with list items / CSS counters
(https://bugzilla.mozilla.org/show_bug.cgi?id=1683910#c26 for all the
gory details) where it causes tons of counter recalc.

An alternative fix for the Firefox cliff would be to set overflow:
hidden on the list item, but I think removing the animation is probably
more sensible, given that as I said it's just burning CPU.

Fixes #8562

### Relates
- #8562