### PR TITLE
Configure Sphinx pytest fixtures as globally accessible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,7 @@ setup(
         'Framework :: Sphinx',
         'Framework :: Sphinx :: Extension',
         'Framework :: Sphinx :: Theme',
+        'Framework :: Pytest',
         'Topic :: Documentation',
         'Topic :: Documentation :: Sphinx',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
@@ -241,6 +242,9 @@ setup(
         ],
         'distutils.commands': [
             'build_sphinx = sphinx.setup_command:BuildDoc',
+        ],
+        'pytest11': [
+            'sphinx = sphinx.testing.fixtures',
         ],
     },
     python_requires=">=3.6",


### PR DESCRIPTION
Makes the fixtures in `sphinx.testing.fixtures` globally accessible whenever Sphinx is installed,
as seen in the [pytest documentation](https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html#making-your-plugin-installable-by-others).

### Feature or Bugfix

- Feature

### Purpose

Allow users to use `sphinx.testing.fixtures` without having to configure `pytest_plugins` in a `conftest.py` file.

### Detail

- #10392

### Relates

- #7008
