### PR TITLE
Reduce DeprecationWarnings

### DIFF
--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -30,10 +30,10 @@ def test_theme_api(app, status, warning):
         themes.append('alabaster')
 
     # test Theme class API
-    assert set(app.html_themes.keys()) == set(themes)
-    assert app.html_themes['test-theme'] == app.srcdir / 'test_theme' / 'test-theme'
-    assert app.html_themes['ziptheme'] == app.srcdir / 'ziptheme.zip'
-    assert app.html_themes['staticfiles'] == app.srcdir / 'test_theme' / 'staticfiles'
+    assert set(app.registry.html_themes.keys()) == set(themes)
+    assert app.registry.html_themes['test-theme'] == app.srcdir / 'test_theme' / 'test-theme'
+    assert app.registry.html_themes['ziptheme'] == app.srcdir / 'ziptheme.zip'
+    assert app.registry.html_themes['staticfiles'] == app.srcdir / 'test_theme' / 'staticfiles'
 
     # test Theme instance API
     theme = app.builder.theme

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,8 @@
 import contextlib
 import http.server
 import pathlib
-import ssl
 import threading
+from ssl import PROTOCOL_TLS_SERVER, SSLContext
 
 # Generated with:
 # $ openssl req -new -x509 -days 3650 -nodes -out cert.pem \
@@ -27,11 +27,9 @@ class HttpServerThread(threading.Thread):
 class HttpsServerThread(HttpServerThread):
     def __init__(self, handler, *args, **kwargs):
         super().__init__(handler, *args, **kwargs)
-        self.server.socket = ssl.wrap_socket(
-            self.server.socket,
-            certfile=CERT_FILE,
-            server_side=True,
-        )
+        sslcontext = SSLContext(PROTOCOL_TLS_SERVER)
+        sslcontext.load_cert_chain(CERT_FILE)
+        self.server.socket = sslcontext.wrap_socket(self.server.socket, server_side=True)
 
 
 def create_server(thread_class):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- app.html_themes was replaced by registry.html_themes
- ssl.wrap_context() has been deprecated now
- see https://github.com/sphinx-doc/sphinx/runs/4490369684?check_suite_focus=true