### PR TITLE
Fix #10279: autodoc: Default values are rendered as a string literal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,8 @@ Features added
 Bugs fixed
 ----------
 
+* #10279: autodoc: Default values for keyword only arguments in overloaded
+  functions are rendered as a string literal
 * #10236: html search: objects are duplicated in search result
 * #9962: texinfo: Deprecation message for ``@definfoenclose`` command on
   bulding texinfo document

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -775,7 +775,10 @@ def signature_from_ast(node: ast.FunctionDef, code: str = '') -> inspect.Signatu
                                 annotation=annotation))
 
     for i, arg in enumerate(args.kwonlyargs):
-        default = ast_unparse(args.kw_defaults[i], code) or Parameter.empty  # type: ignore
+        if args.kw_defaults[i] is None:
+            default = Parameter.empty
+        else:
+            default = DefaultValue(ast_unparse(args.kw_defaults[i], code))  # type: ignore  # NOQA
         annotation = ast_unparse(arg.annotation, code) or Parameter.empty
         params.append(Parameter(arg.arg, Parameter.KEYWORD_ONLY, default=default,
                                 annotation=annotation))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- When processing overloaded functions, autodoc unexpectedly renders its
default values for kwonlyargs as a string literal unexpectedly
- refs: #10279 