### PR TITLE
BUG: prevent automatic inline conversion by class

### DIFF
--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -13,7 +13,7 @@ import posixpath
 import re
 import urllib.parse
 import warnings
-from typing import TYPE_CHECKING, Iterable, Tuple, cast
+from typing import TYPE_CHECKING, Iterable, Set, Tuple, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, Text
@@ -59,7 +59,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     # Override docutils.writers.html5_polyglot:HTMLTranslator
     # otherwise, nodes like <inline classes="s">...</inline> will be
     # converted to <s>...</s> by `visit_inline`.
-    supported_inline_tags = set()
+    supported_inline_tags: Set[str] = set()
 
     def __init__(self, document: nodes.document, builder: Builder) -> None:
         super().__init__(document, builder)

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -56,6 +56,10 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     """
 
     builder: "StandaloneHTMLBuilder" = None
+    # Override docutils.writers.html5_polyglot:HTMLTranslator
+    # otherwise, nodes like <inline classes="s">...</inline> will be
+    # converted to <s>...</s> by `visit_inline`.
+    supported_inline_tags = set()
 
     def __init__(self, document: nodes.document, builder: Builder) -> None:
         super().__init__(document, builder)


### PR DESCRIPTION

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
To prevent inline nodes from being automatically coerced into specific HTML 5 elements.

This was a new feature added in docutils 0.17 and conflicts with some of the short class names added in https://github.com/sphinx-doc/sphinx/pull/9023, namely "s" which is automatically coerced into a strike-through element.

### Relates
See #9872 for motivation.

---

This is largely a drive-by effort. I don't know if this is the way you all would prefer to solve this, but I was able to get it working, and it seems like a very mild change. No hard feelings if this isn't the way you want to go.

