### PR TITLE
Fix #8933: viewcode: Failed to create back-links on parallel build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -83,6 +83,7 @@ Bugs fixed
   :confval:`cpp_index_common_prefix` instead of the first that matches.
 * C, properly reject function declarations when a keyword is used
   as parameter name.
+* #8933: viewcode: Failed to create back-links on parallel build
 
 Testing
 --------

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -146,7 +146,14 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: Iterable[str],
     if not hasattr(env, '_viewcode_modules'):
         env._viewcode_modules = {}  # type: ignore
     # now merge in the information from the subprocess
-    env._viewcode_modules.update(other._viewcode_modules)  # type: ignore
+    for modname, entry in other._viewcode_modules.items():  # type: ignore
+        if modname not in env._viewcode_modules:  # type: ignore
+            env._viewcode_modules[modname] = entry  # type: ignore
+        else:
+            used = env._viewcode_modules[modname][2]  # type: ignore
+            for fullname, docname in entry[2].items():
+                if fullname not in used:
+                    used[fullname] = docname
 
 
 def env_purge_doc(app: Sphinx, env: BuildEnvironment, docname: str) -> None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- On parallel build mode, viewcode losts the back-links information on
gathering results from each process.  As a result, some back-links are
missing in the generated viewcode pages.
- This fixes the merging back-links process for parallel builds.
- refs: #8933