### PR TITLE
use 'callable' to check if object is callable (B004)

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -206,7 +206,7 @@ class Config:
                 except ValueError as exc:
                     raise ValueError(__('invalid number %r for config value %r, ignoring') %
                                      (value, name)) from exc
-            elif hasattr(defvalue, '__call__'):
+            elif callable(defvalue):
                 return value
             elif defvalue is not None and not isinstance(defvalue, str):
                 raise ValueError(__('cannot override config setting %r with unsupported '
@@ -257,7 +257,7 @@ class Config:
         if name not in self.values:
             raise AttributeError(__('No such config value: %s') % name)
         default = self.values[name][0]
-        if hasattr(default, '__call__'):
+        if callable(default):
             return default(self)
         return default
 
@@ -413,7 +413,7 @@ def check_confval_types(app: "Sphinx", config: Config) -> None:
     for confval in config:
         default, rebuild, annotations = config.values[confval.name]
 
-        if hasattr(default, '__call__'):
+        if callable(default):
             default = default(config)  # evaluate default value
         if default is None and not annotations:
             continue  # neither inferable nor expliclitly annotated types

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -301,7 +301,7 @@ def isstaticmethod(obj: Any, cls: Any = None, name: str = None) -> bool:
 def isdescriptor(x: Any) -> bool:
     """Check if the object is some kind of descriptor."""
     for item in '__get__', '__set__', '__delete__':
-        if hasattr(safe_getattr(x, item, None), '__call__'):
+        if callable(safe_getattr(x, item, None)):
             return True
     return False
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -99,7 +99,7 @@ def check_xpath(etree, fname, path, check, be_found=True):
     else:
         assert nodes != [], ('did not find any node matching xpath '
                              '%r in file %s' % (path, fname))
-    if hasattr(check, '__call__'):
+    if callable(check):
         check(nodes)
     elif not check:
         # only check for node presence


### PR DESCRIPTION
from the [bugbear](https://pypi.org/project/flake8-bugbear/) docs-

> B004: Using hasattr(x, '__call__') to test if x is callable is unreliable. If x implements custom __getattr__ or its __call__ is itself not callable, you might get misleading results. Use callable(x) for consistent results.

also, it looks better.