### PR TITLE
Fix #9330: versionchanged causes error during pdf build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9330: changeset domain: :rst:dir:`versionchanged` with contents being a list
+  will cause error during pdf build
 * #9313: LaTeX: complex table with merged cells broken since 4.0
 
 Testing

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -74,8 +74,10 @@ class VersionChange(SphinxDirective):
         if self.content:
             self.state.nested_parse(self.content, self.content_offset, node)
         classes = ['versionmodified', versionlabel_classes[self.name]]
-        if len(node):
-            if isinstance(node[0], nodes.paragraph) and node[0].rawsource:
+        if len(node) > 0 and isinstance(node[0], nodes.paragraph):
+            # the contents start with a paragraph
+            if node[0].rawsource:
+                # make the first paragraph translatable
                 content = nodes.inline(node[0].rawsource, translatable=True)
                 content.source = node[0].source
                 content.line = node[0].line
@@ -84,10 +86,16 @@ class VersionChange(SphinxDirective):
 
             para = cast(nodes.paragraph, node[0])
             para.insert(0, nodes.inline('', '%s: ' % text, classes=classes))
-        else:
+        elif len(node) > 0:
+            # the contents do not starts with a paragraph
             para = nodes.paragraph('', '',
-                                   nodes.inline('', '%s.' % text,
-                                                classes=classes),
+                                   nodes.inline('', '%s: ' % text, classes=classes),
+                                   translatable=False)
+            node.insert(0, para)
+        else:
+            # the contents are empty
+            para = nodes.paragraph('', '',
+                                   nodes.inline('', '%s.' % text, classes=classes),
                                    translatable=False)
             node.append(para)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The versionchanged directive breaks doctree if its contents start with
non-paragraph element (ex. lists, tables, and so on).  It causes build
error in LaTeX.
- This inserts a paragraph if the first child of the contents is not a
paragraph not to break doctree.
- refs: #9330