### PR TITLE
Fix #9868: 4.3.0: pytest is failing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@ Bugs fixed
   having invalid __doc__ atribute
 * #9872: html: Class namespace collision between autodoc signatures and
   docutils-0.17
+* #9868: imgmath: Crashed if the dvisvgm command failed to convert equation
 * #9864: mathjax: Failed to render equations via MathJax v2.  The loading method
   of MathJax is back to "async" method again
 

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -12,7 +12,6 @@ import posixpath
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 from os import path
 from subprocess import PIPE, CalledProcessError
@@ -43,11 +42,11 @@ templates_path = path.join(package_dir, 'templates', 'imgmath')
 class MathExtError(SphinxError):
     category = 'Math extension error'
 
-    def __init__(self, msg: str, stderr: bytes = None, stdout: bytes = None) -> None:
+    def __init__(self, msg: str, stderr: str = None, stdout: str = None) -> None:
         if stderr:
-            msg += '\n[stderr]\n' + stderr.decode(sys.getdefaultencoding(), 'replace')
+            msg += '\n[stderr]\n' + stderr
         if stdout:
-            msg += '\n[stdout]\n' + stdout.decode(sys.getdefaultencoding(), 'replace')
+            msg += '\n[stdout]\n' + stdout
         super().__init__(msg)
 
 
@@ -135,7 +134,8 @@ def compile_math(latex: str, builder: Builder) -> str:
     command.append('math.tex')
 
     try:
-        subprocess.run(command, stdout=PIPE, stderr=PIPE, cwd=tempdir, check=True)
+        subprocess.run(command, stdout=PIPE, stderr=PIPE, cwd=tempdir, check=True,
+                       encoding='ascii')
         return path.join(tempdir, 'math.dvi')
     except OSError as exc:
         logger.warning(__('LaTeX command %r cannot be run (needed for math '

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -16,7 +16,6 @@ import sys
 import types
 from inspect import Parameter
 
-import _testcapi
 import pytest
 
 from sphinx.util import inspect
@@ -627,8 +626,6 @@ def test_isattributedescriptor(app):
         def __get__(self, obj, typ=None):
             pass
 
-    testinstancemethod = _testcapi.instancemethod(str.__repr__)
-
     assert inspect.isattributedescriptor(Base.prop) is True                    # property
     assert inspect.isattributedescriptor(Base.meth) is False                   # method
     assert inspect.isattributedescriptor(Base.staticmeth) is False             # staticmethod
@@ -639,7 +636,16 @@ def test_isattributedescriptor(app):
     assert inspect.isattributedescriptor(dict.__dict__['fromkeys']) is False   # ClassMethodDescriptorType  # NOQA
     assert inspect.isattributedescriptor(types.FrameType.f_locals) is True     # GetSetDescriptorType       # NOQA
     assert inspect.isattributedescriptor(datetime.timedelta.days) is True      # MemberDescriptorType       # NOQA
-    assert inspect.isattributedescriptor(testinstancemethod) is False          # instancemethod (C-API)     # NOQA
+
+    try:
+        # _testcapi module cannot be importable in some distro
+        # refs: https://github.com/sphinx-doc/sphinx/issues/9868
+        import _testcapi
+
+        testinstancemethod = _testcapi.instancemethod(str.__repr__)
+        assert inspect.isattributedescriptor(testinstancemethod) is False      # instancemethod (C-API)     # NOQA
+    except ImportError:
+        pass
 
 
 def test_isproperty(app):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fix #9868: ImportError on testing sphinx.util.inspect
- Fix #9868: imgmath: Crashed if the dvisvgm command failed to convert equation
- refs: #9868 