### PR TITLE
ci(tox.ini): add COLORTERM to passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ passenv =
     https_proxy
     http_proxy
     no_proxy
+    COLORTERM
     PERL
     PERL5LIB
     PYTEST_ADDOPTS


### PR DESCRIPTION
This is required for [kitty](https://sw.kovidgoyal.net/kitty/), which
uses TERM=xterm-kitty, which is not detected as being a colored
terminal, without its `COLORTERM=truecolor` also being passed [1].

1: https://github.com/sphinx-doc/sphinx/blob/d194e0f4909b0887b37e2a32787f6b4c0fe8862a/sphinx/util/console.py#L70-L71