### PR TITLE
🐛 FIX: `Config.__getitem__` typing

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -255,7 +255,7 @@ class Config:
             return default(self)
         return default
 
-    def __getitem__(self, name: str) -> str:
+    def __getitem__(self, name: str) -> Any:
         return getattr(self, name)
 
     def __setitem__(self, name: str, value: Any) -> None:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1023,7 +1023,7 @@ class PythonModuleIndex(Index):
                  ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         content: Dict[str, List[IndexEntry]] = {}
         # list of prefixes to ignore
-        ignores: List[str] = self.domain.env.config['modindex_common_prefix']  # type: ignore
+        ignores: List[str] = self.domain.env.config['modindex_common_prefix']
         ignores = sorted(ignores, key=len, reverse=True)
         # list of all modules, sorted by module name
         modules = sorted(self.domain.data['modules'].items(),


### PR DESCRIPTION
Should return `Any` (as for `__getattr__`) rather than `str`