### PR TITLE
Fix #8838 by forcing horizontal mode before inserting the penalty

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -417,7 +417,7 @@
 \DisableKeyvalOption{sphinx}{mathnumfig}
 % To allow hyphenation of first word in narrow contexts; no option,
 % customization to be done via 'preamble' key
-\newcommand*\sphinxAtStartPar{\hskip\z@skip}
+\newcommand*\sphinxAtStartPar{\leavevmode\nobreak\hskip\z@skip}
 % No need for the \hspace{0pt} trick (\hskip\z@skip) with luatex
 \ifdefined\directlua\let\sphinxAtStartPar\@empty\fi
 % user interface: options can be changed midway in a document!


### PR DESCRIPTION

### Relates
- #8838, #8840

This is better fix of #8838 than #8840. I have understood the underlying LaTeX problem.

With this input:

```rest
.. tabularcolumns:: |*{4}{p{2cm}|}

.. table:: tabular not ok

   +------------------------+------------+----------+------------------+
   | Header row, column 1   | Header 2   | Header 3 | Header 4         |
   +========================+============+==========+==================+
   | body row               | ...        | ...      | aaaaaaaaaaaaaaaa |
   +------------------------+------------+----------+------------------+
   | body row, merged columns            | column 3 | column 4         |
   +------------------------+------------+----------+------------------+
```

one gets

![Capture d’écran 2021-02-12 à 17 48 10](https://user-images.githubusercontent.com/2589111/107797099-d7352280-6d5a-11eb-9e87-36f8c7b85260.png)

with #8840 but the better

![Capture d’écran 2021-02-12 à 17 48 45](https://user-images.githubusercontent.com/2589111/107797068-cedce780-6d5a-11eb-84bf-36a076de7f64.png)


with this one. (it is deliberate here that I use a string that TeX does not hyphenate; else there would be no overflow)

My other tests give results ok.

For example

```rest
.. table:: tabulary

   +------------------------+------------+----------+----------+
   | Header row, column 1   | Header 2   | Header 3 | Header 4 |
   +========================+============+==========+==========+
   | body row               | ...        | ...      |          |
   +------------------------+------------+----------+----------+
   | body row, merged columns            | column 3 | column 4 |
   +------------------------+------------+----------+----------+
   | body row, merged columns and rows   |          |          |
   |                                     |          |          |
   | let's make this 2 paragraphs        | column 3 | column 4 |
   +-------------------------------------+----------+----------+
```

@tk0miya I know merging at such late date into 3.x is a bit annoying because we have refactored a lot latex on master then merging 3.x in master may be complicated but I think this one will be ok, so I am proposing to merge into 3.x.

