### PR TITLE
Fix #9456: html search: html_copy_source can't control the search summaries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ Bugs fixed
   with the HEAD of 3.10
 * #9490: autodoc: Some objects under ``typing`` module are not displayed well
   with the HEAD of 3.10
+* #9456: html search: html_copy_source can't control the search summaries
 * #9435: linkcheck: Failed to check anchors in github.com
 
 Testing

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -276,7 +276,7 @@ var Search = {
           setTimeout(function() {
             displayNextItem();
           }, 5);
-        } else {
+        } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
           $.ajax({url: requestUrl,
                   dataType: "text",
                   complete: function(jqxhr, textstatus) {
@@ -289,6 +289,12 @@ var Search = {
                       displayNextItem();
                     }, 5);
                   }});
+        } else {
+          // no source available, just display title
+          Search.output.append(listItem);
+          setTimeout(function() {
+            displayNextItem();
+          }, 5);
         }
       }
       // search finished, update title and status message


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- This reverts commit 634b05f3a5070fef9854a1bc862c66665d2ea8b9.
- So far, users can disable showing summary texts via `html_copy_source`
setting.  But this change always show them forcedly.  To keep
compatibility, it should be reverted temporarily.
- refs: #9456
