### PR TITLE
C and C++, fix nested params

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -93,6 +93,8 @@ Bugs fixed
 * C, properly reject function declarations when a keyword is used
   as parameter name.
 * #8933: viewcode: Failed to create back-links on parallel build
+* #8960: C and C++, fix rendering of (member) function pointer types in
+  function parameter lists.
 
 Testing
 --------

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -669,15 +669,24 @@ class ASTParameters(ASTBase):
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:
         verify_description_mode(mode)
-        paramlist = addnodes.desc_parameterlist()
-        for arg in self.args:
-            param = addnodes.desc_parameter('', '', noemph=True)
-            if mode == 'lastIsName':  # i.e., outer-function params
+        # only use the desc_parameterlist for the outer list, not for inner lists
+        if mode == 'lastIsName':
+            paramlist = addnodes.desc_parameterlist()
+            for arg in self.args:
+                param = addnodes.desc_parameter('', '', noemph=True)
                 arg.describe_signature(param, 'param', env, symbol=symbol)
-            else:
-                arg.describe_signature(param, 'markType', env, symbol=symbol)
-            paramlist += param
-        signode += paramlist
+                paramlist += param
+            signode += paramlist
+        else:
+            signode += nodes.Text('(', '(')
+            first = True
+            for arg in self.args:
+                if not first:
+                    signode += nodes.Text(', ', ', ')
+                first = False
+                arg.describe_signature(signode, 'markType', env, symbol=symbol)
+            signode += nodes.Text(')', ')')
+
         for attr in self.attrs:
             signode += nodes.Text(' ')
             attr.describe_signature(signode)

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -1967,15 +1967,23 @@ class ASTParametersQualifiers(ASTBase):
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:
         verify_description_mode(mode)
-        paramlist = addnodes.desc_parameterlist()
-        for arg in self.args:
-            param = addnodes.desc_parameter('', '', noemph=True)
-            if mode == 'lastIsName':  # i.e., outer-function params
+        # only use the desc_parameterlist for the outer list, not for inner lists
+        if mode == 'lastIsName':
+            paramlist = addnodes.desc_parameterlist()
+            for arg in self.args:
+                param = addnodes.desc_parameter('', '', noemph=True)
                 arg.describe_signature(param, 'param', env, symbol=symbol)
-            else:
-                arg.describe_signature(param, 'markType', env, symbol=symbol)
-            paramlist += param
-        signode += paramlist
+                paramlist += param
+            signode += paramlist
+        else:
+            signode += nodes.Text('(', '(')
+            first = True
+            for arg in self.args:
+                if not first:
+                    signode += nodes.Text(', ', ', ')
+                first = False
+                arg.describe_signature(signode, 'markType', env, symbol=symbol)
+            signode += nodes.Text(')', ')')
 
         def _add_anno(signode: TextElement, text: str) -> None:
             signode += nodes.Text(' ')

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -420,6 +420,9 @@ def test_function_definitions():
     with pytest.raises(DefinitionError):
         parse('function', 'void f(int for)')
 
+    # from #8960
+    check('function', 'void f(void (*p)(int, double), int i)', {1: 'f'})
+
 
 def test_nested_name():
     check('struct', '{key}.A', {1: "A"})

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -619,6 +619,9 @@ def test_function_definitions():
     # from breathe#441
     check('function', 'auto MakeThingy() -> Thingy*', {1: 'MakeThingy', 2: '10MakeThingyv'})
 
+    # from #8960
+    check('function', 'void f(void (*p)(int, double), int i)', {2: '1fPFvidEi'})
+
 
 def test_operators():
     check('function', 'void operator new()', {1: "new-operator", 2: "nwv"})


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Only use ``addnodes.desc_parameterlist`` for function parameter lists for the main parameter lists, not potentially nested lists in (member) function pointers.

### Detail
Fixes #8960

