### PR TITLE
Py, use more desc_sig_* nodes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Features added
 * #9691: C, added new info-field ``retval``
   for :rst:dir:`c:function` and :rst:dir:`c:macro`.
 * C++, added new info-field ``retval`` for :rst:dir:`cpp:function`.
+* #9672: More CSS classes on Python domain descriptions
 
 Bugs fixed
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,9 @@ Incompatible changes
 * #9672: The rendering of Python domain declarations is implemented
   with more docutils nodes to allow better CSS styling.
   It may break existing styling.
-
+* #9672: the signature of
+  :py:meth:`domains.py.PyObject.def get_signature_prefix` has changed to
+  return a list of nodes instead of a plain string.
 
 Deprecated
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -13,7 +13,7 @@ Incompatible changes
   with more docutils nodes to allow better CSS styling.
   It may break existing styling.
 * #9672: the signature of
-  :py:meth:`domains.py.PyObject.def get_signature_prefix` has changed to
+  :py:meth:`domains.py.PyObject.get_signature_prefix` has changed to
   return a list of nodes instead of a plain string.
 
 Deprecated

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@ Incompatible changes
 
 * #9649: ``searchindex.js``: the embedded data has changed format to allow
   objects with the same name in different domains.
+* #9672: The rendering of Python domain declarations is implemented
+  with more docutils nodes to allow better CSS styling.
+  It may break existing styling.
+
 
 Deprecated
 ----------

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -850,7 +850,11 @@ class PyAttribute(PyObject):
 
         value = self.options.get('value')
         if value:
-            signode += addnodes.desc_annotation(value, ' = ' + value)
+            signode += addnodes.desc_annotation(value, '',
+                                                addnodes.desc_sig_space(),
+                                                addnodes.desc_sig_punctuation('', '='),
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(value))
 
         return fullname, prefix
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -903,15 +903,18 @@ class PyProperty(PyObject):
 
         return fullname, prefix
 
-    def get_signature_prefix(self, sig: str) -> str:
-        prefix = []
+    def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
+        prefix: List[nodes.Node] = []
         if 'abstractmethod' in self.options:
-            prefix.append('abstract')
+            prefix.append(nodes.Text('abstract'))
+            prefix.append(addnodes.desc_sig_space())
         if 'classmethod' in self.options:
-            prefix.append('class')
+            prefix.append(nodes.Text('class'))
+            prefix.append(addnodes.desc_sig_space())
 
-        prefix.append('property')
-        return ' '.join(prefix) + ' '
+        prefix.append(nodes.Text('property'))
+        prefix.append(addnodes.desc_sig_space())
+        return prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -714,11 +714,12 @@ class PyClasslike(PyObject):
 
     allow_nesting = True
 
-    def get_signature_prefix(self, sig: str) -> str:
+    def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         if 'final' in self.options:
-            return 'final %s ' % self.objtype
+            return [nodes.Text('final'), addnodes.desc_sig_space(),
+                    nodes.Text(self.objtype), addnodes.desc_sig_space()]
         else:
-            return '%s ' % self.objtype
+            return [nodes.Text(self.objtype), addnodes.desc_sig_space()]
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         if self.objtype == 'class':

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -228,13 +228,13 @@ def _parse_arglist(arglist: str, env: BuildEnvironment = None) -> addnodes.desc_
         if param.annotation is not param.empty:
             children = _parse_annotation(param.annotation, env)
             node += addnodes.desc_sig_punctuation('', ':')
-            node += nodes.Text(' ')
+            node += addnodes.desc_sig_space()
             node += addnodes.desc_sig_name('', '', *children)  # type: ignore
         if param.default is not param.empty:
             if param.annotation is not param.empty:
-                node += nodes.Text(' ')
+                node += addnodes.desc_sig_space()
                 node += addnodes.desc_sig_operator('', '=')
-                node += nodes.Text(' ')
+                node += addnodes.desc_sig_space()
             else:
                 node += addnodes.desc_sig_operator('', '=')
             node += nodes.inline('', param.default, classes=['default_value'],

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -843,7 +843,10 @@ class PyAttribute(PyObject):
         typ = self.options.get('type')
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(typ, '', nodes.Text(': '), *annotations)
+            signode += addnodes.desc_annotation(typ, '',
+                                                addnodes.desc_sig_punctuation('', ':'),
+                                                addnodes.desc_sig_space(),
+                                                *annotations)
 
         value = self.options.get('value')
         if value:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -889,7 +889,10 @@ class PyProperty(PyObject):
         typ = self.options.get('type')
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(typ, '', nodes.Text(': '), *annotations)
+            signode += addnodes.desc_annotation(typ, '',
+                                                addnodes.desc_sig_punctuation('', ':'),
+                                                addnodes.desc_sig_space(),
+                                                *annotations)
 
         return fullname, prefix
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -124,6 +124,12 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
         elif isinstance(node, ast.Constant):  # type: ignore
             if node.value is Ellipsis:
                 return [addnodes.desc_sig_punctuation('', "...")]
+            elif isinstance(node.value, bool):
+                return [addnodes.desc_sig_keyword('', repr(node.value))]
+            elif isinstance(node.value, int):
+                return [addnodes.desc_sig_literal_number('', repr(node.value))]
+            elif isinstance(node.value, str):
+                return [addnodes.desc_sig_literal_string('', repr(node.value))]
             else:
                 return [nodes.Text(repr(node.value))]
         elif isinstance(node, ast.Expr):
@@ -513,7 +519,9 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
 
         anno = self.options.get('annotation')
         if anno:
-            signode += addnodes.desc_annotation(' ' + anno, ' ' + anno)
+            signode += addnodes.desc_annotation(' ' + anno, '',
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(anno))
 
         return fullname, prefix
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -751,25 +751,27 @@ class PyMethod(PyObject):
         else:
             return True
 
-    def get_signature_prefix(self, sig: str) -> str:
-        prefix = []
+    def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
+        prefix: List[nodes.Node] = []
         if 'final' in self.options:
-            prefix.append('final')
+            prefix.append(nodes.Text('final'))
+            prefix.append(addnodes.desc_sig_space())
         if 'abstractmethod' in self.options:
-            prefix.append('abstract')
+            prefix.append(nodes.Text('abstract'))
+            prefix.append(addnodes.desc_sig_space())
         if 'async' in self.options:
-            prefix.append('async')
+            prefix.append(nodes.Text('async'))
+            prefix.append(addnodes.desc_sig_space())
         if 'classmethod' in self.options:
-            prefix.append('classmethod')
+            prefix.append(nodes.Text('classmethod'))
+            prefix.append(addnodes.desc_sig_space())
         if 'property' in self.options:
-            prefix.append('property')
+            prefix.append(nodes.Text('property'))
+            prefix.append(addnodes.desc_sig_space())
         if 'staticmethod' in self.options:
-            prefix.append('static')
-
-        if prefix:
-            return ' '.join(prefix) + ' '
-        else:
-            return ''
+            prefix.append(nodes.Text('static'))
+            prefix.append(addnodes.desc_sig_space())
+        return prefix
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
         name, cls = name_cls

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -682,7 +682,11 @@ class PyVariable(PyObject):
 
         value = self.options.get('value')
         if value:
-            signode += addnodes.desc_annotation(value, ' = ' + value)
+            signode += addnodes.desc_annotation(value, '',
+                                                addnodes.desc_sig_space(),
+                                                addnodes.desc_sig_punctuation('', '='),
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(value))
 
         return fullname, prefix
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -482,10 +482,7 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
-            if isinstance(sig_prefix, str):
-                signode += addnodes.desc_annotation(sig_prefix, sig_prefix)
-            else:
-                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
+            signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -118,7 +118,9 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
             result.extend(unparse(node.right))
             return result
         elif isinstance(node, ast.BitOr):
-            return [nodes.Text(' '), addnodes.desc_sig_punctuation('', '|'), nodes.Text(' ')]
+            return [addnodes.desc_sig_space(),
+                    addnodes.desc_sig_punctuation('', '|'),
+                    addnodes.desc_sig_space()]
         elif isinstance(node, ast.Constant):  # type: ignore
             if node.value is Ellipsis:
                 return [addnodes.desc_sig_punctuation('', "...")]

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -618,11 +618,12 @@ class PyFunction(PyObject):
         'async': directives.flag,
     })
 
-    def get_signature_prefix(self, sig: str) -> str:
+    def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         if 'async' in self.options:
-            return 'async '
+            return [addnodes.desc_sig_keyword('', 'async'),
+                    addnodes.desc_sig_space()]
         else:
-            return ''
+            return []
 
     def needs_arglist(self) -> bool:
         return True

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -676,7 +676,9 @@ class PyVariable(PyObject):
         typ = self.options.get('type')
         if typ:
             annotations = _parse_annotation(typ, self.env)
-            signode += addnodes.desc_annotation(typ, '', nodes.Text(': '), *annotations)
+            signode += addnodes.desc_annotation(typ, '',
+                                                addnodes.desc_sig_punctuation('', ':'),
+                                                addnodes.desc_sig_space(), *annotations)
 
         value = self.options.get('value')
         if value:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -138,7 +138,9 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
                 # once
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation('', ', '))
+                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_space())
+                result.pop()
                 result.pop()
             result.append(addnodes.desc_sig_punctuation('', ']'))
             return result

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -165,7 +165,9 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
                 result = []
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation('', ', '))
+                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_space())
+                result.pop()
                 result.pop()
             else:
                 result = [addnodes.desc_sig_punctuation('', '('),

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -424,11 +424,11 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
 
     allow_nesting = False
 
-    def get_signature_prefix(self, sig: str) -> str:
+    def get_signature_prefix(self, sig: str) -> List[nodes.Node]:
         """May return a prefix to put before the object name in the
         signature.
         """
-        return ''
+        return []
 
     def needs_arglist(self) -> bool:
         """May return true if an empty argument list is to be generated even if
@@ -482,7 +482,10 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
-            signode += addnodes.desc_annotation(sig_prefix, sig_prefix)
+            if isinstance(sig_prefix, str):
+                signode += addnodes.desc_annotation(sig_prefix, sig_prefix)
+            else:
+                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -131,6 +131,8 @@ def _parse_annotation(annotation: str, env: BuildEnvironment = None) -> List[Nod
             elif isinstance(node.value, str):
                 return [addnodes.desc_sig_literal_string('', repr(node.value))]
             else:
+                # handles None, which is further handled by type_to_xref later
+                # and fallback for other types that should be converted
                 return [nodes.Text(repr(node.value))]
         elif isinstance(node, ast.Expr):
             return unparse(node.value)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -841,7 +841,11 @@ def test_pyattribute(app):
                                                                         [desc_sig_punctuation, "["],
                                                                         [pending_xref, "str"],
                                                                         [desc_sig_punctuation, "]"])],
-                                                     [desc_annotation, " = ''"])],
+                                                     [desc_annotation, (desc_sig_space,
+                                                                        [desc_sig_punctuation, '='],
+                                                                        desc_sig_space,
+                                                                        "''")]
+                                                     )],
                                    [desc_content, ()]))
     assert_node(doctree[1][1][1][0][1][2], pending_xref, **{"py:class": "Class"})
     assert_node(doctree[1][1][1][0][1][4], pending_xref, **{"py:class": "Class"})

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -18,7 +18,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.addnodes import (desc, desc_addname, desc_annotation, desc_content, desc_name,
                              desc_optional, desc_parameter, desc_parameterlist, desc_returns,
-                             desc_sig_keyword,
+                             desc_sig_keyword, desc_sig_literal_number, desc_sig_literal_string,
                              desc_sig_name, desc_sig_operator, desc_sig_punctuation,
                              desc_signature, desc_sig_space, pending_xref)
 from sphinx.domains import IndexEntry
@@ -354,22 +354,22 @@ def test_parse_annotation_Literal(app):
     doctree = _parse_annotation("Literal[True, False]", app.env)
     assert_node(doctree, ([pending_xref, "Literal"],
                           [desc_sig_punctuation, "["],
-                          "True",
+                          [desc_sig_keyword, "True"],
                           [desc_sig_punctuation, ","],
                           desc_sig_space,
-                          "False",
+                          [desc_sig_keyword, "False"],
                           [desc_sig_punctuation, "]"]))
 
     doctree = _parse_annotation("typing.Literal[0, 1, 'abc']", app.env)
     assert_node(doctree, ([pending_xref, "typing.Literal"],
                           [desc_sig_punctuation, "["],
-                          "0",
+                          [desc_sig_literal_number, "0"],
                           [desc_sig_punctuation, ","],
                           desc_sig_space,
-                          "1",
+                          [desc_sig_literal_number, "1"],
                           [desc_sig_punctuation, ","],
                           desc_sig_space,
-                          "'abc'",
+                          [desc_sig_literal_string, "'abc'"],
                           [desc_sig_punctuation, "]"]))
 
 
@@ -555,7 +555,8 @@ def test_pydata_signature_old(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, "version"],
-                                                    [desc_annotation, " = 1"])],
+                                                    [desc_annotation, (desc_sig_space,
+                                                                       "= 1")])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="data",
                 domain="py", objtype="data", noindex=False)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -520,7 +520,7 @@ def test_pyexception_signature(app):
     text = ".. py:exception:: builtins.IOError"
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "exception "],
+                          [desc, ([desc_signature, ([desc_annotation, ('exception', desc_sig_space)],
                                                     [desc_addname, "builtins."],
                                                     [desc_name, "IOError"])],
                                   desc_content)]))
@@ -583,7 +583,7 @@ def test_pyobject_prefix(app):
             "   .. py:method:: FooBar.say")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ('class', desc_sig_space)],
                                                     [desc_name, "Foo"])],
                                   [desc_content, (addnodes.index,
                                                   desc,
@@ -653,11 +653,14 @@ def test_pyclass_options(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_name, "Class1"])],
                                   [desc_content, ()])],
                           addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "final class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("final",
+                                                                       desc_sig_space,
+                                                                       "class",
+                                                                       desc_sig_space)],
                                                     [desc_name, "Class2"])],
                                   [desc_content, ()])]))
 
@@ -693,7 +696,7 @@ def test_pymethod_options(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
                                                   desc,
@@ -786,7 +789,7 @@ def test_pyclassmethod(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
                                                   desc)])]))
@@ -807,7 +810,7 @@ def test_pystaticmethod(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
                                                   desc)])]))
@@ -830,7 +833,7 @@ def test_pyattribute(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
                                                   desc)])]))
@@ -868,7 +871,7 @@ def test_pyproperty(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_name, "Class"])],
                                   [desc_content, (addnodes.index,
                                                   desc,
@@ -932,7 +935,7 @@ def test_canonical(app):
     domain = app.env.get_domain('py')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_addname, "io."],
                                                     [desc_name, "StringIO"])],
                                   desc_content)]))
@@ -990,7 +993,7 @@ def test_info_field_list(app):
     assert_node(doctree, (nodes.target,
                           addnodes.index,
                           addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "class "],
+                          [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                                     [desc_addname, "example."],
                                                     [desc_name, "Class"])],
                                   [desc_content, nodes.field_list, nodes.field])]))
@@ -1081,7 +1084,7 @@ def test_info_field_list_piped_type(app):
                 (nodes.target,
                  addnodes.index,
                  addnodes.index,
-                 [desc, ([desc_signature, ([desc_annotation, "class "],
+                 [desc, ([desc_signature, ([desc_annotation, ("class", desc_sig_space)],
                                            [desc_addname, "example."],
                                            [desc_name, "Class"])],
                          [desc_content, nodes.field_list, nodes.field, (nodes.field_name,

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -725,7 +725,7 @@ def test_pymethod_options(app):
     # :classmethod:
     assert_node(doctree[1][1][2], addnodes.index,
                 entries=[('single', 'meth2() (Class class method)', 'Class.meth2', '', None)])
-    assert_node(doctree[1][1][3], ([desc_signature, ([desc_annotation, "classmethod "],
+    assert_node(doctree[1][1][3], ([desc_signature, ([desc_annotation, ("classmethod", desc_sig_space)],
                                                      [desc_name, "meth2"],
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
@@ -735,7 +735,7 @@ def test_pymethod_options(app):
     # :staticmethod:
     assert_node(doctree[1][1][4], addnodes.index,
                 entries=[('single', 'meth3() (Class static method)', 'Class.meth3', '', None)])
-    assert_node(doctree[1][1][5], ([desc_signature, ([desc_annotation, "static "],
+    assert_node(doctree[1][1][5], ([desc_signature, ([desc_annotation, ("static", desc_sig_space)],
                                                      [desc_name, "meth3"],
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
@@ -745,7 +745,7 @@ def test_pymethod_options(app):
     # :async:
     assert_node(doctree[1][1][6], addnodes.index,
                 entries=[('single', 'meth4() (Class method)', 'Class.meth4', '', None)])
-    assert_node(doctree[1][1][7], ([desc_signature, ([desc_annotation, "async "],
+    assert_node(doctree[1][1][7], ([desc_signature, ([desc_annotation, ("async", desc_sig_space)],
                                                      [desc_name, "meth4"],
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
@@ -755,7 +755,7 @@ def test_pymethod_options(app):
     # :property:
     assert_node(doctree[1][1][8], addnodes.index,
                 entries=[('single', 'meth5() (Class property)', 'Class.meth5', '', None)])
-    assert_node(doctree[1][1][9], ([desc_signature, ([desc_annotation, "property "],
+    assert_node(doctree[1][1][9], ([desc_signature, ([desc_annotation, ("property", desc_sig_space)],
                                                      [desc_name, "meth5"])],
                                    [desc_content, ()]))
     assert 'Class.meth5' in domain.objects
@@ -764,7 +764,7 @@ def test_pymethod_options(app):
     # :abstractmethod:
     assert_node(doctree[1][1][10], addnodes.index,
                 entries=[('single', 'meth6() (Class method)', 'Class.meth6', '', None)])
-    assert_node(doctree[1][1][11], ([desc_signature, ([desc_annotation, "abstract "],
+    assert_node(doctree[1][1][11], ([desc_signature, ([desc_annotation, ("abstract", desc_sig_space)],
                                                       [desc_name, "meth6"],
                                                       [desc_parameterlist, ()])],
                                     [desc_content, ()]))
@@ -774,7 +774,7 @@ def test_pymethod_options(app):
     # :final:
     assert_node(doctree[1][1][12], addnodes.index,
                 entries=[('single', 'meth7() (Class method)', 'Class.meth7', '', None)])
-    assert_node(doctree[1][1][13], ([desc_signature, ([desc_annotation, "final "],
+    assert_node(doctree[1][1][13], ([desc_signature, ([desc_annotation, ("final", desc_sig_space)],
                                                       [desc_name, "meth7"],
                                                       [desc_parameterlist, ()])],
                                     [desc_content, ()]))
@@ -795,7 +795,7 @@ def test_pyclassmethod(app):
                                                   desc)])]))
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'meth() (Class class method)', 'Class.meth', '', None)])
-    assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, "classmethod "],
+    assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, ("classmethod", desc_sig_space)],
                                                      [desc_name, "meth"],
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))
@@ -816,7 +816,7 @@ def test_pystaticmethod(app):
                                                   desc)])]))
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'meth() (Class static method)', 'Class.meth', '', None)])
-    assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, "static "],
+    assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, ("static", desc_sig_space)],
                                                      [desc_name, "meth"],
                                                      [desc_parameterlist, ()])],
                                    [desc_content, ()]))

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -310,11 +310,13 @@ def test_parse_annotation(app):
                           [desc_sig_punctuation, "]"]))
 
     doctree = _parse_annotation("Callable[[int, int], int]", app.env)
+    print(doctree)
     assert_node(doctree, ([pending_xref, "Callable"],
                           [desc_sig_punctuation, "["],
                           [desc_sig_punctuation, "["],
                           [pending_xref, "int"],
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"],
                           [desc_sig_punctuation, ", "],

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -19,7 +19,7 @@ from sphinx import addnodes
 from sphinx.addnodes import (desc, desc_addname, desc_annotation, desc_content, desc_name,
                              desc_optional, desc_parameter, desc_parameterlist, desc_returns,
                              desc_sig_name, desc_sig_operator, desc_sig_punctuation,
-                             desc_signature, pending_xref)
+                             desc_signature, desc_sig_space, pending_xref)
 from sphinx.domains import IndexEntry
 from sphinx.domains.python import (PythonDomain, PythonModuleIndex, _parse_annotation,
                                    _pseudo_parse_arglist, py_sig_re)
@@ -484,9 +484,9 @@ def test_pyfunction_with_union_type_operator(app):
                                                         [desc_sig_punctuation, ":"],
                                                         " ",
                                                         [desc_sig_name, ([pending_xref, "int"],
-                                                                         " ",
+                                                                         desc_sig_space,
                                                                          [desc_sig_punctuation, "|"],
-                                                                         " ",
+                                                                         desc_sig_space,
                                                                          [pending_xref, "None"])])])])
 
 
@@ -553,9 +553,9 @@ def test_pydata_with_union_type_operator(app):
                 ([desc_name, "version"],
                  [desc_annotation, (": ",
                                     [pending_xref, "int"],
-                                    " ",
+                                    desc_sig_space,
                                     [desc_sig_punctuation, "|"],
-                                    " ",
+                                    desc_sig_space,
                                     [pending_xref, "str"])]))
 
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -835,15 +835,16 @@ def test_pyattribute(app):
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'attr (Class attribute)', 'Class.attr', '', None)])
     assert_node(doctree[1][1][1], ([desc_signature, ([desc_name, "attr"],
-                                                     [desc_annotation, (": ",
+                                                     [desc_annotation, ([desc_sig_punctuation, ':'],
+                                                                        desc_sig_space,
                                                                         [pending_xref, "Optional"],
                                                                         [desc_sig_punctuation, "["],
                                                                         [pending_xref, "str"],
                                                                         [desc_sig_punctuation, "]"])],
                                                      [desc_annotation, " = ''"])],
                                    [desc_content, ()]))
-    assert_node(doctree[1][1][1][0][1][1], pending_xref, **{"py:class": "Class"})
-    assert_node(doctree[1][1][1][0][1][3], pending_xref, **{"py:class": "Class"})
+    assert_node(doctree[1][1][1][0][1][2], pending_xref, **{"py:class": "Class"})
+    assert_node(doctree[1][1][1][0][1][4], pending_xref, **{"py:class": "Class"})
     assert 'Class.attr' in domain.objects
     assert domain.objects['Class.attr'] == ('index', 'Class.attr', 'attribute', False)
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -537,7 +537,12 @@ def test_pydata_signature(app):
                                                     [desc_annotation, ([desc_sig_punctuation, ':'],
                                                                        desc_sig_space,
                                                                        [pending_xref, "int"])],
-                                                    [desc_annotation, " = 1"])],
+                                                    [desc_annotation, (
+                                                        desc_sig_space,
+                                                        [desc_sig_punctuation, '='],
+                                                        desc_sig_space,
+                                                        "1")]
+                                                    )],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="data",
                 domain="py", objtype="data", noindex=False)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -879,7 +879,8 @@ def test_pyproperty(app):
                                                   desc)])]))
     assert_node(doctree[1][1][0], addnodes.index,
                 entries=[('single', 'prop1 (Class property)', 'Class.prop1', '', None)])
-    assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, "abstract property "],
+    assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, ("abstract", desc_sig_space,
+                                                                        "property", desc_sig_space)],
                                                      [desc_name, "prop1"],
                                                      [desc_annotation, ([desc_sig_punctuation, ':'],
                                                                         desc_sig_space,
@@ -887,7 +888,8 @@ def test_pyproperty(app):
                                    [desc_content, ()]))
     assert_node(doctree[1][1][2], addnodes.index,
                 entries=[('single', 'prop2 (Class property)', 'Class.prop2', '', None)])
-    assert_node(doctree[1][1][3], ([desc_signature, ([desc_annotation, "class property "],
+    assert_node(doctree[1][1][3], ([desc_signature, ([desc_annotation, ("class", desc_sig_space,
+                                                                        "property", desc_sig_space)],
                                                      [desc_name, "prop2"],
                                                      [desc_annotation, ([desc_sig_punctuation, ':'],
                                                                         desc_sig_space,

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -18,9 +18,10 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.addnodes import (desc, desc_addname, desc_annotation, desc_content, desc_name,
                              desc_optional, desc_parameter, desc_parameterlist, desc_returns,
-                             desc_sig_keyword, desc_sig_literal_number, desc_sig_literal_string,
-                             desc_sig_name, desc_sig_operator, desc_sig_punctuation,
-                             desc_signature, desc_sig_space, pending_xref)
+                             desc_sig_keyword, desc_sig_literal_number,
+                             desc_sig_literal_string, desc_sig_name, desc_sig_operator,
+                             desc_sig_punctuation, desc_sig_space, desc_signature,
+                             pending_xref)
 from sphinx.domains import IndexEntry
 from sphinx.domains.python import (PythonDomain, PythonModuleIndex, _parse_annotation,
                                    _pseudo_parse_arglist, py_sig_re)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -291,7 +291,7 @@ def test_parse_annotation(app):
                           [desc_sig_punctuation, "["],
                           [pending_xref, "int"],
                           [desc_sig_punctuation, ","],
-                          [desc_sig_space],
+                          desc_sig_space,
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
 
@@ -307,7 +307,7 @@ def test_parse_annotation(app):
                           [desc_sig_punctuation, "["],
                           [pending_xref, "int"],
                           [desc_sig_punctuation, ","],
-                          [desc_sig_space],
+                          desc_sig_space,
                           [desc_sig_punctuation, "..."],
                           [desc_sig_punctuation, "]"]))
 
@@ -385,7 +385,7 @@ def test_pyfunction_signature(app):
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "name"],
                                                       [desc_sig_punctuation, ":"],
-                                                      " ",
+                                                      desc_sig_space,
                                                       [nodes.inline, pending_xref, "str"])])
 
 
@@ -403,7 +403,7 @@ def test_pyfunction_signature_full(app):
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, ([desc_parameter, ([desc_sig_name, "a"],
                                                         [desc_sig_punctuation, ":"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_name, pending_xref, "str"])],
                                       [desc_parameter, ([desc_sig_name, "b"],
                                                         [desc_sig_operator, "="],
@@ -411,28 +411,28 @@ def test_pyfunction_signature_full(app):
                                       [desc_parameter, ([desc_sig_operator, "*"],
                                                         [desc_sig_name, "args"],
                                                         [desc_sig_punctuation, ":"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_name, pending_xref, "str"])],
                                       [desc_parameter, ([desc_sig_name, "c"],
                                                         [desc_sig_punctuation, ":"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_name, pending_xref, "bool"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_operator, "="],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [nodes.inline, "True"])],
                                       [desc_parameter, ([desc_sig_name, "d"],
                                                         [desc_sig_punctuation, ":"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_name, pending_xref, "tuple"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_operator, "="],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [nodes.inline, "(1, 2)"])],
                                       [desc_parameter, ([desc_sig_operator, "**"],
                                                         [desc_sig_name, "kwargs"],
                                                         [desc_sig_punctuation, ":"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_name, pending_xref, "str"])])])
 
 
@@ -491,7 +491,7 @@ def test_pyfunction_with_union_type_operator(app):
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, ([desc_parameter, ([desc_sig_name, "age"],
                                                         [desc_sig_punctuation, ":"],
-                                                        " ",
+                                                        desc_sig_space,
                                                         [desc_sig_name, ([pending_xref, "int"],
                                                                          desc_sig_space,
                                                                          [desc_sig_punctuation, "|"],

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -534,7 +534,8 @@ def test_pydata_signature(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, "version"],
-                                                    [desc_annotation, (": ",
+                                                    [desc_annotation, ([desc_sig_punctuation, ':'],
+                                                                       desc_sig_space,
                                                                        [pending_xref, "int"])],
                                                     [desc_annotation, " = 1"])],
                                   desc_content)]))
@@ -560,7 +561,8 @@ def test_pydata_with_union_type_operator(app):
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1][0],
                 ([desc_name, "version"],
-                 [desc_annotation, (": ",
+                 [desc_annotation, ([desc_sig_punctuation, ':'],
+                                    desc_sig_space,
                                     [pending_xref, "int"],
                                     desc_sig_space,
                                     [desc_sig_punctuation, "|"],
@@ -596,10 +598,11 @@ def test_pydata(app):
                           addnodes.index,
                           [desc, ([desc_signature, ([desc_addname, "example."],
                                                     [desc_name, "var"],
-                                                    [desc_annotation, (": ",
+                                                    [desc_annotation, ([desc_sig_punctuation, ':'],
+                                                                       desc_sig_space,
                                                                        [pending_xref, "int"])])],
                                   [desc_content, ()])]))
-    assert_node(doctree[3][0][2][1], pending_xref, **{"py:module": "example"})
+    assert_node(doctree[3][0][2][2], pending_xref, **{"py:module": "example"})
     assert 'example.var' in domain.objects
     assert domain.objects['example.var'] == ('index', 'example.var', 'data', False)
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -18,6 +18,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.addnodes import (desc, desc_addname, desc_annotation, desc_content, desc_name,
                              desc_optional, desc_parameter, desc_parameterlist, desc_returns,
+                             desc_sig_keyword,
                              desc_sig_name, desc_sig_operator, desc_sig_punctuation,
                              desc_signature, desc_sig_space, pending_xref)
 from sphinx.domains import IndexEntry
@@ -626,7 +627,8 @@ def test_pyfunction(app):
                           nodes.target,
                           addnodes.index,
                           addnodes.index,
-                          [desc, ([desc_signature, ([desc_annotation, "async "],
+                          [desc, ([desc_signature, ([desc_annotation, ([desc_sig_keyword, 'async'],
+                                                                       desc_sig_space)],
                                                     [desc_addname, "example."],
                                                     [desc_name, "func2"],
                                                     [desc_parameterlist, ()])],

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -290,7 +290,8 @@ def test_parse_annotation(app):
     assert_node(doctree, ([pending_xref, "Tuple"],
                           [desc_sig_punctuation, "["],
                           [pending_xref, "int"],
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          [desc_sig_space],
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
 
@@ -305,7 +306,8 @@ def test_parse_annotation(app):
     assert_node(doctree, ([pending_xref, "Tuple"],
                           [desc_sig_punctuation, "["],
                           [pending_xref, "int"],
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          [desc_sig_space],
                           [desc_sig_punctuation, "..."],
                           [desc_sig_punctuation, "]"]))
 
@@ -319,7 +321,8 @@ def test_parse_annotation(app):
                           desc_sig_space,
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"],
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
 
@@ -328,7 +331,8 @@ def test_parse_annotation(app):
                           [desc_sig_punctuation, "["],
                           [desc_sig_punctuation, "["],
                           [desc_sig_punctuation, "]"],
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
                           [pending_xref, "int"],
                           [desc_sig_punctuation, "]"]))
 
@@ -350,7 +354,8 @@ def test_parse_annotation_Literal(app):
     assert_node(doctree, ([pending_xref, "Literal"],
                           [desc_sig_punctuation, "["],
                           "True",
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
                           "False",
                           [desc_sig_punctuation, "]"]))
 
@@ -358,9 +363,11 @@ def test_parse_annotation_Literal(app):
     assert_node(doctree, ([pending_xref, "typing.Literal"],
                           [desc_sig_punctuation, "["],
                           "0",
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
                           "1",
-                          [desc_sig_punctuation, ", "],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
                           "'abc'",
                           [desc_sig_punctuation, "]"]))
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -876,14 +876,16 @@ def test_pyproperty(app):
                 entries=[('single', 'prop1 (Class property)', 'Class.prop1', '', None)])
     assert_node(doctree[1][1][1], ([desc_signature, ([desc_annotation, "abstract property "],
                                                      [desc_name, "prop1"],
-                                                     [desc_annotation, (": ",
+                                                     [desc_annotation, ([desc_sig_punctuation, ':'],
+                                                                        desc_sig_space,
                                                                         [pending_xref, "str"])])],
                                    [desc_content, ()]))
     assert_node(doctree[1][1][2], addnodes.index,
                 entries=[('single', 'prop2 (Class property)', 'Class.prop2', '', None)])
     assert_node(doctree[1][1][3], ([desc_signature, ([desc_annotation, "class property "],
                                                      [desc_name, "prop2"],
-                                                     [desc_annotation, (": ",
+                                                     [desc_annotation, ([desc_sig_punctuation, ':'],
+                                                                        desc_sig_space,
                                                                         [pending_xref, "str"])])],
                                    [desc_content, ()]))
     assert 'Class.prop1' in domain.objects


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix?
- Refactoring

### Purpose
A continuation of #9023, changing many parts of the Python domain to use more of the ``addnodes.desc_sig_*`` nodes for markup. This especially includes the use of the space node to make sure spaces are not swallowed if themes use alternative CSS (#9599).

### Detail
All of the changes are relatively simple, but it is not complete: the whole ``pendinx_xref`` handling is a bit more complicated than I dare to touch right now.

### TODO and Context
- Any semi-trivial places I missed?
- Probably for another PR: the ``pending_xref`' handling.
  It seem like a name ``A.B.C`` becomes a single xref with the content being a ``nodes.Tex``.
  I think it would be good to change it to something like a 
  1. ``pending_xref`` with target ``A`` and content ``desc_sig_name`` with ``A``
  2. ``.`` as punctuation
  3. ``pending_xref`` with target ``A.B`` and content ``desc_sig_name`` with ``B``
  4. ``.`` as punctuation
  5. ``pending_xref`` with target ``A.B.C`` and content ``desc_sig_name`` with ``C``
- For another PR: write some documentation for how to style domain elements in HTML
- For another PR: work around the ``<span class="pre">`` wrapping in
  https://github.com/sphinx-doc/sphinx/blob/699d03f597130bc39ffa95c6e2cbcf006c6385f6/sphinx/writers/html.py#L709 and https://github.com/sphinx-doc/sphinx/blob/699d03f597130bc39ffa95c6e2cbcf006c6385f6/sphinx/writers/html5.py#L645

### Relates
- Continuation of #9023
- Fixes some parts of #9599 (ping @mattip)
- Perhaps fixes some of #9663? (ping @pradyunsg)