### PR TITLE
Fix #8860: doc: recipe directive crashes with AttributeError

### DIFF
--- a/doc/development/tutorials/examples/recipe.py
+++ b/doc/development/tutorials/examples/recipe.py
@@ -24,7 +24,7 @@ class RecipeDirective(ObjectDescription):
 
     def add_target_and_index(self, name_cls, sig, signode):
         signode['ids'].append('recipe' + '-' + sig)
-        if 'noindex' not in self.options:
+        if 'contains' not in self.options:
             ingredients = [
                 x.strip() for x in self.options.get('contains').split(',')]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The pre check in the `ReceipeDirective.add_target_and_index() was wrong.
It checkes non-existing option "noindex", but it should check "contains"
option instead.
- refs: #8860 