### PR TITLE
ImageConverter: Guess MIME type for "data:" URIs

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -228,6 +228,12 @@ class ImageConverter(BaseImageConverter):
 
     def guess_mimetypes(self, node: nodes.image) -> List[str]:
         if '?' in node['candidates']:
+            uri = node.get('uri', '')
+            if uri.startswith('data:'):
+                header = uri[len('data:'):].split(',', 1)[0]
+                mimetype = header.split(';', 1)[0]
+                if mimetype:
+                    return [mimetype]
             return []
         elif '*' in node['candidates']:
             return [guess_mimetype(node['uri'])]


### PR DESCRIPTION
This is a naive (but defensive) implementation that fixes #10073.

If somebody has a better implementation, please go ahead!

### Feature or Bugfix

Arguable. I'd say it's a bugfix.

### Detail

I don't really know what `'?'` means in `node['candidates']`, so I can't be sure that my PR doesn't break anything.

However, unless something other than a `data` URI also happens to start with `'data:'`, I think we should be safe.
