### PR TITLE
Fix #9979: Error level messages were displayed as warning messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Bugs fixed
 * #9940: LaTeX: Multi-function declaration in Python domain has cramped
   vertical spacing in latexpdf output
 * #9390: texinfo: Do not emit labels inside footnotes
+* #9979: Error level messages were displayed as warning messages
 
 Testing
 --------

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -111,7 +111,14 @@ class SphinxInfoLogRecord(SphinxLogRecord):
 
 class SphinxWarningLogRecord(SphinxLogRecord):
     """Warning log record class supporting location"""
-    prefix = 'WARNING: '
+    @property
+    def prefix(self) -> str:  # type: ignore
+        if self.levelno >= logging.CRITICAL:
+            return 'CRITICAL: '
+        elif self.levelno >= logging.ERROR:
+            return 'ERROR: '
+        else:
+            return 'WARNING: '
 
 
 class SphinxLoggerAdapter(logging.LoggerAdapter):

--- a/tests/test_util_logging.py
+++ b/tests/test_util_logging.py
@@ -41,9 +41,9 @@ def test_info_and_warning(app, status, warning):
 
     assert 'message1' not in warning.getvalue()
     assert 'message2' not in warning.getvalue()
-    assert 'message3' in warning.getvalue()
-    assert 'message4' in warning.getvalue()
-    assert 'message5' in warning.getvalue()
+    assert 'WARNING: message3' in warning.getvalue()
+    assert 'CRITICAL: message4' in warning.getvalue()
+    assert 'ERROR: message5' in warning.getvalue()
 
 
 def test_Exception(app, status, warning):
@@ -305,8 +305,8 @@ def test_colored_logs(app, status, warning):
     assert 'message2\n' in status.getvalue()  # not colored
     assert 'message3\n' in status.getvalue()  # not colored
     assert colorize('red', 'WARNING: message4') in warning.getvalue()
-    assert 'WARNING: message5\n' in warning.getvalue()  # not colored
-    assert colorize('darkred', 'WARNING: message6') in warning.getvalue()
+    assert 'CRITICAL: message5\n' in warning.getvalue()  # not colored
+    assert colorize('darkred', 'ERROR: message6') in warning.getvalue()
 
     # color specification
     logger.debug('message7', color='white')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9979 