### PR TITLE
autosummary: autosummary: import_by_name() now raises ImportExceptionGroup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #10031: autosummary: ``sphinx.ext.autosummary.import_by_name()`` now raises
+  ``ImportExceptionGroup`` instead of ``ImportError`` when it failed to import
+  target object.  Please handle the exception if your extension uses the
+  function to import Python object.  As a workaround, you can disable the
+  behavior via ``grouped_exception=False`` keyword argument until v7.0.
 * #9962: texinfo: Customizing styles of emphasized text via ``@definfoenclose``
   command was not supported because the command was deprecated since texinfo 6.8
 * #2068: :confval:`intersphinx_disabled_reftypes` has changed default value

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -431,7 +431,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
         ensuredir(path)
 
         try:
-            name, obj, parent, modname = import_by_name(entry.name, grouped_exception=True)
+            name, obj, parent, modname = import_by_name(entry.name)
             qualname = name.replace(modname + ".", "")
         except ImportExceptionGroup as exc:
             try:
@@ -508,7 +508,7 @@ def find_autosummary_in_docstring(name: str, module: str = None, filename: str =
                       RemovedInSphinx50Warning, stacklevel=2)
 
     try:
-        real_name, obj, parent, modname = import_by_name(name, grouped_exception=True)
+        real_name, obj, parent, modname = import_by_name(name)
         lines = pydoc.getdoc(obj).splitlines()
         return find_autosummary_in_lines(lines, module=name, filename=filename)
     except AttributeError:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- It starts to `ImportExceptionGroup` exception instead of `ImportError` by default
when it failed to import target object.
- refs: #10031 