### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ coverage:
   status:
     project:
       default:
-        enabled: no
+        informational: true
     patch:
       default:
-        enabled: no
+        informational: true


### PR DESCRIPTION
Subject: add informational Codecov status checks

### Feature or Bugfix
- Refactoring

### Purpose
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. I know there has been some churn on this file on having status checks at all, and I'd love to understand what has been so painful there.

Let me know if this makes sense or if we can do something that would be helpful.

### Detail

### Relates

