### PR TITLE
Fix #8952: Exceptions raised in a Directive cause parallel builds to hang

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #8952: Exceptions raised in a Directive cause parallel builds to hang
+
 Testing
 --------
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Do shutdown explicitly when failure on the subprocess.
