### PR TITLE
RFC: unique ids for singlehtml

### DIFF
--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -17,6 +17,7 @@ from docutils.nodes import Node
 from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment.adapters.toctree import TocTree
+from sphinx.environment import BuildEnvironment
 from sphinx.locale import __
 from sphinx.util import logging, progress_message
 from sphinx.util.console import darkgreen  # type: ignore
@@ -186,11 +187,23 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
             self.handle_page('opensearch', {}, 'opensearch.xml', outfilename=fn)
 
 
+def setup_singlehtml_env(app: Sphinx, env: BuildEnvironment, docname: str) -> None:
+    if app.builder.name != 'singlehtml':
+        return
+
+    # configure document-specific prefixes to prevent conflicting ids in an
+    # assembled doctree
+    prefix = '{}-'.format(docname)
+    env.settings['id_prefix'] = prefix
+    env.settings['auto_id_prefix'] = prefix
+
+
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.setup_extension('sphinx.builders.html')
 
     app.add_builder(SingleFileHTMLBuilder)
     app.add_config_value('singlehtml_sidebars', lambda self: self.html_sidebars, 'html')
+    app.connect('env-prepare', setup_singlehtml_env)
 
     return {
         'version': 'builtin',

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -457,6 +457,8 @@ class BuildEnvironment:
         self.temp_data['default_domain'] = \
             self.domains.get(self.config.primary_domain)
 
+        self.events.emit('env-prepare', self, docname)
+
     # utilities to use while reading a document
 
     @property

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -38,6 +38,7 @@ core_events = {
     'config-inited': 'config',
     'env-get-outdated': 'env, added, changed, removed',
     'env-get-updated': 'env',
+    'env-prepare': 'env, docname',
     'env-purge-doc': 'env, docname',
     'env-before-read-docs': 'env, docnames',
     'env-check-consistency': 'env',

--- a/tests/roots/test-singlehtml_ids/index.rst
+++ b/tests/roots/test-singlehtml_ids/index.rst
@@ -1,0 +1,8 @@
+test
+====
+
+.. toctree::
+
+   page1
+   page2
+   subpage/page3

--- a/tests/roots/test-singlehtml_ids/page1.rst
+++ b/tests/roots/test-singlehtml_ids/page1.rst
@@ -1,0 +1,4 @@
+page
+----
+
+contents

--- a/tests/roots/test-singlehtml_ids/page2.rst
+++ b/tests/roots/test-singlehtml_ids/page2.rst
@@ -1,0 +1,4 @@
+page
+----
+
+contents

--- a/tests/roots/test-singlehtml_ids/subpage/page3.rst
+++ b/tests/roots/test-singlehtml_ids/subpage/page3.rst
@@ -1,0 +1,4 @@
+page
+----
+
+contents

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1652,3 +1652,12 @@ def test_html_signaturereturn_icon(app):
     content = (app.outdir / 'index.html').read_text()
 
     assert ('<span class="sig-return-icon">&#x2192;</span>' in content)
+
+
+@pytest.mark.sphinx('singlehtml', testroot='singlehtml_ids')
+def test_singlehtml_ids(app):
+    app.build()
+    content = (app.outdir / 'index.html').read_text()
+
+    section_ids = re.findall(r'<section id="(.+?)"', content)
+    assert len(section_ids) == len(set(section_ids))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
The following provides a proposed change to help handle an issue with the re-use of tag identifiers when using a `singlehtml` builder. Considering the following example documentation:

```
(index.rst)
test
====

.. toctree::

   page1
   page2

(page1.rst)
page
----

contents

(page2.rst)
page
----

contents
```

When this documentation is built with `singlehtml`, it will generated multiple section tags with the same id `page` (generated by docutils). When trying to build references to these sections (in a TOC), the TOC entries for each page will point to the first section entry.

To help deal with this, there is a desire to generate unique IDs across all processed documents (before assembling a single doctree). Inspecting docutils's implementation, there appears to be two setting options (`id_prefix` and `auto_id_prefix`) which can hint to how identifiers are generated. Assuming this is a good approach to generating unique identifiers, there will be an attempt to have a `singlehtml` builder to somehow configure docutils with unique prefix entries. To get this to work, an event `env-prepare` has been added to allow the builder to hook on when an environment is prepared for a specific document. When the event is triggered, the environment's setting is configured with a prefix value related to the document's name. When docutils prepares a document for Sphinx, there should be an (almost) unique set of identifiers for the builder to use.

---

There is a concern here about the introduction of the `env-prepare` event. I suspect that this may not be desired due to the implications/maintenance associated with introducing a new event. I am for switching up how this is done; however, I do not know enough about the internals of Sphinx to know the best way to approach this. While this maybe achieved with using a transform, I did not know what type of complexity would be involved to replace all detected duplicate identifiers (and references targeting these IDs) at a later stage in the Sphinx building processes.