### PR TITLE
Fix the testcase for linkcheck refers removed URLs

### DIFF
--- a/tests/roots/test-linkcheck/links.txt
+++ b/tests/roots/test-linkcheck/links.txt
@@ -2,14 +2,14 @@ This is from CPython documentation.
 
 * Also, if there is a `default namespace <https://www.w3.org/TR/2006/REC-xml-names-20060816/#defaulting>`__, that full URI gets prepended to all of the non-prefixed tags.
 
-* The URL having anchor: `http://www.sphinx-doc.org/en/1.4.8/tutorial.html#install-sphinx`_
+* The URL having anchor: `https://www.sphinx-doc.org/en/master/usage/installation.html#overview`_
 
 Some additional anchors to exercise ignore code
 
 * `Example Bar invalid <https://www.google.com/#!bar>`_
 * `Example Bar invalid <https://www.google.com#!bar>`_ tests that default ignore anchor of #! does not need to be prefixed with /
 * `Example Bar invalid <https://www.google.com/#top>`_
-* `Example anchor invalid <http://www.sphinx-doc.org/en/1.7/intro.html#does-not-exist>`_
+* `Example anchor invalid <http://www.sphinx-doc.org/en/master/index.html#does-not-exist>`_
 * `Complete nonsense <https://localhost:7777/doesnotexist>`_
 * `Example valid local file <conf.py>`_
 * `Example invalid local file <path/to/notfound>`_

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -97,7 +97,7 @@ def test_defaults_json(app):
     assert "Anchor 'top' not found" == \
         rowsby["https://www.google.com/#top"]["info"]
     assert "Anchor 'does-not-exist' not found" == \
-        rowsby["http://www.sphinx-doc.org/en/1.7/intro.html#does-not-exist"]["info"]
+        rowsby["http://www.sphinx-doc.org/en/master/index.html#does-not-exist"]["info"]
     # images should fail
     assert "Not Found for url: https://www.google.com/image.png" in \
         rowsby["https://www.google.com/image.png"]["info"]
@@ -108,7 +108,7 @@ def test_defaults_json(app):
     confoverrides={'linkcheck_anchors_ignore': ["^!", "^top$"],
                    'linkcheck_ignore': [
                        'https://localhost:7777/doesnotexist',
-                       'http://www.sphinx-doc.org/en/1.7/intro.html#',
+                       'http://www.sphinx-doc.org/en/master/index.html#',
                        'https://www.google.com/image.png',
                        'https://www.google.com/image2.png',
                        'path/to/notfound']


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Some public URLs are disabled now.
  For more details, see https://github.com/sphinx-doc/sphinx/issues/8309