### PR TITLE
fix #10363 make sphinxmaketitle ruler use \linewidth not \textwidth

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -108,6 +108,8 @@ Bugs fixed
   too much vertical whitespace
 * #10188: LaTeX: alternating multiply referred footnotes produce a ``?`` in
   pdf output
+* #10363: LaTeX: make ``'howto'`` title page rule use ``\linewidth`` for
+  compatibility with usage of a ``twocolumn`` class option
 * #10318: ``:prepend:`` option of :rst:dir:`literalinclude` directive does not
   work with ``:dedent:`` option
 

--- a/sphinx/texinputs/sphinxhowto.cls
+++ b/sphinx/texinputs/sphinxhowto.cls
@@ -42,7 +42,7 @@
 % ``Bjarne'' style a bit better.
 %
 \newcommand{\sphinxmaketitle}{%
-  \noindent\rule{\textwidth}{1pt}\par
+  \noindent\rule{\linewidth}{1pt}\par
     \begingroup % for PDF information dictionary
        \def\endgraf{ }\def\and{\& }%
        \pdfstringdefDisableCommands{\def\\{, }}% overwrite hyperref setup
@@ -74,7 +74,7 @@
     \sphinxtableofcontentshook
     \tableofcontents
   \endgroup
-  \noindent\rule{\textwidth}{1pt}\par
+  \noindent\rule{\linewidth}{1pt}\par
   \vspace{12pt}%
 }
 \newcommand\sphinxtableofcontentshook{}


### PR DESCRIPTION
Subject: use \linewidth not \textwidth for sphinxmaketitle ruler

  - branche Others: 4.5.x

### Feature or Bugfix
- Bugfix

### Purpose
 sphinxmaketitle should use \linewidth not \textwidth for his ruler

### Relates
- https://github.com/sphinx-doc/sphinx/issues/10363

