### PR TITLE
fix: proper error messages if autosummary fails to import module

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -645,7 +645,7 @@ def _import_by_name(name: str, last_errors = None) -> Tuple[Any, Any, str]:
                 return getattr(mod, name_parts[-1]), mod, modname
             except (ImportError, IndexError, AttributeError) as e:
                 if last_errors is not None:
-                    last_errors.append(str(str(e.args[0])))
+                    last_errors.append(str(e))
                 pass
 
         # ... then as MODNAME, MODNAME.OBJ1, MODNAME.OBJ1.OBJ2, ...

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -677,7 +677,7 @@ def _import_by_name(name: str, last_errors = None) -> Tuple[Any, Any, str]:
         raise ImportError(*e.args) from e
 
 
-def import_ivar_by_name(name: str, prefixes: List[str] = [None]) -> Tuple[str, Any, Any, str]:
+def import_ivar_by_name(name: str, prefixes: List[str] = [None], last_errors = None) -> Tuple[str, Any, Any, str]:
     """Import an instance variable that has the given *name*, under one of the
     *prefixes*.  The first name that succeeds is used.
     """
@@ -690,7 +690,9 @@ def import_ivar_by_name(name: str, prefixes: List[str] = [None]) -> Tuple[str, A
         # check for presence in `annotations` to include dataclass attributes
         if (qualname, attr) in analyzer.attr_docs or (qualname, attr) in analyzer.annotations:
             return real_name + "." + attr, INSTANCEATTR, obj, modname
-    except (ImportError, ValueError, PycodeError):
+    except (ImportError, ValueError, PycodeError) as e:
+        if last_errors is not None:
+            last_errors.append(str(e.args[0]))
         pass
 
     raise ImportError

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -658,7 +658,7 @@ def _import_by_name(name: str, last_errors = None) -> Tuple[Any, Any, str]:
                 import_module(modname)
             except ImportError as e:
                 if last_errors is not None:
-                    last_errors.append(str(e.args[0]))
+                    last_errors.append(str(e))
                 continue
 
             if modname in sys.modules:
@@ -692,7 +692,7 @@ def import_ivar_by_name(name: str, prefixes: List[str] = [None], last_errors = N
             return real_name + "." + attr, INSTANCEATTR, obj, modname
     except (ImportError, ValueError, PycodeError) as e:
         if last_errors is not None:
-            last_errors.append(str(e.args[0]))
+            last_errors.append(str(e))
         pass
 
     raise ImportError

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -617,6 +617,8 @@ def get_import_prefixes_from_env(env: BuildEnvironment) -> List[str]:
 def import_by_name(name: str, prefixes: List[str] = [None], last_errors = None) -> Tuple[str, Any, Any, str]:
     """Import a Python object that has the given *name*, under one of the
     *prefixes*.  The first name that succeeds is used.
+    If importing fails, *last_errors* will contain the exceptions raised during
+    import and may help to identify the problem.
     """
     tried = []
     for prefix in prefixes:
@@ -645,8 +647,7 @@ def _import_by_name(name: str, last_errors = None) -> Tuple[Any, Any, str]:
                 return getattr(mod, name_parts[-1]), mod, modname
             except (ImportError, IndexError, AttributeError) as e:
                 if last_errors is not None:
-                    last_errors.append(str(e))
-                pass
+                    last_errors.append(e)
 
         # ... then as MODNAME, MODNAME.OBJ1, MODNAME.OBJ1.OBJ2, ...
         last_j = 0
@@ -658,7 +659,7 @@ def _import_by_name(name: str, last_errors = None) -> Tuple[Any, Any, str]:
                 import_module(modname)
             except ImportError as e:
                 if last_errors is not None:
-                    last_errors.append(str(e))
+                    last_errors.append(e)
                 continue
 
             if modname in sys.modules:
@@ -692,8 +693,7 @@ def import_ivar_by_name(name: str, prefixes: List[str] = [None], last_errors = N
             return real_name + "." + attr, INSTANCEATTR, obj, modname
     except (ImportError, ValueError, PycodeError) as e:
         if last_errors is not None:
-            last_errors.append(str(e))
-        pass
+            last_errors.append(e)
 
     raise ImportError
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -421,9 +421,11 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
         except ImportError as e:
             try:
                 # try to importl as an instance attribute
-                name, obj, parent, modname = import_ivar_by_name(entry.name)
+                name, obj, parent, modname = import_ivar_by_name(entry.name, last_errors=last_errors)
                 qualname = name.replace(modname + ".", "")
             except ImportError:
+                # remove duplicates
+                last_errors = list(set(last_errors))
                 logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') % (entry.name, e, last_errors))
                 continue
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -413,8 +413,10 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
         path = output_dir or os.path.abspath(entry.path)
         ensuredir(path)
 
+        last_errors = list()
+
         try:
-            name, obj, parent, modname = import_by_name(entry.name)
+            name, obj, parent, modname = import_by_name(entry.name, last_errors=last_errors)
             qualname = name.replace(modname + ".", "")
         except ImportError as e:
             try:
@@ -422,7 +424,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
                 name, obj, parent, modname = import_ivar_by_name(entry.name)
                 qualname = name.replace(modname + ".", "")
             except ImportError:
-                logger.warning(__('[autosummary] failed to import %r: %s') % (entry.name, e))
+                logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') % (entry.name, e, last_errors))
                 continue
 
         context: Dict[str, Any] = {}

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -413,20 +413,21 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
         path = output_dir or os.path.abspath(entry.path)
         ensuredir(path)
 
-        last_errors = list()
+        last_errors = []
 
         try:
             name, obj, parent, modname = import_by_name(entry.name, last_errors=last_errors)
             qualname = name.replace(modname + ".", "")
         except ImportError as e:
             try:
-                # try to importl as an instance attribute
+                # try to import as an instance attribute
                 name, obj, parent, modname = import_ivar_by_name(entry.name, last_errors=last_errors)
                 qualname = name.replace(modname + ".", "")
             except ImportError:
-                # remove duplicates
-                last_errors = list(set(last_errors))
-                logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') % (entry.name, e, last_errors))
+                # Convert exceptions to strings and remove duplicates (covert to set, then to list)
+                last_errors_str = list({str(e) in last_errors})
+                logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') %
+                               (entry.name, e, last_errors_str))
                 continue
 
         context: Dict[str, Any] = {}

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -425,8 +425,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
                 qualname = name.replace(modname + ".", "")
             except ImportError:
                 # Convert exceptions to strings and remove duplicates (convert to set, then to list)
-                last_errors_str = list([str(e) for e in last_errors])
-                last_errors_str = list(set(last_errors_str))
+                last_errors_str = list(set(str(e) for e in last_errors))
                 logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') %
                                (entry.name, e, last_errors_str))
                 continue

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -425,7 +425,8 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
                 qualname = name.replace(modname + ".", "")
             except ImportError:
                 # Convert exceptions to strings and remove duplicates (covert to set, then to list)
-                last_errors_str = list({str(e) in last_errors})
+                last_errors_str = list([str(e) for e in last_errors])
+                last_errors_str = list(set(last_errors_str))
                 logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') %
                                (entry.name, e, last_errors_str))
                 continue

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -424,7 +424,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
                 name, obj, parent, modname = import_ivar_by_name(entry.name, last_errors=last_errors)
                 qualname = name.replace(modname + ".", "")
             except ImportError:
-                # Convert exceptions to strings and remove duplicates (covert to set, then to list)
+                # Convert exceptions to strings and remove duplicates (convert to set, then to list)
                 last_errors_str = list([str(e) for e in last_errors])
                 last_errors_str = list(set(last_errors_str))
                 logger.warning(__('[autosummary] failed to import %r: %s. Possible hints: %s') %


### PR DESCRIPTION
Subject: Show proper error messages if autosummary fails to import module

Fixes #7989

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

As described in #7989, autosummary currently does not provide helpful error messages.

E.g., let's say I have a module called fancy_bob, which in its init.py uses `import filelock` (or any other external module).
Then in my docs I write:

```rst

.. autosummary::
   :toctree: _autosummary
   :recursive:

   fancy_bob
```

If the filelock module is not installed, autosummary will just fail with:

```
[autosummary] failed to import 'fancy_bob': no module named fancy_bob.
```

This error message is completely misleading, since it actually finds the module `fancy_bob` but then fails to import its dependencies.

This MR changes the error output in a way that you at least get some hints what went wrong, e.g., now you get:

```
[autosummary] failed to import 'fancy_bob': no module named fancy_bob. Possible hints: ["No module named 'filelock'"]
```

Or if there is a syntax error in the module's init.py, it will show:

```
[autosummary] failed to import 'fancy_bob': no module named fancy_bob. Possible hints: ['invalid syntax (__init__.py, line 4)']
```

### Reproduction

@astrojuanlu provided a nice example project to reproduce the issue in https://github.com/astrojuanlu/sphinx-autosummary-tracebacks

Not setting the pythonpath properly results in:
```
[autosummary] failed to import 'test_pkg.A': no module named test_pkg.A. Possible hints: ["No module named 'test_pkg'", 'no module named test_pkg']
```

Setting the pythonpath gives the correct error:
```
[autosummary] failed to import 'test_pkg.A': no module named test_pkg.A. Possible hints: ['no module named test_pkg', "No module named 'attr'"]
```

I.e., `"No module named 'attr'`


### Detail
- #7989

### Relates
- <URL or Ticket>

