### PR TITLE
Fix release of Sphinx by forcing upgrades to dependencies

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,24 @@
+Release 4.2.0 (in development)
+==============================
+
+Dependencies
+------------
+
+Incompatible changes
+--------------------
+
+Deprecated
+----------
+
+Features added
+--------------
+
+Bugs fixed
+----------
+
+Testing
+--------
+
 Release 4.1.1 (in development)
 ==============================
 

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ if sys.version_info < (3, 6):
     sys.exit(1)
 
 install_requires = [
-    'sphinxcontrib-applehelp',
-    'sphinxcontrib-devhelp',
-    'sphinxcontrib-jsmath',
-    'sphinxcontrib-htmlhelp',
-    'sphinxcontrib-serializinghtml',
-    'sphinxcontrib-qthelp',
+    'sphinxcontrib-applehelp>=1.0.2',
+    'sphinxcontrib-devhelp>=1.0.2',
+    'sphinxcontrib-jsmath>=1.0.1',
+    'sphinxcontrib-htmlhelp>=2.0.0',
+    'sphinxcontrib-serializinghtml>=1.1.5',
+    'sphinxcontrib-qthelp>=1.0.3',
     'Jinja2>=2.3',
     'Pygments>=2.0',
     'docutils>=0.14,<0.18',

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -27,8 +27,8 @@ if 'PYTHONWARNINGS' not in os.environ:
 warnings.filterwarnings('ignore', "'U' mode is deprecated",
                         DeprecationWarning, module='docutils.io')
 
-__version__ = '4.1.1+'
-__released__ = '4.1.1'  # used when Sphinx builds its own docs
+__version__ = '4.2.0+'
+__released__ = '4.2.0'  # used when Sphinx builds its own docs
 
 #: Version info for better programmatic use.
 #:
@@ -38,7 +38,7 @@ __released__ = '4.1.1'  # used when Sphinx builds its own docs
 #:
 #: .. versionadded:: 1.2
 #:    Before version 1.2, check the string ``sphinx.__version__``.
-version_info = (4, 1, 1, 'beta', 0)
+version_info = (4, 2, 0, 'beta', 0)
 
 package_dir = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

This fixes #9434, and should probably go into a new 4.1.1 release


### Detail

We should probably have a proper versioning policy for these dependencies. Are they really all required? Should some be optional, and not break Sphinx if they aren't able to be imported? 

It seems that each should probably be updated as a dependency on each Sphinx release, given that they cause breaking changes Sphinx if they get out of date. 

### Relates

#9434

