### PR TITLE
Add mandatory GitHub token to lock workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,5 +14,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v2
         with:
+          github-token: ${{ github.token }}
           issue-lock-inactive-days: '30'
           pr-lock-inactive-days: '30'


### PR DESCRIPTION
Follow-up to #9417. Tested on my fork: https://github.com/astrojuanlu/sphinx/actions/workflows/lock.yml, https://github.com/astrojuanlu/sphinx/actions/runs/1014314290