### PR TITLE
Fix #10058: autosummary: Imported members are not shown

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -54,6 +54,8 @@ Bugs fixed
   position-only-arguments
 * #9194: autodoc: types under the "typing" module are not hyperlinked
 * #10009: autodoc: Crashes if target object raises an error on getting docstring
+* #10058: autosummary: Imported members are not shown when
+  ``autodoc_class_signature = 'separated'``
 * #9947: i18n: topic directive having a bullet list can't be translatable
 * #9878: mathjax: MathJax configuration is placed after loading MathJax itself
 * #9857: Generated RFC links use outdated base url

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -372,8 +372,6 @@ class Autosummary(SphinxDirective):
                                location=self.get_location())
                 items.append((display_name, '', '', real_name))
                 continue
-            if documenter.options.members and not documenter.check_module():
-                continue
 
             # try to also get a source code analyzer for attribute docs
             try:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Originally, the `check_module()` call was added at 21b8384 to hide
imported members on generating stubs.  But it was incorrect approach.
Therefore it was disabled by b433197 and fixed the original issue by
another approach at 2390c554.
- Finally, the `check_module()` call becomes meaningless code.  But, at
present, it causes that imported members are not shown when
`autodoc_class_signature` is 'separated'.  To resolve the problem, this
removes the meaningless call.
- refs: #10058 and #10060