### PR TITLE
Close #9664: autodoc: autodoc-process-bases supports reST snippet

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Features added
 --------------
 
 * #9639: autodoc: Support asynchronous generator functions
+* #9664: autodoc: ``autodoc-process-bases`` supports to inject reST snippet as a
+  base class
 
 Bugs fixed
 ----------

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -768,8 +768,6 @@ needed docstring processing in event :event:`autodoc-process-docstring`:
 
 .. event:: autodoc-process-bases (app, name, obj, options, bases)
 
-   .. versionadded:: 4.1
-
    Emitted when autodoc has read and processed a class to determine the
    base-classes.  *bases* is a list of classes that the event handler can
    modify **in place** to change what Sphinx puts into the output.  It's
@@ -780,6 +778,12 @@ needed docstring processing in event :event:`autodoc-process-docstring`:
    :param obj: the object itself
    :param options: the options given to the class directive
    :param bases: the list of base classes signature. see above.
+
+   .. versionadded:: 4.1
+   .. versionchanged:: 4.3
+
+      ``bases`` can contain a string as a base class name.  It will be processed
+      as reST mark-up'ed text.
 
 
 Skipping members

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -113,6 +113,8 @@ def restify(cls: Optional[Type]) -> str:
             return ':py:obj:`None`'
         elif cls is Ellipsis:
             return '...'
+        elif isinstance(cls, str):
+            return cls
         elif cls in INVALID_BUILTIN_CLASSES:
             return ':py:class:`%s`' % INVALID_BUILTIN_CLASSES[cls]
         elif inspect.isNewType(cls):

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -48,6 +48,7 @@ def test_restify():
     assert restify(Struct) == ":py:class:`struct.Struct`"
     assert restify(TracebackType) == ":py:class:`types.TracebackType`"
     assert restify(Any) == ":py:obj:`~typing.Any`"
+    assert restify('str') == "str"
 
 
 def test_restify_type_hints_containers():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- This allows to inject a reST snippet through autodoc-process-bases
event.  It helps to modify the base classes of any class to the expected
mark-up'ed text by custom extension.
- refs: #9664 