### PR TITLE
Fix #9487: autodoc: typehint for cached_property is not shown

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9487: autodoc: typehint for cached_property is not shown
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2703,9 +2703,16 @@ class PropertyDocumenter(DocstringStripSignatureMixin, ClassLevelDocumenter):  #
         if self.isclassmethod:
             self.add_line('   :classmethod:', sourcename)
 
-        if safe_getattr(self.object, 'fget', None) and self.config.autodoc_typehints != 'none':
+        if safe_getattr(self.object, 'fget', None):  # property
+            func = self.object.fget
+        elif safe_getattr(self.object, 'func', None):  # cached_property
+            func = self.object.func
+        else:
+            func = None
+
+        if func and self.config.autodoc_typehints != 'none':
             try:
-                signature = inspect.signature(self.object.fget,
+                signature = inspect.signature(func,
                                               type_aliases=self.config.autodoc_type_aliases)
                 if signature.return_annotation is not Parameter.empty:
                     objrepr = stringify_typehint(signature.return_annotation)

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1084,6 +1084,7 @@ def test_autodoc_cached_property(app):
         '',
         '   .. py:property:: Foo.prop',
         '      :module: target.cached_property',
+        '      :type: int',
         '',
     ]
 

--- a/tests/test_ext_autodoc_autoproperty.py
+++ b/tests/test_ext_autodoc_autoproperty.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import sys
+
 import pytest
 
 from .test_ext_autodoc import do_autodoc
@@ -39,5 +41,18 @@ def test_class_properties(app):
         '   :type: int',
         '',
         '   docstring',
+        '',
+    ]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_cached_properties(app):
+    actual = do_autodoc(app, 'property', 'target.cached_property.Foo.prop')
+    assert list(actual) == [
+        '',
+        '.. py:property:: Foo.prop',
+        '   :module: target.cached_property',
+        '   :type: int',
         '',
     ]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9487 