### PR TITLE
Fix mypy violations (Third-party Library Stubs) (with mypy-0.900)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,11 @@ extras_require = {
     'lint': [
         'flake8>=3.5.0',
         'isort',
-        'mypy>=0.800',
+        'mypy>=0.900',
         'docutils-stubs',
+        "types-typed-ast",
+        "types-pkg_resources",
+        "types-requests",
     ],
     'test': [
         'pytest',


### PR DESCRIPTION
Subject: Fix mypy violations (Third-party Library Stubs) (with mypy-0.900)

### Feature or Bugfix
- Refactoring

### Purpose

Fix mypy violations (Third-party Library Stubs) (with mypy-0.900)


### Detail

Add to setup.py
* types-typed-ast 
* types-pkg_resources
* types-requests


Because, mypy 0.900  has made a  Breaking Change.  

[**Third-party Library Stubs in Stub Packages (Breaking Change)**](https://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html)

github actions error 
Excerpt.
```
sphinx/pycode/ast.py:19:1: error: Library stubs not installed for "typed_ast" (or incompatible with Python 3.6)
sphinx/theming.py:19:1: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.6)
sphinx/registry.py:24:1: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.6)
sphinx/util/requests.py:17:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.6)
54
sphinx/util/requests.py:24:1: error: Library stubs not installed for "requests.packages.urllib3.exceptions" (or incompatible with Python 3.6)
sphinx/builders/linkcheck.py:28:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.6)
sphinx/builders/linkcheck.py:29:1: error: Library stubs not installed for "requests.exceptions" (or incompatible with Python 3.6)
```

### Relates
- None

