### PR TITLE
Fix #9313

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* 9313: LaTeX: complex table with merged cells broken since 4.0
+
 Testing
 --------
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -966,7 +966,7 @@ class LaTeXTranslator(SphinxTranslator):
                     # insert suitable strut for equalizing row heights in given multirow
                     self.body.append(r'\sphinxtablestrut{%d}' % cell.cell_id)
                 else:  # use \multicolumn for wide multirow cell
-                    self.body.append(r'\multicolumn{%d}{|l|}\sphinxtablestrut{%d}}' %
+                    self.body.append(r'\multicolumn{%d}{|l|}{\sphinxtablestrut{%d}}' %
                                      (cell.width, cell.cell_id))
 
     def depart_row(self, node: Element) -> None:


### PR DESCRIPTION
At #8875, a `{` was accidentally removed from writers/latex.py 
 

As I have been absent a long time I don't know if 4.0.3 or upcoming 4.1.0 is better branch