### PR TITLE
Fix #9876: autodoc: Failed to document a class on binary module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #9876: autodoc: Failed to document an imported class that is built from native
+  binary module
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1771,9 +1771,12 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
     def add_content(self, more_content: Optional[StringList], no_docstring: bool = False
                     ) -> None:
         if self.doc_as_attr and self.modname != self.get_real_modname():
-            # override analyzer to obtain doccomment around its definition.
-            self.analyzer = ModuleAnalyzer.for_module(self.modname)
-            self.analyzer.analyze()
+            try:
+                # override analyzer to obtain doccomment around its definition.
+                self.analyzer = ModuleAnalyzer.for_module(self.modname)
+                self.analyzer.analyze()
+            except PycodeError:
+                pass
 
         if self.doc_as_attr and not self.get_variable_comment():
             try:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #9876 