### PR TITLE
Searchtools: don't assume that all themes define some elements

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -209,7 +209,7 @@ const Search = {
     Search.output = out.appendChild(searchList);
 
     const searchProgress = document.getElementById("search-progress");
-    // Not all themes may have this element.
+    // Some themes don't use the search progress node
     if (searchProgress) {
       searchProgress.innerText = _("Preparing search...");
     }

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -48,7 +48,7 @@ if (!Scorer) {
 }
 
 const _removeChildren = (element) => {
-  while (element.lastChild) element.removeChild(element.lastChild);
+  while (element && element.lastChild) element.removeChild(element.lastChild);
 };
 
 /**
@@ -208,9 +208,11 @@ const Search = {
     Search.status = out.appendChild(searchSummary);
     Search.output = out.appendChild(searchList);
 
-    document.getElementById("search-progress").innerText = _(
-      "Preparing search..."
-    );
+    const searchProgress = document.getElementById("search-progress");
+    // Not all themes may have this element.
+    if (searchProgress) {
+      searchProgress.innerText = _("Preparing search...");
+    }
     Search.startPulse();
 
     // index already loaded, the browser was quick!


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

When retrieving a non-existent element, jQuery would still return an
object (kind of empty one, so method calls won't raise a null
exception), but now `getElementById` will return null and raise an
exception when trying to call a method on that value.

This mainly affects the rtd theme,
which completely overrides the search page
https://github.com/readthedocs/sphinx_rtd_theme/blob/d64dadf1ceec4f9ff6c1ca2d3ea4c3d0fdb0e8d2/sphinx_rtd_theme/search.html

### Relates
- https://github.com/sphinx-doc/sphinx/pull/10028
