### PR TITLE
Rename DocumenterBridge.filename_set to record_dependencies

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Deprecated
 * ``sphinx.directives.patches.CSVTable``
 * ``sphinx.directives.patches.ListTable``
 * ``sphinx.directives.patches.RSTTable``
+* ``sphinx.ext.autodoc.directive.DocumenterBridge.filename_set``
 * ``sphinx.registry.SphinxComponentRegistry.get_source_input()``
 * ``sphinx.registry.SphinxComponentRegistry.source_inputs``
 * ``sphinx.transforms.FigureAligner``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -42,6 +42,11 @@ The following is a list of deprecated interfaces.
      - 6.0
      - ``docutils.parsers.rst.diretives.tables.RSTTable``
 
+   * - ``sphinx.ext.autodoc.directive.DocumenterBridge.filename_set``
+     - 4.0
+     - 6.0
+     - ``sphinx.ext.autodoc.directive.DocumenterBridge.record_dependencies``
+
    * - ``sphinx.registry.SphinxComponentRegistry.get_source_input()``
      - 4.0
      - 6.0

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -918,15 +918,15 @@ class Documenter:
             self.analyzer = None
             # at least add the module.__file__ as a dependency
             if hasattr(self.module, '__file__') and self.module.__file__:
-                self.directive.filename_set.add(self.module.__file__)
+                self.directive.record_dependencies.add(self.module.__file__)
         else:
-            self.directive.filename_set.add(self.analyzer.srcname)
+            self.directive.record_dependencies.add(self.analyzer.srcname)
 
         if self.real_modname != guess_modname:
             # Add module to dependency list if target object is defined in other module.
             try:
                 analyzer = ModuleAnalyzer.for_module(guess_modname)
-                self.directive.filename_set.add(analyzer.srcname)
+                self.directive.record_dependencies.add(analyzer.srcname)
             except PycodeError:
                 pass
 

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -16,7 +16,7 @@ from docutils.statemachine import StringList
 from docutils.utils import Reporter, assemble_option_dict
 
 from sphinx.config import Config
-from sphinx.deprecation import RemovedInSphinx50Warning
+from sphinx.deprecation import RemovedInSphinx50Warning, RemovedInSphinx60Warning
 from sphinx.environment import BuildEnvironment
 from sphinx.ext.autodoc import Documenter, Options
 from sphinx.util import logging
@@ -56,12 +56,18 @@ class DocumenterBridge:
         self._reporter = reporter
         self.genopt = options
         self.lineno = lineno
-        self.filename_set: Set[str] = set()
+        self.record_dependencies: Set[str] = set()
         self.result = StringList()
         self.state = state
 
     def warn(self, msg: str) -> None:
         logger.warning(msg, location=(self.env.docname, self.lineno))
+
+    @property
+    def filename_set(self) -> Set:
+        warnings.warn('DocumenterBridge.filename_set is deprecated.',
+                      RemovedInSphinx60Warning, stacklevel=2)
+        return self.record_dependencies
 
     @property
     def reporter(self) -> Reporter:
@@ -158,7 +164,7 @@ class AutodocDirective(SphinxDirective):
 
         # record all filenames as dependencies -- this will at least
         # partially make automatic invalidation possible
-        for fn in params.filename_set:
+        for fn in params.record_dependencies:
             self.state.document.settings.record_dependencies.add(fn)
 
         result = parse_generated_content(self.state, params.result, documenter)

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -68,7 +68,7 @@ def make_directive_bridge(env):
         env = env,
         genopt = options,
         result = ViewList(),
-        filename_set = set(),
+        record_dependencies = set(),
         state = Mock(),
     )
     directive.state.document.settings.tab_width = 8


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- DocumenterBridge.filename_set has been used since its beginning.  On the
other hand, in docutils, record_dependencies attribute is well-used to
store the list of dependency files.  So this renames it to docutils'
standard attribute.