### PR TITLE
i18n: meta strings are not translated with docutils-0.18

### DIFF
--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -16,6 +16,13 @@ from docutils.nodes import Element
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
+try:
+    from docutils.nodes import meta as docutils_meta  # type: ignore
+except ImportError:
+    # docutils-0.17 or older
+    from docutils.parsers.rst.directives.html import MetaBody
+    docutils_meta = MetaBody.meta
+
 
 class document(nodes.document):
     """The document root element patched by Sphinx.

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -29,13 +29,10 @@ from sphinx.util.osutil import SEP, os_path, relpath
 from sphinx.util.typing import OptionSpec
 
 try:
-    from docutils.nodes import meta as meta_node  # type: ignore
     from docutils.parsers.rst.directives.misc import Meta as MetaBase  # type: ignore
 except ImportError:
     # docutils-0.17 or older
     from docutils.parsers.rst.directives.html import Meta as MetaBase
-    from docutils.parsers.rst.directives.html import MetaBody
-    meta_node = MetaBody.meta
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -74,8 +71,10 @@ class Meta(MetaBase, SphinxDirective):
     def run(self) -> List[Node]:
         result = super().run()
         for node in result:
+            # for docutils-0.17 or older.  Since docutils-0.18, patching is no longer needed
+            # because it uses picklable node; ``docutils.nodes.meta``.
             if (isinstance(node, nodes.pending) and
-               isinstance(node.details['nodes'][0], meta_node)):
+               isinstance(node.details['nodes'][0], addnodes.docutils_meta)):
                 meta = node.details['nodes'][0]
                 meta.source = self.env.doc2path(self.env.docname)
                 meta.line = self.lineno

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -15,7 +15,7 @@ from os import path
 from typing import IO, Any, Dict, Iterable, List, Optional, Set, Tuple, Type
 
 from docutils import nodes
-from docutils.nodes import Node
+from docutils.nodes import Element, Node
 
 from sphinx import addnodes, package_dir
 from sphinx.environment import BuildEnvironment
@@ -193,8 +193,9 @@ class WordCollector(nodes.NodeVisitor):
         self.found_title_words: List[str] = []
         self.lang = lang
 
-    def is_meta_keywords(self, node: addnodes.meta) -> bool:
-        if isinstance(node, addnodes.meta) and node.get('name') == 'keywords':
+    def is_meta_keywords(self, node: Element) -> bool:
+        if (isinstance(node, (addnodes.meta, addnodes.docutils_meta)) and
+                node.get('name') == 'keywords'):
             meta_lang = node.get('lang')
             if meta_lang is None:  # lang not specified
                 return True
@@ -220,7 +221,7 @@ class WordCollector(nodes.NodeVisitor):
             self.found_words.extend(self.lang.split(node.astext()))
         elif isinstance(node, nodes.title):
             self.found_title_words.extend(self.lang.split(node.astext()))
-        elif isinstance(node, addnodes.meta) and self.is_meta_keywords(node):
+        elif isinstance(node, Element) and self.is_meta_keywords(node):
             keywords = node['content']
             keywords = [keyword.strip() for keyword in keywords.split(',')]
             self.found_words.extend(keywords)

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -234,12 +234,17 @@ class Locale(SphinxTransform):
 
             # update translatable nodes
             if isinstance(node, addnodes.translatable):
-                node.apply_translated_message(msg, msgstr)
+                node.apply_translated_message(msg, msgstr)  # type: ignore
                 continue
 
             # update meta nodes
             if isinstance(node, nodes.pending) and is_pending_meta(node):
+                # docutils-0.17 or older
                 node.details['nodes'][0]['content'] = msgstr
+                continue
+            elif isinstance(node, addnodes.docutils_meta):
+                # docutils-0.18+
+                node['content'] = msgstr
                 continue
 
             if isinstance(node, nodes.image) and node.get('alt') == msg:

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -233,9 +233,11 @@ def is_translatable(node: Node) -> bool:
             return False
         return True
 
-    if isinstance(node, addnodes.meta):
+    if is_pending_meta(node) or isinstance(node, addnodes.meta):
+        # docutils-0.17 or older
         return True
-    if is_pending_meta(node):
+    elif isinstance(node, addnodes.docutils_meta):
+        # docutils-0.18+
         return True
 
     return False
@@ -274,9 +276,14 @@ def extract_messages(doctree: Element) -> Iterable[Tuple[Element, str]]:
             else:
                 msg = ''
         elif isinstance(node, META_TYPE_NODES):
+            # docutils-0.17 or older
             msg = node.rawcontent
         elif isinstance(node, nodes.pending) and is_pending_meta(node):
+            # docutils-0.17 or older
             msg = node.details['nodes'][0].rawcontent
+        elif isinstance(node, addnodes.docutils_meta):
+            # docutils-0.18+
+            msg = node["content"]
         else:
             msg = node.rawsource.replace('\n', ' ').strip()
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- i18n feature for meta strings does not work if docutils-0.18 used.
- Note: Since docutils-0.18, patch for meta directive is no longer
needed because it uses a picklable meta nodes; `docutils.nodes.meta`.
- refs: #9777 