### PR TITLE
Fix #9436, #9471: autodoc: crashed if autodoc_class_signature = "separated"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ Bugs fixed
   with the HEAD of 3.10
 * #9490: autodoc: Some objects under ``typing`` module are not displayed well
   with the HEAD of 3.10
+* #9436, #9471: autodoc: crashed if ``autodoc_class_signature = "separated"``
 * #9435: linkcheck: Failed to check anchors in github.com
 
 Testing

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -257,6 +257,9 @@ def between(marker: str, what: Sequence[str] = None, keepempty: bool = False,
 # But we define this class here to keep compatibility (see #4538)
 class Options(dict):
     """A dict/attribute hybrid that returns None on nonexisting keys."""
+    def copy(self) -> "Options":
+        return Options(super().copy())
+
     def __getattr__(self, name: str) -> Any:
         try:
             return self[name.replace('_', '-')]
@@ -1445,9 +1448,11 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         super().__init__(*args)
 
         if self.config.autodoc_class_signature == 'separated':
+            self.options = self.options.copy()
+
             # show __init__() method
             if self.options.special_members is None:
-                self.options['special-members'] = {'__new__', '__init__'}
+                self.options['special-members'] = ['__new__', '__init__']
             else:
                 self.options.special_members.append('__new__')
                 self.options.special_members.append('__init__')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- A list should be used for special-members option instead of set.
- refs: #9436, #9471