### PR TITLE
Set refdoc to be used by missing-reference, intersphinx

### DIFF
--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -78,7 +78,8 @@ class ReferencesResolver(SphinxPostTransform):
 
             typ = node['reftype']
             target = node['reftarget']
-            refdoc = node.get('refdoc', self.env.docname)
+            node.setdefault('refdoc', self.env.docname)
+            refdoc = node.get('refdoc')
             domain = None
 
             try:


### PR DESCRIPTION
### Feature or Bugfix
Bugfix

### Purpose
Intersphinx checks for `refdoc` attribute in node during the `missing-reference` event. To determine to correct relative reference uri.
https://github.com/sphinx-doc/sphinx/blob/cf38356a088acc0052d6cbb50f04c3773ab690c4/sphinx/ext/intersphinx.py#L330-L332

It is called from `post_transforms`, all other options that are tried/checked before, do get a separate `refdoc` as an argument. Though the `missing-reference` event only gets it if it was already in the node, as it doesn't have a separate `refdoc` argument.
https://github.com/sphinx-doc/sphinx/blob/cf38356a088acc0052d6cbb50f04c3773ab690c4/sphinx/transforms/post_transforms/__init__.py#L98-L100

I have not experienced a situation yet, where it was already set.

By not providing the `missing-reference` event with the back-up 'refdoc' from https://github.com/sphinx-doc/sphinx/blob/cf38356a088acc0052d6cbb50f04c3773ab690c4/sphinx/transforms/post_transforms/__init__.py#L81

Relative reference uri's don't work in intersphinx.

So either we need to set the `refdoc` attribute to node or change the API of `missing-reference`, so that it accepts `refdoc` as a separate argument.  I choose the first option, but I am open to implement the second one if you prefer that one.

P.S.: also the viewcode extension expects the `refdoc` attribute of the `node` to be set. So that would favor the first option, which I implemented.
https://github.com/sphinx-doc/sphinx/blob/cf38356a088acc0052d6cbb50f04c3773ab690c4/sphinx/ext/viewcode.py#L204-L205

### Detail
By not having the `refdoc` in intersphinx, it doesn't know how deep you are in your package, therefore it can't determine relative paths to references. It will use assume your are in the root of your package, which will generate broken links as the depth mismatches.

### Relates
Fixes #7634