### PR TITLE
Allow 403 response in linkcheck

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -472,7 +472,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                                                 auth=auth_info, **kwargs)
                         response.raise_for_status()
             except HTTPError as err:
-                if err.response.status_code == 401:
+                if err.response.status_code in (401, 403):
                     # We'll take "Unauthorized" as working.
                     return 'working', ' - unauthorized', 0
                 elif err.response.status_code == 429:


### PR DESCRIPTION
Subject: Allows 403 response in linkcheck

### Feature or Bugfix
- Feature

### Purpose
Described in https://github.com/sphinx-doc/sphinx/issues/9761

### Detail

### Relates
https://github.com/sphinx-doc/sphinx/issues/9761

