### PR TITLE
[IMP] util: detect incorrect locale_dirs path

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -91,8 +91,11 @@ class CatalogRepository:
 
         for locale_dir in self._locale_dirs:
             locale_dir = path.join(self.basedir, locale_dir)
-            if path.exists(path.join(locale_dir, self.language, 'LC_MESSAGES')):
+            locale_path = path.join(locale_dir, self.language, 'LC_MESSAGES')
+            if path.exists(locale_path):
                 yield locale_dir
+            else:
+                logger.verbose(__('locale_dir %s does not exists'), locale_path)
 
     @property
     def pofiles(self) -> Generator[Tuple[str, str], None, None]:


### PR DESCRIPTION
In case the config is incorrect (e.g. wrong relative path), it is silently ignored.
This makes it easier for debugging.

Subject: <short purpose of this pull request>

### Feature or Bugfix
- Feature/Improvement

### Purpose
It was not clear to me that the `locale_dirs` variable was relative to the source dir and not to the config path. It took me a long time to detect this was the reason my translations were ignored when building.
With this logger, I could have understood the error was in my config file.
