### PR TITLE
Provide more semantic structure for screen-readers

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -415,7 +415,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
     # overwritten
     def visit_title(self, node: Element) -> None:
         if isinstance(node.parent, addnodes.compact_paragraph) and node.parent.get('toctree'):
-            self.body.append(self.starttag(node, 'p', '', CLASS='caption'))
+            self.body.append(self.starttag(node, 'p', '', CLASS='caption', ROLE='heading'))
             self.body.append('<span class="caption-text">')
             self.context.append('</span></p>\n')
         else:

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -366,7 +366,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     # overwritten
     def visit_title(self, node: Element) -> None:
         if isinstance(node.parent, addnodes.compact_paragraph) and node.parent.get('toctree'):
-            self.body.append(self.starttag(node, 'p', '', CLASS='caption'))
+            self.body.append(self.starttag(node, 'p', '', CLASS='caption', ROLE='heading'))
             self.body.append('<span class="caption-text">')
             self.context.append('</span></p>\n')
         else:

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -622,7 +622,7 @@ def test_html_meta(app):
     assert expected_expr in result
     expected_expr = '<meta content="I18N, SPHINX, MARKUP" name="keywords" />'
     assert expected_expr in result
-    expected_expr = '<p class="caption"><span class="caption-text">HIDDEN TOC</span></p>'
+    expected_expr = '<p class="caption" role="heading"><span class="caption-text">HIDDEN TOC</span></p>'
     assert expected_expr in result
 
 


### PR DESCRIPTION
Subject: Fix menu narration for sceen-readers

### Feature or Bugfix

Accessibility bugfix

### Purpose

The use of `<p>` for submenu captions lacks semantic information. Screen-readers don't narrate the menu correctly. This PR adds role="heading" to the caption as an ARIA landmark.

### Detail

I don't yet know how to test my changes locally, so there may be errors. Please advise if I got it wrong.

### Relates

Fixes https://github.com/sphinx-doc/sphinx/issues/8989

Accessibility technique described in https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA12
