### PR TITLE
Fix #10181: napoleon_use_ivar adds unexpected prefix to vars

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ Incompatible changes
 Deprecated
 ----------
 
+* ``sphinx.ext.napoleon.docstring.GoogleDocstring._qualify_name()``
+
 Features added
 --------------
 
@@ -28,6 +30,8 @@ Bugs fixed
   ``no-value`` option
 * #9529: LaTeX: named auto numbered footnote (ex. ``[#named]``) that is referred
   multiple times was rendered to a question mark
+* #10181: napoleon: attributes are displayed like class attributes for google
+  style docstrings when :confval:`napoleon_use_ivar` is enabled
 * #10122: sphinx-build: make.bat does not check the installation of sphinx-build
   command before showing help
 

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -22,6 +22,11 @@ The following is a list of deprecated interfaces.
      - (will be) Removed
      - Alternatives
 
+   * - ``sphinx.ext.napoleon.docstring.GoogleDocstring._qualify_name()``
+     - 4.5
+     - 6.0
+     - N/A
+
    * - ``sphinx.ext.autodoc.AttributeDocumenter._datadescriptor``
      - 4.3
      - 6.0

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -13,11 +13,13 @@
 import collections
 import inspect
 import re
+import warnings
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 from sphinx.application import Sphinx
 from sphinx.config import Config as SphinxConfig
+from sphinx.deprecation import RemovedInSphinx60Warning
 from sphinx.ext.napoleon.iterators import modify_iter
 from sphinx.locale import _, __
 from sphinx.util import logging
@@ -631,7 +633,6 @@ class GoogleDocstring:
             if not _type:
                 _type = self._lookup_annotation(_name)
             if self._config.napoleon_use_ivar:
-                _name = self._qualify_name(_name, self._obj)
                 field = ':ivar %s: ' % _name
                 lines.extend(self._format_block(field, _desc))
                 if _type:
@@ -825,6 +826,8 @@ class GoogleDocstring:
                 "".join(after_colon).strip())
 
     def _qualify_name(self, attr_name: str, klass: Type) -> str:
+        warnings.warn('%s._qualify_name() is deprecated.' %
+                      self.__class__.__name__, RemovedInSphinx60Warning)
         if klass and '.' not in attr_name:
             if attr_name.startswith('~'):
                 attr_name = attr_name[1:]

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -483,6 +483,22 @@ Attributes:
 
    :type: numpy.ndarray
 """
+
+    def test_attributes_with_use_ivar(self):
+        docstring = """\
+Attributes:
+    foo (int): blah blah
+    bar (str): blah blah
+"""
+
+        config = Config(napoleon_use_ivar=True)
+        actual = str(GoogleDocstring(docstring, config, obj=self.__class__))
+        expected = """\
+:ivar foo: blah blah
+:vartype foo: int
+:ivar bar: blah blah
+:vartype bar: str
+"""
         self.assertEqual(expected, actual)
 
     def test_code_block_in_returns_section(self):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 4.0, :ivar: items has not been rendered as hyperlinks.  So any
modules, classes and tilda are now harmful.  This removes the prefixing
filter for napoleon_use_ivar option.
- refs: #10181, #5129 and #5977