### PR TITLE
Fix autodoc_docstring_signature support for __init__ and __new__

### DIFF
--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -114,6 +114,20 @@ class InnerChild(Outer.Inner):
 
 
 class DocstringSig(object):
+    def __new__(cls, *new_args, **new_kwargs):
+        """__new__(cls, d, e=1) -> DocstringSig
+First line of docstring
+
+        rest of docstring
+        """
+
+    def __init__(self, *init_args, **init_kwargs):
+        """__init__(self, a, b=1) -> None
+First line of docstring
+
+        rest of docstring
+        """
+
     def meth(self):
         """meth(FOO, BAR=1) -> BAZ
 First line of docstring

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -287,12 +287,32 @@ def test_autodoc_inherit_docstrings(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_docstring_signature(app):
-    options = {"members": None}
+    options = {"members": None, "special-members": "__init__, __new__"}
     actual = do_autodoc(app, 'class', 'target.DocstringSig', options)
     assert list(actual) == [
         '',
-        '.. py:class:: DocstringSig()',
+        # FIXME: Ideally this would instead be: `DocstringSig(d, e=1)` but
+        # currently `ClassDocumenter` does not apply the docstring signature
+        # logic when extracting a signature from a __new__ or __init__ method.
+        '.. py:class:: DocstringSig(*new_args, **new_kwargs)',
         '   :module: target',
+        '',
+        '',
+        '   .. py:method:: DocstringSig.__init__(self, a, b=1) -> None',
+        '      :module: target',
+        '',
+        '      First line of docstring',
+        '',
+        '      rest of docstring',
+        '',
+        '',
+        '   .. py:method:: DocstringSig.__new__(cls, d, e=1) -> DocstringSig',
+        '      :module: target',
+        '      :staticmethod:',
+        '',
+        '      First line of docstring',
+        '',
+        '      rest of docstring',
         '',
         '',
         '   .. py:method:: DocstringSig.meth(FOO, BAR=1) -> BAZ',
@@ -331,8 +351,29 @@ def test_autodoc_docstring_signature(app):
     actual = do_autodoc(app, 'class', 'target.DocstringSig', options)
     assert list(actual) == [
         '',
-        '.. py:class:: DocstringSig()',
+        '.. py:class:: DocstringSig(*new_args, **new_kwargs)',
         '   :module: target',
+        '',
+        '',
+        '   .. py:method:: DocstringSig.__init__(*init_args, **init_kwargs)',
+        '      :module: target',
+        '',
+        '      __init__(self, a, b=1) -> None',
+        '      First line of docstring',
+        '',
+        '              rest of docstring',
+        '',
+        '',
+        '',
+        '   .. py:method:: DocstringSig.__new__(cls, *new_args, **new_kwargs)',
+        '      :module: target',
+        '      :staticmethod:',
+        '',
+        '      __new__(cls, d, e=1) -> DocstringSig',
+        '      First line of docstring',
+        '',
+        '              rest of docstring',
+        '',
         '',
         '',
         '   .. py:method:: DocstringSig.meth()',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
The `MethodDocumenter.get_doc` method added by
51ae283a38ed297df3fd5e0554dcc9acaa103e8c prevents
`DocstringSignatureMixin` from working correctly for `__init__` and
`__new__` methods.  Additionally, the `__new__` docstring was not obtained
correctly.

This commit checks for `self._new_docstrings` being set, and also
corrects the logic for obtaining the `__new__` docstring.

There still remains the issue that when the class signature is
obtained from the signature of `__init__` or `__new__`, only the real
signature is used, due to the use of `sphinx.util.inspect.signature`;
the `autodoc_docstring_signature` option does not have any effect.
