### PR TITLE
Fix #9387: xml: XML Builder ignores custom visitors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -88,6 +88,7 @@ Bugs fixed
 * #9306: Linkcheck reports broken link when remote server closes the connection
   on HEAD request
 * #9280: py domain: "exceptions" module is not displayed
+* #9387: xml: XML Builder ignores custom visitors
 * #9224: ``:param:`` and ``:type:`` fields does not support a type containing
   whitespace (ex. ``Dict[str, str]``)
 * #8945: when transforming typed fields, call the specified role instead of

--- a/sphinx/writers/xml.py
+++ b/sphinx/writers/xml.py
@@ -19,7 +19,9 @@ class XMLWriter(BaseXMLWriter):
     def __init__(self, builder: Builder) -> None:
         super().__init__()
         self.builder = builder
-        self.translator_class = self.builder.get_translator_class()
+
+        # A lambda function to generate translator lazily
+        self.translator_class = lambda document: self.builder.create_translator(document)
 
     def translate(self, *args: Any, **kwargs: Any) -> None:
         self.document.settings.newlines = \


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- So far, XML builder only allows to switch its translator to custom one.
But it does not support to install custom visitor methods.  This allows
to use them expectedly.
- refs: #9387 