### PR TITLE
Fix rendering of nested type annotations with alias defined

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,7 @@ Bugs fixed
   directive with ``:property:`` option
 * #9708: needs_extension failed to check double-digit version correctly
 * #9688: Fix :rst:dir:`code`` does not recognize ``:class:`` option
+* inspect: Nested type annotations with alias defined are not rendered correctly.
 
 Testing
 --------


### PR DESCRIPTION
Subject: Fix rendering of nested type annotations with alias defined

### Feature or Bugfix
- Bugfix

### Purpose
- Make autodoc usable with nested types with alias defined

### Detail
The current implementation replaces type annotations with a alias defined by the class TypeAliasForwardRef. This class is later again replaced by the type defined in the alias map.

This commit fixes the problem that this second replacement does not happen if the aliased type is nested in another generic type (e.g. Iterator[aliased_type]). The new function goes recursivly through the nested types and replaces the internal class TypeAliasForwardRef again by the correct annotation.

### Relates


