### PR TITLE
Fix #10057: Failed to scan documents on the root directory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,8 @@ Bugs fixed
   at info-field-list
 * #9390: texinfo: Do not emit labels inside footnotes
 * #9979: Error level messages were displayed as warning messages
+* #10057: Failed to scan documents if the project is placed onto the root
+  directory
 
 Testing
 --------

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -72,10 +72,11 @@ def get_matching_files(dirname: str,
     """
     # dirname is a normalized absolute path.
     dirname = path.normpath(path.abspath(dirname))
-    dirlen = len(dirname) + 1    # exclude final os.path.sep
 
     for root, dirs, files in os.walk(dirname, followlinks=True):
-        relativeroot = root[dirlen:]
+        relativeroot = path.relpath(root, dirname)
+        if relativeroot == ".":
+            relativeroot = ""  # suppress dirname for files on the target dir
 
         qdirs = enumerate(path_stabilize(path.join(relativeroot, dn))
                           for dn in dirs)  # type: Iterable[Tuple[int, str]]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- get_matching_files() incorrectly drops the first character of each
path on scanning documents.  It will help users to exclude paths
via exclude_patterns setting.
- Note: Users need to configure `exclude_patterns` to put their document
on the root directory.  This does not help to avoid recursive symlinks
(ex. /proc, /sys)
- refs: #10057 