### PR TITLE
Enable FORCE_COLOR and NO_COLOR for terminal colouring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Other contributors, listed alphabetically, are:
 * Pauli Virtanen -- autodoc improvements, autosummary extension
 * Eric N. Vander Weele -- autodoc improvements
 * Stefan van der Walt -- autosummary extension
+* Hugo van Kemenade -- support FORCE_COLOR and NO_COLOR
 * Thomas Waldmann -- apidoc module fixes
 * John Waltman -- Texinfo builder
 * Barry Warsaw -- setup command improvements

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Deprecated
 Features added
 --------------
 
+* #10260: Enable ``FORCE_COLOR`` and ``NO_COLOR`` for terminal colouring
 * #10234: autosummary: Add "autosummary" CSS class to summary tables
 * #10125: extlinks: Improve suggestion message for a reference having title
 * #9494, #9456: html search: Add a config variable

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -304,6 +304,22 @@ variables to customize behavior:
    Additional options for :program:`sphinx-build`. These options can
    also be set via the shortcut variable **O** (capital 'o').
 
+.. describe:: NO_COLOR
+
+   When set (regardless of value), :program:`sphinx-build`  will not use color
+   in terminal output. ``NO_COLOR`` takes precedence over ``FORCE_COLOR``. See
+   `no-color.org <https://no-color.org/>`__ for other libraries supporting this
+   community standard.
+
+   .. versionadded:: 4.5.0
+
+.. describe:: FORCE_COLOR
+
+   When set (regardless of value), :program:`sphinx-build` will use color in
+   terminal output. ``NO_COLOR`` takes precedence over ``FORCE_COLOR``.
+
+   .. versionadded:: 4.5.0
+
 .. _when-deprecation-warnings-are-displayed:
 
 Deprecation Warnings

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -57,8 +57,12 @@ def term_width_line(text: str) -> str:
 
 
 def color_terminal() -> bool:
+    if 'NO_COLOR' in os.environ:
+        return False
     if sys.platform == 'win32' and colorama is not None:
         colorama.init()
+        return True
+    if 'FORCE_COLOR' in os.environ:
         return True
     if not hasattr(sys.stdout, 'isatty'):
         return False


### PR DESCRIPTION
Subject: Allow these widely-used environment variables to improve readability of output

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose

Colour can help diagnose problems, and a common place for Sphinx and the need to diagnose problems is on a CI.

However, because [GitHub Actions doesn't use a tty](https://github.com/actions/runner/issues/241), output of tools which autodetect the terminal output is usually monochrome.

Normally you only want to enable colour on a tty, because if you're piping data between commands (not a tty) the colour codes can mess up parsing of piped output. But that's not the case here.

That's why many tools and CI setups use the `FORCE_COLOR` environment variable, and/or command-line options to turn it back on.

Other tools for reference:

* pytest [issue](https://github.com/pytest-dev/pytest/issues/7464), [PR](https://github.com/pytest-dev/pytest/pull/7466) and [docs](https://pytest.org/en/7.0.x/reference/reference.html#environment-variables)
* nox [issue](https://github.com/theacodes/nox/issues/502) and [PR](https://github.com/theacodes/nox/pull/524)
* tox [PR](https://github.com/tox-dev/tox/pull/1630)
* pypa/build [PR](https://github.com/pypa/build/pull/335)
* Colorama [WIP PR](https://github.com/tartley/colorama/pull/230)
* Node.js [docs](https://nodejs.org/api/tty.html#writestreamgetcolordepthenv)


### Detail
- Like other tools, `NO_COLOR` takes precedence
- Keep the Windows-specific check before because it initialises `colorama`
- `FORCE_COLOR` next

### Relates
- https://no-color.org/
