### PR TITLE
Make util.typing.restify sanitise unreproducible output

### DIFF
--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -144,7 +144,7 @@ def restify(cls: Optional[Type]) -> str:
             else:
                 return _restify_py36(cls)
     except (AttributeError, TypeError):
-        return repr(cls)
+        return inspect.object_description(cls)
 
 
 def _restify_py37(cls: Optional[Type]) -> str:


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that sphinx generates output that is not reproducible, causing a number of packages in Debian to unreproducible.

Specifically, when Sphinx locates an alias of an instance when generating `autodoc` documentation, it uses the raw Python `repr(...)` of the object and does not sanitise it for memory addresses (etc.) like elsewhere in Sphinx.

This can result in documentation like this:

```
-<dd><p>alias of &lt;webob.client.SendRequest object at 0x7fd769189df0&gt;</p>
+<dd><p>alias of &lt;webob.client.SendRequest object at 0x7f0f02233df0&gt;</p>
```

Patch attached that uses the `object_description` method, which was added to fix precisely this kind of issue.

I originally filed this in Debian as [bug #996948](https://bugs.debian.org/996948).