### PR TITLE
Fix #9878: mathjax: MathJax config is placed after loading MathJax

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@ Features added
 Bugs fixed
 ----------
 
+* #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url
 
 Testing

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -81,11 +81,6 @@ def install_mathjax(app: Sphinx, pagename: str, templatename: str, context: Dict
     domain = cast(MathDomain, app.env.get_domain('math'))
     if app.registry.html_assets_policy == 'always' or domain.has_equations(pagename):
         # Enable mathjax only if equations exists
-        options = {'defer': 'defer'}
-        if app.config.mathjax_options:
-            options.update(app.config.mathjax_options)
-        app.add_js_file(app.config.mathjax_path, **options)  # type: ignore
-
         if app.config.mathjax2_config:
             if app.config.mathjax_path == MATHJAX_URL:
                 logger.warning(
@@ -96,6 +91,11 @@ def install_mathjax(app: Sphinx, pagename: str, templatename: str, context: Dict
         if app.config.mathjax3_config:
             body = 'window.MathJax = %s' % json.dumps(app.config.mathjax3_config)
             app.add_js_file(None, body=body)
+
+        options = {'defer': 'defer'}
+        if app.config.mathjax_options:
+            options.update(app.config.mathjax_options)
+        app.add_js_file(app.config.mathjax_path, **options)  # type: ignore
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- refs: #9878 