### PR TITLE
Fix link to third-party extensions in front page

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -33,7 +33,7 @@
     <li>{%trans path=pathto('ext/builtins')%}<b>Extensions:</b> automatic testing of code snippets, inclusion of
       docstrings from Python modules (API docs), and
       <a href="{{ path }}#builtin-sphinx-extensions">more</a>{%endtrans%}</li>
-    <li>{%trans path=pathto("usage/extensions")%}<b>Contributed extensions:</b> dozens of
+    <li>{%trans path=pathto("usage/extensions/index")%}<b>Contributed extensions:</b> dozens of
       extensions <a href="{{ path }}#third-party-extensions">contributed by users</a>;
       most of them installable from PyPI{%endtrans%}</li>
   </ul>


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix link to third-party extensions in front page, which has been broken (I think) since #7774 was merged in January this year.

