### PR TITLE
refactor: reduce calls of find_pending_xref_conditions (refs: #9240)

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1363,10 +1363,6 @@ def builtin_resolver(app: Sphinx, env: BuildEnvironment,
 
         return s in typing.__all__  # type: ignore
 
-    content = find_pending_xref_condition(node, 'resolved')
-    if content:
-        contnode = content.children[0]  # type: ignore
-
     if node.get('refdomain') != 'py':
         return None
     elif node.get('reftype') in ('class', 'obj') and node.get('reftarget') == 'None':

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -196,14 +196,6 @@ def test_missing_reference_pydomain(tempdir, app, status, warning):
     rn = missing_reference(app, app.env, node, contnode)
     assert rn.astext() == 'Foo.bar'
 
-    # pending_xref_condition="resolved"
-    node = addnodes.pending_xref('', reftarget='Foo.bar', refdomain='py', reftype='attr')
-    node['py:module'] = 'module1'
-    node += addnodes.pending_xref_condition('', 'Foo.bar', condition='resolved')
-    node += addnodes.pending_xref_condition('', 'module1.Foo.bar', condition='*')
-    rn = missing_reference(app, app.env, node, nodes.Text('dummy-cont-node'))
-    assert rn.astext() == 'Foo.bar'
-
 
 def test_missing_reference_stddomain(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- After #9246, `find_pending_xref_conditions()` should be only called from
intended modules.  At present, the Python Domain is the only module to
call it intendedly.  Therefore, this removes the needless calls of the
utility function from "unintended" modules.
- refs: #9240 