### PR TITLE
Fix :samp:`{var}` in manual pages.

### DIFF
--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -59,13 +59,16 @@ class NestedInlineTransform:
         for node in self.document.traverse(matcher):  # type: TextElement
             if any(matcher(subnode) for subnode in node):
                 pos = node.parent.index(node)
-                for subnode in reversed(node[1:]):
+                for subnode in reversed(list(node)):
                     node.remove(subnode)
                     if matcher(subnode):
                         node.parent.insert(pos + 1, subnode)
                     else:
                         newnode = node.__class__('', '', subnode, **node.attributes)
                         node.parent.insert(pos + 1, newnode)
+                # move node if all children became siblings of the node
+                if not len(node):
+                    node.parent.remove(node)
 
 
 class ManualPageTranslator(SphinxTranslator, BaseTranslator):

--- a/tests/roots/test-root/lists.txt
+++ b/tests/roots/test-root/lists.txt
@@ -61,3 +61,10 @@ term1
 
 term2 (**stronged partially**)
     description
+
+Samp tests
+----------
+
+:samp:`{variable_only}`
+:samp:`{variable} and text`
+:samp:`Show {variable} in the middle`

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -27,6 +27,11 @@ def test_all(app, status, warning):
     assert '\n.B term1\n' in content
     assert '\nterm2 (\\fBstronged partially\\fP)\n' in content
 
+    # test samp with braces
+    assert '\n\\fIvariable_only\\fP\n' in content
+    assert '\n\\fIvariable\\fP\\fB and text\\fP\n' in content
+    assert '\n\\fBShow \\fP\\fIvariable\\fP\\fB in the middle\\fP\n' in content
+
     assert 'Footnotes' not in content
 
 


### PR DESCRIPTION
When a samp begins with a variable part, it is not unwrapped for manual
pages.

Fixes #1860.
