### PR TITLE
test: Migrate to Node.findall() from Node.traverse()

### DIFF
--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -79,7 +79,7 @@ def test_domain_py_xrefs(app, status, warning):
         assert_node(node, **attributes)
 
     doctree = app.env.get_doctree('roles')
-    refnodes = list(doctree.traverse(pending_xref))
+    refnodes = list(doctree.findall(pending_xref))
     assert_refnode(refnodes[0], None, None, 'TopLevel', 'class')
     assert_refnode(refnodes[1], None, None, 'top_level', 'meth')
     assert_refnode(refnodes[2], None, 'NestedParentA', 'child_1', 'meth')
@@ -97,7 +97,7 @@ def test_domain_py_xrefs(app, status, warning):
     assert len(refnodes) == 13
 
     doctree = app.env.get_doctree('module')
-    refnodes = list(doctree.traverse(pending_xref))
+    refnodes = list(doctree.findall(pending_xref))
     assert_refnode(refnodes[0], 'module_a.submodule', None,
                    'ModTopLevel', 'class')
     assert_refnode(refnodes[1], 'module_a.submodule', 'ModTopLevel',
@@ -126,7 +126,7 @@ def test_domain_py_xrefs(app, status, warning):
     assert len(refnodes) == 16
 
     doctree = app.env.get_doctree('module_option')
-    refnodes = list(doctree.traverse(pending_xref))
+    refnodes = list(doctree.findall(pending_xref))
     print(refnodes)
     print(refnodes[0])
     print(refnodes[1])

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -36,7 +36,7 @@ def test_process_doc_handle_figure_caption():
         ids={'testid': figure_node},
         citation_refs={},
     )
-    document.traverse.return_value = []
+    document.findall.return_value = []
 
     domain = StandardDomain(env)
     if 'testname' in domain.data['labels']:
@@ -60,7 +60,7 @@ def test_process_doc_handle_table_title():
         ids={'testid': table_node},
         citation_refs={},
     )
-    document.traverse.return_value = []
+    document.findall.return_value = []
 
     domain = StandardDomain(env)
     if 'testname' in domain.data['labels']:

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -67,7 +67,7 @@ def parse(new_document):
         parser = RstParser()
         parser.parse(rst, document)
         SphinxSmartQuotes(document, startnode=None).apply()
-        for msg in document.traverse(nodes.system_message):
+        for msg in list(document.findall(nodes.system_message)):
             if msg['level'] == 1:
                 msg.replace_self([])
         return document

--- a/tests/test_util_nodes.py
+++ b/tests/test_util_nodes.py
@@ -60,31 +60,31 @@ def test_NodeMatcher():
 
     # search by node class
     matcher = NodeMatcher(nodes.paragraph)
-    assert len(list(doctree.traverse(matcher))) == 3
+    assert len(list(doctree.findall(matcher))) == 3
 
     # search by multiple node classes
     matcher = NodeMatcher(nodes.paragraph, nodes.literal_block)
-    assert len(list(doctree.traverse(matcher))) == 4
+    assert len(list(doctree.findall(matcher))) == 4
 
     # search by node attribute
     matcher = NodeMatcher(block=1)
-    assert len(list(doctree.traverse(matcher))) == 1
+    assert len(list(doctree.findall(matcher))) == 1
 
     # search by node attribute (Any)
     matcher = NodeMatcher(block=Any)
-    assert len(list(doctree.traverse(matcher))) == 3
+    assert len(list(doctree.findall(matcher))) == 3
 
     # search by both class and attribute
     matcher = NodeMatcher(nodes.paragraph, block=Any)
-    assert len(list(doctree.traverse(matcher))) == 2
+    assert len(list(doctree.findall(matcher))) == 2
 
     # mismatched
     matcher = NodeMatcher(nodes.title)
-    assert len(list(doctree.traverse(matcher))) == 0
+    assert len(list(doctree.findall(matcher))) == 0
 
     # search with Any does not match to Text node
     matcher = NodeMatcher(blah=Any)
-    assert len(list(doctree.traverse(matcher))) == 0
+    assert len(list(doctree.findall(matcher))) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -70,16 +70,16 @@ def test_picklablility():
     copy.settings.warning_stream = None
     copy.settings.env = None
     copy.settings.record_dependencies = None
-    for metanode in copy.traverse(meta):
+    for metanode in copy.findall(meta):
         metanode.__class__ = addnodes.meta
     loaded = pickle.loads(pickle.dumps(copy, pickle.HIGHEST_PROTOCOL))
-    assert all(getattr(n, 'uid', False) for n in loaded.traverse(is_paragraph))
+    assert all(getattr(n, 'uid', False) for n in loaded.findall(is_paragraph))
 
 
 def test_modified():
     modified = doctrees['modified']
     new_nodes = list(merge_doctrees(original, modified, is_paragraph))
-    uids = [n.uid for n in modified.traverse(is_paragraph)]
+    uids = [n.uid for n in modified.findall(is_paragraph)]
     assert not new_nodes
     assert original_uids == uids
 
@@ -87,7 +87,7 @@ def test_modified():
 def test_added():
     added = doctrees['added']
     new_nodes = list(merge_doctrees(original, added, is_paragraph))
-    uids = [n.uid for n in added.traverse(is_paragraph)]
+    uids = [n.uid for n in added.findall(is_paragraph)]
     assert len(new_nodes) == 1
     assert original_uids == uids[:-1]
 
@@ -95,7 +95,7 @@ def test_added():
 def test_deleted():
     deleted = doctrees['deleted']
     new_nodes = list(merge_doctrees(original, deleted, is_paragraph))
-    uids = [n.uid for n in deleted.traverse(is_paragraph)]
+    uids = [n.uid for n in deleted.findall(is_paragraph)]
     assert not new_nodes
     assert original_uids[::2] == uids
 
@@ -103,7 +103,7 @@ def test_deleted():
 def test_deleted_end():
     deleted_end = doctrees['deleted_end']
     new_nodes = list(merge_doctrees(original, deleted_end, is_paragraph))
-    uids = [n.uid for n in deleted_end.traverse(is_paragraph)]
+    uids = [n.uid for n in deleted_end.findall(is_paragraph)]
     assert not new_nodes
     assert original_uids[:-1] == uids
 
@@ -111,7 +111,7 @@ def test_deleted_end():
 def test_insert():
     insert = doctrees['insert']
     new_nodes = list(merge_doctrees(original, insert, is_paragraph))
-    uids = [n.uid for n in insert.traverse(is_paragraph)]
+    uids = [n.uid for n in insert.findall(is_paragraph)]
     assert len(new_nodes) == 1
     assert original_uids[0] == uids[0]
     assert original_uids[1:] == uids[2:]
@@ -120,7 +120,7 @@ def test_insert():
 def test_insert_beginning():
     insert_beginning = doctrees['insert_beginning']
     new_nodes = list(merge_doctrees(original, insert_beginning, is_paragraph))
-    uids = [n.uid for n in insert_beginning.traverse(is_paragraph)]
+    uids = [n.uid for n in insert_beginning.findall(is_paragraph)]
     assert len(new_nodes) == 1
     assert len(uids) == 4
     assert original_uids == uids[1:]
@@ -130,7 +130,7 @@ def test_insert_beginning():
 def test_insert_similar():
     insert_similar = doctrees['insert_similar']
     new_nodes = list(merge_doctrees(original, insert_similar, is_paragraph))
-    uids = [n.uid for n in insert_similar.traverse(is_paragraph)]
+    uids = [n.uid for n in insert_similar.findall(is_paragraph)]
     assert len(new_nodes) == 1
     assert new_nodes[0].rawsource == 'Anyway I need more'
     assert original_uids[0] == uids[0]


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- docutils still warns for our usage of Node.traverse() in test code.
- Remaining task of https://github.com/sphinx-doc/sphinx/pull/10044