### PR TITLE
Add missing space in intersphinx doc

### DIFF
--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -158,7 +158,7 @@ searching for the root cause of a broken Intersphinx link in a documentation
 project. The following example prints the Intersphinx mapping of the Python 3
 documentation::
 
-   $ python -msphinx.ext.intersphinx https://docs.python.org/3/objects.inv
+   $ python -m sphinx.ext.intersphinx https://docs.python.org/3/objects.inv
 
 Using Intersphinx with inventory file under Basic Authorization
 ---------------------------------------------------------------


### PR DESCRIPTION
Subject: Add missing space in intersphinx doc

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Adds a missing space between `-m` and `sphinx.ext.intersphinx` in the example of showing all mappings in a intersphinx file.