### PR TITLE
Closes #9270: pyramid theme generates incorrect logo links

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,7 @@ Bugs fixed
   :confval:`man_make_section_directory` is not correct
 * #9224: ``:param:`` and ``:type:`` fields does not support a type containing
   whitespace (ex. ``Dict[str, str]``)
+* #9270: autodoc: pyramid theme generates incorrect logo links
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -59,7 +59,7 @@ Bugs fixed
   :confval:`man_make_section_directory` is not correct
 * #9224: ``:param:`` and ``:type:`` fields does not support a type containing
   whitespace (ex. ``Dict[str, str]``)
-* #9270: autodoc: pyramid theme generates incorrect logo links
+* #9270: html theme : pyramid theme generates incorrect logo links
 
 Testing
 --------

--- a/sphinx/themes/pyramid/layout.html
+++ b/sphinx/themes/pyramid/layout.html
@@ -9,11 +9,11 @@
 {% endblock %}
 
 {% block header %}
-{%- if logo %}
+{%- if logo_url %}
 <div class="header" role="banner">
   <div class="logo">
     <a href="{{ pathto(root_doc)|e }}">
-      <img class="logo" src="{{ pathto(logo, 1)|e }}" alt="Logo"/>
+      <img class="logo" src="{{ logo_url|e }}" alt="Logo"/>
     </a>
   </div>
 </div>


### PR DESCRIPTION
Subject: fix #9270: pyramid theme generates incorrect logo links

### Feature or Bugfix
- Bugfix

### Purpose
This is a two line fix to make the pyramid theme use `logo_url` for links to the log specified by `html_logo` similarly to the basic theme.

### Relates
- #9270 

