### PR TITLE
Fix download file with special characters

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -12,6 +12,7 @@ import copy
 import os
 import posixpath
 import re
+import urllib.parse
 import warnings
 from typing import TYPE_CHECKING, Iterable, Tuple, cast
 
@@ -589,7 +590,8 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             self.context.append('</a>')
         elif 'filename' in node:
             atts['class'] += ' internal'
-            atts['href'] = posixpath.join(self.builder.dlpath, node['filename'])
+            atts['href'] = posixpath.join(self.builder.dlpath,
+                                          urllib.parse.quote(node['filename']))
             self.body.append(self.starttag(node, 'a', '', **atts))
             self.context.append('</a>')
         else:

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -11,6 +11,7 @@
 import os
 import posixpath
 import re
+import urllib.parse
 import warnings
 from typing import TYPE_CHECKING, Iterable, Tuple, cast
 
@@ -529,7 +530,8 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             self.context.append('</a>')
         elif 'filename' in node:
             atts['class'] += ' internal'
-            atts['href'] = posixpath.join(self.builder.dlpath, node['filename'])
+            atts['href'] = posixpath.join(self.builder.dlpath,
+                                          urllib.parse.quote(node['filename']))
             self.body.append(self.starttag(node, 'a', '', **atts))
             self.context.append('</a>')
         else:

--- a/tests/roots/test-root/includes.txt
+++ b/tests/roots/test-root/includes.txt
@@ -3,6 +3,7 @@ Testing downloadable files
 
 Download :download:`img.png` here.
 Download :download:`this <subdir/img.png>` there.
+Download :download:`file with special characters <file_with_special_#_chars.xyz>`.
 
 Test file and literal inclusion
 ===============================

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -456,6 +456,12 @@ def test_html_download(app):
     assert (app.outdir / matched.group(1)).exists()
     assert matched.group(1) == filename
 
+    pattern = ('<a class="reference download internal" download="" '
+               'href="(_downloads/.*/)(file_with_special_%23_chars.xyz)">')
+    matched = re.search(pattern, result)
+    assert matched
+    assert (app.outdir / matched.group(1) / "file_with_special_#_chars.xyz").exists()
+
 
 @pytest.mark.sphinx('html', testroot='roles-download')
 def test_html_download_role(app, status, warning):


### PR DESCRIPTION
Subject: Fix encoding special characters in download filenames


### Bugfix

### Purpose
- Allow user to link files with special characters in filename

### Relates
https://github.com/sphinx-doc/sphinx/issues/3097

