### PR TITLE
Fix `highlightSearchWords`'s terms check in `doctools.js`

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -132,7 +132,7 @@ const Documentation = {
   highlightSearchWords: () => {
     const highlight =
       new URLSearchParams(window.location.search).get("highlight") || "";
-    const terms = highlight.toLowerCase().split(/\s+/);
+    const terms = highlight.toLowerCase().split(/\s+/).filter(x => x);
     if (terms.length === 0) return; // nothing to do
 
     // There should never be more than one element matching "div.body"


### PR DESCRIPTION
xref https://github.com/sphinx-doc/sphinx/pull/10335#issuecomment-1101764523

A
