### PR TITLE
fix potential getitem error in resolve_anyref

### DIFF
--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -125,7 +125,7 @@ class ReferencesResolver(SphinxPostTransform):
                 for role in domain.roles:
                     res = domain.resolve_xref(self.env, refdoc, self.app.builder,
                                               role, target, node, contnode)
-                    if res and isinstance(res[0], nodes.Element):
+                    if res and len(res) > 0 and isinstance(res[0], nodes.Element):
                         results.append(('%s:%s' % (domain.name, role), res))
         # now, see how many matches we got...
         if not results:


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

In some cases, sphinx domains (say, from an extension) may return an empty ``Element`` from ``resolve_xref``. In that case, ``res`` will evaluate to ``True``, but ``res[0]`` does not exist (see example below). This patch fixes that problem.

### Detail

Example:

```python
>>> from docutils.nodes import inline
>>> x = inline()
>>> len(x)
0
>>> bool(x)
True
```

### Relates

This problem was originally reported by @choldgraf at https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/232#issuecomment-778705465 as a bug in myst-parser. However, the bug concerned code that was directly copied from Sphinx, whence we thought it good to get it fixed in Sphinx too.