### PR TITLE
Close #8924: autodoc: Support `bound` argument for TypeVar

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,7 @@ Deprecated
 Features added
 --------------
 
+* #8924: autodoc: Support ``bound`` argument for TypeVar
 * #4826: py domain: Add ``:canonical:`` option to python directives to describe
   the location where the object is defined
 * #7784: i18n: The alt text for image is translated by default (without

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1812,6 +1812,8 @@ class TypeVarMixin(DataDocumenterMixinBase):
             attrs = [repr(self.object.__name__)]
             for constraint in self.object.__constraints__:
                 attrs.append(stringify_typehint(constraint))
+            if self.object.__bound__:
+                attrs.append(r"bound=\ " + restify(self.object.__bound__))
             if self.object.__covariant__:
                 attrs.append("covariant=True")
             if self.object.__contravariant__:

--- a/tests/roots/test-ext-autodoc/target/typevar.py
+++ b/tests/roots/test-ext-autodoc/target/typevar.py
@@ -17,6 +17,9 @@ T5 = TypeVar("T5", contravariant=True)
 #: T6
 T6 = NewType("T6", int)
 
+#: T7
+T7 = TypeVar("T7", bound=int)
+
 
 class Class:
     #: T1

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1993,6 +1993,14 @@ def test_autodoc_TypeVar(app):
         '',
         '   alias of :class:`int`',
         '',
+        '',
+        '.. py:data:: T7',
+        '   :module: target.typevar',
+        '',
+        '   T7',
+        '',
+        "   alias of TypeVar('T7', bound=\\ :class:`int`)",
+        '',
     ]
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #8924 