### PR TITLE
Fix #10318: literalinclude: :prepend: option working with :dedent:

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,8 @@ Bugs fixed
   bulding texinfo document
 * #10000: LaTeX: glossary terms with common definition are rendered with
   too much vertical whitespace
+* #10318: ``:prepend:`` option of :rst:dir:`literalinclude` directive does not
+  work with ``:dedent:`` option
 
 Testing
 --------

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -224,9 +224,9 @@ class LiteralIncludeReader:
                        self.start_filter,
                        self.end_filter,
                        self.lines_filter,
+                       self.dedent_filter,
                        self.prepend_filter,
-                       self.append_filter,
-                       self.dedent_filter]
+                       self.append_filter]
             lines = self.read_file(self.filename, location=location)
             for func in filters:
                 lines = func(lines, location=location)

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -252,6 +252,19 @@ def test_LiteralIncludeReader_dedent(literal_inc_path):
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_dedent_and_append_and_prepend(literal_inc_path):
+    # dedent: 2
+    options = {'lines': '9-11', 'dedent': 2, 'prepend': 'class Foo:', 'append': '# comment'}
+    reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("class Foo:\n"
+                       "  def baz():\n"
+                       "      pass\n"
+                       "\n"
+                       "# comment\n")
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader_tabwidth(testroot):
     # tab-width: 4
     options = {'tab-width': 4, 'pyobject': 'Qux'}


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It will always be warned because prepending is processed before
dedenting.  This changes the order of processing options.
- refs: #10318 