### PR TITLE
config: Add 'link_inline_targets'

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -483,6 +483,14 @@ General configuration
       The LaTeX builder obeys this setting (if :confval:`numfig` is set to
       ``True``).
 
+.. confval:: link_inline_targets
+
+   If true, inline targets will be cross-referenceable, even if they don't have
+   an explicit title. For example, when this is set, ``_`this one``` can be
+   cross-referenced using ``:ref:`this one```. Default: ``False``.
+
+   .. versionadded:: 4.4.1
+
 .. confval:: smartquotes
 
    If true, the `Docutils Smart Quotes transform`__, originally based on

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -106,12 +106,17 @@ These roles are described with their respective domains:
 Cross-referencing arbitrary locations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. versionchanged:: 4.4.1
+
+   Added the :confval:`link_inline_targets` config option, allowing optional
+   cross-referencing of inline targets without an explicit title.
+
 .. rst:role:: ref
 
    To support cross-referencing to arbitrary locations in any document, the
    standard reST labels are used.  For this to work label names must be unique
-   throughout the entire documentation.  There are two ways in which you can
-   refer to labels:
+   throughout the entire documentation.  How you refer to a label depends on
+   where the label occurs:
 
    * If you place a label directly before a section title, you can reference to
      it with ``:ref:`label-name```.  For example::
@@ -143,9 +148,12 @@ Cross-referencing arbitrary locations
      The same works for tables that are given an explicit caption using the
      :dudir:`table` directive.
 
-   * Labels that aren't placed before a section title can still be referenced,
-     but you must give the link an explicit title, using this syntax:
-     ``:ref:`Link title <label-name>```.
+   * If a label is not placed before a section title then you have two options.
+     The usual way to do this is to give the link an explicit title, using this
+     syntax: ``:ref:`Link title <label-name>```. In this case, the label,
+     ``label-name``, must be globally unique. Alternatively, to avoid
+     duplication, you can configure :confval:`link_inline_targets` to `True`.
+     In this case, the link text becomes the label.
 
    .. note::
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -136,6 +136,7 @@ class Config:
         'numfig': (False, 'env', []),
         'numfig_secnum_depth': (1, 'env', []),
         'numfig_format': ({}, 'env', []),  # will be initialized in init_numfig_format()
+        'link_inline_targets': (False, 'env', []),
 
         'math_number_all': (False, 'env', []),
         'math_eqref_format': (None, 'env', [str]),

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -763,6 +763,8 @@ class StandardDomain(Domain):
             elif node.tagname == 'rubric':
                 sectname = clean_astext(node)
             elif node.tagname == 'target' and len(node) > 0:
+                if env.config.link_inline_targets is False:
+                    continue
                 # inline target (ex: blah _`blah` blah)
                 sectname = clean_astext(node)
             elif self.is_enumerable_node(node):

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -457,8 +457,18 @@ def test_labeled_rubric(app):
 
 def test_inline_target(app):
     text = "blah _`inline target` blah\n"
+    app.config.link_inline_targets = True
     restructuredtext.parse(app, text)
 
     domain = app.env.get_domain("std")
     assert 'inline target' in domain.labels
     assert domain.labels['inline target'] == ('index', 'inline-target', 'inline target')
+
+
+def test_inline_target_disabled(app):
+    text = "blah _`inline target` blah\n"
+    app.config.link_inline_targets = False
+    restructuredtext.parse(app, text)
+
+    domain = app.env.get_domain("std")
+    assert 'inline target' not in domain.labels


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix

(it's a bit of both)

### Purpose

In Sphinx 4.4.0 as result of #9993, we have lost the ability to use reference-style links in docs except where the references are unique. For example, you can no longer use `[1]` style links. This is a breaking change for many users and should not have been included in a MINOR release.

This PR adds a new configuration option, `link_inline_targets`, to disable this behavior by default.

Closes #10177

### Detail

- Add a new `link_inline_targets` config option
- Update docs to reflect this change

### Relates

- #10177

