### PR TITLE
Fix #9189: autodoc: crashed by ValueError on generating signature of property

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #9189: autodoc: crashed when ValueError is raised on generating signature
+  from a property of the class
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2570,7 +2570,7 @@ class PropertyDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  #
                                self.fullname, exc)
                 return None
             except ValueError:
-                raise
+                return None
 
 
 class NewTypeAttributeDocumenter(AttributeDocumenter):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Autodoc is crashed if `inspect.signature` raises ValueError on
generating signature from a property of the class.  It seems the
original code re-raise the exception meaningless.  So this ignores it
even if raised.
- refs: #9189