### PR TITLE
escape base_uri in extlinks

### DIFF
--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -26,6 +26,7 @@
 """
 
 import re
+import sys
 import warnings
 from typing import Any, Dict, List, Tuple
 
@@ -70,7 +71,12 @@ class ExternalLinksChecker(SphinxPostTransform):
         title = refnode.astext()
 
         for alias, (base_uri, _caption) in self.app.config.extlinks.items():
-            uri_pattern = re.compile(re.escape(base_uri).replace('%s', '(?P<value>.+)'))
+            if sys.version_info < (3, 7):
+                # Replace a leading backslash because re.escape() inserts a backslash before % on python 3.6
+                uri_pattern = re.compile(re.escape(base_uri).replace('\\%s', '(?P<value>.+)'))
+            else:
+                uri_pattern = re.compile(re.escape(base_uri).replace('%s', '(?P<value>.+)'))
+
             match = uri_pattern.match(uri)
             if match and match.groupdict().get('value'):
                 # build a replacement suggestion

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -72,7 +72,8 @@ class ExternalLinksChecker(SphinxPostTransform):
 
         for alias, (base_uri, _caption) in self.app.config.extlinks.items():
             if sys.version_info < (3, 7):
-                # Replace a leading backslash because re.escape() inserts a backslash before % on python 3.6
+                # Replace a leading backslash because re.escape() inserts a backslash before %
+                # on python 3.6
                 uri_pattern = re.compile(re.escape(base_uri).replace('\\%s', '(?P<value>.+)'))
             else:
                 uri_pattern = re.compile(re.escape(base_uri).replace('%s', '(?P<value>.+)'))

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -70,7 +70,7 @@ class ExternalLinksChecker(SphinxPostTransform):
         title = refnode.astext()
 
         for alias, (base_uri, _caption) in self.app.config.extlinks.items():
-            uri_pattern = re.compile(base_uri.replace('%s', '(?P<value>.+)'))
+            uri_pattern = re.compile(re.escape(base_uri).replace('%s', '(?P<value>.+)'))
             match = uri_pattern.match(uri)
             if match and match.groupdict().get('value'):
                 # build a replacement suggestion


### PR DESCRIPTION
Subject: escape base_uri before regex compiling in extlinks

### Feature or Bugfix
- Bugfix

### Purpose
The goal is to to avoid regex issues with URIs containing special characters. We experienced a recent change in the handling of extlinks to break using some sort of external URIs, thus using this fix to avoid that - see the below linked issue for details.


### Relates
Closes https://github.com/sphinx-doc/sphinx/issues/10205 .

