### PR TITLE
Fix search for sphinx_rtd_theme theme

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -209,9 +209,8 @@ const Search = {
     Search.status = out.appendChild(searchSummary);
     Search.output = out.appendChild(searchList);
 
-    document.getElementById("search-progress").innerText = _(
-      "Preparing search..."
-    );
+    let searchProgress = document.getElementById("search-progress");
+    if (searchProgress !== null) searchProgress.innerText = _("Preparing search...");
     Search.startPulse();
 
     // index already loaded, the browser was quick!
@@ -263,7 +262,8 @@ const Search = {
 
     // array of [docname, title, anchor, descr, score, filename]
     let results = [];
-    _removeChildren(document.getElementById("search-progress"));
+    let searchProgress = document.getElementById("search-progress");
+    if (searchProgress !== null) _removeChildren(searchProgress);
 
     // lookup as object
     objectTerms.forEach((term) =>


### PR DESCRIPTION
Since 3b01fbe2adf3077cad5c2cf345c6d000d429d7ac, the search does not work on `sphinx_rtd_theme` theme.
I partially fixed the problem, but there's one more issue:

```
searchtools.js:229 Uncaught TypeError: Cannot read properties of null (reading 'toLowerCase')
    at Object.query (searchtools.js:229:39)
    at Object.setIndex (searchtools.js:171:14)
    at searchindex.js:1:8
```

Can you @AA-Turner help me with that?