### PR TITLE
Fix #10277: html search: Could not search short words (ex. "use")

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Bugs fixed
   ``no-value`` option
 * #9971: autodoc: TypeError is raised when the target object is annotated by
   unhashable object
+* #10277: html search: Could not search short words (ex. "use")
 * #9529: LaTeX: named auto numbered footnote (ex. ``[#named]``) that is referred
   multiple times was rendered to a question mark
 * #9924: LaTeX: multi-line :rst:dir:`cpp:function` directive has big vertical

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -172,10 +172,6 @@ var Search = {
       }
       // stem the word
       var word = stemmer.stemWord(tmp[i].toLowerCase());
-      // prevent stemmer from cutting word smaller than two chars
-      if(word.length < 3 && tmp[i].length >= 3) {
-        word = tmp[i];
-      }
       var toAppend;
       // select the correct list
       if (word[0] == '-') {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #10277 