### PR TITLE
#9413 Declare py namespace on document root to generate valid xml

### DIFF
--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -71,6 +71,7 @@ class XMLBuilder(Builder):
         # work around multiple string % tuple issues in docutils;
         # replace tuples in attribute values with lists
         doctree = doctree.deepcopy()
+        doctree.document.attributes["xmlns:py"] = "https://github.com/sphinx-doc/sphinx/issues/9413"
         for node in doctree.traverse(nodes.Element):
             for att, value in node.attributes.items():
                 if isinstance(value, tuple):


### PR DESCRIPTION
Subject: Declare py namespace in XML writer.

### Feature or Bugfix
- Bugfix

### Purpose
- Autodoc uses `py:class`, `py:module`, etc as attributes for nodes. This causes errors as the generated xml does not have a namespace for `py` declared. This PR fixes this by declaring a `xmlns:py` at the document level.

### Relates
- #9413 

Please recommend what URI to use for the declaration of the `py` xml namespace