### PR TITLE
Fix #10384: test: Skip tests for imgconvert if imagemagick not found

### DIFF
--- a/tests/test_ext_imgconverter.py
+++ b/tests/test_ext_imgconverter.py
@@ -1,12 +1,26 @@
 """Test sphinx.ext.imgconverter extension."""
 
-import os
+import subprocess
+from subprocess import PIPE
 
 import pytest
 
 
+@pytest.fixture
+def if_converter_found(app):
+    image_converter = getattr(app.config, 'image_converter', '')
+    try:
+        if image_converter:
+            subprocess.run([image_converter, '-version'], stdout=PIPE, stderr=PIPE)  # show version
+            return
+    except OSError:  # No such file or directory
+        pass
+
+    pytest.skip('image_converter "%s" is not available' % image_converter)
+
+
+@pytest.mark.usefixtures('if_converter_found')
 @pytest.mark.sphinx('latex', testroot='ext-imgconverter')
-@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_ext_imgconverter(app, status, warning):
     app.builder.build_all()
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #10384 