### PR TITLE
#8904: value.split(';', n - 1) -> value.split('; ', n - 1)

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -365,7 +365,7 @@ def rpartition(s: str, t: str) -> Tuple[str, str]:
 
 def split_into(n: int, type: str, value: str) -> List[str]:
     """Split an index entry into a given number of parts at semicolons."""
-    parts = [x.strip() for x in value.split(';', n - 1)]
+    parts = [x.strip() for x in value.split('; ', n - 1)]
     if sum(1 for part in parts if part) < n:
         raise ValueError('invalid %s index entry %r' % (type, value))
     return parts


### PR DESCRIPTION
Subject: <#8904: fix about '(;)/2'>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- correct the behavior of the split_into function.
- Since this is a fix for parsing strings in index directives/role, there is no environment or extension to depend on in html.
  - As for latex, the code looks fine to me, but I'm not sure.

### Detail
about split_into function

source file:

- sphinx/util/__init__.py

analysis:

- this function is used by two files.
  -  sphinx/environment/adapters/indexentries.py
  - sphinx/writers/latex.py, LaTeXTranslator class, visit_index method.
- When writing multiple terms, they are supposed to be separated by a semicolon, but I understand that the semicolon is followed by a space. With this change, we now include the whitespace after the semicolon to separate them.

### Relates
- #8904 
  - I wrote about the work in #8904.
- [Escaping special characters in index directives](https://stackoverflow.com/questions/66229133/escaping-special-characters-in-index-directives/69598134)

