### PR TITLE
Fix #8938: imgconverter: Show the error of the command availability check

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,7 @@ Features added
 * #2018: html: :confval:`html_favicon` and :confval:`html_logo` now accept URL
   for the image
 * #8070: html search: Support searching for 2characters word
+* #8938: imgconverter: Show the error of the command availability check
 * #7830: Add debug logs for change detection of sources and templates
 * #8201: Emit a warning if toctree contains duplicated entries
 

--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -37,10 +37,10 @@ class ImagemagickConverter(ImageConverter):
             logger.debug('Invoking %r ...', args)
             subprocess.run(args, stdout=PIPE, stderr=PIPE, check=True)
             return True
-        except OSError:
+        except OSError as exc:
             logger.warning(__('convert command %r cannot be run, '
-                              'check the image_converter setting'),
-                           self.config.image_converter)
+                              'check the image_converter setting: %s'),
+                           self.config.image_converter, exc)
             return False
         except CalledProcessError as exc:
             logger.warning(__('convert exited with error:\n'


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Purpose
- imgconverter extension suppresses an OSError like "Cannot allocate
memory" unexpectedly.  So the error should be shown with the warning.
- refs: #8938