### PR TITLE
Update RFC base url

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1005,7 +1005,7 @@ that use Sphinx's HTMLWriter class.
    to indicate the location of document using `The Canonical Link Relation`_.
    Default: ``''``.
 
-   .. _The Canonical Link Relation: https://tools.ietf.org/html/rfc6596
+   .. _The Canonical Link Relation: https://datatracker.ietf.org/doc/html/rfc6596
 
    .. versionadded:: 1.8
 
@@ -2679,7 +2679,7 @@ Options for the linkcheck builder
    doubling the wait time between attempts until it succeeds or exceeds the
    ``linkcheck_rate_limit_timeout``. By default, the timeout is 5 minutes.
 
-   .. _Retry-After: https://tools.ietf.org/html/rfc7231#section-7.1.3
+   .. _Retry-After: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3
 
    .. versionadded:: 3.4
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -51,7 +51,7 @@ default_settings: Dict[str, Any] = {
     'cloak_email_addresses': True,
     'pep_base_url': 'https://www.python.org/dev/peps/',
     'pep_references': None,
-    'rfc_base_url': 'https://tools.ietf.org/html/',
+    'rfc_base_url': 'https://datatracker.ietf.org/doc/html/',
     'rfc_references': None,
     'input_encoding': 'utf-8-sig',
     'doctitle_xform': False,

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -225,9 +225,9 @@ def test_html4_output(app, status, warning):
         (".//a[@href='https://www.python.org/dev/peps/pep-0008']"
          "[@class='pep reference external']/strong",
          'Python Enhancement Proposal #8'),
-        (".//a[@href='https://tools.ietf.org/html/rfc1.html']"
+        (".//a[@href='https://datatracker.ietf.org/doc/html/rfc1.html']"
          "[@class='rfc reference external']/strong", 'RFC 1'),
-        (".//a[@href='https://tools.ietf.org/html/rfc1.html']"
+        (".//a[@href='https://datatracker.ietf.org/doc/html/rfc1.html']"
          "[@class='rfc reference external']/strong", 'Request for Comments #1'),
         (".//a[@href='objects.html#envvar-HOME']"
          "[@class='reference internal']/code/span[@class='pre']", 'HOME'),

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -36,7 +36,7 @@ def settings(app):
     settings.env = app.builder.env
     settings.env.temp_data['docname'] = 'dummy'
     settings.contentsname = 'dummy'
-    settings.rfc_base_url = 'http://tools.ietf.org/html/'
+    settings.rfc_base_url = 'http://datatracker.ietf.org/doc/html/'
     domain_context = sphinx_domains(settings.env)
     domain_context.enable()
     yield settings
@@ -181,10 +181,10 @@ def get_verifier(verify, verify_re):
         'verify',
         ':rfc:`2324`',
         ('<p><span class="target" id="index-0"></span><a class="rfc reference external" '
-         'href="http://tools.ietf.org/html/rfc2324.html"><strong>RFC 2324</strong></a></p>'),
+         'href="http://datatracker.ietf.org/doc/html/rfc2324.html"><strong>RFC 2324</strong></a></p>'),
         ('\\sphinxAtStartPar\n'
          '\\index{RFC@\\spxentry{RFC}!RFC 2324@\\spxentry{RFC 2324}}'
-         '\\sphinxhref{http://tools.ietf.org/html/rfc2324.html}'
+         '\\sphinxhref{http://datatracker.ietf.org/doc/html/rfc2324.html}'
          '{\\sphinxstylestrong{RFC 2324}}')
     ),
     (
@@ -192,11 +192,11 @@ def get_verifier(verify, verify_re):
         'verify',
         ':rfc:`2324#id1`',
         ('<p><span class="target" id="index-0"></span><a class="rfc reference external" '
-         'href="http://tools.ietf.org/html/rfc2324.html#id1">'
+         'href="http://datatracker.ietf.org/doc/html/rfc2324.html#id1">'
          '<strong>RFC 2324#id1</strong></a></p>'),
         ('\\sphinxAtStartPar\n'
          '\\index{RFC@\\spxentry{RFC}!RFC 2324\\#id1@\\spxentry{RFC 2324\\#id1}}'
-         '\\sphinxhref{http://tools.ietf.org/html/rfc2324.html\\#id1}'
+         '\\sphinxhref{http://datatracker.ietf.org/doc/html/rfc2324.html\\#id1}'
          '{\\sphinxstylestrong{RFC 2324\\#id1}}')
     ),
     (


### PR DESCRIPTION
Subject: Update `rfc_base_url`

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Purpose
This updates the `rfc_base_url` to a currently supported subdomain.


### Detail
The tools.ietf.org subdomain is being wound down and services are moving to
datatracker.ietf.org. Links to RFC documents using the old subdomain are being
redirected to datatracker; this updates the configured `rfc_base_url` to
point to the current subdomain.

Discussion: https://mailarchive.ietf.org/arch/msg/ietf/0n-6EXEmkTp3Uv_vj-5Vnm3o0bo/
### Relates
- #9857 

