### PR TITLE
CSS: support for aside.sidebar (from docutils 0.17+)

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -319,7 +319,8 @@ img.align-default, .figure.align-default {
 
 /* -- sidebars -------------------------------------------------------------- */
 
-div.sidebar {
+div.sidebar,
+aside.sidebar {
     margin: 0 0 0.5em 1em;
     border: 1px solid #ddb;
     padding: 7px;
@@ -377,12 +378,14 @@ div.body p.centered {
 /* -- content of sidebars/topics/admonitions -------------------------------- */
 
 div.sidebar > :last-child,
+aside.sidebar > :last-child,
 div.topic > :last-child,
 div.admonition > :last-child {
     margin-bottom: 0;
 }
 
 div.sidebar::after,
+aside.sidebar::after,
 div.topic::after,
 div.admonition::after,
 blockquote::after {


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

Duplicate CSS definitions from `div.sidebar` to `aside.sidebar`, which is generated since `docutils` 0.17.

The old definitions are unchanged, so it should keep working with older `docutils` versions.

### Relates

- fixes #9001

