### PR TITLE
Support mocked decorator for class methods

### DIFF
--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -186,6 +186,7 @@ def ismock(subject: Any) -> bool:
 
     return False
 
+
 def undecorate(subject: _MockObject) -> Any:
     """Unwrap mock if *subject* is decorated by mocked object.
 

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -9,7 +9,7 @@ from types import MethodType, ModuleType
 from typing import Any, Generator, Iterator, List, Optional, Sequence, Tuple, Union
 
 from sphinx.util import logging
-from sphinx.util.inspect import safe_getattr
+from sphinx.util.inspect import isboundmethod, safe_getattr
 
 logger = logging.getLogger(__name__)
 
@@ -127,14 +127,6 @@ class MockFinder(MetaPathFinder):
         """Invalidate mocked modules on sys.modules."""
         for modname in self.mocked_modules:
             sys.modules.pop(modname, None)
-
-
-def isboundmethod(method: MethodType) -> bool:
-    """Check if the method is a bound method."""
-    try:
-        return method.__self__ is not None
-    except AttributeError:
-        return False
 
 
 @contextlib.contextmanager

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -166,11 +166,13 @@ def ismock(subject: Any) -> bool:
 
     # check the object is bound method
     if isinstance(subject, MethodType) and isboundmethod(subject):
-        return ismock(subject.__func__)
+        tmp_subject = subject.__func__
+    else:
+        tmp_subject = subject
 
     try:
         # check the object is mocked object
-        __mro__ = safe_getattr(type(subject), '__mro__', [])
+        __mro__ = safe_getattr(type(tmp_subject), '__mro__', [])
         if len(__mro__) > 2 and __mro__[-2] is _MockObject:
             # A mocked object has a MRO that ends with (..., _MockObject, object).
             return True

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -173,13 +173,11 @@ def ismock(subject: Any) -> bool:
 
     # check the object is bound method
     if isinstance(subject, MethodType) and _method_is_bound(subject):
-        tmp_subject = subject.__func__
-    else:
-        tmp_subject = subject
+        return ismock(subject.__func__)
 
     try:
         # check the object is mocked object
-        __mro__ = safe_getattr(type(tmp_subject), '__mro__', [])
+        __mro__ = safe_getattr(type(subject), '__mro__', [])
         if len(__mro__) > 2 and __mro__[-2] is _MockObject:
             # A mocked object has a MRO that ends with (..., _MockObject, object).
             return True

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -129,7 +129,7 @@ class MockFinder(MetaPathFinder):
             sys.modules.pop(modname, None)
 
 
-def _method_is_bound(method: MethodType) -> bool:
+def isboundmethod(method: MethodType) -> bool:
     """Check if the method is a bound method."""
     try:
         return method.__self__ is not None
@@ -173,7 +173,7 @@ def ismock(subject: Any) -> bool:
         return True
 
     # check the object is bound method
-    if isinstance(subject, MethodType) and _method_is_bound(subject):
+    if isinstance(subject, MethodType) and isboundmethod(subject):
         return ismock(subject.__func__)
 
     try:

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -129,7 +129,8 @@ class MockFinder(MetaPathFinder):
             sys.modules.pop(modname, None)
 
 
-def _method_is_bound(method):
+def _method_is_bound(method: MethodType) -> bool:
+    """Check if the method is a bound method."""
     try:
         return method.__self__ is not None
     except AttributeError:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -305,10 +305,7 @@ def isabstractmethod(obj: Any) -> bool:
 
 def isboundmethod(method: MethodType) -> bool:
     """Check if the method is a bound method."""
-    try:
-        return method.__self__ is not None
-    except AttributeError:
-        return False
+    return safe_getattr(method, '__self__', None) is not None
 
 
 def is_cython_function_or_method(obj: Any) -> bool:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -13,7 +13,7 @@ from functools import partial, partialmethod
 from importlib import import_module
 from inspect import Parameter, isclass, ismethod, ismethoddescriptor, ismodule  # NOQA
 from io import StringIO
-from types import ModuleType
+from types import MethodType, ModuleType
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, Type, cast
 
 from sphinx.deprecation import RemovedInSphinx50Warning
@@ -301,6 +301,14 @@ def isdescriptor(x: Any) -> bool:
 def isabstractmethod(obj: Any) -> bool:
     """Check if the object is an abstractmethod."""
     return safe_getattr(obj, '__isabstractmethod__', False) is True
+
+
+def isboundmethod(method: MethodType) -> bool:
+    """Check if the method is a bound method."""
+    try:
+        return method.__self__ is not None
+    except AttributeError:
+        return False
 
 
 def is_cython_function_or_method(obj: Any) -> bool:

--- a/tests/test_ext_autodoc_mock.py
+++ b/tests/test_ext_autodoc_mock.py
@@ -114,6 +114,11 @@ def test_mock_decorator():
         def meth(self):
             pass
 
+        @classmethod
+        @mock.method_deco
+        def class_meth(cls):
+            pass
+
     @mock.class_deco
     class Bar:
         pass
@@ -124,6 +129,7 @@ def test_mock_decorator():
 
     assert undecorate(func).__name__ == "func"
     assert undecorate(Foo.meth).__name__ == "meth"
+    assert undecorate(Foo.class_meth).__name__ == "class_meth"
     assert undecorate(Bar).__name__ == "Bar"
     assert undecorate(Baz).__name__ == "Baz"
 


### PR DESCRIPTION
Subject: support mocked decorator for class methods

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Before this PR, class methods decorated with mocked functions were not shown in the generated documentation.

### Detail
- Consider bound methods in `ismock()` to handle this specific case.

### Relates
- #10310

