### PR TITLE
Feature: 

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -819,7 +819,7 @@ div.code-block-caption code {
 
 table.highlighttable td.linenos,
 span.linenos,
-div.doctest > div.highlight span.gp {  /* gp: Generic.Prompt */
+div.highlight span.gp {  /* gp: Generic.Prompt */
   user-select: none;
   -webkit-user-select: text; /* Safari fallback only */
   -webkit-user-select: none; /* Chrome/Safari */


### PR DESCRIPTION
Remove `div.doctest` in `basic.css_t` so that the selecting feature in snippets code
are not just available for doctests snippets. Basically, I want the following feature : 

![Capture d’écran 2021-04-20 à 11 50 36](https://user-images.githubusercontent.com/37664438/115376049-a516c580-a1ce-11eb-8f3e-e895feeb0cba.png)

which is available for every doctest, to be also available for basic snippet code. 
For example, in the actual `[Sphinx doc](https://www.sphinx-doc.org/en/master/usage/installation.html#installation-from-source)`, when we select a code's snippet, it also selects the `$`sign, which is annoying for multi line snippets : 
![Capture d’écran 2021-04-20 à 11 42 39](https://user-images.githubusercontent.com/37664438/115376444-ffb02180-a1ce-11eb-9784-948c076b81dd.png)

With the modification, we can now do : 

![Capture d’écran 2021-04-20 à 11 43 54](https://user-images.githubusercontent.com/37664438/115376522-0dfe3d80-a1cf-11eb-9e84-266855e36828.png)


This PR is following #9101. I ask for discussion here, because I don't know what was intended `span.gp` at the first place. From my research, it has been introduced by @tk0miya, in #6727

