### PR TITLE
Fix testcases that failed in python3.10.0b4

### DIFF
--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1398,16 +1398,9 @@ def test_slots(app):
 def test_enum_class(app):
     options = {"members": None}
     actual = do_autodoc(app, 'class', 'target.enums.EnumCls', options)
-
-    if sys.version_info < (3, 10):
-        sig = '(value)'
-    else:
-        sig = ('(value, names=None, *, module=None, qualname=None, type=None, start=1, '
-               'boundary=None)')
-
     assert list(actual) == [
         '',
-        '.. py:class:: EnumCls%s' % sig,
+        '.. py:class:: EnumCls(value)',
         '   :module: target.enums',
         '',
         '   this is enum class',

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -215,11 +215,8 @@ def test_signature_annotations():
 
     # optional union
     sig = inspect.signature(f20)
-    if sys.version_info < (3, 7):
-        assert stringify_signature(sig) in ('() -> Optional[Union[int, str]]',
-                                            '() -> Optional[Union[str, int]]')
-    else:
-        assert stringify_signature(sig) == '() -> Optional[Union[int, str]]'
+    assert stringify_signature(sig) in ('() -> Optional[Union[int, str]]',
+                                        '() -> Optional[Union[str, int]]')
 
     # Any
     sig = inspect.signature(f14)

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -142,9 +142,9 @@ def test_restify_type_Literal():
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
 def test_restify_type_union_operator():
-    assert restify(int | None) == "Optional[:class:`int`]"  # type: ignore
+    assert restify(int | None) == ":class:`int` | :obj:`None`"  # type: ignore
     assert restify(int | str) == ":class:`int` | :class:`str`"  # type: ignore
-    assert restify(int | str | None) == "Optional[:class:`int` | :class:`str`]"  # type: ignore
+    assert restify(int | str | None) == ":class:`int` | :class:`str` | :obj:`None`"  # type: ignore
 
 
 def test_restify_broken_type_hints():
@@ -253,9 +253,9 @@ def test_stringify_type_Literal():
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
 def test_stringify_type_union_operator():
-    assert stringify(int | None) == "Optional[int]"  # type: ignore
+    assert stringify(int | None) == "int | None"  # type: ignore
     assert stringify(int | str) == "int | str"  # type: ignore
-    assert stringify(int | str | None) == "Optional[int | str]"  # type: ignore
+    assert stringify(int | str | None) == "int | str | None"  # type: ignore
 
 
 def test_stringify_broken_type_hints():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- Now, 3.10-dev is upgraded to 3.10.0b4. And some testcases get failed.
- This fixes our testcases to follow the latest interpreter.
- This also contains the change in https://github.com/sphinx-doc/sphinx/pull/9443