### PR TITLE
Add Danish translation of message on search page 

### DIFF
--- a/sphinx/locale/da/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/da/LC_MESSAGES/sphinx.po
@@ -3155,7 +3155,7 @@ msgstr "Aktivér venligst JavaScript for at aktivere\n    søgefunktionalitet."
 msgid ""
 "Searching for multiple words only shows matches that contain\n"
 "    all words."
-msgstr "Bemærk: Hvis du søger efter flere ord, vises kun resultater der indeholder alle ord."
+msgstr "Bemærk: Hvis du søger efter flere ord, vises kun resultater der indeholder alle ordene."
 
 #: sphinx/themes/basic/search.html:32
 msgid "search"

--- a/sphinx/locale/da/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/da/LC_MESSAGES/sphinx.po
@@ -3155,7 +3155,7 @@ msgstr "Aktivér venligst JavaScript for at aktivere\n    søgefunktionalitet."
 msgid ""
 "Searching for multiple words only shows matches that contain\n"
 "    all words."
-msgstr ""
+msgstr "Bemærk: Hvis du søger efter flere ord, vises kun resultater der indeholder alle ord."
 
 #: sphinx/themes/basic/search.html:32
 msgid "search"


### PR DESCRIPTION
Tiny change, hopefully no need to explain this in detail. 

Currently this strings seems to be the only string that is not translated which appears in the user interface, when using Danish translation of Sphinx.
