### PR TITLE
Fix linkcheck_auth link to Requests authentication

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2637,10 +2637,8 @@ Options for the linkcheck builder
      A regular expression that matches a URI.
    *auth_info*
      Authentication information to use for that URI. The value can be anything
-     that is understood by the ``requests`` library (see `requests
-     Authentication <requests-auth>`_ for details).
-
-     .. _requests-auth: https://requests.readthedocs.io/en/master/user/authentication/
+     that is understood by the ``requests`` library (see :ref:`requests
+     Authentication <requests:authentication>` for details).
 
    The ``linkcheck`` builder will use the first matching ``auth_info`` value
    it can find in the :confval:`linkcheck_auth` list, so values earlier in the


### PR DESCRIPTION
The link was directing to
https://www.sphinx-doc.org/en/master/usage/requests-auth>. Prefer using
the intersphinx module to generate the link, it’s more robust than
directly linking to the page.


### Feature or Bugfix
- Bugfix