### PR TITLE
Epub: Add WebP mime type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,24 @@
+Release 5.1.0 (in development)
+==============================
+
+Dependencies
+------------
+
+Incompatible changes
+--------------------
+
+Deprecated
+----------
+
+Features added
+--------------
+
+Bugs fixed
+----------
+
+Testing
+--------
+
 Release 5.0.0 beta2 (in development)
 ====================================
 

--- a/sphinx/__init__.py
+++ b/sphinx/__init__.py
@@ -21,8 +21,8 @@ warnings.filterwarnings('ignore', "'U' mode is deprecated",
 warnings.filterwarnings('ignore', 'The frontend.Option class .*',
                         DeprecationWarning, module='docutils.frontend')
 
-__version__ = '5.0.0+'
-__released__ = '5.0.0'  # used when Sphinx builds its own docs
+__version__ = '5.1.0+'
+__released__ = '5.1.0'  # used when Sphinx builds its own docs
 
 #: Version info for better programmatic use.
 #:
@@ -32,7 +32,7 @@ __released__ = '5.0.0'  # used when Sphinx builds its own docs
 #:
 #: .. versionadded:: 1.2
 #:    Before version 1.2, check the string ``sphinx.__version__``.
-version_info = (5, 0, 0, 'beta', 2)
+version_info = (5, 1, 0, 'beta', 0)
 
 package_dir = path.abspath(path.dirname(__file__))
 

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -56,6 +56,7 @@ MEDIA_TYPES = {
     '.xhtml': 'application/xhtml+xml',
     '.css': 'text/css',
     '.png': 'image/png',
+    '.webp': 'image/webp',
     '.gif': 'image/gif',
     '.svg': 'image/svg+xml',
     '.jpg': 'image/jpeg',


### PR DESCRIPTION
When building docs with WebP images using the EPUB builder results in this warning:

`WARNING: unknown mimetype for _images/<image_name>.webp, ignoring`

This commit fixes this by adding the mapping for webp-files to the correct mime type.