### PR TITLE
Document `rst-class`

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -370,7 +370,7 @@ Docutils supports the following directives:
   - :dudir:`include` (include reStructuredText from another file) -- in Sphinx,
     when given an absolute include file path, this directive takes it as
     relative to the source directory
-  - :dudir:`class` (assign a class attribute to the next element) [1]_
+  - :rst:dir:`rst-class` (assign a class attribute to the next element) [1]_
 
 * HTML specifics:
 
@@ -605,6 +605,6 @@ There are some problems one commonly runs into while authoring reST documents:
 
 .. rubric:: Footnotes
 
-.. [1] When the default domain contains a :rst:dir:`class` directive, this
-       directive will be shadowed.  Therefore, Sphinx re-exports it as
+.. [1] Since some domains contain a ``class`` directive, it shadows
+       :dudir:`class` coming from docutils.  Therefore, Sphinx re-exports it as
        :rst:dir:`rst-class`.

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -1269,6 +1269,14 @@ The following is an example taken from the Python Reference Manual::
                : "finally" ":" `suite`
 
 
+Other
+-----
+
+.. rst:directive:: .. rst-class:: [classNames]
+
+   Sets classes on its content, Sphinx equivalent of docutils :dudir:`class`.
+
+
 .. rubric:: Footnotes
 
 .. [#] The LaTeX writer only refers the ``maxdepth`` option of first toctree


### PR DESCRIPTION
### Feature or Bugfix

- Feature

### Purpose

@nienn and I were looking for a way to add a custom CSS class to some content in Sphinx. We both arrived to [this Stack Overflow question](https://stackoverflow.com/a/33497002/554319), but otherwise it was impossible to find in the Sphinx docs. I think this directive is too important to be explained in a tiny footnote, so this is my attempt to document it.

I know it's technically incorrect that `rst-class` belongs to docutils... But from the user perspective, that's totally irrelevant, since they can't use it anyway.