### PR TITLE
#2021: changed autosummary to only consider elements of __all__, if present

### DIFF
--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -46,7 +46,7 @@ from sphinx.locale import __
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.registry import SphinxComponentRegistry
 from sphinx.util import logging, rst, split_full_qualified_name
-from sphinx.util.inspect import safe_getattr, getall
+from sphinx.util.inspect import getall, safe_getattr
 from sphinx.util.osutil import ensuredir
 from sphinx.util.template import SphinxTemplateLoader
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -46,7 +46,7 @@ from sphinx.locale import __
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.registry import SphinxComponentRegistry
 from sphinx.util import logging, rst, split_full_qualified_name
-from sphinx.util.inspect import safe_getattr
+from sphinx.util.inspect import safe_getattr, getall
 from sphinx.util.osutil import ensuredir
 from sphinx.util.template import SphinxTemplateLoader
 
@@ -192,7 +192,8 @@ class ModuleScanner:
 
     def scan(self, imported_members: bool) -> List[str]:
         members = []
-        for name in dir(self.object):
+        # Iterate over __all__ if it exists
+        for name in getall(self.object) or dir(self.object):
             try:
                 value = safe_getattr(self.object, name)
             except AttributeError:
@@ -245,7 +246,8 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
 
     def get_module_members(obj: Any) -> Dict[str, Any]:
         members = {}
-        for name in dir(obj):
+        # Iterate over __all__ if it exists
+        for name in getall(obj) or dir(obj):
             try:
                 members[name] = safe_getattr(obj, name)
             except AttributeError:


### PR DESCRIPTION
Addresses https://github.com/sphinx-doc/sphinx/issues/2021

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix

Not sure if it should be considered a feature enhancement or bug fix.

### Purpose
- autosummary ignores `__all__` files when determining members, this PR changes the behaviour to always respect the `__all__` list, if it exists.

### Detail
Changed 2 iterators from

```python
for name in dir(obj):
```

to

```python
for name in getall(obj) or dir(obj):
```
using the `sphinx.util.inspect.getall` function, which returns `__all__`, if it exists, else `None`.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/2021

