### PR TITLE
Pin Sphinx 3.x to docutils <0.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'sphinxcontrib-qthelp',
     'Jinja2>=2.3',
     'Pygments>=2.0',
-    'docutils>=0.12',
+    'docutils>=0.12,<0.17',
     'snowballstemmer>=1.1',
     'babel>=1.3',
     'alabaster>=0.7,<0.8',


### PR DESCRIPTION
This will address the issues that the latest docutils release caused.
I think this is a good practice in general to make sure we have a defined range of docutils versions,
given that they might change in the future.
Having this defined will mean that 3.x versions of Sphinx will always work,
even when docutils has advanced with additional backwards incompatible features.

We've had more than 10 support requests about this in the past week, so I think this is hitting a lot of users throughout the Sphinx ecosystem and it's very hard to debug if you don't understand what is happening. 

Refs #9065 #9063 #9061 #9051