### PR TITLE
LaTeX: partially revert #8997 for \pysigline

### DIFF
--- a/sphinx/texinputs/sphinxlatexobjects.sty
+++ b/sphinx/texinputs/sphinxlatexobjects.sty
@@ -91,14 +91,20 @@
 % \relax only ends its "dimen" part
   \py@argswidth=\dimexpr\linewidth+\labelwidth\relax\relax
   \item[{\parbox[t]{\py@argswidth}{\raggedright #1\strut}}]
-% this strange incantation is because at its root LaTeX in fact did not
-% imagine a multi-line label, it is always wrapped in a horizontal box at core
-% LaTeX level and we have to find tricks to get correct interline distances.
-  \leavevmode\par\nobreak\vskip-\parskip\prevdepth\dp\strutbox}
+% contrarily to \pysiglinewithargsret, we do not do this:
+%  \leavevmode\par\nobreak\vskip-\parskip\prevdepth\dp\strutbox
+% which would give exact vertical spacing if item parbox is multi-line,
+% as it affects negatively more common situation of \pysigline
+% used twice or more in a row for labels sharing common description,
+% due to bad interaction with the \phantomsection in the mark-up
+}
 \newcommand{\pysiglinewithargsret}[3]{%
   \settowidth{\py@argswidth}{#1\sphinxcode{(}}%
   \py@argswidth=\dimexpr\linewidth+\labelwidth-\py@argswidth\relax\relax
   \item[{#1\sphinxcode{(}\py@sigparams{#2}{#3}}]
+% this strange incantation is because at its root LaTeX in fact did not
+% imagine a multi-line label, it is always wrapped in a horizontal box at core
+% LaTeX level and we have to find tricks to get correct interline distances.
   \leavevmode\par\nobreak\vskip-\parskip\prevdepth\dp\strutbox}
 \newcommand{\pysigstartmultiline}{%
  \def\pysigstartmultiline{\vskip\smallskipamount\parskip\z@skip\itemsep\z@skip}%


### PR DESCRIPTION
Reason is that mark-up such as this:

```rest
   .. attribute:: state
                  state_machine

      The state and state machine which controls the parsing.  Used for
      ``nested_parse``.
```

generates two `\pysigline` each with `\phantomsection`. The latex code
to get good vertical spacing between label and its description, if label
``\parbox`` is multi-line, cause in this context the two (generally,
single-line) labels to be stacked vertically with no spacing.

With #8997 (screenshot from a pdf viewer of sphinx.pdf for current master):
![Capture d’écran 2021-03-15 à 10 43 59](https://user-images.githubusercontent.com/2589111/111138520-513a1080-8580-11eb-8879-172be1fe419b.png)

But it should be (screenshot from firefox pdf viewer of 3.5.x sphinx.pdf on sphinx-doc.org):

![Capture d’écran 2021-03-15 à 10 43 38](https://user-images.githubusercontent.com/2589111/111138476-467f7b80-8580-11eb-9dce-74e88aba8866.png)

This commit keeps the ``\parbox`` which fixes #8980, but drops the
attempt to get very good vertical distance to description, so as to not alter
the possibly more common use case of items with common description.


- Refactoring

The only easy latex way (inside `\pysigline` definition) that I see to get good result in both cases: 1. stacked labels as above or 2. single multi-line label would be to remove the `\vskip-\parskip`. But this means changing output always like this, which has inter-paragraph spacing between label and start of item description:

![Capture d’écran 2021-03-15 à 11 34 11](https://user-images.githubusercontent.com/2589111/111140475-a7a84e80-8582-11eb-9836-6cfbbfa6b73f.png)

(If `\vskip-\parskip` is removed also for `\pysiglinewithargsret` we get for example this

![Capture d’écran 2021-03-15 à 11 34 29](https://user-images.githubusercontent.com/2589111/111140542-b989f180-8582-11eb-997e-005b762f18e3.png)

where there is extra vertical space between label and description compared to current situation.)

I don't have strong opinion,  for time being I propose this PR to fix case of successive `\pysigline` with no paragraph in-between, and accept that vertical distance will not be completely perfect if label occupies more than one line as in #8980 situation (there is a  `\strut` in the `\parbox` which already gives acceptable result).

I did not find usage of `\pysiglinewithargsret` with no intervening item description as is the case as above with `\pysigline` and the `state/state_machine` case.