### PR TITLE
Deprecate SphinxComponentRegistry.get_source_input()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,8 @@ Deprecated
 * ``sphinx.directives.patches.CSVTable``
 * ``sphinx.directives.patches.ListTable``
 * ``sphinx.directives.patches.RSTTable``
+* ``sphinx.registry.SphinxComponentRegistry.get_source_input()``
+* ``sphinx.registry.SphinxComponentRegistry.source_inputs``
 * ``sphinx.transforms.FigureAligner``
 * ``sphinx.util.pycompat.convert_with_2to3()``
 * ``sphinx.util.pycompat.execfile_()``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -47,6 +47,16 @@ The following is a list of deprecated interfaces.
      - 6.0
      - ``docutils.parsers.rst.diretives.tables.RSTTable``
 
+   * - ``sphinx.registry.SphinxComponentRegistry.get_source_input()``
+     - 4.0
+     - 6.0
+     - N/A
+
+   * - ``sphinx.registry.SphinxComponentRegistry.source_inputs``
+     - 4.0
+     - 6.0
+     - N/A
+
    * - ``sphinx.transforms.FigureAligner``
      - 4.0
      - 6.0

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -178,27 +178,12 @@ def read_doc(app: "Sphinx", env: BuildEnvironment, filename: str) -> nodes.docum
         #   CommonMarkParser.
         parser.settings_spec = RSTParser.settings_spec
 
-    input_class = app.registry.get_source_input(filetype)
-    if input_class:
-        # Sphinx-1.8 style
-        source = input_class(app, env, source=None, source_path=filename,  # type: ignore
-                             encoding=env.config.source_encoding)
-        pub = Publisher(reader=reader,
-                        parser=parser,
-                        writer=SphinxDummyWriter(),
-                        source_class=SphinxDummySourceClass,  # type: ignore
-                        destination=NullOutput())
-        pub.process_programmatic_settings(None, env.settings, None)
-        pub.set_source(source, filename)
-    else:
-        # Sphinx-2.0 style
-        pub = Publisher(reader=reader,
-                        parser=parser,
-                        writer=SphinxDummyWriter(),
-                        source_class=SphinxFileInput,
-                        destination=NullOutput())
-        pub.process_programmatic_settings(None, env.settings, None)
-        pub.set_source(source_path=filename)
-
+    pub = Publisher(reader=reader,
+                    parser=parser,
+                    writer=SphinxDummyWriter(),
+                    source_class=SphinxFileInput,
+                    destination=NullOutput())
+    pub.process_programmatic_settings(None, env.settings, None)
+    pub.set_source(source_path=filename)
     pub.publish()
     return pub.document

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -9,6 +9,7 @@
 """
 
 import traceback
+import warnings
 from importlib import import_module
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Tuple, Type, Union
@@ -23,6 +24,7 @@ from pkg_resources import iter_entry_points
 
 from sphinx.builders import Builder
 from sphinx.config import Config
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.domains import Domain, Index, ObjType
 from sphinx.domains.std import GenericObject, Target
 from sphinx.environment import BuildEnvironment
@@ -285,6 +287,9 @@ class SphinxComponentRegistry:
         return parser
 
     def get_source_input(self, filetype: str) -> "Type[Input]":
+        warnings.warn('SphinxComponentRegistry.get_source_input() is deprecated.',
+                      RemovedInSphinx60Warning)
+
         try:
             return self.source_inputs[filetype]
         except KeyError:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The source_input system was deprecated at v2.0.  So no client uses it
longer now.  Therefore this deprecate the getter interface and its
usage.