### PR TITLE
CI: Test with Windows Server 2019

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       if: matrix.coverage
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         architecture: [x86, x64]


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- In nearly days, `windows-latest` image on GHA was changed to Windows
Server 2022.  That causes build errors on building a cython script.
- To avoid the problem, this pins the image for testing on GHA to Windows
Server 2019.
- refs:
  * Succeeded case (Win 2019): https://github.com/sphinx-doc/sphinx/runs/4998470008?check_suite_focus=true
  * Failed case (Win 2022): https://github.com/sphinx-doc/sphinx/runs/5077712630?check_suite_focus=true