### PR TITLE
Fix autodoc: Async staticmethods/ classmethods are considered as not async

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9078: autodoc: Async staticmethods and classmethods are considered as non
+  async coroutine-functions
 * #8870: The style of toctree captions has been changed with docutils-0.17
 * #9001: The style of ``sidebar`` directive has been changed with docutils-0.17
 

--- a/CHANGES
+++ b/CHANGES
@@ -19,7 +19,7 @@ Bugs fixed
 ----------
 
 * #9078: autodoc: Async staticmethods and classmethods are considered as non
-  async coroutine-functions
+  async coroutine-functions with Python3.10
 * #8870: The style of toctree captions has been changed with docutils-0.17
 * #9001: The style of ``sidebar`` directive has been changed with docutils-0.17
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -352,8 +352,18 @@ def isroutine(obj: Any) -> bool:
 
 def iscoroutinefunction(obj: Any) -> bool:
     """Check if the object is coroutine-function."""
-    # unwrap staticmethod, classmethod and partial (except wrappers)
-    obj = unwrap_all(obj, stop=lambda o: hasattr(o, '__wrapped__'))
+    def iswrappedcoroutine(obj: Any) -> bool:
+        """Check if the object is wrapped coroutine-function."""
+        if isstaticmethod(obj) or isclassmethod(obj) or ispartial(obj):
+            # staticmethod, classmethod and partial method are not a wrapped coroutine-function
+            # Note: Since 3.10, staticmethod and classmethod becomes a kind of wrappers
+            return False
+        elif hasattr(obj, '__wrapped__'):
+            return True
+        else:
+            return False
+
+    obj = unwrap_all(obj, stop=iswrappedcoroutine)
     if hasattr(obj, '__code__') and inspect.iscoroutinefunction(obj):
         # check obj.__code__ because iscoroutinefunction() crashes for custom method-like
         # objects (see https://github.com/sphinx-doc/sphinx/issues/6605)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 3.10.0a7, the instances of staticmethod and classmethod have
`__wrapped__` attribute. It confuses sphinx.util.inspect:iscoroutinefunction().

- refs:
  * https://github.com/sphinx-doc/sphinx/issues/9078
  * https://docs.python.org/3.10/whatsnew/3.10.html#other-language-changes
  * https://bugs.python.org/issue43682
