### PR TITLE
Fix #9637: Add Builder.allow_parallel to the list of builder APIs

### DIFF
--- a/doc/extdev/builderapi.rst
+++ b/doc/extdev/builderapi.rst
@@ -16,6 +16,7 @@ Builder API
    .. autoattribute:: name
    .. autoattribute:: format
    .. autoattribute:: epilog
+   .. autoattribute:: allow_parallel
    .. autoattribute:: supported_image_types
    .. autoattribute:: supported_remote_images
    .. autoattribute:: supported_data_uri_images

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -68,7 +68,7 @@ class Builder:
     # doctree versioning method
     versioning_method = 'none'
     versioning_compare = False
-    # allow parallel write_doc() calls
+    #: allow parallel write_doc() calls
     allow_parallel = False
     # support translation
     use_message_catalog = True


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9637 