### PR TITLE
New Sphinx tutorial (intersphinx, postponed)

### DIFF
--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -267,7 +267,7 @@ follows:
        'sphinx.ext.duration',
    ]
 
-After that, every time you generate your documentation, you will see a short
+After that, every time you build your documentation, you will see a short
 durations report at the end of the console output, like this one:
 
 .. code-block:: console
@@ -437,8 +437,8 @@ And make the sentence you added in ``index.rst`` look like this:
    :ref:`install <installation>` the project.
 
 Notice a trick here: the ``install`` part specifies how the link will look like
-(we want it to be a specific word, so the sentence makes sense), whereas the
-``<installation>`` part refers to the actual label we want to add a
+(in this case, using a specific word so the sentence makes sense), whereas the
+``<installation>`` part refers to the actual label you want to add a
 cross-reference to. If you do not include an explicit title, hence using
 ``:ref:`installation```, the section title will be used (in this case,
 ``Installation``). Both the ``:doc:`` and the ``:ref:`` roles will be rendered

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -444,6 +444,67 @@ cross-reference to. If you do not include an explicit title, hence using
 ``Installation``). Both the ``:doc:`` and the ``:ref:`` roles will be rendered
 as hyperlinks in the HTML documentation.
 
+Referencing external projects with intersphinx
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Most likely you are depending on some open source libraries for your own
+project, and there is a chance those dependencies have their documentation
+written in Sphinx and available online. One of the most powerful features of
+Sphinx is the ability to generate cross-references to objects from other
+projects available online, using the
+:doc:`intersphinx </usage/extensions/intersphinx>` extension.
+
+To enable it, first add ``sphinx.ext.intersphinx`` to the list of extensions:
+
+.. code-block:: python
+   :caption: docs/source/conf.py
+
+   extensions = [
+       'sphinx.ext.duration',
+       'sphinx.ext.intersphinx',
+   ]
+
+The way to know whether you can reference an external project is to check
+if it has a publicly available ``objects.inv``, which can be parsed calling
+``python -m sphinx.ext.intersphinx``. For example, this is the output for
+Sphinx itself:
+
+.. code-block:: console
+   :emphasize-lines: 4
+
+   (.venv) $ python -msphinx.ext.intersphinx https://www.sphinx-doc.org/en/master/objects.inv  | grep 'std:doc' -A5
+   std:doc
+           changes                                  Changelog                               : changes.html
+           contents                                 Sphinx documentation contents           : contents.html
+           development/builders                     Configuring builders                    : development/builders.html
+           development/index                        Extending Sphinx                        : development/index.html
+           development/overview                     Developing extensions overview          : development/overview.html
+
+You can now introduce a cross-reference to the ``contents`` section of the
+Sphinx documentation as follows, prefixing it by `sphinx:` to better identify
+it is an external one:
+
+.. code-block:: rst
+   :caption: docs/source/index.rst
+
+   .. note::
+
+      This documentation is built on Sphinx,
+      :doc:`find out more in their docs <sphinx:contents>`.
+
+And finally, to actually link our documentation with the Sphinx one, add a
+:confval:`intersphinx_mapping` dictionary to your  as follows:
+
+.. code-block:: python
+   :caption: docs/source/conf.py
+
+   intersphinx_mapping = {
+       'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+   }
+
+After you build the HTML documentation with ``make html``, you will see a link
+pointing to that specific section of the Sphinx documentation!
+
 Where to go from here
 ---------------------
 

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -447,10 +447,10 @@ as hyperlinks in the HTML documentation.
 Referencing external projects with intersphinx
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Most likely you are depending on some open source libraries for your own
+You are likely depending on some open source libraries for your own
 project, and there is a chance those dependencies have their documentation
 written in Sphinx and available online. One of the most powerful features of
-Sphinx is the ability to generate cross-references to objects from other
+Sphinx is the ability to generate cross-references to other
 projects available online, using the
 :doc:`intersphinx </usage/extensions/intersphinx>` extension.
 
@@ -482,7 +482,7 @@ Sphinx itself:
 
 You can now introduce a cross-reference to the ``contents`` section of the
 Sphinx documentation as follows, prefixing it by `sphinx:` to better identify
-it is an external one:
+it as an external reference:
 
 .. code-block:: rst
    :caption: docs/source/index.rst
@@ -503,7 +503,7 @@ And finally, to actually link our documentation with the Sphinx one, add a
    }
 
 After you build the HTML documentation with ``make html``, you will see a link
-pointing to that specific section of the Sphinx documentation!
+pointing to that specific page of the Sphinx documentation!
 
 Where to go from here
 ---------------------

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -449,7 +449,7 @@ Referencing external projects with intersphinx
 
 You are likely depending on some open source libraries for your own
 project, and there is a chance those dependencies have their documentation
-written in Sphinx and available online. One of the most powerful features of
+written in Sphinx and available online. One of the powerful features of
 Sphinx is the ability to generate cross-references to other
 projects available online, using the
 :doc:`intersphinx </usage/extensions/intersphinx>` extension.

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -480,9 +480,19 @@ Sphinx itself:
            development/index                        Extending Sphinx                        : development/index.html
            development/overview                     Developing extensions overview          : development/overview.html
 
+To link your documentation with the Sphinx one, add a
+:confval:`intersphinx_mapping` dictionary to your ``conf.py`` as follows:
+
+.. code-block:: python
+   :caption: docs/source/conf.py
+
+   intersphinx_mapping = {
+       'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+   }
+
 You can now introduce a cross-reference to the ``contents`` section of the
-Sphinx documentation as follows, prefixing it by `sphinx:` to better identify
-it as an external reference:
+Sphinx documentation as follows, optionally prefixing it by ``sphinx:``, the
+key you used in the ``intersphinx_mapping`` configuration:
 
 .. code-block:: rst
    :caption: docs/source/index.rst
@@ -491,16 +501,6 @@ it as an external reference:
 
       This documentation is built on Sphinx,
       :doc:`find out more in their docs <sphinx:contents>`.
-
-And finally, to actually link our documentation with the Sphinx one, add a
-:confval:`intersphinx_mapping` dictionary to your  as follows:
-
-.. code-block:: python
-   :caption: docs/source/conf.py
-
-   intersphinx_mapping = {
-       'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
-   }
 
 After you build the HTML documentation with ``make html``, you will see a link
 pointing to that specific page of the Sphinx documentation!

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -472,7 +472,7 @@ Sphinx itself:
 .. code-block:: console
    :emphasize-lines: 4
 
-   (.venv) $ python -msphinx.ext.intersphinx https://www.sphinx-doc.org/en/master/objects.inv  | grep 'std:doc' -A5
+   (.venv) $ python -msphinx.ext.intersphinx https://www.sphinx-doc.org/en/master/objects.inv  | grep 'std:doc' --after-context 5
    std:doc
            changes                                  Changelog                               : changes.html
            contents                                 Sphinx documentation contents           : contents.html


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
_(Still draft)_ This is a continuation of the work we did in #9276 and #9355. It expands some sections already started in the first part and adds some new ones, as originally proposed in #9165:

6. Writing narrative documentation with Sphinx (adding a section on intersphinx)
7. Describing code in Sphinx

I plan to add quite some content to (7) (still not pushed), and leave "Autogenerating documentation from code in Sphinx" for the fourth PR. Again, the idea is to keep these pull requests manageable, iterate in small chunks, and in the meanwhile keep the tutorial in a complete state.

Rendered version: https://sphinx--9424.org.readthedocs.build/en/9424/tutorial/index.html

cc @ericholscher

### Relates
- #9165
- #9276
- #9355

