### PR TITLE
Fixing duplicate search results bug (5.0)

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -291,6 +291,20 @@ const Search = {
       return leftScore > rightScore ? 1 : -1;
     });
 
+    // remove duplicate search results
+    // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
+    let seen = new Set();
+    results = results.reverse().reduce((acc, result) => {
+      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      if (!seen.has(resultStr)) {
+        acc.push(result);
+        seen.add(resultStr);
+      }
+      return acc;
+    }, []);
+
+    results = results.reverse();
+
     // for debugging
     //Search.lastresults = results.slice();  // a copy
     // console.info("search results:", Search.lastresults);


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- See #10227 

### Detail

This fix instantiates a hash set to check for whether a result entry has come up previously before including it in the final search result array. Each entry is uniquely represented by a concatenated string of its contents, excluding its score.

Notice that we reverse the array before doing this check, so that in the case of duplicates, the entry with the highest score is kept.

### Relates
- #10227 
- #10228 (fix on 4.x branch)
- #3911

