### PR TITLE
Don't print file extension twice in linkcheck warnings

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -255,7 +255,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
         elif result.status == 'broken':
             if self.app.quiet or self.app.warningiserror:
                 logger.warning(__('broken link: %s (%s)'), result.uri, result.message,
-                               location=(filename, result.lineno))
+                               location=(result.docname, result.lineno))
             else:
                 logger.info(red('broken    ') + result.uri + red(' - ' + result.message))
             self.write_entry('broken', result.docname, filename, result.lineno,
@@ -274,7 +274,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
             linkstat['text'] = text
             if self.config.linkcheck_allowed_redirects:
                 logger.warning('redirect  ' + result.uri + ' - ' + text + ' to ' +
-                               result.message, location=(filename, result.lineno))
+                               result.message, location=(result.docname, result.lineno))
             else:
                 logger.info(color('redirect  ') + result.uri +
                             color(' - ' + text + ' to ' + result.message))

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -305,7 +305,7 @@ def test_linkcheck_allowed_redirects(app, warning):
     assert result["http://localhost:7777/path1"] == "working"
     assert result["http://localhost:7777/path2"] == "redirected"
 
-    assert ("index.rst.rst:1: WARNING: redirect  http://localhost:7777/path2 - with Found to "
+    assert ("index.rst:1: WARNING: redirect  http://localhost:7777/path2 - with Found to "
             "http://localhost:7777/?redirected=1\n" in strip_escseq(warning.getvalue()))
     assert len(warning.getvalue().splitlines()) == 1
 


### PR DESCRIPTION
Subject: Fix duplicate `.rst` extension printed in `linkcheck` warnings

### Feature or Bugfix
- Bugfix

### Purpose

This is just a cosmetic fix.

Right now, `linkcheck` emits
```
file.rst.rst:1: WARNING: broken link: https://example.com
```
With this PR, the file extension is not printed twice, so the warning is emitted like this:
```
file.rst:1: WARNING: broken link: https://example.com
```