### PR TITLE
LaTeX: let underfull calculation in wrapped code lines ignore last line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,8 @@ Bugs fixed
   :confval:`cpp_index_common_prefix` instead of the first that matches.
 * C, properly reject function declarations when a keyword is used
   as parameter name.
+* #8925: LaTeX: 3.5.0 ``verbatimmaxunderfull`` setting does not work as
+  expected
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -75,12 +75,12 @@ Bugs fixed
   change) with late TeXLive 2019
 * #8253: LaTeX: Figures with no size defined get overscaled (compared to images
   with size explicitly set in pixels) (fixed for ``'pdflatex'/'lualatex'`` only)
+* #8925: LaTeX: 3.5.0 ``verbatimmaxunderfull`` setting does not work as
+  expected
 * #8911: C++: remove the longest matching prefix in
   :confval:`cpp_index_common_prefix` instead of the first that matches.
 * C, properly reject function declarations when a keyword is used
   as parameter name.
-* #8925: LaTeX: 3.5.0 ``verbatimmaxunderfull`` setting does not work as
-  expected
 
 Testing
 --------

--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -343,8 +343,21 @@
     \fi\fi
 }%
 % auxiliary paragraph dissector to get max and min widths
+% but minwidth must not take into account the last line
 \newbox\spx@scratchbox
 \def\spx@verb@getwidths {%
+    \unskip\unpenalty
+    \setbox\spx@scratchbox\lastbox
+    \ifvoid\spx@scratchbox
+    \else
+       \setbox\spx@scratchbox\hbox{\unhbox\spx@scratchbox}%
+       \ifdim\spx@verb@maxwidth<\wd\spx@scratchbox
+          \xdef\spx@verb@maxwidth{\number\wd\spx@scratchbox sp}%
+       \fi
+       \expandafter\spx@verb@getwidths@loop
+    \fi
+}%
+\def\spx@verb@getwidths@loop {%
     \unskip\unpenalty
     \setbox\spx@scratchbox\lastbox
     \ifvoid\spx@scratchbox
@@ -356,7 +369,7 @@
        \ifdim\spx@verb@minwidth>\wd\spx@scratchbox
           \xdef\spx@verb@minwidth{\number\wd\spx@scratchbox sp}%
        \fi
-       \expandafter\spx@verb@getwidths
+       \expandafter\spx@verb@getwidths@loop
     \fi
 }%
 % auxiliary macros to implement "cut long line even in middle of word"


### PR DESCRIPTION
Closes: #8925

It is not a critical or severe bug... it is a bug of a feature added at 3.5.0. I hesitated adding to CHANGES a 3.6.0 section and then making the PR on 3.x. In the end making the PR on 3.5.x  but this and milestone can be changed of course. (it depends if there will be a 3.6.0 before next major release).
