### PR TITLE
Fix #8127: py domain: Ellipsis in info-field-list causes nit-picky warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Deprecated
 Features added
 --------------
 
+* #8127: py domain: Ellipsis in info-field-list causes nit-picky warning
 * #9023: More CSS classes on domain descriptions, see :ref:`nodes` for details.
 
 Bugs fixed

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -304,7 +304,7 @@ class PyXrefMixin:
     def make_xrefs(self, rolename: str, domain: str, target: str,
                    innernode: Type[TextlikeNode] = nodes.emphasis,
                    contnode: Node = None, env: BuildEnvironment = None) -> List[Node]:
-        delims = r'(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+)'
+        delims = r'(\s*[\[\]\(\),](?:\s*or\s)?\s*|\s+or\s+|\.\.\.)'
         delims_re = re.compile(delims)
         sub_targets = re.split(delims, target)
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -876,7 +876,9 @@ def test_info_field_list(app):
             "\n"
             "   :param str name: blah blah\n"
             "   :param age: blah blah\n"
-            "   :type age: int\n")
+            "   :type age: int\n"
+            "   :param items: blah blah\n"
+            "   :type items: Tuple[str, ...]\n")
     doctree = restructuredtext.parse(app, text)
     print(doctree)
 
@@ -890,6 +892,7 @@ def test_info_field_list(app):
     assert_node(doctree[3][1][0][0],
                 ([nodes.field_name, "Parameters"],
                  [nodes.field_body, nodes.bullet_list, ([nodes.list_item, nodes.paragraph],
+                                                        [nodes.list_item, nodes.paragraph],
                                                         [nodes.list_item, nodes.paragraph])]))
 
     # :param str name:
@@ -914,6 +917,26 @@ def test_info_field_list(app):
                  "blah blah"))
     assert_node(doctree[3][1][0][0][1][0][1][0][2], pending_xref,
                 refdomain="py", reftype="class", reftarget="int",
+                **{"py:module": "example", "py:class": "Class"})
+
+    # :param items: + :type items:
+    assert_node(doctree[3][1][0][0][1][0][2][0],
+                ([addnodes.literal_strong, "items"],
+                 " (",
+                 [pending_xref, addnodes.literal_emphasis, "Tuple"],
+                 [addnodes.literal_emphasis, "["],
+                 [pending_xref, addnodes.literal_emphasis, "str"],
+                 [addnodes.literal_emphasis, ", "],
+                 [addnodes.literal_emphasis, "..."],
+                 [addnodes.literal_emphasis, "]"],
+                 ")",
+                 " -- ",
+                 "blah blah"))
+    assert_node(doctree[3][1][0][0][1][0][2][0][2], pending_xref,
+                refdomain="py", reftype="class", reftarget="Tuple",
+                **{"py:module": "example", "py:class": "Class"})
+    assert_node(doctree[3][1][0][0][1][0][2][0][4], pending_xref,
+                refdomain="py", reftype="class", reftarget="str",
                 **{"py:module": "example", "py:class": "Class"})
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- On parsing the types, the leading dot of the ellipsis (...) is considered
as a reference name.  And its first dot is considered as a notation for
relative type reference (ex. ".ClassName"). As a result, it was converted
double dots unexpectedly.
- This changes the parsing rule to treat the ellipsis as a symbol, not a
name.
- refs: #8127 