### PR TITLE
Fix enable_search_shortcuts option

### DIFF
--- a/sphinx/themes/basic/static/documentation_options.js_t
+++ b/sphinx/themes/basic/static/documentation_options.js_t
@@ -10,5 +10,5 @@ var DOCUMENTATION_OPTIONS = {
     SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
     NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}},
     SHOW_SEARCH_SUMMARY: {{ 'true' if show_search_summary else 'false' }},
-    ENABLE_SEARCH_SHORTCUTS: {{ 'true' if enable_search_shortcuts|tobool else 'true'}},
+    ENABLE_SEARCH_SHORTCUTS: {{ 'true' if enable_search_shortcuts|tobool else 'false'}},
 };


### PR DESCRIPTION
Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix

- Bugfix

### Purpose

Allow to disable the search shortcuts, currently it's always `true`

