### PR TITLE
Fix #8884: Include sphinx/search/minified-js in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ recursive-include sphinx/texinputs_win *
 recursive-include sphinx/themes *
 recursive-include sphinx/locale *.js *.pot *.po *.mo
 recursive-include sphinx/search/non-minified-js *.js
+recursive-include sphinx/search/minified-js *.js
 recursive-include sphinx/ext/autosummary/templates *
 recursive-include tests *
 recursive-include utils *


### PR DESCRIPTION
In #8867 I added new JS files but unfortunately I forgot to add them to MANIFEST.in, so they are not included in distributed files on PyPI (sorry). Here I am fixing this.