### PR TITLE
Fix #9947: i18n: topic directive having a bullet list can't be translatable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Bugs fixed
 * #9883: autodoc: doccomment for the alias to mocked object was ignored
 * #9908: autodoc: debug message is shown on building document using NewTypes
   with Python 3.10
+* #9947: i18n: topic directive having a bullet list can't be translatable
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url
 * #9909: HTML, prevent line-wrapping in literal text.

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -208,7 +208,7 @@ class ApplySourceWorkaround(SphinxTransform):
 
     def apply(self, **kwargs: Any) -> None:
         for node in self.document.traverse():  # type: Node
-            if isinstance(node, (nodes.TextElement, nodes.image)):
+            if isinstance(node, (nodes.TextElement, nodes.image, nodes.topic)):
                 apply_source_workaround(node)
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -150,6 +150,11 @@ def apply_source_workaround(node: Element) -> None:
         for classifier in reversed(list(node.parent.traverse(nodes.classifier))):
             node.rawsource = re.sub(r'\s*:\s*%s' % re.escape(classifier.astext()),
                                     '', node.rawsource)
+    if isinstance(node, nodes.topic) and node.source is None:
+        # docutils-0.18 does not fill the source attribute of topic
+        logger.debug('[i18n] PATCH: %r to have source, line: %s',
+                     get_full_module_name(node), repr_domxml(node))
+        node.source, node.line = node.parent.source, node.parent.line
 
     # workaround: literal_block under bullet list (#4913)
     if isinstance(node, nodes.literal_block) and node.source is None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It seems docutils does not fill the topic node with the source info when
a topic directive has a bullet list.  As a workaround, This fills the
source info of them.
