### PR TITLE
Bugfix for HEAD of python-3.10

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9489: autodoc: Custom types using ``typing.NewType`` are not displayed well
+  with the HEAD of 3.10
 * #9435: linkcheck: Failed to check anchors in github.com
 
 Testing

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
 
 * #9489: autodoc: Custom types using ``typing.NewType`` are not displayed well
   with the HEAD of 3.10
+* #9490: autodoc: Some objects under ``typing`` module are not displayed well
+  with the HEAD of 3.10
 * #9435: linkcheck: Failed to check anchors in github.com
 
 Testing

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -211,12 +211,15 @@ def getslots(obj: Any) -> Optional[Dict]:
 
 def isNewType(obj: Any) -> bool:
     """Check the if object is a kind of NewType."""
-    __module__ = safe_getattr(obj, '__module__', None)
-    __qualname__ = safe_getattr(obj, '__qualname__', None)
-    if __module__ == 'typing' and __qualname__ == 'NewType.<locals>.new_type':
-        return True
+    if sys.version_info >= (3, 10):
+        return isinstance(obj, typing.NewType)
     else:
-        return False
+        __module__ = safe_getattr(obj, '__module__', None)
+        __qualname__ = safe_getattr(obj, '__qualname__', None)
+        if __module__ == 'typing' and __qualname__ == 'NewType.<locals>.new_type':
+            return True
+        else:
+            return False
 
 
 def isenumclass(x: Any) -> bool:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -171,17 +171,17 @@ def _restify_py37(cls: Optional[Type]) -> str:
             text += r"\ [%s]" % ", ".join(restify(a) for a in cls.__args__)
 
         return text
-    elif hasattr(cls, '__qualname__'):
-        if cls.__module__ == 'typing':
-            return ':class:`~%s.%s`' % (cls.__module__, cls.__qualname__)
-        else:
-            return ':class:`%s.%s`' % (cls.__module__, cls.__qualname__)
     elif hasattr(cls, '_name'):
         # SpecialForm
         if cls.__module__ == 'typing':
             return ':obj:`~%s.%s`' % (cls.__module__, cls._name)
         else:
             return ':obj:`%s.%s`' % (cls.__module__, cls._name)
+    elif hasattr(cls, '__qualname__'):
+        if cls.__module__ == 'typing':
+            return ':class:`~%s.%s`' % (cls.__module__, cls.__qualname__)
+        else:
+            return ':class:`%s.%s`' % (cls.__module__, cls.__qualname__)
     elif isinstance(cls, ForwardRef):
         return ':class:`%s`' % cls.__forward_arg__
     else:
@@ -309,7 +309,7 @@ def stringify(annotation: Any) -> str:
     elif annotation in INVALID_BUILTIN_CLASSES:
         return INVALID_BUILTIN_CLASSES[annotation]
     elif (getattr(annotation, '__module__', None) == 'builtins' and
-          hasattr(annotation, '__qualname__')):
+          getattr(annotation, '__qualname__', None)):
         return annotation.__qualname__
     elif annotation is Ellipsis:
         return '...'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9489 and #9490 
- At the HEAD of 3.10, the implementation of `typing._SpecialForm` and `typing._BaseGenericAlias` has been changed to support __qualname__.
- At the HEAD of 3.10, the implementation of ``typing.NewType`` has been changed to the class based.  To follow the change, this uses ``isinstance`` on ``sphinx.util.inspect:isNewType()`.