### PR TITLE
doctools: fix hideSearchWords

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -168,7 +168,8 @@ const Documentation = {
     document
       .querySelectorAll("span.highlighted")
       .forEach((el) => el.classList.remove("highlighted"));
-    new URLSearchParams(window.location.search).delete('highlight')
+    const url = new URL(window.location);
+    url.searchParams.delete('highlight');
     window.history.replaceState({}, '', url);
   },
 


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

Previous code was:

https://github.com/sphinx-doc/sphinx/blob/b3812f72a98b01bae4b1158761082edc46cfa87f/sphinx/themes/basic/static/doctools.js#L262-L268

The current code is missing declaring `url`.

### Relates

- https://github.com/sphinx-doc/sphinx/pull/10028

