### PR TITLE
Close #9075: autodoc: Add a config variable autodoc_unqualified_typehints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* #9075: autodoc: Add a config variable :confval:`autodoc_unqualified_typehints`
+  to suppress the leading module names of typehints of function signatures (ex.
+  ``io.StringIO`` -> ``StringIO``)
 * #9831: Autosummary now documents only the members specified in a module's
   ``__all__`` attribute if :confval:`autosummary_ignore_module_all` is set to
   ``False``. The default behaviour is unchanged. Autogen also now supports

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -662,6 +662,13 @@ There are also config values that you can set:
    .. __: https://mypy.readthedocs.io/en/latest/kinds_of_types.html#type-aliases
    .. versionadded:: 3.3
 
+.. confval:: autodoc_unqualified_typehints
+
+   If True, the leading module names of typehints of function signatures (ex.
+   ``io.StringIO`` -> ``StringIO``).  Defaults to False.
+
+   .. versionadded:: 4.4
+
 .. confval:: autodoc_preserve_defaults
 
    If True, the default argument values of functions will be not evaluated on

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1295,6 +1295,8 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
     def format_args(self, **kwargs: Any) -> str:
         if self.config.autodoc_typehints in ('none', 'description'):
             kwargs.setdefault('show_annotation', False)
+        if self.config.autodoc_unqualified_typehints:
+            kwargs.setdefault('unqualified_typehints', True)
 
         try:
             self.env.app.emit('autodoc-before-process-signature', self.object, False)
@@ -1323,6 +1325,9 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
             self.add_line('   :async:', sourcename)
 
     def format_signature(self, **kwargs: Any) -> str:
+        if self.config.autodoc_unqualified_typehints:
+            kwargs.setdefault('unqualified_typehints', True)
+
         sigs = []
         if (self.analyzer and
                 '.'.join(self.objpath) in self.analyzer.overloads and
@@ -1561,6 +1566,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
     def format_args(self, **kwargs: Any) -> str:
         if self.config.autodoc_typehints in ('none', 'description'):
             kwargs.setdefault('show_annotation', False)
+        if self.config.autodoc_unqualified_typehints:
+            kwargs.setdefault('unqualified_typehints', True)
 
         try:
             self._signature_class, self._signature_method_name, sig = self._get_signature()
@@ -1581,6 +1588,9 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         if self.config.autodoc_class_signature == 'separated':
             # do not show signatures
             return ''
+
+        if self.config.autodoc_unqualified_typehints:
+            kwargs.setdefault('unqualified_typehints', True)
 
         sig = super().format_signature()
         sigs = []
@@ -2110,6 +2120,8 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
     def format_args(self, **kwargs: Any) -> str:
         if self.config.autodoc_typehints in ('none', 'description'):
             kwargs.setdefault('show_annotation', False)
+        if self.config.autodoc_unqualified_typehints:
+            kwargs.setdefault('unqualified_typehints', True)
 
         try:
             if self.object == object.__init__ and self.parent != object:
@@ -2160,6 +2172,9 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
         pass
 
     def format_signature(self, **kwargs: Any) -> str:
+        if self.config.autodoc_unqualified_typehints:
+            kwargs.setdefault('unqualified_typehints', True)
+
         sigs = []
         if (self.analyzer and
                 '.'.join(self.objpath) in self.analyzer.overloads and
@@ -2833,6 +2848,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('autodoc_typehints_description_target', 'all', True,
                          ENUM('all', 'documented'))
     app.add_config_value('autodoc_type_aliases', {}, True)
+    app.add_config_value('autodoc_unqualified_typehints', False, 'env')
     app.add_config_value('autodoc_warningiserror', True, True)
     app.add_config_value('autodoc_inherit_docstrings', True, True)
     app.add_event('autodoc-before-process-signature')

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -744,10 +744,13 @@ def evaluate_signature(sig: inspect.Signature, globalns: Dict = None, localns: D
 
 
 def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
-                        show_return_annotation: bool = True) -> str:
+                        show_return_annotation: bool = True,
+                        unqualified_typehints: bool = False) -> str:
     """Stringify a Signature object.
 
     :param show_annotation: Show annotation in result
+    :param unqualified_typehints: Show annotations as unqualified
+                                  (ex. io.StringIO -> StringIO)
     """
     args = []
     last_kind = None
@@ -771,7 +774,7 @@ def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
 
         if show_annotation and param.annotation is not param.empty:
             arg.write(': ')
-            arg.write(stringify_annotation(param.annotation))
+            arg.write(stringify_annotation(param.annotation, unqualified_typehints))
         if param.default is not param.empty:
             if show_annotation and param.annotation is not param.empty:
                 arg.write(' = ')
@@ -791,7 +794,7 @@ def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
             show_return_annotation is False):
         return '(%s)' % ', '.join(args)
     else:
-        annotation = stringify_annotation(sig.return_annotation)
+        annotation = stringify_annotation(sig.return_annotation, unqualified_typehints)
         return '(%s) -> %s' % (', '.join(args), annotation)
 
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -350,6 +350,18 @@ def test_parse_annotation(app):
     assert_node(doctree[0], pending_xref, refdomain="py", reftype="obj", reftarget="None")
 
 
+def test_parse_annotation_suppress(app):
+    doctree = _parse_annotation("~typing.Dict[str, str]", app.env)
+    assert_node(doctree, ([pending_xref, "Dict"],
+                          [desc_sig_punctuation, "["],
+                          [pending_xref, "str"],
+                          [desc_sig_punctuation, ","],
+                          desc_sig_space,
+                          [pending_xref, "str"],
+                          [desc_sig_punctuation, "]"]))
+    assert_node(doctree[0], pending_xref, refdomain="py", reftype="class", reftarget="typing.Dict")
+
+
 @pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
 def test_parse_annotation_Literal(app):
     doctree = _parse_annotation("Literal[True, False]", app.env)

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -1142,6 +1142,99 @@ def test_autodoc_typehints_description_and_type_aliases(app):
             '      myint\n' == context)
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc',
+                    confoverrides={'autodoc_unqualified_typehints': True})
+def test_autodoc_unqualified_typehints(app):
+    if sys.version_info < (3, 7):
+        Any = 'Any'
+    else:
+        Any = '~typing.Any'
+
+    options = {"members": None,
+               "undoc-members": None}
+    actual = do_autodoc(app, 'module', 'target.typehints', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.typehints',
+        '',
+        '',
+        '.. py:data:: CONST1',
+        '   :module: target.typehints',
+        '   :type: int',
+        '',
+        '',
+        '.. py:class:: Math(s: str, o: ~typing.Optional[%s] = None)' % Any,
+        '   :module: target.typehints',
+        '',
+        '',
+        '   .. py:attribute:: Math.CONST1',
+        '      :module: target.typehints',
+        '      :type: int',
+        '',
+        '',
+        '   .. py:attribute:: Math.CONST2',
+        '      :module: target.typehints',
+        '      :type: int',
+        '      :value: 1',
+        '',
+        '',
+        '   .. py:method:: Math.decr(a: int, b: int = 1) -> int',
+        '      :module: target.typehints',
+        '',
+        '',
+        '   .. py:method:: Math.horse(a: str, b: int) -> None',
+        '      :module: target.typehints',
+        '',
+        '',
+        '   .. py:method:: Math.incr(a: int, b: int = 1) -> int',
+        '      :module: target.typehints',
+        '',
+        '',
+        '   .. py:method:: Math.nothing() -> None',
+        '      :module: target.typehints',
+        '',
+        '',
+        '   .. py:property:: Math.prop',
+        '      :module: target.typehints',
+        '      :type: int',
+        '',
+        '',
+        '.. py:class:: NewAnnotation(i: int)',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:class:: NewComment(i: int)',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:class:: SignatureFromMetaclass(a: int)',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:function:: complex_func(arg1: str, arg2: List[int], arg3: Tuple[int, '
+        'Union[str, Unknown]] = None, *args: str, **kwargs: str) -> None',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:function:: decr(a: int, b: int = 1) -> int',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:function:: incr(a: int, b: int = 1) -> int',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:function:: missing_attr(c, a: str, b: Optional[str] = None) -> str',
+        '   :module: target.typehints',
+        '',
+        '',
+        '.. py:function:: tuple_args(x: ~typing.Tuple[int, ~typing.Union[int, str]]) '
+        '-> ~typing.Tuple[int, int]',
+        '   :module: target.typehints',
+        '',
+    ]
+
+
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_options(app):
     # no settings

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -259,6 +259,10 @@ def test_signature_annotations():
     sig = inspect.signature(f7)
     assert stringify_signature(sig, show_return_annotation=False) == '(x: Optional[int] = None, y: dict = {})'
 
+    # unqualified_typehints is True
+    sig = inspect.signature(f7)
+    assert stringify_signature(sig, unqualified_typehints=True) == '(x: ~typing.Optional[int] = None, y: dict = {}) -> None'
+
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
 @pytest.mark.sphinx(testroot='ext-autodoc')

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -178,78 +178,156 @@ def test_restify_mock():
 
 
 def test_stringify():
-    assert stringify(int) == "int"
-    assert stringify(str) == "str"
-    assert stringify(None) == "None"
-    assert stringify(Integral) == "numbers.Integral"
-    assert stringify(Struct) == "struct.Struct"
-    assert stringify(TracebackType) == "types.TracebackType"
-    assert stringify(Any) == "Any"
+    assert stringify(int, False) == "int"
+    assert stringify(int, True) == "int"
+
+    assert stringify(str, False) == "str"
+    assert stringify(str, True) == "str"
+
+    assert stringify(None, False) == "None"
+    assert stringify(None, True) == "None"
+
+    assert stringify(Integral, False) == "numbers.Integral"
+    assert stringify(Integral, True) == "~numbers.Integral"
+
+    assert stringify(Struct, False) == "struct.Struct"
+    assert stringify(Struct, True) == "~struct.Struct"
+
+    assert stringify(TracebackType, False) == "types.TracebackType"
+    assert stringify(TracebackType, True) == "~types.TracebackType"
+
+    assert stringify(Any, False) == "Any"
+    assert stringify(Any, True) == "~typing.Any"
 
 
 def test_stringify_type_hints_containers():
-    assert stringify(List) == "List"
-    assert stringify(Dict) == "Dict"
-    assert stringify(List[int]) == "List[int]"
-    assert stringify(List[str]) == "List[str]"
-    assert stringify(Dict[str, float]) == "Dict[str, float]"
-    assert stringify(Tuple[str, str, str]) == "Tuple[str, str, str]"
-    assert stringify(Tuple[str, ...]) == "Tuple[str, ...]"
-    assert stringify(Tuple[()]) == "Tuple[()]"
-    assert stringify(List[Dict[str, Tuple]]) == "List[Dict[str, Tuple]]"
-    assert stringify(MyList[Tuple[int, int]]) == "tests.test_util_typing.MyList[Tuple[int, int]]"
-    assert stringify(Generator[None, None, None]) == "Generator[None, None, None]"
+    assert stringify(List, False) == "List"
+    assert stringify(List, True) == "~typing.List"
+
+    assert stringify(Dict, False) == "Dict"
+    assert stringify(Dict, True) == "~typing.Dict"
+
+    assert stringify(List[int], False) == "List[int]"
+    assert stringify(List[int], True) == "~typing.List[int]"
+
+    assert stringify(List[str], False) == "List[str]"
+    assert stringify(List[str], True) == "~typing.List[str]"
+
+    assert stringify(Dict[str, float], False) == "Dict[str, float]"
+    assert stringify(Dict[str, float], True) == "~typing.Dict[str, float]"
+
+    assert stringify(Tuple[str, str, str], False) == "Tuple[str, str, str]"
+    assert stringify(Tuple[str, str, str], True) == "~typing.Tuple[str, str, str]"
+
+    assert stringify(Tuple[str, ...], False) == "Tuple[str, ...]"
+    assert stringify(Tuple[str, ...], True) == "~typing.Tuple[str, ...]"
+
+    assert stringify(Tuple[()], False) == "Tuple[()]"
+    assert stringify(Tuple[()], True) == "~typing.Tuple[()]"
+
+    assert stringify(List[Dict[str, Tuple]], False) == "List[Dict[str, Tuple]]"
+    assert stringify(List[Dict[str, Tuple]], True) == "~typing.List[~typing.Dict[str, ~typing.Tuple]]"
+
+    assert stringify(MyList[Tuple[int, int]], False) == "tests.test_util_typing.MyList[Tuple[int, int]]"
+    assert stringify(MyList[Tuple[int, int]], True) == "~tests.test_util_typing.MyList[~typing.Tuple[int, int]]"
+
+    assert stringify(Generator[None, None, None], False) == "Generator[None, None, None]"
+    assert stringify(Generator[None, None, None], True) == "~typing.Generator[None, None, None]"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason='python 3.9+ is required.')
 def test_stringify_type_hints_pep_585():
-    assert stringify(list[int]) == "list[int]"
-    assert stringify(list[str]) == "list[str]"
-    assert stringify(dict[str, float]) == "dict[str, float]"
-    assert stringify(tuple[str, str, str]) == "tuple[str, str, str]"
-    assert stringify(tuple[str, ...]) == "tuple[str, ...]"
-    assert stringify(tuple[()]) == "tuple[()]"
-    assert stringify(list[dict[str, tuple]]) == "list[dict[str, tuple]]"
-    assert stringify(type[int]) == "type[int]"
+    assert stringify(list[int], False) == "list[int]"
+    assert stringify(list[int], True) == "list[int]"
+
+    assert stringify(list[str], False) == "list[str]"
+    assert stringify(list[str], True) == "list[str]"
+
+    assert stringify(dict[str, float], False) == "dict[str, float]"
+    assert stringify(dict[str, float], True) == "dict[str, float]"
+
+    assert stringify(tuple[str, str, str], False) == "tuple[str, str, str]"
+    assert stringify(tuple[str, str, str], True) == "tuple[str, str, str]"
+
+    assert stringify(tuple[str, ...], False) == "tuple[str, ...]"
+    assert stringify(tuple[str, ...], True) == "tuple[str, ...]"
+
+    assert stringify(tuple[()], False) == "tuple[()]"
+    assert stringify(tuple[()], True) == "tuple[()]"
+
+    assert stringify(list[dict[str, tuple]], False) == "list[dict[str, tuple]]"
+    assert stringify(list[dict[str, tuple]], True) == "list[dict[str, tuple]]"
+
+    assert stringify(type[int], False) == "type[int]"
+    assert stringify(type[int], True) == "type[int]"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason='python 3.9+ is required.')
 def test_stringify_Annotated():
     from typing import Annotated  # type: ignore
-    assert stringify(Annotated[str, "foo", "bar"]) == "str"  # NOQA
+    assert stringify(Annotated[str, "foo", "bar"], False) == "str"  # NOQA
+    assert stringify(Annotated[str, "foo", "bar"], True) == "str"  # NOQA
 
 
 def test_stringify_type_hints_string():
-    assert stringify("int") == "int"
-    assert stringify("str") == "str"
-    assert stringify(List["int"]) == "List[int]"
-    assert stringify("Tuple[str]") == "Tuple[str]"
-    assert stringify("unknown") == "unknown"
+    assert stringify("int", False) == "int"
+    assert stringify("int", True) == "int"
+
+    assert stringify("str", False) == "str"
+    assert stringify("str", True) == "str"
+
+    assert stringify(List["int"], False) == "List[int]"
+    assert stringify(List["int"], True) == "~typing.List[int]"
+
+    assert stringify("Tuple[str]", False) == "Tuple[str]"
+    assert stringify("Tuple[str]", True) == "Tuple[str]"
+
+    assert stringify("unknown", False) == "unknown"
+    assert stringify("unknown", True) == "unknown"
 
 
 def test_stringify_type_hints_Callable():
-    assert stringify(Callable) == "Callable"
+    assert stringify(Callable, False) == "Callable"
+    assert stringify(Callable, True) == "~typing.Callable"
 
     if sys.version_info >= (3, 7):
-        assert stringify(Callable[[str], int]) == "Callable[[str], int]"
-        assert stringify(Callable[..., int]) == "Callable[[...], int]"
+        assert stringify(Callable[[str], int], False) == "Callable[[str], int]"
+        assert stringify(Callable[[str], int], True) == "~typing.Callable[[str], int]"
+
+        assert stringify(Callable[..., int], False) == "Callable[[...], int]"
+        assert stringify(Callable[..., int], True) == "~typing.Callable[[...], int]"
     else:
-        assert stringify(Callable[[str], int]) == "Callable[str, int]"
-        assert stringify(Callable[..., int]) == "Callable[..., int]"
+        assert stringify(Callable[[str], int], False) == "Callable[str, int]"
+        assert stringify(Callable[[str], int], True) == "~typing.Callable[str, int]"
+
+        assert stringify(Callable[..., int], False) == "Callable[..., int]"
+        assert stringify(Callable[..., int], True) == "~typing.Callable[..., int]"
 
 
 def test_stringify_type_hints_Union():
-    assert stringify(Optional[int]) == "Optional[int]"
-    assert stringify(Union[str, None]) == "Optional[str]"
-    assert stringify(Union[int, str]) == "Union[int, str]"
+    assert stringify(Optional[int], False) == "Optional[int]"
+    assert stringify(Optional[int], True) == "~typing.Optional[int]"
+
+    assert stringify(Union[str, None], False) == "Optional[str]"
+    assert stringify(Union[str, None], True) == "~typing.Optional[str]"
+
+    assert stringify(Union[int, str], False) == "Union[int, str]"
+    assert stringify(Union[int, str], True) == "~typing.Union[int, str]"
 
     if sys.version_info >= (3, 7):
-        assert stringify(Union[int, Integral]) == "Union[int, numbers.Integral]"
-        assert (stringify(Union[MyClass1, MyClass2]) ==
+        assert stringify(Union[int, Integral], False) == "Union[int, numbers.Integral]"
+        assert stringify(Union[int, Integral], True) == "~typing.Union[int, ~numbers.Integral]"
+
+        assert (stringify(Union[MyClass1, MyClass2], False) ==
                 "Union[tests.test_util_typing.MyClass1, tests.test_util_typing.<MyClass2>]")
+        assert (stringify(Union[MyClass1, MyClass2], True) ==
+                "~typing.Union[~tests.test_util_typing.MyClass1, ~tests.test_util_typing.<MyClass2>]")
     else:
-        assert stringify(Union[int, Integral]) == "numbers.Integral"
-        assert stringify(Union[MyClass1, MyClass2]) == "tests.test_util_typing.MyClass1"
+        assert stringify(Union[int, Integral], False) == "numbers.Integral"
+        assert stringify(Union[int, Integral], True) == "~numbers.Integral"
+
+        assert stringify(Union[MyClass1, MyClass2], False) == "tests.test_util_typing.MyClass1"
+        assert stringify(Union[MyClass1, MyClass2], True) == "~tests.test_util_typing.MyClass1"
 
 
 def test_stringify_type_hints_typevars():
@@ -258,52 +336,83 @@ def test_stringify_type_hints_typevars():
     T_contra = TypeVar('T_contra', contravariant=True)
 
     if sys.version_info < (3, 7):
-        assert stringify(T) == "T"
-        assert stringify(T_co) == "T_co"
-        assert stringify(T_contra) == "T_contra"
-        assert stringify(List[T]) == "List[T]"
+        assert stringify(T, False) == "T"
+        assert stringify(T, True) == "T"
+
+        assert stringify(T_co, False) == "T_co"
+        assert stringify(T_co, True) == "T_co"
+
+        assert stringify(T_contra, False) == "T_contra"
+        assert stringify(T_contra, True) == "T_contra"
+
+        assert stringify(List[T], False) == "List[T]"
+        assert stringify(List[T], True) == "~typing.List[T]"
     else:
-        assert stringify(T) == "tests.test_util_typing.T"
-        assert stringify(T_co) == "tests.test_util_typing.T_co"
-        assert stringify(T_contra) == "tests.test_util_typing.T_contra"
-        assert stringify(List[T]) == "List[tests.test_util_typing.T]"
+        assert stringify(T, False) == "tests.test_util_typing.T"
+        assert stringify(T, True) == "~tests.test_util_typing.T"
+
+        assert stringify(T_co, False) == "tests.test_util_typing.T_co"
+        assert stringify(T_co, True) == "~tests.test_util_typing.T_co"
+
+        assert stringify(T_contra, False) == "tests.test_util_typing.T_contra"
+        assert stringify(T_contra, True) == "~tests.test_util_typing.T_contra"
+
+        assert stringify(List[T], False) == "List[tests.test_util_typing.T]"
+        assert stringify(List[T], True) == "~typing.List[~tests.test_util_typing.T]"
 
     if sys.version_info >= (3, 10):
-        assert stringify(MyInt) == "tests.test_util_typing.MyInt"
+        assert stringify(MyInt, False) == "tests.test_util_typing.MyInt"
+        assert stringify(MyInt, True) == "~tests.test_util_typing.MyInt"
     else:
-        assert stringify(MyInt) == "MyInt"
+        assert stringify(MyInt, False) == "MyInt"
+        assert stringify(MyInt, True) == "MyInt"
 
 
 def test_stringify_type_hints_custom_class():
-    assert stringify(MyClass1) == "tests.test_util_typing.MyClass1"
-    assert stringify(MyClass2) == "tests.test_util_typing.<MyClass2>"
+    assert stringify(MyClass1, False) == "tests.test_util_typing.MyClass1"
+    assert stringify(MyClass1, True) == "~tests.test_util_typing.MyClass1"
+
+    assert stringify(MyClass2, False) == "tests.test_util_typing.<MyClass2>"
+    assert stringify(MyClass2, True) == "~tests.test_util_typing.<MyClass2>"
 
 
 def test_stringify_type_hints_alias():
     MyStr = str
     MyTuple = Tuple[str, str]
-    assert stringify(MyStr) == "str"
-    assert stringify(MyTuple) == "Tuple[str, str]"  # type: ignore
+
+    assert stringify(MyStr, False) == "str"
+    assert stringify(MyStr, True) == "str"
+
+    assert stringify(MyTuple, False) == "Tuple[str, str]"  # type: ignore
+    assert stringify(MyTuple, True) == "~typing.Tuple[str, str]"  # type: ignore
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason='python 3.8+ is required.')
 def test_stringify_type_Literal():
     from typing import Literal  # type: ignore
-    assert stringify(Literal[1, "2", "\r"]) == "Literal[1, '2', '\\r']"
+    assert stringify(Literal[1, "2", "\r"], False) == "Literal[1, '2', '\\r']"
+    assert stringify(Literal[1, "2", "\r"], True) == "~typing.Literal[1, '2', '\\r']"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='python 3.10+ is required.')
 def test_stringify_type_union_operator():
-    assert stringify(int | None) == "int | None"  # type: ignore
-    assert stringify(int | str) == "int | str"  # type: ignore
-    assert stringify(int | str | None) == "int | str | None"  # type: ignore
+    assert stringify(int | None, False) == "int | None"  # type: ignore
+    assert stringify(int | None, True) == "int | None"  # type: ignore
+
+    assert stringify(int | str, False) == "int | str"  # type: ignore
+    assert stringify(int | str, True) == "int | str"  # type: ignore
+
+    assert stringify(int | str | None, False) == "int | str | None"  # type: ignore
+    assert stringify(int | str | None, True) == "int | str | None"  # type: ignore
 
 
 def test_stringify_broken_type_hints():
-    assert stringify(BrokenType) == 'tests.test_util_typing.BrokenType'
+    assert stringify(BrokenType, False) == 'tests.test_util_typing.BrokenType'
+    assert stringify(BrokenType, True) == '~tests.test_util_typing.BrokenType'
 
 
 def test_stringify_mock():
     with mock(['unknown']):
         import unknown
-        assert stringify(unknown.secret.Class) == 'unknown.secret.Class'
+        assert stringify(unknown.secret.Class, False) == 'unknown.secret.Class'
+        assert stringify(unknown.secret.Class, True) == 'unknown.secret.Class'


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- If autodoc_unqualified_typehints feature enabled, autodoc suppresses the
leading module names of typehints of function signatures (ex.
`io.StringIO` -> `StringIO`)
- refs: #9075 