### PR TITLE
refactor: Reduce usages of distutils (refs: #9820)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from distutils import log
 from io import StringIO
 
 from setuptools import find_packages, setup
@@ -148,8 +147,8 @@ else:
                 if catalog.fuzzy and not self.use_fuzzy:
                     continue
 
-                log.info('writing JavaScript strings in catalog %r to %r',
-                         po_file, js_file)
+                self.log.info('writing JavaScript strings in catalog %r to %r',
+                              po_file, js_file)
 
                 jscatalog = {}
                 for message in catalog:

--- a/tests/roots/test-setup/setup.py
+++ b/tests/roots/test-setup/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 from sphinx.setup_command import BuildDoc
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- distutils module is now deprecated and will be removed since Python
3.12.  So this reduces the usages of the module.
- refs: #9820 