### PR TITLE
Close #9993: std domain: Allow to refer an inline target via ref role

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ Features added
   checking in matched documents.
 * #9793: sphinx-build: Allow to use the parallel build feature in macOS on macOS
   and Python3.8+
+* #9993: std domain: Allow to refer an inline target (ex. ``_`target name```)
+  via :rst:role:`ref` role
 * #9391: texinfo: improve variable in ``samp`` role
 * #9578: texinfo: Add :confval:`texinfo_cross_references` to disable cross
   references for readability with standalone readers

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -770,10 +770,11 @@ class StandardDomain(Domain):
                 sectname = clean_astext(title)
             elif node.tagname == 'rubric':
                 sectname = clean_astext(node)
+            elif node.tagname == 'target' and len(node) > 0:
+                # inline target (ex: blah _`blah` blah)
+                sectname = clean_astext(node)
             elif self.is_enumerable_node(node):
                 sectname = self.get_numfig_title(node)
-                if not sectname:
-                    continue
             else:
                 toctree = next(iter(node.traverse(addnodes.toctree)), None)
                 if toctree and toctree.get('caption'):
@@ -781,7 +782,8 @@ class StandardDomain(Domain):
                 else:
                     # anonymous-only labels
                     continue
-            self.labels[name] = docname, labelid, sectname
+            if sectname:
+                self.labels[name] = docname, labelid, sectname
 
     def add_program_option(self, program: str, name: str, docname: str, labelid: str) -> None:
         self.progoptions[program, name] = (docname, labelid)

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -452,3 +452,12 @@ def test_labeled_rubric(app):
     domain = app.env.get_domain("std")
     assert 'label' in domain.labels
     assert domain.labels['label'] == ('index', 'label', 'blah blah blah')
+
+
+def test_inline_target(app):
+    text = "blah _`inline target` blah\n"
+    restructuredtext.parse(app, text)
+
+    domain = app.env.get_domain("std")
+    assert 'inline target' in domain.labels
+    assert domain.labels['inline target'] == ('index', 'inline-target', 'inline target')


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #9993 