### PR TITLE
Fixing duplicate search results bug

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -238,6 +238,17 @@ var Search = {
       }
     });
 
+    // remove duplicate search results
+    var seen = new Set();
+    results = results.reduce((acc, result) => {
+      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      if (!seen.has(resultStr)) {
+        acc.push(result);
+        seen.add(resultStr);
+      }
+      return acc;
+    }, []);
+
     // for debugging
     //Search.lastresults = results.slice();  // a copy
     //console.info('search results:', Search.lastresults);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -239,8 +239,9 @@ var Search = {
     });
 
     // remove duplicate search results
+    // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     var seen = new Set();
-    results = results.reduce((acc, result) => {
+    results = results.reverse().reduce((acc, result) => {
       let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
@@ -248,6 +249,8 @@ var Search = {
       }
       return acc;
     }, []);
+
+    results = results.reverse();
 
     // for debugging
     //Search.lastresults = results.slice();  // a copy


### PR DESCRIPTION

### Feature or Bugfix
- Bugfix


### Purpose
- See #10227 

### Detail

This fix instantiates a hash set to check for whether a result entry has come up previously before including it in the final search result array. Each entry is uniquely represented by a concatenated string of its contents, excluding its score. 

Notice that we reverse the array before doing this check, so that in the case of duplicates, the entry with the highest score is kept. 

### Relates
- #10227 
- #3911