### PR TITLE
Fix #8380: html search: tags for search result are broken

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #8380: html search: tags for search result are broken
+
 Testing
 --------
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -509,7 +509,7 @@ var Search = {
     var excerpt = ((start > 0) ? '...' : '') +
       $.trim(text.substr(start, 240)) +
       ((start + 240 - text.length) ? '...' : '');
-    var rv = $('<p class="context"></div>').text(excerpt);
+    var rv = $('<p class="context"></p>').text(excerpt);
     $.each(hlwords, function() {
       rv = rv.highlightText(this, 'highlighted');
     });


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/commit/339cab76579ee2b9b0c6ed85cdf3f89afe589067#commitcomment-50575087
- Thanks @hokorobi!