### PR TITLE
Revert the removal of sphinx.util:force_decode()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* Revert the removal of ``sphinx.util:force_decode()`` to become some 3rd party
+  extensions available again during 5.0
+
 Bugs fixed
 ----------
 

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -1015,7 +1015,7 @@ The following is a list of deprecated interfaces.
 
    * - ``sphinx.util.force_decode()``
      - 2.0
-     - 4.0
+     - 5.0
      - N/A
 
    * - ``sphinx.util.get_matching_docs()``

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -337,6 +337,23 @@ def parselinenos(spec: str, total: int) -> List[int]:
     return items
 
 
+def force_decode(string: str, encoding: str) -> str:
+    """Forcibly get a unicode string out of a bytestring."""
+    warnings.warn('force_decode() is deprecated.',
+                  RemovedInSphinx50Warning, stacklevel=2)
+    if isinstance(string, bytes):
+        try:
+            if encoding:
+                string = string.decode(encoding)
+            else:
+                # try decoding with utf-8, should only work for real UTF-8
+                string = string.decode()
+        except UnicodeError:
+            # last resort -- can't fail
+            string = string.decode('latin1')
+    return string
+
+
 def rpartition(s: str, t: str) -> Tuple[str, str]:
     """Similar to str.rpartition from 2.5, but doesn't return the separator."""
     warnings.warn('rpartition() is now deprecated.', RemovedInSphinx50Warning, stacklevel=2)


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Refactoring

### Purpose
- After the release of 4.0.0, some 3rd party extensions have became not
working with the latest Sphinx because `force_decode()` function was
removed.  It was deprecated since Sphinx-2.0 and warned for the removal
since 3.0.
- This reverts the removal and extends its deprecation period to 5.0.0.  I
hope it helps users of these extensions.
- refs: https://github.com/sphinx-doc/sphinx/pull/5620#issuecomment-860163848
- cc: @stevepiercy 