### PR TITLE
Fix progress logging for parallel builds

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -660,6 +660,17 @@ def old_status_iterator(iterable: Iterable, summary: str, color: str = "darkgree
         logger.info('')
 
 
+def log_status_message(item: str, summary: str, color: str, progress: int,
+                       length: int, verbosity: int = 0) -> None:
+    s = '{}[{:3d}%] {}'.format(summary, (100 * progress) // length,
+                               colorize(color, item))
+    if verbosity:
+        s += '\n'
+    else:
+        s = term_width_line(s)
+    logger.info(s, nonl=True)
+
+
 # new version with progress info
 def status_iterator(iterable: Iterable, summary: str, color: str = "darkgreen",
                     length: int = 0, verbosity: int = 0,
@@ -667,18 +678,12 @@ def status_iterator(iterable: Iterable, summary: str, color: str = "darkgreen",
     if length == 0:
         yield from old_status_iterator(iterable, summary, color, stringify_func)
         return
-    l = 0
+    l = None
     summary = bold(summary)
-    for item in iterable:
-        l += 1
-        s = '%s[%3d%%] %s' % (summary, 100 * l / length, colorize(color, stringify_func(item)))
-        if verbosity:
-            s += '\n'
-        else:
-            s = term_width_line(s)
-        logger.info(s, nonl=True)
+    for l, item in enumerate(iterable):
+        log_status_message(stringify_func(item), summary, color, l + 1, length, verbosity)
         yield item
-    if l > 0:
+    if l is not None:
         logger.info('')
 
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -665,10 +665,9 @@ def log_status_message(item: str, summary: str, color: str, progress: int,
     s = '{}[{:3d}%] {}'.format(summary, (100 * progress) // length,
                                colorize(color, item))
     if verbosity:
-        s += '\n'
+        logger.info(s)
     else:
-        s = term_width_line(s)
-    logger.info(s, nonl=True)
+        logger.info(term_width_line(s), nonl=True)
 
 
 # new version with progress info


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Currently, the progress bar increases when each parallel task is submitted for processing. However, that doesn't necessarily mean any progress has actually been made yet. The result is the progress bar very quickly jumps to 100% and stalls at

> waiting for workers ...

This updates the progress bar as individual tasks are joined, for long-running builds this creates a meaningfully sense of progress. This both creates a nicer user-experience for users, and also prevents CI jobs from timing out from lack of activity.

