### PR TITLE
autodoc.typehints can accurately represent overloads

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -590,7 +590,7 @@ There are also config values that you can set:
 
       New option ``'description'`` is added.
 
-   .. versionadded:: 4.0
+   .. versionadded:: 4.1
 
       New option ``'both'`` is added.
 

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -573,14 +573,26 @@ There are also config values that you can set:
    This value controls how to represent typehints.  The setting takes the
    following values:
 
-   * ``'signature'`` -- Show typehints as its signature (default)
-   * ``'description'`` -- Show typehints as content of function or method
+   * ``'signature'`` -- Show typehints in the signature (default)
+   * ``'description'`` -- Show typehints as content of the function or method
+     The typehints of overloaded functions or methods will still be represented
+     in the signature.
    * ``'none'`` -- Do not show typehints
+   * ``'both'`` -- Show typehints in the signature and as content of
+     the function or method
+
+   Overloaded functions or methods will not have typehints included in the
+   description because it is impossible to accurately represent all possible
+   overloads as a list of parameters.
 
    .. versionadded:: 2.1
    .. versionadded:: 3.0
 
       New option ``'description'`` is added.
+
+   .. versionadded:: 4.0
+
+      New option ``'both'`` is added.
 
 .. confval:: autodoc_typehints_description_target
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1314,7 +1314,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
         sigs = []
         if (self.analyzer and
                 '.'.join(self.objpath) in self.analyzer.overloads and
-                self.config.autodoc_typehints == 'signature'):
+                self.config.autodoc_typehints != 'none'):
             # Use signatures for overloaded functions instead of the implementation function.
             overloaded = True
         else:
@@ -1560,7 +1560,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         sigs = []
 
         overloads = self.get_overloaded_signatures()
-        if overloads and self.config.autodoc_typehints == 'signature':
+        if overloads and self.config.autodoc_typehints != 'none':
             # Use signatures for overloaded methods instead of the implementation method.
             method = safe_getattr(self._signature_class, self._signature_method_name, None)
             __globals__ = safe_getattr(method, '__globals__', {})
@@ -2109,7 +2109,7 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
         sigs = []
         if (self.analyzer and
                 '.'.join(self.objpath) in self.analyzer.overloads and
-                self.config.autodoc_typehints == 'signature'):
+                self.config.autodoc_typehints != 'none'):
             # Use signatures for overloaded methods instead of the implementation method.
             overloaded = True
         else:
@@ -2666,7 +2666,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('autodoc_docstring_signature', True, True)
     app.add_config_value('autodoc_mock_imports', [], True)
     app.add_config_value('autodoc_typehints', "signature", True,
-                         ENUM("signature", "description", "none"))
+                         ENUM("signature", "description", "none", "both"))
     app.add_config_value('autodoc_typehints_description_target', 'all', True,
                          ENUM('all', 'documented'))
     app.add_config_value('autodoc_type_aliases', {}, True)

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -40,7 +40,7 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
 def merge_typehints(app: Sphinx, domain: str, objtype: str, contentnode: Element) -> None:
     if domain != 'py':
         return
-    if app.config.autodoc_typehints != 'description':
+    if app.config.autodoc_typehints not in ('both', 'description'):
         return
 
     try:

--- a/tests/roots/test-ext-autodoc/index.rst
+++ b/tests/roots/test-ext-autodoc/index.rst
@@ -10,4 +10,6 @@
 
 .. autofunction:: target.typehints.incr
 
+.. autofunction:: target.overload.sum
+
 .. autofunction:: target.typehints.tuple_args

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -695,6 +695,14 @@ def test_autodoc_typehints_description(app):
             '      Tuple[int, int]\n'
             in context)
 
+    # Overloads still get displyed in the signature
+    assert ('target.overload.sum(x: int, y: int = 0) -> int\n'
+            'target.overload.sum(x: float, y: float = 0.0) -> float\n'
+            'target.overload.sum(x: str, y: str = None) -> str\n'
+            '\n'
+            '   docstring\n'
+            in context)
+
 
 @pytest.mark.sphinx('text', testroot='ext-autodoc',
                     confoverrides={'autodoc_typehints': "description",
@@ -785,6 +793,46 @@ def test_autodoc_typehints_description_with_documented_init_no_undoc(app):
 def test_autodoc_typehints_description_for_invalid_node(app):
     text = ".. py:function:: hello; world"
     restructuredtext.parse(app, text)  # raises no error
+
+
+@pytest.mark.sphinx('text', testroot='ext-autodoc',
+                    confoverrides={'autodoc_typehints': "both"})
+def test_autodoc_typehints_both(app):
+    (app.srcdir / 'index.rst').write_text(
+        '.. autofunction:: target.typehints.incr\n'
+        '\n'
+        '.. autofunction:: target.typehints.tuple_args\n'
+        '\n'
+        '.. autofunction:: target.overload.sum\n'
+    )
+    app.build()
+    context = (app.outdir / 'index.txt').read_text()
+    assert ('target.typehints.incr(a: int, b: int = 1) -> int\n'
+            '\n'
+            '   Parameters:\n'
+            '      * **a** (*int*) --\n'
+            '\n'
+            '      * **b** (*int*) --\n'
+            '\n'
+            '   Return type:\n'
+            '      int\n'
+            in context)
+    assert ('target.typehints.tuple_args(x: Tuple[int, Union[int, str]]) -> Tuple[int, int]\n'
+            '\n'
+            '   Parameters:\n'
+            '      **x** (*Tuple**[**int**, **Union**[**int**, **str**]**]*) --\n'
+            '\n'
+            '   Return type:\n'
+            '      Tuple[int, int]\n'
+            in context)
+
+    # Overloads still get displyed in the signature
+    assert ('target.overload.sum(x: int, y: int = 0) -> int\n'
+            'target.overload.sum(x: float, y: float = 0.0) -> float\n'
+            'target.overload.sum(x: str, y: str = None) -> str\n'
+            '\n'
+            '   docstring\n'
+            in context)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason='python 3.7+ is required.')


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Purpose
Let's say we have the following method (adapted from https://www.python.org/dev/peps/pep-0484/#function-method-overloading):
```python
from typing import Callable, Iterable, Iterator, Tuple, TypeVar, overload

T1 = TypeVar('T1')
T2 = TypeVar('T2')
S = TypeVar('S')

@overload
def map(func: Callable[[T1], S], iter1: Iterable[T1]) -> Iterator[S]: ...
@overload
def map(func: Callable[[T1, T2], S],
        iter1: Iterable[T1], iter2: Iterable[T2]) -> Iterator[S]: ...
def map(func, *iterables):
    """Do a map.

    :param func: The function.
    :param iter1: An iterable.
    :param iter2: Another iterable.

    :returns: A new iterable.
    """
```
Currently, when `autotype_typehints` is set to `description`, this method would be displayed as though the following ReST were typed.

```restructuredtext
.. py::method: map(func, *iterables)

      Do a map.

      :param func: The function.
      :param iter1: An iterable.
      :param iter2: Another iterable.
      :param iterables:

      :returns: A new iterable.
```

Note the addition of the new parameter, and the lack of parameter types and return types. However it is impossible to represent this overload purely as a list of parameters. So there is no behaviour that we can give to `'description'` so that it can accurately represent all overloads. Trying to display any type (even of Union of all possible types) would misguide a user.

Therefore this pull request introduces two changes to allow users to choose how to solve this problem. Firstly, overloads will never try to be displayed in the description, even when `autodoc_typehints` is set to `'description'`, because we cannot accurately represent overloads in this way. This is mentioned in the documentation to make it clear why we have to do this.

The second change is that `autodoc_typehints` can be set to `'both'` to allow type hints to be included both in the signature and in the description. The typehints for overloads will still never try to be displayed in the description.

When `autodoc_typehints` is set to `'both'`,  `'description'`, or `'signature'` the above function will now display as:

```restructuredtext
.. py::method: map(func: Callable[[T1], S], iter1: Iterable[T1]) -> Iterator[S]
               map(func: Callable[[T1, T2], S], iter1: Iterable[T1], iter2: Iterable[T2]) -> Iterator[S]

      Do a map.

      :param func: The function.
      :param iter1: An iterable.
      :param iter2: Another iterable.

      :returns: A new iterable.
```
