### PR TITLE
Fix #10421: autodoc_preserve_defaults doesn't work on class methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -92,6 +92,8 @@ Bugs fixed
   function
 * #10305: autodoc: Failed to extract optional forward-ref'ed typehints correctly
   via :confval:`autodoc_type_aliases`
+* #10421: autodoc: :confval:`autodoc_preserve_defaults` doesn't work on class
+  methods
 * #10214: html: invalid language tag was generated if :confval:`language`
   contains a country code (ex. zh_CN)
 * #10236: html search: objects are duplicated in search result

--- a/tests/roots/test-ext-autodoc/target/preserve_defaults.py
+++ b/tests/roots/test-ext-autodoc/target/preserve_defaults.py
@@ -22,3 +22,9 @@ class Class:
              now: datetime = datetime.now(), color: int = 0xFFFFFF,
              *, kwarg1, kwarg2 = 0xFFFFFF) -> None:
         """docstring"""
+
+    @classmethod
+    def clsmeth(cls, name: str = CONSTANT, sentinel: Any = SENTINEL,
+                now: datetime = datetime.now(), color: int = 0xFFFFFF,
+                *, kwarg1, kwarg2 = 0xFFFFFF) -> None:
+        """docstring"""

--- a/tests/test_ext_autodoc_preserve_defaults.py
+++ b/tests/test_ext_autodoc_preserve_defaults.py
@@ -28,6 +28,15 @@ def test_preserve_defaults(app):
         '   docstring',
         '',
         '',
+        '   .. py:method:: Class.clsmeth(name: str = CONSTANT, sentinel: ~typing.Any = '
+        'SENTINEL, now: ~datetime.datetime = datetime.now(), color: int = %s, *, '
+        'kwarg1, kwarg2=%s) -> None' % (color, color),
+        '      :module: target.preserve_defaults',
+        '      :classmethod:',
+        '',
+        '      docstring',
+        '',
+        '',
         '   .. py:method:: Class.meth(name: str = CONSTANT, sentinel: ~typing.Any = '
         'SENTINEL, now: ~datetime.datetime = datetime.now(), color: int = %s, *, '
         'kwarg1, kwarg2=%s) -> None' % (color, color),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #10421 