### PR TITLE
Fix typing in docfields.py

### DIFF
--- a/sphinx/util/docfields.py
+++ b/sphinx/util/docfields.py
@@ -21,7 +21,7 @@ from sphinx.util import logging
 from sphinx.util.typing import TextlikeNode
 
 if TYPE_CHECKING:
-    from sphinx.directive import ObjectDescription
+    from sphinx.directives import ObjectDescription
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Subject: Fixes a typo’d import behind a typeguard

### Feature or Bugfix
- Bugfix