### PR TITLE
Fix #9600: autosummary: Typehints including commas confuses autosummary

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,8 @@ Bugs fixed
   are not displayed well
 * #9481: autosummary: some warnings contain non-existing filenames
 * #9568: autosummary: summarise overlined sectioned headings correctly
+* #9600: autosummary: Type annotations which contain commas in autosummary table
+  are not removed completely
 * #9481: c domain: some warnings contain non-existing filenames
 * #9481: cpp domain: some warnings contain non-existing filenames
 * #9456: html search: abbreation marks are inserted to the search result if

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -58,6 +58,7 @@ import posixpath
 import re
 import sys
 import warnings
+from inspect import Parameter
 from os import path
 from types import ModuleType
 from typing import Any, Dict, List, Optional, Tuple, Type, cast
@@ -87,6 +88,7 @@ from sphinx.registry import SphinxComponentRegistry
 from sphinx.util import logging, rst
 from sphinx.util.docutils import (NullReporter, SphinxDirective, SphinxRole, new_document,
                                   switch_source_input)
+from sphinx.util.inspect import signature_from_str
 from sphinx.util.matching import Matcher
 from sphinx.util.typing import OptionSpec
 from sphinx.writers.html import HTMLTranslator
@@ -456,10 +458,32 @@ def strip_arg_typehint(s: str) -> str:
     return s.split(':')[0].strip()
 
 
+def _cleanup_signature(s: str) -> str:
+    """Clean up signature using inspect.signautre() for mangle_signature()"""
+    try:
+        sig = signature_from_str(s)
+        parameters = list(sig.parameters.values())
+        for i, param in enumerate(parameters):
+            if param.annotation is not Parameter.empty:
+                # Remove typehints
+                param = param.replace(annotation=Parameter.empty)
+            if param.default is not Parameter.empty:
+                # Replace default value by "None"
+                param = param.replace(default=None)
+            parameters[i] = param
+        sig = sig.replace(parameters=parameters, return_annotation=Parameter.empty)
+        return str(sig)
+    except Exception:
+        # Return the original signature string if failed to clean (ex. parsing error)
+        return s
+
+
 def mangle_signature(sig: str, max_chars: int = 30) -> str:
     """Reformat a function signature to a more compact form."""
+    s = _cleanup_signature(sig)
+
     # Strip return type annotation
-    s = re.sub(r"\)\s*->\s.*$", ")", sig)
+    s = re.sub(r"\)\s*->\s.*$", ")", s)
 
     # Remove parenthesis
     s = re.sub(r"^\((.*)\)$", r"\1", s).strip()

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -63,7 +63,7 @@ def test_mangle_signature():
     (a=1, b=2, c=3) :: ([a, b, c])
     (a=1, b=<SomeClass: a, b, c>, c=3) :: ([a, b, c])
     (a=1, b=T(a=1, b=2), c=3) :: ([a, b, c])
-    (a: int, b: int) -> str :: (a, b)
+    (a: Tuple[int, str], b: int) -> str :: (a, b)
     """
 
     TEST = [[y.strip() for y in x.split("::")] for x in TEST.split("\n")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9600
- 