### PR TITLE
C++ (and C), various additions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -58,7 +58,8 @@ Features added
   - ``inline`` variables,
   - ``consteval`` functions,
   - ``constinit`` variables,
-  - ``char8_t``.
+  - ``char8_t``,
+  - ``explicit(<constant expression>)`` specifier.
 
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -53,7 +53,11 @@ Features added
 * #9097: Optimize the paralell build
 * #9131: Add :confval:`nitpick_ignore_regex` to ignore nitpicky warnings using
   regular expressions
-* C++, add support for inline variables.
+* C++, add support for
+
+  - ``inline`` variables,
+  - ``consteval`` functions,
+  - ``constinit`` variables.
 
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -59,7 +59,10 @@ Features added
   - ``consteval`` functions,
   - ``constinit`` variables,
   - ``char8_t``,
-  - ``explicit(<constant expression>)`` specifier.
+  - ``explicit(<constant expression>)`` specifier,
+  - digit separators in literals.
+
+* C, add support for digit separators in literals.
 
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,7 @@ Features added
 * #9097: Optimize the paralell build
 * #9131: Add :confval:`nitpick_ignore_regex` to ignore nitpicky warnings using
   regular expressions
+* C++, add support for inline variables.
 
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -57,7 +57,8 @@ Features added
 
   - ``inline`` variables,
   - ``consteval`` functions,
-  - ``constinit`` variables.
+  - ``constinit`` variables,
+  - ``char8_t``.
 
 
 Bugs fixed

--- a/CHANGES
+++ b/CHANGES
@@ -60,7 +60,9 @@ Features added
   - ``constinit`` variables,
   - ``char8_t``,
   - ``explicit(<constant expression>)`` specifier,
-  - digit separators in literals.
+  - digit separators in literals, and
+  - constraints in placeholder type specifiers, aka. adjective syntax
+    (e.g., ``Sortable auto &v``).
 
 * C, add support for digit separators in literals.
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -5957,12 +5957,13 @@ class DefinitionParser(BaseParser):
                 if threadLocal:
                     continue
 
+            if not inline and outer in ('function', 'member'):
+                inline = self.skip_word('inline')
+                if inline:
+                    continue
+
             if outer == 'function':
                 # function-specifiers
-                if not inline:
-                    inline = self.skip_word('inline')
-                    if inline:
-                        continue
                 if not friend:
                     friend = self.skip_word('friend')
                     if friend:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -319,8 +319,8 @@ _fold_operator_re = re.compile(r'''(?x)
 # see https://en.cppreference.com/w/cpp/keyword
 _keywords = [
     'alignas', 'alignof', 'and', 'and_eq', 'asm', 'auto', 'bitand', 'bitor',
-    'bool', 'break', 'case', 'catch', 'char', 'char16_t', 'char32_t', 'class',
-    'compl', 'concept', 'const', 'consteval', 'constexpr', 'constinit',
+    'bool', 'break', 'case', 'catch', 'char', 'char8_t', 'char16_t', 'char32_t',
+    'class', 'compl', 'concept', 'const', 'consteval', 'constexpr', 'constinit',
     'const_cast', 'continue',
     'decltype', 'default', 'delete', 'do', 'double', 'dynamic_cast', 'else',
     'enum', 'explicit', 'export', 'extern', 'false', 'float', 'for', 'friend',
@@ -427,6 +427,7 @@ _id_fundamental_v2 = {
     'wchar_t': 'w',
     'char32_t': 'Di',
     'char16_t': 'Ds',
+    'char8_t': 'Du',
     'short': 's',
     'short int': 's',
     'signed short': 's',
@@ -4956,8 +4957,8 @@ class DefinitionParser(BaseParser):
     # those without signedness and size modifiers
     # see https://en.cppreference.com/w/cpp/language/types
     _simple_fundemental_types = (
-        'void', 'bool', 'char', 'wchar_t', 'char16_t', 'char32_t', 'int',
-        'float', 'double', 'auto'
+        'void', 'bool', 'char', 'wchar_t', 'char8_t', 'char16_t', 'char32_t',
+        'int', 'float', 'double', 'auto'
     )
 
     _prefix_keys = ('class', 'struct', 'enum', 'union', 'typename')

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -33,10 +33,10 @@ identifier_re = re.compile(r'''(?x)
     )
     [a-zA-Z0-9_]*\b
 ''')
-integer_literal_re = re.compile(r'[1-9][0-9]*')
-octal_literal_re = re.compile(r'0[0-7]*')
-hex_literal_re = re.compile(r'0[xX][0-9a-fA-F][0-9a-fA-F]*')
-binary_literal_re = re.compile(r'0[bB][01][01]*')
+integer_literal_re = re.compile(r'[1-9][0-9]*(\'[0-9]+)*')
+octal_literal_re = re.compile(r'0[0-7]*(\'[0-7]+)*')
+hex_literal_re = re.compile(r'0[xX][0-9a-fA-F]+(\'[0-9a-fA-F]+)*')
+binary_literal_re = re.compile(r'0[bB][01]+(\'[01]+)*')
 integers_literal_suffix_re = re.compile(r'''(?x)
     # unsigned and/or (long) long, in any order, but at least one of them
     (
@@ -50,13 +50,14 @@ integers_literal_suffix_re = re.compile(r'''(?x)
 float_literal_re = re.compile(r'''(?x)
     [+-]?(
     # decimal
-      ([0-9]+[eE][+-]?[0-9]+)
-    | ([0-9]*\.[0-9]+([eE][+-]?[0-9]+)?)
-    | ([0-9]+\.([eE][+-]?[0-9]+)?)
+      ([0-9]+(\'[0-9]+)*[eE][+-]?[0-9]+(\'[0-9]+)*)
+    | (([0-9]+(\'[0-9]+)*)?\.[0-9]+(\'[0-9]+)*([eE][+-]?[0-9]+(\'[0-9]+)*)?)
+    | ([0-9]+(\'[0-9]+)*\.([eE][+-]?[0-9]+(\'[0-9]+)*)?)
     # hex
-    | (0[xX][0-9a-fA-F]+[pP][+-]?[0-9a-fA-F]+)
-    | (0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9a-fA-F]+)?)
-    | (0[xX][0-9a-fA-F]+\.([pP][+-]?[0-9a-fA-F]+)?)
+    | (0[xX][0-9a-fA-F]+(\'[0-9a-fA-F]+)*[pP][+-]?[0-9a-fA-F]+(\'[0-9a-fA-F]+)*)
+    | (0[xX]([0-9a-fA-F]+(\'[0-9a-fA-F]+)*)?\.
+        [0-9a-fA-F]+(\'[0-9a-fA-F]+)*([pP][+-]?[0-9a-fA-F]+(\'[0-9a-fA-F]+)*)?)
+    | (0[xX][0-9a-fA-F]+(\'[0-9a-fA-F]+)*\.([pP][+-]?[0-9a-fA-F]+(\'[0-9a-fA-F]+)*)?)
     )
 ''')
 float_literal_suffix_re = re.compile(r'[fFlL]\b')

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -155,7 +155,8 @@ def test_domain_c_ast_expressions():
     # primary
     exprCheck('true')
     exprCheck('false')
-    ints = ['5', '0', '075', '0x0123456789ABCDEF', '0XF', '0b1', '0B1']
+    ints = ['5', '0', '075', '0x0123456789ABCDEF', '0XF', '0b1', '0B1',
+            "0b0'1'0", "00'1'2", "0x0'1'2", "1'2'3"]
     unsignedSuffix = ['', 'u', 'U']
     longSuffix = ['', 'l', 'L', 'll', 'LL']
     for i in ints:
@@ -170,14 +171,18 @@ def test_domain_c_ast_expressions():
                 '5e42', '5e+42', '5e-42',
                 '5.', '5.e42', '5.e+42', '5.e-42',
                 '.5', '.5e42', '.5e+42', '.5e-42',
-                '5.0', '5.0e42', '5.0e+42', '5.0e-42']:
+                '5.0', '5.0e42', '5.0e+42', '5.0e-42',
+                "1'2'3e7'8'9", "1'2'3.e7'8'9",
+                ".4'5'6e7'8'9", "1'2'3.4'5'6e7'8'9"]:
             expr = e + suffix
             exprCheck(expr)
         for e in [
                 'ApF', 'Ap+F', 'Ap-F',
                 'A.', 'A.pF', 'A.p+F', 'A.p-F',
                 '.A', '.ApF', '.Ap+F', '.Ap-F',
-                'A.B', 'A.BpF', 'A.Bp+F', 'A.Bp-F']:
+                'A.B', 'A.BpF', 'A.Bp+F', 'A.Bp-F',
+                "A'B'Cp1'2'3", "A'B'C.p1'2'3",
+                ".D'E'Fp1'2'3", "A'B'C.D'E'Fp1'2'3"]:
             expr = "0x" + e + suffix
             exprCheck(expr)
     exprCheck('"abc\\"cba"')  # string

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -436,6 +436,7 @@ def test_domain_cpp_ast_member_definitions():
     check('member', 'int b : 1 || new int{0}', {1: 'b__i', 2: '1b'})
 
     check('member', 'inline int n', {1: 'n__i', 2: '1n'})
+    check('member', 'constinit int n', {1: 'n__i', 2: '1n'})
 
 
 def test_domain_cpp_ast_function_definitions():
@@ -567,6 +568,7 @@ def test_domain_cpp_ast_function_definitions():
     check("function", "void f(int *volatile const p)", {1: "f__iPVC", 2: "1fPVCi"})
 
     check('function', 'extern int f()', {1: 'f', 2: '1fv'})
+    check('function', 'consteval int f()', {1: 'f', 2: '1fv'})
 
     check('function', 'decltype(auto) f()', {1: 'f', 2: "1fv"})
 

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -174,7 +174,8 @@ def test_domain_cpp_ast_expressions():
     exprCheck('nullptr', 'LDnE')
     exprCheck('true', 'L1E')
     exprCheck('false', 'L0E')
-    ints = ['5', '0', '075', '0x0123456789ABCDEF', '0XF', '0b1', '0B1']
+    ints = ['5', '0', '075', '0x0123456789ABCDEF', '0XF', '0b1', '0B1',
+            "0b0'1'0", "00'1'2", "0x0'1'2", "1'2'3"]
     unsignedSuffix = ['', 'u', 'U']
     longSuffix = ['', 'l', 'L', 'll', 'LL']
     for i in ints:
@@ -187,11 +188,15 @@ def test_domain_cpp_ast_expressions():
     decimalFloats = ['5e42', '5e+42', '5e-42',
                      '5.', '5.e42', '5.e+42', '5.e-42',
                      '.5', '.5e42', '.5e+42', '.5e-42',
-                     '5.0', '5.0e42', '5.0e+42', '5.0e-42']
+                     '5.0', '5.0e42', '5.0e+42', '5.0e-42',
+                     "1'2'3e7'8'9", "1'2'3.e7'8'9",
+                     ".4'5'6e7'8'9", "1'2'3.4'5'6e7'8'9"]
     hexFloats = ['ApF', 'Ap+F', 'Ap-F',
                  'A.', 'A.pF', 'A.p+F', 'A.p-F',
                  '.A', '.ApF', '.Ap+F', '.Ap-F',
-                 'A.B', 'A.BpF', 'A.Bp+F', 'A.Bp-F']
+                 'A.B', 'A.BpF', 'A.Bp+F', 'A.Bp-F',
+                 "A'B'Cp1'2'3", "A'B'C.p1'2'3",
+                 ".D'E'Fp1'2'3", "A'B'C.D'E'Fp1'2'3"]
     for suffix in ['', 'f', 'F', 'l', 'L']:
         for e in decimalFloats:
             expr = e + suffix

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -435,6 +435,8 @@ def test_domain_cpp_ast_member_definitions():
     # check('member', 'int b : (true ? 8 : a) = 42', {1: 'b__i', 2: '1b'})
     check('member', 'int b : 1 || new int{0}', {1: 'b__i', 2: '1b'})
 
+    check('member', 'inline int n', {1: 'n__i', 2: '1n'})
+
 
 def test_domain_cpp_ast_function_definitions():
     check('function', 'void f(volatile int)', {1: "f__iV", 2: "1fVi"})

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -866,6 +866,15 @@ def test_domain_cpp_ast_templates():
     check('type', 'template<C T = int&> {key}A', {2: 'I_1CE1A'}, key='using')
 
 
+def test_domain_cpp_ast_placeholder_types():
+    check('function', 'void f(Sortable auto &v)', {1: 'f__SortableR', 2: '1fR8Sortable'})
+    check('function', 'void f(const Sortable auto &v)', {1: 'f__SortableCR', 2: '1fRK8Sortable'})
+    check('function', 'void f(Sortable decltype(auto) &v)', {1: 'f__SortableR', 2: '1fR8Sortable'})
+    check('function', 'void f(const Sortable decltype(auto) &v)', {1: 'f__SortableCR', 2: '1fRK8Sortable'})
+    check('function', 'void f(Sortable decltype ( auto ) &v)', {1: 'f__SortableR', 2: '1fR8Sortable'},
+          output='void f(Sortable decltype(auto) &v)')
+
+
 def test_domain_cpp_ast_requires_clauses():
     check('function', 'template<typename T> requires A auto f() -> void requires B',
           {4: 'I0EIQaa1A1BE1fvv'})

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -571,6 +571,8 @@ def test_domain_cpp_ast_function_definitions():
     check('function', 'extern int f()', {1: 'f', 2: '1fv'})
     check('function', 'consteval int f()', {1: 'f', 2: '1fv'})
 
+    check('function', 'explicit(true) void f()', {1: 'f', 2: '1fv'})
+
     check('function', 'decltype(auto) f()', {1: 'f', 2: "1fv"})
 
     # TODO: make tests for functions in a template, e.g., Test<int&&()>

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -126,6 +126,7 @@ def test_domain_cpp_ast_fundamental_types():
             id = t.replace(" ", "-").replace("long", "l").replace("int", "i")
             id = id.replace("bool", "b").replace("char", "c")
             id = id.replace("wc_t", "wchar_t").replace("c16_t", "char16_t")
+            id = id.replace("c8_t", "char8_t")
             id = id.replace("c32_t", "char32_t")
             return "f__%s" % id
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
* C++, add support for
  - ``inline`` variables,
  - ``consteval`` functions,
  - ``constinit`` variables,
  - ``char8_t``,
  - ``explicit(<constant expression>)`` specifier,
  - digit separators in literals, and
  - constraints in placeholder type specifiers, aka. adjective syntax (e.g., ``Sortable auto &v``).
* C, add support for digit separators in literals.

