### PR TITLE
Add brief section on documenting other languages to tutorial

### DIFF
--- a/doc/tutorial/describing-code.rst
+++ b/doc/tutorial/describing-code.rst
@@ -243,8 +243,7 @@ Sphinx also supports documenting and cross-referencing objects written in
 other programming languages. There are four extra built-in domains:
 C, C++, JavaScript, and reStructuredText, and third party extensions may
 define domains for more languages, such as
-`.NET <https://sphinxcontrib-dotnetdomain.readthedocs.io>`,
-`Fortran <https://sphinx-fortran.readthedocs.io>`_,
+`Fortran <https://sphinx-fortran.readthedocs.io>`_
 or `Julia <http://bastikr.github.io/sphinx-julia>`_.
 
 For example, to document a C++ type definition, you would use the built-in

--- a/doc/tutorial/describing-code.rst
+++ b/doc/tutorial/describing-code.rst
@@ -240,11 +240,13 @@ Documenting and cross-referencing objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sphinx also supports documenting and cross-referencing objects written in
-other programming languages. There are four extra built-in domains:
-C, C++, JavaScript, and reStructuredText, and third party extensions may
+other programming languages. There are four additional built-in domains:
+C, C++, JavaScript, and reStructuredText. Third-party extensions may
 define domains for more languages, such as
-`Fortran <https://sphinx-fortran.readthedocs.io>`_
-or `Julia <http://bastikr.github.io/sphinx-julia>`_.
+
+- `Fortran <https://sphinx-fortran.readthedocs.io>`_,
+- `Julia <http://bastikr.github.io/sphinx-julia>`_, or
+- `PHP <https://github.com/markstory/sphinxcontrib-phpdomain>`_.
 
 For example, to document a C++ type definition, you would use the built-in
 :rst:dir:`cpp:type` directive, as follows:

--- a/doc/tutorial/describing-code.rst
+++ b/doc/tutorial/describing-code.rst
@@ -14,8 +14,11 @@ section apply for the other domains as well.
 
 .. _tutorial-describing-objects:
 
+Python
+------
+
 Documenting Python objects
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sphinx offers several roles and directives to document Python objects,
 all grouped together in :ref:`the Python domain <python-domain>`. For example,
@@ -68,7 +71,7 @@ Notice several things:
    ``.. function::`` directly.
 
 Cross-referencing Python objects
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, most of these directives generate entities that can be
 cross-referenced from any part of the documentation by using
@@ -123,7 +126,7 @@ And finally, this is how the result would look:
 Beautiful, isn't it?
 
 Including doctests in your documentation
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since you are now describing code from a Python library, it will become useful
 to keep both the documentation and the code as synchronized as possible.
@@ -229,3 +232,43 @@ And finally, ``make test`` reports success!
 For big projects though, this manual approach can become a bit tedious.
 In the next section, you will see :doc:`how to automate the
 process </tutorial/automatic-doc-generation>`.
+
+Other languages (C, C++, others)
+--------------------------------
+
+Documenting and cross-referencing objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sphinx also supports documenting and cross-referencing objects written in
+other programming languages. There are four extra built-in domains:
+C, C++, JavaScript, and reStructuredText, and third party extensions may
+define domains for more languages, such as
+`.NET <https://sphinxcontrib-dotnetdomain.readthedocs.io>`,
+`Fortran <https://sphinx-fortran.readthedocs.io>`_,
+or `Julia <http://bastikr.github.io/sphinx-julia>`_.
+
+For example, to document a C++ type definition, you would use the built-in
+:rst:dir:`cpp:type` directive, as follows:
+
+.. code-block:: rst
+
+   .. cpp:type:: std::vector<int> CustomList
+
+      A typedef-like declaration of a type.
+
+Which would give the following result:
+
+.. cpp:type:: std::vector<int> CustomList
+
+   A typedef-like declaration of a type.
+
+All such directives then generate generate references that can be
+cross-referenced by using the corresponding role. For example, to reference
+the previous type definition, you can use the :rst:role:`cpp:type` role
+as follows:
+
+.. code-block:: rst
+
+   Cross reference to :cpp:type:`CustomList`.
+
+Which would produce a hyperlink to the previous definition: :cpp:type:`CustomList`.

--- a/doc/tutorial/describing-code.rst
+++ b/doc/tutorial/describing-code.rst
@@ -262,7 +262,7 @@ Which would give the following result:
 
    A typedef-like declaration of a type.
 
-All such directives then generate generate references that can be
+All such directives then generate references that can be
 cross-referenced by using the corresponding role. For example, to reference
 the previous type definition, you can use the :rst:role:`cpp:type` role
 as follows:


### PR DESCRIPTION
Short follow-up to https://github.com/sphinx-doc/sphinx/pull/9534#issuecomment-919259206, where it was discussed that it would be good to expand on the Sphinx capabilities of documenting other languages.

It sort of deviates from the main tutorial in that it doesn't add any C++ code to the supposed documentation of Lumache, but I hope it serves at least for clarifying that Sphinx is capable of much more than just documenting Python objects.

cc @tk0miya @jakobandersen 