### PR TITLE
Documentation: Mention `nitpick_ignore(_regex)` in docs of `warn-missing-reference`

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -298,7 +298,9 @@ Here is a more detailed list of these events.
 
    Emitted when a cross-reference to an object cannot be resolved even after
    :event:`missing-reference`.  If the event handler can emit warnings for
-   the missing reference, it should return ``True``.
+   the missing reference, it should return ``True``. The configuration variables
+   :confval:`nitpick_ignore` and :confval:`nitpick_ignore_regex` prevent the
+   event from being emitted for the corresponding nodes.
 
    .. versionadded:: 3.4
 


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Documentation

### Purpose
Explains that the `warn-missing-reference` will be not emitted if the node matches the settings of `nitpick_ignore(_regex)`

### Relates
This came up in sqlalchemyorg/sphinx-paramlinks#14 where this fact was not clear to me. So I thought that this clarification might be helpful for others as well :)

