### PR TITLE
C++, fixes for recent additions

### DIFF
--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -869,7 +869,7 @@ class ASTNumberLiteral(ASTLiteral):
 
     def get_id(self, version: int) -> str:
         # TODO: floats should be mangled by writing the hex of the binary representation
-        return "L%sE" % self.data
+        return "L%sE" % self.data.replace("'", "")
 
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7895,7 +7895,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     return {
         'version': 'builtin',
-        'env_version': 3,
+        'env_version': 4,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -182,9 +182,9 @@ def test_domain_cpp_ast_expressions():
         for u in unsignedSuffix:
             for l in longSuffix:
                 expr = i + u + l
-                exprCheck(expr, 'L' + expr + 'E')
+                exprCheck(expr, 'L' + expr.replace("'", "") + 'E')
                 expr = i + l + u
-                exprCheck(expr, 'L' + expr + 'E')
+                exprCheck(expr, 'L' + expr.replace("'", "") + 'E')
     decimalFloats = ['5e42', '5e+42', '5e-42',
                      '5.', '5.e42', '5.e+42', '5.e-42',
                      '.5', '.5e42', '.5e+42', '.5e-42',
@@ -200,10 +200,10 @@ def test_domain_cpp_ast_expressions():
     for suffix in ['', 'f', 'F', 'l', 'L']:
         for e in decimalFloats:
             expr = e + suffix
-            exprCheck(expr, 'L' + expr + 'E')
+            exprCheck(expr, 'L' + expr.replace("'", "") + 'E')
         for e in hexFloats:
             expr = "0x" + e + suffix
-            exprCheck(expr, 'L' + expr + 'E')
+            exprCheck(expr, 'L' + expr.replace("'", "") + 'E')
     exprCheck('"abc\\"cba"', 'LA8_KcE')  # string
     exprCheck('this', 'fpT')
     # character literals
@@ -216,13 +216,13 @@ def test_domain_cpp_ast_expressions():
             exprCheck("{}'{}'".format(p, c), t + val)
     # user-defined literals
     for i in ints:
-        exprCheck(i + '_udl', 'clL_Zli4_udlEL' + i + 'EE')
-        exprCheck(i + 'uludl', 'clL_Zli5uludlEL' + i + 'EE')
+        exprCheck(i + '_udl', 'clL_Zli4_udlEL' + i.replace("'", "") + 'EE')
+        exprCheck(i + 'uludl', 'clL_Zli5uludlEL' + i.replace("'", "") + 'EE')
     for f in decimalFloats:
-        exprCheck(f + '_udl', 'clL_Zli4_udlEL' + f + 'EE')
-        exprCheck(f + 'fudl', 'clL_Zli4fudlEL' + f + 'EE')
+        exprCheck(f + '_udl', 'clL_Zli4_udlEL' + f.replace("'", "") + 'EE')
+        exprCheck(f + 'fudl', 'clL_Zli4fudlEL' + f.replace("'", "") + 'EE')
     for f in hexFloats:
-        exprCheck('0x' + f + '_udl', 'clL_Zli4_udlEL0x' + f + 'EE')
+        exprCheck('0x' + f + '_udl', 'clL_Zli4_udlEL0x' + f.replace("'", "") + 'EE')
     for p, t in charPrefixAndIds:
         for c, val in chars:
             exprCheck("{}'{}'_udl".format(p, c), 'clL_Zli4_udlE' + t + val + 'E')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
For #9379, fix name mangling to not include digit separators and update env version to invalidate previous pickled ASTs.

