### PR TITLE
Fix #9608: apidoc: module is not described if implicit namespace package

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9608: apidoc: apidoc does not generate a module definition for implicit
+  namespace package
 * #9487: autodoc: typehint for cached_property is not shown
 * #9509: autodoc: AttributeError is raised on failed resolving typehints
 * #9518: autodoc: autodoc_docstring_signature does not effect to ``__init__()``

--- a/sphinx/templates/apidoc/package.rst_t
+++ b/sphinx/templates/apidoc/package.rst_t
@@ -19,6 +19,10 @@
 {{- [pkgname, "package"] | join(" ") | e | heading }}
 {% endif %}
 
+{%- if is_namespace %}
+.. py:module:: {{ pkgname }}
+{% endif %}
+
 {%- if modulefirst and not is_namespace %}
 {{ automodule(pkgname, automodule_options) }}
 {% endif %}

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -635,6 +635,8 @@ def test_namespace_package_file(tempdir):
     assert content == ("testpkg namespace\n"
                        "=================\n"
                        "\n"
+                       ".. py:module:: testpkg\n"
+                       "\n"
                        "Submodules\n"
                        "----------\n"
                        "\n"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9608 
- To make implicit namespace packages referencable, this outputs empty
module definitions for them.