### PR TITLE
Lock closed issues and pull requests after a period of inactivity

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,18 @@
+name: 'Lock old threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          issue-lock-inactive-days: '30'
+          pr-lock-inactive-days: '30'


### PR DESCRIPTION
See discussion at https://github.com/sphinx-doc/sphinx/issues/9237.

This bot will lock **closed** issues and pull requests that have been inactive for more than 30 days. The period of inactivity can be configured to something else.

Once this pull request is merged, it will process threads in batches of 50, once per day. After it's done, it will check once per day if there are any threads to close. This will need a bit less than (734+61) / 50 = 16 days to catch up. If we want, we can accelerate it: for example, make it catch up with everything once per hour (and it will be done in 16 hours), and once that's done, switch back to once per day (to "reduce resource usage" as explained in [their documentation](https://github.com/dessant/lock-threads#examples)).