### PR TITLE
Exclude substitution definitions from gettext build

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -144,6 +144,17 @@ class I18nBuilder(Builder):
         return
 
     def write_doc(self, docname: str, doctree: nodes.document) -> None:
+        def is_node_part_of_substitution_definition(node: nodes.Node) -> bool:
+            """Check the node and its parents to see if any of them is a substitution
+            definition.
+            """
+            # return False
+            if isinstance(node, nodes.substitution_definition):
+                return True
+            if node.parent:
+                return is_node_part_of_substitution_definition(node.parent)
+            return False
+
         catalog = self.catalogs[docname_to_domain(docname, self.config.gettext_compact)]
 
         for toctree in self.env.tocs[docname].traverse(addnodes.toctree):
@@ -152,6 +163,8 @@ class I18nBuilder(Builder):
                 catalog.add(msg, node)
 
         for node, msg in extract_messages(doctree):
+            if is_node_part_of_substitution_definition(node):
+                continue
             catalog.add(msg, node)
 
         if 'index' in self.env.config.gettext_additional_targets:

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -79,8 +79,11 @@ class ImageCollector(EnvironmentCollector):
 
                 # Update `node['uri']` to a relative path from srcdir
                 # from a relative path from current document.
+                original_uri = node['uri']
                 node['uri'], _ = app.env.relfn2path(imguri, docname)
                 candidates['*'] = node['uri']
+                if node['uri'] != original_uri:
+                    node['original_uri'] = original_uri
 
             # map image paths to unique image names (so that they can be put
             # into a single directory)

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -265,7 +265,11 @@ def extract_messages(doctree: Element) -> Iterable[Tuple[Element, str]]:
             if node.get('alt'):
                 yield node, node['alt']
             if node.get('translatable'):
-                msg = '.. image:: %s' % node['uri']
+                if node.hasattr('original_uri'):
+                    image_uri = node['original_uri']
+                else:
+                    image_uri = node['uri']
+                msg = '.. image:: %s' % image_uri
             else:
                 msg = ''
         elif isinstance(node, META_TYPE_NODES):

--- a/tests/roots/test-intl/conf.py
+++ b/tests/roots/test-intl/conf.py
@@ -6,3 +6,13 @@ html_additional_pages = {'contents': 'contents.html'}
 release = version = '2013.120'
 gettext_additional_targets = ['index']
 exclude_patterns = ['_build']
+rst_prolog = '''
+.. |subst_prolog_1| replace:: prolog substitute text
+
+.. |subst_prolog_2| image:: /img.png
+'''
+rst_epilog = '''
+.. |subst_epilog_1| replace:: epilog substitute text
+
+.. |subst_epilog_2| image:: /i18n.png
+'''

--- a/tests/roots/test-intl/index.txt
+++ b/tests/roots/test-intl/index.txt
@@ -31,6 +31,7 @@ CONTENTS
    section
    topic
    prolog_epilog_substitution
+   prolog_epilog_substitution_excluded
 
 .. toctree::
    :maxdepth: 2

--- a/tests/roots/test-intl/index.txt
+++ b/tests/roots/test-intl/index.txt
@@ -30,6 +30,7 @@ CONTENTS
    refs
    section
    topic
+   prolog_epilog_substitution
 
 .. toctree::
    :maxdepth: 2

--- a/tests/roots/test-intl/prolog_epilog_substitution.txt
+++ b/tests/roots/test-intl/prolog_epilog_substitution.txt
@@ -1,0 +1,12 @@
+:tocdepth: 2
+
+i18n with prolog and epilog substitutions
+=========================================
+
+This is content that contains |subst_prolog_1|.
+
+Substituted image |subst_prolog_2| here.
+
+This is content that contains |subst_epilog_1|.
+
+Substituted image |subst_epilog_2| here.

--- a/tests/roots/test-intl/prolog_epilog_substitution_excluded.txt
+++ b/tests/roots/test-intl/prolog_epilog_substitution_excluded.txt
@@ -1,0 +1,6 @@
+:tocdepth: 2
+
+i18n without prolog and epilog substitutions
+============================================
+
+This is content that does not include prolog and epilog substitutions.

--- a/tests/roots/test-intl/xx/LC_MESSAGES/prolog_epilog_substitution.po
+++ b/tests/roots/test-intl/xx/LC_MESSAGES/prolog_epilog_substitution.po
@@ -1,0 +1,44 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021, Alvin Wong
+# This file is distributed under the same license as the sphinx package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: sphinx tests\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-21 12:00+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "i18n with prolog and epilog substitutions"
+msgstr "I18N WITH PROLOG AND EPILOG SUBSTITUTIONS"
+
+msgid "This is content that contains |subst_prolog_1|."
+msgstr "THIS IS CONTENT THAT CONTAINS |subst_prolog_1|."
+
+msgid "Substituted image |subst_prolog_2| here."
+msgstr "SUBSTITUTED IMAGE |subst_prolog_2| HERE."
+
+msgid "This is content that contains |subst_epilog_1|."
+msgstr "THIS IS CONTENT THAT CONTAINS |subst_epilog_1|."
+
+msgid "Substituted image |subst_epilog_2| here."
+msgstr "SUBSTITUTED IMAGE |subst_epilog_2| HERE."
+
+msgid "subst_prolog_2"
+msgstr "SUBST_PROLOG_2 TRANSLATED"
+
+msgid ".. image:: /img.png"
+msgstr ".. image:: /i18n.png"
+
+msgid "subst_epilog_2"
+msgstr "SUBST_EPILOG_2 TRANSLATED"
+
+msgid ".. image:: /i18n.png"
+msgstr ".. image:: /img.png"

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -192,3 +192,41 @@ def test_build_single_pot(app):
          'msgid "Generated section".*'),
         result,
         flags=re.S)
+
+
+@pytest.mark.sphinx(
+    'gettext', testroot='intl', srcdir='gettext-subst',
+    confoverrides={'gettext_compact': False,
+                   'gettext_additional_targets': ['image']})
+def test_gettext_prolog_epilog_substitution(app):
+    app.builder.build_all()
+
+    _msgid_getter = re.compile(r'msgid "(.*)"').search
+
+    def msgid_getter(msgid):
+        m = _msgid_getter(msgid)
+        if m:
+            return m.groups()[0]
+        return None
+
+    assert (app.outdir / 'prolog_epilog_substitution.pot').isfile()
+    pot = (app.outdir / 'prolog_epilog_substitution.pot').read_text()
+    msgids = [_f for _f in map(msgid_getter, pot.splitlines()) if _f]
+
+    expected_msgids = [
+        "i18n with prolog and epilog substitutions",
+        "This is content that contains |subst_prolog_1|.",
+        "Substituted image |subst_prolog_2| here.",
+        "This is content that contains |subst_epilog_1|.",
+        "Substituted image |subst_epilog_2| here.",
+        "subst_prolog_2",
+        ".. image:: /img.png",
+        "subst_epilog_2",
+        ".. image:: /i18n.png",
+    ]
+    for expect in expected_msgids:
+        assert expect in msgids
+        msgids.remove(expect)
+
+    # unexpected msgid existent
+    assert msgids == []

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -1194,6 +1194,18 @@ def test_additional_targets_should_be_translated(app):
     expected_expr = """<img alt="IMG -&gt; I18N" src="_images/i18n.png" />"""
     assert_count(expected_expr, result, 1)
 
+    # [prolog_epilog_substitution.txt]
+
+    result = (app.outdir / 'prolog_epilog_substitution.html').read_text()
+
+    # alt and src for image block should be translated
+    expected_expr = """<img alt="SUBST_PROLOG_2 TRANSLATED" src="_images/i18n.png" />"""
+    assert_count(expected_expr, result, 1)
+
+    # alt and src for image block should be translated
+    expected_expr = """<img alt="SUBST_EPILOG_2 TRANSLATED" src="_images/img.png" />"""
+    assert_count(expected_expr, result, 1)
+
 
 @sphinx_intl
 @pytest.mark.sphinx('text')
@@ -1204,6 +1216,22 @@ def test_text_references(app, warning):
     warnings = warning.getvalue().replace(os.sep, '/')
     warning_expr = 'refs.txt:\\d+: ERROR: Unknown target name:'
     assert_count(warning_expr, warnings, 0)
+
+
+@sphinx_intl
+@pytest.mark.sphinx('text')
+@pytest.mark.test_params(shared_result='test_intl_basic')
+def test_text_prolog_epilog_substitution(app, warning):
+    app.build()
+    # --- check warning for literal block
+    result = (app.outdir / 'prolog_epilog_substitution.txt').read_text()
+    expect = ("26. I18N WITH PROLOG AND EPILOG SUBSTITUTIONS"
+              "\n*********************************************\n"
+              "\nTHIS IS CONTENT THAT CONTAINS prolog substitute text.\n"
+              "\nSUBSTITUTED IMAGE [image: SUBST_PROLOG_2 TRANSLATED][image] HERE.\n"
+              "\nTHIS IS CONTENT THAT CONTAINS epilog substitute text.\n"
+              "\nSUBSTITUTED IMAGE [image: SUBST_EPILOG_2 TRANSLATED][image] HERE.\n")
+    assert_startswith(result, expect)
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
Subject: Exclude substitution definitions from gettext build

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Fix `rst_prolog` and `rst_epilog` substitutions appearing in every POT files pointlessly.

### Detail
- Exclude substitution definitions from the gettext message extraction, to avoid substitution definitions from appearing in every POT files even if the substitutions are not used in those pages. Fixes a regression from ebc3c68b78d5cf51f9aa49ca38dd371b7c204cd8 which was introduced in 3.5.0.

### Relates
- #9428

