### PR TITLE
Fix CI: Downgrade python for transifex CI

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -15,6 +15,8 @@ jobs:
         ref: 4.x
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+        python-version: 3.9  # https://github.com/transifex/transifex-client/pull/330
     - name: Install dependencies
       run:  pip install -U babel jinja2 transifex-client
     - name: Extract translations from source code


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The latest transifex-client could not be installed on python 3.10
environment.  This downgrade python to 3.9 to be install the latest one.
- ref: https://github.com/transifex/transifex-client/pull/330
