### PR TITLE
Fix #9413: xml: Invalid XML was generated when cross referencing python objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -75,6 +75,7 @@ Bugs fixed
 * #10015: py domain: types under the "typing" module are not hyperlinked defined
   at info-field-list
 * #9390: texinfo: Do not emit labels inside footnotes
+* #9413: xml: Invalid XML was generated when cross referencing python objects
 * #9979: Error level messages were displayed as warning messages
 * #10057: Failed to scan documents if the project is placed onto the root
   directory

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -71,6 +71,9 @@ class XMLBuilder(Builder):
         # work around multiple string % tuple issues in docutils;
         # replace tuples in attribute values with lists
         doctree = doctree.deepcopy()
+        for domain in self.env.domains.values():
+            xmlns = "xmlns:" + domain.name
+            doctree[xmlns] = "https://www.sphinx-doc.org/"  # type: ignore
         for node in doctree.findall(nodes.Element):
             for att, value in node.attributes.items():
                 if isinstance(value, tuple):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9413 