### PR TITLE
Fix #10434: extra whitespace in pdf output for highlighted inline code

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1710,11 +1710,11 @@ class LaTeXTranslator(SphinxTranslator):
         # TODO: Use nowrap option once LaTeX formatter supports it
         # https://github.com/pygments/pygments/pull/1343
         hlcode = hlcode.replace(r'\begin{Verbatim}[commandchars=\\\{\}]',
-                                r'\sphinxcode{\sphinxupquote{')
+                                r'\sphinxcode{\sphinxupquote{%')
         # get consistent trailer
-        hlcode = hlcode.rstrip()[:-14]  # strip \end{Verbatim}
+        hlcode = hlcode.rstrip()[:-15]  # strip \n\end{Verbatim}
         self.body.append(hlcode)
-        self.body.append('}}')
+        self.body.append('%' + CR + '}}')
         raise nodes.SkipNode
 
     def depart_literal(self, node: Element) -> None:

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1623,7 +1623,7 @@ def test_latex_code_role(app):
         r'\PYG{p}{)}'
         r'\PYG{p}{:} '
         r'\PYG{k}{pass}')
-    assert (r'Inline \sphinxcode{\sphinxupquote{' + '\n' +
-            common_content + '\n}} code block') in content
+    assert (r'Inline \sphinxcode{\sphinxupquote{%' + '\n' +
+            common_content + '%\n}} code block') in content
     assert (r'\begin{sphinxVerbatim}[commandchars=\\\{\}]' +
             '\n' + common_content + '\n' + r'\end{sphinxVerbatim}') in content


### PR DESCRIPTION
Related: #10251

As explained in #10434 I am not sure if good or bad, but this maintains existing behaviour from before code highlighting was added by #10251

Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix of merged Feature


### Relates
- #10251

