### PR TITLE
Add option "scale_html" for "graphviz" extension

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -12,6 +12,7 @@
 import posixpath
 import re
 import subprocess
+import xml.etree.ElementTree as ET
 from os import path
 from subprocess import PIPE, CalledProcessError
 from typing import Any, Dict, List, Tuple
@@ -35,8 +36,6 @@ from sphinx.writers.latex import LaTeXTranslator
 from sphinx.writers.manpage import ManualPageTranslator
 from sphinx.writers.texinfo import TexinfoTranslator
 from sphinx.writers.text import TextTranslator
-
-import xml.etree.ElementTree as ET
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +275,7 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict, format: str,
                                '[stdout]\n%r') % (exc.stderr, exc.stdout)) from exc
 
 
-def render_dot_html__svg_get_objwidth(scale: str, outfn: str, filename: str):
+def render_dot_html__svg_get_objwidth(scale: str, outfn: str, filename: str) -> str:
     try:
         tmpwidth = float(scale)
     except Exception:

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -279,21 +279,22 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict, format: str,
 def render_dot_html__svg_get_objwidth(scale: str, outfn: str, filename: str):
     try:
         tmpwidth = float(scale)
-    except:
+    except Exception:
         logger.warning(__('"scale_html" FAIL for "%s"' % filename))
-        logger.warning(__('"scale_html" MUST numeric (1.0 - 100Percent; 0.1 - 10Percent): "%s"' % scale))
+        logger.warning(__('"scale_html" MUST numeric\n'
+                          '(1.0 - 100Percent; 0.1 - 10Percent): "%s"' % scale))
         return ''
     #
     try:
         r_size = re.compile(r'(?P<num>\d*\.?\d+)\s?(?P<uni>[a-zA-Z]+)')
         tree = ET.parse(outfn)
         g_size = r_size.match(tree.getroot().attrib["width"])
-        tmpwidth = round( tmpwidth * float( g_size.group("num") ) )
+        tmpwidth = round(tmpwidth * float( g_size.group("num")))
         return 'width="%r%s"' % (tmpwidth, g_size.group("uni"))
-    except:
+    except Exception:
         logger.warning(__('"scale_html" FAIL for "%s"' % filename))
         return ''
-    #  
+    #
     return ''
 
 
@@ -326,10 +327,10 @@ def render_dot_html(self: HTMLTranslator, node: graphviz, code: str, options: Di
             objStyle = ''
             if 'scale_html' in node:
                 scale_arr = node['scale_html'].split(':')
-                objWidth = render_dot_html__svg_get_objwidth(scale_arr[0], outfn, filename)        
+                objWidth = render_dot_html__svg_get_objwidth(scale_arr[0], outfn, filename)
                 if objWidth:
                     if 'strong' in scale_arr:
-                        objStyle ='style="max-width:unset"'
+                        objStyle = 'style="max-width:unset"'
 
             self.body.append('<div class="graphviz">')
             self.body.append('<object data="%s" type="image/svg+xml" class="%s" %s %s>\n' %

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -288,7 +288,7 @@ def render_dot_html__svg_get_objwidth(scale: str, outfn: str, filename: str) -> 
         r_size = re.compile(r'(?P<num>\d*\.?\d+)\s?(?P<uni>[a-zA-Z]+)')
         tree = ET.parse(outfn)
         g_size = r_size.match(tree.getroot().attrib["width"])
-        tmpwidth = round(tmpwidth * float( g_size.group("num")))
+        tmpwidth = round(tmpwidth * float(g_size.group("num")))
         return 'width="%r%s"' % (tmpwidth, g_size.group("uni"))
     except Exception:
         logger.warning(__('"scale_html" FAIL for "%s"' % filename))

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -332,8 +332,12 @@ def render_dot_html(self: HTMLTranslator, node: graphviz, code: str, options: Di
                         objStyle = 'style="max-width:unset"'
 
             self.body.append('<div class="graphviz">')
-            self.body.append('<object data="%s" type="image/svg+xml" class="%s" %s %s>\n' %
-                             (fname, imgcls, objWidth, objStyle))
+            if objWidth:
+                self.body.append('<object data="%s" type="image/svg+xml" class="%s" %s %s>\n' %
+                                 (fname, imgcls, objWidth, objStyle))
+            else:
+                self.body.append('<object data="%s" type="image/svg+xml" class="%s">\n' %
+                                 (fname, imgcls))
             self.body.append('<p class="warning">%s</p>' % alt)
             self.body.append('</object></div>\n')
         else:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature
- Bug

### Purpose
This change allows you to set the scale of the sphinx.ext.graphviz graphs (`svg`) in the resulting `*.html`.

### Detail
the resulting examples with different settings
- default
   - window full width
      ![T01_fullSize_1](https://user-images.githubusercontent.com/394362/108455560-48f7f980-7290-11eb-90f2-58f106de8bc0.png)
   - window min width
     ![T01_minSize](https://user-images.githubusercontent.com/394362/108391939-030d4800-7234-11eb-8050-cbd376e0b5a8.png)

- `:scale_html: 0.8`
   - window full width 
      ![T02_fullSize_1](https://user-images.githubusercontent.com/394362/108455690-7d6bb580-7290-11eb-9de5-f1105c12e991.png)
   - window min width
      ![T02_minSize](https://user-images.githubusercontent.com/394362/108392585-acecd480-7234-11eb-919c-9b083e127c26.png)

- `:scale_html: 0.8:strong`
    - window full width 
    ![T03_fullSize](https://user-images.githubusercontent.com/394362/108392985-06ed9a00-7235-11eb-994d-16a2574ce6eb.png)
   - window min width
      ![T03_minSize](https://user-images.githubusercontent.com/394362/108392995-094ff400-7235-11eb-96be-671b43be0052.png)


### Relates
https://github.com/sphinx-doc/sphinx/pull/8903

