### PR TITLE
CI: Fix "Sync translation" task

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -20,6 +20,8 @@ jobs:
         python-version: 3.9  # https://github.com/transifex/transifex-client/pull/330
     - name: Install dependencies
       run:  pip install -U babel jinja2 transifex-client
+    - name: Install Sphinx
+      run:  pip install .
     - name: Extract translations from source code
       run:  python utils/babel_runner.py extract
     - name: Push translations to transifex.com
@@ -41,6 +43,8 @@ jobs:
         python-version: 3.9  # https://github.com/transifex/transifex-client/pull/330
     - name: Install dependencies
       run:  pip install -U babel jinja2 transifex-client
+    - name: Install Sphinx
+      run:  pip install .
     - name: Extract translations from source code
       run:  python utils/babel_runner.py extract
     - name: Pull translations to transifex.com


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The last "Sync translation" task was failed by ModuleNotFoundError.  It
was raised because Sphinx was not installed on processing translations.
- refs: https://github.com/sphinx-doc/sphinx/runs/6143331590?check_suite_focus=true