### PR TITLE
ImageConverter: ignore '?' image URIs

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -197,11 +197,10 @@ class ImageConverter(BaseImageConverter):
     def match(self, node: nodes.image) -> bool:
         if not self.app.builder.supported_image_types:
             return False
+        elif '?' in node['candidates']:
+            return False
         elif set(self.guess_mimetypes(node)) & set(self.app.builder.supported_image_types):
             # builder supports the image; no need to convert
-            return False
-        elif node['uri'].startswith('data:'):
-            # all data URI MIME types are assumed to be supported
             return False
         elif self.available is None:
             # store the value to the class variable to share it during the build


### PR DESCRIPTION
While #10073 has fixed my minimal example, it wasn't enough to fix my original problem https://github.com/spatialaudio/nbsphinx/pull/559.

It turns out that on top of `data:` URIs, remote URIs have also been automatically handled as "not supported" and therefore unnecessarily invoked the image converters.

This PR ignores all `'?'` images, which includes `data:` URIs, therefore I've reverted the changes from  #10099, which are no longer necessary.

I still don't know what `'?'` means exactly, it would probably be nice to add a comment explaining what that is and why it's ignored.

Example project for experiments: https://github.com/mgeier/rsvgconverter-bug