### PR TITLE
C++, support spaceship operator

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -69,6 +69,7 @@ Features added
 * #7830: Add debug logs for change detection of sources and templates
 * #8201: Emit a warning if toctree contains duplicated entries
 * #8326: ``master_doc`` is now renamed to :confval:`root_doc`
+* #8942: C++, add support for the C++20 spaceship operator, ``<=>``.
 
 Bugs fixed
 ----------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -306,6 +306,7 @@ _operator_re = re.compile(r'''(?x)
     |   \+\+ | --
     |   ->\*? | \,
     |   (<<|>>)=? | && | \|\|
+    |   <=>
     |   [!<>=/*%+|&^~-]=?
     |   (\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|xor|xor_eq)\b)
 ''')
@@ -494,6 +495,7 @@ _id_operator_v2 = {
     '>': 'gt',
     '<=': 'le',
     '>=': 'ge',
+    '<=>': 'ss',
     '!': 'nt', 'not': 'nt',
     '&&': 'aa', 'and': 'aa',
     '||': 'oo', 'or': 'oo',
@@ -528,7 +530,7 @@ _expression_bin_ops = [
     ['^', 'xor'],
     ['&', 'bitand'],
     ['==', '!=', 'not_eq'],
-    ['<=', '>=', '<', '>'],
+    ['<=>', '<=', '>=', '<', '>'],
     ['<<', '>>'],
     ['+', '-'],
     ['*', '/', '%'],
@@ -5309,7 +5311,7 @@ class DefinitionParser(BaseParser):
         # exclusive-or   = and              ^
         # and            = equality         &
         # equality       = relational       ==, !=
-        # relational     = shift            <, >, <=, >=
+        # relational     = shift            <, >, <=, >=, <=>
         # shift          = additive         <<, >>
         # additive       = multiplicative   +, -
         # multiplicative = pm               *, /, %

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -289,13 +289,16 @@ def test_expressions():
     exprCheck('5 == 42', 'eqL5EL42E')
     exprCheck('5 != 42', 'neL5EL42E')
     exprCheck('5 not_eq 42', 'neL5EL42E')
-    # ['<=', '>=', '<', '>']
+    # ['<=', '>=', '<', '>', '<=>']
     exprCheck('5 <= 42', 'leL5EL42E')
     exprCheck('A <= 42', 'le1AL42E')
     exprCheck('5 >= 42', 'geL5EL42E')
     exprCheck('5 < 42', 'ltL5EL42E')
     exprCheck('A < 42', 'lt1AL42E')
     exprCheck('5 > 42', 'gtL5EL42E')
+    exprCheck('A > 42', 'gt1AL42E')
+    exprCheck('5 <=> 42', 'ssL5EL42E')
+    exprCheck('A <=> 42', 'ss1AL42E')
     # ['<<', '>>']
     exprCheck('5 << 42', 'lsL5EL42E')
     exprCheck('A << 42', 'ls1AL42E')
@@ -661,6 +664,7 @@ def test_operators():
     check('function', 'void operator>()', {1: "gt-operator", 2: "gtv"})
     check('function', 'void operator<=()', {1: "lte-operator", 2: "lev"})
     check('function', 'void operator>=()', {1: "gte-operator", 2: "gev"})
+    check('function', 'void operator<=>()', {1: None, 2: "ssv"})
     check('function', 'void operator!()', {1: "not-operator", 2: "ntv"})
     check('function', 'void operator not()', {2: "ntv"})
     check('function', 'void operator&&()', {1: "sand-operator", 2: "aav"})


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
Support the ``<=>`` operator added in C++20.

### Details
Note that when written in roles the ``<`` may need to escaped to disambiguate with xrefs with explicit titles. E.g., ``:cpp:func:`operator<=>` `` is an (attempted) reference to ``=`` with title ``operator``, but ``:cpp:func:`operator\<=>` `` is a reference to ``operator<=>`` with implicit title.

### Relates
Fixes #8942.

