### PR TITLE
Fix module attributes not output "all attributes"

### DIFF
--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -327,7 +327,7 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
         ns['exceptions'], ns['all_exceptions'] = \
             get_members(obj, {'exception'}, imported=imported_members)
         ns['attributes'], ns['all_attributes'] = \
-            get_module_attrs(ns['members'])
+            get_module_attrs(dir(obj))
         ispackage = hasattr(obj, '__path__')
         if ispackage and recursive:
             ns['modules'], ns['all_modules'] = get_modules(obj)


### PR DESCRIPTION
Subject: Fix autosummary module attributes not output "all attributes"

4.x
 

### Feature or Bugfix
<!-- please choose -->
- show all module attributes

 
### Detail

sample.py
```py a.py
import networkx as nx
a = 3#Built-in Types
G = nx.DiGraph()# any other object types
```
in the sample
only show "a" if varable is "Built-in Types"
NOT show "G" if varable is "any other object types"

 
