### PR TITLE
Fix #9844: autodoc: Failed to preserve defvalues for partial function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@ Bugs fixed
   decorated by functools.lru_cache
 * #9879: autodoc: AttributeError is raised on building document for an object
   having invalid __doc__ atribute
+* #9844: autodoc: Failed to process a function wrapped with functools.partial if
+  :confval:`autodoc_preserve_defaults` enabled
 * #9872: html: Class namespace collision between autodoc signatures and
   docutils-0.17
 * #9864: mathjax: Failed to render equations via MathJax v2.  The loading method

--- a/sphinx/ext/autodoc/preserve_defaults.py
+++ b/sphinx/ext/autodoc/preserve_defaults.py
@@ -73,7 +73,7 @@ def update_defvalue(app: Sphinx, obj: Any, bound_method: bool) -> None:
         lines = inspect.getsource(obj).splitlines()
         if lines[0].startswith((' ', r'\t')):
             lines.insert(0, '')  # insert a dummy line to follow what get_function_def() does.
-    except OSError:
+    except (OSError, TypeError):
         lines = []
 
     try:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9844 