### PR TITLE
Add man_skip_desc_subtitle option

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -402,6 +402,12 @@ General configuration
 
    .. versionadded:: 1.7
 
+
+.. confval:: man_skip_desc_subtitle
+
+   If true, Sphinx manpage builder will not generate a descriptive subtitle
+   for each man page. Default is ``False``.
+
 .. confval:: nitpicky
 
    If true, Sphinx will warn about *all* references where the target cannot be

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -129,6 +129,7 @@ class Config:
         'needs_sphinx': (None, None, [str]),
         'needs_extensions': ({}, None, []),
         'manpages_url': (None, 'env', []),
+        'man_skip_desc_subtitle': (False, 'env', []),
         'nitpicky': (False, None, []),
         'nitpick_ignore': ([], None, []),
         'nitpick_ignore_regex': ([], None, []),

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -113,8 +113,9 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
     def header(self) -> str:
         tmpl = (".TH \"%(title_upper)s\" \"%(manual_section)s\""
                 " \"%(date)s\" \"%(version)s\" \"%(manual_group)s\"\n"
-                ".SH NAME\n"
-                "%(title)s \\- %(subtitle)s\n")
+                ".SH NAME\n")
+        if (not self.config.man_skip_desc_subtitle):
+            tmpl += "%(title)s \\- %(subtitle)s\n"
         return tmpl % self._docinfo
 
     def visit_start_of_file(self, node: Element) -> None:


### PR DESCRIPTION
A configuration value to optionally skip printing the description
of a command as a subtitle when generating a manpage.
This commit addresses https://github.com/sphinx-doc/sphinx/issues/9430

Signed-off-by: Harumi Kuno <harumi.kuno@hpe.com>

Subject:  add option to manpage builder to not generate descriptive subtitle

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
@jsquyres and I would like to generate both groff files and also html files from a single set of rst man page files.
However, the manpage.py writer currently always prints a subtitle (added by the manpage.py builder) with a description of the command (the html writer does not do this).

The problem is that there is currently no way to turn that off and if the man page files already include descriptions of the commands (e.g., because the rst files were ported from nroff files), then that description will appear twice in the generated man page.

For example, if rst/conf.py contains the following:
```
man_pages=[("ompi/mpi/man/man3/MPI_Abort.3","MPI_Abort", "(from conf.py) Terminates MPI execution environment","",3)]
```

Then the generated man page will look like this:
```
MPI_ABORT(3)                            Open MPI                            MPI_ABORT(3)

NAME
       MPI_Abort - (from conf.py) Terminates MPI execution environment

       MPI_Abort - Terminates MPI execution environment.

SYNTAX
   C Syntax
          #include <mpi.h>
          int MPI_Abort(MPI_Comm comm, int errorcode)
...
```

With this change, someone could invoke sphinx-build with a configuration option, like this:

```
sphinx-build  -b man  -D man_skip_desc_subtitle=True rst/ man/
```

And then the generated man page will look like this:
```
MPI_ABORT(3)                            Open MPI                            MPI_ABORT(3)

NAME
       MPI_Abort - Terminates MPI execution environment.

SYNTAX
   C Syntax
          #include <mpi.h>
          int MPI_Abort(MPI_Comm comm, int errorcode)
...
```

### Relates
- https://github.com/sphinx-doc/sphinx/issues/9430
- https://github.com/sphinx-doc/sphinx/pull/9588
