### PR TITLE
Add option for autodoc to show types with class-only (no module prefix)

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -2814,6 +2814,8 @@ def setup(app: Sphinx) -> Dict[str, Any]:
                          ENUM("signature", "description", "none", "both"))
     app.add_config_value('autodoc_typehints_description_target', 'all', True,
                          ENUM('all', 'documented'))
+    app.add_config_value('autodoc_typehints_types_qualified', 'full', True,
+                         ENUM('full', 'class-only'))
     app.add_config_value('autodoc_type_aliases', {}, True)
     app.add_config_value('autodoc_warningiserror', True, True)
     app.add_config_value('autodoc_inherit_docstrings', True, True)

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -30,9 +30,9 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
             sig = inspect.signature(obj, type_aliases=app.config.autodoc_type_aliases)
             for param in sig.parameters.values():
                 if param.annotation is not param.empty:
-                    annotation[param.name] = typing.stringify(param.annotation)
+                    annotation[param.name] = typing.stringify(param.annotation, app.config)
             if sig.return_annotation is not sig.empty:
-                annotation['return'] = typing.stringify(sig.return_annotation)
+                annotation['return'] = typing.stringify(sig.return_annotation, app.config)
     except (TypeError, ValueError):
         pass
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Sometimes modules are used like packages in java, so you can have long redundant module prefixes and the type will be shown in the documentation as a very long string, e.g., `Returns: com.mycompany.something.module.MyType`.
- This feature PR will add an option to autodoc
  ```
  app.add_config_value('autodoc_typehints_types_qualified', 'full', True,
                       ENUM('full', 'class-only'))
  ```
- By default (`"full"`), everything stays as it is.
- If `"class-only"` is used, types are shown in the documentation as `__qualname__` and not `__module__.__qualname__`
  ```
  autodoc_typehints_types_qualified = "class-only"
  ```
- `Returns: com.mycompany.something.module.MyType` -> `Returns: MyType`.
- Links continue to work.

### Detail
- An example project can be found [here](https://github.com/gschwaer/sphinx_test/tree/autodoc_long_type_names).
- This PR needs some input:
  - Is the way it is implemented ok for sphinx? (passing the config from `sphinx.ext.autodoc.typehints` to `sphinx.util.typing`)
  - What about the name `autodoc_typehints_types_qualified`? Is it clear enough?
- TODO
  - [ ] A description in the documentation of `sphinx.ext.autodoc` is still missing.

### Relates
- This is a feature that [agronholm/sphinx-autodoc-typehints](https://github.com/agronholm/sphinx-autodoc-typehints) called `typehints_fully_qualified`. But this extension has some issues and since `sphinx.ext.autodoc` now supports typehints it is obsolete IMO.

