### PR TITLE
Fix #8915: html theme: The translation of sphinx_rtd_theme does not work

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Incompatible changes
 * html theme: Move a script tag for documentation_options.js in
   basic/layout.html to ``script_files`` variable
 * html theme: Move CSS tags in basic/layout.html to ``css_files`` variable
+* #8915: html theme: Emit a warning for sphinx_rtd_theme-0.2.4 or older
 * #8508: LaTeX: uplatex becomes a default setting of latex_engine for Japanese
   documents
 * #5977: py domain: ``:var:``, ``:cvar:`` and ``:ivar:`` fields do not create
@@ -69,6 +70,7 @@ Bugs fixed
 ----------
 
 * #8380: html search: Paragraphs in search results are not identified as ``<p>``
+* #8915: html theme: The translation of sphinx_rtd_theme does not work
 * #8342: Emit a warning if a unknown domain is given for directive or role (ex.
   ``:unknown:doc:``)
 * #8711: LaTeX: backticks in code-blocks trigger latexpdf build warning (and font

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -178,8 +178,6 @@ class HTMLThemeFactory:
         """Try to load a theme having specifed name."""
         if name == 'alabaster':
             self.load_alabaster_theme()
-        elif name == 'sphinx_rtd_theme':
-            self.load_sphinx_rtd_theme()
         else:
             self.load_external_theme(name)
 
@@ -237,13 +235,13 @@ class HTMLThemeFactory:
         if name not in self.themes:
             self.load_extra_theme(name)
 
+        if name not in self.themes and name == 'sphinx_rtd_theme':
+            # sphinx_rtd_theme (< 0.2.5)  # RemovedInSphinx60Warning
+            logger.warning(__('sphinx_rtd_theme (< 0.3.0) found. '
+                              'It will not be available since Sphinx-6.0'))
+            self.load_sphinx_rtd_theme()
+
         if name not in self.themes:
-            if name == 'sphinx_rtd_theme':
-                raise ThemeError(__('sphinx_rtd_theme is no longer a hard dependency '
-                                    'since version 1.4.0. Please install it manually.'
-                                    '(pip install sphinx_rtd_theme)'))
-            else:
-                raise ThemeError(__('no theme named %r found '
-                                    '(missing theme.conf?)') % name)
+            raise ThemeError(__('no theme named %r found (missing theme.conf?)') % name)
 
         return Theme(name, self.themes[name], factory=self)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since sphinx_rtd_theme-0.5.0, it supports translations.  But Sphinx core
disallows to enable it because theming framework gives special treatment
for the theme for a long time.
- This goes to load it via setuptools at first to enable the translations.
- Note: The special treatment for sphinx_rtd_theme (< 0.2.0) is not
removed yet.  But it will be removed in the next major release.