### PR TITLE
C++, requires expressions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,9 @@ Features added
     (e.g., ``Sortable auto &v``).
 
 * C, add support for digit separators in literals.
+* #7296: C++, add experimental support for non-parametrised requires
+  expressions. Permalinks to entities where they are used may currently not be
+  unique, and they will not be stable for future versions.
 
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -65,8 +65,8 @@ Features added
     (e.g., ``Sortable auto &v``).
 
 * C, add support for digit separators in literals.
-* #7296: C++, add experimental support for non-parametrised requires
-  expressions. Permalinks to entities where they are used may currently not be
+* #7296: C++, add experimental support for requires expressions.
+  Permalinks to entities where they are used may currently not be
   unique, and they will not be stable for future versions.
 
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -1132,7 +1132,7 @@ class ASTRequiresExpression(ASTExpression):
         if version <= 3:
             raise NoOldIdError
         elif version == 4:
-            return "missing-requires-expression-mangling--dont-rely-on-this-link"
+            return "missing_requires_expression_mangling__dont_rely_on_this_link"
         assert False
 
     def describe_signature(self, signode: TextElement, mode: str,
@@ -5383,7 +5383,7 @@ class Symbol:
         if expr.params is None:
             return
 
-        name = "__requires-expression-dont-rely-on-this-link{}"
+        name = "__requires_expression__dont_rely_on_this_link{}"
         name = name.format(env.new_serialno('cpp-requires-expr'))
         nn = ASTNestedName([ASTNestedNameElement(ASTIdentifier(name), None)], [False], False)
         decl = ASTDeclaration(objectType='requiresExpression', directiveType=None,

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -2322,12 +2322,12 @@ class ASTNoexceptSpec(ASTBase):
 
 
 class ASTParametersQualifiers(ASTBase):
-    def __init__(self, args: List[ASTFunctionParameter], volatile: bool, const: bool,
+    def __init__(self, params: List[ASTFunctionParameter], volatile: bool, const: bool,
                  refQual: Optional[str], exceptionSpec: Optional[ASTNoexceptSpec],
                  trailingReturn: Optional["ASTType"],
                  override: bool, final: bool, attrs: List[ASTAttribute],
                  initializer: Optional[str]) -> None:
-        self.args = args
+        self.params = params
         self.volatile = volatile
         self.const = const
         self.refQual = refQual
@@ -2340,7 +2340,7 @@ class ASTParametersQualifiers(ASTBase):
 
     @property
     def function_params(self) -> List[ASTFunctionParameter]:
-        return self.args
+        return self.params
 
     def get_modifiers_id(self, version: int) -> str:
         res = []
@@ -2359,18 +2359,18 @@ class ASTParametersQualifiers(ASTBase):
 
     def get_param_id(self, version: int) -> str:
         if version == 1:
-            if len(self.args) == 0:
+            if len(self.params) == 0:
                 return ''
             else:
-                return '__' + '.'.join(a.get_id(version) for a in self.args)
-        if len(self.args) == 0:
+                return '__' + '.'.join(a.get_id(version) for a in self.params)
+        if len(self.params) == 0:
             return 'v'
         else:
-            return ''.join(a.get_id(version) for a in self.args)
+            return ''.join(a.get_id(version) for a in self.params)
 
     @property
     def requires_expressions(self) -> Generator["ASTRequiresExpression", None, None]:
-        for a in self.args:
+        for a in self.params:
             yield from a.requires_expressions
         if self.exceptionSpec is not None:
             yield from self.exceptionSpec.requires_expressions
@@ -2381,7 +2381,7 @@ class ASTParametersQualifiers(ASTBase):
         res = []
         res.append('(')
         first = True
-        for a in self.args:
+        for a in self.params:
             if not first:
                 res.append(', ')
             first = False
@@ -2418,7 +2418,7 @@ class ASTParametersQualifiers(ASTBase):
         # only use the desc_parameterlist for the outer list, not for inner lists
         if mode == 'lastIsName':
             paramlist = addnodes.desc_parameterlist()
-            for arg in self.args:
+            for arg in self.params:
                 param = addnodes.desc_parameter('', '', noemph=True)
                 arg.describe_signature(param, 'param', env, symbol=symbol)
                 paramlist += param
@@ -2426,7 +2426,7 @@ class ASTParametersQualifiers(ASTBase):
         else:
             signode += addnodes.desc_sig_punctuation('(', '(')
             first = True
-            for arg in self.args:
+            for arg in self.params:
                 if not first:
                     signode += addnodes.desc_sig_punctuation(',', ',')
                     signode += addnodes.desc_sig_space()

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -120,7 +120,7 @@ p.admonition-title {
   font-weight: bold;
 }
 
-dt:target, .highlighted {
+dt:target, .highlighted, .sig span:target {
   background-color: #fbe54e;
 }
 

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -678,7 +678,7 @@ dl > dd:last-child > :last-child {
     margin-bottom: 0;
 }
 
-dt:target, span.highlighted {
+dt:target, span.highlighted, .sig span:target {
     background-color: #fbe54e;
 }
 

--- a/sphinx/themes/epub/static/epub.css_t
+++ b/sphinx/themes/epub/static/epub.css_t
@@ -470,7 +470,7 @@ dd {
     margin-left: 30px;
 }
 
-dt:target, .highlighted {
+dt:target, .highlighted, .sig span:target {
     background-color: #ddd;
 }
 

--- a/sphinx/themes/nonav/static/nonav.css
+++ b/sphinx/themes/nonav/static/nonav.css
@@ -378,7 +378,7 @@ dd {
     margin-left: 30px;
 }
 
-dt:target, .highlighted {
+dt:target, .highlighted, .sig span:target {
     background-color: #ddd;
 }
 

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -371,7 +371,7 @@ def test_domain_cpp_ast_expressions():
 
     # requires expressions
     # --------------------
-    requires_v4_id = 'missing-requires-expression-mangling--dont-rely-on-this-link'
+    requires_v4_id = 'missing_requires_expression_mangling__dont_rely_on_this_link'
     # non-parametrised
     exprCheck('requires {{}}', None, requires_v4_id)
     exprCheck('requires {{ typename T::type; }}', None, requires_v4_id)

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -37,6 +37,14 @@ def parse(name, string):
     return ast
 
 
+class MockEnv:
+    i = 0
+
+    def new_serialno(self, category: str = '') -> int:
+        MockEnv.i += 1
+        return MockEnv.i - 1
+
+
 def _check(name, input, idDict, output, key, asTextOutput):
     if key is None:
         key = name
@@ -61,8 +69,8 @@ def _check(name, input, idDict, output, key, asTextOutput):
         print("Result:   ", res)
         print("Expected: ", outputAst)
         raise DefinitionError("")
-    rootSymbol = Symbol(None, None, None, None, None, None, None)
-    symbol = rootSymbol.add_declaration(ast, docname="TestDoc", line=42)
+    rootSymbol = Symbol(None, None, None, None, None, None, None, None)
+    symbol = rootSymbol.add_declaration(ast, docname="TestDoc", line=42, env=MockEnv())
     parentNode = addnodes.desc()
     signode = addnodes.desc_signature(input, '')
     parentNode += signode

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -362,7 +362,9 @@ def test_domain_cpp_ast_expressions():
     exprCheck('a(b(c, 1 + d...)..., e(f..., g))', 'cl1aspcl1b1cspplL1E1dEcl1esp1f1gEE')
 
     # requires expressions
+    # --------------------
     requires_v4_id = 'missing-requires-expression-mangling--dont-rely-on-this-link'
+    # non-parametrised
     exprCheck('requires {{}}', None, requires_v4_id)
     exprCheck('requires {{ typename T::type; }}', None, requires_v4_id)
     exprCheck('requires {{ {{ a++ }}; }}', None, requires_v4_id)
@@ -375,6 +377,8 @@ def test_domain_cpp_ast_expressions():
               ' {{ a++ }} noexcept -> int;'
               ' requires C<T>;'
               ' a++; }}', None, requires_v4_id)
+    # parametrised
+    exprCheck('requires(T a) {{}}', None, requires_v4_id)
 
 
 def test_domain_cpp_ast_type_definitions():


### PR DESCRIPTION
This PR is at the moment only for testing purposes. See the last point of the "Details" section.

### Feature or Bugfix
- Feature

### Purpose
Add support for [requires expressions](https://en.cppreference.com/w/cpp/language/constraints) in the C++ domain.

### Detail
- Both non-parametrised and parametrised expressions are suppoprted, both in declarations and in ``cpp:expr`` roles.
- Links to parameters in parametrised expresisons will use serial numbers for the IDs. Therefore, as opposed to all other IDs, these links are not stable when permuting elements of a document/page.
- There is no proper name mangling of the expressions, and the IDs therefore contain substrings ``missing_requires_expression_mangling__dont_rely_on_this_link``, and if the requires expression is the only element to disambiguate between two declarations, then there will be a "duplicate declaration" warning.
  Once the compilers know how to mangle these expressions, this PR can be updated.
  Example to test a compiler:
  ```c++
  // Construct where the requires expression needs mangling
  template<typename T>
  decltype(requires { typename T::blah; }) f() { return true; }

  struct A { 
      using type = int;
  };

  void g() {
      f<A>();
  }
  ```


### Relates
Fixes #7296.

