### PR TITLE
texinfo: improve variable in :samp: directives

### DIFF
--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -194,6 +194,7 @@ class TexinfoTranslator(SphinxTranslator):
         self.curfilestack: List[str] = []
         self.footnotestack: List[Dict[str, List[Union[collected_footnote, bool]]]] = []  # NOQA
         self.in_footnote = 0
+        self.in_samp = 0
         self.handled_abbrs: Set[str] = set()
         self.colwidths: List[int] = None
 
@@ -809,15 +810,23 @@ class TexinfoTranslator(SphinxTranslator):
         self.body.append('}')
 
     def visit_emphasis(self, node: Element) -> None:
-        self.body.append('@emph{')
+        element = 'emph' if not self.in_samp else 'var'
+        self.body.append('@%s{' % element)
 
     def depart_emphasis(self, node: Element) -> None:
         self.body.append('}')
 
+    def is_samp(self, node: Element) -> bool:
+        return 'samp' in node['classes']
+
     def visit_literal(self, node: Element) -> None:
+        if self.is_samp(node):
+            self.in_samp += 1
         self.body.append('@code{')
 
     def depart_literal(self, node: Element) -> None:
+        if self.is_samp(node):
+            self.in_samp -= 1
         self.body.append('}')
 
     def visit_superscript(self, node: Element) -> None:

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -112,3 +112,14 @@ def test_texinfo_escape_id(app, status, warning):
     assert translator.escape_id('Hello(world)') == 'Hello world'
     assert translator.escape_id('Hello world.') == 'Hello world'
     assert translator.escape_id('.') == '.'
+
+
+@pytest.mark.sphinx('texinfo', testroot='root')
+def test_texinfo_samp_with_variable(app, status, warning):
+    app.build()
+
+    output = (app.outdir / 'sphinxtests.texi').read_text()
+
+    assert '@code{@var{variable_only}}' in output
+    assert '@code{@var{variable} and text}' in output
+    assert '@code{Show @var{variable} in the middle}' in output


### PR DESCRIPTION
The following snippet:
Show :samp:`Samp with a {variable}.`

Ends in .info as:
Show ‘Samp with a `variable'.’

Which is suboptimal and @var{variable} should be rather used.
That results in ‘Samp with a VARIABLE.’.
