### PR TITLE
Fix type annotations (for jinja2)

### DIFF
--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -23,7 +23,7 @@ from sphinx.util import logging
 from sphinx.util.osutil import mtimes_of_files
 
 try:
-    from jinja2.utils import pass_context  # type: ignore # jinja2-3.0 or above
+    from jinja2.utils import pass_context
 except ImportError:
     from jinja2 import contextfunction as pass_context
 

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -235,7 +235,7 @@ def save_traceback(app: "Sphinx") -> str:
                    platform.python_version(),
                    platform.python_implementation(),
                    docutils.__version__, docutils.__version_details__,
-                   jinja2.__version__,  # type: ignore
+                   jinja2.__version__,
                    last_msgs)).encode())
     if app is not None:
         for ext in app.extensions.values():

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -24,7 +24,7 @@ from sphinx.locale import __
 from sphinx.util import docutils, logging
 
 try:
-    from jinja2.utils import pass_environment  # type: ignore  # jinja2-3.0 or above
+    from jinja2.utils import pass_environment
 except ImportError:
     from jinja2 import environmentfilter as pass_environment
 
@@ -61,7 +61,7 @@ def textwidth(text: str, widechars: str = 'WF') -> int:
 def heading(env: Environment, text: str, level: int = 1) -> str:
     """Create a heading for *level*."""
     assert level <= 3
-    width = textwidth(text, WIDECHARS[env.language])  # type: ignore
+    width = textwidth(text, WIDECHARS[env.language])
     sectioning_char = SECTIONING_CHARS[level - 1]
     return '%s\n%s' % (text, sectioning_char * width)
 

--- a/sphinx/util/tags.py
+++ b/sphinx/util/tags.py
@@ -69,18 +69,18 @@ class Tags:
 
         def eval_node(node: Node) -> bool:
             if isinstance(node, nodes.CondExpr):
-                if eval_node(node.test):  # type: ignore
-                    return eval_node(node.expr1)  # type: ignore
+                if eval_node(node.test):
+                    return eval_node(node.expr1)
                 else:
-                    return eval_node(node.expr2)  # type: ignore
+                    return eval_node(node.expr2)
             elif isinstance(node, nodes.And):
-                return eval_node(node.left) and eval_node(node.right)  # type: ignore
+                return eval_node(node.left) and eval_node(node.right)
             elif isinstance(node, nodes.Or):
-                return eval_node(node.left) or eval_node(node.right)  # type: ignore
+                return eval_node(node.left) or eval_node(node.right)
             elif isinstance(node, nodes.Not):
-                return not eval_node(node.node)  # type: ignore
+                return not eval_node(node.node)
             elif isinstance(node, nodes.Name):
-                return self.tags.get(node.name, False)  # type: ignore
+                return self.tags.get(node.name, False)
             else:
                 raise ValueError('invalid node, check parsing')
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Jinja2 starts to bundle its typehints since v3.0.  As a result, mypy
warns "ignore" hint is needless.  This removes them all to keep it
valid.