### PR TITLE
Fix #8959: using UNIX path separator confuses Sphinx on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Deprecated
 Features added
 --------------
 
+* #8959: using UNIX path separator in image directive confuses Sphinx on Windows
+
 Bugs fixed
 ----------
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -10,7 +10,6 @@
 
 import os
 import pickle
-import posixpath
 import warnings
 from collections import defaultdict
 from copy import copy
@@ -34,6 +33,7 @@ from sphinx.util import DownloadFiles, FilenameUniqDict, logging
 from sphinx.util.docutils import LoggingReporter
 from sphinx.util.i18n import CatalogRepository, docname_to_domain
 from sphinx.util.nodes import is_translatable
+from sphinx.util.osutil import canon_path, os_path
 
 if False:
     # For type annotation
@@ -351,6 +351,7 @@ class BuildEnvironment:
         source dir, while relative filenames are relative to the dir of the
         containing document.
         """
+        filename = os_path(filename)
         if filename.startswith('/') or filename.startswith(os.sep):
             rel_fn = filename[1:]
         else:
@@ -358,7 +359,7 @@ class BuildEnvironment:
                                                 base=None))
             rel_fn = path.join(docdir, filename)
 
-        return (posixpath.normpath(rel_fn),
+        return (canon_path(path.normpath(rel_fn)),
                 path.normpath(path.join(self.srcdir, rel_fn)))
 
     @property

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -16,7 +16,6 @@ import pytest
 from docutils import nodes
 
 from sphinx.errors import SphinxError
-from sphinx.testing.path import path
 
 
 def request_session_head(url, **kwargs):
@@ -137,17 +136,16 @@ def test_image_glob(app, status, warning):
     doctree = app.env.get_doctree('subdir/index')
 
     assert isinstance(doctree[0][1], nodes.image)
-    sub = path('subdir')
-    assert doctree[0][1]['candidates'] == {'*': sub / 'rimg.png'}
-    assert doctree[0][1]['uri'] == sub / 'rimg.png'
+    assert doctree[0][1]['candidates'] == {'*': 'subdir/rimg.png'}
+    assert doctree[0][1]['uri'] == 'subdir/rimg.png'
 
     assert isinstance(doctree[0][2], nodes.image)
     assert doctree[0][2]['candidates'] == {'application/pdf': 'subdir/svgimg.pdf',
                                            'image/svg+xml': 'subdir/svgimg.svg'}
-    assert doctree[0][2]['uri'] == sub / 'svgimg.*'
+    assert doctree[0][2]['uri'] == 'subdir/svgimg.*'
 
     assert isinstance(doctree[0][3], nodes.figure)
     assert isinstance(doctree[0][3][0], nodes.image)
     assert doctree[0][3][0]['candidates'] == {'application/pdf': 'subdir/svgimg.pdf',
                                               'image/svg+xml': 'subdir/svgimg.svg'}
-    assert doctree[0][3][0]['uri'] == sub / 'svgimg.*'
+    assert doctree[0][3][0]['uri'] == 'subdir/svgimg.*'


### PR DESCRIPTION
Subject: <short purpose of this pull request>
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #8959 