### PR TITLE
Fix #9866: autodoc: doccoment for the imported class was ignored

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Features added
 Bugs fixed
 ----------
 
+* #9866: autodoc: doccoment for the imported class was ignored
 * #9857: Generated RFC links use outdated base url
 
 Testing

--- a/tests/roots/test-ext-autodoc/target/classes.py
+++ b/tests/roots/test-ext-autodoc/target/classes.py
@@ -37,3 +37,6 @@ Alias = Foo
 
 #: docstring
 OtherAlias = Bar
+
+#: docstring
+IntAlias = int

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1870,12 +1870,15 @@ def test_autodoc_GenericAlias(app):
             '   .. py:attribute:: Class.T',
             '      :module: target.genericalias',
             '',
+            '      A list of int',
+            '',
             '      alias of :py:class:`~typing.List`\\ [:py:class:`int`]',
             '',
             '.. py:attribute:: T',
             '   :module: target.genericalias',
             '',
-            '   alias of :py:class:`~typing.List`\\ [:py:class:`int`]',
+            '   A list of int',
+            '',
         ]
     else:
         assert list(actual) == [

--- a/tests/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc_autoclass.py
@@ -407,6 +407,18 @@ def test_class_alias_having_doccomment(app):
     ]
 
 
+def test_class_alias_for_imported_object_having_doccomment(app):
+    actual = do_autodoc(app, 'class', 'target.classes.IntAlias')
+    assert list(actual) == [
+        '',
+        '.. py:attribute:: IntAlias',
+        '   :module: target.classes',
+        '',
+        '   docstring',
+        '',
+    ]
+
+
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_coroutine(app):
     options = {"members": None}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Autodoc tried to scan doccomment on the module where the class defined.
But it failed to get it if the class is imported from other module.
- This analyzes the target module to obtain the doccomment.
- refs: #9866 
