### PR TITLE
Fix #10214: html: invalid language tag was generated for zh_CN

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,8 @@ Bugs fixed
 
 * #10279: autodoc: Default values for keyword only arguments in overloaded
   functions are rendered as a string literal
+* #10214: html: invalid language tag was generated if :confval:`language`
+  contains a country code (ex. zh_CN)
 * #10236: html search: objects are duplicated in search result
 * #9962: texinfo: Deprecation message for ``@definfoenclose`` command on
   bulding texinfo document

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -7,7 +7,7 @@ import re
 import sys
 from datetime import datetime
 from os import path
-from typing import IO, Any, Dict, Iterable, Iterator, List, Set, Tuple, Type
+from typing import IO, Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Type
 from urllib.parse import quote
 
 from docutils import nodes
@@ -66,6 +66,17 @@ def get_stable_hash(obj: Any) -> str:
     elif isinstance(obj, (list, tuple)):
         obj = sorted(get_stable_hash(o) for o in obj)
     return md5(str(obj).encode()).hexdigest()
+
+
+def convert_locale_to_language_tag(locale: Optional[str]) -> Optional[str]:
+    """Convert a locale string to a language tag (ex. en_US -> en-US).
+
+    refs: BCP 47 (:rfc:`5646`)
+    """
+    if locale:
+        return locale.replace('_', '-')
+    else:
+        return None
 
 
 class Stylesheet(str):
@@ -510,7 +521,7 @@ class StandaloneHTMLBuilder(Builder):
             'file_suffix': self.out_suffix,
             'link_suffix': self.link_suffix,
             'script_files': self.script_files,
-            'language': self.config.language,
+            'language': convert_locale_to_language_tag(self.config.language),
             'css_files': self.css_files,
             'sphinx_version': __display_version__,
             'sphinx_version_tuple': sphinx_version,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- So far, HTML builder output the `language` configuration as a language
tag for HTML.  But it takes locale string in ANSI C, not IETF language
code.
- This converts locale string to language tag to generate valid language
tag for HTML.
- refs: #10214 