### PR TITLE
Move `babel` support to a dedicated utility file

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run:  pip install -U babel jinja2 transifex-client
     - name: Extract translations from source code
-      run:  python setup.py extract_messages
+      run:  python utils/babel_runner.py extract
     - name: Push translations to transifex.com
       run:  cd sphinx/locale && tx push -s --no-interactive --parallel
       env:
@@ -42,13 +42,13 @@ jobs:
     - name: Install dependencies
       run:  pip install -U babel jinja2 transifex-client
     - name: Extract translations from source code
-      run:  python setup.py extract_messages
+      run:  python utils/babel_runner.py extract
     - name: Pull translations to transifex.com
       run:  cd sphinx/locale && tx pull -a -f --no-interactive --parallel
       env:
         TX_TOKEN: ${{ secrets.TX_TOKEN }}
     - name: Compile message catalogs
-      run:  python setup.py compile_catalog
+      run:  python utils/babel_runner.py compile
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/doc/internals/contributing.rst
+++ b/doc/internals/contributing.rst
@@ -252,17 +252,19 @@ locales.  The translations are kept as gettext ``.po`` files translated from the
 master template :file:`sphinx/locale/sphinx.pot`.
 
 Sphinx uses `Babel <https://babel.pocoo.org/en/latest/>`_ to extract messages
-and maintain the catalog files.  It is integrated in ``setup.py``:
+and maintain the catalog files.  The ``utils`` directory contains a helper
+script, ``babel_runner.py``.
 
-* Use ``python setup.py extract_messages`` to update the ``.pot`` template.
-* Use ``python setup.py update_catalog`` to update all existing language
+* Use ``python babel_runner.py extract`` to update the ``.pot`` template.
+* Use ``python babel_runner.py update`` to update all existing language
   catalogs in ``sphinx/locale/*/LC_MESSAGES`` with the current messages in the
   template file.
-* Use ``python setup.py compile_catalog`` to compile the ``.po`` files to binary
+* Use ``python babel_runner.py compile`` to compile the ``.po`` files to binary
   ``.mo`` files and ``.js`` files.
 
-When an updated ``.po`` file is submitted, run compile_catalog to commit both
-the source and the compiled catalogs.
+When an updated ``.po`` file is submitted, run
+``python babel_runner.py compile`` to commit both the source and the compiled
+catalogs.
 
 When a new locale is submitted, add a new directory with the ISO 639-1 language
 identifier and put ``sphinx.po`` in there.  Don't forget to update the possible
@@ -273,9 +275,9 @@ The Sphinx core messages can also be translated on `Transifex
 which is provided by the ``transifex_client`` Python package, can be used to
 pull translations in ``.po`` format from Transifex.  To do this, go to
 ``sphinx/locale`` and then run ``tx pull -f -l LANG`` where ``LANG`` is an
-existing language identifier.  It is good practice to run ``python setup.py
-update_catalog`` afterwards to make sure the ``.po`` file has the canonical
-Babel formatting.
+existing language identifier.  It is good practice to run
+``python babel_runner.py update`` afterwards to make sure the ``.po`` file has the
+canonical Babel formatting.
 
 
 Debugging tips

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,20 +12,6 @@ upload = upload --sign --identity=36580288
 [build_sphinx]
 warning-is-error = 1
 
-[extract_messages]
-mapping_file = babel.cfg
-output_file = sphinx/locale/sphinx.pot
-keywords = _ __ l_ lazy_gettext
-
-[update_catalog]
-input_file = sphinx/locale/sphinx.pot
-domain = sphinx
-output_dir = sphinx/locale/
-
-[compile_catalog]
-domain = sphinx
-directory = sphinx/locale/
-
 [flake8]
 max-line-length = 95
 ignore = E116,E241,E251,E741,W504,I101

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-import os
 import sys
-from io import StringIO
 
 from setuptools import find_packages, setup
 
@@ -56,120 +54,6 @@ extras_require = {
         'cython',
     ],
 }
-
-# Provide a "compile_catalog" command that also creates the translated
-# JavaScript files if Babel is available.
-
-cmdclass = {}
-
-
-class Tee:
-    def __init__(self, stream):
-        self.stream = stream
-        self.buffer = StringIO()
-
-    def write(self, s):
-        self.stream.write(s)
-        self.buffer.write(s)
-
-    def flush(self):
-        self.stream.flush()
-
-
-try:
-    from json import dump
-
-    from babel.messages.frontend import compile_catalog
-    from babel.messages.pofile import read_po
-except ImportError:
-    pass
-else:
-    class compile_catalog_plusjs(compile_catalog):
-        """
-        An extended command that writes all message strings that occur in
-        JavaScript files to a JavaScript file along with the .mo file.
-
-        Unfortunately, babel's setup command isn't built very extensible, so
-        most of the run() code is duplicated here.
-        """
-
-        def run(self):
-            try:
-                sys.stderr = Tee(sys.stderr)
-                compile_catalog.run(self)
-            finally:
-                if sys.stderr.buffer.getvalue():
-                    print("Compiling failed.")
-                    sys.exit(1)
-
-            if isinstance(self.domain, list):
-                for domain in self.domain:
-                    self._run_domain_js(domain)
-            else:
-                self._run_domain_js(self.domain)
-
-        def _run_domain_js(self, domain):
-            po_files = []
-            js_files = []
-
-            if not self.input_file:
-                if self.locale:
-                    po_files.append((self.locale,
-                                     os.path.join(self.directory, self.locale,
-                                                  'LC_MESSAGES',
-                                                  domain + '.po')))
-                    js_files.append(os.path.join(self.directory, self.locale,
-                                                 'LC_MESSAGES',
-                                                 domain + '.js'))
-                else:
-                    for locale in os.listdir(self.directory):
-                        po_file = os.path.join(self.directory, locale,
-                                               'LC_MESSAGES',
-                                               domain + '.po')
-                        if os.path.exists(po_file):
-                            po_files.append((locale, po_file))
-                            js_files.append(os.path.join(self.directory, locale,
-                                                         'LC_MESSAGES',
-                                                         domain + '.js'))
-            else:
-                po_files.append((self.locale, self.input_file))
-                if self.output_file:
-                    js_files.append(self.output_file)
-                else:
-                    js_files.append(os.path.join(self.directory, self.locale,
-                                                 'LC_MESSAGES',
-                                                 domain + '.js'))
-
-            for js_file, (locale, po_file) in zip(js_files, po_files):
-                with open(po_file, encoding='utf8') as infile:
-                    catalog = read_po(infile, locale)
-
-                if catalog.fuzzy and not self.use_fuzzy:
-                    continue
-
-                self.log.info('writing JavaScript strings in catalog %r to %r',
-                              po_file, js_file)
-
-                jscatalog = {}
-                for message in catalog:
-                    if any(x[0].endswith(('.js', '.js_t', '.html'))
-                           for x in message.locations):
-                        msgid = message.id
-                        if isinstance(msgid, (list, tuple)):
-                            msgid = msgid[0]
-                        jscatalog[msgid] = message.string
-
-                with open(js_file, 'wt', encoding='utf8') as outfile:
-                    outfile.write('Documentation.addTranslations(')
-                    dump({
-                        'messages': jscatalog,
-                        'plural_expr': catalog.plural_expr,
-                        'locale': str(catalog.locale)
-                    }, outfile, sort_keys=True, indent=4)
-                    outfile.write(');')
-
-    cmdclass['compile_catalog'] = compile_catalog_plusjs
-
 
 setup(
     name='Sphinx',
@@ -246,5 +130,4 @@ setup(
     python_requires=">=3.6",
     install_requires=install_requires,
     extras_require=extras_require,
-    cmdclass=cmdclass,
 )

--- a/utils/babel_runner.py
+++ b/utils/babel_runner.py
@@ -1,0 +1,109 @@
+from io import StringIO
+from json import dump
+import os
+import sys
+
+from babel.messages.frontend import compile_catalog
+from babel.messages.pofile import read_po
+
+# Provide a "compile_catalog" command that also creates the translated
+# JavaScript files if Babel is available.
+
+
+class Tee:
+    def __init__(self, stream):
+        self.stream = stream
+        self.buffer = StringIO()
+
+    def write(self, s):
+        self.stream.write(s)
+        self.buffer.write(s)
+
+    def flush(self):
+        self.stream.flush()
+
+
+class compile_catalog_plusjs(compile_catalog):
+    """
+    An extended command that writes all message strings that occur in
+    JavaScript files to a JavaScript file along with the .mo file.
+
+    Unfortunately, babel's setup command isn't built very extensible, so
+    most of the run() code is duplicated here.
+    """
+
+    def run(self):
+        try:
+            sys.stderr = Tee(sys.stderr)
+            compile_catalog.run(self)
+        finally:
+            if sys.stderr.buffer.getvalue():
+                print("Compiling failed.")
+                sys.exit(1)
+
+        if isinstance(self.domain, list):
+            for domain in self.domain:
+                self._run_domain_js(domain)
+        else:
+            self._run_domain_js(self.domain)
+
+    def _run_domain_js(self, domain):
+        po_files = []
+        js_files = []
+
+        if not self.input_file:
+            if self.locale:
+                po_files.append((self.locale,
+                                 os.path.join(self.directory, self.locale,
+                                              'LC_MESSAGES',
+                                              domain + '.po')))
+                js_files.append(os.path.join(self.directory, self.locale,
+                                             'LC_MESSAGES',
+                                             domain + '.js'))
+            else:
+                for locale in os.listdir(self.directory):
+                    po_file = os.path.join(self.directory, locale,
+                                           'LC_MESSAGES',
+                                           domain + '.po')
+                    if os.path.exists(po_file):
+                        po_files.append((locale, po_file))
+                        js_files.append(os.path.join(self.directory, locale,
+                                                     'LC_MESSAGES',
+                                                     domain + '.js'))
+        else:
+            po_files.append((self.locale, self.input_file))
+            if self.output_file:
+                js_files.append(self.output_file)
+            else:
+                js_files.append(os.path.join(self.directory, self.locale,
+                                             'LC_MESSAGES',
+                                             domain + '.js'))
+
+        for js_file, (locale, po_file) in zip(js_files, po_files):
+            with open(po_file, encoding='utf8') as infile:
+                catalog = read_po(infile, locale)
+
+            if catalog.fuzzy and not self.use_fuzzy:
+                continue
+
+            self.log.info('writing JavaScript strings in catalog %r to %r',
+                          po_file, js_file)
+
+            jscatalog = {}
+            for message in catalog:
+                if any(x[0].endswith(('.js', '.js_t', '.html'))
+                       for x in message.locations):
+                    msgid = message.id
+                    if isinstance(msgid, (list, tuple)):
+                        msgid = msgid[0]
+                    jscatalog[msgid] = message.string
+
+            with open(js_file, 'wt', encoding='utf8') as outfile:
+                outfile.write('Documentation.addTranslations(')
+                dump({
+                    'messages': jscatalog,
+                    'plural_expr': catalog.plural_expr,
+                    'locale': str(catalog.locale)
+                }, outfile, sort_keys=True, indent=4)
+                outfile.write(');')
+


### PR DESCRIPTION
Running arbitrary commands from `setup.py` [is deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html). This moves the babel and translations support to a decdicated file, `utils/babel_runner.py`, and updates documentation and the transifex workflow to match.

A

### Feature or Bugfix
- Refactoring

