### PR TITLE
Fix #10121: html: <div> tag for admonition is not closed w/ docutils-0.18

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -14,7 +14,7 @@ import posixpath
 import re
 import urllib.parse
 import warnings
-from typing import TYPE_CHECKING, Iterable, Tuple, cast
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, Text
@@ -284,6 +284,9 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         if name:
             node.insert(0, nodes.title(name, admonitionlabels[name]))
         self.set_first_last(node)
+
+    def depart_admonition(self, node: Optional[Element] = None) -> None:
+        self.body.append('</div>\n')
 
     def visit_seealso(self, node: Element) -> None:
         self.visit_admonition(node, 'seealso')

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -13,7 +13,7 @@ import posixpath
 import re
 import urllib.parse
 import warnings
-from typing import TYPE_CHECKING, Iterable, Set, Tuple, cast
+from typing import TYPE_CHECKING, Iterable, Optional, Set, Tuple, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node, Text
@@ -258,6 +258,9 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             node, 'div', CLASS=('admonition ' + name)))
         if name:
             node.insert(0, nodes.title(name, admonitionlabels[name]))
+
+    def depart_admonition(self, node: Optional[Element] = None) -> None:
+        self.body.append('</div>\n')
 
     def visit_seealso(self, node: Element) -> None:
         self.visit_admonition(node, 'seealso')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since v0.18, docutils has output <aside> tag to represent admonitions.
On the other hand, our custom HTML Writer overrides the handler for
admonition nodes halfly.  As a result, the opening and closing tags
become mismatched.  This fully overrides the handler to use <div> tag to
represent admonitions.
- refs: #10121 