### PR TITLE
Remove leftover travis badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,6 @@
    :target: http://www.sphinx-doc.org/
    :alt: Documentation Status
 
-.. image:: https://travis-ci.org/sphinx-doc/sphinx.svg?branch=master
-   :target: https://travis-ci.org/sphinx-doc/sphinx
-   :alt: Build Status (Travis CI)
-
 .. image:: https://ci.appveyor.com/api/projects/status/github/sphinx-doc/sphinx?branch=master&svg=true
    :target: https://ci.appveyor.com/project/sphinxdoc/sphinx
    :alt: Build Status (AppVeyor)


### PR DESCRIPTION
### Bugfix
- Bugfix

### Purpose
- Simply remove, what appears to be a leftover, Travis-CI badge. Last Travis build was apparently 15e6273a123a09c9d101121d64e1acfb47e53c28.