### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ install_requires = [
     'alabaster>=0.7,<0.8',
     'imagesize',
     'requests>=2.5.0',
-    'setuptools',
     'packaging',
+    "importlib-metadata>=4.4; python_version < '3.10'",
 ]
 
 extras_require = {
@@ -47,7 +47,6 @@ extras_require = {
         'mypy>=0.920',
         'docutils-stubs',
         "types-typed-ast",
-        "types-pkg_resources",
         "types-requests",
     ],
     'test': [

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -21,6 +21,7 @@ from docutils.nodes import Element, Node, TextElement
 from docutils.parsers import Parser
 from docutils.parsers.rst import Directive
 from docutils.transforms import Transform
+
 try:  # Python < 3.10 (backport)
     from importlib_metadata import entry_points
 except ImportError:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -21,7 +21,7 @@ from docutils.nodes import Element, Node, TextElement
 from docutils.parsers import Parser
 from docutils.parsers.rst import Directive
 from docutils.transforms import Transform
-try:
+try:  # Python < 3.10 (backport)
     from importlib_metadata import entry_points
 except ImportError:
     from importlib.metadata import entry_points

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -147,9 +147,9 @@ class SphinxComponentRegistry:
             return
 
         if name not in self.builders:
-            builder_eps = entry_points(group='sphinx.builders')
+            builder_entry_points = entry_points(group='sphinx.builders')
             try:
-                entry_point = builder_eps[name]
+                entry_point = builder_entry_points[name]
             except KeyError as exc:
                 raise SphinxError(__('Builder name %s not registered or available'
                                      ' through entry point') % name) from exc

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -21,7 +21,10 @@ from docutils.nodes import Element, Node, TextElement
 from docutils.parsers import Parser
 from docutils.parsers.rst import Directive
 from docutils.transforms import Transform
-from pkg_resources import iter_entry_points
+try:
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 from sphinx.builders import Builder
 from sphinx.config import Config
@@ -143,14 +146,14 @@ class SphinxComponentRegistry:
             return
 
         if name not in self.builders:
-            entry_points = iter_entry_points('sphinx.builders', name)
+            builder_eps = entry_points(group='sphinx.builders')
             try:
-                entry_point = next(entry_points)
-            except StopIteration as exc:
+                entry_point = builder_eps[name]
+            except KeyError as exc:
                 raise SphinxError(__('Builder name %s not registered or available'
                                      ' through entry point') % name) from exc
 
-            self.load_extension(app, entry_point.module_name)
+            self.load_extension(app, entry_point.module)
 
     def create_builder(self, app: "Sphinx", name: str) -> Builder:
         if name not in self.builders:

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -204,9 +204,9 @@ class HTMLThemeFactory:
         Sphinx refers to ``sphinx_themes`` entry_points.
         """
         # look up for new styled entry_points at first
-        theme_eps = entry_points(group='sphinx.html_themes')
+        theme_entry_points = entry_points(group='sphinx.html_themes')
         try:
-            entry_point = theme_eps[name]
+            entry_point = theme_entry_points[name]
             self.app.registry.load_extension(self.app, entry_point.module)
             return
         except KeyError:

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -16,7 +16,10 @@ from os import path
 from typing import TYPE_CHECKING, Any, Dict, List
 from zipfile import ZipFile
 
-import pkg_resources
+try:  # Python < 3.10 (backport)
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 from sphinx import package_dir
 from sphinx.errors import ThemeError
@@ -201,12 +204,12 @@ class HTMLThemeFactory:
         Sphinx refers to ``sphinx_themes`` entry_points.
         """
         # look up for new styled entry_points at first
-        entry_points = pkg_resources.iter_entry_points('sphinx.html_themes', name)
+        theme_eps = entry_points(group='sphinx.html_themes')
         try:
-            entry_point = next(entry_points)
-            self.app.registry.load_extension(self.app, entry_point.module_name)
+            entry_point = theme_eps[name]
+            self.app.registry.load_extension(self.app, entry_point.module)
             return
-        except StopIteration:
+        except KeyError:
             pass
 
     def find_themes(self, theme_path: str) -> Dict[str, str]:


### PR DESCRIPTION
### Feature or Bugfix

- Feature

### Purpose

As discussed in #9595, `importlib.metadata` is the modern way to find entry points, replacing `pkg_resources`. It's in the standard library from 3.8, but part of the API I've used is new in 3.10, so the [`importlib_metadata` backport](https://pypi.org/project/importlib-metadata/) is used on older versions.

Concretely, `pkg_resources` scans metadata from all packages at import time, which is generally considered a bad thing. `importlib.metadata` only scans metadata when it's called.