### PR TITLE
#8904: value.split(';', n - 1) -> value.split('; ', n - 1)

### DIFF
--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -365,7 +365,7 @@ def rpartition(s: str, t: str) -> Tuple[str, str]:
 
 def split_into(n: int, type: str, value: str) -> List[str]:
     """Split an index entry into a given number of parts at semicolons."""
-    parts = [x.strip() for x in value.split(';', n - 1)]
+    parts = [x.strip() for x in value.split('; ', n - 1)]
     if sum(1 for part in parts if part) < n:
         raise ValueError('invalid %s index entry %r' % (type, value))
     return parts


### PR DESCRIPTION
Subject: #8904 fix about split_into function.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- For value.split used in the split_into function, the argument has been modified to properly separate the terms.
- Since this is a modification of the term delimiters in the index directive, there is no particular environment or extension that it depends on.

### Detail
about syntax index directive

- A semicolon is followed by a space.
- Therefore, changing the argument of the value.split function from ";" to "; "+space is no problem. In fact, it is appropriate to change it.

```rst
.. index:: term1; term2
```

source code

- sphinx/util/__init__.py
  -  The target of this revision.
-  sphinx/environment/adapters/indexentries.py
  - IndexEntries class, create_index method
    - split_into is being used.
    - The fix was written in #8904.
- sphinx/writers/latex.py
  - LaTeXTranslator class, visit_index method
    - split_into is being used. 
    - The fix for split_into should not be a problem since it is a read-dependent change, but I have not checked it.

### Relates
- #8904

