### PR TITLE
The latest docutils converts :pep: role to the "https" URL (again)

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -166,16 +166,17 @@ def get_verifier(verify, verify_re):
     ),
     (
         # pep role with anchor
-        'verify',
+        'verify_re',
         ':pep:`8#id1`',
+        # since docutils-0.19, :pep: role points to python.org via https schema
         ('<p><span class="target" id="index-0"></span><a class="pep reference external" '
-         'href="http://www.python.org/dev/peps/pep-0008#id1">'
+         'href="https?://www.python.org/dev/peps/pep-0008#id1">'
          '<strong>PEP 8#id1</strong></a></p>'),
-        ('\\sphinxAtStartPar\n'
-         '\\index{Python Enhancement Proposals@\\spxentry{Python Enhancement Proposals}'
-         '!PEP 8\\#id1@\\spxentry{PEP 8\\#id1}}\\sphinxhref'
-         '{http://www.python.org/dev/peps/pep-0008\\#id1}'
-         '{\\sphinxstylestrong{PEP 8\\#id1}}')
+        (r'\\sphinxAtStartPar\n'
+         r'\\index{Python Enhancement Proposals@\\spxentry{Python Enhancement Proposals}'
+         r'!PEP 8\\#id1@\\spxentry{PEP 8\\#id1}}\\sphinxhref'
+         r'{https?://www.python.org/dev/peps/pep-0008\\#id1}'
+         r'{\\sphinxstylestrong{PEP 8\\#id1}}')
     ),
     (
         # rfc role


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- docutils-0.19 (unreleased) generates "https" URL from :pep: role.
- Same as https://github.com/sphinx-doc/sphinx/pull/10170