### PR TITLE
Proof of Concept: add "H" shortcut for hiding search matches

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -235,7 +235,7 @@ var Documentation = {
         });
       }, 10);
       $('<p class="highlight-link"><a href="javascript:Documentation.' +
-        'hideSearchWords()">' + _('Hide Search Matches') + '</a></p>')
+        'hideSearchWords()" accesskey="H">' + _('Hide Search Matches') + '</a></p>')
           .appendTo($('#searchbox'));
     }
   },


### PR DESCRIPTION
I don't think this is a good idea, I just want to illustrate how part of #9337 could be implemented using `accesskey`.

Rendered: https://sphinx--9539.org.readthedocs.build/en/9539/usage/configuration.html?highlight=search%20term