### PR TITLE
Fix #8885: html: AttributeError for CSS/JS files on html_context

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Bugs fixed
 ----------
 
 * #8884: html: minified js stemmers not included in the distributed package
+* #8885: html: AttributeError is raised if CSS/JS files are installed via
+  :confval:`html_context`
 * #8880: viewcode: ExtensionError is raised on incremental build after
   unparsable python module found
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1036,7 +1036,7 @@ class StandaloneHTMLBuilder(Builder):
 
         # sort JS/CSS before rendering HTML
         ctx['script_files'].sort(key=lambda js: js.priority)
-        ctx['css_files'].sort(key=lambda js: js.priority)
+        ctx['css_files'].sort(key=lambda css: css.priority)
 
         try:
             output = self.templates.render(templatename, ctx)

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1035,8 +1035,20 @@ class StandaloneHTMLBuilder(Builder):
             templatename = newtmpl
 
         # sort JS/CSS before rendering HTML
-        ctx['script_files'].sort(key=lambda js: js.priority)
-        ctx['css_files'].sort(key=lambda css: css.priority)
+        try:
+            # Convert script_files to list to support non-list script_files (refs: #8889)
+            ctx['script_files'] = sorted(list(ctx['script_files']), key=lambda js: js.priority)
+        except AttributeError:
+            # Skip sorting if users modifies script_files directly (maybe via `html_context`).
+            # refs: #8885
+            #
+            # Note: priority sorting feature will not work in this case.
+            pass
+
+        try:
+            ctx['css_files'] = sorted(list(ctx['css_files']), key=lambda css: css.priority)
+        except AttributeError:
+            pass
 
         try:
             output = self.templates.render(templatename, ctx)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 3.5.0, priority has been added to control CSS/JS files.  But it's
not working if projects installs custom CSS/JS files via `html_context`
instead of `html_css_files` and `html_js_files`.  This avoids the crash
to keep it "not broken".
- #8885 