### PR TITLE
Use license_files to fix setuptools deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [egg_info]
 tag_build = .dev


### PR DESCRIPTION
Subject: Use license_files to fix setuptools deprecation warning

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Fix deprecation warning so Sphinx is ready for future versions of setuptools

### Detail
- The `license_file` option is now marked as deprecated. Use `license_files` instead:

```
  /home/runner/work/sphinx/sphinx/.tox/du15/lib/python3.7/site-packages/setuptools/config.py:510: DeprecationWarning: The license_file parameter is deprecated, use license_files instead.
```

https://github.com/sphinx-doc/sphinx/runs/5677768304?check_suite_focus=true#step:9:1832

### Relates
- https://setuptools.pypa.io/en/latest/history.html#v56-0-0

