### PR TITLE
Fix #9305 LaTeX: backslash in sphinxupquote error with Japanese

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Bugs fixed
 * #9330: changeset domain: :rst:dir:`versionchanged` with contents being a list
   will cause error during pdf build
 * #9313: LaTeX: complex table with merged cells broken since 4.0
+* #9305: LaTeX: backslash may cause Improper discretionary list pdf build error
+  with Japanese engines
 
 Testing
 --------

--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -765,7 +765,8 @@
       % break at . , ; ? ! /
       \sphinxbreaksviaactive
       % break also at \
-      \let\sphinx@textbackslash\textbackslash
+      \setbox8=\hbox{\textbackslash}%
+      \def\sphinx@textbackslash{\copy8}%
       \let\textbackslash\sphinxtextbackslash
       % by default, no continuation symbol on next line but may be added
       \let\sphinxafterbreak\sphinxafterbreakofinlineliteral


### PR DESCRIPTION

### Relates
- Fix #9305 

