### PR TITLE
Closes #9418: Fix missing bracket for empty Callable annotations.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #9418: a Callable annotation with no parameters (e.g. Callable[[], None]) will
+  be rendered with a bracket missing (Callable[], None])
+
 Testing
 --------
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -129,10 +129,14 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
             return unparse(node.value)
         elif isinstance(node, ast.List):
             result = [addnodes.desc_sig_punctuation('', '[')]
-            for elem in node.elts:
-                result.extend(unparse(elem))
-                result.append(addnodes.desc_sig_punctuation('', ', '))
-            result.pop()
+            if node.elts:
+                # check if there are elements in node.elts to only pop the
+                # last element of result if the for-loop was run at least
+                # once
+                for elem in node.elts:
+                    result.extend(unparse(elem))
+                    result.append(addnodes.desc_sig_punctuation('', ', '))
+                result.pop()
             result.append(addnodes.desc_sig_punctuation('', ']'))
             return result
         elif isinstance(node, ast.Module):


### PR DESCRIPTION
Subject: Fix missing bracket for empty Callable annotations. This solves issue #9418 

### Feature or Bugfix
- Bugfix

### Purpose
- When rendering a `Callable` type annotation, the output is missing a bracket if the `Callable` requires no parameters (the first element is empty): `Callable[[], None]` is rendered as `Callable[], None]`.

### Detail
When unparsing a parsed annotation containing an `ast.List` object, the following pseudo-code is run:
``` python
result.append('[')
for elem in node.elts:
    result.append(elem)
    result.append(', ')
result.pop()
result.append(']')
```
The last element (the extra comma) is popped. However, if the `ast.List` object is empty, the for-loop is skipped and the popped element is the opening `[`.
An if-condition was added to check whether `node.elts` is empty before popping the last element of `result`.

### Relates
- Issue #9418 

