### PR TITLE
Fix mathjax v3 config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Incompatible changes
 * #7425: MathJax: The MathJax was changed from 2 to 3. Users using a custom
   MathJax configuration may have to set the old MathJax path or update their
   configuration for version 3. See :mod:`sphinx.ext.mathjax`.
+* #8971: Update MathJax configuration script to support MathJax v2 and v3. Issue
+  warnings when v2 configuration is used with the default MathJax URL.
 * #7784: i18n: The msgid for alt text of image is changed
 * #5560: napoleon: :confval:`napoleon_use_param` also affect "other parameters"
   section
@@ -217,7 +219,7 @@ Bugs fixed
   inside function type signatures
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
-  bracketed, not braced (and is anyhow not needed) 
+  bracketed, not braced (and is anyhow not needed)
 * #8849: LaTex: code-block printed out of margin (see the opt-in LaTeX syntax
   boolean :ref:`verbatimforcewraps <latexsphinxsetupforcewraps>` for use via
   the :ref:`'sphinxsetup' <latexsphinxsetup>` key of ``latex_elements``)

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -225,6 +225,11 @@ Sphinx but is set to automatically include it from a third-party site.
    `CommonHTML Output Processor Options`_. General configuration options are
    described at `Configuring MathJax`_.
 
+   If any of the options described in the `MathJax v2.7 documentation`_ are used,
+   and the ``mathjax_path`` is set to the default, a warning is raised notifying of
+   the configuration mismatch. This warning can be suppressed by setting
+   ``mathjax_no_v2_warning`` to ``True`` in ``conf.py``.
+
    The default value of ``mathjax_config`` is empty (not configured).
 
    .. versionadded:: 1.8
@@ -235,6 +240,14 @@ Sphinx but is set to automatically include it from a third-party site.
 .. _MathML Input Processor Options: http://docs.mathjax.org/en/latest/options/input/mathml.html
 .. _CommonHTML Output Processor Options: http://docs.mathjax.org/en/latest/options/output/chtml.html
 .. _Configuring MathJax: http://docs.mathjax.org/en/latest/options/index.html
+.. _MathJax v2.7 documentation: https://docs.mathjax.org/en/v2.7-latest/options/hub.html
+
+.. confval:: mathjax_no_v2_warning
+
+   A Boolean option that suppresses the warning when ``mathjax_config`` appears to
+   be set up for MathJax v2.
+
+   .. versionadded:: 4.0
 
 :mod:`sphinx.ext.jsmath` -- Render math via JavaScript
 ------------------------------------------------------

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -190,7 +190,7 @@ Sphinx but is set to automatically include it from a third-party site.
 
 .. confval:: mathjax_options
 
-   The options to the ``script`` tag for MathJax.  For example, you can set integrity
+   The options to the ``script`` tag for MathJax. For example, you can set integrity
    option with following setting::
 
        mathjax_options = {
@@ -203,8 +203,9 @@ Sphinx but is set to automatically include it from a third-party site.
 
 .. confval:: mathjax_config
 
-   The inline configuration options for MathJax. The value is set on the ``window.MathJax`` object.
-   For more information, please read `Configuration Using an In-Line Script`_.
+   The inline configuration options for MathJax. The value is set on the
+   ``window.MathJax`` object. For more information, please read
+   `Configuration Using an In-Line Script`_.
 
    For example (for MathJax v3)::
 
@@ -217,11 +218,12 @@ Sphinx but is set to automatically include it from a third-party site.
            },
        }
 
-   would add the macro ``\\RR``, which would typeset a blackboard-style R when used, and process escaped
-   dollar signs to produce a literal ``$`` character. To see the available configuration options with
-   the `default MathJax components`_, see `TeX Input Processor Options`_,
-   `MathML Input Processor Options`_, and `CommonHTML Output Processor Options`_. General configuration
-   options are described at `Configuring MathJax`_.
+   would add the macro ``\\RR``, which would typeset a blackboard-style R when used,
+   and process escaped dollar signs to produce a literal ``$`` character. To see
+   the available configuration options with the `default MathJax components`_, see
+   `TeX Input Processor Options`_, `MathML Input Processor Options`_, and
+   `CommonHTML Output Processor Options`_. General configuration options are
+   described at `Configuring MathJax`_.
 
    The default value of ``mathjax_config`` is empty (not configured).
 

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -144,7 +144,9 @@ are built:
    Version 4.0 changes the version of MathJax used to version 3. You may need to
    override ``mathjax_path`` to
    ``https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML``
-   or update your configuration options for version 3.
+   or `update your configuration options for version 3`_.
+
+.. _update your configuration options for version 3: http://docs.mathjax.org/en/latest/web/configuration.html#converting-your-v2-configuration-to-v3
 
 .. versionadded:: 1.1
 
@@ -152,7 +154,7 @@ This extension puts math as-is into the HTML files.  The JavaScript package
 MathJax_ is then loaded and transforms the LaTeX markup to readable math live in
 the browser.
 
-Because MathJax (and the necessary fonts) is very large, it is not included in
+Because MathJax and the necessary fonts are very large, it is not included in
 Sphinx but is set to automatically include it from a third-party site.
 
 .. attention::
@@ -188,7 +190,7 @@ Sphinx but is set to automatically include it from a third-party site.
 
 .. confval:: mathjax_options
 
-   The options to script tag for mathjax.  For example, you can set integrity
+   The options to the ``script`` tag for MathJax.  For example, you can set integrity
    option with following setting::
 
        mathjax_options = {
@@ -201,22 +203,36 @@ Sphinx but is set to automatically include it from a third-party site.
 
 .. confval:: mathjax_config
 
-   The inline configuration options for mathjax.  The value is used as a
-   parameter of ``MathJax.Hub.Config()``.  For more information, please
-   read `Using in-line configuration options`_.
+   The inline configuration options for MathJax. The value is set on the ``window.MathJax`` object.
+   For more information, please read `Configuration Using an In-Line Script`_.
 
-   For example::
+   For example (for MathJax v3)::
 
        mathjax_config = {
-           'extensions': ['tex2jax.js'],
-           'jax': ['input/TeX', 'output/HTML-CSS'],
+           "tex": {
+               "macros": {
+                   "RR": "\\mathbb{R}",
+               },
+               "processEscapes": True,
+           },
        }
 
-   The default is empty (not configured).
+   would add the macro ``\\RR``, which would typeset a blackboard-style R when used, and process escaped
+   dollar signs to produce a literal ``$`` character. To see the available configuration options with
+   the `default MathJax components`_, see `TeX Input Processor Options`_,
+   `MathML Input Processor Options`_, and `CommonHTML Output Processor Options`_. General configuration
+   options are described at `Configuring MathJax`_.
+
+   The default value of ``mathjax_config`` is empty (not configured).
 
    .. versionadded:: 1.8
 
-.. _Using in-line configuration options: https://docs.mathjax.org/en/latest/configuration.html#using-in-line-configuration-options
+.. _Configuration Using an In-Line Script: http://docs.mathjax.org/en/latest/web/configuration.html#configuration-using-an-in-line-script
+.. _default MathJax components: http://docs.mathjax.org/en/latest/web/components/combined.html#tex-mml-chtml
+.. _TeX Input Processor Options: http://docs.mathjax.org/en/latest/options/input/tex.html
+.. _MathML Input Processor Options: http://docs.mathjax.org/en/latest/options/input/mathml.html
+.. _CommonHTML Output Processor Options: http://docs.mathjax.org/en/latest/options/output/chtml.html
+.. _Configuring MathJax: http://docs.mathjax.org/en/latest/options/index.html
 
 :mod:`sphinx.ext.jsmath` -- Render math via JavaScript
 ------------------------------------------------------

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -24,7 +24,7 @@ from sphinx.util.math import get_node_equation_number
 from sphinx.writers.html import HTMLTranslator
 
 # more information for mathjax secure url is here:
-# https://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn
+# https://docs.mathjax.org/en/latest/web/configuration.html#loading-mathjax
 MATHJAX_URL = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 
 
@@ -78,15 +78,16 @@ def install_mathjax(app: Sphinx, pagename: str, templatename: str, context: Dict
 
     domain = cast(MathDomain, app.env.get_domain('math'))
     if domain.has_equations(pagename):
+        # The configuration script must come before the MathJax script
+        if app.config.mathjax_config:
+            body = "window.MathJax = {:s}".format(json.dumps(app.config.mathjax_config))
+            app.add_js_file(None, body=body)
+
         # Enable mathjax only if equations exists
         options = {'async': 'async'}
         if app.config.mathjax_options:
             options.update(app.config.mathjax_options)
         app.add_js_file(app.config.mathjax_path, **options)  # type: ignore
-
-        if app.config.mathjax_config:
-            body = "MathJax.Hub.Config(%s)" % json.dumps(app.config.mathjax_config)
-            app.add_js_file(None, type="text/x-mathjax-config", body=body)
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -81,6 +81,7 @@ def install_mathjax(app: Sphinx, pagename: str, templatename: str, context: Dict
 
     domain = cast(MathDomain, app.env.get_domain('math'))
 
+    # Enable mathjax only if equations exists
     if domain.has_equations(pagename):
         # The configuration script must come before the MathJax script
         if app.config.mathjax_config:
@@ -102,16 +103,17 @@ def install_mathjax(app: Sphinx, pagename: str, templatename: str, context: Dict
                 "CommonHTML"
             }
             configured_for_v2 = set(app.config.mathjax_config.keys()) & mathjax2_options
-            if configured_for_v2 and app.config.mathjax_path == MATHJAX_URL:
+            default_url = app.config.mathjax_path == MATHJAX_URL
+            if (configured_for_v2 and default_url and not app.config.mathjax_no_v2_warning):
                 mj2_url = ("https://docs.mathjax.org/en/v2.7-latest/start.html#using-a-"
                            "content-delivery-network-cdn")
                 logger.warning(__("'mathjax_config' appears to be for MathJax v2. You may "
                                   "need to set the 'mathjax_path' option to load MathJax v2, "
-                                  "see %s"), mj2_url)
+                                  "see %s.\nThis message can be suppressed by setting "
+                                  "'mathjax_no_v2_warning' to be 'True' in conf.py."), mj2_url)
             body = "window.MathJax = {:s}".format(json.dumps(app.config.mathjax_config))
             app.add_js_file(None, body=body)
 
-        # Enable mathjax only if equations exists
         options = {'async': 'async'}
         if app.config.mathjax_options:
             options.update(app.config.mathjax_options)
@@ -128,6 +130,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('mathjax_inline', [r'\(', r'\)'], 'html')
     app.add_config_value('mathjax_display', [r'\[', r'\]'], 'html')
     app.add_config_value('mathjax_config', None, 'html')
+    app.add_config_value('mathjax_no_v2_warning', False, 'html')
     app.connect('html-page-context', install_mathjax)
 
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -20,9 +20,9 @@ from sphinx.application import Sphinx
 from sphinx.domains.math import MathDomain
 from sphinx.errors import ExtensionError
 from sphinx.locale import _, __
+from sphinx.util import logging
 from sphinx.util.math import get_node_equation_number
 from sphinx.writers.html import HTMLTranslator
-from sphinx.util import logging
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,8 @@ def install_mathjax(app: Sphinx, pagename: str, templatename: str, context: Dict
             }
             configured_for_v2 = set(app.config.mathjax_config.keys()) & mathjax2_options
             if configured_for_v2 and app.config.mathjax_path == MATHJAX_URL:
-                mj2_url = "https://docs.mathjax.org/en/v2.7-latest/start.html#using-a-content-delivery-network-cdn"
+                mj2_url = ("https://docs.mathjax.org/en/v2.7-latest/start.html#using-a-"
+                           "content-delivery-network-cdn")
                 logger.warning(__("'mathjax_config' appears to be for MathJax v2. You may "
                                   "need to set the 'mathjax_path' option to load MathJax v2, "
                                   "see %s"), mj2_url)

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -242,6 +242,20 @@ def test_mathjax_config_v2_warning(app, status, warning):
 @pytest.mark.sphinx('html', testroot='ext-math',
                     confoverrides={'extensions': ['sphinx.ext.mathjax'],
                                    'mathjax_config': {'extensions': ['tex2jax.js']},
+                                   'mathjax_no_v2_warning': True})
+def test_mathjax_config_v2_suppress_warning(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'index.html').read_text()
+    assert ('<script >'
+            'window.MathJax = {"extensions": ["tex2jax.js"]}'
+            '</script>' in content)
+    assert "'mathjax_config' appears to be" not in warning.getvalue()
+
+
+@pytest.mark.sphinx('html', testroot='ext-math',
+                    confoverrides={'extensions': ['sphinx.ext.mathjax'],
+                                   'mathjax_config': {'extensions': ['tex2jax.js']},
                                    'mathjax_path': 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'})
 def test_mathjax_config_v2_no_warning(app, status, warning):
     app.builder.build_all()

--- a/tests/test_ext_math.py
+++ b/tests/test_ext_math.py
@@ -215,14 +215,42 @@ def test_math_compat(app, status, warning):
 
 @pytest.mark.sphinx('html', testroot='ext-math',
                     confoverrides={'extensions': ['sphinx.ext.mathjax'],
-                                   'mathjax_config': {'extensions': ['tex2jax.js']}})
+                                   'mathjax_config': {'tex': {'processEscapes': True}}})
 def test_mathjax_config(app, status, warning):
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').read_text()
-    assert ('<script type="text/x-mathjax-config">'
-            'MathJax.Hub.Config({"extensions": ["tex2jax.js"]})'
+    print(repr(content))
+    assert ('<script >'
+            'window.MathJax = {"tex": {"processEscapes": true}}'
             '</script>' in content)
+
+
+@pytest.mark.sphinx('html', testroot='ext-math',
+                    confoverrides={'extensions': ['sphinx.ext.mathjax'],
+                                   'mathjax_config': {'extensions': ['tex2jax.js']}})
+def test_mathjax_config_v2_warning(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'index.html').read_text()
+    assert ('<script >'
+            'window.MathJax = {"extensions": ["tex2jax.js"]}'
+            '</script>' in content)
+    assert "'mathjax_config' appears to be" in warning.getvalue()
+
+
+@pytest.mark.sphinx('html', testroot='ext-math',
+                    confoverrides={'extensions': ['sphinx.ext.mathjax'],
+                                   'mathjax_config': {'extensions': ['tex2jax.js']},
+                                   'mathjax_path': 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'})
+def test_mathjax_config_v2_no_warning(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'index.html').read_text()
+    assert ('<script >'
+            'window.MathJax = {"extensions": ["tex2jax.js"]}'
+            '</script>' in content)
+    assert "'mathjax_config' appears to be" not in warning.getvalue()
 
 
 @pytest.mark.sphinx('html', testroot='ext-math',


### PR DESCRIPTION
Subject: Fix #8195

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- As discussed in #8195, the configuration format for MathJax v3 no longer uses the `Hub.Config()` function. This change sets a mapping on the `window.MathJax` object, which works for v2 and v3.
- Add a warning to configuration that appears to be for v2 which won't work for v3.
