### PR TITLE
Remove unnecesary sleep when submitting parallel tasks

### DIFF
--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -100,12 +100,13 @@ class ParallelTasks:
                                        args=(psend, task_func, arg))
         self._procs[tid] = proc
         self._precvsWaiting[tid] = precv
-        self._join_one()
+        _ = self._join_one()
 
     def join(self) -> None:
         try:
             while self._pworking:
-                self._join_one()
+                if not self._join_one():
+                    time.sleep(0.02)
         except Exception:
             # shutdown other child processes on failure
             self.terminate()
@@ -119,7 +120,8 @@ class ParallelTasks:
             self._precvs.pop(tid)
             self._pworking -= 1
 
-    def _join_one(self) -> None:
+    def _join_one(self) -> bool:
+        joined_any = False
         for tid, pipe in self._precvs.items():
             if pipe.poll():
                 exc, logs, result = pipe.recv()
@@ -131,14 +133,16 @@ class ParallelTasks:
                 self._procs[tid].join()
                 self._precvs.pop(tid)
                 self._pworking -= 1
+                joined_any = True
                 break
-        else:
-            time.sleep(0.02)
+
         while self._precvsWaiting and self._pworking < self.nproc:
             newtid, newprecv = self._precvsWaiting.popitem()
             self._precvs[newtid] = newprecv
             self._procs[newtid].start()
             self._pworking += 1
+
+        return joined_any
 
 
 def make_chunks(arguments: Sequence[str], nproc: int, maxbatch: int = 10) -> List[Any]:

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -100,7 +100,7 @@ class ParallelTasks:
                                        args=(psend, task_func, arg))
         self._procs[tid] = proc
         self._precvsWaiting[tid] = precv
-        _ = self._join_one()
+        self._join_one()
 
     def join(self) -> None:
         try:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
`ParallelTasks.add_task` calls `_join_one` to poll for finished workers and possibly start the just-submitted task. However, it will also trigger the `time.sleep` call if no sub-processes are completed which unnecessarily slows down the launching of workers. Instead, I raise the `time.sleep` call into `join` so that `add_task` never starts a sleep.

The sleep is only 20 ms per task so this doesn't make a huge difference. 

