### PR TITLE
Fix `user-selection` in Safari and Internet Explorer

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -563,7 +563,7 @@ There are also config values that you can set:
 
 .. confval:: autodoc_typehints
 
-   This value controls how to represents typehints.  The setting takes the
+   This value controls how to represent typehints.  The setting takes the
    following values:
 
    * ``'signature'`` -- Show typehints as its signature (default)

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -819,7 +819,7 @@ div.code-block-caption code {
 
 table.highlighttable td.linenos,
 span.linenos,
-div.highlight span.gp {  /* gp: Generic.Prompt */
+div.doctest > div.highlight span.gp {  /* gp: Generic.Prompt */
   user-select: none;
   -webkit-user-select: text; /* Safari fallback only */
   -webkit-user-select: none; /* Chrome/Safari */

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -817,11 +817,15 @@ div.code-block-caption code {
     background-color: transparent;
 }
 
-table.highlighttable td.linenos,
-span.linenos,
-div.doctest > div.highlight span.gp {  /* gp: Generic.Prompt */
-    user-select: none;
+/* From https://stackoverflow.com/a/34372191 */
+span.gp {  /* gp: Generic.Prompt */ 
+  user-select: none;
+  -webkit-user-select: text; /* Safari fallback only */
+  -webkit-user-select: none; /* Chrome/Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+ */
 }
+
 
 div.code-block-caption span.caption-number {
     padding: 0.1em 0.3em;

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -818,6 +818,8 @@ div.code-block-caption code {
 }
 
 /* From https://stackoverflow.com/a/34372191 */
+table.highlighttable td.linenos,
+span.linenos,
 span.gp {  /* gp: Generic.Prompt */ 
   user-select: none;
   -webkit-user-select: text; /* Safari fallback only */

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -820,7 +820,7 @@ div.code-block-caption code {
 /* From https://stackoverflow.com/a/34372191 */
 table.highlighttable td.linenos,
 span.linenos,
-span.gp {  /* gp: Generic.Prompt */ 
+div.highlight span.gp {  /* gp: Generic.Prompt */
   user-select: none;
   -webkit-user-select: text; /* Safari fallback only */
   -webkit-user-select: none; /* Chrome/Safari */

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -817,7 +817,6 @@ div.code-block-caption code {
     background-color: transparent;
 }
 
-/* From https://stackoverflow.com/a/34372191 */
 table.highlighttable td.linenos,
 span.linenos,
 div.highlight span.gp {  /* gp: Generic.Prompt */
@@ -827,7 +826,6 @@ div.highlight span.gp {  /* gp: Generic.Prompt */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+ */
 }
-
 
 div.code-block-caption span.caption-number {
     padding: 0.1em 0.3em;


### PR DESCRIPTION
Subject: On safari and Internet explorer, the code's selection wasn't working properly.
Before (Safari) : 
![Capture d’écran 2021-04-15 à 12 13 50](https://user-images.githubusercontent.com/37664438/114853444-14ae3e80-9de4-11eb-922a-14052d09a92a.png)

After (Still on Safari)
![Capture d’écran 2021-04-15 à 12 13 57](https://user-images.githubusercontent.com/37664438/114853470-1aa41f80-9de4-11eb-9df9-f812be1780e9.png)

This is due to https://stackoverflow.com/a/34372191

### Relates
- #9098

