### PR TITLE
doctools: fix shortcuts

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -176,10 +176,7 @@ const Documentation = {
    * helper function to focus on search bar
    */
   focusSearchBar : () => {
-    document
-      .querySelectorAll("input[name=q]")
-      .first()
-      .focus()
+    document.querySelectorAll("input[name=q]")[0]?.focus();
   },
 
   /**
@@ -232,24 +229,24 @@ const Documentation = {
             const prevLink = document.querySelector('link[rel="prev"]');
             if (prevLink && prevLink.href) {
               window.location.href = prevLink.href;
-              return false;
+              event.preventDefault();
             }
             break;
           case "ArrowRight":
             if (!DOCUMENTATION_OPTIONS.NAVIGATION_WITH_KEYS)
               break;
 
-            const nextLink = document.querySelector('link[rel="next"]').href;
+            const nextLink = document.querySelector('link[rel="next"]');
             if (nextLink && nextLink.href) {
               window.location.href = nextLink.href;
-              return false;
+              event.preventDefault();
             }
             break;
           case "Escape":
             if (!DOCUMENTATION_OPTIONS.ENABLE_SEARCH_SHORTCUTS)
               break;
             Documentation.hideSearchWords();
-            return false;
+            event.preventDefault();
         }
       }
 
@@ -259,7 +256,7 @@ const Documentation = {
           if (!DOCUMENTATION_OPTIONS.ENABLE_SEARCH_SHORTCUTS)
             break;
           Documentation.focusSearchBar();
-          return false;
+          event.preventDefault();
       }
     });
   },


### PR DESCRIPTION

### Feature or Bugfix

- Bugfix


### Purpose

Fixes several bugs related to the shortcuts defined by sphinx's basic theme

### Detail

- Previous code was using JQuery to add the listeners https://github.com/sphinx-doc/sphinx/blob/b3812f72a98b01bae4b1158761082edc46cfa87f/sphinx/themes/basic/static/doctools.js#L304

  Looks like by convention returning false mean preventDefault,
  but now with pure js this needs to be called explicitly.

- querySelectorAll is an array-like object, it doesn't have a first()
  method.
- nextLink was being assigned the `href` attribute instead of the
  object itself.


### Relates

- https://github.com/sphinx-doc/sphinx/pull/10028/
