### PR TITLE
Fix #9500: LaTeX: Failed to build Japanese document on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -119,6 +119,7 @@ Bugs fixed
   with the HEAD of 3.10
 * #9436, #9471: autodoc: crashed if ``autodoc_class_signature = "separated"``
 * #9456: html search: html_copy_source can't control the search summaries
+* #9500: LaTeX: Failed to build Japanese document on Windows
 * #9435: linkcheck: Failed to check anchors in github.com
 
 Release 4.1.1 (released Jul 15, 2021)

--- a/sphinx/texinputs/make.bat_t
+++ b/sphinx/texinputs/make.bat_t
@@ -4,7 +4,7 @@ REM Command file for Sphinx documentation
 
 pushd %~dp0
 
-{% if latex_engine == 'platex' -%}
+{% if latex_engine in ('platex', 'uplatex') -%}
 REM latexmkrc is read then overridden by latexmkjarc
 set PDFLATEX=latexmk -r latexmkjarc -pdfdvi -dvi- -ps-
 {% else -%}

--- a/sphinx/texinputs_win/Makefile_t
+++ b/sphinx/texinputs_win/Makefile_t
@@ -16,7 +16,7 @@ LATEX = latex
 PDFLATEX = {{ latex_engine }}
 MAKEINDEX = makeindex
 
-{% if latex_engine == 'platex' %}
+{% if latex_engine in ('platex', 'uplatex') -%}
 all: all-pdf-ja
 all-pdf: all-pdf-ja
 {% else %}
@@ -28,12 +28,12 @@ all-ps: $(ALLPS)
 
 all-pdf-ja:
 	for f in *.pdf *.png *.gif *.jpg *.jpeg; do extractbb $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do {{ latex_engine }} -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do {{ latex_engine }} -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do {{ latex_engine }} -kanji=utf8 $(LATEXOPTS) $$f; done
 	-for f in *.idx; do mendex -U -f -d "`basename $$f .idx`.dic" -s python.ist $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
-	for f in *.tex; do platex -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do {{ latex_engine }} -kanji=utf8 $(LATEXOPTS) $$f; done
+	for f in *.tex; do {{ latex_engine }} -kanji=utf8 $(LATEXOPTS) $$f; done
 	for f in *.dvi; do dvipdfmx $$f; done
 
 zip: all-$(FMT)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- At present, LaTeX builder generates a Makefile for PDFLaTeX instead of
upLaTeX in building Japanese document on Windows.  This adds upLaTeX
support to Makefile for Windows.
- refs: #9500