### PR TITLE
doc: Fix grammar in documentation for `autodoc_typehints`

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -563,7 +563,7 @@ There are also config values that you can set:
 
 .. confval:: autodoc_typehints
 
-   This value controls how to represents typehints.  The setting takes the
+   This value controls how to represent typehints.  The setting takes the
    following values:
 
    * ``'signature'`` -- Show typehints as its signature (default)


### PR DESCRIPTION
### Documentation Fix
> This value controls how to represents typehints.

represents -> represent