### PR TITLE
Follow new structure of docutils-0.18

### DIFF
--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Sequence
 from docutils import nodes
 from docutils.nodes import Element
 
+from sphinx.util import docutils
+
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
@@ -563,13 +565,15 @@ def setup(app: "Sphinx") -> Dict[str, Any]:
     app.add_node(start_of_file)
     app.add_node(highlightlang)
     app.add_node(tabular_col_spec)
-    app.add_node(meta)
     app.add_node(pending_xref)
     app.add_node(number_reference)
     app.add_node(download_reference)
     app.add_node(literal_emphasis)
     app.add_node(literal_strong)
     app.add_node(manpage)
+
+    if docutils.__version_info__ < (0, 18):
+        app.add_node(meta)
 
     return {
         'version': 'builtin',

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, cast
 from docutils import nodes
 from docutils.nodes import Node, make_id, system_message
 from docutils.parsers.rst import directives
-from docutils.parsers.rst.directives import html, images, tables
+from docutils.parsers.rst.directives import images, tables
 
 from sphinx import addnodes
 from sphinx.deprecation import RemovedInSphinx60Warning
@@ -26,6 +26,15 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import set_source_info
 from sphinx.util.osutil import SEP, os_path, relpath
 from sphinx.util.typing import OptionSpec
+
+try:
+    from docutils.nodes import meta as meta_node  # type: ignore
+    from docutils.parsers.rst.directives.misc import Meta as MetaBase  # type: ignore
+except ImportError:
+    # docutils-0.17 or older
+    from docutils.parsers.rst.directives.html import Meta as MetaBase
+    from docutils.parsers.rst.directives.html import MetaBody
+    meta_node = MetaBody.meta
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -60,19 +69,19 @@ class Figure(images.Figure):
         return [figure_node]
 
 
-class Meta(html.Meta, SphinxDirective):
+class Meta(MetaBase, SphinxDirective):
     def run(self) -> List[Node]:
         result = super().run()
         for node in result:
             if (isinstance(node, nodes.pending) and
-               isinstance(node.details['nodes'][0], html.MetaBody.meta)):
+               isinstance(node.details['nodes'][0], meta_node)):
                 meta = node.details['nodes'][0]
                 meta.source = self.env.doc2path(self.env.docname)
                 meta.line = self.lineno
-                meta.rawcontent = meta['content']  # type: ignore
+                meta.rawcontent = meta['content']
 
                 # docutils' meta nodes aren't picklable because the class is nested
-                meta.__class__ = addnodes.meta  # type: ignore
+                meta.__class__ = addnodes.meta
 
         return result
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 default_settings: Dict[str, Any] = {
+    'embed_images': False,
     'embed_stylesheet': False,
     'cloak_email_addresses': True,
     'pep_base_url': 'https://www.python.org/dev/peps/',
@@ -54,6 +55,7 @@ default_settings: Dict[str, Any] = {
     'input_encoding': 'utf-8-sig',
     'doctitle_xform': False,
     'sectsubtitle_xform': False,
+    'section_self_link': False,
     'halt_level': 5,
     'file_insertion_enabled': True,
     'smartquotes_locales': [],

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -11,11 +11,16 @@
 import pickle
 
 import pytest
-from docutils.parsers.rst.directives.html import MetaBody
 
 from sphinx import addnodes
 from sphinx.testing.util import SphinxTestApp
 from sphinx.versioning import add_uids, get_ratio, merge_doctrees
+
+try:
+    from docutils.parsers.rst.directives.html import MetaBody
+    meta = MetaBody.meta
+except ImportError:
+    from docutils.nodes import meta
 
 app = original = original_uids = None
 
@@ -64,7 +69,7 @@ def test_picklablility():
     copy.settings.warning_stream = None
     copy.settings.env = None
     copy.settings.record_dependencies = None
-    for metanode in copy.traverse(MetaBody.meta):
+    for metanode in copy.traverse(meta):
         metanode.__class__ = addnodes.meta
     loaded = pickle.loads(pickle.dumps(copy, pickle.HIGHEST_PROTOCOL))
     assert all(getattr(n, 'uid', False) for n in loaded.traverse(is_paragraph))


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- To prepare supporting docutils-0.18, this follows the new structure of docutils-0.18.
- It helps to upgrade docutils dependency in the future release.
- This does not change the dependency of Sphinx.
- This code was tested at #9700.