### PR TITLE
Close #9378: setuptools: Add the build directory to sys.path automatically

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 * #9445: autodoc: Support class properties
 * #9445: py domain: ``:py:property:`` directive supports ``:classmethod:``
   option to describe the class property
+* #9378: setuptools: Add the build directory to sys.path automatically if
+  ``build_sphinx`` command is invoked after ``build`` command
 
 Bugs fixed
 ----------

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -160,6 +160,8 @@ class BuildDoc(Command):
         if self.nitpicky:
             confoverrides['nitpicky'] = self.nitpicky
 
+        self.setup_syspath()
+
         for builder, builder_target_dir in self.builder_target_dirs:
             app = None
 
@@ -187,3 +189,10 @@ class BuildDoc(Command):
             src = app.config.root_doc + app.builder.out_suffix  # type: ignore
             dst = app.builder.get_outfilename('index')  # type: ignore
             os.symlink(src, dst)
+
+    def setup_syspath(self) -> None:
+        """Set up sys.path to import target modules from the build directory."""
+        build = self.distribution.command_obj.get('build')  # type: ignore
+        build_lib = getattr(build, 'build_lib', None)
+        if build_lib and os.path.exists(build_lib) and build_lib not in sys.path:
+            sys.path.append(build_lib)


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Now `build_sphinx` command set up `sys.path` automatically if the build
directory found.
- refs: #9378 