### PR TITLE
Fix #9781: autodoc_preserve_defaults does not support hexadecimal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -66,6 +66,8 @@ Bugs fixed
 * #9756: autodoc: Crashed if classmethod does not have __func__ attribute
 * #9757: autodoc: :confval:`autodoc_inherit_docstrings` does not effect to
   overriden classmethods
+* #9781: autodoc: :confval:`autodoc_preserve_defaults` does not support
+  hexadecimal numeric
 * #9630: autosummary: Failed to build summary table if :confval:`primary_domain`
   is not 'py'
 * #9670: html: Fix download file with special characters

--- a/tests/roots/test-ext-autodoc/target/preserve_defaults.py
+++ b/tests/roots/test-ext-autodoc/target/preserve_defaults.py
@@ -7,7 +7,8 @@ SENTINEL = object()
 
 def foo(name: str = CONSTANT,
         sentinel: Any = SENTINEL,
-        now: datetime = datetime.now()) -> None:
+        now: datetime = datetime.now(),
+        color: int = 0xFFFFFF) -> None:
     """docstring"""
 
 
@@ -15,5 +16,5 @@ class Class:
     """docstring"""
 
     def meth(self, name: str = CONSTANT, sentinel: Any = SENTINEL,
-             now: datetime = datetime.now()) -> None:
+             now: datetime = datetime.now(), color: int = 0xFFFFFF) -> None:
         """docstring"""

--- a/tests/test_ext_autodoc_preserve_defaults.py
+++ b/tests/test_ext_autodoc_preserve_defaults.py
@@ -8,6 +8,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import sys
+
 import pytest
 
 from .test_ext_autodoc import do_autodoc
@@ -16,6 +18,11 @@ from .test_ext_autodoc import do_autodoc
 @pytest.mark.sphinx('html', testroot='ext-autodoc',
                     confoverrides={'autodoc_preserve_defaults': True})
 def test_preserve_defaults(app):
+    if sys.version_info < (3, 8):
+        color = "16777215"
+    else:
+        color = "0xFFFFFF"
+
     options = {"members": None}
     actual = do_autodoc(app, 'module', 'target.preserve_defaults', options)
     assert list(actual) == [
@@ -30,14 +37,14 @@ def test_preserve_defaults(app):
         '',
         '',
         '   .. py:method:: Class.meth(name: str = CONSTANT, sentinel: Any = SENTINEL, '
-        'now: datetime.datetime = datetime.now()) -> None',
+        'now: datetime.datetime = datetime.now(), color: int = %s) -> None' % color,
         '      :module: target.preserve_defaults',
         '',
         '      docstring',
         '',
         '',
         '.. py:function:: foo(name: str = CONSTANT, sentinel: Any = SENTINEL, now: '
-        'datetime.datetime = datetime.now()) -> None',
+        'datetime.datetime = datetime.now(), color: int = %s) -> None' % color,
         '   :module: target.preserve_defaults',
         '',
         '   docstring',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9781 