### PR TITLE
Fix typos discovered by codespell (again)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -314,7 +314,7 @@ Incompatible changes
   ``autodoc_typehints='description'`` and ``autoclass_content='class'`` set
 * #8898: extlinks: "%s" becomes required keyword in the link caption string
 * domain: The ``Index`` class becomes subclasses of ``abc.ABC`` to indicate
-  methods that must be overrided in the concrete classes
+  methods that must be overridden in the concrete classes
 * #4826: py domain: The structure of python objects is changed.  A boolean value
   is added to indicate that the python object is canonical one
 * #7425: MathJax: The MathJax was changed from 2 to 3. Users using a custom
@@ -1026,7 +1026,7 @@ Bugs fixed
   module has submodules
 * #4258: napoleon: decorated special methods are not shown
 * #7799: napoleon: parameters are not escaped for combined params in numpydoc
-* #7780: napoleon: multiple paramaters declaration in numpydoc was wrongly
+* #7780: napoleon: multiple parameters declaration in numpydoc was wrongly
   recognized when napoleon_use_params=True
 * #7715: LaTeX: ``numfig_secnum_depth > 1`` leads to wrong figure links
 * #7846: html theme: XML-invalid files were generated
@@ -1392,7 +1392,7 @@ Incompatible changes
   has been renamed to ``sphinx_line_type``.
 * #6462: double backslashes in domain directives are no longer replaced by
   single backslashes as default. A new configuration value
-  :confval:`strip_signature_backslash` can be used by users to reenable it.
+  :confval:`strip_signature_backslash` can be used by users to re-enable it.
 
 3.0.0 final
 
@@ -1465,7 +1465,7 @@ Features added
 
   - Cross-referencing respecting the current scope.
   - Possible to document anonymous entities.
-  - More specific directives and roles for each type of entitiy,
+  - More specific directives and roles for each type of entity,
     e.g., handling scoping of enumerators.
   - New role :rst:role:`c:expr` for rendering expressions and types
     in text.
@@ -1852,7 +1852,7 @@ Features added
 * #6533: LaTeX: refactor visit_enumerated_list() to use ``\sphinxsetlistlabels``
 * #6628: quickstart: Use ``https://docs.python.org/3/`` for default setting of
   :confval:`intersphinx_mapping`
-* #6419: sphinx-build: give reasons why rebuilded
+* #6419: sphinx-build: give reasons why rebuilt
 
 Bugs fixed
 ----------

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -574,7 +574,7 @@ The colors used in the above are provided by the ``svgnames`` option of the
 It is possible to insert further uses of the ``\sphinxsetup`` LaTeX macro
 directly into the body of the document, via the help of the :rst:dir:`raw`
 directive. This chapter is styled in the PDF output using the following at the
-start of the chaper::
+start of the chapter::
 
   .. raw:: latex
 
@@ -607,7 +607,7 @@ macros may be significant.
 Do not use quotes to enclose values, whether numerical or strings.
 
 ``bookmarksdepth``
-    Controls the depth of the collapsable bookmarks panel in the PDF.
+    Controls the depth of the collapsible bookmarks panel in the PDF.
     May be either a number (e.g. ``3``) or a LaTeX sectioning name (e.g.
     ``subsubsection``, i.e. without backslash).
     For details, refer to the ``hyperref`` LaTeX docs.

--- a/doc/man/sphinx-quickstart.rst
+++ b/doc/man/sphinx-quickstart.rst
@@ -35,7 +35,7 @@ Options
 
 .. option:: --no-sep
 
-   If specified, create build directroy under source directroy.
+   If specified, create build directory under source directory.
 
 .. option:: --dot=DOT
 

--- a/doc/usage/extensions/graphviz.rst
+++ b/doc/usage/extensions/graphviz.rst
@@ -83,7 +83,7 @@ It adds these directives:
       .. versionadded:: 1.6
 
    .. rst:directive:option:: class: class names
-      :type: a list of class names separeted by spaces
+      :type: a list of class names separated by spaces
 
       The class name of the graph.
 
@@ -139,7 +139,7 @@ It adds these directives:
       .. versionadded:: 1.6
 
    .. rst:directive:option:: class: class names
-      :type: a list of class names separeted by spaces
+      :type: a list of class names separated by spaces
 
       The class name of the graph.
 
@@ -191,7 +191,7 @@ It adds these directives:
       .. versionadded:: 1.6
 
    .. rst:directive:option:: class: class names
-      :type: a list of class names separeted by spaces
+      :type: a list of class names separated by spaces
 
       The class name of the graph.
 

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -143,7 +143,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
     embedded = True
     # disable download role
     download_support = False
-    # dont' create links to original images from images
+    # don't create links to original images from images
     html_scaled_image_link = False
     # don't generate search index or include search page
     search = False

--- a/sphinx/builders/latex/constants.py
+++ b/sphinx/builders/latex/constants.py
@@ -199,7 +199,7 @@ ADDITIONAL_SETTINGS: Dict[Any, Dict[str, Any]] = {
         'babel':        '\\usepackage{babel}',
         'fontenc':      '\\usepackage{xeCJK}',
         # set formatcom=\xeCJKVerbAddon to prevent xeCJK from adding extra spaces in
-        # fancyvrb Verbatim enviroment.
+        # fancyvrb Verbatim environment.
         'fvset':        '\\fvset{fontsize=\\small,formatcom=\\xeCJKVerbAddon}',
     },
     ('xelatex', 'el'): {

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -415,7 +415,7 @@ def check_confval_types(app: "Sphinx", config: Config) -> None:
         if hasattr(default, '__call__'):
             default = default(config)  # evaluate default value
         if default is None and not annotations:
-            continue  # neither inferrable nor expliclitly annotated types
+            continue  # neither inferable nor expliclitly annotated types
 
         if annotations is Any:
             # any type of value is accepted

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -2255,7 +2255,7 @@ class DefinitionParser(BaseParser):
 
     def _parse_initializer_list(self, name: str, open: str, close: str
                                 ) -> Tuple[List[ASTExpression], bool]:
-        # Parse open and close with the actual initializer-list inbetween
+        # Parse open and close with the actual initializer-list in between
         # -> initializer-clause '...'[opt]
         #  | initializer-list ',' initializer-clause '...'[opt]
         # TODO: designators
@@ -3446,7 +3446,7 @@ class CNamespacePopObject(SphinxDirective):
     def run(self) -> List[Node]:
         stack = self.env.temp_data.get('c:namespace_stack', None)
         if not stack or len(stack) == 0:
-            logger.warning("C namespace pop on empty stack. Defaulting to gobal scope.",
+            logger.warning("C namespace pop on empty stack. Defaulting to global scope.",
                            location=self.get_location())
             stack = []
         else:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -162,7 +162,7 @@ T = TypeVar('T')
         trailing-type-specifier ->
             rest-of-trailing
             ("class" | "struct" | "union" | "typename") rest-of-trailing
-            build-in -> "char" | "bool" | etc.
+            built-in -> "char" | "bool" | etc.
             decltype-specifier
         rest-of-trailing -> (with some simplification)
             "::"[opt] list-of-elements-separated-by-::
@@ -1709,7 +1709,7 @@ class ASTOperatorBuildIn(ASTOperator):
         else:
             ids = _id_operator_v2
         if self.op not in ids:
-            raise Exception('Internal error: Build-in operator "%s" can not '
+            raise Exception('Internal error: Built-in operator "%s" can not '
                             'be mapped to an id.' % self.op)
         return ids[self.op]
 
@@ -2479,7 +2479,7 @@ class ASTDeclaratorNameParamQual(ASTDeclarator):
     def get_type_id(self, version: int, returnTypeId: str) -> str:
         assert version >= 2
         res = []
-        # TOOD: can we actually have both array ops and paramQual?
+        # TODO: can we actually have both array ops and paramQual?
         res.append(self.get_ptr_suffix_id(version))
         if self.paramQual:
             res.append(self.get_modifiers_id(version))
@@ -5217,7 +5217,7 @@ class DefinitionParser(BaseParser):
                                 ) -> Tuple[List[Union[ASTExpression,
                                                       ASTBracedInitList]],
                                            bool]:
-        # Parse open and close with the actual initializer-list inbetween
+        # Parse open and close with the actual initializer-list in between
         # -> initializer-clause '...'[opt]
         #  | initializer-list ',' initializer-clause '...'[opt]
         self.skip_ws()
@@ -6358,7 +6358,7 @@ class DefinitionParser(BaseParser):
         if outer in ('type', 'function'):
             # We allow type objects to just be a name.
             # Some functions don't have normal return types: constructors,
-            # destrutors, cast operators
+            # destructors, cast operators
             prevErrors = []
             startPos = self.pos
             # first try without the type
@@ -6562,7 +6562,7 @@ class DefinitionParser(BaseParser):
                 self.fail("Expected 'typename' or 'class' after "
                           "template template parameter list.")
             else:
-                self.fail("Expected 'typename' or 'class' in tbe "
+                self.fail("Expected 'typename' or 'class' in the "
                           "beginning of template type parameter.")
             self.skip_ws()
             parameterPack = self.skip_string('...')
@@ -7282,7 +7282,7 @@ class CPPNamespacePopObject(SphinxDirective):
     def run(self) -> List[Node]:
         stack = self.env.temp_data.get('cpp:namespace_stack', None)
         if not stack or len(stack) == 0:
-            logger.warning("C++ namespace pop on empty stack. Defaulting to gobal scope.",
+            logger.warning("C++ namespace pop on empty stack. Defaulting to global scope.",
                            location=self.get_location())
             stack = []
         else:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1062,7 +1062,7 @@ class PythonModuleIndex(Index):
         # list of all modules, sorted by module name
         modules = sorted(self.domain.data['modules'].items(),
                          key=lambda x: x[0].lower())
-        # sort out collapsable modules
+        # sort out collapsible modules
         prev_modname = ''
         num_toplevels = 0
         for modname, (docname, node_id, synopsis, platforms, deprecated) in modules:

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -107,7 +107,7 @@ class IndexEntries:
                 lckey = lckey[1:]
 
             if lckey[0:1].isalpha() or lckey.startswith('_'):
-                # put non-symbol characters at the folloing group (1)
+                # put non-symbol characters at the following group (1)
                 sortkey = (1, lckey)
             else:
                 # put symbols at the front of the index (0)

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1424,7 +1424,7 @@ _METACLASS_CALL_BLACKLIST = [
 ]
 
 
-# Types whose __new__ signature is a pass-thru.
+# Types whose __new__ signature is a pass-through.
 _CLASS_NEW_BLACKLIST = [
     'typing.Generic.__new__',
 ]
@@ -1613,7 +1613,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
                     if qualname in analyzer.overloads:
                         return analyzer.overloads.get(qualname)
                     elif qualname in analyzer.tagorder:
-                        # the constructor is defined in the class, but not overrided.
+                        # the constructor is defined in the class, but not overridden.
                         return []
                 except PycodeError:
                     pass

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -224,7 +224,7 @@ def get_documenter(app: Sphinx, obj: Any, parent: Any) -> Type[Documenter]:
     else:
         parent_doc = parent_doc_cls(FakeDirective(), "")
 
-    # Get the corrent documenter class for *obj*
+    # Get the correct documenter class for *obj*
     classes = [cls for cls in app.registry.documenters.values()
                if cls.can_document_member(obj, '', False, parent_doc)]
     if classes:

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -16,7 +16,7 @@
 \ifdefined\pdfimageresolution
     \pdfimageresolution= \numexpr \dimexpr1in\relax/\sphinxpxdimen\relax
 \fi
-%% let collapsable pdf bookmarks panel have high depth per default
+%% let collapsible pdf bookmarks panel have high depth per default
 \PassOptionsToPackage{bookmarksdepth=5}{hyperref}
 <% if use_xindy -%>
 %% turn off hyperref patch of \index as sphinx.xdy xindy module takes care of

--- a/sphinx/texinputs/LICRlatin2utf8.xdy
+++ b/sphinx/texinputs/LICRlatin2utf8.xdy
@@ -24,7 +24,7 @@
 ;;   covered by original tex/inputenc/utf8.xdy.
 ;;
 ;; - There is a problem that ȷ is not supported out-of-the box by LaTeX
-;;   with inputenc, one must add explicitely
+;;   with inputenc, one must add explicitly
 ;;       \DeclareUnicodeCharacter{0237}{\j}
 ;;   to preamble of LaTeX document.  However this character is not supported
 ;;   by the TeX "times" font used by default by Sphinx for pdflatex engine.

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -77,7 +77,7 @@
 % \DeclareStringOption is not convenient for the handling of these dimensions
 % because we want to assign the values to the corresponding registers. Even if
 % we added the code to the key handler it would be too late for the initial
-% set-up and we would need to do initial assignments explicitely. We end up
+% set-up and we would need to do initial assignments explicitly. We end up
 % using \define@key directly.
 % verbatim
 \sphinxverbatimsep=\fboxsep

--- a/sphinx/texinputs/sphinx.xdy
+++ b/sphinx/texinputs/sphinx.xdy
@@ -15,7 +15,7 @@
 
 ;; xindy base module latex.xdy loads tex.xdy and the latter instructs
 ;; xindy to ignore **all** TeX macros in .idx entries, except those
-;; explicitely described in merge rule.  But when after applying all
+;; explicitly described in merge rule.  But when after applying all
 ;; merge rules an empty string results, xindy raises an error:
 
 ;;   ERROR: CHAR: index 0 should be less than the length of the string
@@ -31,7 +31,7 @@
 ;; scripts for the pdflatex engine.
 
 ;; Another issue caused by xindy ignoring all TeX macros except those
-;; explicitely declared reveals itself when attempting to index ">>>",
+;; explicitly declared reveals itself when attempting to index ">>>",
 ;; as the ">" is converted to "\textgreater{}" by Sphinx's LaTeX
 ;; escaping.
 

--- a/sphinx/texinputs/sphinxlatexlists.sty
+++ b/sphinx/texinputs/sphinxlatexlists.sty
@@ -10,7 +10,7 @@
 
 \newcommand\sphinxsetlistlabels[5]
 {% #1 = style, #2 = enum, #3 = enumnext, #4 = prefix, #5 = suffix
- % #2 and #3 are counters used by enumerate environement e.g. enumi, enumii.
+ % #2 and #3 are counters used by enumerate environment e.g. enumi, enumii.
  % #1 is a macro such as \arabic or \alph
  % prefix and suffix are strings (by default empty and a dot).
  \@namedef{the#2}{#1{#2}}%

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -181,7 +181,7 @@ class AutoNumbering(SphinxTransform):
 
 class SortIds(SphinxTransform):
     """
-    Sort secion IDs so that the "id[0-9]+" one comes last.
+    Sort section IDs so that the "id[0-9]+" one comes last.
     """
     default_priority = 261
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -178,7 +178,7 @@ class Locale(SphinxTransform):
                     #        old_name entry still exists in nameids and
                     #        nametypes for another duplicated entry.
                     #
-                    #   * if _id is provided: bellow process
+                    #   * if _id is provided: below process
                     if _id:
                         if not explicit:
                             # _id was not duplicated.

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -413,7 +413,7 @@ class SphinxRole:
 class ReferenceRole(SphinxRole):
     """A base class for reference roles.
 
-    The reference roles can accpet ``link title <target>`` style as a text for
+    The reference roles can accept ``link title <target>`` style as a text for
     the role.  The parsed result; link title and target will be stored to
     ``self.title`` and ``self.target``.
     """
@@ -514,7 +514,7 @@ def new_document(source_path: str, settings: Any = None) -> nodes.document:
         __document_cache__ = docutils.utils.new_document(source_path)
 
     if settings is None:
-        # Make a copy of ``settings`` from cache to accelerate instansiation
+        # Make a copy of ``settings`` from cache to accelerate instantiation
         settings = copy(__document_cache__.settings)
 
     # Create a new instance of nodes.document using cached reporter

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -129,7 +129,7 @@ def docname_to_domain(docname: str, compaction: Union[bool, str]) -> str:
         return docname
 
 
-# date_format mappings: ustrftime() to bable.dates.format_datetime()
+# date_format mappings: ustrftime() to babel.dates.format_datetime()
 date_format_mappings = {
     '%a':  'EEE',     # Weekday as locale’s abbreviated name.
     '%A':  'EEEE',    # Weekday as locale’s full name.

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -361,7 +361,7 @@ def educate_tokens(text_tokens: Iterable[Tuple[str, str]],
             text = smartquotes.educateSingleBackticks(text, language)
 
         if do_quotes:
-            # Replace plain quotes to prevent converstion to
+            # Replace plain quotes to prevent conversion to
             # 2-character sequence in French.
             context = prev_token_last_char.replace('"', ';').replace("'", ';')
             text = educateQuotes(context + text, language)[1:]

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -2,7 +2,7 @@
     sphinx.util.typing
     ~~~~~~~~~~~~~~~~~~
 
-    The composit types for Sphinx.
+    The composite types for Sphinx.
 
     :copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1313,7 +1313,7 @@ class LaTeXTranslator(SphinxTranslator):
         base, ext = path.splitext(uri)
         if self.in_title and base:
             # Lowercase tokens forcely because some fncychap themes capitalize
-            # the options of \sphinxincludegraphics unexpectly (ex. WIDTH=...).
+            # the options of \sphinxincludegraphics unexpectedly (ex. WIDTH=...).
             self.body.append(r'\lowercase{\sphinxincludegraphics%s}{{%s}%s}' %
                              (options, base, ext))
         else:

--- a/tests/roots/test-ext-autodoc/target/preserve_defaults.py
+++ b/tests/roots/test-ext-autodoc/target/preserve_defaults.py
@@ -6,7 +6,7 @@ SENTINEL = object()
 
 
 def foo(name: str = CONSTANT,
-        sentinal: Any = SENTINEL,
+        sentinel: Any = SENTINEL,
         now: datetime = datetime.now()) -> None:
     """docstring"""
 
@@ -14,6 +14,6 @@ def foo(name: str = CONSTANT,
 class Class:
     """docstring"""
 
-    def meth(self, name: str = CONSTANT, sentinal: Any = SENTINEL,
+    def meth(self, name: str = CONSTANT, sentinel: Any = SENTINEL,
              now: datetime = datetime.now()) -> None:
         """docstring"""

--- a/tests/roots/test-ext-viewcode/objects.rst
+++ b/tests/roots/test-ext-viewcode/objects.rst
@@ -103,7 +103,7 @@ Javascript items
 .. js:function:: bar.baz(href, callback[, errback])
 
    :param string href: The location of the resource.
-   :param callback: Get's called with the data returned by the resource.
+   :param callback: Gets called with the data returned by the resource.
    :throws InvalidHref: If the `href` is invalid.
    :returns: `undefined`
 

--- a/tests/roots/test-root/footnote.txt
+++ b/tests/roots/test-root/footnote.txt
@@ -32,7 +32,7 @@ footnotes in table
     :header-rows: 1
 
     * - name [#]_
-      - desription
+      - description
     * - VIDIOC_CROPCAP
       - Information about VIDIOC_CROPCAP [#]_
 

--- a/tests/roots/test-root/objects.txt
+++ b/tests/roots/test-root/objects.txt
@@ -129,7 +129,7 @@ Javascript items
 .. js:function:: bar.baz(href, callback[, errback])
 
    :param string href: The location of the resource.
-   :param callback: Get's called with the data returned by the resource.
+   :param callback: Gets called with the data returned by the resource.
    :throws InvalidHref: If the `href` is invalid.
    :returns: `undefined`
 

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -346,7 +346,7 @@ def test_epub_css_files(app):
     content = (app.outdir / 'index.xhtml').read_text()
     assert '<link rel="stylesheet" type="text/css" href="_static/css/epub.css" />' in content
 
-    # files in html_css_files are not outputed
+    # files in html_css_files are not outputted
     assert ('<link rel="stylesheet" type="text/css" href="_static/css/style.css" />'
             not in content)
     assert ('<link media="print" rel="stylesheet" title="title" type="text/css" '

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,7 +34,7 @@ def test_event_allowed_exceptions():
     events = EventManager(object())  # pass an dummy object as an app
     events.connect('builder-inited', raise_error, priority=500)
 
-    # all errors are conveted to ExtensionError
+    # all errors are converted to ExtensionError
     with pytest.raises(ExtensionError):
         events.emit('builder-inited')
 

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -825,7 +825,7 @@ def test_autodoc_typehints_description(app):
             '      Tuple[int, int]\n'
             in context)
 
-    # Overloads still get displyed in the signature
+    # Overloads still get displayed in the signature
     assert ('target.overload.sum(x: int, y: int = 0) -> int\n'
             'target.overload.sum(x: float, y: float = 0.0) -> float\n'
             'target.overload.sum(x: str, y: str = None) -> str\n'
@@ -956,7 +956,7 @@ def test_autodoc_typehints_both(app):
             '      Tuple[int, int]\n'
             in context)
 
-    # Overloads still get displyed in the signature
+    # Overloads still get displayed in the signature
     assert ('target.overload.sum(x: int, y: int = 0) -> int\n'
             'target.overload.sum(x: float, y: float = 0.0) -> float\n'
             'target.overload.sum(x: str, y: str = None) -> str\n'

--- a/tests/test_ext_autodoc_preserve_defaults.py
+++ b/tests/test_ext_autodoc_preserve_defaults.py
@@ -29,14 +29,14 @@ def test_preserve_defaults(app):
         '   docstring',
         '',
         '',
-        '   .. py:method:: Class.meth(name: str = CONSTANT, sentinal: Any = SENTINEL, '
+        '   .. py:method:: Class.meth(name: str = CONSTANT, sentinel: Any = SENTINEL, '
         'now: datetime.datetime = datetime.now()) -> None',
         '      :module: target.preserve_defaults',
         '',
         '      docstring',
         '',
         '',
-        '.. py:function:: foo(name: str = CONSTANT, sentinal: Any = SENTINEL, now: '
+        '.. py:function:: foo(name: str = CONSTANT, sentinel: Any = SENTINEL, now: '
         'datetime.datetime = datetime.now()) -> None',
         '   :module: target.preserve_defaults',
         '',

--- a/tests/test_pycode_parser.py
+++ b/tests/test_pycode_parser.py
@@ -233,7 +233,7 @@ def test_class():
     parser.parse()
     assert parser.comments == {('Foo', 'attr1'): 'comment1',
                                ('Foo', 'a'): 'comment3',
-                               ('Foo', 'attr2'): 'overrided'}
+                               ('Foo', 'attr2'): 'overridden'}
     assert parser.definitions == {'Foo': ('class', 1, 11),
                                   'Foo.__init__': ('def', 5, 8),
                                   'Foo.some_method': ('def', 10, 11)}

--- a/tests/test_pycode_parser.py
+++ b/tests/test_pycode_parser.py
@@ -224,7 +224,7 @@ def test_class():
               '\n'
               '    def __init__(self):\n'
               '        self.a = 1 + 1  #: comment3\n'
-              '        self.attr2 = 1 + 1  #: overrided\n'
+              '        self.attr2 = 1 + 1  #: overridden\n'
               '        b = 1 + 1  #: comment5\n'
               '\n'
               '    def some_method(self):\n'

--- a/tests/test_util_docstrings.py
+++ b/tests/test_util_docstrings.py
@@ -26,7 +26,7 @@ def test_separate_metadata():
     assert docstring == ':param baz:\n'
     assert metadata == {'foo': 'bar'}
 
-    # field_list like text following just after paragaph is not a field_list
+    # field_list like text following just after paragraph is not a field_list
     text = ("blah blah blah\n"
             ":meta foo: bar\n"
             ":meta baz:\n")

--- a/tests/test_util_docutils.py
+++ b/tests/test_util_docutils.py
@@ -45,7 +45,7 @@ def test_SphinxFileOutput(tmpdir):
     output.write(content)
     os.utime(filename, (0, 0))
 
-    # overrite it again
+    # overwrite it again
     output.write(content)
     assert os.stat(filename).st_mtime != 0  # updated
 
@@ -55,11 +55,11 @@ def test_SphinxFileOutput(tmpdir):
     output.write(content)
     os.utime(filename, (0, 0))
 
-    # overrite it again
+    # overwrite it again
     output.write(content)
     assert os.stat(filename).st_mtime == 0  # not updated
 
-    # overrite it again (content changed)
+    # overwrite it again (content changed)
     output.write(content + "; content change")
     assert os.stat(filename).st_mtime != 0  # updated
 

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -272,7 +272,7 @@ def test_pending_warnings(app, status, warning):
 
     logger.warning('message1')
     with logging.pending_warnings():
-        # not logged yet (bufferred) in here
+        # not logged yet (buffered) in here
         logger.warning('message2')
         logger.warning('message3')
         assert 'WARNING: message1' in warning.getvalue()


### PR DESCRIPTION
Subject: Fix typos discovered by [codespell](https://pypi.org/project/codespell/).

Redo of #9620 on an up-to-date `4.x` branch.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
```
codespell --ignore-words-list="alph,ba,ede,ist,ment,ser,statics,te,uptodate" \
          --skip="*.css,*.js,*.po,*/da.py,*/de.py,*/fr.py,*/it.py,*/nl.py,*/no.py,*/pt.py,*/ru.py,*/sv.py,*/zh.py,EXAMPLES"
```

### Relates
- <URL or Ticket>

