### PR TITLE
setup.py: Fix broken url on the Sphinx PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ else:
 setup(
     name='Sphinx',
     version=sphinx.__version__,
-    url='https://sphinx-doc.org/',
+    url='https://www.sphinx-doc.org/',
     download_url='https://pypi.org/project/Sphinx/',
     license='BSD',
     author='Georg Brandl',


### PR DESCRIPTION
Subject: <short purpose of this pull request>

* https://sphinx-doc.org/ is a broken link.
* https://www.sphinx-doc.org/ works as expected.
* This can be seen on the `Homepage` link on https://pypi.org/project/Sphinx/

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>
- Fix broken `Homepage` link on https://pypi.org/project/Sphinx/

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

