### PR TITLE
Fix #9981: std domain: Strip value part of the option directive from genindex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ Features added
 * #10055: sphinx-build: Create directories when ``-w`` option given
 * #9993: std domain: Allow to refer an inline target (ex. ``_`target name```)
   via :rst:role:`ref` role
+* #9981: std domain: Strip value part of the option directive from general index
 * #9391: texinfo: improve variable in ``samp`` role
 * #9578: texinfo: Add :confval:`texinfo_cross_references` to disable cross
   references for readability with standalone readers

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -242,7 +242,7 @@ class Cmdoption(ObjectDescription[str]):
             descr = _('%s command line option') % currprogram
         else:
             descr = _('command line option')
-        for option in sig.split(', '):
+        for option in signode.get('allnames', []):
             entry = '; '.join([descr, option])
             self.indexnode['entries'].append(('pair', entry, signode['ids'][0], '', None))
 

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -97,6 +97,9 @@ def test_cmd_option_with_optional_value(app):
                           [desc, ([desc_signature, ([desc_name, '-j'],
                                                     [desc_addname, '[=N]'])],
                                   [desc_content, ()])]))
+    assert_node(doctree[0], addnodes.index,
+                entries=[('pair', 'command line option; -j', 'cmdoption-j', '', None)])
+
     objects = list(app.env.get_domain("std").get_objects())
     assert ('-j', '-j', 'cmdoption', 'index', 'cmdoption-j', 1) in objects
 
@@ -355,10 +358,8 @@ def test_multiple_cmdoptions(app):
                                                     [desc_addname, " directory"])],
                                   [desc_content, ()])]))
     assert_node(doctree[0], addnodes.index,
-                entries=[('pair', 'cmd command line option; -o directory',
-                          'cmdoption-cmd-o', '', None),
-                         ('pair', 'cmd command line option; --output directory',
-                          'cmdoption-cmd-o', '', None)])
+                entries=[('pair', 'cmd command line option; -o', 'cmdoption-cmd-o', '', None),
+                         ('pair', 'cmd command line option; --output', 'cmdoption-cmd-o', '', None)])
     assert ('cmd', '-o') in domain.progoptions
     assert ('cmd', '--output') in domain.progoptions
     assert domain.progoptions[('cmd', '-o')] == ('index', 'cmdoption-cmd-o')


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- `signode["allnames"]` is a list of option names. It would be better to use instead of `sig` here.
- refs: #9981 and #10029