### PR TITLE
Fix #9435: linkcheck: Failed to check anchors in github.com

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #9435: linkcheck: Disable checking automatically generated anchors on
+  github.com (ex. anchors in reST/Markdown documents)
+
 Deprecated
 ----------
 
@@ -15,6 +18,8 @@ Features added
 
 Bugs fixed
 ----------
+
+* #9435: linkcheck: Failed to check anchors in github.com
 
 Testing
 --------

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -714,7 +714,10 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_event('linkcheck-process-uri')
 
     app.connect('config-inited', compile_linkcheck_allowed_redirects, priority=800)
-    app.connect('linkcheck-process-uri', rewrite_github_anchor)
+
+    # FIXME: Disable URL rewrite handler for github.com temporarily.
+    # ref: https://github.com/sphinx-doc/sphinx/issues/9435
+    # app.connect('linkcheck-process-uri', rewrite_github_anchor)
 
     return {
         'version': 'builtin',

--- a/tests/roots/test-linkcheck/links.txt
+++ b/tests/roots/test-linkcheck/links.txt
@@ -13,8 +13,7 @@ Some additional anchors to exercise ignore code
 * `Complete nonsense <https://localhost:7777/doesnotexist>`_
 * `Example valid local file <conf.py>`_
 * `Example invalid local file <path/to/notfound>`_
-* https://github.com/sphinx-doc/sphinx#documentation
-* https://github.com/sphinx-doc/sphinx#user-content-testing
+* https://github.com/sphinx-doc/sphinx/blob/4.x/sphinx/__init__.py#L2
 
 .. image:: https://www.google.com/image.png
 .. figure:: https://www.google.com/image2.png

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -66,8 +66,8 @@ def test_defaults_json(app):
                  "info"]:
         assert attr in row
 
-    assert len(content.splitlines()) == 12
-    assert len(rows) == 12
+    assert len(content.splitlines()) == 11
+    assert len(rows) == 11
     # the output order of the rows is not stable
     # due to possible variance in network latency
     rowsby = {row["uri"]: row for row in rows}
@@ -88,7 +88,7 @@ def test_defaults_json(app):
     assert dnerow['uri'] == 'https://localhost:7777/doesnotexist'
     assert rowsby['https://www.google.com/image2.png'] == {
         'filename': 'links.txt',
-        'lineno': 20,
+        'lineno': 19,
         'status': 'broken',
         'code': 0,
         'uri': 'https://www.google.com/image2.png',
@@ -102,10 +102,6 @@ def test_defaults_json(app):
     # images should fail
     assert "Not Found for url: https://www.google.com/image.png" in \
         rowsby["https://www.google.com/image.png"]["info"]
-    # The anchor of the URI for github.com is automatically modified
-    assert 'https://github.com/sphinx-doc/sphinx#documentation' not in rowsby
-    assert 'https://github.com/sphinx-doc/sphinx#user-content-documentation' in rowsby
-    assert 'https://github.com/sphinx-doc/sphinx#user-content-testing' in rowsby
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The approach of `rewrite_github_anchor` makes some anchors valid.  But
it also makes other kind of anchors invalid.  This disables the handler
to make them valid again (while 4.1.x release).
- refs: #9435, #9016