### PR TITLE
Fix missing break statement for arrow shortcuts.

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -301,12 +301,14 @@ var Documentation = {
               window.location.href = prevHref;
               return false;
             }
+            break;
           case 39: // right
             var nextHref = $('link[rel="next"]').prop('href');
             if (nextHref) {
               window.location.href = nextHref;
               return false;
             }
+            break;
         }
       }
     });


### PR DESCRIPTION
When one presses left key at the first page, `case 37` falls
through to `case 39` and the next page is visited.