### PR TITLE
Use explicit title instead of <no title> in the title bar of subpages

### DIFF
--- a/sphinx/environment/collectors/title.py
+++ b/sphinx/environment/collectors/title.py
@@ -39,9 +39,10 @@ class TitleCollector(EnvironmentCollector):
         longtitlenode = titlenode
         # explicit title set with title directive; use this only for
         # the <title> tag in HTML output
-        if 'title' in doctree:
+        explicit_title = nodes.Text(doctree['title']) if 'title' in doctree else None
+        if explicit_title:
             longtitlenode = nodes.title()
-            longtitlenode += nodes.Text(doctree['title'])
+            longtitlenode += explicit_title
         # look for first section title and use that as the title
         for node in doctree.traverse(nodes.section):
             visitor = SphinxContentsFilter(doctree)
@@ -50,7 +51,7 @@ class TitleCollector(EnvironmentCollector):
             break
         else:
             # document has no title
-            titlenode += nodes.Text('<no title>')
+            titlenode += explicit_title or nodes.Text('<no title>')
         app.env.titles[app.env.docname] = titlenode
         app.env.longtitles[app.env.docname] = longtitlenode
 

--- a/sphinx/environment/collectors/title.py
+++ b/sphinx/environment/collectors/title.py
@@ -39,10 +39,9 @@ class TitleCollector(EnvironmentCollector):
         longtitlenode = titlenode
         # explicit title set with title directive; use this only for
         # the <title> tag in HTML output
-        explicit_title = nodes.Text(doctree['title']) if 'title' in doctree else None
-        if explicit_title:
+        if 'title' in doctree:
             longtitlenode = nodes.title()
-            longtitlenode += explicit_title
+            longtitlenode += nodes.Text(doctree['title'])
         # look for first section title and use that as the title
         for node in doctree.traverse(nodes.section):
             visitor = SphinxContentsFilter(doctree)
@@ -51,7 +50,7 @@ class TitleCollector(EnvironmentCollector):
             break
         else:
             # document has no title
-            titlenode += explicit_title or nodes.Text('<no title>')
+            titlenode += nodes.Text(doctree.get('title', '<no title>'))
         app.env.titles[app.env.docname] = titlenode
         app.env.longtitles[app.env.docname] = longtitlenode
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

Subject: Use explicit title instead of <no title> in the title bar of subpages

### Feature or Bugfix
- Bugfix

### Purpose
- This fixes a bug when a page has no title but sets the metadata title through the [title directive](https://docutils.sourceforge.io/docs/ref/rst/directives.html#metadata-document-title). The title is shown correctly in the title bar of that page, but it still shows "no title" in subpages. 

### Detail
This fix uses the explicitly provided title instead of "no title" for `titlenode`, when no title is found in the document. 

### Relates

