### PR TITLE
Deprecate app.html_themes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.application.Sphinx.html_theme``
 * ``sphinx.util.docstrings.extract_metadata()``
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -22,6 +22,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.application.Sphinx.html_theme``
+     - 4.1
+     - 6.0
+     - ``sphinx.registry.SphinxComponentRegistry.html_themes``
+
    * - ``sphinx.util.docstrings.extract_metadata()``
      - 4.1
      - 6.0

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -14,6 +14,7 @@ import os
 import pickle
 import platform
 import sys
+import warnings
 from collections import deque
 from io import StringIO
 from os import path
@@ -29,6 +30,7 @@ from pygments.lexer import Lexer
 import sphinx
 from sphinx import locale, package_dir
 from sphinx.config import Config
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.domains import Domain, Index
 from sphinx.environment import BuildEnvironment
 from sphinx.environment.collectors import EnvironmentCollector
@@ -145,7 +147,6 @@ class Sphinx:
         self.env: Optional[BuildEnvironment] = None
         self.project: Optional[Project] = None
         self.registry = SphinxComponentRegistry()
-        self.html_themes: Dict[str, str] = {}
 
         # validate provided directories
         self.srcdir = abspath(srcdir)
@@ -1184,13 +1185,13 @@ class Sphinx:
     def add_html_theme(self, name: str, theme_path: str) -> None:
         """Register a HTML Theme.
 
-        The *name* is a name of theme, and *path* is a full path to the theme
-        (refs: :ref:`distribute-your-theme`).
+        The *name* is a name of theme, and *theme_path* is a full path to the
+        theme (refs: :ref:`distribute-your-theme`).
 
         .. versionadded:: 1.6
         """
         logger.debug('[app] adding HTML theme: %r, %r', name, theme_path)
-        self.html_themes[name] = theme_path
+        self.registry.add_html_theme(name, theme_path)
 
     def add_html_math_renderer(self, name: str,
                                inline_renderers: Tuple[Callable, Callable] = None,
@@ -1256,6 +1257,12 @@ class Sphinx:
                 return False
 
         return True
+
+    @property
+    def html_themes(self) -> Dict[str, str]:
+        warnings.warn('app.html_themes is deprecated.',
+                      RemovedInSphinx60Warning)
+        return self.registry.html_themes
 
 
 class TemplateBridge:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -93,6 +93,9 @@ class SphinxComponentRegistry:
         self.html_inline_math_renderers: Dict[str, Tuple[Callable, Callable]] = {}
         self.html_block_math_renderers: Dict[str, Tuple[Callable, Callable]] = {}
 
+        #: HTML themes
+        self.html_themes: Dict[str, str] = {}
+
         #: js_files; list of JS paths or URLs
         self.js_files: List[Tuple[str, Dict[str, Any]]] = []
 
@@ -402,6 +405,9 @@ class SphinxComponentRegistry:
 
         self.html_inline_math_renderers[name] = inline_renderers
         self.html_block_math_renderers[name] = block_renderers
+
+    def add_html_theme(self, name: str, theme_path: str) -> None:
+        self.html_themes[name] = theme_path
 
     def load_extension(self, app: "Sphinx", extname: str) -> None:
         """Load a Sphinx extension."""

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -155,7 +155,7 @@ class HTMLThemeFactory:
 
     def __init__(self, app: "Sphinx") -> None:
         self.app = app
-        self.themes = app.html_themes
+        self.themes = app.registry.html_themes
         self.load_builtin_themes()
         if getattr(app.config, 'html_theme_path', None):
             self.load_additional_themes(app.config.html_theme_path)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- The register is much better to store the HTML themes instead of the
application object.  So this migrates it to the registry object.