### PR TITLE
Recognize a documented attribute of a module as non-imported.

### DIFF
--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -193,8 +193,10 @@ class ModuleScanner:
                            name, exc, type='autosummary')
             return False
 
-    def scan(self, imported_members: bool, attr_docs: Mapping[str,str] = {}) -> List[str]:
+    def scan(self, imported_members: bool) -> List[str]:
         members = []
+        analyzer = ModuleAnalyzer.for_module(self.object.__name__)
+        attr_docs = analyzer.find_attr_docs()
         for name in members_of(self.object, self.app.config):
             try:
                 value = safe_getattr(self.object, name)
@@ -306,6 +308,8 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
         """Find module attributes with docstrings."""
         attrs, public = [], []
         try:
+            analyzer = ModuleAnalyzer.for_module(name)
+            attr_docs = analyzer.find_attr_docs()
             for namespace, attr_name in attr_docs:
                 if namespace == '' and attr_name in members:
                     attrs.append(attr_name)
@@ -334,10 +338,8 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
     ns.update(context)
 
     if doc.objtype == 'module':
-        analyzer = ModuleAnalyzer.for_module(name)
-        attr_docs = analyzer.find_attr_docs()
         scanner = ModuleScanner(app, obj)
-        ns['members'] = scanner.scan(imported_members, attr_docs)
+        ns['members'] = scanner.scan(imported_members)
         ns['functions'], ns['all_functions'] = \
             get_members(obj, {'function'}, imported=imported_members)
         ns['classes'], ns['all_classes'] = \

--- a/tests/roots/test-ext-autosummary/autosummary_class_module.py
+++ b/tests/roots/test-ext-autosummary/autosummary_class_module.py
@@ -1,0 +1,2 @@
+class Class():
+  pass

--- a/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
@@ -1,5 +1,6 @@
 from os import path  # NOQA
 from typing import Union
+from autosummary_class_module import Class
 
 __all__ = [
     "CONSTANT1",
@@ -60,3 +61,7 @@ class _Exc(Exception):
 qux = 2
 #: a module-level attribute that has been excluded from __all__
 quuz = 2
+
+considered_as_imported = Class()
+non_imported_member = Class()
+""" This attribute has a docstring, so it is recognized as a not-imported member """

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -218,15 +218,15 @@ def test_autosummary_generate_content_for_module(app):
     assert context['members'] == ['CONSTANT1', 'CONSTANT2', 'Exc', 'Foo', '_Baz', '_Exc',
                                   '__all__', '__builtins__', '__cached__', '__doc__',
                                   '__file__', '__name__', '__package__', '_quux', 'bar',
-                                  'quuz', 'qux']
+                                  'non_imported_member', 'quuz', 'qux']
     assert context['functions'] == ['bar']
     assert context['all_functions'] == ['_quux', 'bar']
     assert context['classes'] == ['Foo']
     assert context['all_classes'] == ['Foo', '_Baz']
     assert context['exceptions'] == ['Exc']
     assert context['all_exceptions'] == ['Exc', '_Exc']
-    assert context['attributes'] == ['CONSTANT1', 'qux', 'quuz']
-    assert context['all_attributes'] == ['CONSTANT1', 'qux', 'quuz']
+    assert context['attributes'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']
+    assert context['all_attributes'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']
     assert context['fullname'] == 'autosummary_dummy_module'
     assert context['module'] == 'autosummary_dummy_module'
     assert context['objname'] == ''
@@ -276,7 +276,8 @@ def test_autosummary_generate_content_for_module_skipped(app):
     context = template.render.call_args[0][1]
     assert context['members'] == ['CONSTANT1', 'CONSTANT2', '_Baz', '_Exc', '__all__',
                                   '__builtins__', '__cached__', '__doc__', '__file__',
-                                  '__name__', '__package__', '_quux', 'quuz', 'qux']
+                                  '__name__', '__package__', '_quux', 'non_imported_member',
+                                  'quuz', 'qux']
     assert context['functions'] == []
     assert context['classes'] == []
     assert context['exceptions'] == []
@@ -292,18 +293,20 @@ def test_autosummary_generate_content_for_module_imported_members(app):
     assert template.render.call_args[0][0] == 'module'
 
     context = template.render.call_args[0][1]
-    assert context['members'] == ['CONSTANT1', 'CONSTANT2', 'Exc', 'Foo', 'Union', '_Baz',
-                                  '_Exc', '__all__', '__builtins__', '__cached__', '__doc__',
-                                  '__file__', '__loader__', '__name__', '__package__',
-                                  '__spec__', '_quux', 'bar', 'path', 'quuz', 'qux']
+    assert context['members'] == ['CONSTANT1', 'CONSTANT2', 'Class', 'Exc', 'Foo', 'Union',
+                                  '_Baz', '_Exc', '__all__', '__builtins__', '__cached__',
+                                  '__doc__', '__file__', '__loader__', '__name__',
+                                  '__package__', '__spec__', '_quux', 'bar',
+                                  'considered_as_imported', 'non_imported_member', 'path',
+                                  'quuz', 'qux']
     assert context['functions'] == ['bar']
     assert context['all_functions'] == ['_quux', 'bar']
-    assert context['classes'] == ['Foo']
-    assert context['all_classes'] == ['Foo', '_Baz']
+    assert context['classes'] == ['Class', 'Foo']
+    assert context['all_classes'] == ['Class', 'Foo', '_Baz']
     assert context['exceptions'] == ['Exc']
     assert context['all_exceptions'] == ['Exc', '_Exc']
-    assert context['attributes'] == ['CONSTANT1', 'qux', 'quuz']
-    assert context['all_attributes'] == ['CONSTANT1', 'qux', 'quuz']
+    assert context['attributes'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']
+    assert context['all_attributes'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']
     assert context['fullname'] == 'autosummary_dummy_module'
     assert context['module'] == 'autosummary_dummy_module'
     assert context['objname'] == ''
@@ -351,6 +354,7 @@ def test_autosummary_generate(app, status, warning):
             '      CONSTANT1\n'
             '      qux\n'
             '      quuz\n'
+            '      non_imported_member\n'
             '   \n' in module)
 
     Foo = (app.srcdir / 'generated' / 'autosummary_dummy_module.Foo.rst').read_text()


### PR DESCRIPTION
Subject: To recognize better, whether a module attribute is imported or not.

Feature or Bugfix - It changes the behavior of the autosummary, so it is a breaking change,
but this change can or can not (depending on the point of view) be considered as a bugfix

### Purpose
If an object of an imported class is instantiated in a module and it is assigned to a module attribute, 
it has been so far always considered as imported. This results in not documenting some module members.

The behavior comes from the fact, that object.__module__ attribute is inherited from its class
and the comparison of __module__ attribute have been the way how to recognize imported 
stuff.

Since there is probably no simple way how to find out whether an object
was imported or not, this pullrequest solve the issue partially.
If a module attribute is explicitly documented in the source file, 
it is surely non-imported - thus, it is marked so.

