### PR TITLE
Fix #9188: autosummary: warning if list is set to autosummary_generate

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #9188: autosummary: warning is emitted if list value is set to
+  autosummary_generate
+
 Testing
 --------
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -773,7 +773,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect('builder-inited', process_generate_options)
     app.add_config_value('autosummary_context', {}, True)
     app.add_config_value('autosummary_filename_map', {}, 'html')
-    app.add_config_value('autosummary_generate', True, True, [bool])
+    app.add_config_value('autosummary_generate', True, True, [bool, list])
     app.add_config_value('autosummary_generate_overwrite', True, False)
     app.add_config_value('autosummary_mock_imports',
                          lambda config: config.autodoc_mock_imports, 'env')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9188 