### PR TITLE
Reduce the minimum body width in basic theme

### DIFF
--- a/sphinx/themes/basic/theme.conf
+++ b/sphinx/themes/basic/theme.conf
@@ -7,7 +7,7 @@ sidebars = localtoc.html, relations.html, sourcelink.html, searchbox.html
 [options]
 nosidebar = false
 sidebarwidth = 230
-body_min_width = 450
+body_min_width = 300
 body_max_width = 800
 navigation_with_keys = False
 enable_search_shortcuts = True


### PR DESCRIPTION
The current 450px width can cause overflow on the right hand size of small devices, leading to weird x scrolls and the appearance that the theme is busted.