### PR TITLE
Use `settings_default_overrides` in `sphinx.writers.html`

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -54,11 +54,8 @@ def multiply_length(length: str, scale: int) -> str:
 
 class HTMLWriter(Writer):
 
-    # override embed-stylesheet default value to 0.
-    settings_spec = copy.deepcopy(Writer.settings_spec)
-    for _setting in settings_spec[2]:
-        if '--embed-stylesheet' in _setting[1]:
-            _setting[2]['default'] = 0
+    # override embed-stylesheet default value to False.
+    settings_default_overrides = {"embed_stylesheet": False}
 
     def __init__(self, builder: "StandaloneHTMLBuilder") -> None:
         super().__init__()

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -8,7 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-import copy
 import os
 import posixpath
 import re


### PR DESCRIPTION
Docutils wants to move from `optparse` to `argparse` -- this will likely update the `settings_spec` format somewhat.

A transparent backwards compatability layer will be provided, but changes to that backward compat bit won't take effect. Using `settings_default_overrides` is the "proper" thing to do here, and unblocks the work in Docutils. 

From @gmilde in https://sourceforge.net/p/docutils/bugs/441/#18f5/7f0c

> The Sphix "html" writer loops over the base class' settings_spec tuple in order to set a default value ... This should be changed (before retiring the old format) to use `settings_default_overrides` instead.

### Feature or Bugfix
- Bugfix


### Purpose
- Mainly unblocking future work in Docutils

### Relates
- https://sourceforge.net/p/docutils/bugs/441

P.S. I wasn't sure if I should target the 4.x branch or the 4.4.x branch -- this should ideally go out as soon as possible, but Sphinx maintains a cap on Docutils versions anyway, so I don't believe a backport is needed.

A
