### PR TITLE
Only test with coverage on pushes to `sphinx-doc/sphinx`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,10 @@ jobs:
           docutils: du16
         - python: "3.9"
           docutils: du17
-          coverage: "--cov ./ --cov-append --cov-config setup.cfg"
         - python: "3.10"
           docutils: du18
         - python: "3.11-dev"
           docutils: py311
-    env:
-      PYTEST_ADDOPTS: ${{ matrix.coverage }}
 
     steps:
     - uses: actions/checkout@v3
@@ -43,12 +40,9 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install graphviz
     - name: Install dependencies
-      run: python -m pip install -U pip tox codecov
+      run: python -m pip install -U pip tox
     - name: Run Tox
       run: tox -e ${{ matrix.docutils }} -- -vv
-    - name: codecov
-      uses: codecov/codecov-action@v1
-      if: matrix.coverage
 
   windows:
     runs-on: windows-2019
@@ -62,3 +56,32 @@ jobs:
       run:  python -m pip install -U pip tox
     - name: Run Tox
       run:  tox -e py -- -vv
+
+  coverage:
+    # only run on pushes to branches in the sphinx-doc/sphinx repo
+    if: github.repository_owner == 'sphinx-doc' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      PYTEST_ADDOPTS: "--cov ./ --cov-append --cov-config setup.cfg"
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3
+
+    - name: Check Python version
+      run: python --version
+
+    - name: Install graphviz
+      run: sudo apt-get install graphviz
+
+    - name: Install dependencies
+      run: python -m pip install -U tox pip codecov pytest-cov
+
+    - name: Run Tox
+      run: tox -e py -- -vv
+
+    - name: codecov
+      uses: codecov/codecov-action@v3

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,7 @@ extras_require = {
         "types-requests",
     ],
     'test': [
-        'pytest',
-        'pytest-cov',
+        'pytest>=4.6',
         'html5lib',
         "typed_ast; python_version < '3.8'",
         'cython',

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -64,10 +64,7 @@ def app_params(request: Any, test_params: Dict, shared_result: SharedResult,
 
     # ##### process pytest.mark.sphinx
 
-    if hasattr(request.node, 'iter_markers'):  # pytest-3.6.0 or newer
-        markers = request.node.iter_markers("sphinx")
-    else:
-        markers = request.node.get_marker("sphinx")
+    markers = request.node.iter_markers("sphinx")
     pargs = {}
     kwargs: Dict[str, Any] = {}
 
@@ -113,10 +110,7 @@ def test_params(request: Any) -> Dict:
        have same 'shared_result' value.
        **NOTE**: You can not specify both shared_result and srcdir.
     """
-    if hasattr(request.node, 'get_closest_marker'):  # pytest-3.6.0 or newer
-        env = request.node.get_closest_marker('test_params')
-    else:
-        env = request.node.get_marker('test_params')
+    env = request.node.get_closest_marker('test_params')
     kwargs = env.kwargs if env else {}
     result = {
         'shared_result': None,

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -64,16 +64,14 @@ def app_params(request: Any, test_params: Dict, shared_result: SharedResult,
 
     # ##### process pytest.mark.sphinx
 
-    markers = request.node.iter_markers("sphinx")
     pargs = {}
     kwargs: Dict[str, Any] = {}
 
-    if markers is not None:
-        # to avoid stacking positional args
-        for info in reversed(list(markers)):
-            for i, a in enumerate(info.args):
-                pargs[i] = a
-            kwargs.update(info.kwargs)
+    # to avoid stacking positional args
+    for info in reversed(list(request.node.iter_markers("sphinx"))):
+        for i, a in enumerate(info.args):
+            pargs[i] = a
+        kwargs.update(info.kwargs)
 
     args = [pargs[i] for i in sorted(pargs.keys())]
 

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -22,15 +22,13 @@ def apidoc(rootdir, tempdir, apidoc_params):
 
 @pytest.fixture
 def apidoc_params(request):
-    markers = request.node.iter_markers("apidoc")
     pargs = {}
     kwargs = {}
 
-    if markers is not None:
-        for info in reversed(list(markers)):
-            for i, a in enumerate(info.args):
-                pargs[i] = a
-            kwargs.update(info.kwargs)
+    for info in reversed(list(request.node.iter_markers("apidoc"))):
+        for i, a in enumerate(info.args):
+            pargs[i] = a
+        kwargs.update(info.kwargs)
 
     args = [pargs[i] for i in sorted(pargs.keys())]
     return args, kwargs

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -22,10 +22,7 @@ def apidoc(rootdir, tempdir, apidoc_params):
 
 @pytest.fixture
 def apidoc_params(request):
-    if hasattr(request.node, 'iter_markers'):  # pytest-3.6.0 or newer
-        markers = request.node.iter_markers("apidoc")
-    else:
-        markers = request.node.get_marker("apidoc")
+    markers = request.node.iter_markers("apidoc")
     pargs = {}
     kwargs = {}
 

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -18,10 +18,7 @@ def setup_command(request, tempdir, rootdir):
     Run `setup.py build_sphinx` with args and kwargs,
     pass it to the test and clean up properly.
     """
-    if hasattr(request.node, 'get_closest_marker'):  # pytest-3.6.0 or newer
-        marker = request.node.get_closest_marker('setup_command')
-    else:
-        marker = request.node.get_marker('setup_command')
+    marker = request.node.get_closest_marker('setup_command')
     args = marker.args if marker else []
 
     pkgrootdir = tempdir / 'test-setup'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4.0
-envlist = docs,flake8,mypy,twine,coverage,py{36,37,38,39,310},du{14,15,16,17,18}
+envlist = docs,flake8,mypy,twine,py{36,37,38,39,310},du{14,15,16,17,18}
 
 [testenv]
 usedevelop = True
@@ -57,16 +57,6 @@ extras =
     lint
 commands =
     isort --check-only --diff .
-
-[testenv:coverage]
-basepython = python3
-description =
-    Run code coverage checks.
-setenv =
-    PYTEST_ADDOPTS = --cov sphinx --cov-config "{toxinidir}/setup.cfg"
-commands =
-    {[testenv]commands}
-    coverage report
 
 [testenv:mypy]
 basepython = python3


### PR DESCRIPTION
To speed up CI for PRs, this moves the coverage tests to only run on pushes to branches in this repo, rather than on forks and pull requests too.

I also bumped `pytest` to 4.6 and removed some now-redundant code (we had previously always installed `pytest-cov`, which has required `pytest>=4.6` since 2020)

https://github.com/pytest-dev/pytest-cov/blob/694f7fd497b07aaea76d96e484068faf440e8301/setup.py#L125

A

### Feature or Bugfix
- Refactoring

### Relates
- Split from #10164
