### PR TITLE
C++, fix parsing of defaulted function parameters that are function pointers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,8 @@ Bugs fixed
 * #9456: html search: abbreation marks are inserted to the search result if
   failed to fetch the content of the page
 * #9267: html theme: CSS and JS files added by theme were loaded twice
+* #9535 comment: C++, fix parsing of defaulted function parameters that are
+  function pointers.
 
 Testing
 --------

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -5936,13 +5936,6 @@ class DefinitionParser(BaseParser):
                         'Expecting "," or ")" in parameters-and-qualifiers, '
                         'got "%s".' % self.current_char)
 
-        # TODO: why did we have this bail-out?
-        # does it hurt to parse the extra stuff?
-        # it's needed for pointer to member functions
-        if paramMode != 'function' and False:
-            return ASTParametersQualifiers(
-                args, None, None, None, None, None, None, None)
-
         self.skip_ws()
         const = self.skip_word_and_ws('const')
         volatile = self.skip_word_and_ws('volatile')
@@ -5989,7 +5982,8 @@ class DefinitionParser(BaseParser):
 
         self.skip_ws()
         initializer = None
-        if self.skip_string('='):
+        # if this is a function pointer we should not swallow an initializer
+        if paramMode == 'function' and self.skip_string('='):
             self.skip_ws()
             valid = ('0', 'delete', 'default')
             for w in valid:

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -639,6 +639,9 @@ def test_domain_cpp_ast_function_definitions():
     # from #8960
     check('function', 'void f(void (*p)(int, double), int i)', {2: '1fPFvidEi'})
 
+    # from #9535 comment
+    check('function', 'void f(void (*p)(int) = &foo)', {2: '1fPFviE'})
+
 
 def test_domain_cpp_ast_operators():
     check('function', 'void operator new()', {1: "new-operator", 2: "nwv"})


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Fix https://github.com/sphinx-doc/sphinx/issues/9535#issuecomment-899060054.
Only parse function initializers for top-level parameter lists.

