### PR TITLE
Fix #7119: autodoc: Broken doctree was generated by builtin_resolver

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1303,7 +1303,7 @@ def builtin_resolver(app: Sphinx, env: BuildEnvironment,
 
     content = find_pending_xref_condition(node, 'resolved')
     if content:
-        contnode = content.children[0]
+        contnode = content.children[0]  # type: ignore
 
     if node.get('refdomain') != 'py':
         return None

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1301,6 +1301,10 @@ def builtin_resolver(app: Sphinx, env: BuildEnvironment,
 
         return s in typing.__all__  # type: ignore
 
+    content = find_pending_xref_condition(node, 'resolved')
+    if content:
+        contnode = content.children[0]
+
     if node.get('refdomain') != 'py':
         return None
     elif node.get('reftype') in ('class', 'obj') and node.get('reftarget') == 'None':


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The builtin_resolver() generates broken doctree unexpectedly if it
contains pending_xref_condition nodes.
- refs: #7119