### PR TITLE
[Fix regression] Catch, warn about exceptions in autodoc's add_directive_header

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -951,7 +951,13 @@ class Documenter:
             return
 
         # generate the directive header and options, if applicable
-        self.add_directive_header(sig)
+        try:
+            self.add_directive_header(sig)
+        except Exception as exc:
+            logger.warning(__('error while adding directive header for %s: %s'),
+                           self.fullname, exc, type='autodoc')
+            return
+
         self.add_line('', sourcename)
 
         # e.g. the module directive doesn't have content


### PR DESCRIPTION
Subject: Catch, warn about exceptions in autodoc's `add_directive_header`

### Feature or Bugfix

- Bugfix

### Purpose

When building islpy's documentation (specifically, https://github.com/inducer/islpy/commit/0aa174e6956778df0c9e674f83cfb5e0e1d206b2) with sphinx 4.0.0, I get [this traceback](https://gist.github.com/inducer/fbd5b7202ac9158cf91f5d3cd177780f). This patch leads to a more actionable error message:
```                                               
WARNING: error while adding directive header for islpy.ast_expr_op_type.name: no signature found for builtin <instancemethod name at 0x7f9e67b064c0>
WARNING: error while adding directive header for islpy.ast_expr_op_type.value: no signature found for builtin <built-in method  of PyCapsule object at 0x7f9e67b06780>
WARNING: error while adding directive header for islpy.ast_expr_type.name: no signature found for builtin <instancemethod name at 0x7f9e67b06e20>
WARNING: error while adding directive header for islpy.ast_expr_type.value: no signature found for builtin <built-in method  of PyCapsule object at 0x7f9e67b0b120>
WARNING: error while adding directive header for islpy.ast_node_type.name: no signature found for builtin <instancemethod name at 0x7f9e67b0b310>
WARNING: error while adding directive header for islpy.ast_node_type.value: no signature found for builtin <built-in method  of PyCapsule object at 0x7f9e67b0b5d0>
WARNING: error while adding directive header for islpy.ast_loop_type.name: no signature found for builtin <instancemethod name at 0x7f9e67b0b7c0>
...
```
