### PR TITLE
Fix #9009: LaTeX: "release" value with underscore leads to invalid LaTeX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -107,6 +107,7 @@ Bugs fixed
 * #8980: LaTeX: missing line break in ``\pysigline``
 * #8995: LaTeX: legacy ``\pysiglinewithargsret`` does not compute correctly
   available  horizontal space and should use a ragged right style
+* #9009: LaTeX: "release" value with underscore leads to invalid LaTeX
 * #8911: C++: remove the longest matching prefix in
   :confval:`cpp_index_common_prefix` instead of the first that matches.
 * C, properly reject function declarations when a keyword is used

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -71,7 +71,7 @@
 
 \title{<%= title %>}
 \date{<%= date %>}
-\release{<%= release %>}
+\release{<%= release | e %>}
 \author{<%= author %>}
 <%- if logofilename %>
 \newcommand{\sphinxlogo}{\sphinxincludegraphics{<%= logofilename %>}\par}

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -277,14 +277,14 @@ def test_latex_title_after_admonitions(app, status, warning):
 
 
 @pytest.mark.sphinx('latex', testroot='basic',
-                    confoverrides={'release': '1.0'})
+                    confoverrides={'release': '1.0_0'})
 def test_latex_release(app, status, warning):
     app.builder.build_all()
     result = (app.outdir / 'test.tex').read_text()
     print(result)
     print(status.getvalue())
     print(warning.getvalue())
-    assert r'\release{1.0}' in result
+    assert r'\release{1.0\_0}' in result
     assert r'\renewcommand{\releasename}{Release}' in result
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The "release" variable is not escaped on the LaTeX output.
- refs: #9009 