### PR TITLE
Fix py.typed file not being included in source archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include sphinx-quickstart.py
 include sphinx-apidoc.py
 include tox.ini
 include sphinx/locale/.tx/config
+include sphinx/py.typed
 
 recursive-include sphinx/templates *
 recursive-include sphinx/texinputs *


### PR DESCRIPTION
Subject: fix type hints not being supported by builds from source archives

### Feature or Bugfix
- Bugfix

### Purpose
- To support type hints the package must include `py.typed` file. Currently its been missing from source archives generated by build system.

### Detail
- Adding a one line to MANIFEST.in file fixes this issue.


