### PR TITLE
Support docutils-0.18: Consume iterator of Element.traverse()

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -323,14 +323,14 @@ class EpubBuilder(StandaloneHTMLBuilder):
             # a) place them after the last existing footnote
             # b) place them after an (empty) Footnotes rubric
             # c) create an empty Footnotes rubric at the end of the document
-            fns = tree.traverse(nodes.footnote)
+            fns = list(tree.traverse(nodes.footnote))
             if fns:
                 fn = fns[-1]
                 return fn.parent, fn.parent.index(fn) + 1
             for node in tree.traverse(nodes.rubric):
                 if len(node) == 1 and node.astext() == FOOTNOTES_RUBRIC_NAME:
                     return node.parent, node.parent.index(node) + 1
-            doc = tree.traverse(nodes.document)[0]
+            doc = list(tree.traverse(nodes.document))[0]
             rub = nodes.rubric()
             rub.append(nodes.Text(FOOTNOTES_RUBRIC_NAME))
             doc.append(rub)
@@ -339,10 +339,10 @@ class EpubBuilder(StandaloneHTMLBuilder):
         if show_urls == 'no':
             return
         if show_urls == 'footnote':
-            doc = tree.traverse(nodes.document)[0]
+            doc = list(tree.traverse(nodes.document))[0]
             fn_spot, fn_idx = footnote_spot(tree)
             nr = 1
-        for node in tree.traverse(nodes.reference):
+        for node in list(tree.traverse(nodes.reference)):
             uri = node.get('refuri', '')
             if (uri.startswith('http:') or uri.startswith('https:') or
                     uri.startswith('ftp:')) and uri not in node.astext():

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -45,7 +45,7 @@ class SubstitutionDefinitionsRemover(SphinxPostTransform):
     formats = ('latex',)
 
     def run(self, **kwargs: Any) -> None:
-        for node in self.document.traverse(nodes.substitution_definition):
+        for node in list(self.document.traverse(nodes.substitution_definition)):
             node.parent.remove(node)
 
 
@@ -81,7 +81,7 @@ class ShowUrlsTransform(SphinxPostTransform):
         if show_urls is False or show_urls == 'no':
             return
 
-        for node in self.document.traverse(nodes.reference):
+        for node in list(self.document.traverse(nodes.reference)):
             uri = node.get('refuri', '')
             if uri.startswith(URI_SCHEMES):
                 if uri.startswith('mailto:'):
@@ -501,7 +501,7 @@ class BibliographyTransform(SphinxPostTransform):
 
     def run(self, **kwargs: Any) -> None:
         citations = thebibliography()
-        for node in self.document.traverse(nodes.citation):
+        for node in list(self.document.traverse(nodes.citation)):
             node.parent.remove(node)
             citations += node
 
@@ -602,9 +602,9 @@ class IndexInSectionTitleTransform(SphinxPostTransform):
     formats = ('latex',)
 
     def run(self, **kwargs: Any) -> None:
-        for node in self.document.traverse(nodes.title):
+        for node in list(self.document.traverse(nodes.title)):
             if isinstance(node.parent, nodes.section):
-                for i, index in enumerate(node.traverse(addnodes.index)):
+                for i, index in enumerate(list(node.traverse(addnodes.index))):
                     # move the index node next to the section title
                     node.remove(index)
                     node.parent.insert(i + 1, index)

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -48,7 +48,7 @@ class IndexDomain(Domain):
     def process_doc(self, env: BuildEnvironment, docname: str, document: Node) -> None:
         """Process a document after it is read by the environment."""
         entries = self.entries.setdefault(env.docname, [])
-        for node in document.traverse(addnodes.index):
+        for node in list(document.traverse(addnodes.index)):
             try:
                 for entry in node['entries']:
                     split_index_msg(entry[0], entry[1])

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -328,7 +328,7 @@ class PyXrefMixin:
                 text = target[1:]
             elif prefix == '~':
                 text = target.split('.')[-1]
-            for node in result.traverse(nodes.Text):
+            for node in list(result.traverse(nodes.Text)):
                 node.parent[node.parent.index(node)] = nodes.Text(text)
                 break
         elif isinstance(result, pending_xref) and env.config.python_use_unqualified_type_names:

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -193,13 +193,13 @@ class TocTree:
                         for toplevel in children:
                             # nodes with length 1 don't have any children anyway
                             if len(toplevel) > 1:
-                                subtrees = toplevel.traverse(addnodes.toctree)
+                                subtrees = list(toplevel.traverse(addnodes.toctree))
                                 if subtrees:
                                     toplevel[1][:] = subtrees  # type: ignore
                                 else:
                                     toplevel.pop(1)
                     # resolve all sub-toctrees
-                    for subtocnode in toc.traverse(addnodes.toctree):
+                    for subtocnode in list(toc.traverse(addnodes.toctree)):
                         if not (subtocnode.get('hidden', False) and
                                 not includehidden):
                             i = subtocnode.parent.index(subtocnode) + 1

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -583,7 +583,7 @@ def extract_summary(doc: List[str], document: Any) -> str:
                 node = parse(doc, document.settings)
                 if summary.endswith(WELL_KNOWN_ABBREVIATIONS):
                     pass
-                elif not node.traverse(nodes.system_message):
+                elif not list(node.traverse(nodes.system_message)):
                     # considered as that splitting by period does not break inline markups
                     break
 

--- a/sphinx/ext/linkcode.py
+++ b/sphinx/ext/linkcode.py
@@ -39,7 +39,7 @@ def doctree_read(app: Sphinx, doctree: Node) -> None:
         'js': ['object', 'fullname'],
     }
 
-    for objnode in doctree.traverse(addnodes.desc):
+    for objnode in list(doctree.traverse(addnodes.desc)):
         domain = objnode.get('domain')
         uris: Set[str] = set()
         for signode in objnode:

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -131,7 +131,7 @@ class TodoListProcessor:
 
     def process(self, doctree: nodes.document, docname: str) -> None:
         todos: List[todo_node] = sum(self.domain.todos.values(), [])
-        for node in doctree.traverse(todolist):
+        for node in list(doctree.traverse(todolist)):
             if not self.config.todo_include_todos:
                 node.parent.remove(node)
                 continue

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -108,7 +108,7 @@ def doctree_read(app: Sphinx, doctree: Node) -> None:
 
         return False
 
-    for objnode in doctree.traverse(addnodes.desc):
+    for objnode in list(doctree.traverse(addnodes.desc)):
         if objnode.get('domain') != 'py':
             continue
         names: Set[str] = set()
@@ -191,7 +191,7 @@ class ViewcodeAnchorTransform(SphinxPostTransform):
             node.replace_self(refnode)
 
     def remove_viewcode_anchors(self) -> None:
-        for node in self.document.traverse(viewcode_anchor):
+        for node in list(self.document.traverse(viewcode_anchor)):
             node.parent.remove(node)
 
 

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -128,7 +128,7 @@ class MoveModuleTargets(SphinxTransform):
     default_priority = 210
 
     def apply(self, **kwargs: Any) -> None:
-        for node in self.document.traverse(nodes.target):
+        for node in list(self.document.traverse(nodes.target)):
             if not node['ids']:
                 continue
             if ('ismod' in node and
@@ -303,7 +303,7 @@ class FilterSystemMessages(SphinxTransform):
 
     def apply(self, **kwargs: Any) -> None:
         filterlevel = 2 if self.config.keep_warnings else 5
-        for node in self.document.traverse(nodes.system_message):
+        for node in list(self.document.traverse(nodes.system_message)):
             if node['level'] < filterlevel:
                 logger.debug('%s [filtered system message]', node.astext())
                 node.parent.remove(node)

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -488,7 +488,7 @@ class RemoveTranslatableInline(SphinxTransform):
             return
 
         matcher = NodeMatcher(nodes.inline, translatable=Any)
-        for inline in self.document.traverse(matcher):  # type: nodes.inline
+        for inline in list(self.document.traverse(matcher)):  # type: nodes.inline
             inline.parent.remove(inline)
             inline.parent += inline.children
 

--- a/sphinx/transforms/post_transforms/code.py
+++ b/sphinx/transforms/post_transforms/code.py
@@ -42,7 +42,7 @@ class HighlightLanguageTransform(SphinxTransform):
                                            self.config.highlight_language)
         self.document.walkabout(visitor)
 
-        for node in self.document.traverse(addnodes.highlightlang):
+        for node in list(self.document.traverse(addnodes.highlightlang)):
             node.parent.remove(node)
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -343,7 +343,7 @@ def clean_astext(node: Element) -> str:
     node = node.deepcopy()
     for img in node.traverse(nodes.image):
         img['alt'] = ''
-    for raw in node.traverse(nodes.raw):
+    for raw in list(node.traverse(nodes.raw)):
         raw.parent.remove(raw)
     return node.astext()
 
@@ -408,7 +408,7 @@ def inline_all_toctrees(builder: "Builder", docnameset: Set[str], docname: str,
     Record all docnames in *docnameset*, and output docnames with *colorfunc*.
     """
     tree = cast(nodes.document, tree.deepcopy())
-    for toctreenode in tree.traverse(addnodes.toctree):
+    for toctreenode in list(tree.traverse(addnodes.toctree)):
         newnodes = []
         includefiles = map(str, toctreenode['includefiles'])
         for includefile in includefiles:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -651,7 +651,7 @@ class LaTeXTranslator(SphinxTranslator):
                 raise nodes.SkipNode
             else:
                 short = ''
-                if node.traverse(nodes.image):
+                if list(node.traverse(nodes.image)):
                     short = ('[%s]' % self.escape(' '.join(clean_astext(node).split())))
 
                 try:

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -56,7 +56,7 @@ class NestedInlineTransform:
 
     def apply(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, nodes.emphasis, nodes.strong)
-        for node in self.document.traverse(matcher):  # type: TextElement
+        for node in list(self.document.traverse(matcher)):  # type: TextElement
             if any(matcher(subnode) for subnode in node):
                 pos = node.parent.index(node)
                 for subnode in reversed(list(node)):
@@ -227,7 +227,7 @@ class ManualPageTranslator(SphinxTranslator, BaseTranslator):
 
     # overwritten -- don't make whole of term bold if it includes strong node
     def visit_term(self, node: Element) -> None:
-        if node.traverse(nodes.strong):
+        if list(node.traverse(nodes.strong)):
             self.body.append('\n')
         else:
             super().visit_term(node)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since 0.18, Element.traverse() returns an iterator instead of
intermediate object.  As a result, the return value is always considered
as truthy value.  And it becomes fragile when the caller modifies the
doctree on the loop.
- refs: #9777