### PR TITLE
[WIP] 'hidden' option for domain directives

### DIFF
--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -60,6 +60,7 @@ class ObjectDescription(SphinxDirective, Generic[T]):
     final_argument_whitespace = True
     option_spec: OptionSpec = {
         'noindex': directives.flag,
+        'hidden': directives.flag,
     }
 
     # types of doc fields that this directive handles, see sphinx.util.docfields
@@ -170,6 +171,7 @@ class ObjectDescription(SphinxDirective, Generic[T]):
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
         node['noindex'] = noindex = ('noindex' in self.options)
+        node['hidden'] = 'hidden' in self.options
         if self.domain:
             node['classes'].append(self.domain)
         node['classes'].append(node['objtype'])

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3140,9 +3140,11 @@ class CObject(ObjectDescription[ASTDeclaration]):
               names=('rtype',)),
     ]
 
-    option_spec: OptionSpec = {
+    option_spec: OptionSpec = ObjectDescription.option_spec.copy()
+    option_spec.update({
         'noindexentry': directives.flag,
-    }
+    })
+    del option_spec['noindex']  # is in ObjectDescription but doesn't make sense here
 
     def _add_enumerator_to_parent(self, ast: ASTDeclaration) -> None:
         assert ast.objectType == 'enumerator'

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6948,10 +6948,12 @@ class CPPObject(ObjectDescription[ASTDeclaration]):
               names=('returns', 'return')),
     ]
 
-    option_spec: OptionSpec = {
+    option_spec: OptionSpec = ObjectDescription.option_spec.copy()
+    option_spec.update({
         'noindexentry': directives.flag,
         'tparam-line-spec': directives.flag,
-    }
+    })
+    del option_spec['noindex']  # is in ObjectDescription but doesn't make sense here
 
     def _add_enumerator_to_parent(self, ast: ASTDeclaration) -> None:
         assert ast.objectType == 'enumerator'

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -48,10 +48,11 @@ class JSObject(ObjectDescription[Tuple[str, str]]):
     #: based on directive nesting
     allow_nesting = False
 
-    option_spec: OptionSpec = {
+    option_spec: OptionSpec = ObjectDescription.option_spec.copy()
+    option_spec.update({
         'noindex': directives.flag,
         'noindexentry': directives.flag,
-    }
+    })
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
         """Breaks down construct signatures

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -389,13 +389,13 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
     :cvar allow_nesting: Class is an object that allows for nested namespaces
     :vartype allow_nesting: bool
     """
-    option_spec: OptionSpec = {
-        'noindex': directives.flag,
+    option_spec: OptionSpec = ObjectDescription.option_spec.copy()
+    option_spec.update({
         'noindexentry': directives.flag,
         'module': directives.unchanged,
         'canonical': directives.unchanged,
         'annotation': directives.unchanged,
-    }
+    })
 
     doc_field_types = [
         PyTypedField('parameter', label=_('Parameters'),


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
Adding feature for #9662, implemented as suggested in https://github.com/sphinx-doc/sphinx/issues/9662#issuecomment-924127316.

Each domain directive that inherits from ``ObjectDescription`` and keeps the ``option_spec`` entries in that base class gets an option ``hidden``. This will cause the complete document subtree rooted at that declaration to be replaced with an empty ``inline`` node but where all ``ids`` mention in the replaced subtree are put in the new node. As the domains have already run, this effectively hides the declaration, but keeps the anchors in the document.

### Detail
Each ``addnodes.desc`` gets a boolean ``hidden`` attribute based on the option, which the post-transform searches for.
Instead of duplicating the option I have changed the py, c, cpp, and js domains to extend a copy of the ``option_spec`` in ``ObjectDescription``.

### TODO
Assuming this implementation is reasonable the following should be done:

- Add tests for each of the domains (py, c, cpp, js).
- Add documentation.
- Whatever I forgot.

### References
Fixes sphinx-doc/sphinx#9662
