### PR TITLE
Autosummary to include instance attributes

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -664,6 +664,7 @@ def import_ivar_by_name(name: str, prefixes: List[str] = [None]) -> Tuple[str, A
         qualname = real_name.replace(modname + ".", "")
         analyzer = ModuleAnalyzer.for_module(getattr(obj, '__module__', modname))
         analyzer.analyze()
+        # check for presence in `annotations` to include dataclass attributes
         if (qualname, attr) in analyzer.attr_docs or (qualname, attr) in analyzer.annotations:
             return real_name + "." + attr, INSTANCEATTR, obj, modname
     except (ImportError, ValueError, PycodeError):

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -662,8 +662,9 @@ def import_ivar_by_name(name: str, prefixes: List[str] = [None]) -> Tuple[str, A
         name, attr = name.rsplit(".", 1)
         real_name, obj, parent, modname = import_by_name(name, prefixes)
         qualname = real_name.replace(modname + ".", "")
-        analyzer = ModuleAnalyzer.for_module(modname)
-        if (qualname, attr) in analyzer.find_attr_docs():
+        analyzer = ModuleAnalyzer.for_module(getattr(obj, '__module__', modname))
+        analyzer.analyze()
+        if (qualname, attr) in analyzer.attr_docs or (qualname, attr) in analyzer.annotations:
             return real_name + "." + attr, INSTANCEATTR, obj, modname
     except (ImportError, ValueError, PycodeError):
         pass

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -239,15 +239,21 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
                            name, exc, type='autosummary')
             return False
 
+    def attr_getter(obj, name, *defargs):
+        return sphinx.ext.autodoc.autodoc_attrgetter(app, obj, name, *defargs)
+
+    def get_all_members(obj):
+        all_members = sphinx.ext.autodoc.get_class_members(obj, [qualname], attr_getter)
+        return all_members
+
     def get_members(obj: Any, types: Set[str], include_public: List[str] = [],
                     imported: bool = True) -> Tuple[List[str], List[str]]:
         items: List[str] = []
         public: List[str] = []
-        for name in dir(obj):
-            try:
-                value = safe_getattr(obj, name)
-            except AttributeError:
-                continue
+
+        all_members = get_all_members(obj)
+        for name, member in all_members.items():
+            value = member.object
             documenter = get_documenter(app, value, obj)
             if documenter.objtype in types:
                 # skip imported members if expected

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -39,7 +39,7 @@ from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.config import Config
 from sphinx.deprecation import RemovedInSphinx50Warning
-from sphinx.ext.autodoc import Documenter
+from sphinx.ext.autodoc import Documenter, ObjectMember
 from sphinx.ext.autodoc.importer import import_module
 from sphinx.ext.autosummary import get_documenter, import_by_name, import_ivar_by_name
 from sphinx.locale import __
@@ -242,7 +242,7 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
     def attr_getter(obj, name, *defargs):
         return sphinx.ext.autodoc.autodoc_attrgetter(app, obj, name, *defargs)
 
-    def get_all_members(obj):
+    def get_all_members(obj: Any) -> Dict[str, ObjectMember]:
         all_members = sphinx.ext.autodoc.get_class_members(obj, [qualname], attr_getter)
         return all_members
 

--- a/tests/roots/test-autosummary/dummy_module.py
+++ b/tests/roots/test-autosummary/dummy_module.py
@@ -3,6 +3,7 @@
 
    module_attr
    C.class_attr
+   C.instance_attr
    C.prop_attr1
    C.prop_attr2
    C.C2
@@ -50,6 +51,12 @@ class C:
     #:
     #: value is integer.
     class_attr = 42
+
+    def __init__(self):
+        #: This is an instance attribute
+        #:
+        #: value is a string
+        self.instance_attr = "42"
 
     def _prop_attr_get(self):
         """

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -161,6 +161,7 @@ def test_get_items_summary(make_app, app_params):
         'emptyLine': "This is the real summary",
         'module_attr': 'This is a module attribute',
         'C.class_attr': 'This is a class attribute',
+        'C.instance_attr': 'This is an instance attribute',
         'C.prop_attr1': 'This is a function docstring',
         'C.prop_attr2': 'This is a attribute docstring',
         'C.C2': 'This is a nested inner class docstring',
@@ -329,6 +330,7 @@ def test_autosummary_generate(app, status, warning):
             '      ~Foo.CONSTANT3\n'
             '      ~Foo.CONSTANT4\n'
             '      ~Foo.baz\n'
+            '      ~Foo.value\n'
             '   \n' in Foo)
 
     FooBar = (app.srcdir / 'generated' / 'autosummary_dummy_module.Foo.Bar.rst').read_text()


### PR DESCRIPTION
Subject: Autosummary to include instance attributes

### Feature or Bugfix
- Feature

### Detail
- Make `sphinx.ext.autosummary` to use `sphinx.ext.autodoc.get_class_members` instead of `dir(obj)` to discover class members and find instance attributes

### Relates
- https://github.com/sphinx-doc/sphinx/issues/3257

