### PR TITLE
Fix #9032: docs: sphinx.environment.NoUri was removed at v3.0.0

### DIFF
--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -750,8 +750,9 @@ The following is a list of deprecated interfaces.
 
    * - ``sphinx.environment.NoUri``
      - 2.1
-     - 4.0
+     - 3.0
      - ``sphinx.errors.NoUri``
+
    * - ``sphinx.ext.apidoc.format_directive()``
      - 2.1
      - 4.0


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Our deprecation list describes `sphinx.environment.NoUri` was removed at
v4.0.0.  But, acutally, it was removed at v3.0.0 (#6223).
- refs: #9032 