### PR TITLE
PEP role: Include trailing slash in  URL to avoid 301 redirect

### DIFF
--- a/doc/tutorial/automatic-doc-generation.rst
+++ b/doc/tutorial/automatic-doc-generation.rst
@@ -5,7 +5,7 @@ In the :ref:`previous section <tutorial-describing-objects>` of the tutorial
 you manually documented a Python function in Sphinx. However, the description
 was out of sync with the code itself, since the function signature was not
 the same. Besides, it would be nice to reuse `Python
-docstrings <https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring>`_
+docstrings <https://peps.python.org/pep-0257/#what-is-a-docstring>`_
 in the documentation, rather than having to write the information in two
 places.
 

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -662,7 +662,7 @@ There are also config values that you can set:
 
         ...
 
-   .. __: https://www.python.org/dev/peps/pep-0563/
+   .. __: https://peps.python.org/pep-0563/
    .. __: https://mypy.readthedocs.io/en/latest/kinds_of_types.html#type-aliases
    .. versionadded:: 3.3
 

--- a/doc/usage/extensions/doctest.rst
+++ b/doc/usage/extensions/doctest.rst
@@ -94,7 +94,7 @@ a comma-separated list of group names.
      * ``===``: Arbitrary equality clause.
 
      ``pyversion`` option is followed `PEP-440: Version Specifiers
-     <https://www.python.org/dev/peps/pep-0440/#version-specifiers>`__.
+     <https://peps.python.org/pep-0440/#version-specifiers>`__.
 
      .. versionadded:: 1.6
 

--- a/doc/usage/extensions/example_google.py
+++ b/doc/usage/extensions/example_google.py
@@ -57,7 +57,7 @@ def function_with_types_in_docstring(param1, param2):
         bool: The return value. True for success, False otherwise.
 
     .. _PEP 484:
-        https://www.python.org/dev/peps/pep-0484/
+        https://peps.python.org/pep-0484/
 
     """
 

--- a/doc/usage/extensions/example_numpy.py
+++ b/doc/usage/extensions/example_numpy.py
@@ -72,7 +72,7 @@ def function_with_types_in_docstring(param1, param2):
         True if successful, False otherwise.
 
     .. _PEP 484:
-        https://www.python.org/dev/peps/pep-0484/
+        https://peps.python.org/pep-0484/
 
     """
 

--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -50,7 +50,7 @@ the documentation, so it doesn't modify any of the docstrings in your actual
 source code files.
 
 .. _ReStructuredText: https://docutils.sourceforge.io/rst.html
-.. _docstrings: https://www.python.org/dev/peps/pep-0287/
+.. _docstrings: https://peps.python.org/pep-0287/
 .. _Google Python Style Guide:
    https://google.github.io/styleguide/pyguide.html
 .. _Google:
@@ -267,9 +267,9 @@ Google style with types in docstrings::
    `Python 2/3 compatible annotations`_ aren't currently
    supported by Sphinx and won't show up in the docs.
 
-.. _PEP 484: https://www.python.org/dev/peps/pep-0484/
-.. _PEP 526: https://www.python.org/dev/peps/pep-0526/
-.. _Python 2/3 compatible annotations: https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code
+.. _PEP 484: https://peps.python.org/pep-0484/
+.. _PEP 526: https://peps.python.org/pep-0526/
+.. _Python 2/3 compatible annotations: https://peps.python.org/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code
 
 
 Configuration

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1661,7 +1661,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         if not self.doc_as_attr and self.options.show_inheritance:
             if inspect.getorigbases(self.object):
                 # A subclass of generic types
-                # refs: PEP-560 <https://www.python.org/dev/peps/pep-0560/>
+                # refs: PEP-560 <https://peps.python.org/pep-0560/>
                 bases = list(self.object.__orig_bases__)
             elif hasattr(self.object, '__bases__') and len(self.object.__bases__):
                 # A normal class

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -41,7 +41,7 @@ def is_allowed_version(spec: str, version: str) -> bool:
     """Check `spec` satisfies `version` or not.
 
     This obeys PEP-440 specifiers:
-    https://www.python.org/dev/peps/pep-0440/#version-specifiers
+    https://peps.python.org/pep-0440/#version-specifiers
 
     Some examples:
 

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -193,9 +193,9 @@ class PEP(ReferenceRole):
         base_url = self.inliner.document.settings.pep_base_url
         ret = self.target.split('#', 1)
         if len(ret) == 2:
-            return base_url + 'pep-%04d#%s' % (int(ret[0]), ret[1])
+            return base_url + 'pep-%04d/#%s' % (int(ret[0]), ret[1])
         else:
-            return base_url + 'pep-%04d' % int(ret[0])
+            return base_url + 'pep-%04d/' % int(ret[0])
 
 
 class RFC(ReferenceRole):

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -422,7 +422,7 @@ def split_full_qualified_name(name: str) -> Tuple[Optional[str], str]:
     """Split full qualified name to a pair of modname and qualname.
 
     A qualname is an abbreviation for "Qualified name" introduced at PEP-3155
-    (https://www.python.org/dev/peps/pep-3155/).  It is a dotted path name
+    (https://peps.python.org/pep-3155/).  It is a dotted path name
     from the module top-level.
 
     A "full" qualified name means a string containing both module name and

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -212,9 +212,9 @@ def test_html4_output(app, status, warning):
         (".//li/p/code/span[@class='pre']", '^a/$'),
         (".//li/p/code/em/span[@class='pre']", '^varpart$'),
         (".//li/p/code/em/span[@class='pre']", '^i$'),
-        (".//a[@href='https://peps.python.org/pep-0008']"
+        (".//a[@href='https://peps.python.org/pep-0008/']"
          "[@class='pep reference external']/strong", 'PEP 8'),
-        (".//a[@href='https://peps.python.org/pep-0008']"
+        (".//a[@href='https://peps.python.org/pep-0008/']"
          "[@class='pep reference external']/strong",
          'Python Enhancement Proposal #8'),
         (".//a[@href='https://datatracker.ietf.org/doc/html/rfc1.html']"

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -150,10 +150,10 @@ def get_verifier(verify, verify_re):
         'verify',
         ':pep:`8`',
         ('<p><span class="target" id="index-0"></span><a class="pep reference external" '
-         'href="https://peps.python.org/pep-0008"><strong>PEP 8</strong></a></p>'),
+         'href="https://peps.python.org/pep-0008/"><strong>PEP 8</strong></a></p>'),
         ('\\sphinxAtStartPar\n'
          '\\index{Python Enhancement Proposals@\\spxentry{Python Enhancement Proposals}'
-         '!PEP 8@\\spxentry{PEP 8}}\\sphinxhref{https://peps.python.org/pep-0008}'
+         '!PEP 8@\\spxentry{PEP 8}}\\sphinxhref{https://peps.python.org/pep-0008/}'
          '{\\sphinxstylestrong{PEP 8}}')
     ),
     (
@@ -161,12 +161,12 @@ def get_verifier(verify, verify_re):
         'verify',
         ':pep:`8#id1`',
         ('<p><span class="target" id="index-0"></span><a class="pep reference external" '
-         'href="https://peps.python.org/pep-0008#id1">'
+         'href="https://peps.python.org/pep-0008/#id1">'
          '<strong>PEP 8#id1</strong></a></p>'),
         ('\\sphinxAtStartPar\n'
          '\\index{Python Enhancement Proposals@\\spxentry{Python Enhancement Proposals}'
          '!PEP 8\\#id1@\\spxentry{PEP 8\\#id1}}\\sphinxhref'
-         '{https://peps.python.org/pep-0008\\#id1}'
+         '{https://peps.python.org/pep-0008/\\#id1}'
          '{\\sphinxstylestrong{PEP 8\\#id1}}')
     ),
     (


### PR DESCRIPTION
Subject: PEP role: Include trailing / in  URL to avoid 301 redirect

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Link `:pep:8` to `https://peps.python.org/pep-0008/` instead of `https://peps.python.org/pep-0008`

### Detail
- Without the trailing `/`, there's an HTTP 301 redirect to add the slash, which adds a small but unnecessary delay

#### Without trailing `/`, the 301 may take between 20ms and 335ms (caching off)

![image](https://user-images.githubusercontent.com/1324225/159907168-1d7e4af7-0ee7-4712-9d45-892468345913.png)

![image](https://user-images.githubusercontent.com/1324225/159907205-531887c8-a4a7-4a46-9af7-fca3c1840a82.png)

![image](https://user-images.githubusercontent.com/1324225/159907272-055f369e-0a30-4141-b8c2-dd444d89a47e.png)

#### With the trailing `/`, that request is skipped

![image](https://user-images.githubusercontent.com/1324225/159907450-6b7a32c7-2f55-4f66-93bc-c0dbd5b8a566.png)

![image](https://user-images.githubusercontent.com/1324225/159907481-bde88606-d30a-4e85-af36-207c6f3f86cb.png)

![image](https://user-images.githubusercontent.com/1324225/159907507-e5554cf8-78b4-4fac-902c-73d0fa303c6d.png)

- Also update docs and docstrings to use the new form.


### Relates
- https://github.com/sphinx-doc/sphinx/pull/10267

