### PR TITLE
Fix #10175: LaTeX: named footnote ref is linked to an incorrect footnote

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,8 @@ Bugs fixed
   unhashable object
 * #9529: LaTeX: named auto numbered footnote (ex. ``[#named]``) that is referred
   multiple times was rendered to a question mark
+* #10175: LaTeX: named footnote reference is linked to an incorrect footnote if
+  the name is also used in the different document
 * #10181: napoleon: attributes are displayed like class attributes for google
   style docstrings when :confval:`napoleon_use_ivar` is enabled
 * #10122: sphinx-build: make.bat does not check the installation of sphinx-build

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -571,6 +571,7 @@ class LaTeXTranslator(SphinxTranslator):
 
     def visit_start_of_file(self, node: Element) -> None:
         self.curfilestack.append(node['docname'])
+        self.body.append(CR + r'\sphinxstepscope' + CR)
 
     def depart_start_of_file(self, node: Element) -> None:
         self.curfilestack.pop()

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1197,6 +1197,7 @@ def test_latex_table_tabulars(app, status, warning):
     tables = {}
     for chap in re.split(r'\\(?:section|chapter){', result)[1:]:
         sectname, content = chap.split('}', 1)
+        content = re.sub(r'\\sphinxstepscope', '', content)  # filter a separator
         tables[sectname] = content.strip()
 
     def get_expected(name):
@@ -1266,6 +1267,7 @@ def test_latex_table_longtable(app, status, warning):
     tables = {}
     for chap in re.split(r'\\(?:section|chapter){', result)[1:]:
         sectname, content = chap.split('}', 1)
+        content = re.sub(r'\\sphinxstepscope', '', content)  # filter a separator
         tables[sectname] = content.strip()
 
     def get_expected(name):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- A named footnote reference will be converted to a hyperlink to an
incorrect footnote if the name is also used in the different document.
- refs: #10175 