### PR TITLE
HTML Templates: Add blocks to search page

### DIFF
--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -20,6 +20,7 @@
 {% endblock %}
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>
+  {% block scriptwarning %}
   <div id="fallback" class="admonition warning">
   <script>$('#fallback').hide();</script>
   <p>
@@ -27,15 +28,21 @@
     functionality.{% endtrans %}
   </p>
   </div>
+  {% endblock %}
+  {% block searchtext %}
   <p>
     {% trans %}Searching for multiple words only shows matches that contain
     all words.{% endtrans %}
   </p>
+  {% endblock %}
+  {% block searchbox %}
   <form action="" method="get">
     <input type="text" name="q" aria-labelledby="search-documentation" value="" />
     <input type="submit" value="{{ _('search') }}" />
     <span id="search-progress" style="padding-left: 10px"></span>
   </form>
+  {% endblock %}
+  {% block searchresults %}
   {% if search_performed %}
     <h2>{{ _('Search Results') }}</h2>
     {% if not search_results %}
@@ -53,4 +60,5 @@
     </ul>
   {% endif %}
   </div>
+  {% endblock %}
 {% endblock %}


### PR DESCRIPTION
This allows themes to customize the default search page.

Subject: Add blocks to search page


### Feature or Bugfix
- Feature

### Purpose
- Some themes may want to for example style the search box differently, instead of writing the whole search page they can easily override a single block.

### Detail
- None

### Relates
- None

