### PR TITLE
test: Disable testing with python3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
           python: 3.9
           docutils: du16
           coverage: "--cov ./ --cov-append --cov-config setup.cfg"
-        - name: py310-dev
-          python: 3.10-dev
-          docutils: du17
-          os: ubuntu-latest  # required
+        # - name: py310-dev
+        #   python: 3.10-dev
+        #   docutils: du17
+        #   os: ubuntu-latest  # required
     env:
       PYTEST_ADDOPTS: ${{ matrix.coverage }}
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- pytest has crashed on testing with python 3.10.0a7. To avoid the error,
this disables testing with python3.10 for a while.