### PR TITLE
test: Follow the new HTML structure of docutils-0.18

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -361,8 +361,6 @@ def test_html4_output(app, status, warning):
     'index.html': [
         (".//meta[@name='hc'][@content='hcval']", ''),
         (".//meta[@name='hc_co'][@content='hcval_co']", ''),
-        (".//dt[@class='label']/span[@class='brackets']", r'Ref1'),
-        (".//dt[@class='label']", ''),
         (".//li[@class='toctree-l1']/a", 'Testing various markup'),
         (".//li[@class='toctree-l2']/a", 'Inline markup'),
         (".//title", 'Sphinx <Tests>'),
@@ -400,6 +398,26 @@ def test_html4_output(app, status, warning):
         (".//a", "entry"),
         (".//li/a", "double"),
     ],
+    'otherext.html': [
+        (".//h1", "Generated section"),
+        (".//a[@href='_sources/otherext.foo.txt']", ''),
+    ]
+}))
+@pytest.mark.sphinx('html', tags=['testtag'],
+                    confoverrides={'html_context.hckey_co': 'hcval_co'})
+@pytest.mark.test_params(shared_result='test_build_html_output')
+def test_html5_output(app, cached_etree_parse, fname, expect):
+    app.build()
+    print(app.outdir / fname)
+    check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
+
+
+@pytest.mark.skipif(docutils.__version_info__ >= (0, 18), reason='docutils-0.17 or below is required.')
+@pytest.mark.parametrize("fname,expect", flat_dict({
+    'index.html': [
+        (".//dt[@class='label']/span[@class='brackets']", r'Ref1'),
+        (".//dt[@class='label']", ''),
+    ],
     'footnote.html': [
         (".//a[@class='footnote-reference brackets'][@href='#id9'][@id='id1']", r"1"),
         (".//a[@class='footnote-reference brackets'][@href='#id10'][@id='id2']", r"2"),
@@ -417,15 +435,42 @@ def test_html4_output(app, status, warning):
         (".//a[@class='fn-backref'][@href='#id7']", r"5"),
         (".//a[@class='fn-backref'][@href='#id8']", r"6"),
     ],
-    'otherext.html': [
-        (".//h1", "Generated section"),
-        (".//a[@href='_sources/otherext.foo.txt']", ''),
-    ]
 }))
-@pytest.mark.sphinx('html', tags=['testtag'],
-                    confoverrides={'html_context.hckey_co': 'hcval_co'})
-@pytest.mark.test_params(shared_result='test_build_html_output')
-def test_html5_output(app, cached_etree_parse, fname, expect):
+@pytest.mark.sphinx('html')
+@pytest.mark.test_params(shared_result='test_build_html_output_docutils17')
+def test_docutils17_output(app, cached_etree_parse, fname, expect):
+    app.build()
+    print(app.outdir / fname)
+    check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
+
+
+@pytest.mark.skipif(docutils.__version_info__ < (0, 18), reason='docutils-0.18+ is required.')
+@pytest.mark.parametrize("fname,expect", flat_dict({
+    'index.html': [
+        (".//div[@class='citation']/span", r'Ref1'),
+        (".//div[@class='citation']/span", r'Ref_1'),
+    ],
+    'footnote.html': [
+        (".//a[@class='footnote-reference brackets'][@href='#id9'][@id='id1']", r"1"),
+        (".//a[@class='footnote-reference brackets'][@href='#id10'][@id='id2']", r"2"),
+        (".//a[@class='footnote-reference brackets'][@href='#foo'][@id='id3']", r"3"),
+        (".//a[@class='reference internal'][@href='#bar'][@id='id4']/span", r"\[bar\]"),
+        (".//a[@class='reference internal'][@href='#baz-qux'][@id='id5']/span", r"\[baz_qux\]"),
+        (".//a[@class='footnote-reference brackets'][@href='#id11'][@id='id6']", r"4"),
+        (".//a[@class='footnote-reference brackets'][@href='#id12'][@id='id7']", r"5"),
+        (".//aside[@class='footnote brackets']/span/a[@href='#id1']", r"1"),
+        (".//aside[@class='footnote brackets']/span/a[@href='#id2']", r"2"),
+        (".//aside[@class='footnote brackets']/span/a[@href='#id3']", r"3"),
+        (".//div[@class='citation']/span/a[@href='#id4']", r"bar"),
+        (".//div[@class='citation']/span/a[@href='#id5']", r"baz_qux"),
+        (".//aside[@class='footnote brackets']/span/a[@href='#id6']", r"4"),
+        (".//aside[@class='footnote brackets']/span/a[@href='#id7']", r"5"),
+        (".//aside[@class='footnote brackets']/span/a[@href='#id8']", r"6"),
+    ],
+}))
+@pytest.mark.sphinx('html')
+@pytest.mark.test_params(shared_result='test_build_html_output_docutils18')
+def test_docutils18_output(app, cached_etree_parse, fname, expect):
     app.build()
     print(app.outdir / fname)
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Since docutils-0.18, the HTML structure for citations and footnotes has
been changed.  This modifies our testcase to follow the new HTML structure.
- I suppose this is the last piece of #9777. After merging this, we can unpin the docutils-0.18.
- I'm not sure this is a breaking change or not. I need an advice from RtD team @ericholscher 
- refs: #9777 