### PR TITLE
LaTeX: fix '\raggedright' escaping causing "aggedright" text

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1210,7 +1210,7 @@ class LaTeXTranslator(SphinxTranslator):
         ncolumns = node['ncolumns']
         if self.compact_list > 1:
             self.body.append(r'\setlength{\multicolsep}{0pt}' + CR)
-        self.body.append(r'\begin{multicols}{' + ncolumns + '}\raggedright' + CR)
+        self.body.append(r'\begin{multicols}{' + ncolumns + r'}\raggedright' + CR)
         self.body.append(r'\begin{itemize}\setlength{\itemsep}{0pt}'
                          r'\setlength{\parskip}{0pt}' + CR)
         if self.table:


### PR DESCRIPTION
Sphinx version 4.0 introduced a bug in handling hlists in its LaTeX backend.
Due to improper backslash escaping,
LaTeX "\raggedright" command gets written as
Carriage Return character (0x0D) followed by "aggedright".

This results in stray "aggedright" text appearing in the resulting PDF
and lack of effect \raggedright was supposed to achieve.

Fix this by converting the remaining string to a raw string.

This appears to be the only occurrence of such a missing escaping
based on a quick grep.

Fixes #9734.

Fixes: 20884bb0c9f7: "refactor: LaTeX: Use raw strings for LaTeX macros"

### Feature or Bugfix
- Bugfix