### PR TITLE
Fix test_enum_class with Python 3.10-beta4

### DIFF
--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1398,16 +1398,9 @@ def test_slots(app):
 def test_enum_class(app):
     options = {"members": None}
     actual = do_autodoc(app, 'class', 'target.enums.EnumCls', options)
-
-    if sys.version_info < (3, 10):
-        sig = '(value)'
-    else:
-        sig = ('(value, names=None, *, module=None, qualname=None, type=None, start=1, '
-               'boundary=None)')
-
     assert list(actual) == [
         '',
-        '.. py:class:: EnumCls%s' % sig,
+        '.. py:class:: EnumCls(value)',
         '   :module: target.enums',
         '',
         '   this is enum class',


### PR DESCRIPTION
Subject: Fix test_enum_class with Python 3.10-beta4

### Feature or Bugfix
- Bugfix

### Detail
The fix was tested during rpm package build in Fedora, which then succeeded.
Because the changes were only postponed, I propose to keep the if/else clause, but removing it entirely is also an option.

### Relates
#9442

