### PR TITLE
Prevent line wrapping in literals

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
   with Python 3.10
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url
+* #9909: HTML, prevent line-wrapping in literal text.
 
 Testing
 --------

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -757,6 +757,7 @@ span.pre {
     -ms-hyphens: none;
     -webkit-hyphens: none;
     hyphens: none;
+    white-space: nowrap;
 }
 
 div[class*="highlight-"] {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
At https://github.com/sphinx-doc/sphinx/blob/17dfa811078205bd415700361e97e945112b89eb/sphinx/writers/html5.py#L645-L649 it is indicated that the ``pre`` class is preventing line wrapping.  The CSS was added in https://github.com/sphinx-doc/sphinx/commit/37bb9c2c336d7a374b952a78f90880a0a7282442, but it doesn't include the ``line-wrap`` attribute.
In Docutils I found the CSS
```css
/* do not wrap at hyphens and similar: */
.literal > span.pre { white-space: nowrap; }
```
This PR adds the same to ``pre`` in the basic Sphinx theme.

### Relates
Fixes #9909.

