### PR TITLE
doc: Use "console" for the highlight language of console output

### DIFF
--- a/doc/development/theming.rst
+++ b/doc/development/theming.rst
@@ -285,7 +285,7 @@ engine, allowing you to embed variables and control behavior.
 
 For example, the following JavaScript structure:
 
-.. code-block:: bash
+.. code-block:: none
 
    mymodule/
    ├── _static
@@ -294,7 +294,7 @@ For example, the following JavaScript structure:
 
 Will result in the following static file placed in your HTML's build output:
 
-.. code-block:: bash
+.. code-block:: none
 
    _build/
    └── html

--- a/doc/man/sphinx-autogen.rst
+++ b/doc/man/sphinx-autogen.rst
@@ -75,7 +75,7 @@ and assuming ``docs/index.rst`` contained the following:
 
 If you run the following:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ PYTHONPATH=. sphinx-autogen docs/index.rst
 

--- a/doc/usage/advanced/setuptools.rst
+++ b/doc/usage/advanced/setuptools.rst
@@ -64,7 +64,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-E` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -E
 
@@ -75,7 +75,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-a` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -a
 
@@ -88,7 +88,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-s` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -s $SOURCE_DIR
 
@@ -105,7 +105,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-c` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -c $CONFIG_DIR
 
@@ -117,7 +117,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-b` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -b $BUILDER
 
@@ -131,7 +131,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-W` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -W
 
@@ -169,7 +169,7 @@ Options for setuptools integration
 
    This can also be set by passing the `-i` flag to ``setup.py``:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ python setup.py build_sphinx -i
 

--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -239,13 +239,13 @@ PDF builds using LaTeX.  Please choose one for your purpose.
    commands.  For example, you can use following command to create a Sphinx
    project:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ docker run -it --rm -v /path/to/document:/docs sphinxdoc/sphinx sphinx-quickstart
 
    And you can following command this to build HTML document:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ docker run --rm -v /path/to/document:/docs sphinxdoc/sphinx make html
 

--- a/doc/usage/quickstart.rst
+++ b/doc/usage/quickstart.rst
@@ -39,7 +39,7 @@ Sphinx comes with a script called :program:`sphinx-quickstart` that sets up a
 source directory and creates a default :file:`conf.py` with the most useful
 configuration values from a few questions it asks you. To use this, run:
 
-.. code-block:: shell
+.. code-block:: console
 
    $ sphinx-quickstart
 
@@ -128,7 +128,7 @@ Running the build
 Now that you have added some files and content, let's make a first build of the
 docs.  A build is started with the :program:`sphinx-build` program:
 
-.. code-block:: shell
+.. code-block:: console
 
    $ sphinx-build -b html sourcedir builddir
 
@@ -144,7 +144,7 @@ However, :program:`sphinx-quickstart` script creates a :file:`Makefile` and a
 :file:`make.bat` which make life even easier for you. These can be executed by
 running :command:`make` with the name of the builder. For example.
 
-.. code-block:: shell
+.. code-block:: console
 
    $ make html
 

--- a/doc/usage/theming.rst
+++ b/doc/usage/theming.rst
@@ -70,7 +70,7 @@ directory containing :file:`conf.py` and use this configuration::
 The third form is a Python package.  If a theme you want to use is distributed
 as a Python package, you can use it after installing
 
-.. code-block:: bash
+.. code-block:: console
 
     # installing theme package
     $ pip install sphinxjp.themes.dotted


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
Using "console" language is better for the console example (including
command-line prompt)
