### PR TITLE
Fix #9537: autodoc: Some typing.* objects are broken

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Bugs fixed
 
 * #9504: autodoc: generate incorrect reference to the parent class if the target
   class inherites the class having ``_name`` attribute
+* #9537: autodoc: Some objects under ``typing`` module are not displayed well
+  with the HEAD of 3.10
 * #9512: sphinx-build: crashed with the HEAD of Python 3.10
 
 Testing

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -148,7 +148,9 @@ def _restify_py37(cls: Optional[Type]) -> str:
             args = ', '.join(restify(a) for a in cls.__args__)
             return ':obj:`~typing.Union`\\ [%s]' % args
     elif inspect.isgenericalias(cls):
-        if getattr(cls, '_name', None):
+        if isinstance(cls.__origin__, typing._SpecialForm):
+            text = restify(cls.__origin__)  # type: ignore
+        elif getattr(cls, '_name', None):
             if cls.__module__ == 'typing':
                 text = ':class:`~%s.%s`' % (cls.__module__, cls._name)
             else:
@@ -344,7 +346,7 @@ def _stringify_py37(annotation: Any) -> str:
         if not isinstance(annotation.__args__, (list, tuple)):
             # broken __args__ found
             pass
-        elif qualname == 'Union':
+        elif qualname in ('Optional', 'Union'):
             if len(annotation.__args__) > 1 and annotation.__args__[-1] is NoneType:
                 if len(annotation.__args__) > 2:
                     args = ', '.join(stringify(a) for a in annotation.__args__[:-1])


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- At the HEAD of 3.10, the implementation of `typing._GenericAlias` has
been changed to have correct _name and __name__.
- refs: #9537 