### PR TITLE
Remove sphinx.util.docutils.__version_info__ on 7.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -54,6 +54,7 @@ Deprecated
 * The ``language`` argument of ``sphinx.util.i18n:format_date()`` becomes
   required
 * ``sphinx.builders.html.html5_ready``
+* ``sphinx.util.docutils.__version_info__``
 * ``sphinx.util.docutils.is_html5_writer_available()``
 * ``sphinx.writers.latex.LaTeXWriter.docclasses``
 

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -47,6 +47,11 @@ The following is a list of deprecated interfaces.
      - 7.0
      - N/A
 
+   * - ``sphinx.util.docutils.__version_info__``
+     - 5.0
+     - 7.0
+     - ``docutils.__version_info__``
+
    * - ``sphinx.util.docutils.is_html5_writer_available()``
      - 5.0
      - 7.0

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -19,8 +19,7 @@ from docutils.parsers.rst.states import Inliner
 from docutils.statemachine import State, StateMachine, StringList
 from docutils.utils import Reporter, unescape
 
-from sphinx.deprecation import (RemovedInSphinx60Warning, RemovedInSphinx70Warning,
-                                deprecated_alias)
+from sphinx.deprecation import RemovedInSphinx70Warning, deprecated_alias
 from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
@@ -38,7 +37,7 @@ deprecated_alias('sphinx.util.docutils',
                  {
                      '__version_info__': docutils.__version_info__,
                  },
-                 RemovedInSphinx60Warning,
+                 RemovedInSphinx70Warning,
                  {
                      '__version_info__': 'docutils.__version_info__',
                  })


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/pull/10372#discussion_r862988028