### PR TITLE
Fix #9205: py domain: canonical option causes xref resolution error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ Bugs fixed
   autosummary_generate
 * #8380: html search: tags for search result are broken
 * #9198: i18n: Babel emits errors when running compile_catalog
+* #9205: py domain: The :canonical: option causes "more than one target for
+  cross-reference" warning
 
 Testing
 --------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1269,9 +1269,13 @@ class PythonDomain(Domain):
         if not matches:
             return None
         elif len(matches) > 1:
-            logger.warning(__('more than one target found for cross-reference %r: %s'),
-                           target, ', '.join(match[0] for match in matches),
-                           type='ref', subtype='python', location=node)
+            canonicals = [m for m in matches if not m[1].aliased]
+            if len(canonicals) == 1:
+                matches = canonicals
+            else:
+                logger.warning(__('more than one target found for cross-reference %r: %s'),
+                               target, ', '.join(match[0] for match in matches),
+                               type='ref', subtype='python', location=node)
         name, obj = matches[0]
 
         if obj[2] == 'module':

--- a/tests/roots/test-domain-py/canonical.rst
+++ b/tests/roots/test-domain-py/canonical.rst
@@ -1,0 +1,9 @@
+caninical
+=========
+
+:py:class:`.Foo`
+
+.. py:module:: canonical
+
+.. py:class:: Foo
+   :canonical: original.module.Foo

--- a/tests/roots/test-domain-py/index.rst
+++ b/tests/roots/test-domain-py/index.rst
@@ -5,3 +5,6 @@ test-domain-py
 
     roles
     module
+    module_option
+    abbr
+    canonical

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -236,6 +236,17 @@ def test_domain_py_find_obj(app, status, warning):
               ('roles', 'NestedParentA.NestedChildA.subchild_1', 'method', False))])
 
 
+@pytest.mark.sphinx('html', testroot='domain-py', freshenv=True)
+def test_domain_py_canonical(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'canonical.html').read_text()
+    assert ('<a class="reference internal" href="#canonical.Foo" title="canonical.Foo">'
+            '<code class="xref py py-class docutils literal notranslate">'
+            '<span class="pre">Foo</span></code></a>' in content)
+    assert warning.getvalue() == ''
+
+
 def test_get_full_qualified_name():
     env = Mock(domaindata={})
     domain = PythonDomain(env)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The :canonical: option causes "more than one target for
cross-reference" warning because the class having the same name is
registered.
- refs: #9205 