### PR TITLE
Fix #9968: autodoc: ivars are not shown if __init__ has posonlyargs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,8 @@ Bugs fixed
 * #9883: autodoc: doccomment for the alias to mocked object was ignored
 * #9908: autodoc: debug message is shown on building document using NewTypes
   with Python 3.10
+* #9968: autodoc: instance variables are not shown if __init__ method has
+  position-only-arguments
 * #9947: i18n: topic directive having a bullet list can't be translatable
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -312,6 +312,10 @@ class VariableCommentPicker(ast.NodeVisitor):
         """Returns the name of the first argument if in a function."""
         if self.current_function and self.current_function.args.args:
             return self.current_function.args.args[0]
+        elif (self.current_function and
+              getattr(self.current_function.args, 'posonlyargs', None)):
+            # for py38+
+            return self.current_function.args.posonlyargs[0]  # type: ignore
         else:
             return None
 

--- a/tests/test_pycode.py
+++ b/tests/test_pycode.py
@@ -191,3 +191,18 @@ def test_ModuleAnalyzer_find_attr_docs():
                                  'Qux': 15,
                                  'Qux.attr1': 16,
                                  'Qux.attr2': 17}
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8),
+                    reason='posonlyargs are available since python3.8.')
+def test_ModuleAnalyzer_find_attr_docs_for_posonlyargs_method():
+    code = ('class Foo(object):\n'
+            '    def __init__(self, /):\n'
+            '       self.attr = None  #: attribute comment\n')
+    analyzer = ModuleAnalyzer.for_string(code, 'module')
+    docs = analyzer.find_attr_docs()
+    assert set(docs) == {('Foo', 'attr')}
+    assert docs[('Foo', 'attr')] == ['attribute comment', '']
+    assert analyzer.tagorder == {'Foo': 0,
+                                 'Foo.__init__': 1,
+                                 'Foo.attr': 2}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9968 