### PR TITLE
support srearch template with extended-length path

### DIFF
--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -1,7 +1,7 @@
 """Glue code for the jinja2 templating engine."""
 
+import pathlib
 from os import path
-import os
 from pprint import pformat
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Tuple, Union
 
@@ -117,10 +117,7 @@ class SphinxFileSystemLoader(FileSystemLoader):
 
     def get_source(self, environment: Environment, template: str) -> Tuple[str, str, Callable]:
         for searchpath in self.searchpath:
-            filename = path.join(searchpath, template)
-            # Repalce '/' by os.sep if The searchpath is an extended-length path.
-            if filename.startswith("\\\\?\\"):
-                filename = filename.replace('/', os.sep)
+            filename = str(pathlib.Path(searchpath, template))
             f = open_if_exists(filename)
             if f is None:
                 continue

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -1,6 +1,7 @@
 """Glue code for the jinja2 templating engine."""
 
 from os import path
+import os
 from pprint import pformat
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Tuple, Union
 
@@ -117,6 +118,9 @@ class SphinxFileSystemLoader(FileSystemLoader):
     def get_source(self, environment: Environment, template: str) -> Tuple[str, str, Callable]:
         for searchpath in self.searchpath:
             filename = path.join(searchpath, template)
+            # Repalce '/' by os.sep if The searchpath is an extended-length path.
+            if filename.startswith("\\\\?\\"):
+                filename = filename.replace('/', os.sep)
             f = open_if_exists(filename)
             if f is None:
                 continue


### PR DESCRIPTION
Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->
master ? maybe.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Some template file contains forward slash in the path, which is not supported by the extended-length path on windows.

This bug is the result of a combination of many libraries and tools：
- bazel convert python library path into extended-length path to support paths longer than 260 characters;
- os.path library in python does not convert the forward slash in the path;
- [extended-length path](https://stackoverflow.com/questions/21194530/what-does-mean-when-prepended-to-a-file-path) on windows does not support forward slash;
- some sphinx theme like [furo](https://github.com/pradyunsg/furo) include template file with forward slash;
- sphinx use `os.path.join` to concat template file path.

Fixing this bug in sphinx is the easiest way for some use case, although it doesn't solve the most essential problem, this commit is at least harmless to other developers.

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
see also:
 - https://github.com/bazelbuild/rules_python/issues/680
 - https://stackoverflow.com/questions/21194530/what-does-mean-when-prepended-to-a-file-path

