### PR TITLE
Fix #10200: apidoc: Duplicated submodules are shown for modules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -72,6 +72,8 @@ Features added
 Bugs fixed
 ----------
 
+* #10200: apidoc: Duplicated submodules are shown for modules having both .pyx
+  and .so files
 * #10279: autodoc: Default values for keyword only arguments in overloaded
   functions are rendered as a string literal
 * #10280: autodoc: :confval:`autodoc_docstring_signature` unexpectedly generates

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -117,6 +117,7 @@ def create_package_file(root: str, master_package: str, subroot: str, py_files: 
     submodules = [sub.split('.')[0] for sub in py_files
                   if not is_skipped_module(path.join(root, sub), opts, excludes) and
                   not is_initpy(sub)]
+    submodules = sorted(set(submodules))
     submodules = [module_join(master_package, subroot, modname)
                   for modname in submodules]
     options = copy(OPTIONS)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #10200