### PR TITLE
Remove commas when describing characters for section headings

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -245,10 +245,10 @@ follow:
 
 * ``#`` with overline, for parts
 * ``*`` with overline, for chapters
-* ``=``, for sections
-* ``-``, for subsections
-* ``^``, for subsubsections
-* ``"``, for paragraphs
+* ``=`` for sections
+* ``-`` for subsections
+* ``^`` for subsubsections
+* ``"`` for paragraphs
 
 Of course, you are free to use your own marker characters (see the reST
 documentation), and use a deeper nesting level, but keep in mind that most


### PR DESCRIPTION
Subject: Remove commas when describing characters for section headings in docs

### Feature or Bugfix
- Bugfix

### Purpose
In the .html of the docs the theme does not display inline code and therefore it is a little confusing which characters to use for denoting section headings. I suggest removal of the commas here, but am very happy for this to be rejected in favour of a different solution. Just trying to be helpful by opening the request. 

### Detail
- No more detail necessary I don't think? 

### Relates
- Related to issue #10154