### PR TITLE
Fix #10122: make.bat should check the installation before help

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
 ----------
 
 * #10133: autodoc: Crashed when mocked module is used for type annotation
+* #10122: sphinx-build: make.bat does not check the installation of sphinx-build
+  command before showing help
 
 Testing
 --------

--- a/sphinx/templates/quickstart/make.bat.new_t
+++ b/sphinx/templates/quickstart/make.bat.new_t
@@ -10,8 +10,6 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR={{ rsrcdir }}
 set BUILDDIR={{ rbuilddir }}
 
-if "%1" == "" goto help
-
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.
@@ -24,6 +22,8 @@ if errorlevel 9009 (
 	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )
+
+if "%1" == "" goto help
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #10122 