### PR TITLE
Fix mypy violations (delete type: ignore ) (with mypy-0.900)

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -573,13 +573,13 @@ def setup(app: "Sphinx", status: IO, warning: IO) -> None:
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
 
-    info_handler = NewLineStreamHandler(SafeEncodingWriter(status))  # type: ignore
+    info_handler = NewLineStreamHandler(SafeEncodingWriter(status))
     info_handler.addFilter(InfoFilter())
     info_handler.addFilter(InfoLogRecordTranslator(app))
     info_handler.setLevel(VERBOSITY_MAP[app.verbosity])
     info_handler.setFormatter(ColorizeFormatter())
 
-    warning_handler = WarningStreamHandler(SafeEncodingWriter(warning))  # type: ignore
+    warning_handler = WarningStreamHandler(SafeEncodingWriter(warning))
     warning_handler.addFilter(WarningSuppressor(app))
     warning_handler.addFilter(WarningLogRecordTranslator(app))
     warning_handler.addFilter(WarningIsErrorFilter(app))
@@ -587,7 +587,7 @@ def setup(app: "Sphinx", status: IO, warning: IO) -> None:
     warning_handler.setLevel(logging.WARNING)
     warning_handler.setFormatter(ColorizeFormatter())
 
-    messagelog_handler = logging.StreamHandler(LastMessagesWriter(app, status))  # type: ignore
+    messagelog_handler = logging.StreamHandler(LastMessagesWriter(app, status))
     messagelog_handler.addFilter(InfoFilter())
     messagelog_handler.setLevel(VERBOSITY_MAP[app.verbosity])
     messagelog_handler.setFormatter(ColorizeFormatter())

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -223,13 +223,13 @@ def _restify_py36(cls: Optional[Type]) -> str:
         else:
             reftext = ':class:`%s`' % qualname
 
-        if cls.__args__ is None or len(cls.__args__) <= 2:  # type: ignore  # NOQA
-            params = cls.__args__  # type: ignore
-        elif cls.__origin__ == Generator:  # type: ignore
-            params = cls.__args__  # type: ignore
+        if cls.__args__ is None or len(cls.__args__) <= 2:
+            params = cls.__args__
+        elif cls.__origin__ == Generator:
+            params = cls.__args__
         else:  # typing.Callable
-            args = ', '.join(restify(arg) for arg in cls.__args__[:-1])  # type: ignore
-            result = restify(cls.__args__[-1])  # type: ignore
+            args = ', '.join(restify(arg) for arg in cls.__args__[:-1])
+            result = restify(cls.__args__[-1])
             return reftext + '\\ [[%s], %s]' % (args, result)
 
         if params:


### PR DESCRIPTION
Subject: Fix mypy violations (delete type: ignore ) (with mypy-0.900)

### Feature or Bugfix
- Refactoring

### Purpose

Fix mypy violations (delete type: ignore ) (with mypy-0.900)


### Detail

Remove "type: ignore" from the following files
* sphinx/util/logging.py
* sphinx/util/typing.py

github actions error 
Excerpt.

```
sphinx/util/logging.py:576: error: unused "type: ignore" comment
sphinx/util/logging.py:582: error: unused "type: ignore" comment
sphinx/util/logging.py:590: error: unused "type: ignore" comment
sphinx/util/typing.py:226: error: unused "type: ignore" comment
sphinx/util/typing.py:227: error: unused "type: ignore" comment
sphinx/util/typing.py:228: error: unused "type: ignore" comment
sphinx/util/typing.py:229: error: unused "type: ignore" comment
sphinx/util/typing.py:231: error: unused "type: ignore" comment
sphinx/util/typing.py:232: error: unused "type: ignore" comment
```

### Relates
- None

