### PR TITLE
extlink: Add support for suppressing 'hardcoded link' warnings

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -317,6 +317,7 @@ General configuration
    * ``app.add_generic_role``
    * ``app.add_source_parser``
    * ``download.not_readable``
+   * ``extlink.hardcoded``
    * ``image.not_readable``
    * ``ref.term``
    * ``ref.ref``

--- a/doc/usage/extensions/extlinks.rst
+++ b/doc/usage/extensions/extlinks.rst
@@ -59,3 +59,10 @@ The extension adds a config value:
 
    Since links are generated from the role in the reading stage, they appear as
    ordinary links to e.g. the ``linkcheck`` builder.
+
+.. versionchanged:: 4.4.0
+
+   Added warning on hardcoded links that could be replaced with an extlink.
+   This can be disabled with::
+
+      suppress_warnings = ["extlink.hardcoded"]

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -76,7 +76,8 @@ class ExternalLinksChecker(SphinxPostTransform):
                 msg = __('hardcoded link %r could be replaced by an extlink '
                          '(try using %r instead)')
                 replacement = f":{alias}:`{match.groupdict().get('value')}`"
-                logger.warning(msg, uri, replacement, location=refnode)
+                logger.warning(msg, uri, replacement, location=refnode,
+                               type="extlink", subtype="hardcoded")
 
 
 def make_link_role(name: str, base_url: str, caption: str) -> RoleFunction:


### PR DESCRIPTION
Subject: Add support for suppressing 'hardcoded link' warnings

### Feature or Bugfix

- Bugfix

### Purpose
These warnings were added in v4.4.0, but some projects may prefer to hide them,
eg. if hardcoded links appear in docstrings.



### Relates
- [PR 9800](https://github.com/sphinx-doc/sphinx/pull/9800), which introduced these warnings

