### PR TITLE
Deprecate DocumenterBridge.warn()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,7 @@ Deprecated
 * ``sphinx.directives.patches.ListTable``
 * ``sphinx.directives.patches.RSTTable``
 * ``sphinx.ext.autodoc.directive.DocumenterBridge.filename_set``
+* ``sphinx.ext.autodoc.directive.DocumenterBridge.warn()``
 * ``sphinx.registry.SphinxComponentRegistry.get_source_input()``
 * ``sphinx.registry.SphinxComponentRegistry.source_inputs``
 * ``sphinx.transforms.FigureAligner``

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -47,6 +47,11 @@ The following is a list of deprecated interfaces.
      - 6.0
      - ``sphinx.ext.autodoc.directive.DocumenterBridge.record_dependencies``
 
+   * - ``sphinx.ext.autodoc.directive.DocumenterBridge.warn()``
+     - 4.0
+     - 6.0
+     - :ref:`logging-api`
+
    * - ``sphinx.registry.SphinxComponentRegistry.get_source_input()``
      - 4.0
      - 6.0

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -61,6 +61,9 @@ class DocumenterBridge:
         self.state = state
 
     def warn(self, msg: str) -> None:
+        warnings.warn('DocumenterBridge.warn is deprecated.  Plase use sphinx.util.logging '
+                      'module instead.',
+                      RemovedInSphinx60Warning, stacklevel=2)
         logger.warning(msg, location=(self.env.docname, self.lineno))
 
     @property


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since 1.6, sphinx.util.logging module became the default logging
interface of Sphinx. It allows sphinx-components to output log
without the app (or env) object.  According to the policy,
DocumenterBridge.warn() is no longer needed and should be replaced by
the logging module.
