### PR TITLE
The latest docutils converts :pep: role to the "https" URL

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -154,14 +154,15 @@ def get_verifier(verify, verify_re):
 @pytest.mark.parametrize('type,rst,html_expected,latex_expected', [
     (
         # pep role
-        'verify',
+        'verify_re',
         ':pep:`8`',
+        # since docutils-0.19, :pep: role points to python.org via https schema
         ('<p><span class="target" id="index-0"></span><a class="pep reference external" '
-         'href="http://www.python.org/dev/peps/pep-0008"><strong>PEP 8</strong></a></p>'),
-        ('\\sphinxAtStartPar\n'
-         '\\index{Python Enhancement Proposals@\\spxentry{Python Enhancement Proposals}'
-         '!PEP 8@\\spxentry{PEP 8}}\\sphinxhref{http://www.python.org/dev/peps/pep-0008}'
-         '{\\sphinxstylestrong{PEP 8}}')
+         'href="https?://www.python.org/dev/peps/pep-0008"><strong>PEP 8</strong></a></p>'),
+        (r'\\sphinxAtStartPar\n'
+         r'\\index{Python Enhancement Proposals@\\spxentry{Python Enhancement Proposals}'
+         r'!PEP 8@\\spxentry{PEP 8}}\\sphinxhref{https?://www.python.org/dev/peps/pep-0008}'
+         r'{\\sphinxstylestrong{PEP 8}}')
     ),
     (
         # pep role with anchor


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- docutils-0.19 (unreleased) generates "https" URL from :pep: role.
- refs: https://github.com/sphinx-doc/sphinx/runs/5080565975?check_suite_focus=true