### PR TITLE
test: empty tuple type is now repesented w/o args since py3.11

### DIFF
--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -78,7 +78,12 @@ def test_restify_type_hints_containers():
                                              "[:py:class:`str`, :py:class:`str`, "
                                              ":py:class:`str`]")
     assert restify(Tuple[str, ...]) == ":py:class:`~typing.Tuple`\\ [:py:class:`str`, ...]"
-    assert restify(Tuple[()]) == ":py:class:`~typing.Tuple`\\ [()]"
+
+    if sys.version_info < (3, 11):
+        assert restify(Tuple[()]) == ":py:class:`~typing.Tuple`\\ [()]"
+    else:
+        assert restify(Tuple[()]) == ":py:class:`~typing.Tuple`"
+
     assert restify(List[Dict[str, Tuple]]) == (":py:class:`~typing.List`\\ "
                                                "[:py:class:`~typing.Dict`\\ "
                                                "[:py:class:`str`, :py:class:`~typing.Tuple`]]")
@@ -270,9 +275,14 @@ def test_stringify_type_hints_containers():
     assert stringify(Tuple[str, ...], "fully-qualified") == "typing.Tuple[str, ...]"
     assert stringify(Tuple[str, ...], "smart") == "~typing.Tuple[str, ...]"
 
-    assert stringify(Tuple[()]) == "Tuple[()]"
-    assert stringify(Tuple[()], "fully-qualified") == "typing.Tuple[()]"
-    assert stringify(Tuple[()], "smart") == "~typing.Tuple[()]"
+    if sys.version_info < (3, 11):
+        assert stringify(Tuple[()]) == "Tuple[()]"
+        assert stringify(Tuple[()], "fully-qualified") == "typing.Tuple[()]"
+        assert stringify(Tuple[()], "smart") == "~typing.Tuple[()]"
+    else:
+        assert stringify(Tuple[()]) == "Tuple"
+        assert stringify(Tuple[()], "fully-qualified") == "typing.Tuple"
+        assert stringify(Tuple[()], "smart") == "~typing.Tuple"
 
     assert stringify(List[Dict[str, Tuple]]) == "List[Dict[str, Tuple]]"
     assert stringify(List[Dict[str, Tuple]], "fully-qualified") == "typing.List[typing.Dict[str, typing.Tuple]]"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- refs: https://github.com/python/cpython/commit/15df8f8d89a0e563bdd15e4cd6734298736a5a1d
