### PR TITLE
Fix #9944 (LaTeX writer visit_desc_content())

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #9917: C and C++, parse fundamental types no matter the order of simple type
   specifiers.
+* #9944: LaTeX: extra vertical whitespace for some nested declarations
 
 Testing
 --------

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -757,9 +757,7 @@ class LaTeXTranslator(SphinxTranslator):
         self._depart_signature_line(node)
 
     def visit_desc_content(self, node: Element) -> None:
-        if node.children and not isinstance(node.children[0], nodes.paragraph):
-            # avoid empty desc environment which causes a formatting bug
-            self.body.append('~')
+        pass
 
     def depart_desc_content(self, node: Element) -> None:
         pass


### PR DESCRIPTION
Relates #9926 

With this, the following

```
.. option:: -mmmx
            -msse
            -msse2

   .. note::

      A note in the option description

.. c:function:: PyObject *PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)

   .. note::

      Extra vertical space also in this case if note is first item

.. cpp:class:: Data

   .. cpp:union:: @data

      .. cpp:var:: int a

      .. cpp:var:: double b

Explicit ref: :cpp:var:Data::@data::a. Short-hand ref: :cpp:var:Data::a.
```

produces

![Capture d’écran 2021-12-05 à 21 44 56](https://user-images.githubusercontent.com/2589111/144764095-1fcf0a3c-3f2a-4449-90a4-9a9393637c5e.png)

Comparing to the output shown in issue #9944, it only fixes the vertical space for the option with note and nested declaration case, not for the note at start of function description.

The PR removes from LaTeX markup  an  `~`  which was added 14 years ago at 3761223d85b16. The `~` causes LaTeX to enter into paragraph mode and then this causes vertical space if some "display block" type of entity (such as a note) follows).

It *seems* not to be needed anymore. I could not find an example where the `~` to avoid empty contents would avoid a "formatting bug" and don't know where to look.




