### PR TITLE
test: manpage: double quotes are escaped since docutils-0.18

### DIFF
--- a/tests/test_smartquotes.py
+++ b/tests/test_smartquotes.py
@@ -11,6 +11,8 @@
 import pytest
 from html5lib import HTMLParser
 
+from sphinx.util import docutils
+
 
 @pytest.mark.sphinx(buildername='html', testroot='smartquotes', freshenv=True)
 def test_basic(app, status, warning):
@@ -51,7 +53,10 @@ def test_man_builder(app, status, warning):
     app.build()
 
     content = (app.outdir / 'python.1').read_text()
-    assert '\\-\\- "Sphinx" is a tool that makes it easy ...' in content
+    if docutils.__version_info__ > (0, 18):
+        assert r'\-\- \(dqSphinx\(dq is a tool that makes it easy ...' in content
+    else:
+        assert r'\-\- "Sphinx" is a tool that makes it easy ...' in content
 
 
 @pytest.mark.sphinx(buildername='latex', testroot='smartquotes', freshenv=True)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Double quotes are escaped to `\(dq` on manpage output since
docutils-0.18.
- refs: #9777 