### PR TITLE
Fix #9108: docs: Use default pygments_theme to get accessiblity

### DIFF
--- a/doc/_themes/sphinx13/theme.conf
+++ b/doc/_themes/sphinx13/theme.conf
@@ -1,4 +1,4 @@
 [theme]
 inherit = basic
 stylesheet = sphinx13.css
-pygments_style = trac
+pygments_style = default


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- To increse accessiblity of our docs, this changes the pygments_theme of
sphinx-docs.org to "default".  It was updated to meet WCAG AA in
https://github.com/pygments/pygments/pull/1940.
- refs: #9108 