### PR TITLE
Fix a spelling typo in tests (s/änhlich/ähnlich)

### DIFF
--- a/tests/roots/test-glossary/index.rst
+++ b/tests/roots/test-glossary/index.rst
@@ -18,5 +18,5 @@ test-glossary
    über
       Gewisse
 
-   änhlich
+   ähnlich
       Dinge

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -352,7 +352,7 @@ This tests :CLASS:`role names in uppercase`.
    über
       Gewisse
 
-   änhlich
+   ähnlich
       Dinge
 
 .. productionlist::

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1454,9 +1454,9 @@ def test_latex_glossary(app, status, warning):
     app.builder.build_all()
 
     result = (app.outdir / 'python.tex').read_text()
-    assert ('\\item[{änhlich\\index{änhlich@\\spxentry{änhlich}|spxpagem}'
+    assert ('\\item[{ähnlich\\index{ähnlich@\\spxentry{ähnlich}|spxpagem}'
             r'\phantomsection'
-            r'\label{\detokenize{index:term-anhlich}}}] \leavevmode' in result)
+            r'\label{\detokenize{index:term-ahnlich}}}] \leavevmode' in result)
     assert (r'\item[{boson\index{boson@\spxentry{boson}|spxpagem}\phantomsection'
             r'\label{\detokenize{index:term-boson}}}] \leavevmode' in result)
     assert (r'\item[{\sphinxstyleemphasis{fermion}'


### PR DESCRIPTION
refactoring, fix a typo in a root test to avoid misadventures such as #9996 when copying pasting for other testing
