### PR TITLE
themes: use noscript for search js notification

### DIFF
--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -21,13 +21,14 @@
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>
   {% block scriptwarning %}
-  <div id="fallback" class="admonition warning">
-  <script>$('#fallback').hide();</script>
+  <noscript>
+  <div class="admonition warning">
   <p>
     {% trans %}Please activate JavaScript to enable the search
     functionality.{% endtrans %}
   </p>
   </div>
+  </noscript>
   {% endblock %}
   {% block searchtext %}
   <p>


### PR DESCRIPTION

### Feature or Bugfix
- Feature

### Purpose
The "search.html" template will generate a warning admonition about requiring JavaScript for search and automatically hiding the element when supported. While functional, if a client renders the page slowly, the warning notification may be visible to the user for a moment.

Instead of relying on JavaScript to suppress this warning, use a `noscript` tag to hide the warning for clients who do not support JavaScript. This also has the benefit of one less JavaScript call required by a client.

### Detail
The following example shows the loading of a documentation, where the search warning is temporarily visible:

_(during page load)_
![image](https://user-images.githubusercontent.com/1834509/132281465-0560c8a1-13ac-4178-8742-e5696c936c19.png)

_(after page load)_
![image](https://user-images.githubusercontent.com/1834509/132281470-1d428dcd-ead0-4b47-9655-a1bffbb373f3.png)

The switch to `noscript` tags prevents this.