### PR TITLE
LaTeX: prohibit also with xelatex linebreaks at dashes in literal text (not code-blocks) (fixes #9925)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,8 @@ Bugs fixed
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url
 * #9909: HTML, prevent line-wrapping in literal text.
+* #9925: LaTeX: prohibit also with ``'xelatex'`` line splitting at dashes of
+  inline and parsed literals
 
 Testing
 --------

--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -1,7 +1,7 @@
 %% LITERAL BLOCKS
 %
 % change this info string if making any custom modification
-\ProvidesFile{sphinxlatexliterals.sty}[2021/01/27 code-blocks and parsed literals]
+\ProvidesFile{sphinxlatexliterals.sty}[2021/12/06 code-blocks and parsed literals]
 
 % Provides support for this output mark-up from Sphinx latex writer:
 %
@@ -711,6 +711,9 @@
  \ifspx@opt@parsedliteralwraps
    \sbox\sphinxcontinuationbox {\spx@opt@verbatimcontinued}%
    \sbox\sphinxvisiblespacebox {\spx@opt@verbatimvisiblespace}%
+% this uses a monospace font and linebreaks at dashes will be inhibited with
+% pdflatex; not so with xelatex (cf \defaultfontfeatures in latex writer) so:
+   \def\sphinxhyphen{\mbox{-}}%
    \sphinxbreaksattexescapedchars
    \sphinxbreaksviaactiveinparsedliteral
    \sphinxbreaksatspaceinparsedliteral
@@ -762,6 +765,10 @@
 \protected\def\sphinxupquote#1{{\def\@tempa{alltt}%
   \ifx\@tempa\@currenvir\else
    \ifspx@opt@inlineliteralwraps
+      % a priori, this is typeset using a monospace font (cf \sphinxcode in
+      % sphinxlatexstyletext.sty) so linebreaks at dashes are inhibited;
+      % but, for xelatex or in case of non-monospace font, let's do this:
+      \def\sphinxhyphen{\mbox{-}}%
       % break at . , ; ? ! /
       \sphinxbreaksviaactive
       % break also at \

--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -704,6 +704,10 @@
 % the \catcode13=5\relax (deactivate end of input lines) is left to callers
 \newcommand*{\sphinxunactivateextrasandspace}{\catcode32=10\relax
       \sphinxunactivateextras}%
+% alltt uses a monospace font and linebreaks at dashes (which are escaped
+% to \sphinxhyphen{} which expands to -\kern\z@) are inhibited with pdflatex.
+% Not with xelatex (cf \defaultfontfeatures in latex writer), so:
+\newcommand*{\sphinxhypheninparsedliteral}{\sphinxhyphennobreak}
 % now for the modified alltt environment
 \newenvironment{sphinxalltt}
 {% at start of next line to workaround Emacs/AUCTeX issue with this file
@@ -711,9 +715,7 @@
  \ifspx@opt@parsedliteralwraps
    \sbox\sphinxcontinuationbox {\spx@opt@verbatimcontinued}%
    \sbox\sphinxvisiblespacebox {\spx@opt@verbatimvisiblespace}%
-% this uses a monospace font and linebreaks at dashes will be inhibited with
-% pdflatex; not so with xelatex (cf \defaultfontfeatures in latex writer) so:
-   \def\sphinxhyphen{\mbox{-}}%
+   \let\sphinxhyphen\sphinxhypheninparsedliteral
    \sphinxbreaksattexescapedchars
    \sphinxbreaksviaactiveinparsedliteral
    \sphinxbreaksatspaceinparsedliteral
@@ -760,15 +762,15 @@
 \protected\def\sphinxtextbackslashbreakafter
  {\discretionary{\sphinx@textbackslash}{\sphinxafterbreak}{\sphinx@textbackslash}}
 \let\sphinxtextbackslash\sphinxtextbackslashbreakafter
+% - is escaped to \sphinxhyphen{} and this default ensures no linebreak
+% behaviour (also with a non monospace font, or with xelatex)
+\newcommand*{\sphinxhyphenininlineliteral}{\sphinxhyphennobreak}
 % the macro must be protected if it ends up used in moving arguments,
 % in 'alltt' \@noligs is done already, and the \scantokens must be avoided.
 \protected\def\sphinxupquote#1{{\def\@tempa{alltt}%
   \ifx\@tempa\@currenvir\else
+   \let\sphinxhyphen\sphinxhyphenininlineliteral
    \ifspx@opt@inlineliteralwraps
-      % a priori, this is typeset using a monospace font (cf \sphinxcode in
-      % sphinxlatexstyletext.sty) so linebreaks at dashes are inhibited;
-      % but, for xelatex or in case of non-monospace font, let's do this:
-      \def\sphinxhyphen{\mbox{-}}%
       % break at . , ; ? ! /
       \sphinxbreaksviaactive
       % break also at \

--- a/sphinx/texinputs/sphinxlatexstyletext.sty
+++ b/sphinx/texinputs/sphinxlatexstyletext.sty
@@ -1,7 +1,7 @@
 %% TEXT STYLING
 %
 % change this info string if making any custom modification
-\ProvidesFile{sphinxlatexstyletext.sty}[2021/01/27 text styling]
+\ProvidesFile{sphinxlatexstyletext.sty}[2021/12/06 text styling]
 
 % Basically everything here consists of macros which are part of the latex
 % markup produced by the Sphinx latex writer
@@ -72,11 +72,17 @@
 
 % Special characters
 %
-% This definition prevents en-dash and em-dash TeX ligatures.
+% The \kern\z@ is to prevent en-dash and em-dash TeX ligatures.
+% A linebreak can occur after the dash in regular text (this is
+% normal behaviour of "-" in TeX, it is not related to \kern\z@).
 %
-% It inserts a potential breakpoint after the hyphen. This is to keep in sync
-% with behavior in code-blocks, parsed and inline literals. For a breakpoint
-% before the hyphen use \leavevmode\kern\z@- (within \makeatletter/\makeatother)
+% Parsed-literals and inline literals also use the \sphinxhyphen
+% but linebreaks there are prevented due to monospace font family.
+% (xelatex needs a special addition, cf. sphinxlatexliterals.sty)
+%
+% Inside code-blocks, dashes are escaped via another macro, from
+% Pygments latex output (search for \PYGZhy in sphinxlatexliterals.sty),
+% and are configured to allow linebreaks despite the monospace font.
 \protected\def\sphinxhyphen#1{-\kern\z@}
 % The {} from texescape mark-up is kept, else -- gives en-dash in PDF bookmark
 \def\sphinxhyphenforbookmarks{-}

--- a/sphinx/texinputs/sphinxlatexstyletext.sty
+++ b/sphinx/texinputs/sphinxlatexstyletext.sty
@@ -83,7 +83,9 @@
 % Inside code-blocks, dashes are escaped via another macro, from
 % Pygments latex output (search for \PYGZhy in sphinxlatexliterals.sty),
 % and are configured to allow linebreaks despite the monospace font.
+% (the #1 swallows the {} from \sphinxhyphen{} mark-up)
 \protected\def\sphinxhyphen#1{-\kern\z@}
+\protected\def\sphinxhyphennobreak#1{\mbox{-}}
 % The {} from texescape mark-up is kept, else -- gives en-dash in PDF bookmark
 \def\sphinxhyphenforbookmarks{-}
 


### PR DESCRIPTION
Fix #9925 

The behaviour of xelatex diverged from the one of pdflatex: the latter prohibited linebreaks at dashes in literal text (not code-blocks) as after effect of monospace font. But not so with xelatex. Now it will be prohibited for both, even if not using monospace font for the literal text rendering.

Linebreaks at dashes encountered in regular text will still be happening (on purpose).

The PR also fixes some truly misleading comments in sphinxlatexstyletext.sty file