### PR TITLE
Close #9268: python_use_unqualified_type_names supports type field

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,8 @@ Features added
 * #9176: i18n: Emit a debug message if message catalog file not found under
   :confval:`locale_dirs`
 * #1874: py domain: Support union types using ``|`` in info-field-list
+* #9268: py domain: :confval:`python_use_unqualified_type_names` supports type
+  field in info-field-list
 * #9097: Optimize the paralell build
 * #9131: Add :confval:`nitpick_ignore_regex` to ignore nitpicky warnings using
   regular expressions

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -299,6 +299,16 @@ class PyXrefMixin:
             for node in result.traverse(nodes.Text):
                 node.parent[node.parent.index(node)] = nodes.Text(text)
                 break
+        elif isinstance(result, pending_xref) and env.config.python_use_unqualified_type_names:
+            children = result.children
+            result.clear()
+
+            shortname = target.split('.')[-1]
+            textnode = innernode('', shortname)
+            contnodes = [pending_xref_condition('', '', textnode, condition='resolved'),
+                         pending_xref_condition('', '', *children, condition='*')]
+            result.extend(contnodes)
+
         return result
 
     def make_xrefs(self, rolename: str, domain: str, target: str,

--- a/tests/roots/test-domain-py-python_use_unqualified_type_names/index.rst
+++ b/tests/roots/test-domain-py-python_use_unqualified_type_names/index.rst
@@ -4,5 +4,9 @@ domain-py-smart_reference
 .. py:class:: Name
    :module: foo
 
+   :param name: blah blah
+   :type name: foo.Name
+   :param age: blah blah
+   :type age: foo.Age
 
 .. py:function:: hello(name: foo.Name, age: foo.Age)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -1147,6 +1147,9 @@ def test_python_python_use_unqualified_type_names(app, status, warning):
     assert ('<span class="n"><a class="reference internal" href="#foo.Name" title="foo.Name">'
             '<span class="pre">Name</span></a></span>' in content)
     assert '<span class="n"><span class="pre">foo.Age</span></span>' in content
+    assert ('<p><strong>name</strong> (<a class="reference internal" href="#foo.Name" '
+            'title="foo.Name"><em>Name</em></a>) – blah blah</p>' in content)
+    assert '<p><strong>age</strong> (<em>foo.Age</em>) – blah blah</p>' in content
 
 
 @pytest.mark.sphinx('html', testroot='domain-py-python_use_unqualified_type_names',
@@ -1157,6 +1160,9 @@ def test_python_python_use_unqualified_type_names_disabled(app, status, warning)
     assert ('<span class="n"><a class="reference internal" href="#foo.Name" title="foo.Name">'
             '<span class="pre">foo.Name</span></a></span>' in content)
     assert '<span class="n"><span class="pre">foo.Age</span></span>' in content
+    assert ('<p><strong>name</strong> (<a class="reference internal" href="#foo.Name" '
+            'title="foo.Name"><em>foo.Name</em></a>) – blah blah</p>' in content)
+    assert '<p><strong>age</strong> (<em>foo.Age</em>) – blah blah</p>' in content
 
 
 @pytest.mark.sphinx('dummy', testroot='domain-py-xref-warning')


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #9268 
