### PR TITLE
Fix autodoc: Remove debug print

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@ Bugs fixed
 ----------
 
 * #9866: autodoc: doccoment for the imported class was ignored
+* autodoc: debug message is shown on building document using NewTypes with
+  Python 3.10
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url
 

--- a/CHANGES
+++ b/CHANGES
@@ -26,8 +26,8 @@ Bugs fixed
 ----------
 
 * #9866: autodoc: doccoment for the imported class was ignored
-* autodoc: debug message is shown on building document using NewTypes with
-  Python 3.10
+* #9908: autodoc: debug message is shown on building document using NewTypes
+  with Python 3.10
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- A message is shown on building document using NewTypes with Python
3.10.
