### PR TITLE
Fix sphinx-doc#9322: KeyError is raised on PropagateDescDomain transform

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #9313: LaTeX: complex table with merged cells broken since 4.0
+* #9322: KeyError is raised on PropagateDescDomain transform
 
 Testing
 --------

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -249,7 +249,8 @@ class PropagateDescDomain(SphinxPostTransform):
 
     def run(self, **kwargs: Any) -> None:
         for node in self.document.traverse(addnodes.desc_signature):
-            node['classes'].append(node.parent['domain'])
+            if node.parent.get('domain'):
+                node['classes'].append(node.parent['domain'])
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- PropageteDescDomain applies the domain name from the "domain" attribute
of parent node (desc node) to the desc_signature node.  The structure
has longly generated by ObjectDescription.  But it must not be a new
rule.
- This allows to build document that contains non standard doctree.
- refs: #9322
