### PR TITLE
[i18N] Caution and Warning trans same Simplified Chinese  word

### DIFF
--- a/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
@@ -2956,7 +2956,7 @@ msgstr "注意"
 
 #: sphinx/locale/__init__.py:251
 msgid "Caution"
-msgstr "警告"
+msgstr "小心"
 
 #: sphinx/locale/__init__.py:252
 msgid "Danger"


### PR DESCRIPTION
Subject:  fix tranlation error

change “caution” ’s trasnlation from “警告” to “小心”


### Feature or Bugfix

- Bugfix

### Purpose



### Detail

- bug1 word “Caution” and “Waring” has the same translation in chinese

```
#: sphinx/locale/__init__.py:251
msgid "Caution"
msgstr "警告"
```
    

```
#: sphinx/ext/napoleon/docstring.py:714
msgid "Warns"
msgstr "警告"
```


change “Caution” to “小心”

```
#: sphinx/locale/__init__.py:251
msgid "Caution"
msgstr "小心"
```