### PR TITLE
Fix typo in doc/intl.rst

### DIFF
--- a/doc/usage/advanced/intl.rst
+++ b/doc/usage/advanced/intl.rst
@@ -118,7 +118,7 @@ section describe an easy way to translate with *sphinx-intl*.
 
 #. Translate po files.
 
-   AS noted above, these are located in the ``./locale/<lang>/LC_MESSAGES``
+   As noted above, these are located in the ``./locale/<lang>/LC_MESSAGES``
    directory.  An example of one such file, from Sphinx, ``builders.po``, is
    given below.
 
@@ -193,7 +193,7 @@ pot file to the po file, use the :command:`sphinx-intl update` command.
 
 .. code-block:: console
 
-   $ sphinx-intl update -p _build/locale
+   $ sphinx-intl update -p _build/gettext
 
 
 Using Transifex service for team translation


### PR DESCRIPTION
Subject: Fix typo in update command in doc/usage/advanced/intl.rst

The pot files are in the `gettext` folder instead of `locale` folder.

### Feature or Bugfix

- Feature
- Bugfix √
- Refactoring
