### PR TITLE
Remove redundant code for Python < 3.6

### DIFF
--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -2452,7 +2452,6 @@ def test_type_union_operator(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_hide_value(app):
     options = {'members': None}

--- a/tests/test_ext_autodoc_autoattribute.py
+++ b/tests/test_ext_autodoc_autoattribute.py
@@ -39,7 +39,6 @@ def test_autoattribute_novalue(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autoattribute_typed_variable(app):
     actual = do_autodoc(app, 'attribute', 'target.typed_vars.Class.attr2')
@@ -52,7 +51,6 @@ def test_autoattribute_typed_variable(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autoattribute_typed_variable_in_alias(app):
     actual = do_autodoc(app, 'attribute', 'target.typed_vars.Alias.attr2')
@@ -65,7 +63,6 @@ def test_autoattribute_typed_variable_in_alias(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autoattribute_instance_variable(app):
     actual = do_autodoc(app, 'attribute', 'target.typed_vars.Class.attr4')
@@ -80,7 +77,6 @@ def test_autoattribute_instance_variable(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autoattribute_instance_variable_in_alias(app):
     actual = do_autodoc(app, 'attribute', 'target.typed_vars.Alias.attr4')
@@ -198,7 +194,6 @@ def test_autoattribute_TypeVar(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autoattribute_hide_value(app):
     actual = do_autodoc(app, 'attribute', 'target.hide_value.Foo.SENTINEL1')

--- a/tests/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc_autoclass.py
@@ -102,7 +102,6 @@ def test_inherited_instance_variable(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='py36+ is available since python3.6.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_uninitialized_attributes(app):
     options = {"members": None,
@@ -130,7 +129,6 @@ def test_uninitialized_attributes(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='py36+ is available since python3.6.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_undocumented_uninitialized_attributes(app):
     options = {"members": None,

--- a/tests/test_ext_autodoc_autodata.py
+++ b/tests/test_ext_autodoc_autodata.py
@@ -39,7 +39,6 @@ def test_autodata_novalue(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodata_typed_variable(app):
     actual = do_autodoc(app, 'data', 'target.typed_vars.attr2')
@@ -54,7 +53,6 @@ def test_autodata_typed_variable(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodata_type_comment(app):
     actual = do_autodoc(app, 'data', 'target.typed_vars.attr3')
@@ -126,7 +124,6 @@ def test_autodata_TypeVar(app):
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='python 3.6+ is required.')
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodata_hide_value(app):
     actual = do_autodoc(app, 'data', 'target.hide_value.SENTINEL1')

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1,7 +1,6 @@
 """Tests for :mod:`sphinx.ext.napoleon.docstring` module."""
 
 import re
-import sys
 from collections import namedtuple
 from contextlib import contextmanager
 from inspect import cleandoc
@@ -15,9 +14,8 @@ from sphinx.ext.napoleon.docstring import (GoogleDocstring, NumpyDocstring,
                                            _convert_numpy_type_spec, _recombine_set_tokens,
                                            _token_type, _tokenize_type_spec)
 
-if sys.version_info >= (3, 6):
-    from .ext_napoleon_pep526_data_google import PEP526GoogleClass
-    from .ext_napoleon_pep526_data_numpy import PEP526NumpyClass
+from .ext_napoleon_pep526_data_google import PEP526GoogleClass
+from .ext_napoleon_pep526_data_numpy import PEP526NumpyClass
 
 
 class NamedtupleSubclass(namedtuple('NamedtupleSubclass', ('attr1', 'attr2'))):
@@ -1162,14 +1160,13 @@ Do as you please
         self.assertEqual(expected, actual)
 
     def test_pep526_annotations(self):
-        if sys.version_info >= (3, 6):
-            # Test class attributes annotations
-            config = Config(
-                napoleon_attr_annotations=True
-            )
-            actual = str(GoogleDocstring(cleandoc(PEP526GoogleClass.__doc__), config, app=None, what="class",
-                                         obj=PEP526GoogleClass))
-            expected = """\
+        # Test class attributes annotations
+        config = Config(
+            napoleon_attr_annotations=True
+        )
+        actual = str(GoogleDocstring(cleandoc(PEP526GoogleClass.__doc__), config, app=None, what="class",
+                                     obj=PEP526GoogleClass))
+        expected = """\
 Sample class with PEP 526 annotations and google docstring
 
 .. attribute:: attr1
@@ -1184,7 +1181,7 @@ Sample class with PEP 526 annotations and google docstring
 
    :type: str
 """
-            self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_preprocess_types(self):
         docstring = """\
@@ -2573,14 +2570,13 @@ class TestNumpyDocstring:
         assert actual == expected
 
     def test_pep526_annotations(self):
-        if sys.version_info >= (3, 6):
-            # test class attributes annotations
-            config = Config(
-                napoleon_attr_annotations=True
-            )
-            actual = str(NumpyDocstring(cleandoc(PEP526NumpyClass.__doc__), config, app=None, what="class",
-                                        obj=PEP526NumpyClass))
-            expected = """\
+        # test class attributes annotations
+        config = Config(
+            napoleon_attr_annotations=True
+        )
+        actual = str(NumpyDocstring(cleandoc(PEP526NumpyClass.__doc__), config, app=None, what="class",
+                                    obj=PEP526NumpyClass))
+        expected = """\
 Sample class with PEP 526 annotations and numpy docstring
 
 .. attribute:: attr1
@@ -2595,5 +2591,5 @@ Sample class with PEP 526 annotations and numpy docstring
 
    :type: str
 """
-            print(actual)
-            assert expected == actual
+        print(actual)
+        assert expected == actual


### PR DESCRIPTION
Subject: Remove redundant code for Python < 3.6

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
- Now Python 3.6 is the minimum supported, remove some redundant `if`s and `skipif`s

