### PR TITLE
Fix #10015: autodoc: autodoc_typehints_format='short' does not work when autodoc_typehints='description'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,8 @@ Bugs fixed
 * #9944: LaTeX: extra vertical whitespace for some nested declarations
 * #9940: LaTeX: Multi-function declaration in Python domain has cramped
   vertical spacing in latexpdf output
+* #10015: py domain: types under the "typing" module are not hyperlinked defined
+  at info-field-list
 * #9390: texinfo: Do not emit labels inside footnotes
 * #9979: Error level messages were displayed as warning messages
 

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -23,6 +23,11 @@ from sphinx.util import inspect, typing
 def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
                      options: Dict, args: str, retann: str) -> None:
     """Record type hints to env object."""
+    if app.config.autodoc_typehints_format == 'short':
+        mode = 'smart'
+    else:
+        mode = 'fully-qualified'
+
     try:
         if callable(obj):
             annotations = app.env.temp_data.setdefault('annotations', {})
@@ -30,9 +35,9 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
             sig = inspect.signature(obj, type_aliases=app.config.autodoc_type_aliases)
             for param in sig.parameters.values():
                 if param.annotation is not param.empty:
-                    annotation[param.name] = typing.stringify(param.annotation)
+                    annotation[param.name] = typing.stringify(param.annotation, mode)
             if sig.return_annotation is not sig.empty:
-                annotation['return'] = typing.stringify(sig.return_annotation)
+                annotation['return'] = typing.stringify(sig.return_annotation, mode)
     except (TypeError, ValueError):
         pass
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -1196,7 +1196,9 @@ def test_type_field(app):
     text = (".. py:data:: var1\n"
             "   :type: .int\n"
             ".. py:data:: var2\n"
-            "   :type: ~builtins.int\n")
+            "   :type: ~builtins.int\n"
+            ".. py:data:: var3\n"
+            "   :type: typing.Optional[typing.Tuple[int, typing.Any]]\n")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index,
                           [desc, ([desc_signature, ([desc_name, "var1"],
@@ -1209,9 +1211,28 @@ def test_type_field(app):
                                                     [desc_annotation, ([desc_sig_punctuation, ':'],
                                                                        desc_sig_space,
                                                                        [pending_xref, "int"])])],
+                                  [desc_content, ()])],
+                          addnodes.index,
+                          [desc, ([desc_signature, ([desc_name, "var3"],
+                                                    [desc_annotation, ([desc_sig_punctuation, ":"],
+                                                                       desc_sig_space,
+                                                                       [pending_xref, "Optional"],
+                                                                       [desc_sig_punctuation, "["],
+                                                                       [pending_xref, "Tuple"],
+                                                                       [desc_sig_punctuation, "["],
+                                                                       [pending_xref, "int"],
+                                                                       [desc_sig_punctuation, ","],
+                                                                       desc_sig_space,
+                                                                       [pending_xref, "Any"],
+                                                                       [desc_sig_punctuation, "]"],
+                                                                       [desc_sig_punctuation, "]"])])],
                                   [desc_content, ()])]))
     assert_node(doctree[1][0][1][2], pending_xref, reftarget='int', refspecific=True)
     assert_node(doctree[3][0][1][2], pending_xref, reftarget='builtins.int', refspecific=False)
+    assert_node(doctree[5][0][1][2], pending_xref, reftarget='typing.Optional', refspecific=False)
+    assert_node(doctree[5][0][1][4], pending_xref, reftarget='typing.Tuple', refspecific=False)
+    assert_node(doctree[5][0][1][6], pending_xref, reftarget='int', refspecific=False)
+    assert_node(doctree[5][0][1][9], pending_xref, reftarget='typing.Any', refspecific=False)
 
 
 @pytest.mark.sphinx(freshenv=True)

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -835,7 +835,7 @@ def test_autodoc_typehints_description(app):
             '      **x** (*Tuple**[**int**, **Union**[**int**, **str**]**]*) --\n'
             '\n'
             '   Return type:\n'
-            '      Tuple[int, int]\n'
+            '      *Tuple*[int, int]\n'
             in context)
 
     # Overloads still get displayed in the signature
@@ -887,7 +887,7 @@ def test_autodoc_typehints_description_no_undoc(app):
             '      another tuple\n'
             '\n'
             '   Return type:\n'
-            '      Tuple[int, int]\n'
+            '      *Tuple*[int, int]\n'
             in context)
 
 
@@ -978,7 +978,7 @@ def test_autodoc_typehints_both(app):
             '      **x** (*Tuple**[**int**, **Union**[**int**, **str**]**]*) --\n'
             '\n'
             '   Return type:\n'
-            '      Tuple[int, int]\n'
+            '      *Tuple*[int, int]\n'
             in context)
 
     # Overloads still get displayed in the signature


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- refs: #10015 
- This also fixes the types under the "typing" module are not hyperlinked defined
+  at info-field-list