### PR TITLE
In translated docs, sort glossaries by translated terms

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -831,6 +831,9 @@ Glossary
    .. versionchanged:: 1.4
       Index key for glossary term should be considered *experimental*.
 
+   .. versionchanged:: 4.4
+      In internationalized documentation, the ``:sorted:`` flag sorts
+      according to translated terms.
 
 Meta-information markup
 -----------------------

--- a/tests/roots/test-intl/glossary_terms.txt
+++ b/tests/roots/test-intl/glossary_terms.txt
@@ -12,3 +12,18 @@ i18n with glossary terms
       The corresponding glossary #2
 
 link to :term:`Some term`.
+
+Translated glossary should be sorted by translated terms:
+
+.. glossary::
+   :sorted:
+
+   AAA
+      Define AAA
+
+   CCC
+   EEE
+      Define CCC
+
+   BBB
+      Define BBB

--- a/tests/roots/test-intl/xx/LC_MESSAGES/glossary_terms.po
+++ b/tests/roots/test-intl/xx/LC_MESSAGES/glossary_terms.po
@@ -33,3 +33,27 @@ msgstr "THE CORRESPONDING GLOSSARY #2"
 
 msgid "link to :term:`Some term`."
 msgstr "LINK TO :term:`SOME NEW TERM`."
+
+msgid "Translated glossary should be sorted by translated terms:"
+msgstr "TRANSLATED GLOSSARY SHOULD BE SORTED BY TRANSLATED TERMS:"
+
+msgid "BBB"
+msgstr "TRANSLATED TERM XXX"
+
+msgid "Define BBB"
+msgstr "DEFINE XXX"
+
+msgid "AAA"
+msgstr "TRANSLATED TERM YYY"
+
+msgid "Define AAA"
+msgstr "DEFINE YYY"
+
+msgid "CCC"
+msgstr "TRANSLATED TERM ZZZ"
+
+msgid "EEE"
+msgstr "VVV"
+
+msgid "Define CCC"
+msgstr "DEFINE ZZZ"

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -241,13 +241,29 @@ def test_text_glossary_term(app, warning):
     app.build()
     # --- glossary terms: regression test for #1090
     result = (app.outdir / 'glossary_terms.txt').read_text()
-    expect = ("18. I18N WITH GLOSSARY TERMS"
-              "\n****************************\n"
-              "\nSOME NEW TERM"
-              "\n   THE CORRESPONDING GLOSSARY\n"
-              "\nSOME OTHER NEW TERM"
-              "\n   THE CORRESPONDING GLOSSARY #2\n"
-              "\nLINK TO *SOME NEW TERM*.\n")
+    expect = (r"""18. I18N WITH GLOSSARY TERMS
+****************************
+
+SOME NEW TERM
+   THE CORRESPONDING GLOSSARY
+
+SOME OTHER NEW TERM
+   THE CORRESPONDING GLOSSARY #2
+
+LINK TO *SOME NEW TERM*.
+
+TRANSLATED GLOSSARY SHOULD BE SORTED BY TRANSLATED TERMS:
+
+TRANSLATED TERM XXX
+   DEFINE XXX
+
+TRANSLATED TERM YYY
+   DEFINE YYY
+
+TRANSLATED TERM ZZZ
+VVV
+   DEFINE ZZZ
+""")
     assert result == expect
     warnings = getwarning(warning)
     assert 'term not in glossary' not in warnings


### PR DESCRIPTION
This is done by moving the sorting from the glossary directive to a
transform operating after the i18n transform.

Closes #9827

### Feature or Bugfix
- Bugfix

### Purpose

Translated glossaries were sorted according to alphabetical order of English terms, which makes no sense to a reader of the native language. An example can be found here: https://docs.python.org/fr/3/glossary.html. This sorts them according to translated terms instead. To this end, the glossary directive no longer sorts the entries itself. Instead, it sets a boolean attribute on the glossary node, and a transform happening after the i18n transform takes care of sorting glossaries with this attribute.

This is my first contribution to Sphinx and I'm still new to the code; please let me know if I've missed something.

### Relates

#9827
