### PR TITLE
doc: Update explanation of autodoc_unqualified_typehints (ref: #9931)

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -664,8 +664,8 @@ There are also config values that you can set:
 
 .. confval:: autodoc_unqualified_typehints
 
-   If True, the leading module names of typehints of function signatures (ex.
-   ``io.StringIO`` -> ``StringIO``).  Defaults to False.
+   If True, the leading module names of typehints of function signatures are
+   removed (ex.  ``io.StringIO`` -> ``StringIO``).  Defaults to False.
 
    .. versionadded:: 4.4
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9931
- refs: https://github.com/sphinx-doc/sphinx/commit/d3162d1ff2e24f4d190ed3ba5bc76d72c781f791#r61893008
