### PR TITLE
C, C++, alias fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,9 @@ Features added
 Bugs fixed
 ----------
 
+* C, C++, fix ``KeyError`` when an ``alias`` directive is the first C/C++
+  directive in a file with another C/C++ directive later.
+
 Testing
 --------
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3454,7 +3454,8 @@ class AliasNode(nodes.Element):
             if 'c:parent_symbol' not in env.temp_data:
                 root = env.domaindata['c']['root_symbol']
                 env.temp_data['c:parent_symbol'] = root
-            self.parentKey = env.temp_data['c:parent_symbol'].get_lookup_key()
+                env.ref_context['c:parent_key'] = root.get_lookup_key()
+            self.parentKey = env.ref_context['c:parent_key']
         else:
             assert parentKey is not None
             self.parentKey = parentKey

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7177,7 +7177,8 @@ class AliasNode(nodes.Element):
             if 'cpp:parent_symbol' not in env.temp_data:
                 root = env.domaindata['cpp']['root_symbol']
                 env.temp_data['cpp:parent_symbol'] = root
-            self.parentKey = env.temp_data['cpp:parent_symbol'].get_lookup_key()
+                env.ref_context['cpp:parent_key'] = root.get_lookup_key()
+            self.parentKey = env.ref_context['cpp:parent_key']
         else:
             assert parentKey is not None
             self.parentKey = parentKey


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Fix ``KeyError`` on
```rst
.. c:alias:: whatever

.. c:function:: void f()
```
and the same but in the ``cpp`` domain.

### Relates
Bug found via https://github.com/michaeljones/breathe/issues/667

