### PR TITLE
Fix #9752: autodoc: Failed to detect type annotation for slots attribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.ext.autodoc.AttributeDocumenter._datadescriptor``
 * ``sphinx.writers.html.HTMLTranslator._fieldlist_row_index``
 * ``sphinx.writers.html.HTMLTranslator._table_row_index``
 * ``sphinx.writers.html5.HTML5Translator._fieldlist_row_index``
@@ -61,6 +62,7 @@ Bugs fixed
 * #9607: autodoc: Incorrect base class detection for the subclasses of the
   generic class
 * #9755: autodoc: memory addresses are shown for aliases
+* #9752: autodoc: Failed to detect type annotation for slots attribute
 * #9630: autosummary: Failed to build summary table if :confval:`primary_domain`
   is not 'py'
 * #9670: html: Fix download file with special characters

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -22,6 +22,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.ext.autodoc.AttributeDocumenter._datadescriptor``
+     - 4.3
+     - 6.0
+     - N/A
+
    * - ``sphinx.writers.html.HTMLTranslator._fieldlist_row_index``
      - 4.3
      - 6.0

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2329,12 +2329,11 @@ class SlotsMixin(DataDocumenterMixinBase):
 
         return ret
 
-    def should_suppress_directive_header(self) -> bool:
+    def should_suppress_value_header(self) -> bool:
         if self.object is SLOTSATTR:
-            self._datadescriptor = True
             return True
         else:
-            return super().should_suppress_directive_header()
+            return super().should_suppress_value_header()
 
     def get_doc(self, ignore: int = None) -> Optional[List[List[str]]]:
         if self.object is SLOTSATTR:
@@ -2351,6 +2350,15 @@ class SlotsMixin(DataDocumenterMixinBase):
                 return []
         else:
             return super().get_doc(ignore)  # type: ignore
+
+    @property
+    def _datadescriptor(self) -> bool:
+        warnings.warn('AttributeDocumenter._datadescriptor() is deprecated.',
+                      RemovedInSphinx60Warning)
+        if self.object is SLOTSATTR:
+            return True
+        else:
+            return False
 
 
 class RuntimeInstanceAttributeMixin(DataDocumenterMixinBase):

--- a/tests/roots/test-ext-autodoc/target/slots.py
+++ b/tests/roots/test-ext-autodoc/target/slots.py
@@ -10,6 +10,7 @@ class Bar:
     __slots__ = {'attr1': 'docstring of attr1',
                  'attr2': 'docstring of attr2',
                  'attr3': None}
+    __annotations__ = {'attr1': int}
 
     def __init__(self):
         self.attr2 = None  #: docstring of instance attr2

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1359,6 +1359,7 @@ def test_slots(app):
         '',
         '   .. py:attribute:: Bar.attr1',
         '      :module: target.slots',
+        '      :type: int',
         '',
         '      docstring of attr1',
         '',

--- a/tests/test_ext_autodoc_autoattribute.py
+++ b/tests/test_ext_autodoc_autoattribute.py
@@ -129,6 +129,7 @@ def test_autoattribute_slots_variable_dict(app):
         '',
         '.. py:attribute:: Bar.attr1',
         '   :module: target.slots',
+        '   :type: int',
         '',
         '   docstring of attr1',
         '',

--- a/tests/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc_autoclass.py
@@ -243,6 +243,7 @@ def test_slots_attribute(app):
         '',
         '   .. py:attribute:: Bar.attr1',
         '      :module: target.slots',
+        '      :type: int',
         '',
         '      docstring of attr1',
         '',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9752 