### PR TITLE
Update docs for theming

### DIFF
--- a/doc/development/theming.rst
+++ b/doc/development/theming.rst
@@ -256,6 +256,9 @@ Here is some sample code to accomplish this:
 
 .. code-block:: python
 
+   from os import path
+   from sphinx.util.fileutil import copy_asset_file
+
    def copy_custom_files(app, exc):
        if app.builder.format == 'html' and not exc:
            staticdir = path.join(app.builder.outdir, '_static')


### PR DESCRIPTION
We should add the import sentences for `copy_asset_file` and `path`, or it would take time for users to find them.