### PR TITLE
Process only directive before traversing doctree

### DIFF
--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -324,6 +324,8 @@ class TocTree:
         else:
             kwargs['maxdepth'] = int(kwargs['maxdepth'])
         kwargs['collapse'] = collapse
+        # Handle only directives that wrap an entire toctree.
+        process_only_nodes(doctree, builder.tags)
         for toctreenode in doctree.traverse(addnodes.toctree):
             toctree = self.resolve(docname, builder, toctreenode, prune=True, **kwargs)
             if toctree:

--- a/tests/test_environment_toctree.py
+++ b/tests/test_environment_toctree.py
@@ -213,7 +213,6 @@ def test_get_toctree_for(app):
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
                                      bullet_list,
-                                     bullet_list,
                                      bullet_list)])
 
     assert_node(toctree[1],
@@ -237,12 +236,10 @@ def test_get_toctree_for(app):
     assert_node(toctree[1][3][0][0], reference, refuri="")
 
     assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
-    assert_node(toctree[3],
                 ([list_item, compact_paragraph, reference, "Latest reference"],
                  [list_item, compact_paragraph, reference, "Python"]))
-    assert_node(toctree[3][0][0][0], reference, refuri="http://sphinx-doc.org/latest/")
-    assert_node(toctree[3][1][0][0], reference, refuri="http://python.org/")
+    assert_node(toctree[2][0][0][0], reference, refuri="http://sphinx-doc.org/latest/")
+    assert_node(toctree[2][1][0][0], reference, refuri="http://python.org/")
 
 
 @pytest.mark.sphinx('xml', testroot='toctree')
@@ -252,7 +249,6 @@ def test_get_toctree_for_collapse(app):
     toctree = TocTree(app.env).get_toctree_for('index', app.builder, collapse=True)
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
-                                     bullet_list,
                                      bullet_list,
                                      bullet_list)])
 
@@ -268,12 +264,10 @@ def test_get_toctree_for_collapse(app):
     assert_node(toctree[1][3][0][0], reference, refuri="")
 
     assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
-    assert_node(toctree[3],
                 ([list_item, compact_paragraph, reference, "Latest reference"],
                  [list_item, compact_paragraph, reference, "Python"]))
-    assert_node(toctree[3][0][0][0], reference, refuri="http://sphinx-doc.org/latest/")
-    assert_node(toctree[3][1][0][0], reference, refuri="http://python.org/")
+    assert_node(toctree[2][0][0][0], reference, refuri="http://sphinx-doc.org/latest/")
+    assert_node(toctree[2][1][0][0], reference, refuri="http://python.org/")
 
 
 @pytest.mark.sphinx('xml', testroot='toctree')
@@ -284,7 +278,6 @@ def test_get_toctree_for_maxdepth(app):
                                                collapse=False, maxdepth=3)
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
-                                     bullet_list,
                                      bullet_list,
                                      bullet_list)])
 
@@ -314,12 +307,10 @@ def test_get_toctree_for_maxdepth(app):
     assert_node(toctree[1][3][0][0], reference, refuri="")
 
     assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
-    assert_node(toctree[3],
                 ([list_item, compact_paragraph, reference, "Latest reference"],
                  [list_item, compact_paragraph, reference, "Python"]))
-    assert_node(toctree[3][0][0][0], reference, refuri="http://sphinx-doc.org/latest/")
-    assert_node(toctree[3][1][0][0], reference, refuri="http://python.org/")
+    assert_node(toctree[2][0][0][0], reference, refuri="http://sphinx-doc.org/latest/")
+    assert_node(toctree[2][1][0][0], reference, refuri="http://python.org/")
 
 
 @pytest.mark.sphinx('xml', testroot='toctree')
@@ -330,7 +321,6 @@ def test_get_toctree_for_includehidden(app):
                                                includehidden=False)
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
-                                     bullet_list,
                                      bullet_list)])
 
     assert_node(toctree[1],
@@ -351,6 +341,3 @@ def test_get_toctree_for_includehidden(app):
     assert_node(toctree[1][0][1][2][0][0], reference, refuri="foo#foo-2", secnumber=[1, 3])
     assert_node(toctree[1][1][0][0], reference, refuri="bar", secnumber=[2])
     assert_node(toctree[1][2][0][0], reference, refuri="http://sphinx-doc.org/")
-
-    assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])


### PR DESCRIPTION
This changes the output of `toctree` if it is wrapped by a `only`, so it is a breaking change. I think this is a bugfix, so it can maybe go into 4.2 too?

### Feature or Bugfix
<!-- please choose -->
- Bugfix (consider this a bug, `toctree` should take into acount `only`.

### Purpose
- This ensures that a `toctree` that is wrapped by a `only` is only traversed when generated the global `toctree` when the tags match.

### Relates
- Fixes #9819.

