### PR TITLE
Add unicode multiplication to texescape

### DIFF
--- a/sphinx/util/texescape.py
+++ b/sphinx/util/texescape.py
@@ -29,6 +29,8 @@ tex_replacements = [
     # map special Unicode characters to TeX commands
     ('✓', r'\(\checkmark\)'),
     ('✔', r'\(\pmb{\checkmark}\)'),
+    ('✕', r'\(\times\)'),
+    ('✖', r'\(\pmb{\times}\)'),
     # used to separate -- in options
     ('﻿', r'{}'),
     # map some special Unicode characters to similar ASCII ones


### PR DESCRIPTION
Subject: Add unicode multiplication to texescape

- Feature

### Purpose
Since checkmark already exists, it makes sense to have this too.
Both signs are used as "yes" or "no" replacements in text UIs.
(scratching my own itch: I am writing documentation to a program that
uses these symbols: ✔, ✖)
