### PR TITLE
html: fix missing reverting when adding css files to specific page

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1026,7 +1026,7 @@ class StandaloneHTMLBuilder(Builder):
 
         # revert script_files and css_files
         self.script_files[:] = self._script_files
-        self.css_files[:] = self.css_files
+        self.css_files[:] = self._css_files
 
         self.update_page_context(pagename, templatename, ctx, event_arg)
         newtmpl = self.app.emit_firstresult('html-page-context', pagename,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
fix missing reverting when adding css files via `app.add_css_file` on `html-page-context` event

### Detail
- currently stylesheet tags are repeated in the rendered html on every subsequent page
- see the [minimal example that reproduces the bug](https://github.com/bonartm/insert_css_demo). the [rendered page](https://github.com/bonartm/insert_css_demo/blob/main/_build/html/third.html) contains the same `test.css` three times
- with every new page and a corresponding directive the css file is added again although it is already there. this does not happen with js files added to the page (e.g. the `test.js` in the example).
- adding the underscore as it was done for js files solves this bug

### Relates

- #8631

