### PR TITLE
CI: refactor tox.ini; Install HEAD of docutils directly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,7 @@ commands=
 
 [testenv:du-latest]
 commands =
-    git clone https://repo.or.cz/docutils.git {temp_dir}/docutils
-    python -m pip install {temp_dir}/docutils/docutils
-    rm -rf {temp_dir}/docutils
+    python -m pip install "git+https://repo.or.cz/docutils.git#subdirectory=docutils"
     {[testenv]commands}
 
 [testenv:flake8]


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Install HEAD of docutils directly via `#subdirectory` fragment (thanks to @AA-Turner!)