### PR TITLE
Support docutils-0.18: Set auto_id_prefix explicitly

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 default_settings: Dict[str, Any] = {
+    'auto_id_prefix': 'id',
     'embed_images': False,
     'embed_stylesheet': False,
     'cloak_email_addresses': True,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since docutils-0.18, auto_id_prefix setting will be changed to `'%'`
from `'id'`.  To keep backward compatibility of node IDs, this sets
`'id'` to settings explicitly.