### PR TITLE
[proposal] the "ja" message of _("see %s") and _("see also %s") in sphinx.po

### DIFF
--- a/sphinx/locale/ja/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ja/LC_MESSAGES/sphinx.po
@@ -2371,12 +2371,12 @@ msgstr "ドキュメントはどの toctree にも含まれていません"
 #: sphinx/environment/adapters/indexentries.py:78
 #, python-format
 msgid "see %s"
-msgstr "%sを参照"
+msgstr "「%s」を参照"
 
 #: sphinx/environment/adapters/indexentries.py:82
 #, python-format
 msgid "see also %s"
-msgstr "%sも参照"
+msgstr "「%s」も参照"
 
 #: sphinx/environment/adapters/indexentries.py:85
 #, python-format


### PR DESCRIPTION
Subject: Adjust the message so that it is natural as Japanese.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Others: 4.x

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Refactoring

### Purpose
Adjust the message so that it is natural as Japanese.

### Detail
_("see %s") of the "ja" sphinx.po

- current status.: "%sを参照"
- proposal: "「%s」を参照"

_("see also %s") of the "ja" sphinx.po

- current status: "%sも参照"
- proposal:  "「%s」も参照"

### Relates
none.

### other
You can use locale_dirs to deal with this, but I suggested it because I thought it was a change that many Japanese would accept.