### PR TITLE
Fix selection of parameter names in HTML theme

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -731,8 +731,9 @@ dl.glossary dt {
 
 .classifier:before {
     font-style: normal;
-    margin: 0.5em;
+    margin: 0 0.5em;
     content: ":";
+    display: inline-block;
 }
 
 abbr, acronym {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Parameters are written in HTML as (leaving out some internal classes):
```
<strong>name</strong><span class="classifier"><a><code><span>TypeName</span></code></a></span>
```
but in rendered form there's a colon between the name and type. This colon is inserted virtually using CSS, but since it doesn't exist, the browser thinks both sides are part of the same word.

Styling the virtual text as inline block makes it be treated as a break, but also makes it apply vertical margins, so we need to set those to zero as well.

### Relates
- See https://github.com/matplotlib/matplotlib/issues/21432