### PR TITLE
FIX: do not try to compute the boolean value of a numpy array

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -255,9 +255,10 @@ def isclassmethod(obj: Any, cls: Any = None, name: str = None) -> bool:
     elif inspect.ismethod(obj) and obj.__self__ is not None and isclass(obj.__self__):
         return True
     elif cls and name:
+        placeholder = object()
         for basecls in getmro(cls):
-            meth = basecls.__dict__.get(name)
-            if meth:
+            meth = basecls.__dict__.get(name, placeholder)
+            if meth is not placeholder:
                 return isclassmethod(meth)
 
     return False


### PR DESCRIPTION
Subject: Correctly handle numpy arrays as class attributes

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Purpose


### Detail

The following class will fail on sphinx master branch:

```python
class IdentityTransform:
    """
    A special class that does one thing, the identity transform, in a
    fast way.
    """
    _mtx = np.identity(3)

```
(which is a short version of 
https://github.com/matplotlib/matplotlib/blob/e044cf50021a2231760e4e95354f4b334c77525b/lib/matplotlib/transforms.py#L2073-L2120)

with:

```pytb

Traceback (most recent call last):
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/cmd/build.py", line 280, in build_main
    app.build(args.force_all, filenames)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/application.py", line 343, in build
    self.builder.build_update()
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 293, in build_update
    self.build(to_build,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 307, in build
    updated_docnames = set(self.read())
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 414, in read
    self._read_serial(docnames)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 435, in _read_serial
    self.read_doc(docname)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 475, in read_doc
    doctree = read_doc(self.app, self.env, self.env.doc2path(docname))
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/io.py", line 189, in read_doc
    pub.publish()
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/core.py", line 217, in publish
    self.document = self.reader.read(self.source, self.parser,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/io.py", line 109, in read
    self.parse()
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/readers/__init__.py", line 77, in parse
    self.parser.parse(self.input, document)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/parsers.py", line 101, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 170, in run
    results = StateMachineWS.run(self, input_lines, input_offset,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/statemachine.py", line 241, in run
    context, next_state, result = self.check_line(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/statemachine.py", line 459, in check_line
    return method(match, context, next_state)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 3005, in text
    self.section(title.lstrip(), source, style, lineno + 1, messages)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 393, in new_subsection
    newabsoffset = self.nested_parse(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 281, in nested_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/statemachine.py", line 241, in run
    context, next_state, result = self.check_line(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/statemachine.py", line 459, in check_line
    return method(match, context, next_state)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2344, in explicit_markup
    self.explicit_list(blank_finish)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2369, in explicit_list
    newline_offset, blank_finish = self.nested_list_parse(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 318, in nested_list_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/statemachine.py", line 241, in run
    context, next_state, result = self.check_line(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/statemachine.py", line 459, in check_line
    return method(match, context, next_state)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2647, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2354, in explicit_construct
    return method(self, expmatch)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2096, in directive
    return self.run_directive(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2146, in run_directive
    result = directive_instance.run()
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/directive.py", line 162, in run
    documenter.generate(more_content=self.content)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 979, in generate
    self.document_members(all_members)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 860, in document_members
    documenter.generate(
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 1769, in generate
    return super().generate(more_content=more_content,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 979, in generate
    self.document_members(all_members)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 1760, in document_members
    super().document_members(all_members)
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 842, in document_members
    for (mname, member, isattr) in self.filter_members(members, want_all):
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 723, in filter_members
    doc = getdoc(member, self.get_attr, self.config.autodoc_inherit_docstrings,
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/util/inspect.py", line 848, in getdoc
    if cls and name and isclassmethod(obj, cls, name):
  File "/home/tcaswell/.virtualenvs/bleeding/lib/python3.10/site-packages/sphinx/util/inspect.py", line 260, in isclassmethod
    if meth:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

```

This issue was introduced in 38d80c3d0f899a6fa40e52b9b3f7ac5bcaa73311
