### PR TITLE
Skip "data:" URIs in ImageConverter

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -200,6 +200,9 @@ class ImageConverter(BaseImageConverter):
         elif set(self.guess_mimetypes(node)) & set(self.app.builder.supported_image_types):
             # builder supports the image; no need to convert
             return False
+        elif node['uri'].startswith('data:'):
+            # all data URI MIME types are assumed to be supported
+            return False
         elif self.available is None:
             # store the value to the class variable to share it during the build
             self.__class__.available = self.is_available()


### PR DESCRIPTION
Fixes #10073.

Supersedes and closes #10074.

This alternative has been suggested by @tk0miya in https://github.com/sphinx-doc/sphinx/issues/10073#issuecomment-1012000857.

If a builder supports "data" URIs, we should assume that it supports all possible MIME types.

Using a "data" URI with an exotic image format doesn't really make sense.

### Feature or Bugfix

- Bugfix