### PR TITLE
refactor: Create a copy of settings on Builder.write_doctree()

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -476,11 +476,6 @@ class Builder:
             publisher.publish()
             doctree = publisher.document
 
-            # The settings object is reused by the Publisher for each document.
-            # Becuase we modify the settings object in ``write_doctree``, we
-            # need to ensure that each doctree has an independent copy.
-            doctree.settings = doctree.settings.copy()
-
         # store time of reading, for outdated files detection
         # (Some filesystems have coarse timestamp resolution;
         # therefore time.time() can be older than filesystem's timestamp.
@@ -499,6 +494,10 @@ class Builder:
         # make it picklable
         doctree.reporter = None
         doctree.transformer = None
+
+        # Create a copy of settings object before modification because it is
+        # shared with other documents.
+        doctree.settings = doctree.settings.copy()
         doctree.settings.warning_stream = None
         doctree.settings.env = None
         doctree.settings.record_dependencies = None


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- refs: https://github.com/sphinx-doc/sphinx/pull/10337#discussion_r867373662

@AA-Turner I think creating a copy on `write_doctree()` is simple and natural for me. What do you think?