### PR TITLE
Fix #9589: autodoc: typing.Annotated has wrongly been rendered

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,8 +18,8 @@ Bugs fixed
 
 * #9504: autodoc: generate incorrect reference to the parent class if the target
   class inherites the class having ``_name`` attribute
-* #9537: autodoc: Some objects under ``typing`` module are not displayed well
-  with the HEAD of 3.10
+* #9537, #9589: autodoc: Some objects under ``typing`` module are not displayed
+  well with the HEAD of 3.10
 * #9512: sphinx-build: crashed with the HEAD of Python 3.10
 
 Testing

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -306,6 +306,8 @@ def stringify(annotation: Any) -> str:
         return 'None'
     elif annotation in INVALID_BUILTIN_CLASSES:
         return INVALID_BUILTIN_CLASSES[annotation]
+    elif str(annotation).startswith('typing.Annotated'):  # for py310+
+        pass
     elif (getattr(annotation, '__module__', None) == 'builtins' and
           getattr(annotation, '__qualname__', None)):
         return annotation.__qualname__


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- At the HEAD of 3.10, the implementation of `typing.Annotated` has
been changed to have __qualname__.
- refs: #9589 