### PR TITLE
Update link to OpenSearch.

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1309,11 +1309,11 @@ that use Sphinx's HTMLWriter class.
 
 .. confval:: html_use_opensearch
 
-   If nonempty, an `OpenSearch <https://www.opensearch.org/>`_ description
-   file will be output, and all pages will contain a ``<link>`` tag referring
-   to it.  Since OpenSearch doesn't support relative URLs for its search page
-   location, the value of this option must be the base URL from which these
-   documents are served (without trailing slash), e.g.
+   If nonempty, an `OpenSearch <https://github.com/dewitt/opensearch>`_
+   description file will be output, and all pages will contain a ``<link>``
+   tag referring to it.  Since OpenSearch doesn't support relative URLs for
+   its search page location, the value of this option must be the base URL
+   from which these documents are served (without trailing slash), e.g.
    ``"https://docs.python.org"``.  The default is ``''``.
 
 .. confval:: html_file_suffix


### PR DESCRIPTION
Amazon repurposed the opensearch.org domain.

It is now hosting their ElasticSearch fork.