### PR TITLE
doc: Fix autodoc extension example

### DIFF
--- a/doc/development/tutorials/examples/autodoc_intenum.py
+++ b/doc/development/tutorials/examples/autodoc_intenum.py
@@ -9,7 +9,7 @@ from sphinx.ext.autodoc import ClassDocumenter, bool_option
 
 class IntEnumDocumenter(ClassDocumenter):
     objtype = 'intenum'
-    directivetype = 'class'
+    directivetype = ClassDocumenter.objtype
     priority = 10 + ClassDocumenter.priority
     option_spec = dict(ClassDocumenter.option_spec)
     option_spec['hex'] = bool_option
@@ -18,7 +18,10 @@ class IntEnumDocumenter(ClassDocumenter):
     def can_document_member(cls,
                             member: Any, membername: str,
                             isattr: bool, parent: Any) -> bool:
-        return isinstance(member, IntEnum)
+        try:
+            return issubclass(member, IntEnum)
+        except TypeError:
+            return False
 
     def add_directive_header(self, sig: str) -> None:
         super().add_directive_header(sig)


### PR DESCRIPTION
Subject: Minor fixes to the example code of the autodoc extension tutorial

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix (in example code)

---
Documenter class attributes:
- `directivetype` is set to mimic `ClassDocumenter`. Reflect that.

`can_document_member` method fixes:
- `isinstance` would work on the enum members, but that is not what we want here. `issubclass` raises a TypeError when called on objects that are not classes.