### PR TITLE
Create GitHub release from tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,18 @@
+name: Create release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body: "Changelog: https://www.sphinx-doc.org/en/master/changes.html"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@ name: Create release
 on:
   push:
     tags:
-    - '*'
+    - "v*.*.*"
 
 jobs:
   create-release:


### PR DESCRIPTION
Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Make things easier for maintainers

### Detail
- Automatically create a GitHub Release from tags
- This will then notify people who are watching releases for this repo
- It doesn't run for normal pushes or PRs:
![image](https://user-images.githubusercontent.com/1324225/141435953-081af27b-c2a5-4a56-81b4-cabec18b2fe1.png)
- It only runs for tags:
![image](https://user-images.githubusercontent.com/1324225/141436202-563f07ec-9af5-4f45-9962-cff21b7a03d2.png)
- Demo run: https://github.com/hugovk/sphinx/runs/4187569255?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1324225/141436396-a4c10839-4d87-4f0f-a499-7b1463ef5ee5.png)

- Example release: https://github.com/hugovk/sphinx/releases/tag/1.6.7
![image](https://user-images.githubusercontent.com/1324225/141436433-7c3cebb5-67c5-4450-84c6-3ee20595e027.png)

- We can adjust the body text of the release as needed.
- https://github.com/actions/create-release is archived, so of the ones linked from there, this uses the one with the most stars: https://github.com/softprops/action-gh-release

### Relates
- https://github.com/sphinx-doc/sphinx/issues/9824#issuecomment-966447577

