### PR TITLE
Fix #9267: html theme: CSS and JS files added by theme were loaded twice

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
 * #9481: cpp domain: some warnings contain non-existing filenames
 * #9456: html search: abbreation marks are inserted to the search result if
   failed to fetch the content of the page
+* #9267: html theme: CSS and JS files added by theme were loaded twice
 
 Testing
 --------

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -287,13 +287,14 @@ class StandaloneHTMLBuilder(Builder):
 
         if dark_style is not None:
             self.dark_highlighter = PygmentsBridge('html', dark_style)
-            self.add_css_file('pygments_dark.css',
-                              media='(prefers-color-scheme: dark)',
-                              id='pygments_dark_css')
+            self.app.add_css_file('pygments_dark.css',
+                                  media='(prefers-color-scheme: dark)',
+                                  id='pygments_dark_css')
         else:
             self.dark_highlighter = None
 
     def init_css_files(self) -> None:
+        self.css_files = []
         self.add_css_file('pygments.css', priority=200)
         self.add_css_file(self._get_style_filename(), priority=200)
 
@@ -311,6 +312,7 @@ class StandaloneHTMLBuilder(Builder):
         self.css_files.append(Stylesheet(filename, **kwargs))
 
     def init_js_files(self) -> None:
+        self.script_files = []
         self.add_js_file('documentation_options.js', id="documentation_options",
                          data_url_root='', priority=200)
         self.add_js_file('jquery.js', priority=200)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9267 