### PR TITLE
let user skip printing command description

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Features added
 * #9479: autodoc: Emit a warning if target is a mocked object
 * #9447: html theme: Expose the version of Sphinx in the form of tuple as a
   template variable ``sphinx_version_tuple``
+* #9594: manpage: Suppress the title of man page if description is empty
 * #9445: py domain: ``:py:property:`` directive supports ``:classmethod:``
   option to describe the class property
 * #9524: test: SphinxTestApp can take ``builddir`` as an argument

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2331,6 +2331,8 @@ These options influence manual page output.
 
    *description*
      Description of the manual page.  This is used in the NAME section.
+     Can be an empty string if you do not want to automatically generate
+     the NAME section.
 
    *authors*
      A list of strings with authors, or a single string.  Can be an empty

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -112,10 +112,10 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
     # overwritten -- added quotes around all .TH arguments
     def header(self) -> str:
         tmpl = (".TH \"%(title_upper)s\" \"%(manual_section)s\""
-                " \"%(date)s\" \"%(version)s\" \"%(manual_group)s\"\n"
-                ".SH NAME\n")
+                " \"%(date)s\" \"%(version)s\" \"%(manual_group)s\"\n")
         if self._docinfo['subtitle']:
-            tmpl += "%(title)s \\- %(subtitle)s\n"
+            tmpl += (".SH NAME\n"
+                     "%(title)s \\- %(subtitle)s\n")
         return tmpl % self._docinfo
 
     def visit_start_of_file(self, node: Element) -> None:

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -113,8 +113,9 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
     def header(self) -> str:
         tmpl = (".TH \"%(title_upper)s\" \"%(manual_section)s\""
                 " \"%(date)s\" \"%(version)s\" \"%(manual_group)s\"\n"
-                ".SH NAME\n"
-                "%(title)s \\- %(subtitle)s\n")
+                ".SH NAME\n")
+        if self._docinfo['subtitle']:
+            tmpl += "%(title)s \\- %(subtitle)s\n"
         return tmpl % self._docinfo
 
     def visit_start_of_file(self, node: Element) -> None:

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -23,6 +23,9 @@ def test_all(app, status, warning):
     assert r'\fBprint \fP\fIi\fP\fB\en\fP' in content
     assert r'\fBmanpage\en\fP' in content
 
+    # heading (title + description)
+    assert r'sphinxtests \- Sphinx <Tests> 0.6alpha1' in content
+
     # term of definition list including nodes.strong
     assert '\n.B term1\n' in content
     assert '\nterm2 (\\fBstronged partially\\fP)\n' in content
@@ -33,6 +36,15 @@ def test_all(app, status, warning):
     assert '\n\\fBShow \\fP\\fIvariable\\fP\\fB in the middle\\fP\n' in content
 
     assert 'Footnotes' not in content
+
+
+@pytest.mark.sphinx('man', testroot='basic',
+                    confoverrides={'man_pages': [('index', 'title', None, [], 1)]})
+def test_man_pages_empty_description(app, status, warning):
+    app.builder.build_all()
+
+    content = (app.outdir / 'title.1').read_text()
+    assert r'title \-' not in content
 
 
 @pytest.mark.sphinx('man', testroot='basic',


### PR DESCRIPTION
Subject: let user skip printing command description

Update manpage builder to skip printing the description of a command as a subtitle if the supplied description is blank.
This commit addresses #9430

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Bugfix


### Purpose
Many well-established software library projects that predate RST have a large number of existing *roff-style man pages.
Such projects often have both online documentation on the web and also man pages for use on linux operating systems.
When such packages choose to switch their man pages from nroff to RST, they may want to use a single set of RST files as source to produce both their online documentation (html files) and also their linux man pages (nroff files).

However, the manpage.py builder currently always adds a subtitle with a description of the command that is provided as input to config and the html builders do not do this.

This means that the RST author currently has to produce different RST source files for the manpage and the html  builders, 
because if the RST file contains a description of the command then that description will appear twice in the generated man page, and if the RST file does NOT contain a description of the command, then there will be no description in the generated html file.

For example, @jsquyres and I would like to generate both groff files and also html files from a single set of rst man page files for the Open-MPI project (https://github.com/open-mpi/). Here is a simple example: https://github.com/jsquyres/ompi-sphinx-dist/blob/main/docs/src/ompi-man/man3/MPI_Abort.3.rst . Some examples of the original nroff files are here: https://github.com/open-mpi/ompi/tree/master/ompi/mpi/man/man3 

If rst/conf.py contains the following:
```
man_pages=[("ompi/mpi/man/man3/MPI_Abort.3","MPI_Abort", "(from conf.py) Terminates MPI execution environment","",3)]
```

... then the generated man page will look like this:
```
MPI_ABORT(3)                            Open MPI                            MPI_ABORT(3)

NAME
       MPI_Abort - (from conf.py) Terminates MPI execution environment

       MPI_Abort - Terminates MPI execution environment.

SYNTAX
   C Syntax
          #include <mpi.h>
          int MPI_Abort(MPI_Comm comm, int errorcode)
...
```

If we omit the "MPI_Abort - Terminates MPI execution environment." line from the RST file, then the generated html page will lose that command description.

This PR would make it possible for us to use sphinx-build to produce both HTML and manpage files from a single set of RST files.


### Detail
 - #9430


### Relates
- Please see issue #9430
