### PR TITLE
Intersphinx, refactoring and intersphinx_disable_domains

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,11 @@ Features added
 * #2068, add :confval:`intersphinx_disabled_domains` for disabling
   interphinx resolution of cross-references in specific domains when they
   do not have an explicit inventory specification.
+* #2068, add :confval:`intersphinx_disabled_refs` for disabling
+  interphinx resolution of cross-references that do not have an explicit
+  inventory specification. Specific types of cross-references can be disabled,
+  e.g., ``std:doc`` or all cross-references in a specific domain,
+  e.g., ``std``.
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,11 @@ Features added
 * #9695: More CSS classes on Javascript domain descriptions
 * #9683: Revert the removal of ``add_stylesheet()`` API.  It will be kept until
   the Sphinx-6.0 release
+* #2068, add :confval:`intersphinx_disabled_domains` for disabling
+  interphinx resolution of cross-references in specific domains when they
+  do not have an explicit inventory specification.
+  ``sphinx-quickstart`` will insert
+  ``intersphinx_disabled_domains = ['std']`` in its generated ``conf.py``.
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -47,11 +47,11 @@ Features added
 * #9695: More CSS classes on Javascript domain descriptions
 * #9683: Revert the removal of ``add_stylesheet()`` API.  It will be kept until
   the Sphinx-6.0 release
-* #2068, add :confval:`intersphinx_disabled_refs` for disabling
+* #2068, add :confval:`intersphinx_disabled_reftypes` for disabling
   interphinx resolution of cross-references that do not have an explicit
   inventory specification. Specific types of cross-references can be disabled,
   e.g., ``std:doc`` or all cross-references in a specific domain,
-  e.g., ``std``.
+  e.g., ``std:*``.
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -50,8 +50,6 @@ Features added
 * #2068, add :confval:`intersphinx_disabled_domains` for disabling
   interphinx resolution of cross-references in specific domains when they
   do not have an explicit inventory specification.
-  ``sphinx-quickstart`` will insert
-  ``intersphinx_disabled_domains = ['std']`` in its generated ``conf.py``.
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -47,9 +47,6 @@ Features added
 * #9695: More CSS classes on Javascript domain descriptions
 * #9683: Revert the removal of ``add_stylesheet()`` API.  It will be kept until
   the Sphinx-6.0 release
-* #2068, add :confval:`intersphinx_disabled_domains` for disabling
-  interphinx resolution of cross-references in specific domains when they
-  do not have an explicit inventory specification.
 * #2068, add :confval:`intersphinx_disabled_refs` for disabling
   interphinx resolution of cross-references that do not have an explicit
   inventory specification. Specific types of cross-references can be disabled,

--- a/CHANGES
+++ b/CHANGES
@@ -85,6 +85,8 @@ Bugs fixed
 * #9733: Fix for logging handler flushing warnings in the middle of the docs
   build
 * #9656: Fix warnings without subtype being incorrectly suppressed
+* Intersphinx, for unresolved references with an explicit inventory,
+  e.g., ``proj:myFunc``, leave the inventory prefix in the unresolved text.
 
 Testing
 --------

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -157,7 +157,7 @@ linking:
    - the name of a specific reference type,
      e.g., ``std:doc``, ``py:func``, or ``cpp:class``,
    - the name of a whole domain, e.g., ``std``, ``py``, or ``cpp``, or
-   - the special name ``all``.
+   - the special name ``*``.
 
    When a cross-reference without an explicit inventory specification is being
    resolved by intersphinx, skip resolution it matches one of the
@@ -171,7 +171,7 @@ linking:
    At the same time, all cross-references generated in, e.g., Python,
    declarations will still be attempted to be resolved by intersphinx.
 
-   If ``all`` is in the list of domains, then no references without an explicit
+   If ``*`` is in the list of domains, then no references without an explicit
    inventory will be resolved by intersphinx.
 
 

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -148,21 +148,28 @@ linking:
       exception is raised if the server has not issued a response for timeout
       seconds.
 
-.. confval:: intersphinx_disabled_domains
+.. confval:: intersphinx_disabled_refs
 
-   .. versionadded:: 4.2
+   .. versionadded:: 4.3
 
-   A list of strings being the name of a domain, or the special name ``all``.
+   A list of strings being either:
+
+   - the name of a specific reference type,
+     e.g., ``std:doc``, ``py:func``, or ``cpp:class``,
+   - the name of a whole domain, e.g., ``std``, ``py``, or ``cpp``, or
+   - the special name ``all``.
+
    When a cross-reference without an explicit inventory specification is being
-   resolved by intersphinx, skip resolution if either the domain of the
-   cross-reference is in this list or the special name ``all`` is in the list.
+   resolved by intersphinx, skip resolution it matches one of the
+   specifications in this list.
 
-   For example, with ``intersphinx_disabled_domains = ['std']`` a cross-reference
-   ``:doc:`installation``` will not be attempted to be resolved by intersphinx, but
-   ``:doc:`otherbook:installation``` will be attempted to be resolved in the
-   inventory named ``otherbook`` in :confval:`intersphinx_mapping`.
-   At the same time, all cross-references generated in, e.g., Python, declarations
-   will still be attempted to be resolved by intersphinx.
+   For example, with ``intersphinx_disabled_refs = ['std:doc']``
+   a cross-reference ``:doc:`installation``` will not be attempted to be
+   resolved by intersphinx, but ``:doc:`otherbook:installation``` will be
+   attempted to be resolved in the inventory named ``otherbook`` in
+   :confval:`intersphinx_mapping`.
+   At the same time, all cross-references generated in, e.g., Python,
+   declarations will still be attempted to be resolved by intersphinx.
 
    If ``all`` is in the list of domains, then no references without an explicit
    inventory will be resolved by intersphinx.

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -154,7 +154,7 @@ linking:
 
    A list of strings being the name of a domain, or the special name ``all``.
    When a cross-reference without an explicit inventory specification is being
-   resolve by intersphinx, skip resolution if either the domain of the
+   resolved by intersphinx, skip resolution if either the domain of the
    cross-reference is in this list or the special name ``all`` is in the list.
 
    For example, with ``intersphinx_disabled_domains = ['std']`` a cross-reference

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -159,6 +159,8 @@ linking:
    - the name of a whole domain, e.g., ``std``, ``py``, or ``cpp``, or
    - the special name ``*``.
 
+   The default value is an empty list.
+
    When a cross-reference without an explicit inventory specification is being
    resolved by intersphinx, skip resolution it matches one of the
    specifications in this list.

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -148,24 +148,25 @@ linking:
       exception is raised if the server has not issued a response for timeout
       seconds.
 
-.. confval:: intersphinx_disabled_refs
+.. confval:: intersphinx_disabled_reftypes
 
    .. versionadded:: 4.3
 
    A list of strings being either:
 
-   - the name of a specific reference type,
+   - the name of a specific reference type in a domain,
      e.g., ``std:doc``, ``py:func``, or ``cpp:class``,
-   - the name of a whole domain, e.g., ``std``, ``py``, or ``cpp``, or
-   - the special name ``*``.
+   - the name of a domain, and a wildcard, e.g.,
+     ``std:*``, ``py:*``, or ``cpp:*``, or
+   - simply a wildcard ``*``.
 
    The default value is an empty list.
 
    When a cross-reference without an explicit inventory specification is being
-   resolved by intersphinx, skip resolution it matches one of the
+   resolved by intersphinx, skip resolution if it matches one of the
    specifications in this list.
 
-   For example, with ``intersphinx_disabled_refs = ['std:doc']``
+   For example, with ``intersphinx_disabled_reftypes = ['std:doc']``
    a cross-reference ``:doc:`installation``` will not be attempted to be
    resolved by intersphinx, but ``:doc:`otherbook:installation``` will be
    attempted to be resolved in the inventory named ``otherbook`` in

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -148,6 +148,25 @@ linking:
       exception is raised if the server has not issued a response for timeout
       seconds.
 
+.. confval:: intersphinx_disabled_domains
+
+   .. versionadded:: 4.2
+
+   A list of strings being the name of a domain, or the special name ``all``.
+   When a cross-reference without an explicit inventory specification is being
+   resolve by intersphinx, skip resolution if either the domain of the
+   cross-reference is in this list or the special name ``all`` is in the list.
+
+   For example, with ``intersphinx_disabled_domains = ['std']`` a cross-reference
+   ``:doc:`installation``` will not be attempted to be resolved by intersphinx, but
+   ``:doc:`otherbook:installation``` will be attempted to be resolved in the
+   inventory named ``otherbook`` in :confval:`intersphinx_mapping`.
+   At the same time, all cross-references generated in, e.g., Python, declarations
+   will still be attempted to be resolved by intersphinx.
+
+   If ``all`` is in the list of domains, then no references without an explicit
+   inventory will be resolved by intersphinx.
+
 
 Showing all links of an Intersphinx mapping file
 ------------------------------------------------

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -29,11 +29,11 @@ import posixpath
 import sys
 import time
 from os import path
-from typing import IO, Any, Dict, List, Tuple
+from typing import IO, Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 from docutils import nodes
-from docutils.nodes import TextElement
+from docutils.nodes import Element, TextElement
 from docutils.utils import relative_path
 
 import sphinx
@@ -41,11 +41,12 @@ from sphinx.addnodes import pending_xref
 from sphinx.application import Sphinx
 from sphinx.builders.html import INVENTORY_FILENAME
 from sphinx.config import Config
+from sphinx.domains import Domain
 from sphinx.environment import BuildEnvironment
 from sphinx.locale import _, __
 from sphinx.util import logging, requests
 from sphinx.util.inventory import InventoryFile
-from sphinx.util.typing import Inventory
+from sphinx.util.typing import Inventory, InventoryInner
 
 logger = logging.getLogger(__name__)
 
@@ -258,105 +259,187 @@ def load_mappings(app: Sphinx) -> None:
                 inventories.main_inventory.setdefault(type, {}).update(objects)
 
 
-def missing_reference(app: Sphinx, env: BuildEnvironment, node: pending_xref,
-                      contnode: TextElement) -> nodes.reference:
-    """Attempt to resolve a missing reference via intersphinx references."""
-    target = node['reftarget']
-    inventories = InventoryAdapter(env)
-    objtypes: List[str] = None
-    if node['reftype'] == 'any':
-        # we search anything!
-        objtypes = ['%s:%s' % (domain.name, objtype)
-                    for domain in env.domains.values()
-                    for objtype in domain.object_types]
-        domain = None
+def _create_element_from_result(domain: Domain, inv_name: Optional[str],
+                                data: InventoryInner,
+                                node: pending_xref, contnode: TextElement) -> Element:
+    proj, version, uri, dispname = data
+    if '://' not in uri and node.get('refdoc'):
+        # get correct path in case of subdirectories
+        uri = path.join(relative_path(node['refdoc'], '.'), uri)
+    if version:
+        reftitle = _('(in %s v%s)') % (proj, version)
     else:
-        domain = node.get('refdomain')
-        if not domain:
+        reftitle = _('(in %s)') % (proj,)
+    newnode = nodes.reference('', '', internal=False, refuri=uri, reftitle=reftitle)
+    if node.get('refexplicit'):
+        # use whatever title was given
+        newnode.append(contnode)
+    elif dispname == '-' or \
+            (domain.name == 'std' and node['reftype'] == 'keyword'):
+        # use whatever title was given, but strip prefix
+        title = contnode.astext()
+        if inv_name is not None and title.startswith(inv_name + ':'):
+            newnode.append(contnode.__class__(title[len(inv_name) + 1:],
+                                              title[len(inv_name) + 1:]))
+        else:
+            newnode.append(contnode)
+    else:
+        # else use the given display name (used for :ref:)
+        newnode.append(contnode.__class__(dispname, dispname))
+    return newnode
+
+
+def _resolve_reference_in_domain_by_target(
+        inv_name: Optional[str], inventory: Inventory,
+        domain: Domain, objtypes: List[str],
+        target: str,
+        node: pending_xref, contnode: TextElement) -> Optional[Element]:
+    for objtype in objtypes:
+        if objtype not in inventory:
+            # Continue if there's nothing of this kind in the inventory
+            continue
+
+        if target in inventory[objtype]:
+            # Case sensitive match, use it
+            data = inventory[objtype][target]
+        elif objtype == 'std:term':
+            # Check for potential case insensitive matches for terms only
+            target_lower = target.lower()
+            insensitive_matches = list(filter(lambda k: k.lower() == target_lower,
+                                              inventory[objtype].keys()))
+            if insensitive_matches:
+                data = inventory[objtype][insensitive_matches[0]]
+            else:
+                # No case insensitive match either, continue to the next candidate
+                continue
+        else:
+            # Could reach here if we're not a term but have a case insensitive match.
+            # This is a fix for terms specifically, but potentially should apply to
+            # other types.
+            continue
+        return _create_element_from_result(domain, inv_name, data, node, contnode)
+    return None
+
+
+def _resolve_reference_in_domain(inv_name: Optional[str], inventory: Inventory,
+                                 domain: Domain, objtypes: List[str],
+                                 node: pending_xref, contnode: TextElement
+                                 ) -> Optional[Element]:
+    # we adjust the object types for backwards compatibility
+    if domain.name == 'std' and 'cmdoption' in objtypes:
+        # until Sphinx-1.6, cmdoptions are stored as std:option
+        objtypes.append('option')
+    if domain.name == 'py' and 'attribute' in objtypes:
+        # Since Sphinx-2.1, properties are stored as py:method
+        objtypes.append('method')
+
+    # the inventory contains domain:type as objtype
+    objtypes = ["{}:{}".format(domain.name, t) for t in objtypes]
+
+    # without qualification
+    res = _resolve_reference_in_domain_by_target(inv_name, inventory, domain, objtypes,
+                                                 node['reftarget'], node, contnode)
+    if res is not None:
+        return res
+
+    # try with qualification of the current scope instead
+    full_qualified_name = domain.get_full_qualified_name(node)
+    if full_qualified_name is None:
+        return None
+    return _resolve_reference_in_domain_by_target(inv_name, inventory, domain, objtypes,
+                                                  full_qualified_name, node, contnode)
+
+
+def _resolve_reference(env: BuildEnvironment, inv_name: Optional[str], inventory: Inventory,
+                       node: pending_xref, contnode: TextElement) -> Optional[Element]:
+    # figure out which object types we should look for
+    typ = node['reftype']
+    if typ == 'any':
+        for domain_name, domain in env.domains.items():
+            objtypes = list(domain.object_types)
+            res = _resolve_reference_in_domain(inv_name, inventory,
+                                               domain, objtypes,
+                                               node, contnode)
+            if res is not None:
+                return res
+        return None
+    else:
+        domain_name = node.get('refdomain')
+        if not domain_name:
             # only objects in domains are in the inventory
             return None
-        objtypes = env.get_domain(domain).objtypes_for_role(node['reftype'])
+        domain = env.get_domain(domain_name)
+        objtypes = domain.objtypes_for_role(typ)
         if not objtypes:
             return None
-        objtypes = ['%s:%s' % (domain, objtype) for objtype in objtypes]
-    if 'std:cmdoption' in objtypes:
-        # until Sphinx-1.6, cmdoptions are stored as std:option
-        objtypes.append('std:option')
-    if 'py:attribute' in objtypes:
-        # Since Sphinx-2.1, properties are stored as py:method
-        objtypes.append('py:method')
+        return _resolve_reference_in_domain(inv_name, inventory,
+                                            domain, objtypes,
+                                            node, contnode)
 
-    to_try = [(inventories.main_inventory, target)]
-    if domain:
-        full_qualified_name = env.get_domain(domain).get_full_qualified_name(node)
-        if full_qualified_name:
-            to_try.append((inventories.main_inventory, full_qualified_name))
-    in_set = None
-    if ':' in target:
-        # first part may be the foreign doc set name
-        setname, newtarget = target.split(':', 1)
-        if setname in inventories.named_inventory:
-            in_set = setname
-            to_try.append((inventories.named_inventory[setname], newtarget))
-            if domain:
-                node['reftarget'] = newtarget
-                full_qualified_name = env.get_domain(domain).get_full_qualified_name(node)
-                if full_qualified_name:
-                    to_try.append((inventories.named_inventory[setname], full_qualified_name))
-    for inventory, target in to_try:
-        for objtype in objtypes:
-            if objtype not in inventory:
-                # Continue if there's nothing of this kind in the inventory
-                continue
-            if target in inventory[objtype]:
-                # Case sensitive match, use it
-                proj, version, uri, dispname = inventory[objtype][target]
-            elif objtype == 'std:term':
-                # Check for potential case insensitive matches for terms only
-                target_lower = target.lower()
-                insensitive_matches = list(filter(lambda k: k.lower() == target_lower,
-                                                  inventory[objtype].keys()))
-                if insensitive_matches:
-                    proj, version, uri, dispname = inventory[objtype][insensitive_matches[0]]
-                else:
-                    # No case insensitive match either, continue to the next candidate
-                    continue
-            else:
-                # Could reach here if we're not a term but have a case insensitive match.
-                # This is a fix for terms specifically, but potentially should apply to
-                # other types.
-                continue
 
-            if '://' not in uri and node.get('refdoc'):
-                # get correct path in case of subdirectories
-                uri = path.join(relative_path(node['refdoc'], '.'), uri)
-            if version:
-                reftitle = _('(in %s v%s)') % (proj, version)
-            else:
-                reftitle = _('(in %s)') % (proj,)
-            newnode = nodes.reference('', '', internal=False, refuri=uri, reftitle=reftitle)
-            if node.get('refexplicit'):
-                # use whatever title was given
-                newnode.append(contnode)
-            elif dispname == '-' or \
-                    (domain == 'std' and node['reftype'] == 'keyword'):
-                # use whatever title was given, but strip prefix
-                title = contnode.astext()
-                if in_set and title.startswith(in_set + ':'):
-                    newnode.append(contnode.__class__(title[len(in_set) + 1:],
-                                                      title[len(in_set) + 1:]))
-                else:
-                    newnode.append(contnode)
-            else:
-                # else use the given display name (used for :ref:)
-                newnode.append(contnode.__class__(dispname, dispname))
-            return newnode
-    # at least get rid of the ':' in the target if no explicit title given
-    if in_set is not None and not node.get('refexplicit', True):
-        if len(contnode) and isinstance(contnode[0], nodes.Text):
-            contnode[0] = nodes.Text(newtarget, contnode[0].rawsource)
+def inventory_exists(env: BuildEnvironment, inv_name: str) -> bool:
+    return inv_name in InventoryAdapter(env).named_inventory
 
-    return None
+
+def resolve_reference_in_inventory(env: BuildEnvironment,
+                                   inv_name: str,
+                                   node: pending_xref,
+                                   contnode: TextElement) -> Optional[Element]:
+    """Attempt to resolve a missing reference via intersphinx references.
+
+    Resolution is tried in the given inventory with the target as is.
+
+    Requires ``inventory_exists(env, inv_name)``.
+    """
+    assert inventory_exists(env, inv_name)
+    return _resolve_reference(env, inv_name, InventoryAdapter(env).named_inventory[inv_name],
+                              node, contnode)
+
+
+def resolve_reference_any_inventory(env: BuildEnvironment,
+                                    node: pending_xref,
+                                    contnode: TextElement) -> Optional[Element]:
+    """Attempt to resolve a missing reference via intersphinx references.
+
+    Resolution is tried with the target as is in any inventory.
+    """
+    return _resolve_reference(env, None, InventoryAdapter(env).main_inventory, node, contnode)
+
+
+def resolve_reference_detect_inventory(env: BuildEnvironment,
+                                       node: pending_xref,
+                                       contnode: TextElement) -> Optional[Element]:
+    """Attempt to resolve a missing reference via intersphinx references.
+
+    Resolution is tried first with the target as is in any inventory.
+    If this does not succeed, then the target is split by the first ``:``,
+    to form ``inv_name:newtarget``. If ``inv_name`` is a named inventory, then resolution
+    is tried in that inventory with the new target.
+    """
+
+    # ordinary direct lookup, use data as is
+    res = resolve_reference_any_inventory(env, node, contnode)
+    if res is not None:
+        return res
+
+    # try splitting the target into 'inv_name:target'
+    target = node['reftarget']
+    if ':' not in target:
+        return None
+    inv_name, newtarget = target.split(':', 1)
+    if not inventory_exists(env, inv_name):
+        return None
+    node['reftarget'] = newtarget
+    res_inv = resolve_reference_in_inventory(env, inv_name, node, contnode)
+    node['reftarget'] = target
+    return res_inv
+
+
+def missing_reference(app: Sphinx, env: BuildEnvironment, node: pending_xref,
+                      contnode: TextElement) -> Optional[Element]:
+    """Attempt to resolve a missing reference via intersphinx references."""
+
+    return resolve_reference_detect_inventory(env, node, contnode)
 
 
 def normalize_intersphinx_mapping(app: Sphinx, config: Config) -> None:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -431,7 +431,6 @@ def resolve_reference_any_inventory(env: BuildEnvironment,
 
 
 def resolve_reference_detect_inventory(env: BuildEnvironment,
-                                       honor_disabled_refs: bool,
                                        node: pending_xref, contnode: TextElement
                                        ) -> Optional[Element]:
     """Attempt to resolve a missing reference via intersphinx references.
@@ -443,7 +442,7 @@ def resolve_reference_detect_inventory(env: BuildEnvironment,
     """
 
     # ordinary direct lookup, use data as is
-    res = resolve_reference_any_inventory(env, honor_disabled_refs, node, contnode)
+    res = resolve_reference_any_inventory(env, True, node, contnode)
     if res is not None:
         return res
 
@@ -464,7 +463,7 @@ def missing_reference(app: Sphinx, env: BuildEnvironment, node: pending_xref,
                       contnode: TextElement) -> Optional[Element]:
     """Attempt to resolve a missing reference via intersphinx references."""
 
-    return resolve_reference_detect_inventory(env, True, node, contnode)
+    return resolve_reference_detect_inventory(env, node, contnode)
 
 
 def normalize_intersphinx_mapping(app: Sphinx, config: Config) -> None:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -340,7 +340,7 @@ def _resolve_reference_in_domain(env: BuildEnvironment,
 
     # now that the objtypes list is complete we can remove the disabled ones
     if honor_disabled_refs:
-        disabled = env.config.intersphinx_disabled_refs
+        disabled = env.config.intersphinx_disabled_reftypes
         objtypes = [o for o in objtypes if o not in disabled]
 
     # without qualification
@@ -363,14 +363,14 @@ def _resolve_reference(env: BuildEnvironment, inv_name: Optional[str], inventory
     # disabling should only be done if no inventory is given
     honor_disabled_refs = honor_disabled_refs and inv_name is None
 
-    if honor_disabled_refs and '*' in env.config.intersphinx_disabled_refs:
+    if honor_disabled_refs and '*' in env.config.intersphinx_disabled_reftypes:
         return None
 
     typ = node['reftype']
     if typ == 'any':
         for domain_name, domain in env.domains.items():
             if honor_disabled_refs \
-                    and domain_name in env.config.intersphinx_disabled_refs:
+                    and (domain_name + ":*") in env.config.intersphinx_disabled_reftypes:
                 continue
             objtypes = list(domain.object_types)
             res = _resolve_reference_in_domain(env, inv_name, inventory,
@@ -386,7 +386,7 @@ def _resolve_reference(env: BuildEnvironment, inv_name: Optional[str], inventory
             # only objects in domains are in the inventory
             return None
         if honor_disabled_refs \
-                and domain_name in env.config.intersphinx_disabled_refs:
+                and (domain_name + ":*") in env.config.intersphinx_disabled_reftypes:
             return None
         domain = env.get_domain(domain_name)
         objtypes = domain.objtypes_for_role(typ)
@@ -494,7 +494,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('intersphinx_mapping', {}, True)
     app.add_config_value('intersphinx_cache_limit', 5, False)
     app.add_config_value('intersphinx_timeout', None, False)
-    app.add_config_value('intersphinx_disabled_refs', [], True)
+    app.add_config_value('intersphinx_disabled_reftypes', [], True)
     app.connect('config-inited', normalize_intersphinx_mapping, priority=800)
     app.connect('builder-inited', load_mappings)
     app.connect('missing-reference', missing_reference)

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -363,7 +363,7 @@ def _resolve_reference(env: BuildEnvironment, inv_name: Optional[str], inventory
     # disabling should only be done if no inventory is given
     honor_disabled_refs = honor_disabled_refs and inv_name is None
 
-    if honor_disabled_refs and 'all' in env.config.intersphinx_disabled_refs:
+    if honor_disabled_refs and '*' in env.config.intersphinx_disabled_refs:
         return None
 
     typ = node['reftype']

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -46,7 +46,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.locale import _, __
 from sphinx.util import logging, requests
 from sphinx.util.inventory import InventoryFile
-from sphinx.util.typing import Inventory, InventoryInner
+from sphinx.util.typing import Inventory, InventoryItem
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +260,7 @@ def load_mappings(app: Sphinx) -> None:
 
 
 def _create_element_from_result(domain: Domain, inv_name: Optional[str],
-                                data: InventoryInner,
+                                data: InventoryItem,
                                 node: pending_xref, contnode: TextElement) -> Element:
     proj, version, uri, dispname = data
     if '://' not in uri and node.get('refdoc'):

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -108,6 +108,10 @@ html_static_path = ['{{ dot }}static']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
+
+# Prevent accidental intersphinx resolution for labels, documents, and other
+# basic cross-references.
+intersphinx_disabled_domains = ['std']
 {%- endif %}
 {%- if 'sphinx.ext.todo' in extensions %}
 

--- a/sphinx/templates/quickstart/conf.py_t
+++ b/sphinx/templates/quickstart/conf.py_t
@@ -109,9 +109,6 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
 
-# Prevent accidental intersphinx resolution for labels, documents, and other
-# basic cross-references.
-intersphinx_disabled_domains = ['std']
 {%- endif %}
 {%- if 'sphinx.ext.todo' in extensions %}
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -70,8 +70,8 @@ OptionSpec = Dict[str, Callable[[str], Any]]
 TitleGetter = Callable[[nodes.Node], str]
 
 # inventory data on memory
-InventoryInner = Tuple[str, str, str, str]
-Inventory = Dict[str, Dict[str, InventoryInner]]
+InventoryItem = Tuple[str, str, str, str]
+Inventory = Dict[str, Dict[str, InventoryItem]]
 
 
 def get_type_hints(obj: Any, globalns: Dict = None, localns: Dict = None) -> Dict[str, Any]:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -70,7 +70,8 @@ OptionSpec = Dict[str, Callable[[str], Any]]
 TitleGetter = Callable[[nodes.Node], str]
 
 # inventory data on memory
-Inventory = Dict[str, Dict[str, Tuple[str, str, str, str]]]
+InventoryInner = Tuple[str, str, str, str]
+Inventory = Dict[str, Dict[str, InventoryInner]]
 
 
 def get_type_hints(obj: Any, globalns: Dict = None, localns: Dict = None) -> Dict[str, Any]:

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -45,7 +45,7 @@ def reference_check(app, *args, **kwds):
 def set_config(app, mapping):
     app.config.intersphinx_mapping = mapping
     app.config.intersphinx_cache_limit = 0
-    app.config.intersphinx_disabled_refs = []
+    app.config.intersphinx_disabled_reftypes = []
 
 
 @mock.patch('sphinx.ext.intersphinx.InventoryFile')
@@ -338,19 +338,19 @@ def test_missing_reference_disabled_domain(tempdir, app, status, warning):
         assert_(rn, 'func()')
 
     # the base case, everything should resolve
-    assert app.config.intersphinx_disabled_refs == []
+    assert app.config.intersphinx_disabled_reftypes == []
     case(term=True, doc=True, py=True)
 
     # disabled a single ref type
-    app.config.intersphinx_disabled_refs = ['std:doc']
+    app.config.intersphinx_disabled_reftypes = ['std:doc']
     case(term=True, doc=False, py=True)
 
     # disabled a whole domain
-    app.config.intersphinx_disabled_refs = ['std']
+    app.config.intersphinx_disabled_reftypes = ['std:*']
     case(term=False, doc=False, py=True)
 
     # disabled all domains
-    app.config.intersphinx_disabled_refs = ['*']
+    app.config.intersphinx_disabled_reftypes = ['*']
     case(term=False, doc=False, py=False)
 
 

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -133,12 +133,12 @@ def test_missing_reference(tempdir, app, status, warning):
                          refexplicit=True)
     assert rn[0].astext() == 'py3k:module2'
 
-    # prefix given, target not found and nonexplicit title: prefix is stripped
+    # prefix given, target not found and nonexplicit title: prefix is not stripped
     node, contnode = fake_node('py', 'mod', 'py3k:unknown', 'py3k:unknown',
                                refexplicit=False)
     rn = missing_reference(app, app.env, node, contnode)
     assert rn is None
-    assert contnode[0].astext() == 'unknown'
+    assert contnode[0].astext() == 'py3k:unknown'
 
     # prefix given, target not found and explicit title: nothing is changed
     node, contnode = fake_node('py', 'mod', 'py3k:unknown', 'py3k:unknown',

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -350,7 +350,7 @@ def test_missing_reference_disabled_domain(tempdir, app, status, warning):
     case(term=False, doc=False, py=True)
 
     # disabled all domains
-    app.config.intersphinx_disabled_refs = ['all']
+    app.config.intersphinx_disabled_refs = ['*']
     case(term=False, doc=False, py=False)
 
 

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -42,6 +42,12 @@ def reference_check(app, *args, **kwds):
     return missing_reference(app, app.env, node, contnode)
 
 
+def set_config(app, mapping):
+    app.config.intersphinx_mapping = mapping
+    app.config.intersphinx_cache_limit = 0
+    app.config.intersphinx_disabled_domains = []
+
+
 @mock.patch('sphinx.ext.intersphinx.InventoryFile')
 @mock.patch('sphinx.ext.intersphinx._read_from_url')
 def test_fetch_inventory_redirection(_read_from_url, InventoryFile, app, status, warning):
@@ -90,13 +96,12 @@ def test_fetch_inventory_redirection(_read_from_url, InventoryFile, app, status,
 def test_missing_reference(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'https://docs.python.org/': inv_file,
         'py3k': ('https://docs.python.org/py3k/', inv_file),
         'py3krel': ('py3k', inv_file),  # relative path
         'py3krelparent': ('../../py3k', inv_file),  # relative path, parent dir
-    }
-    app.config.intersphinx_cache_limit = 0
+    })
 
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
@@ -169,10 +174,9 @@ def test_missing_reference(tempdir, app, status, warning):
 def test_missing_reference_pydomain(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'https://docs.python.org/': inv_file,
-    }
-    app.config.intersphinx_cache_limit = 0
+    })
 
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
@@ -210,10 +214,9 @@ def test_missing_reference_pydomain(tempdir, app, status, warning):
 def test_missing_reference_stddomain(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'cmd': ('https://docs.python.org/', inv_file),
-    }
-    app.config.intersphinx_cache_limit = 0
+    })
 
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
@@ -242,10 +245,9 @@ def test_missing_reference_stddomain(tempdir, app, status, warning):
 def test_missing_reference_cppdomain(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'https://docs.python.org/': inv_file,
-    }
-    app.config.intersphinx_cache_limit = 0
+    })
 
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
@@ -269,10 +271,9 @@ def test_missing_reference_cppdomain(tempdir, app, status, warning):
 def test_missing_reference_jsdomain(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'https://docs.python.org/': inv_file,
-    }
-    app.config.intersphinx_cache_limit = 0
+    })
 
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
@@ -291,14 +292,63 @@ def test_missing_reference_jsdomain(tempdir, app, status, warning):
     assert rn.astext() == 'baz()'
 
 
+def test_missing_reference_disabled_domain(tempdir, app, status, warning):
+    inv_file = tempdir / 'inventory'
+    inv_file.write_bytes(inventory_v2)
+    set_config(app, {
+        'inv': ('https://docs.python.org/', inv_file),
+    })
+
+    # load the inventory and check if it's done correctly
+    normalize_intersphinx_mapping(app, app.config)
+    load_mappings(app)
+
+    def case(std_without, std_with, py_without, py_with):
+        def assert_(rn, expected):
+            if expected is None:
+                assert rn is None
+            else:
+                assert rn.astext() == expected
+
+        kwargs = {}
+
+        node, contnode = fake_node('std', 'doc', 'docname', 'docname', **kwargs)
+        rn = missing_reference(app, app.env, node, contnode)
+        assert_(rn, std_without)
+
+        node, contnode = fake_node('std', 'doc', 'inv:docname', 'docname', **kwargs)
+        rn = missing_reference(app, app.env, node, contnode)
+        assert_(rn, std_with)
+
+        # an arbitrary ref in another domain
+        node, contnode = fake_node('py', 'func', 'module1.func', 'func()', **kwargs)
+        rn = missing_reference(app, app.env, node, contnode)
+        assert_(rn, py_without)
+
+        node, contnode = fake_node('py', 'func', 'inv:module1.func', 'func()', **kwargs)
+        rn = missing_reference(app, app.env, node, contnode)
+        assert_(rn, py_with)
+
+    # the base case, everything should resolve
+    assert app.config.intersphinx_disabled_domains == []
+    case('docname', 'docname', 'func()', 'func()')
+
+    # disabled one domain
+    app.config.intersphinx_disabled_domains = ['std']
+    case(None, 'docname', 'func()', 'func()')
+
+    # disabled all domains
+    app.config.intersphinx_disabled_domains = ['all']
+    case(None, 'docname', None, 'func()')
+
+
 @pytest.mark.xfail(os.name != 'posix', reason="Path separator mismatch issue")
 def test_inventory_not_having_version(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2_not_having_version)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'https://docs.python.org/': inv_file,
-    }
-    app.config.intersphinx_cache_limit = 0
+    })
 
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
@@ -318,16 +368,15 @@ def test_load_mappings_warnings(tempdir, app, status, warning):
     """
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_mapping = {
+    set_config(app, {
         'https://docs.python.org/': inv_file,
         'py3k': ('https://docs.python.org/py3k/', inv_file),
         'repoze.workflow': ('http://docs.repoze.org/workflow/', inv_file),
         'django-taggit': ('http://django-taggit.readthedocs.org/en/latest/',
                           inv_file),
         12345: ('http://www.sphinx-doc.org/en/stable/', inv_file),
-    }
+    })
 
-    app.config.intersphinx_cache_limit = 0
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
@@ -337,7 +386,7 @@ def test_load_mappings_warnings(tempdir, app, status, warning):
 def test_load_mappings_fallback(tempdir, app, status, warning):
     inv_file = tempdir / 'inventory'
     inv_file.write_bytes(inventory_v2)
-    app.config.intersphinx_cache_limit = 0
+    set_config(app, {})
 
     # connect to invalid path
     app.config.intersphinx_mapping = {


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix
- Refactoring

### Purpose
In short, this PR implements https://github.com/sphinx-doc/sphinx/pull/8981#issuecomment-879815795 and thus fixes #2068 and replaces #8981 (second commit) and part of #8929 (first commit).
At the same time the PR serves as a basis for a better implementation of #9062, and contains part of the refactoring in #8929.

### Detail
The first commit is primarily refactoring, though in the case where a target contains a prefix ``something:`` and the resolution fails, the old code would strip the prefix in the final output. Now this prefix is shown in the output to avoid hiding the information from the source code. I consider this a minor "bug" fix.

The refactoring consists splitting the resolution into multiple functions:
- The top-level is the three functions
  - ``resolve_reference_in_inventory``: lookup in a user-specified inventory
  - ``resolve_reference_any_inventory``: lookup in any inventory
  - ``resolve_reference_detect_inventory``: try first ``any`` and otherwise try to extract a prefix from the target. The ``missing_reference`` handler directly calls this one.
- The domain-specific resolution is in ``_resolve_reference_in_domain`` and ``_resolve_reference_in_domain_by_target``. Abstractly, these are the ones that need to be split and moved to the domain classes (see #8929).

The second commit implements ``intersphinx_disable_domains`` which defaults to ``[]`` for backwards compatibility. For now I added
```py
intersphinx_disabled_domains = ['std']
```
to the ``conf.py`` generated by ``sphinx-quickstart``. The rationale is that I believe ``:ref`` and ``:doc:`` references most often are intended to be local, and a simple typo or missing file may silently make them resolve to external documents (i.e., the problem discussed in #2068 and #8981. All other built-in domains either do not export objects for intersphinx (``changeset``, ``citation``, ``index``, ``math``) or they are programming language domains (``c``, ``cpp``, ``js``, ``py``, ``rst``) which generates cross-references in declarations where the user can not add an inventory specification.
Note, ``std`` also contains the object types ``term``, ``token``, ``envvar``, and ``cmdoption``, but my guess is that users rarely have external links for these, and in all cases one can provide an explicit inventory specification.