### PR TITLE
Searchtools: fix null query on setIndex

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -167,8 +167,9 @@ const Search = {
   setIndex: (index) => {
     Search._index = index;
     if (Search._queued_query !== null) {
+      const query = Search._queued_query;
       Search._queued_query = null;
-      Search.query(Search._queued_query);
+      Search.query(query);
     }
   },
 


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

Previous to https://github.com/sphinx-doc/sphinx/pull/10028 this code was https://github.com/sphinx-doc/sphinx/blob/b60caca9408bb778ec0b277eed105dab8cfae0bb/sphinx/themes/basic/static/searchtools.js#L93-L100

The current code is making `Search._queued_query` null,
and then doing a search with that instead of doing the search
with the previous value.

### Relates

-  https://github.com/sphinx-doc/sphinx/pull/10028

