### PR TITLE
Update Chocolatey Install Link

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -120,7 +120,7 @@ Chocolatey
    $ choco install sphinx
    
 You would need to `install Chocolatey
-<https://chocolatey.org/install/>`_
+<https://chocolatey.org/install>`_
 before running this.
 
 For more information, refer to the `chocolatey page`__.


### PR DESCRIPTION
The install URL returned a 404 but now it is updated to the new location

Subject: Update Install Link for Chocolatey in installation.rst

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
**Bugfix**

### Purpose
- Maintain correct URL's for active links

### Detail
- Link contained an incorrect URL

### Relates
- None

