### PR TITLE
Close #5603: autodoc: Allow to refer to a python object using canonical name

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -66,6 +66,8 @@ Features added
 
 * #8924: autodoc: Support ``bound`` argument for TypeVar
 * #7383: autodoc: Support typehints for properties
+* #5603: autodoc: Allow to refer to a python class using its canonical name
+  when the class has two different names; a canonical name and an alias name
 * #7549: autosummary: Enable :confval:`autosummary_generate` by default
 * #4826: py domain: Add ``:canonical:`` option to python directives to describe
   the location where the object is defined

--- a/tests/roots/test-ext-autodoc/target/canonical/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/canonical/__init__.py
@@ -1,0 +1,1 @@
+from target.canonical.original import Bar, Foo

--- a/tests/roots/test-ext-autodoc/target/canonical/original.py
+++ b/tests/roots/test-ext-autodoc/target/canonical/original.py
@@ -1,0 +1,15 @@
+class Foo:
+    """docstring"""
+
+    def meth(self):
+        """docstring"""
+
+
+def bar():
+    class Bar:
+        """docstring"""
+
+    return Bar
+
+
+Bar = bar()

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -2474,3 +2474,34 @@ def test_hide_value(app):
         '   :meta hide-value:',
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_canonical(app):
+    options = {'members': None,
+               'imported-members': None}
+    actual = do_autodoc(app, 'module', 'target.canonical', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.canonical',
+        '',
+        '',
+        '.. py:class:: Bar()',
+        '   :module: target.canonical',
+        '',
+        '   docstring',
+        '',
+        '',
+        '.. py:class:: Foo()',
+        '   :module: target.canonical',
+        '   :canonical: target.canonical.original.Foo',
+        '',
+        '   docstring',
+        '',
+        '',
+        '   .. py:method:: Foo.meth()',
+        '      :module: target.canonical',
+        '',
+        '      docstring',
+        '',
+    ]


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- This generates `:canonical:` option for `:py:class:` directive if the
target class is imported from other module.  It allows users to refer it
using both the new name (imported name) and the original name (canonical
name).
- It helps a library that implements some class in private module (like
`_io.StringIO`), and publish it as public module (like `io.StringIO`).
- refs: #4826, #4944, #4065, #5603, #5589, #8449

### Remaining Tasks
- [x] ~~Support imported functions~~