### PR TITLE
Always cast the special_members as a list

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1449,6 +1449,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             if self.options.special_members is None:
                 self.options['special-members'] = {'__new__', '__init__'}
             else:
+                # TODO: It is unclear is special_members is supposed to be a list or a set
+                self.options.special_members = list(self.options.special_members)
                 self.options.special_members.append('__new__')
                 self.options.special_members.append('__init__')
 


### PR DESCRIPTION
This is a potential fix for 

https://github.com/sphinx-doc/sphinx/issues/9471

https://github.com/sphinx-doc/sphinx/issues/9436

Autodoc is mixing `set` and `list` types for the same `self.options.special_members` variable.

However because the original code is not typed, it is hard to deduct from the context if the fix is "correct" or "clean". I suggest some of the original authors review the fix.