### PR TITLE
doc: fix grammar of possessive of plural noun

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -118,7 +118,7 @@
     this part of the documentation is for you.{%endtrans%}</p>
 
     <ul>
-      <li>{%trans path=pathto("internals/contributing")%}<a href="{{ path }}">Sphinx Contributors’s Guide</a></li>{%endtrans%}
+      <li>{%trans path=pathto("internals/contributing")%}<a href="{{ path }}">Sphinx Contributors’ Guide</a></li>{%endtrans%}
       <li>{%trans path=pathto("internals/authors")%}<a href="{{ path }}">Sphinx Authors</a></li>{%endtrans%}
     </ul>
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Fix spelling of `Contributors's` to `Contribuitors'`

### Detail
Refer to Purpose

### Relates
Null

