### PR TITLE
Fix issue with warnings without subtype being incorrectly suppressed

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -364,7 +364,8 @@ def is_suppressed_warning(type: str, subtype: str, suppress_warnings: List[str])
             target, subtarget = warning_type, None
 
         if target == type:
-            if (subtype is None or subtarget is None or
+            if (subtype is None and subtarget is None
+               or subtarget is None or
                subtarget == subtype or subtarget == '*'):
                 return True
 

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -131,6 +131,7 @@ def test_is_suppressed_warning():
     assert is_suppressed_warning("ref", "option", suppress_warnings) is True
     assert is_suppressed_warning("files", "image", suppress_warnings) is True
     assert is_suppressed_warning("files", "stylesheet", suppress_warnings) is True
+    assert is_suppressed_warning("rest", None, suppress_warnings) is False
     assert is_suppressed_warning("rest", "syntax", suppress_warnings) is False
     assert is_suppressed_warning("rest", "duplicated_labels", suppress_warnings) is True
 
@@ -143,33 +144,39 @@ def test_suppress_warnings(app, status, warning):
 
     app.config.suppress_warnings = []
     warning.truncate(0)
+    logger.warning('message0', type='test')
     logger.warning('message1', type='test', subtype='logging')
     logger.warning('message2', type='test', subtype='crash')
     logger.warning('message3', type='actual', subtype='logging')
+    assert 'message0' in warning.getvalue()
     assert 'message1' in warning.getvalue()
     assert 'message2' in warning.getvalue()
     assert 'message3' in warning.getvalue()
-    assert app._warncount == 3
+    assert app._warncount == 4
 
     app.config.suppress_warnings = ['test']
     warning.truncate(0)
+    logger.warning('message0', type='test')
     logger.warning('message1', type='test', subtype='logging')
     logger.warning('message2', type='test', subtype='crash')
     logger.warning('message3', type='actual', subtype='logging')
+    assert 'message0' not in warning.getvalue()
     assert 'message1' not in warning.getvalue()
     assert 'message2' not in warning.getvalue()
     assert 'message3' in warning.getvalue()
-    assert app._warncount == 4
+    assert app._warncount == 5
 
     app.config.suppress_warnings = ['test.logging']
     warning.truncate(0)
+    logger.warning('message0', type='test')
     logger.warning('message1', type='test', subtype='logging')
     logger.warning('message2', type='test', subtype='crash')
     logger.warning('message3', type='actual', subtype='logging')
+    assert 'message0' in warning.getvalue()
     assert 'message1' not in warning.getvalue()
     assert 'message2' in warning.getvalue()
     assert 'message3' in warning.getvalue()
-    assert app._warncount == 6
+    assert app._warncount == 8
 
 
 def test_warningiserror(app, status, warning):


### PR DESCRIPTION
### Feature or Bugfix
Bugfix

### Purpose
This fixes an issue with warnings that have been raised with no subtype being suppressed if a suppress warnings value with a subtype has been set. e.g. all `autodoc` warnings should not be suppressed if `autodoc.import_object` is only set to be suppressed.

### Detail
This issue occurred as logic previously only checked if error `subtype` was `None`, without checking that the `subtarget` was also `None`.

### Relates
Noticed this issue when looking at #9655 

