### PR TITLE
"Hide Search Matches" removes "highlight" parameter from URL

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -264,6 +264,9 @@ var Documentation = {
   hideSearchWords : function() {
     $('#searchbox .highlight-link').fadeOut(300);
     $('span.highlighted').removeClass('highlighted');
+    var url = new URL(window.location);
+    url.searchParams.delete('highlight');
+    window.history.replaceState({}, '', url);
   },
 
   /**


### PR DESCRIPTION
When clicking "Hide Search Matches", this will modify the URL in the browser, removing the `?highlight=xyz` part (without reloading the page).

This makes it easier to share the link without highlighting.

This is a slight variation of a part of #9337. No new history entry is created, though.

Try it out: https://sphinx--9551.org.readthedocs.build/en/9551/extdev/appapi.html?highlight=sphinx