### PR TITLE
Closes #10344: remove incorrect example

### DIFF
--- a/doc/development/theming.rst
+++ b/doc/development/theming.rst
@@ -245,29 +245,6 @@ Now, you will have access to this function in jinja like so:
    </div>
 
 
-Add your own static files to the build assets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you are packaging your own build assets with an extension
-(e.g., a CSS or JavaScript file), you need to ensure that they are placed
-in the ``_static/`` folder of HTML outputs. To do so, you may copy them directly
-into a build's ``_static/`` folder at build time, generally via an event hook.
-Here is some sample code to accomplish this:
-
-.. code-block:: python
-
-   from os import path
-   from sphinx.util.fileutil import copy_asset_file
-
-   def copy_custom_files(app, exc):
-       if app.builder.format == 'html' and not exc:
-           staticdir = path.join(app.builder.outdir, '_static')
-           copy_asset_file('path/to/myextension/_static/myjsfile.js', staticdir)
-
-   def setup(app):
-       app.connect('builder-inited', copy_custom_files)
-
-
 Inject JavaScript based on user configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This example was added as part of #7058 based on comment from
@tk0miya https://github.com/sphinx-doc/sphinx/pull/7058#discussion_r459184203.

It happens that static files under the `static` folder of a theme are
already automatically added, as stated in
https://www.sphinx-doc.org/en/master/development/theming.html#creating-themes
and as commented two days later by @tk0miya
https://github.com/sphinx-doc/sphinx/pull/7058#discussion_r459957378.

Hence this example is both wrong and superfluous.

Subject: remove incorrect example

### Feature or Bugfix

- Bugfix (documentation)
