### PR TITLE
Allow case-insensitive match of :term: references through intersphinx

### DIFF
--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -305,9 +305,19 @@ def missing_reference(app: Sphinx, env: BuildEnvironment, node: pending_xref,
                     to_try.append((inventories.named_inventory[setname], full_qualified_name))
     for inventory, target in to_try:
         for objtype in objtypes:
-            if objtype not in inventory or target not in inventory[objtype]:
-                continue
-            proj, version, uri, dispname = inventory[objtype][target]
+            # Special case handling for term to search in a case insensitive fashion
+            if objtype == 'std:term' and objtype in inventory:
+                cased_keys = {k.lower(): k for k in inventory[objtype].keys()}
+                if target.lower() in cased_keys:
+                    corrected_target = cased_keys[target.lower()]
+                    proj, version, uri, dispname = inventory[objtype][corrected_target]
+                else:
+                    continue
+            else:
+                # Default behaviour pre-patch
+                if objtype not in inventory or target not in inventory[objtype]:
+                    continue
+                proj, version, uri, dispname = inventory[objtype][target]
             if '://' not in uri and node.get('refdoc'):
                 # get correct path in case of subdirectories
                 uri = path.join(relative_path(node['refdoc'], '.'), uri)


### PR DESCRIPTION
Subject: Allow case-insensitive match of :term: references through intersphinx

### Feature or Bugfix

- Bugfix

### Purpose
- #9291 describes a problem where term references are resolved in a case insensitive fashion when matching a locally defined glossary, but when that same glossary is accessed through intersphinx this stops working and the term can only be matched with exact case. I'm not particularly familiar with the architecture of sphinx so I might well have put this in the wrong place, but it does fix this issue.

### Detail

Simple code change, detects that the objtype is `std:term`, builds a dict of lower case to original case for all keys in the inventory under inspection and uses that to perform case insensitive matching.

### Relates
- #9291 

