### PR TITLE
Fix #9962: texinfo: Do not use @definfoenclose to empasize string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #9962: texinfo: Customizing styles of emphasized text via ``@definfoenclose``
+  command was not supported because the command was deprecated since texinfo 6.8
 * #2068: :confval:`intersphinx_disabled_reftypes` has changed default value
   from an empty list to ``['std:doc']`` as avoid too surprising silent
   intersphinx resolutions.
@@ -22,6 +24,9 @@ Features added
 
 Bugs fixed
 ----------
+
+* #9962: texinfo: Deprecation message for ``@definfoenclose`` command on
+  bulding texinfo document
 
 Testing
 --------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -350,19 +350,3 @@ The following notes may be helpful if you want to create Texinfo files:
   scheme ``info``.  For example::
 
      info:Texinfo#makeinfo_options
-
-- Inline markup
-
-  The standard formatting for ``*strong*`` and ``_emphasis_`` can
-  result in ambiguous output when used to markup parameter names and
-  other values.  Since this is a fairly common practice, the default
-  formatting has been changed so that ``emphasis`` and ``strong`` are
-  now displayed like ```literal'``\s.
-
-  The standard formatting can be re-enabled by adding the following to
-  your :file:`conf.py`::
-
-     texinfo_elements = {'preamble': """
-     @definfoenclose strong,*,*
-     @definfoenclose emph,_,_
-     """}

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -58,8 +58,6 @@ TEMPLATE = """\
 @exampleindent %(exampleindent)s
 @finalout
 %(direntry)s
-@definfoenclose strong,`,'
-@definfoenclose emph,`,'
 @c %%**end of header
 
 @copying
@@ -805,17 +803,21 @@ class TexinfoTranslator(SphinxTranslator):
     # -- Inline
 
     def visit_strong(self, node: Element) -> None:
-        self.body.append('@strong{')
+        self.body.append('`')
 
     def depart_strong(self, node: Element) -> None:
-        self.body.append('}')
+        self.body.append("'")
 
     def visit_emphasis(self, node: Element) -> None:
-        element = 'emph' if not self.in_samp else 'var'
-        self.body.append('@%s{' % element)
+        if self.in_samp:
+            self.body.append('@var{')
+            self.context.append('}')
+        else:
+            self.body.append('`')
+            self.context.append("'")
 
     def depart_emphasis(self, node: Element) -> None:
-        self.body.append('}')
+        self.body.append(self.context.pop())
 
     def is_samp(self, node: Element) -> bool:
         return 'samp' in node['classes']


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since texinfo-6.8, `@definfoenclose` command has been deprecated. This
stops to use it to reduce the deprecation warning.
- This also disables the customization the styles of emphasized text via
the command.
- refs: #9962 