### PR TITLE
Fix #9757: autodoc_inherit_docstrings does not effect to overriden classmethods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,8 @@ Bugs fixed
 * #9755: autodoc: memory addresses are shown for aliases
 * #9752: autodoc: Failed to detect type annotation for slots attribute
 * #9756: autodoc: Crashed if classmethod does not have __func__ attribute
+* #9757: autodoc: :confval:`autodoc_inherit_docstrings` does not effect to
+  overriden classmethods
 * #9630: autosummary: Failed to build summary table if :confval:`primary_domain`
   is not 'py'
 * #9670: html: Fix download file with special characters

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -866,7 +866,9 @@ def getdoc(obj: Any, attrgetter: Callable = safe_getattr,
         for basecls in getmro(cls):
             meth = basecls.__dict__.get(name)
             if meth and hasattr(meth, '__func__'):
-                return getdoc(meth.__func__)
+                doc = getdoc(meth.__func__)
+                if doc is not None or not allow_inherited:
+                    return doc
 
     doc = attrgetter(obj, '__doc__', None)
     if ispartial(obj) and doc == obj.__class__.__doc__:

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -677,6 +677,25 @@ def test_unpartial():
     assert inspect.unpartial(func3) is func1
 
 
+def test_getdoc_inherited_classmethod():
+    class Foo:
+        @classmethod
+        def meth(self):
+            """
+            docstring
+                indented text
+            """
+
+    class Bar(Foo):
+        @classmethod
+        def meth(self):
+            # inherited classmethod
+            pass
+
+    assert inspect.getdoc(Bar.meth, getattr, False, Bar, "meth") is None
+    assert inspect.getdoc(Bar.meth, getattr, True, Bar, "meth") == Foo.meth.__doc__
+
+
 def test_getdoc_inherited_decorated_method():
     class Foo:
         def meth(self):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9757 