### PR TITLE
Fix #9210: viewcode: crashed if non importable modules found on parallel build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9210: viewcode: crashed if non importable modules found on parallel build
+
 Testing
 --------
 

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -150,10 +150,11 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: Iterable[str],
         if modname not in env._viewcode_modules:  # type: ignore
             env._viewcode_modules[modname] = entry  # type: ignore
         else:
-            used = env._viewcode_modules[modname][2]  # type: ignore
-            for fullname, docname in entry[2].items():
-                if fullname not in used:
-                    used[fullname] = docname
+            if env._viewcode_modules[modname]:  # type: ignore
+                used = env._viewcode_modules[modname][2]  # type: ignore
+                for fullname, docname in entry[2].items():
+                    if fullname not in used:
+                        used[fullname] = docname
 
 
 def env_purge_doc(app: Sphinx, env: BuildEnvironment, docname: str) -> None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9210 