### PR TITLE
Make fallback for changed get_signature_prefix()

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -495,7 +495,13 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
-            signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
+            if type(sig_prefix) is str:
+                logger.warning("Python directive get_signature_prefix() returns a str ('{}')"
+                               " instead of a list of nodes (changed in 4.3).".format(sig_prefix),
+                               location=signode)
+                signode += addnodes.desc_annotation(sig_prefix, '', nodes.Text(sig_prefix, sig_prefix))
+            else:
+                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -496,10 +496,12 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
             if type(sig_prefix) is str:
-                logger.warning("Python directive get_signature_prefix() returns a str ('{}')"
-                               " instead of a list of nodes (changed in 4.3).".format(sig_prefix),
-                               location=signode)
-                signode += addnodes.desc_annotation(sig_prefix, '', nodes.Text(sig_prefix, sig_prefix))
+                logger.warning(
+                    "Python directive get_signature_prefix() returns a str ('{}')"
+                    " instead of a list of nodes (changed in 4.3).".format(sig_prefix),
+                    location=signode)
+                signode += addnodes.desc_annotation(sig_prefix, '',  # type: ignore
+                                                    nodes.Text(sig_prefix))  # type: ignore
             else:
                 signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -496,10 +496,12 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
             if type(sig_prefix) is str:
-                logger.warning(
-                    "Python directive get_signature_prefix() returns a str ('{}')"
-                    " instead of a list of nodes (changed in 4.3).".format(sig_prefix),
-                    location=signode)
+                warnings.warn(
+                    "Python directive method get_signature_prefix()"
+                    " returning a string is deprecated."
+                    " It must now return a list of nodes."
+                    " Return value was '{}'.".format(sig_prefix),
+                    RemovedInSphinx50Warning)
                 signode += addnodes.desc_annotation(sig_prefix, '',  # type: ignore
                                                     nodes.Text(sig_prefix))  # type: ignore
             else:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
In #9672 the signature of ``get_signature_prefix()`` in the Python domain was changed to return a list of docutils nodes instead of string. Based on #9832 it looks like some extensions (https://pypi.org/project/autodoc-pydantic/) indeed overwrites this method.
This PR adds a fallback check for ``str`` and warns about the changed interface.

### Detail
This is quick and dirty PR to get started. I guess it should use one of the deprecation facilities, but I'm not exactly sure.

### Relates
Fixes #9832


