### PR TITLE
Document Python version support

### DIFF
--- a/doc/internals/release-process.rst
+++ b/doc/internals/release-process.rst
@@ -100,6 +100,27 @@ But you can also explicitly enable the pending ones using e.g.
 ``PYTHONWARNINGS=default`` (see the :ref:`Python docs on configuring warnings
 <python:describing-warning-filters>`) for more details.
 
+Python version support policy
+-----------------------------
+
+The minimum Python version Sphinx supports is the default Python version
+installed in the oldest `Long Term Support version of
+Ubuntu <https://ubuntu.com/about/release-cycle>`_ that has standard support.
+For example, as of July 2021, Ubuntu 16.04 has just entered extended
+security maintenance (therefore, it doesn't count as standard support) and
+the oldest LTS release to consider is Ubuntu 18.04 LTS, supported until
+April 2023 and shipping Python 3.6.
+
+This is a summary table with the current policy:
+
+========== ========= ======
+Date       Ubuntu    Python
+========== ========= ======
+April 2021 18.04 LTS 3.6+
+---------- --------- ------
+April 2023 20.04 LTS 3.8+
+========== ========= ======
+
 Release procedures
 ------------------
 


### PR DESCRIPTION
See https://groups.google.com/g/sphinx-dev/c/oDJ0KOLAmGk/m/X6N_UxpABAAJ for discussion. Note that this pull request documents the existing policy.

This is how it looks like: https://sphinx--9396.org.readthedocs.build/en/9396/internals/release-process.html#python-version-support-policy

![Screenshot 2021-07-01 at 20-20-39 Sphinx’s release process — Sphinx documentation](https://user-images.githubusercontent.com/316517/124172232-dbfc3800-daa9-11eb-93a3-ced4e54f8ba7.png)
