### PR TITLE
Fix #9110: autodoc: metadata of GenericAlias is not rendered as a reference in py37+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Features added
 --------------
 
 * #8818: autodoc: Super class having ``Any`` arguments causes nit-picky warning
+* #9110: autodoc: metadata of GenericAlias is not rendered as a reference in
+  py37+
 * #9103: LaTeX: imgconverter: conversion runs even if not needed
 * #8127: py domain: Ellipsis in info-field-list causes nit-picky warning
 * #9023: More CSS classes on domain descriptions, see :ref:`nodes` for details.

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1767,8 +1767,7 @@ class GenericAliasMixin(DataDocumenterMixinBase):
 
     def update_content(self, more_content: StringList) -> None:
         if inspect.isgenericalias(self.object):
-            alias = stringify_typehint(self.object)
-            more_content.append(_('alias of %s') % alias, '')
+            more_content.append(_('alias of %s') % restify(self.object), '')
             more_content.append('', '')
 
         super().update_content(more_content)

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1915,7 +1915,7 @@ def test_autodoc_GenericAlias(app):
             '',
             '      A list of int',
             '',
-            '      alias of List[int]',
+            '      alias of :class:`~typing.List`\\ [:class:`int`]',
             '',
             '',
             '.. py:data:: T',
@@ -1923,7 +1923,7 @@ def test_autodoc_GenericAlias(app):
             '',
             '   A list of int',
             '',
-            '   alias of List[int]',
+            '   alias of :class:`~typing.List`\\ [:class:`int`]',
             '',
         ]
 

--- a/tests/test_ext_autodoc_autoattribute.py
+++ b/tests/test_ext_autodoc_autoattribute.py
@@ -156,7 +156,7 @@ def test_autoattribute_GenericAlias(app):
             '',
             '   A list of int',
             '',
-            '   alias of List[int]',
+            '   alias of :class:`~typing.List`\\ [:class:`int`]',
             '',
         ]
 

--- a/tests/test_ext_autodoc_autodata.py
+++ b/tests/test_ext_autodoc_autodata.py
@@ -96,7 +96,7 @@ def test_autodata_GenericAlias(app):
             '',
             '   A list of int',
             '',
-            '   alias of List[int]',
+            '   alias of :class:`~typing.List`\\ [:class:`int`]',
             '',
         ]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- GenericAliasMixin should use `restify()` to render the metadata of
GenericAlias as py36 does.
- refs: #9110