### PR TITLE
Add tests for dataclasses: autodoc and autosummary

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Features added
   entry and the definition of ``__init__()`` method
 * #8061, #9218: autodoc: Support variable comment for alias classes
 * #3257: autosummary: Support instance attributes for classes
+  and attributes for dataclasses
 * #9129: html search: Show search summaries when html_copy_source = False
 * #9120: html theme: Eliminate prompt characters of code-block from copyable
   text

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ extras_require = {
         'docutils-stubs',
     ],
     'test': [
+        'dataclasses; python_version < "3.7"',
         'pytest',
         'pytest-cov',
         'html5lib',

--- a/tests/roots/test-autosummary/dummy_module.py
+++ b/tests/roots/test-autosummary/dummy_module.py
@@ -7,7 +7,12 @@
    C.prop_attr1
    C.prop_attr2
    C.C2
+   D.str_field
+   D.int_field
+   D.list_field
 """
+
+from dataclasses import dataclass, field
 
 
 def withSentence():
@@ -79,6 +84,14 @@ class C:
         '''
         This is a nested inner class docstring
         '''
+
+
+@dataclass
+class D:
+    #: This is str field
+    str_field: str
+    int_field: int
+    list_field: list = field(default_factory=list)
 
 
 def func(arg_, *args, **kwargs):

--- a/tests/roots/test-ext-autodoc/target/dataclasses_.py
+++ b/tests/roots/test-ext-autodoc/target/dataclasses_.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class D:
+    #: This is a str field
+    str_field: str
+    int_field: int  #: This is an int field
+    list_field: list = field(default_factory=list)
+
+
+@dataclass
+class DNoDoc:
+    str_field: str
+    int_field: int
+    list_field: list = field(default_factory=list)

--- a/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from os import path  # NOQA
 from typing import Union
 
@@ -48,3 +49,11 @@ class _Exc(Exception):
 
 #: a module-level attribute
 qux = 2
+
+
+@dataclass
+class D:
+    #: This is str field
+    str_field: str
+    int_field: int
+    list_field: list = field(default_factory=list)

--- a/tests/roots/test-ext-autosummary/index.rst
+++ b/tests/roots/test-ext-autosummary/index.rst
@@ -13,4 +13,5 @@
    autosummary_dummy_module.Foo.value
    autosummary_dummy_module.bar
    autosummary_dummy_module.qux
+   autosummary_dummy_module.D
    autosummary_importfail

--- a/tests/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc_autoclass.py
@@ -344,9 +344,15 @@ def test_class_alias_having_doccomment(app):
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_dataclasses(app):
     actual = do_autodoc(app, 'class', 'target.dataclasses_.D')
+
+    if sys.version_info < (3, 7):
+        args = "str_field:str, int_field:int, list_field:list=<factory>"
+    else:
+        args = "str_field: str, int_field: int, list_field: list = <factory>"
+
     assert list(actual) == [
         '',
-        '.. py:class:: D(str_field: str, int_field: int, list_field: list = <factory>)',
+        f'.. py:class:: D({args})',
         '   :module: target.dataclasses_',
         ''
     ]
@@ -356,9 +362,15 @@ def test_dataclasses(app):
 def test_dataclasses_members(app):
     options = {"members": None}
     actual = do_autodoc(app, 'class', 'target.dataclasses_.D', options)
+
+    if sys.version_info < (3, 7):
+        args = "str_field:str, int_field:int, list_field:list=<factory>"
+    else:
+        args = "str_field: str, int_field: int, list_field: list = <factory>"
+
     assert list(actual) == [
         '',
-        '.. py:class:: D(str_field: str, int_field: int, list_field: list = <factory>)',
+        f'.. py:class:: D({args})',
         '   :module: target.dataclasses_',
         '',
         '',
@@ -383,9 +395,15 @@ def test_dataclasses_undoc_members(app):
     options = {"members": None,
                "undoc-members": None}
     actual = do_autodoc(app, 'class', 'target.dataclasses_.DNoDoc', options)
+
+    if sys.version_info < (3, 7):
+        args = "str_field:str, int_field:int, list_field:list=<factory>"
+    else:
+        args = "str_field: str, int_field: int, list_field: list = <factory>"
+
     assert list(actual) == [
         '',
-        '.. py:class:: DNoDoc(str_field: str, int_field: int, list_field: list = <factory>)',
+        f'.. py:class:: DNoDoc({args})',
         '   :module: target.dataclasses_',
         '',
         '',

--- a/tests/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc_autoclass.py
@@ -339,3 +339,68 @@ def test_class_alias_having_doccomment(app):
         '   docstring',
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_dataclasses(app):
+    actual = do_autodoc(app, 'class', 'target.dataclasses_.D')
+    assert list(actual) == [
+        '',
+        '.. py:class:: D(str_field: str, int_field: int, list_field: list = <factory>)',
+        '   :module: target.dataclasses_',
+        ''
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_dataclasses_members(app):
+    options = {"members": None}
+    actual = do_autodoc(app, 'class', 'target.dataclasses_.D', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: D(str_field: str, int_field: int, list_field: list = <factory>)',
+        '   :module: target.dataclasses_',
+        '',
+        '',
+        '   .. py:attribute:: D.int_field',
+        '      :module: target.dataclasses_',
+        '      :type: int',
+        '',
+        '      This is an int field',
+        '',
+        '',
+        '   .. py:attribute:: D.str_field',
+        '      :module: target.dataclasses_',
+        '      :type: str',
+        '',
+        '      This is a str field',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_dataclasses_undoc_members(app):
+    options = {"members": None,
+               "undoc-members": None}
+    actual = do_autodoc(app, 'class', 'target.dataclasses_.DNoDoc', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: DNoDoc(str_field: str, int_field: int, list_field: list = <factory>)',
+        '   :module: target.dataclasses_',
+        '',
+        '',
+        '   .. py:attribute:: DNoDoc.int_field',
+        '      :module: target.dataclasses_',
+        '      :type: int',
+        '',
+        '',
+        '   .. py:attribute:: DNoDoc.list_field',
+        '      :module: target.dataclasses_',
+        '      :type: list',
+        '',
+        '',
+        '   .. py:attribute:: DNoDoc.str_field',
+        '      :module: target.dataclasses_',
+        '      :type: str',
+        ''
+    ]


### PR DESCRIPTION
Subject: Add tests with dataclasses

This PR is a continuation to https://github.com/sphinx-doc/sphinx/pull/9146 where support for instance attributes in `autosummary` was added. As Phil correctly pointed out this change also fixes generated content for `dataclasses`. This change was hard to notice because there were no unit tests including `dataclasses` present. As `dataclasses` became somehow standard thing for python >= 3.7 I believe it's a good idea to test if content generated for them is correct.  

### Feature or Bugfix
- Testing

### Purpose
- Test documenting dataclasses

### Relates
- https://github.com/sphinx-doc/sphinx/pull/9146

