### PR TITLE
option to include toctree in inlined builds

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1553,6 +1553,13 @@ Options for Single HTML output
    are ignored.  For more information, refer to :confval:`html_sidebars`.  By
    default, it is same as :confval:`html_sidebars`.
 
+.. confval:: singlehtml_toctree
+
+   If true, TOC tree directives are inserted at their current locations,
+   instead of being replaced.  Default is ``False``.  This can be useful if a
+   documentation's theme does not support sidebar TOC trees or is configured
+   with sidebars disabled.
+
 
 .. _htmlhelp-options:
 

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -76,9 +76,10 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
     def assemble_doctree(self) -> nodes.document:
         master = self.config.root_doc
         tree = self.env.get_doctree(master)
-        tree = inline_all_toctrees(self, set(), master, tree, darkgreen, [master])
+        tree = inline_all_toctrees(self, set(), master, tree, darkgreen, [master],
+                                   replace=not self.config.singlehtml_toctree)
         tree['docname'] = master
-        self.env.resolve_references(tree, master, self)
+        self.env.get_and_resolve_doctree(master, self, doctree=tree)
         self.fix_refuris(tree)
         return tree
 
@@ -191,6 +192,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_builder(SingleFileHTMLBuilder)
     app.add_config_value('singlehtml_sidebars', lambda self: self.html_sidebars, 'html')
+    app.add_config_value('singlehtml_toctree', False, 'html')
 
     return {
         'version': 'builtin',

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -401,8 +401,8 @@ def process_index_entry(entry: str, targetid: str
 
 
 def inline_all_toctrees(builder: "Builder", docnameset: Set[str], docname: str,
-                        tree: nodes.document, colorfunc: Callable, traversed: List[str]
-                        ) -> nodes.document:
+                        tree: nodes.document, colorfunc: Callable, traversed: List[str],
+                        replace: bool = True) -> nodes.document:
     """Inline all toctrees in the *tree*.
 
     Record all docnames in *docnameset*, and output docnames with *colorfunc*.
@@ -418,7 +418,7 @@ def inline_all_toctrees(builder: "Builder", docnameset: Set[str], docname: str,
                     logger.info(colorfunc(includefile) + " ", nonl=True)
                     subtree = inline_all_toctrees(builder, docnameset, includefile,
                                                   builder.env.get_doctree(includefile),
-                                                  colorfunc, traversed)
+                                                  colorfunc, traversed, replace=replace)
                     docnameset.add(includefile)
                 except Exception:
                     logger.warning(__('toctree contains ref to nonexisting file %r'),
@@ -430,7 +430,13 @@ def inline_all_toctrees(builder: "Builder", docnameset: Set[str], docname: str,
                         if 'docname' not in sectionnode:
                             sectionnode['docname'] = includefile
                     newnodes.append(sof)
-        toctreenode.parent.replace(toctreenode, newnodes)
+
+        if replace:
+            toctreenode.parent.replace(toctreenode, newnodes)
+        else:
+            for node in newnodes:
+                toctreenode.parent.append(node)
+
     return tree
 
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -596,6 +596,56 @@ def test_tocdepth_singlehtml(app, cached_etree_parse, fname, expect):
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
 
 
+@pytest.mark.parametrize("fname,expect", flat_dict({
+    'index.html': [
+        (".//li[@class='toctree-l3']/a", '1.1.1. Foo A1', True),
+        (".//li[@class='toctree-l3']/a", '1.2.1. Foo B1', True),
+        (".//li[@class='toctree-l3']/a", '2.1.1. Bar A1', False),
+        (".//li[@class='toctree-l3']/a", '2.2.1. Bar B1', False),
+
+        # index.rst
+        (".//h1", 'test-tocdepth', True),
+
+        # foo.rst
+        (".//h2", 'Foo', True),
+        (".//h3", 'Foo A', True),
+        (".//h4", 'Foo A1', True),
+        (".//h3", 'Foo B', True),
+        (".//h4", 'Foo B1', True),
+        (".//h2//span[@class='section-number']", '1. ', True),
+        (".//h3//span[@class='section-number']", '1.1. ', True),
+        (".//h4//span[@class='section-number']", '1.1.1. ', True),
+        (".//h3//span[@class='section-number']", '1.2. ', True),
+        (".//h4//span[@class='section-number']", '1.2.1. ', True),
+
+        # bar.rst
+        (".//h2", 'Bar', True),
+        (".//h3", 'Bar A', True),
+        (".//h3", 'Bar B', True),
+        (".//h4", 'Bar B1', True),
+        (".//h2//span[@class='section-number']", '2. ', True),
+        (".//h3//span[@class='section-number']", '2.1. ', True),
+        (".//h3//span[@class='section-number']", '2.2. ', True),
+        (".//h4//span[@class='section-number']", '2.2.1. ', True),
+
+        # baz.rst
+        (".//h4", 'Baz A', True),
+        (".//h4//span[@class='section-number']", '2.1.1. ', True),
+    ],
+}))
+@pytest.mark.sphinx(
+    'singlehtml',
+    testroot='tocdepth',
+    confoverrides={
+        'html_theme': 'basic',
+        'singlehtml_toctree': True,
+    })
+@pytest.mark.test_params(shared_result='test_build_singlehtml_tocdepth_toctree')
+def test_tocdepth_singlehtml_toctree(app, cached_etree_parse, fname, expect):
+    app.build()
+    check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
+
+
 @pytest.mark.sphinx('html', testroot='numfig')
 @pytest.mark.test_params(shared_result='test_build_html_numfig')
 def test_numfig_disabled_warn(app, warning):


### PR DESCRIPTION
Subject: option to include toctrees in inlined builds

### Feature or Bugfix
- Feature

### Purpose
- nodes: support not replacing inlined toctree nodes
- singlehtml: option to include toc tree entries in the main document

### Detail

The `inline_all_toctrees` will replace toctree nodes with the contents of each toctree entry. While replacing the toctree node is preferable for most builders (and themes), some uses cases may wish to leave the TOC tree in. For example, if an HTML theme does not support a sidebar which produces a TOC tree, the resulting documentation will not have any TOC tree in the final output.

This commit introduces a `replace` option to the `inline_all_toctrees` function which allows a builder to explicitly decide if toctree nodes are replaced (the previous use case and the default state) or leave the toctree nodes in (which can later be resolved on).

Documentation which use an HTML theme which do not support a table of contents (e.g. `basic`) or a configuration which has `nosidebar` set, there will be no TOC tree generated in the final document. To support the use case where a user wishes to have TOC tree entries rendered in the document, a `singlehtml_toctree` option can be set to `True` to enable this.

---

An end goal of this pull request is to extend the `inline_all_toctrees` capability to third-party builders which may also want to inline documents, but support leaving the TOC tree entries on a page.

### Relates
-  #1863
- sphinx-contrib/confluencebuilder#447

