### PR TITLE
Closes #9733: Fix for logging handler flushing warnings in the middle of the docs build

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -171,6 +171,11 @@ class MemoryHandler(logging.handlers.BufferingHandler):
     def shouldFlush(self, record: logging.LogRecord) -> bool:
         return False  # never flush
 
+    def flush(self) -> None:
+        # suppress any flushes triggered by importing packages that flush
+        # all handlers at initialization time
+        pass
+
     def flushTo(self, logger: logging.Logger) -> None:
         self.acquire()
         try:


### PR DESCRIPTION
Subject: Fix for logging handler flushing warnings in the middle of the docs build

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
My project was mysteriously dropping warnings (see https://github.com/sphinx-doc/sphinx/issues/9733 for detailed repro) and I realized that it's because it imports libraries like airflow and mlflow that set up loggers automatically when they are imported. This causes this handler to flush even though shouldFlush is set to always return False. A simple workaround is to override flush to be a no-op.

### Relates
https://github.com/sphinx-doc/sphinx/issues/9733

