### PR TITLE
C++, cpp_index_common_prefix remove longest prefix instead of first

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -75,6 +75,8 @@ Bugs fixed
   change) with late TeXLive 2019
 * #8253: LaTeX: Figures with no size defined get overscaled (compared to images
   with size explicitly set in pixels) (fixed for ``'pdflatex'/'lualatex'`` only)
+* #8911: C++: remove the longest matching prefix in
+  :confval:`cpp_index_common_prefix` instead of the first that matches.
 
 Testing
 --------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7644,10 +7644,11 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("cpp_debug_lookup", False, '')
     app.add_config_value("cpp_debug_show_tree", False, '')
 
-    def setDebugFlags(app):
+    def initStuff(app):
         Symbol.debug_lookup = app.config.cpp_debug_lookup
         Symbol.debug_show_tree = app.config.cpp_debug_show_tree
-    app.connect("builder-inited", setDebugFlags)
+        app.config.cpp_index_common_prefix.sort(reverse=True)
+    app.connect("builder-inited", initStuff)
 
     return {
         'version': 'builtin',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Before, the first matching prefix in the ``cpp_index_common_prefix`` list was removed. Pre-sort in reverse order such that the first one is also the longest one.

### Relates
Fixes #8911

