### PR TITLE
tox: support coverage on win32

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ basepython = python3
 description =
     Run code coverage checks.
 setenv =
-    PYTEST_ADDOPTS = --cov sphinx --cov-config {toxinidir}/setup.cfg
+    PYTEST_ADDOPTS = --cov sphinx --cov-config "{toxinidir}/setup.cfg"
 commands =
     {[testenv]commands}
     coverage report


### PR DESCRIPTION
When invoking the `coverage` on a Windows environment, the following exception may generate:

    ...
        raise CoverageException(f"Couldn't read {fname!r} as a config file")
    coverage.exceptions.CoverageException: Couldn't read 'C:mycodesphinx/setup.cfg' as a config file
    ERROR: InvocationError for command 'C:\mycode\sphinx\.tox\coverage\Scripts\python.EXE' -X dev -m pytest --durations 25 (exited with code 1)

Enclosing with configuration file with quotes can improve the handling of a provided path on multiple platform types.
