### PR TITLE
BUG: Fix rebuild regression

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1248,7 +1248,13 @@ def validate_html_favicon(app: Sphinx, config: Config) -> None:
         config.html_favicon = None  # type: ignore
 
 
-UNSET = object()
+class _stable_repr_object():
+
+    def __repr__(self):
+        return '<object>'
+
+
+UNSET = _stable_repr_object()
 
 
 def migrate_html_add_permalinks(app: Sphinx, config: Config) -> None:


### PR DESCRIPTION
On fc8247a3cd42fa85d4f0b3ac6ed6cd0fdb12e115 (good) or earlier or this PR, doing two consecutive builds in a row I see:
```
$ make clean && make html_dev-noplot && make html_dev-noplot
building [html]: targets for 50 source files that are out of date
updating environment: [new config] 755 added, 0 changed, 0 removed
...
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 7 changed, 0 removed
```
On #8905 / 102393fbc2b2a59ee7464298cdf9b9db3a40e225 (bad) or `master`, I see:
```
$ make clean && make html_dev-noplot && make html_dev-noplot
building [html]: targets for 50 source files that are out of date
updating environment: [new config] 755 added, 0 changed, 0 removed
...
building [html]: targets for 755 source files that are out of date
updating environment: 0 added, 7 changed, 0 removed
```
This regression causes all documents to be rewritten in the `writing output...` stage, which takes the incremental build from ~10 seconds to ~2 minutes, which is a tough efficiency regression when trying to iteratively write docs.

I think this is due to `object()` not having a stable `repr` across runs because the memory location / `id` can change, and `id` is in the `__repr__` of `object` instances. So this PR ensures that `UNSET` has a stable `__repr__`, and fixes my incremental doc builds.

I went to add a test and realized it's not so easy because you actually need multiple *Python processes* to get this effect, because within a given process the `UNSET` will have a stable repr. So that's why there is no test. And maybe this is why it escaped existing tests if there are any that check to make sure things are not unnecessarily rebuilt.