### PR TITLE
Fix #8992: autodoc: Failed to resolve types.TracebackType type annotation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -89,6 +89,7 @@ Bugs fixed
 * #8917: autodoc: Raises a warning if function has wrong __globals__ value
 * #8415: autodoc: a TypeVar imported from other module is not resolved (in
   Python 3.7 or above)
+* #8992: autodoc: Failed to resolve types.TracebackType type annotation
 * #8905: html: html_add_permalinks=None and html_add_permalinks="" are ignored
 * #8380: html search: Paragraphs in search results are not identified as ``<p>``
 * #8915: html theme: The translation of sphinx_rtd_theme does not work

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -11,6 +11,7 @@
 import sys
 from numbers import Integral
 from struct import Struct
+from types import TracebackType
 from typing import (Any, Callable, Dict, Generator, List, NewType, Optional, Tuple, TypeVar,
                     Union)
 
@@ -45,6 +46,7 @@ def test_restify():
     assert restify(None) == ":obj:`None`"
     assert restify(Integral) == ":class:`numbers.Integral`"
     assert restify(Struct) == ":class:`struct.Struct`"
+    assert restify(TracebackType) == ":class:`types.TracebackType`"
     assert restify(Any) == ":obj:`Any`"
 
 
@@ -133,7 +135,8 @@ def test_stringify():
     assert stringify(str) == "str"
     assert stringify(None) == "None"
     assert stringify(Integral) == "numbers.Integral"
-    assert restify(Struct) == ":class:`struct.Struct`"
+    assert stringify(Struct) == "struct.Struct"
+    assert stringify(TracebackType) == "types.TracebackType"
     assert stringify(Any) == "Any"
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The builtin module, ``types.TracebackType`` does not have correct module
name.  This allows to refer it automatically.
- refs: #8992