### PR TITLE
Fix typos in doc/extdev/deprecated.rst

### DIFF
--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -40,12 +40,12 @@ The following is a list of deprecated interfaces.
    * - ``sphinx.directives.patches.ListTable``
      - 4.0
      - 6.0
-     - ``docutils.parsers.rst.diretives.tables.ListSVTable``
+     - ``docutils.parsers.rst.directives.tables.ListSVTable``
 
    * - ``sphinx.directives.patches.RSTTable``
      - 4.0
      - 6.0
-     - ``docutils.parsers.rst.diretives.tables.RSTTable``
+     - ``docutils.parsers.rst.directives.tables.RSTTable``
 
    * - ``sphinx.ext.autodoc.directive.DocumenterBridge.filename_set``
      - 4.0
@@ -85,7 +85,7 @@ The following is a list of deprecated interfaces.
    * - ``sphinx.util.smartypants``
      - 4.0
      - 6.0
-     - ``docutils.utils.smartyquotes``
+     - ``docutils.utils.smartquotes``
 
    * - ``sphinx.util.typing.DirectiveOption``
      - 4.0


### PR DESCRIPTION
Just minor typo fixes for deprecation table.