### PR TITLE
Set multiprocessing start method to `fork`

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -12,7 +12,6 @@
 
 import os
 import pickle
-import platform
 import sys
 import warnings
 from collections import deque
@@ -194,12 +193,6 @@ class Sphinx:
 
         # say hello to the world
         logger.info(bold(__('Running Sphinx v%s') % sphinx.__display_version__))
-
-        # notice for parallel build on macOS and py38+
-        if sys.version_info > (3, 8) and platform.system() == 'Darwin' and parallel > 1:
-            logger.info(bold(__("For security reasons, parallel mode is disabled on macOS and "
-                                "python3.8 and above. For more details, please read "
-                                "https://github.com/sphinx-doc/sphinx/issues/6803")))
 
         # status code for command-line application
         self.statuscode = 0

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -9,8 +9,6 @@
 """
 
 import os
-import platform
-import sys
 import time
 import traceback
 from math import sqrt
@@ -28,12 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 # our parallel functionality only works for the forking Process
-#
-# Note: "fork" is not recommended on macOS and py38+.
-#       see https://bugs.python.org/issue33725
-parallel_available = (multiprocessing and
-                      (os.name == 'posix') and
-                      not (sys.version_info > (3, 8) and platform.system() == 'Darwin'))
+parallel_available = multiprocessing and os.name == 'posix'
 
 
 class SerialTasks:
@@ -64,7 +57,7 @@ class ParallelTasks:
         # task arguments
         self._args: Dict[int, Optional[List[Any]]] = {}
         # list of subprocesses (both started and waiting)
-        self._procs: Dict[int, multiprocessing.Process] = {}
+        self._procs: Dict[int, multiprocessing.context.ForkProcess] = {}
         # list of receiving pipe connections of running subprocesses
         self._precvs: Dict[int, Any] = {}
         # list of receiving pipe connections of waiting subprocesses
@@ -96,8 +89,8 @@ class ParallelTasks:
         self._result_funcs[tid] = result_func or (lambda arg, result: None)
         self._args[tid] = arg
         precv, psend = multiprocessing.Pipe(False)
-        proc = multiprocessing.Process(target=self._process,
-                                       args=(psend, task_func, arg))
+        context = multiprocessing.get_context('fork')
+        proc = context.Process(target=self._process, args=(psend, task_func, arg))
         self._procs[tid] = proc
         self._precvsWaiting[tid] = precv
         self._join_one()

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -10,8 +10,6 @@
 
 import codecs
 import os
-import platform
-import sys
 
 import pytest
 from docutils import nodes
@@ -311,8 +309,6 @@ def test_colored_logs(app, status, warning):
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
-@pytest.mark.xfail(platform.system() == 'Darwin' and sys.version_info > (3, 8),
-                   reason="Not working on macOS and py38")
 def test_logging_in_ParallelTasks(app, status, warning):
     logging.setup(app, status, warning)
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
Subject: Set multiprocessing start method to `fork`

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Explicitly set the multiprocessing start method to `fork` since the code depends on this behavior.

### Detail
Since Python 3.8, the default start method was changed to `spawn` on macOS, which is incompatible with how Sphinx handles parallelization. The change was made in macOS *not* due to a new security concern but because Apple decided to prevent *potential* problems with calling something between `fork()` and `exec()` by failing early. This problem is not unique to macOS or even Python, and depends on the implementation.

From looking at the use of `multiprocessing` in Sphinx, I don't believe this will cause issues on macOS.


### Relates
- https://github.com/sphinx-doc/sphinx/pull/6879

