### PR TITLE
Fix error in Pybind11 docstrings

### DIFF
--- a/sphinx/util/docstrings.py
+++ b/sphinx/util/docstrings.py
@@ -57,10 +57,10 @@ def prepare_docstring(s: str, ignore: int = None, tabsize: int = 8) -> List[str]
     if ignore is None:
         ignore = 1
     else:
-        warnings.warn("The 'ignore' argument to parepare_docstring() is deprecated.",
+        warnings.warn("The 'ignore' argument to prepare_docstring() is deprecated.",
                       RemovedInSphinx50Warning, stacklevel=2)
 
-    lines = s.expandtabs(tabsize).splitlines()
+    lines = str(s).expandtabs(tabsize).splitlines()
     # Find minimum indentation of any non-blank lines after ignored lines.
     margin = sys.maxsize
     for line in lines[ignore:]:


### PR DESCRIPTION
Subject: Fix error in Pybind11 docstrings

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Would you consider this fix for an uninvestigated bug? A year ago I noticed that certain docstrings generated by https://github.com/pybind/pybind11 return an object and thus cause Sphinx to error (on `splitlines()`). Since the edited function is already declaring `s` as `str` in the signature, `str(s)` didn't seem too outrageous. Feel free to close if it is.


