### PR TITLE
[autodoc] Fix uncatched exception in get type hints

### DIFF
--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -86,6 +86,9 @@ def get_type_hints(obj: Any, globalns: Dict = None, localns: Dict = None) -> Dic
     except NameError:
         # Failed to evaluate ForwardRef (maybe TYPE_CHECKING)
         return safe_getattr(obj, '__annotations__', {})
+    except AttributeError:
+        # Failed to evaluate ForwardRef (maybe not runtime checkable)
+        return safe_getattr(obj, '__annotations__', {})
     except TypeError:
         # Invalid object is given. But try to get __annotations__ as a fallback for
         # the code using type union operator (PEP 604) in python 3.9 or below.


### PR DESCRIPTION
Subject: Fix uncatched exception in get type hints

### Feature or Bugfix
- Bugfix

### Purpose
- `get_type_hints` by `autodoc` from not runtime checkable `ForwardRef` may cause `AttributeError` instead of `NameError`

### Detail

Some modules like `loguru` provide a stub file include types defined not at runtime. As mentioned in `mypy` stub file guide, these types may cause errors if used in runtime.

Error occured because of the following code in autodoc:

https://github.com/sphinx-doc/sphinx/blob/f59026865a8c658acbc6d5690c146f4be0851854/sphinx/ext/autodoc/__init__.py#L1981-L2005

Following Code will raise `AttributeError` when building:

```python
import loguru

# loguru.Logger not exists at runtime actually
my_logger: "loguru.Logger" = loguru.logger
```

Following Code will be processed successfully (`NameError` has been caught):

```python
from typing import TYPE_CHECKING

import loguru

if TYPE_CHECKING:
	from loguru import Logger

my_logger: "Logger" = loguru.logger
```

If `AttributeError` is catched in `get_type_hints`, these `ForwardRef` will be treated as raw string and building will be successful. But, i dont know if this change may cause some unexpected building success.

#### Full Example

Repo: https://github.com/yanyongyu/loguru-issue480

Build Log: https://github.com/yanyongyu/loguru-issue480/runs/3177938743

### Relates
- https://github.com/Delgan/loguru/issues/480

