### PR TITLE
Fix #9404: autodoc: autoclass raises TypeError for dict-like object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -90,6 +90,8 @@ Bugs fixed
 * #9364: autodoc: single element tuple on the default argument value is wrongly
   rendered
 * #9362: autodoc: AttributeError is raised on processing a subclass of Tuple[()]
+* #9404: autodoc: TypeError is raised on processing dict-like object (not a
+  class) via autoclass directive
 * #9317: html: Pushing left key causes visiting the next page at the first page
 * #9381: html: URL for html_favicon and html_log does not work
 * #9270: html theme : pyramid theme generates incorrect logo links

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -127,7 +127,7 @@ def restify(cls: Optional[Type]) -> str:
                 return _restify_py37(cls)
             else:
                 return _restify_py36(cls)
-    except AttributeError:
+    except (AttributeError, TypeError):
         return repr(cls)
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The autoclass directive raises TypeError when dict-like object (not a
class) is given as a subject.
- refs: #9404 