### PR TITLE
Fix #10058: Autosummary excludes stuff from its table if `autodoc_class_signature`='separated'.

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -256,8 +256,9 @@ class Autosummary(SphinxDirective):
     }
 
     def run(self) -> List[Node]:
+        opts = Options({'imported-members': self.env.app.config.autosummary_imported_members})
         self.bridge = DocumenterBridge(self.env, self.state.document.reporter,
-                                       Options(), self.lineno, self.state)
+                                       opts, self.lineno, self.state)
 
         names = [x.strip().split()[0] for x in self.content
                  if x.strip() and re.search(r'^[~a-zA-Z_]', x.strip()[0])]

--- a/tests/roots/test-ext-autosummary-imported_members/conf.py
+++ b/tests/roots/test-ext-autosummary-imported_members/conf.py
@@ -6,3 +6,6 @@ sys.path.insert(0, os.path.abspath('.'))
 extensions = ['sphinx.ext.autosummary']
 autosummary_generate = True
 autosummary_imported_members = True
+
+# test for #10058 - shoud be scoped just to test_autosummary_imported_members_table_10058
+autodoc_class_signature = 'separated'

--- a/tests/roots/test-ext-autosummary-imported_members/index.rst
+++ b/tests/roots/test-ext-autosummary-imported_members/index.rst
@@ -5,3 +5,10 @@ test-ext-autosummary-mock_imports
    :toctree: generated
 
    autosummary_dummy_package
+
+.. currentmodule:: autosummary_dummy_package
+
+.. autosummary::
+
+   foo
+   Bar


### PR DESCRIPTION
Subject: Fix #10058: Autosummary excludes stuff from its table if `autodoc_class_signature`='separated'.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
When using autosummary with `autodoc_class_signature` = 'separated', it won't include any Classes in its summary table, even if you explicitly ask for them.

This seems to be because when this method is set, the ClassDocumenter gets its `options.members` set to `['__new__', '__init__']`; it seems to be always `None`/`[]` in other cases. So I think the `check_module()` check ([ext/autosummary/\_\_init__.py:376](https://github.com/sphinx-doc/sphinx/blob/6402acde81e39cf010925c925733546dd6a2f822/sphinx/ext/autosummary/__init__.py#L375)) has never really been working properly, but it hasn't mattered because `options.members` is normally falsy in most situations.

The included test shows the broken behaviour pretty clearly, the fix commit seems to make sense to me but I'm not familiar with Sphinx source code, maybe there's a better fix.


