### PR TITLE
Change default value of intersphinx_disabled_reftypes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,13 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #2068: :confval:`intersphinx_disabled_reftypes` has changed default value
+  from an empty list to ``['std:doc']`` as avoid too surprising silent
+  intersphinx resolutions.
+  To migrate: either add an explicit inventory name to the references
+  intersphinx should resolve, or explicitly set the value of this configuration
+  variable to an empty list.
+
 Deprecated
 ----------
 

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -152,6 +152,10 @@ linking:
 
    .. versionadded:: 4.3
 
+   .. versionchanged:: 5.0
+
+      Changed default value from an empty list to ``['std:doc']``.
+
    A list of strings being either:
 
    - the name of a specific reference type in a domain,
@@ -160,7 +164,7 @@ linking:
      ``std:*``, ``py:*``, or ``cpp:*``, or
    - simply a wildcard ``*``.
 
-   The default value is an empty list.
+   The default value is ``['std:doc']``.
 
    When a cross-reference without an explicit inventory specification is being
    resolved by intersphinx, skip resolution if it matches one of the

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -494,7 +494,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('intersphinx_mapping', {}, True)
     app.add_config_value('intersphinx_cache_limit', 5, False)
     app.add_config_value('intersphinx_timeout', None, False)
-    app.add_config_value('intersphinx_disabled_reftypes', [], True)
+    app.add_config_value('intersphinx_disabled_reftypes', ['std:doc'], True)
     app.connect('config-inited', normalize_intersphinx_mapping, priority=800)
     app.connect('builder-inited', load_mappings)
     app.connect('missing-reference', missing_reference)


### PR DESCRIPTION
### Purpose
Incompatible change of default value for ``intersphinx_disabled_reftypes`` to disallow ``std:doc`` references without an explicit intersphinx inventory to be resolved by intersphinx.

Implements step 2 of https://github.com/sphinx-doc/sphinx/pull/9459#issuecomment-922247195, essentially fixing #2068.

### Detail
Transparent intersphinx resolution is great in many cases, but for `:doc:` and `:ref:` it can be surprising, hence disabling them by default is preferable. Users can change the configuration variable, or better yet, write an explicit intersphinx inventory name in each reference they intend to go outside the current project.