### PR TITLE
Prevent corrections and completions in search field

### DIFF
--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -37,7 +37,7 @@
   {% endblock %}
   {% block searchbox %}
   <form action="" method="get">
-    <input type="text" name="q" aria-labelledby="search-documentation" value="" />
+    <input type="text" name="q" aria-labelledby="search-documentation" value="" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
     <input type="submit" value="{{ _('search') }}" />
     <span id="search-progress" style="padding-left: 10px"></span>
   </form>

--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -12,7 +12,7 @@
   <h3 id="searchlabel">{{ _('Quick search') }}</h3>
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" aria-labelledby="searchlabel" />
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
       <input type="submit" value="{{ _('Go') }}" />
     </form>
     </div>


### PR DESCRIPTION
### Purpose

In particular mobile browsers use correction mechanisms on input fields.
Search will often be done with technical terms or even class/method/etc
names that these correction mechanisms do not know, resulting in unwanted
changes. This PR deactivates these correction mechanisms.

### Detail

While I haven't been able to find official reference documentation on
these input attributes, there are multiple sources, describing this, e.g.

References:

- Autocomplete: https://www.w3schools.com/howto/howto_html_autocomplete_off.asp
- Spellckeck: https://www.w3schools.com/howto/howto_html_spellcheck_disable.asp

I did not find official reference docs on autocorrect and autocapitalize, but
they are mentioned in various sources, e.g.

- https://mgearon.com/html/disable-autocomplete-autocapitalize-and-autocorrect/
- https://stackoverflow.com/questions/35513968/disable-auto-correct-in-safari-text-input
- https://davidwalsh.name/disable-autocorrect

and it works, as can easily be checked with a mobile device on the demos in the above
links.


