### PR TITLE
Fix #8880: viewcode: ExtensionError is raised on incremental build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #8884: html: minified js stemmers not included in the distributed package
+* #8880: viewcode: ExtensionError is raised on incremental build after
+  unparsable python module found
 
 Testing
 --------


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- viewcode causes ExtensionError on incremental build after unparsable
python module found for the document on the past build.
- Internally, `False` is stored into `env._viewcode_modules[modname]` for
the modules that failed to parse on the past build.  But `env-purge-doc`
does not handle them.
- refs: #8880
