### PR TITLE
Fix #9195: autodoc: The args of `typing.Literal` are wrongly rendered

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Features added
   allows you to define an alias for a class with module name like
   ``foo.bar.BazClass``
 * #9175: autodoc: Special member is not documented in the module
+* #9195: autodoc: The arguments of ``typing.Literal`` are wrongly rendered
 * #3257: autosummary: Support instance attributes for classes
 * #9129: html search: Show search summaries when html_copy_source = False
 * #9120: html theme: Eliminate prompt characters of code-block from copyable

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -153,6 +153,7 @@ def _restify_py37(cls: Optional[Type]) -> str:
         else:
             text = restify(cls.__origin__)
 
+        origin = getattr(cls, '__origin__', None)
         if not hasattr(cls, '__args__'):
             pass
         elif all(is_system_TypeVar(a) for a in cls.__args__):
@@ -161,6 +162,8 @@ def _restify_py37(cls: Optional[Type]) -> str:
         elif cls.__module__ == 'typing' and cls._name == 'Callable':
             args = ', '.join(restify(a) for a in cls.__args__[:-1])
             text += r"\ [[%s], %s]" % (args, restify(cls.__args__[-1]))
+        elif cls.__module__ == 'typing' and getattr(origin, '_name', None) == 'Literal':
+            text += r"\ [%s]" % ', '.join(repr(a) for a in cls.__args__)
         elif cls.__args__:
             text += r"\ [%s]" % ", ".join(restify(a) for a in cls.__args__)
 
@@ -362,6 +365,9 @@ def _stringify_py37(annotation: Any) -> str:
             args = ', '.join(stringify(a) for a in annotation.__args__[:-1])
             returns = stringify(annotation.__args__[-1])
             return '%s[[%s], %s]' % (qualname, args, returns)
+        elif qualname == 'Literal':
+            args = ', '.join(repr(a) for a in annotation.__args__)
+            return '%s[%s]' % (qualname, args)
         elif str(annotation).startswith('typing.Annotated'):  # for py39+
             return stringify(annotation.__args__[0])
         elif all(is_system_TypeVar(a) for a in annotation.__args__):

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -133,6 +133,12 @@ def test_restify_type_ForwardRef():
     assert restify(ForwardRef("myint")) == ":class:`myint`"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
+def test_restify_type_Literal():
+    from typing import Literal  # type: ignore
+    assert restify(Literal[1, "2", "\r"]) == ":obj:`~typing.Literal`\\ [1, '2', '\\r']"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
 def test_restify_type_union_operator():
     assert restify(int | None) == "Optional[:class:`int`]"  # type: ignore
@@ -235,6 +241,12 @@ def test_stringify_type_hints_alias():
     MyTuple = Tuple[str, str]
     assert stringify(MyStr) == "str"
     assert stringify(MyTuple) == "Tuple[str, str]"  # type: ignore
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
+def test_stringify_type_Literal():
+    from typing import Literal  # type: ignore
+    assert stringify(Literal[1, "2", "\r"]) == "Literal[1, '2', '\\r']"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- They should be rendered as "repr" form.
- refs: #9195 