### PR TITLE
Fix #9504: autodoc: generate incorrect reference to the parent class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9504: autodoc: generate incorrect reference to the parent class if the target
+  class inherites the class having ``_name`` attribute
 * #9512: sphinx-build: crashed with the HEAD of Python 3.10
 
 Testing

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -171,12 +171,8 @@ def _restify_py37(cls: Optional[Type]) -> str:
             text += r"\ [%s]" % ", ".join(restify(a) for a in cls.__args__)
 
         return text
-    elif hasattr(cls, '_name'):
-        # SpecialForm
-        if cls.__module__ == 'typing':
-            return ':obj:`~%s.%s`' % (cls.__module__, cls._name)
-        else:
-            return ':obj:`%s.%s`' % (cls.__module__, cls._name)
+    elif isinstance(cls, typing._SpecialForm):
+        return ':obj:`~%s.%s`' % (cls.__module__, cls._name)
     elif hasattr(cls, '__qualname__'):
         if cls.__module__ == 'typing':
             return ':class:`~%s.%s`' % (cls.__module__, cls.__qualname__)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Autodoc generates incorrect references to the parent class the target
class inherites the class having `_name` attribute.  It conciders the
parent is a kind of SpecialForm'ed class by mistake.  This uses
`isinstance(X, SpecialForm)` to check that.
- Note: SpecialForm became a class since Python 3.7.
- refs: #9504
