### PR TITLE
Sometimes _viewcode_modules can be False; don't crash when it is

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -152,7 +152,11 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: Iterable[str],
 def env_purge_doc(app: Sphinx, env: BuildEnvironment, docname: str) -> None:
     modules = getattr(env, '_viewcode_modules', {})
 
-    for modname, (code, tags, used, refname) in list(modules.items()):
+    for modname, entry in list(modules.items()):
+        if entry is False:
+            continue
+
+        code, tags, used, refname = entry
         for fullname in list(used):
             if used[fullname] == docname:
                 used.pop(fullname)


### PR DESCRIPTION
Subject: Sometimes _viewcode_modules can be False; don't crash when it is

Not sure if this is a 'good' fix for the problem, but my documentation builds now. It appears that when `ModuleAnalyzer.for_module(modname)` fails at viewcode.py:90 then it sets the module to False, thus breaking when env_purge_doc is called. 

Not sure what the ModuleAnalyzer does or why it failed, but I don't care? Would be great to get this out in a 3.5.1 release as soon as possible since this breaks existing documentation.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
- Fixes #8880

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- #8880

