### PR TITLE
Fix typo in numfig_format documentation

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -453,7 +453,7 @@ General configuration
    As a special character, ``%s`` will be replaced to figure number.
 
    Default is to use ``'Fig. %s'`` for ``'figure'``, ``'Table %s'`` for
-   ``'table'``, ``'Listing %s'`` for ``'code-block'`` and ``'Section'`` for
+   ``'table'``, ``'Listing %s'`` for ``'code-block'`` and ``'Section %s'`` for
    ``'section'``.
 
    .. versionadded:: 1.3


### PR DESCRIPTION
Just fixes a small typo in the documentation for `numfig_format`.

Thanks very much to all the sphinx maintainers for this wonderful tool!  It is a great asset to the community.