### PR TITLE
Revert "Close #9993: std domain: Allow to refer an inline target via ref role"

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -762,11 +762,10 @@ class StandardDomain(Domain):
                 sectname = clean_astext(title)
             elif node.tagname == 'rubric':
                 sectname = clean_astext(node)
-            elif node.tagname == 'target' and len(node) > 0:
-                # inline target (ex: blah _`blah` blah)
-                sectname = clean_astext(node)
             elif self.is_enumerable_node(node):
                 sectname = self.get_numfig_title(node)
+                if not sectname:
+                    continue
             else:
                 toctree = next(node.findall(addnodes.toctree), None)
                 if toctree and toctree.get('caption'):
@@ -774,8 +773,7 @@ class StandardDomain(Domain):
                 else:
                     # anonymous-only labels
                     continue
-            if sectname:
-                self.labels[name] = docname, labelid, sectname
+            self.labels[name] = docname, labelid, sectname
 
     def add_program_option(self, program: str, name: str, docname: str, labelid: str) -> None:
         self.progoptions[program, name] = (docname, labelid)

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -453,12 +453,3 @@ def test_labeled_rubric(app):
     domain = app.env.get_domain("std")
     assert 'label' in domain.labels
     assert domain.labels['label'] == ('index', 'label', 'blah blah blah')
-
-
-def test_inline_target(app):
-    text = "blah _`inline target` blah\n"
-    restructuredtext.parse(app, text)
-
-    domain = app.env.get_domain("std")
-    assert 'inline target' in domain.labels
-    assert domain.labels['inline target'] == ('index', 'inline-target', 'inline target')


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

Closes #10177

### Purpose
- Revert #9998

### Detail
- Revert this change, which inadvertently made reference-style links need to be globally unique rather than locally unique

### Relates
- #10177

