### PR TITLE
#1708 Changed the visited link color for all themes except alabaster

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,7 +50,8 @@ Bugs fixed
   :confval:`html_context`
 * #8880: viewcode: ExtensionError is raised on incremental build after
   unparsable python module found
-* #1708: Made visited links default color different
+* #1708: Made visited links default color different for all themes except alabaster
+
 Release 3.5.0 (released Feb 14, 2021)
 =====================================
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,25 +1,3 @@
-Release 4.0.0
-==============================
-
-Dependencies
-------------
-
-Incompatible changes
---------------------
-
-Deprecated
-----------
-
-Features added
---------------
-
-Bugs fixed
-----------
-* #1708: Made visited links default color different for all themes except alabaster
-
-Testing
---------
-
 Release 3.5.4 (in development)
 ==============================
 

--- a/CHANGES
+++ b/CHANGES
@@ -50,7 +50,7 @@ Bugs fixed
   :confval:`html_context`
 * #8880: viewcode: ExtensionError is raised on incremental build after
   unparsable python module found
-
+* #1708: Made visited links default color different
 Release 3.5.0 (released Feb 14, 2021)
 =====================================
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,25 @@
+Release 4.0.0
+==============================
+
+Dependencies
+------------
+
+Incompatible changes
+--------------------
+
+Deprecated
+----------
+
+Features added
+--------------
+
+Bugs fixed
+----------
+* #1708: Made visited links default color different for all themes except alabaster
+
+Testing
+--------
+
 Release 3.5.4 (in development)
 ==============================
 
@@ -50,7 +72,6 @@ Bugs fixed
   :confval:`html_context`
 * #8880: viewcode: ExtensionError is raised on incremental build after
   unparsable python module found
-* #1708: Made visited links default color different for all themes except alabaster
 
 Release 3.5.0 (released Feb 14, 2021)
 =====================================

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -41,6 +41,10 @@ a {
   color: {{ theme_linkcolor }};
 }
 
+a:visited {
+  color: initial;
+}
+
 div.bodywrapper a, div.footer a {
   text-decoration: underline;
 }

--- a/sphinx/themes/bizstyle/static/bizstyle.css_t
+++ b/sphinx/themes/bizstyle/static/bizstyle.css_t
@@ -176,6 +176,10 @@ a {
     text-decoration: none;
 }
 
+a:visited {
+    color: initial;
+}
+
 a:hover {
     color: {{ theme_maincolor }};
     text-decoration: underline;

--- a/sphinx/themes/classic/theme.conf
+++ b/sphinx/themes/classic/theme.conf
@@ -24,7 +24,7 @@ headbgcolor      = #f2f2f2
 headtextcolor    = #20435c
 headlinkcolor    = #c60f0f
 linkcolor        = #355f7c
-visitedlinkcolor = #355f7c
+visitedlinkcolor = initial
 codebgcolor      = unset
 codetextcolor    = unset
 

--- a/sphinx/themes/nature/static/nature.css_t
+++ b/sphinx/themes/nature/static/nature.css_t
@@ -137,6 +137,10 @@ a {
     text-decoration: none;
 }
 
+a:visited {
+    color: initial;
+}
+
 a:hover {
     color: #E32E00;
     text-decoration: underline;

--- a/sphinx/themes/pyramid/static/pyramid.css_t
+++ b/sphinx/themes/pyramid/static/pyramid.css_t
@@ -177,6 +177,10 @@ a, a .pre {
     text-decoration: none;
 }
 
+a:visited {
+    color: initial;
+}
+
 a:hover, a:hover .pre {
     text-decoration: underline;
 }

--- a/sphinx/themes/scrolls/theme.conf
+++ b/sphinx/themes/scrolls/theme.conf
@@ -9,5 +9,5 @@ body_max_width = 680
 headerbordercolor = #1752b4
 subheadlinecolor  = #0d306b
 linkcolor         = #1752b4
-visitedlinkcolor  = #444
+visitedlinkcolor  = initial
 admonitioncolor   = #28437f

--- a/sphinx/themes/sphinxdoc/static/sphinxdoc.css_t
+++ b/sphinx/themes/sphinxdoc/static/sphinxdoc.css_t
@@ -147,6 +147,10 @@ a {
     text-decoration: none;
 }
 
+a:visited {
+    color: initial;
+}
+
 a:hover {
     color: #2491CF;
 }


### PR DESCRIPTION
Subject: Changing the visited link colour for all themes except alabaster

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Bugfix
<!-- please choose -->
The colors of the visited link have been changed for all themes except alabaster, as I'll commit to the alabaster repository later.

### Detail
- I've changed the colour of all visited links to initial so that it can use the colours as defaulted by the browser.

