### PR TITLE
Ignore nitpick warnings with regular expressions using `nitpick_ignore_regex`

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -419,6 +419,20 @@ General configuration
 
    .. versionadded:: 1.1
 
+.. confval:: nitpick_ignore_regex
+
+   An extended version of :confval:`nitpick_ignore`, which instead interprets
+   the ``type`` and ``target`` strings as regular expressions. Note, that the
+   regular expression must match the whole string (as if the ``^`` and ``$``
+   markers were inserted).
+
+   For example, ``(r'py:.*', r'foo.*bar\.B.*')`` will ignore nitpicky warnings
+   for all python entities that start with ``'foo'`` and have ``'bar.B'`` in
+   them, such as ``('py:const', 'foo_package.bar.BAZ_VALUE')`` or
+   ``('py:class', 'food.bar.Barman')``.
+
+   .. versionadded:: 4.1
+
 .. confval:: numfig
 
    If true, figures, tables and code-blocks are automatically numbered if they

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -131,6 +131,7 @@ class Config:
         'manpages_url': (None, 'env', []),
         'nitpicky': (False, None, []),
         'nitpick_ignore': ([], None, []),
+        'nitpick_ignore_regex': ([], None, []),
         'numfig': (False, 'env', []),
         'numfig_secnum_depth': (1, 'env', []),
         'numfig_format': ({}, 'env', []),  # will be initialized in init_numfig_format()

--- a/tests/roots/test-nitpicky-warnings/conf.py
+++ b/tests/roots/test-nitpicky-warnings/conf.py
@@ -1,0 +1,1 @@
+nitpicky = True

--- a/tests/roots/test-nitpicky-warnings/index.rst
+++ b/tests/roots/test-nitpicky-warnings/index.rst
@@ -1,0 +1,7 @@
+test-nitpicky-warnings
+======================
+
+:py:const:`prefix.anything.postfix`
+:py:class:`prefix.anything`
+:py:class:`anything.postfix`
+:js:class:`prefix.anything.postfix`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -311,3 +311,34 @@ def test_check_enum_for_list_failed(logger):
     config.init_values()
     check_confval_types(None, config)
     assert logger.warning.called
+
+
+nitpick_warnings = [
+    "WARNING: py:const reference target not found: prefix.anything.postfix",
+    "WARNING: py:class reference target not found: prefix.anything",
+    "WARNING: py:class reference target not found: anything.postfix",
+    "WARNING: js:class reference target not found: prefix.anything.postfix",
+]
+
+
+@pytest.mark.sphinx(testroot='nitpicky-warnings')
+def test_nitpick_base(app, status, warning):
+    app.builder.build_all()
+
+    warning = warning.getvalue().strip().split('\n')
+    assert len(warning) == len(nitpick_warnings)
+    for actual, expected in zip(warning, nitpick_warnings):
+        assert expected in actual
+
+
+@pytest.mark.sphinx(testroot='nitpicky-warnings', confoverrides={
+    'nitpick_ignore': [
+        ('py:const', 'prefix.anything.postfix'),
+        ('py:class', 'prefix.anything'),
+        ('py:class', 'anything.postfix'),
+        ('js:class', 'prefix.anything.postfix'),
+    ],
+})
+def test_nitpick_ignore(app, status, warning):
+    app.builder.build_all()
+    assert not len(warning.getvalue().strip())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -342,3 +342,46 @@ def test_nitpick_base(app, status, warning):
 def test_nitpick_ignore(app, status, warning):
     app.builder.build_all()
     assert not len(warning.getvalue().strip())
+
+
+@pytest.mark.sphinx(testroot='nitpicky-warnings', confoverrides={
+    'nitpick_ignore_regex': [
+        (r'py:.*', r'.*postfix'),
+        (r'.*:class', r'prefix.*'),
+    ]
+})
+def test_nitpick_ignore_regex1(app, status, warning):
+    app.builder.build_all()
+    assert not len(warning.getvalue().strip())
+
+
+@pytest.mark.sphinx(testroot='nitpicky-warnings', confoverrides={
+    'nitpick_ignore_regex': [
+        (r'py:.*', r'prefix.*'),
+        (r'.*:class', r'.*postfix'),
+    ]
+})
+def test_nitpick_ignore_regex2(app, status, warning):
+    app.builder.build_all()
+    assert not len(warning.getvalue().strip())
+
+
+@pytest.mark.sphinx(testroot='nitpicky-warnings', confoverrides={
+    'nitpick_ignore_regex': [
+        # None of these should match
+        (r'py:', r'.*'),
+        (r':class', r'.*'),
+        (r'', r'.*'),
+        (r'.*', r'anything'),
+        (r'.*', r'prefix'),
+        (r'.*', r'postfix'),
+        (r'.*', r''),
+    ]
+})
+def test_nitpick_ignore_regex_fullmatch(app, status, warning):
+    app.builder.build_all()
+
+    warning = warning.getvalue().strip().split('\n')
+    assert len(warning) == len(nitpick_warnings)
+    for actual, expected in zip(warning, nitpick_warnings):
+        assert expected in actual


### PR DESCRIPTION
Subject: Allow regex patterns in nitpick_ignore.

Edit: this PR originally proposed adding glob-like pattern matching, but after some discussion, it was changed to use regex patterns instead.

### Feature or Bugfix
- Feature

### Purpose

Allow the user to specify regex patterns in the `nitpick_ignore`. Currently, the user is forced to enumerate all the `nitpicks` that should be ignored, even if they follow a predictable pattern. So after some time, the `nitpick_ignore` array might end up looking something like this:

```python
nitpick_ignore = [
    ('py:mod', 'foo'),
    ('py:class', 'foo.Something'),
    ('py:mod', 'foo.bar'),
    ('py:class', 'foo.bar.Baz'),
    ('py:func', 'foo.bar.boo.'),
    # ... etc ...
]
```

With this PR, the user can instead define `nitpick_ignore_regex = [(r'py:.*', r'foo\..*')]`.

### Compatibility

<s>I reuse the `sphinx.util.matching` mechanism to match glob patterns. To be completely honest, I am not 100% sure if it is okay to match the `type` and `target` of the nitpick warnings like paths (i.e. are there any cases where `type` or `target` may contain the symbols `/?[]^*` and **not** be a path). Based on the use cases of `nitpick_ignore`, that I've personally seen, I don't expect this to be an issue, but this is **technically** a breaking change if somebody is currently matching something like `[woops]!`.</s>

Edit: no longer applicable, see further discussion in the comments.

### Tests

I didn't find any tests for the current behaviour of `nitpick_ignore`, so I've implemented the tests both for the current behaviour and the new regex feature. I did this by finding existing tests, which already use `nitpicky=True` and `assert` that there **should** be some errors. I copied these tests, added the `nitpick_ignore_regex` option and `assert`ed that the errors are gone in that case.