### PR TITLE
Close #10146: autodoc: autodoc_default_options does not support `no-value` option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@ Bugs fixed
 ----------
 
 * #10133: autodoc: Crashed when mocked module is used for type annotation
+* #10146: autodoc: :confval:`autodoc_default_options` does not support
+  ``no-value`` option
 * #10122: sphinx-build: make.bat does not check the installation of sphinx-build
   command before showing help
 

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -528,7 +528,8 @@ There are also config values that you can set:
    The supported options are ``'members'``, ``'member-order'``,
    ``'undoc-members'``, ``'private-members'``, ``'special-members'``,
    ``'inherited-members'``, ``'show-inheritance'``, ``'ignore-module-all'``,
-   ``'imported-members'``, ``'exclude-members'`` and ``'class-doc-from'``.
+   ``'imported-members'``, ``'exclude-members'``, ``'class-doc-from'`` and
+   ``'no-value'``.
 
    .. versionadded:: 1.8
 
@@ -539,6 +540,9 @@ There are also config values that you can set:
       Added ``'imported-members'``.
 
    .. versionchanged:: 4.1
+      Added ``'class-doc-from'``.
+
+   .. versionchanged:: 4.5
       Added ``'class-doc-from'``.
 
 .. confval:: autodoc_docstring_signature

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -543,7 +543,7 @@ There are also config values that you can set:
       Added ``'class-doc-from'``.
 
    .. versionchanged:: 4.5
-      Added ``'class-doc-from'``.
+      Added ``'no-value'``.
 
 .. confval:: autodoc_docstring_signature
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1001,7 +1001,8 @@ class ModuleDocumenter(Documenter):
         'platform': identity, 'deprecated': bool_option,
         'member-order': member_order_option, 'exclude-members': exclude_members_option,
         'private-members': members_option, 'special-members': members_option,
-        'imported-members': bool_option, 'ignore-module-all': bool_option
+        'imported-members': bool_option, 'ignore-module-all': bool_option,
+        'no-value': bool_option,
     }
 
     def __init__(self, *args: Any) -> None:

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 AUTODOC_DEFAULT_OPTIONS = ['members', 'undoc-members', 'inherited-members',
                            'show-inheritance', 'private-members', 'special-members',
                            'ignore-module-all', 'exclude-members', 'member-order',
-                           'imported-members', 'class-doc-from']
+                           'imported-members', 'class-doc-from', 'no-value']
 
 AUTODOC_EXTENDABLE_OPTIONS = ['members', 'private-members', 'special-members',
                               'exclude-members']

--- a/tests/test_ext_autodoc_autoattribute.py
+++ b/tests/test_ext_autodoc_autoattribute.py
@@ -32,7 +32,7 @@ def test_autoattribute(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autoattribute_novalue(app):
-    options = {'no-value': True}
+    options = {'no-value': None}
     actual = do_autodoc(app, 'attribute', 'target.Class.attr', options)
     assert list(actual) == [
         '',

--- a/tests/test_ext_autodoc_autodata.py
+++ b/tests/test_ext_autodoc_autodata.py
@@ -32,7 +32,7 @@ def test_autodata(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodata_novalue(app):
-    options = {'no-value': True}
+    options = {'no-value': None}
     actual = do_autodoc(app, 'data', 'target.integer', options)
     assert list(actual) == [
         '',


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- refs: #10146 