### PR TITLE
Refactor C and  C++ tests

### DIFF
--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -112,7 +112,7 @@ def check(name, input, idDict, output=None, key=None, asTextOutput=None):
                asTextOutput + ';' if asTextOutput is not None else None)
 
 
-def test_expressions():
+def test_domain_c_ast_expressions():
     def exprCheck(expr, output=None):
         class Config:
             c_id_attributes = ["id_attr"]
@@ -269,7 +269,7 @@ def test_expressions():
     exprCheck('a or_eq 5')
 
 
-def test_type_definitions():
+def test_domain_c_ast_type_definitions():
     check('type', "{key}T", {1: "T"})
 
     check('type', "{key}bool *b", {1: 'b'}, key='typedef')
@@ -290,7 +290,7 @@ def test_type_definitions():
           {1: 'gpio_callback_t'}, key='typedef')
 
 
-def test_macro_definitions():
+def test_domain_c_ast_macro_definitions():
     check('macro', 'M', {1: 'M'})
     check('macro', 'M()', {1: 'M'})
     check('macro', 'M(arg)', {1: 'M'})
@@ -306,7 +306,7 @@ def test_macro_definitions():
         check('macro', 'M(arg1, arg2..., arg3)', {1: 'M'})
 
 
-def test_member_definitions():
+def test_domain_c_ast_member_definitions():
     check('member', 'void a', {1: 'a'})
     check('member', '_Bool a', {1: 'a'})
     check('member', 'bool a', {1: 'a'})
@@ -364,7 +364,7 @@ def test_member_definitions():
     check('member', 'int b : 3', {1: 'b'})
 
 
-def test_function_definitions():
+def test_domain_c_ast_function_definitions():
     check('function', 'void f()', {1: 'f'})
     check('function', 'void f(int)', {1: 'f'})
     check('function', 'void f(int i)', {1: 'f'})
@@ -424,29 +424,29 @@ def test_function_definitions():
     check('function', 'void f(void (*p)(int, double), int i)', {1: 'f'})
 
 
-def test_nested_name():
+def test_domain_c_ast_nested_name():
     check('struct', '{key}.A', {1: "A"})
     check('struct', '{key}.A.B', {1: "A.B"})
     check('function', 'void f(.A a)', {1: "f"})
     check('function', 'void f(.A.B a)', {1: "f"})
 
 
-def test_struct_definitions():
+def test_domain_c_ast_struct_definitions():
     check('struct', '{key}A', {1: 'A'})
 
 
-def test_union_definitions():
+def test_domain_c_ast_union_definitions():
     check('union', '{key}A', {1: 'A'})
 
 
-def test_enum_definitions():
+def test_domain_c_ast_enum_definitions():
     check('enum', '{key}A', {1: 'A'})
 
     check('enumerator', '{key}A', {1: 'A'})
     check('enumerator', '{key}A = 42', {1: 'A'})
 
 
-def test_anon_definitions():
+def test_domain_c_ast_anon_definitions():
     check('struct', '@a', {1: "@a"}, asTextOutput='struct [anonymous]')
     check('union', '@a', {1: "@a"}, asTextOutput='union [anonymous]')
     check('enum', '@a', {1: "@a"}, asTextOutput='enum [anonymous]')
@@ -454,7 +454,7 @@ def test_anon_definitions():
     check('struct', '@a.A', {1: "@a.A"}, asTextOutput='struct [anonymous].A')
 
 
-def test_initializers():
+def test_domain_c_ast_initializers():
     idsMember = {1: 'v'}
     idsFunction = {1: 'f'}
     # no init
@@ -473,7 +473,7 @@ def test_initializers():
     # TODO: designator-list
 
 
-def test_attributes():
+def test_domain_c_ast_attributes():
     # style: C++
     check('member', '[[]] int f', {1: 'f'})
     check('member', '[ [ ] ] int f', {1: 'f'},
@@ -566,14 +566,14 @@ def extract_role_links(app, filename):
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
-def test_build_domain_c(app, status, warning):
+def test_domain_c_build(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "index")
     assert len(ws) == 0
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
-def test_build_domain_c_namespace(app, status, warning):
+def test_domain_c_build_namespace(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "namespace")
     assert len(ws) == 0
@@ -583,7 +583,7 @@ def test_build_domain_c_namespace(app, status, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
-def test_build_domain_c_anon_dup_decl(app, status, warning):
+def test_domain_c_build_anon_dup_decl(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "anon-dup-decl")
     assert len(ws) == 2
@@ -592,7 +592,7 @@ def test_build_domain_c_anon_dup_decl(app, status, warning):
 
 
 @pytest.mark.sphinx(confoverrides={'nitpicky': True})
-def test_build_domain_c_semicolon(app, warning):
+def test_domain_c_build_semicolon(app, warning):
     text = """
 .. c:member:: int member;
 .. c:var:: int var;
@@ -611,7 +611,7 @@ def test_build_domain_c_semicolon(app, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
-def test_build_function_param_target(app, warning):
+def test_domain_c_build_function_param_target(app, warning):
     # the anchor for function parameters should be the function
     app.builder.build_all()
     ws = filter_warnings(warning, "function_param_target")
@@ -624,14 +624,14 @@ def test_build_function_param_target(app, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
-def test_build_ns_lookup(app, warning):
+def test_domain_c_build_ns_lookup(app, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "ns_lookup")
     assert len(ws) == 0
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})
-def test_build_field_role(app, status, warning):
+def test_domain_c_build_field_role(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "field-role")
     assert len(ws) == 0
@@ -645,49 +645,8 @@ def _get_obj(app, queryName):
     return (queryName, "not", "found")
 
 
-def test_cfunction(app):
-    text = (".. c:function:: PyObject* "
-            "PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)")
-    doctree = restructuredtext.parse(app, text)
-    assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
-
-    entry = _get_obj(app, 'PyType_GenericAlloc')
-    assert entry == ('index', 'c.PyType_GenericAlloc', 'function')
-
-
-def test_cmember(app):
-    text = ".. c:member:: PyObject* PyTypeObject.tp_bases"
-    doctree = restructuredtext.parse(app, text)
-    assert_node(doctree[1], addnodes.desc, desctype="member",
-                domain="c", objtype="member", noindex=False)
-
-    entry = _get_obj(app, 'PyTypeObject.tp_bases')
-    assert entry == ('index', 'c.PyTypeObject.tp_bases', 'member')
-
-
-def test_cvar(app):
-    text = ".. c:var:: PyObject* PyClass_Type"
-    doctree = restructuredtext.parse(app, text)
-    assert_node(doctree[1], addnodes.desc, desctype="var",
-                domain="c", objtype="var", noindex=False)
-
-    entry = _get_obj(app, 'PyClass_Type')
-    assert entry == ('index', 'c.PyClass_Type', 'member')
-
-
-def test_noindexentry(app):
-    text = (".. c:function:: void f()\n"
-            ".. c:function:: void g()\n"
-            "   :noindexentry:\n")
-    doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
-    assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C function)', 'c.f', '', None)])
-    assert_node(doctree[2], addnodes.index, entries=[])
-
-
 @pytest.mark.sphinx(testroot='domain-c-intersphinx', confoverrides={'nitpicky': True})
-def test_intersphinx(tempdir, app, status, warning):
+def test_domain_c_build_intersphinx(tempdir, app, status, warning):
     # a splitting of test_ids_vs_tags0 into the primary directives in a remote project,
     # and then the references in the test project
     origSource = """\
@@ -735,3 +694,44 @@ _var c:member 1 index.html#c.$ -
     app.builder.build_all()
     ws = filter_warnings(warning, "index")
     assert len(ws) == 0
+
+
+def test_domain_c_parse_cfunction(app):
+    text = (".. c:function:: PyObject* "
+            "PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)")
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree[1], addnodes.desc, desctype="function",
+                domain="c", objtype="function", noindex=False)
+
+    entry = _get_obj(app, 'PyType_GenericAlloc')
+    assert entry == ('index', 'c.PyType_GenericAlloc', 'function')
+
+
+def test_domain_c_parse_cmember(app):
+    text = ".. c:member:: PyObject* PyTypeObject.tp_bases"
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree[1], addnodes.desc, desctype="member",
+                domain="c", objtype="member", noindex=False)
+
+    entry = _get_obj(app, 'PyTypeObject.tp_bases')
+    assert entry == ('index', 'c.PyTypeObject.tp_bases', 'member')
+
+
+def test_domain_c_parse_cvar(app):
+    text = ".. c:var:: PyObject* PyClass_Type"
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree[1], addnodes.desc, desctype="var",
+                domain="c", objtype="var", noindex=False)
+
+    entry = _get_obj(app, 'PyClass_Type')
+    assert entry == ('index', 'c.PyClass_Type', 'member')
+
+
+def test_domain_c_parse_noindexentry(app):
+    text = (".. c:function:: void f()\n"
+            ".. c:function:: void g()\n"
+            "   :noindexentry:\n")
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C function)', 'c.f', '', None)])
+    assert_node(doctree[2], addnodes.index, entries=[])

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -117,7 +117,7 @@ def check(name, input, idDict, output=None, key=None, asTextOutput=None):
            asTextOutput + ';' if asTextOutput is not None else None)
 
 
-def test_fundamental_types():
+def test_domain_cpp_ast_fundamental_types():
     # see https://en.cppreference.com/w/cpp/language/types
     for t, id_v2 in cppDomain._id_fundamental_v2.items():
         def makeIdV1():
@@ -137,7 +137,7 @@ def test_fundamental_types():
         check("function", "void f(%s arg)" % t, {1: makeIdV1(), 2: makeIdV2()})
 
 
-def test_expressions():
+def test_domain_cpp_ast_expressions():
     def exprCheck(expr, id, id4=None):
         ids = 'IE1CIA%s_1aE'
         # call .format() on the expr to unescape double curly braces
@@ -351,7 +351,7 @@ def test_expressions():
     exprCheck('a(b(c, 1 + d...)..., e(f..., g))', 'cl1aspcl1b1cspplL1E1dEcl1esp1f1gEE')
 
 
-def test_type_definitions():
+def test_domain_cpp_ast_type_definitions():
     check("type", "public bool b", {1: "b", 2: "1b"}, "{key}bool b", key='typedef')
     check("type", "{key}bool A::b", {1: "A::b", 2: "N1A1bE"}, key='typedef')
     check("type", "{key}bool *b", {1: "b", 2: "1b"}, key='typedef')
@@ -396,7 +396,7 @@ def test_type_definitions():
     check('type', '{key}T = Q<A::operator bool>', {2: '1T'}, key='using')
 
 
-def test_concept_definitions():
+def test_domain_cpp_ast_concept_definitions():
     check('concept', 'template<typename Param> {key}A::B::Concept',
           {2: 'I0EN1A1B7ConceptE'})
     check('concept', 'template<typename A, typename B, typename ...C> {key}Foo',
@@ -407,7 +407,7 @@ def test_concept_definitions():
         parse('concept', 'template<typename T> template<typename U> {key}Foo')
 
 
-def test_member_definitions():
+def test_domain_cpp_ast_member_definitions():
     check('member', '  const  std::string  &  name = 42',
           {1: "name__ssCR", 2: "4name"}, output='const std::string &name = 42')
     check('member', '  const  std::string  &  name', {1: "name__ssCR", 2: "4name"},
@@ -436,7 +436,7 @@ def test_member_definitions():
     check('member', 'int b : 1 || new int{0}', {1: 'b__i', 2: '1b'})
 
 
-def test_function_definitions():
+def test_domain_cpp_ast_function_definitions():
     check('function', 'void f(volatile int)', {1: "f__iV", 2: "1fVi"})
     check('function', 'void f(std::size_t)', {1: "f__std::s", 2: "1fNSt6size_tE"})
     check('function', 'operator bool() const', {1: "castto-b-operatorC", 2: "NKcvbEv"})
@@ -624,7 +624,7 @@ def test_function_definitions():
     check('function', 'void f(void (*p)(int, double), int i)', {2: '1fPFvidEi'})
 
 
-def test_operators():
+def test_domain_cpp_ast_operators():
     check('function', 'void operator new()', {1: "new-operator", 2: "nwv"})
     check('function', 'void operator new[]()', {1: "new-array-operator", 2: "nav"})
     check('function', 'void operator delete()', {1: "delete-operator", 2: "dlv"})
@@ -684,14 +684,14 @@ def test_operators():
     check('function', 'void operator[]()', {1: "subscript-operator", 2: "ixv"})
 
 
-def test_nested_name():
+def test_domain_cpp_ast_nested_name():
     check('class', '{key}::A', {1: "A", 2: "1A"})
     check('class', '{key}::A::B', {1: "A::B", 2: "N1A1BE"})
     check('function', 'void f(::A a)', {1: "f__A", 2: "1f1A"})
     check('function', 'void f(::A::B a)', {1: "f__A::B", 2: "1fN1A1BE"})
 
 
-def test_class_definitions():
+def test_domain_cpp_ast_class_definitions():
     check('class', 'public A', {1: "A", 2: "1A"}, output='{key}A')
     check('class', 'private {key}A', {1: "A", 2: "1A"})
     check('class', '{key}A final', {1: 'A', 2: '1A'})
@@ -722,11 +722,11 @@ def test_class_definitions():
           {2: 'I_DpiE1TIJX(Is)EEE', 3: 'I_DpiE1TIJX2IsEEE'})
 
 
-def test_union_definitions():
+def test_domain_cpp_ast_union_definitions():
     check('union', '{key}A', {2: "1A"})
 
 
-def test_enum_definitions():
+def test_domain_cpp_ast_enum_definitions():
     check('enum', '{key}A', {2: "1A"})
     check('enum', '{key}A : std::underlying_type<B>::type', {2: "1A"})
     check('enum', '{key}A : unsigned int', {2: "1A"})
@@ -737,7 +737,7 @@ def test_enum_definitions():
     check('enumerator', '{key}A = std::numeric_limits<unsigned long>::max()', {2: "1A"})
 
 
-def test_anon_definitions():
+def test_domain_cpp_ast_anon_definitions():
     check('class', '@a', {3: "Ut1_a"}, asTextOutput='class [anonymous]')
     check('union', '@a', {3: "Ut1_a"}, asTextOutput='union [anonymous]')
     check('enum', '@a', {3: "Ut1_a"}, asTextOutput='enum [anonymous]')
@@ -748,7 +748,7 @@ def test_anon_definitions():
           asTextOutput='int f(int [anonymous])')
 
 
-def test_templates():
+def test_domain_cpp_ast_templates():
     check('class', "A<T>", {2: "IE1AI1TE"}, output="template<> {key}A<T>")
     # first just check which objects support templating
     check('class', "template<> {key}A", {2: "IE1A"})
@@ -854,7 +854,7 @@ def test_templates():
     check('type', 'template<C T = int&> {key}A', {2: 'I_1CE1A'}, key='using')
 
 
-def test_requires_clauses():
+def test_domain_cpp_ast_requires_clauses():
     check('function', 'template<typename T> requires A auto f() -> void requires B',
           {4: 'I0EIQaa1A1BE1fvv'})
     check('function', 'template<typename T> requires A || B or C void f()',
@@ -863,7 +863,7 @@ def test_requires_clauses():
           {4: 'I0EIQooaa1A1Baa1C1DE1fvv'})
 
 
-def test_template_args():
+def test_domain_cpp_ast_template_args():
     # from breathe#218
     check('function',
           "template<typename F> "
@@ -878,7 +878,7 @@ def test_template_args():
           key='using')
 
 
-def test_initializers():
+def test_domain_cpp_ast_initializers():
     idsMember = {1: 'v__T', 2: '1v'}
     idsFunction = {1: 'f__T', 2: '1f1T'}
     idsTemplate = {2: 'I_1TE1fv', 4: 'I_1TE1fvv'}
@@ -912,7 +912,7 @@ def test_initializers():
     check('member', 'T v = T{}', idsMember)
 
 
-def test_attributes():
+def test_domain_cpp_ast_attributes():
     # style: C++
     check('member', '[[]] int f', {1: 'f__i', 2: '1f'})
     check('member', '[ [ ] ] int f', {1: 'f__i', 2: '1f'},
@@ -960,7 +960,7 @@ def test_attributes():
     check('function', 'void f() [[attr1]] [[attr2]]', {1: 'f', 2: '1fv'})
 
 
-def test_xref_parsing():
+def test_domain_cpp_ast_xref_parsing():
     def check(target):
         class Config:
             cpp_id_attributes = ["id_attr"]
@@ -993,7 +993,7 @@ def filter_warnings(warning, file):
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
-def test_build_domain_cpp_multi_decl_lookup(app, status, warning):
+def test_domain_cpp_build_multi_decl_lookup(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "lookup-key-overload")
     assert len(ws) == 0
@@ -1003,7 +1003,7 @@ def test_build_domain_cpp_multi_decl_lookup(app, status, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
-def test_build_domain_cpp_warn_template_param_qualified_name(app, status, warning):
+def test_domain_cpp_build_warn_template_param_qualified_name(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "warn-template-param-qualified-name")
     assert len(ws) == 2
@@ -1012,14 +1012,14 @@ def test_build_domain_cpp_warn_template_param_qualified_name(app, status, warnin
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
-def test_build_domain_cpp_backslash_ok_true(app, status, warning):
+def test_domain_cpp_build_backslash_ok_true(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "backslash")
     assert len(ws) == 0
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
-def test_build_domain_cpp_semicolon(app, status, warning):
+def test_domain_cpp_build_semicolon(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "semicolon")
     assert len(ws) == 0
@@ -1027,7 +1027,7 @@ def test_build_domain_cpp_semicolon(app, status, warning):
 
 @pytest.mark.sphinx(testroot='domain-cpp',
                     confoverrides={'nitpicky': True, 'strip_signature_backslash': True})
-def test_build_domain_cpp_backslash_ok_false(app, status, warning):
+def test_domain_cpp_build_backslash_ok_false(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "backslash")
     assert len(ws) == 1
@@ -1035,7 +1035,7 @@ def test_build_domain_cpp_backslash_ok_false(app, status, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
-def test_build_domain_cpp_anon_dup_decl(app, status, warning):
+def test_domain_cpp_build_anon_dup_decl(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "anon-dup-decl")
     assert len(ws) == 2
@@ -1044,7 +1044,7 @@ def test_build_domain_cpp_anon_dup_decl(app, status, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-cpp')
-def test_build_domain_cpp_misuse_of_roles(app, status, warning):
+def test_domain_cpp_build_misuse_of_roles(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "roles-targets-ok")
     assert len(ws) == 0
@@ -1092,7 +1092,7 @@ def test_build_domain_cpp_misuse_of_roles(app, status, warning):
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'add_function_parentheses': True})
-def test_build_domain_cpp_with_add_function_parentheses_is_True(app, status, warning):
+def test_domain_cpp_build_with_add_function_parentheses_is_True(app, status, warning):
     app.builder.build_all()
 
     def check(spec, text, file):
@@ -1133,7 +1133,7 @@ def test_build_domain_cpp_with_add_function_parentheses_is_True(app, status, war
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'add_function_parentheses': False})
-def test_build_domain_cpp_with_add_function_parentheses_is_False(app, status, warning):
+def test_domain_cpp_build_with_add_function_parentheses_is_False(app, status, warning):
     app.builder.build_all()
 
     def check(spec, text, file):
@@ -1174,7 +1174,7 @@ def test_build_domain_cpp_with_add_function_parentheses_is_False(app, status, wa
 
 
 @pytest.mark.sphinx(testroot='domain-cpp')
-def test_xref_consistency(app, status, warning):
+def test_domain_cpp_build_xref_consistency(app, status, warning):
     app.builder.build_all()
 
     test = 'xref_consistency.html'
@@ -1238,39 +1238,14 @@ not found in `{test}`
 
 
 @pytest.mark.sphinx(testroot='domain-cpp', confoverrides={'nitpicky': True})
-def test_build_domain_cpp_field_role(app, status, warning):
+def test_domain_cpp_build_field_role(app, status, warning):
     app.builder.build_all()
     ws = filter_warnings(warning, "field-role")
     assert len(ws) == 0
 
 
-def test_noindexentry(app):
-    text = (".. cpp:function:: void f()\n"
-            ".. cpp:function:: void g()\n"
-            "   :noindexentry:\n")
-    doctree = restructuredtext.parse(app, text)
-    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
-    assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C++ function)', '_CPPv41fv', '', None)])
-    assert_node(doctree[2], addnodes.index, entries=[])
-
-
-def test_mix_decl_duplicate(app, warning):
-    # Issue 8270
-    text = (".. cpp:struct:: A\n"
-            ".. cpp:function:: void A()\n"
-            ".. cpp:struct:: A\n")
-    restructuredtext.parse(app, text)
-    ws = warning.getvalue().split("\n")
-    assert len(ws) == 5
-    assert "index.rst:2: WARNING: Duplicate C++ declaration, also defined at index:1." in ws[0]
-    assert "Declaration is '.. cpp:function:: void A()'." in ws[1]
-    assert "index.rst:3: WARNING: Duplicate C++ declaration, also defined at index:1." in ws[2]
-    assert "Declaration is '.. cpp:struct:: A'." in ws[3]
-    assert ws[4] == ""
-
-
 @pytest.mark.sphinx(testroot='domain-cpp-intersphinx', confoverrides={'nitpicky': True})
-def test_intersphinx(tempdir, app, status, warning):
+def test_domain_cpp_build_intersphinx(tempdir, app, status, warning):
     origSource = """\
 .. cpp:class:: _class
 .. cpp:struct:: _struct
@@ -1330,3 +1305,28 @@ _var cpp:member 1 index.html#_CPPv44$ -
     app.builder.build_all()
     ws = filter_warnings(warning, "index")
     assert len(ws) == 0
+
+
+def test_domain_cpp_parse_noindexentry(app):
+    text = (".. cpp:function:: void f()\n"
+            ".. cpp:function:: void g()\n"
+            "   :noindexentry:\n")
+    doctree = restructuredtext.parse(app, text)
+    assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
+    assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C++ function)', '_CPPv41fv', '', None)])
+    assert_node(doctree[2], addnodes.index, entries=[])
+
+
+def test_domain_cpp_parse_mix_decl_duplicate(app, warning):
+    # Issue 8270
+    text = (".. cpp:struct:: A\n"
+            ".. cpp:function:: void A()\n"
+            ".. cpp:struct:: A\n")
+    restructuredtext.parse(app, text)
+    ws = warning.getvalue().split("\n")
+    assert len(ws) == 5
+    assert "index.rst:2: WARNING: Duplicate C++ declaration, also defined at index:1." in ws[0]
+    assert "Declaration is '.. cpp:function:: void A()'." in ws[1]
+    assert "index.rst:3: WARNING: Duplicate C++ declaration, also defined at index:1." in ws[2]
+    assert "Declaration is '.. cpp:struct:: A'." in ws[3]
+    assert ws[4] == ""


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
Rename and reorder tests to be consistent and easier to filter on.