### PR TITLE
doc: Build PDF document on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,8 @@
 version: 2
+
+formats:
+  - pdf
+
 python:
   version: 3
   install:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- At present, sphinx-doc.org does not provide the PDF formatted document.
- refs: #8881 