### PR TITLE
Fix #9095: autodoc: TypeError is raised on processing broken metaclass

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Features added
 --------------
 
 * #8818: autodoc: Super class having ``Any`` arguments causes nit-picky warning
+* #9095: autodoc: TypeError is raised on processing broken metaclass
 * #9103: LaTeX: imgconverter: conversion runs even if not needed
 * #8127: py domain: Ellipsis in info-field-list causes nit-picky warning
 * #9023: More CSS classes on domain descriptions, see :ref:`nodes` for details.

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -108,7 +108,14 @@ def import_object(modname: str, objpath: List[str], objtype: str = '',
             logger.debug('[autodoc] getattr(_, %r)', attrname)
             mangled_name = mangle(obj, attrname)
             obj = attrgetter(obj, mangled_name)
-            logger.debug('[autodoc] => %r', obj)
+
+            try:
+                logger.debug('[autodoc] => %r', obj)
+            except TypeError:
+                # fallback of failure on logging for broken object
+                # refs: https://github.com/sphinx-doc/sphinx/issues/9095
+                logger.debug('[autodoc] => %r', (obj,))
+
             object_name = attrname
         return [module, parent, object_name, obj]
     except (AttributeError, ImportError) as exc:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The logging module is crashed when the target object is a broken
metaclass that raises a TypeError on `isinstance()`.
- This adds a workaround code to avoid the error.
- refs: #9095 