### PR TITLE
Replace distutils.versions.LooseVersion by packaging.version.Version

### DIFF
--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -8,11 +8,11 @@
     :license: BSD, see LICENSE for details.
 """
 
-from distutils.version import LooseVersion
 from functools import partial
 from importlib import import_module
 from typing import Any, Dict
 
+from packaging import version
 from pygments import __version__ as pygmentsversion
 from pygments import highlight
 from pygments.filters import ErrorToken
@@ -64,7 +64,7 @@ _LATEX_ADD_STYLES_FIXPYG = r'''
              {\let\fcolorbox\spx@fixpyg@fcolorbox\PYG@do{#2}}}
 \makeatother
 '''
-if tuple(LooseVersion(pygmentsversion).version) <= (2, 7, 4):
+if version.parse(pygmentsversion).release <= (2, 7, 4):
     _LATEX_ADD_STYLES += _LATEX_ADD_STYLES_FIXPYG
 
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -12,7 +12,6 @@ import os
 import re
 from contextlib import contextmanager
 from copy import copy
-from distutils.version import LooseVersion
 from os import path
 from types import ModuleType
 from typing import (IO, TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Set,
@@ -26,6 +25,7 @@ from docutils.parsers.rst import Directive, directives, roles
 from docutils.parsers.rst.states import Inliner
 from docutils.statemachine import State, StateMachine, StringList
 from docutils.utils import Reporter, unescape
+from packaging import version
 
 from sphinx.errors import SphinxError
 from sphinx.locale import _
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 
-__version_info__ = tuple(LooseVersion(docutils.__version__).version)
+__version_info__ = version.parse(docutils.__version__).release
 additional_nodes: Set[Type[Element]] = set()
 
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -10,13 +10,13 @@
 
 import os
 import re
-from distutils.version import LooseVersion
 from itertools import chain, cycle
 from unittest.mock import ANY, call, patch
 
 import pygments
 import pytest
 from html5lib import HTMLParser
+from packaging import version
 
 from sphinx.builders.html import validate_html_extra_path, validate_html_static_path
 from sphinx.errors import ConfigError
@@ -28,6 +28,9 @@ if docutils.__version_info__ < (0, 17):
     FIGURE_CAPTION = ".//div[@class='figure align-default']/p[@class='caption']"
 else:
     FIGURE_CAPTION = ".//figure/figcaption/p"
+
+
+PYGMENTS_VERSION = version.parse(pygments.__version__).release
 
 
 ENV_WARNINGS = """\
@@ -1576,8 +1579,7 @@ def test_html_codeblock_linenos_style_table(app):
     app.build()
     content = (app.outdir / 'index.html').read_text()
 
-    pygments_version = tuple(LooseVersion(pygments.__version__).version)
-    if pygments_version >= (2, 8):
+    if PYGMENTS_VERSION >= (2, 8):
         assert ('<div class="linenodiv"><pre><span class="normal">1</span>\n'
                 '<span class="normal">2</span>\n'
                 '<span class="normal">3</span>\n'
@@ -1592,8 +1594,7 @@ def test_html_codeblock_linenos_style_inline(app):
     app.build()
     content = (app.outdir / 'index.html').read_text()
 
-    pygments_version = tuple(LooseVersion(pygments.__version__).version)
-    if pygments_version > (2, 7):
+    if PYGMENTS_VERSION > (2, 7):
         assert '<span class="linenos">1</span>' in content
     else:
         assert '<span class="lineno">1 </span>' in content


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Distutils module are now deprecated and will be removed in Python 3.12.
This replaces it by packaging module and reduces the dependency to it.
- refs: #9820