### PR TITLE
Ensure ObjectDescription signature nodes include line numbers

### DIFF
--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -159,12 +159,12 @@ class ObjectDescription(SphinxDirective, Generic[T]):
         node.document = self.state.document
         source, line = self.get_source_info()
         # If any options were specified to the directive,
-        # `self.state.document.current_line` will at this point be set to
-        # `None`.  To ensure nodes created as part of the signature have a line
+        # self.state.document.current_line will at this point be set to
+        # None.  To ensure nodes created as part of the signature have a line
         # number set, set the document's line number correctly.
         #
         # Note that we need to subtract one from the line number since
-        # `note_source` uses 0-based line numbers.
+        # note_source uses 0-based line numbers.
         if line is not None:
             line -= 1
         self.state.document.note_source(source, line)

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -157,6 +157,15 @@ class ObjectDescription(SphinxDirective, Generic[T]):
 
         node = addnodes.desc()
         node.document = self.state.document
+        source, line = self.get_source_info()
+        # If any options were specified to the directive,
+        # `self.state.document.current_line` will at this point be set to
+        # `None`.  To ensure nodes created as part of the signature have a line
+        # number set, set the document's line number correctly.
+        #
+        # Note that we need to subtract one from the line number since
+        # `note_source` uses 0-based line numbers.
+        self.state.document.note_source(source, line - 1 if line is not None else None)
         node['domain'] = self.domain
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -165,7 +165,9 @@ class ObjectDescription(SphinxDirective, Generic[T]):
         #
         # Note that we need to subtract one from the line number since
         # `note_source` uses 0-based line numbers.
-        self.state.document.note_source(source, line - 1 if line is not None else None)
+        if line is not None:
+            line -= 1
+        self.state.document.note_source(source, line)
         node['domain'] = self.domain
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -4,6 +4,7 @@ import re
 import sys
 from unittest.mock import Mock
 
+import docutils.utils
 import pytest
 from docutils import nodes
 
@@ -1372,3 +1373,16 @@ def test_warn_missing_reference(app, status, warning):
     assert "index.rst:6: WARNING: undefined label: 'no-label'" in warning.getvalue()
     assert ("index.rst:6: WARNING: Failed to create a cross reference. "
             "A title or caption not found: 'existing-label'") in warning.getvalue()
+
+
+@pytest.mark.sphinx(confoverrides={'nitpicky': True})
+@pytest.mark.parametrize('include_options', (True, False))
+def test_signature_line_number(app, include_options):
+    text = (".. py:function:: foo(bar : string)\n" +
+            ("   :noindexentry:\n" if include_options else ""))
+    doc = restructuredtext.parse(app, text)
+    xrefs = list(doc.findall(condition=addnodes.pending_xref))
+    assert len(xrefs) == 1
+    source, line = docutils.utils.get_source_line(xrefs[0])
+    assert 'index.rst' in source
+    assert line == 1


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose
Previously, if any options were specified to the directive, line
numbers were not properly included in the signature nodes.
