### PR TITLE
Fix #9512: sphinx-build: crashed with the HEAD of Python 3.10

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9512: sphinx-build: crashed with the HEAD of Python 3.10
+
 Testing
 --------
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -33,10 +33,10 @@ else:
             ref = _ForwardRef(self.arg)
             return ref._eval_type(globalns, localns)
 
-if sys.version_info > (3, 10):
-    from types import Union as types_Union
-else:
-    types_Union = None
+try:
+    from types import UnionType  # type: ignore  # python 3.10 or above
+except ImportError:
+    UnionType = None
 
 if False:
     # For type annotation
@@ -114,7 +114,7 @@ def restify(cls: Optional[Type]) -> str:
             return ':class:`%s`' % INVALID_BUILTIN_CLASSES[cls]
         elif inspect.isNewType(cls):
             return ':class:`%s`' % cls.__name__
-        elif types_Union and isinstance(cls, types_Union):
+        elif UnionType and isinstance(cls, UnionType):
             if len(cls.__args__) > 1 and None in cls.__args__:
                 args = ' | '.join(restify(a) for a in cls.__args__ if a)
                 return 'Optional[%s]' % args
@@ -337,7 +337,7 @@ def _stringify_py37(annotation: Any) -> str:
     elif hasattr(annotation, '__origin__'):
         # instantiated generic provided by a user
         qualname = stringify(annotation.__origin__)
-    elif types_Union and isinstance(annotation, types_Union):  # types.Union (for py3.10+)
+    elif UnionType and isinstance(annotation, UnionType):  # types.Union (for py3.10+)
         qualname = 'types.Union'
     else:
         # we weren't able to extract the base type, appending arguments would


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Recently, `types.Union` was renamed to `types.UnionType` on the HEAD
of 3.10 (refs: python/cpython#27342). After this change, sphinx-build
has been crashed because of ImportError.
- refs: #9512 