### PR TITLE
WIP: Support nameless section cross-references within the same document (autosectionlabel_prefix_document)

### DIFF
--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -83,6 +83,8 @@ class ReferencesResolver(SphinxPostTransform):
             domain = None
 
             try:
+                if target.startswith(':'):
+                    target = refdoc.lower() + target
                 if 'refdomain' in node and node['refdomain']:
                     # let the domain try to resolve the reference
                     try:


### PR DESCRIPTION
Subject: Support nameless section cross-references within the same document

### Feature or Bugfix
- Feature

### Purpose
When using `autosectionlabel_prefix_document` the full name of the
document containing the target location has to used in the reference,
even when the location is in the same document as the reference,
for example within foo/bar.rst:
```
:ref:`foo/bar:Heading`
```
This change allows the document name to be omitted when referring to the
same document, the example can now be written as:
```
:ref:`:Heading`
```
### Detail
Needs more I am sure, especially documentation.

Is it this simple (works when I have used it)? Does it break anything else?
Are target and refdoc definitely not None? Is `+` for string concatenation OK?
