### PR TITLE
Update example to use recommended usage

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -1673,7 +1673,7 @@ There is a set of directives allowing documenting command-line programs:
 
       .. program:: svn
 
-      .. option:: -r revision
+      .. option:: -r <revision>
 
          Specify the revision to work upon.
 


### PR DESCRIPTION
Subject: The docs recommend enclosing option-arguments in angle brackets, but the very next example code block shows an option-argument not in angle brackets.

### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- The docs recommend enclosing option-arguments in angle brackets, but the very next example code block shows an option-argument not in angle brackets.

### Detail
- adds angle brackets to the aforementioned option-argument

### Relates
- https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#directive-option

