### PR TITLE
Fix #8180: Docstring metadata ignored for attributes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #8180: autodoc: Docstring metadata ignored for attributes
+
 Testing
 --------
 

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -280,12 +280,19 @@ def get_class_members(subject: Any, objpath: List[str], attrgetter: Callable
                     members[name] = ObjectMember(name, INSTANCEATTR, class_=cls,
                                                  docstring=docstring)
 
-            # append instance attributes (cf. self.attr1) if analyzer knows
+            # append or complete instance attributes (cf. self.attr1) if analyzer knows
             if analyzer:
                 for (ns, name), docstring in analyzer.attr_docs.items():
                     if ns == qualname and name not in members:
+                        # otherwise unknown instance attribute
                         members[name] = ObjectMember(name, INSTANCEATTR, class_=cls,
                                                      docstring='\n'.join(docstring))
+                    elif (ns == qualname and docstring and
+                          isinstance(members[name], ObjectMember) and
+                          not members[name].docstring):
+                        # attribute is already known, because dir(subject) enumerates it.
+                        # But it has no docstring yet
+                        members[name].docstring = '\n'.join(docstring)
     except AttributeError:
         pass
 

--- a/tests/roots/test-ext-autodoc/target/private.py
+++ b/tests/roots/test-ext-autodoc/target/private.py
@@ -13,3 +13,15 @@ def _public_function(name):
 
 PRIVATE_CONSTANT = None  #: :meta private:
 _PUBLIC_CONSTANT = None  #: :meta public:
+
+
+class Foo:
+    #: A public class attribute whose name starts with an underscore.
+    #:
+    #: :meta public:
+    _public_attribute = 47
+
+    #: A private class attribute whose name does not start with an underscore.
+    #:
+    #: :meta private:
+    private_attribute = 11

--- a/tests/test_ext_autodoc_private_members.py
+++ b/tests/test_ext_autodoc_private_members.py
@@ -102,3 +102,57 @@ def test_private_members(app):
         '   :meta public:',
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_attributes(app):
+    app.config.autoclass_content = 'class'
+    options = {"members": None}
+    actual = do_autodoc(app, 'class', 'target.private.Foo', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: Foo()',
+        '   :module: target.private',
+        '',
+        '',
+        '   .. py:attribute:: Foo._public_attribute',
+        '      :module: target.private',
+        '      :value: 47',
+        '',
+        '      A public class attribute whose name starts with an underscore.',
+        '',
+        '      :meta public:',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_private_attributes_and_private_members(app):
+    app.config.autoclass_content = 'class'
+    options = {"members": None,
+               "private-members": None}
+    actual = do_autodoc(app, 'class', 'target.private.Foo', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: Foo()',
+        '   :module: target.private',
+        '',
+        '',
+        '   .. py:attribute:: Foo._public_attribute',
+        '      :module: target.private',
+        '      :value: 47',
+        '',
+        '      A public class attribute whose name starts with an underscore.',
+        '',
+        '      :meta public:',
+        '',
+        '',
+        '   .. py:attribute:: Foo.private_attribute',
+        '      :module: target.private',
+        '      :value: 11',
+        '',
+        '      A private class attribute whose name does not start with an underscore.',
+        '',
+        '      :meta private:',
+        '',
+    ]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Add test cases for #8180.
- Fix the bug reported in #8180. The change may also help to implement #8700 and #8922

### Detail
- The change adds two tests in test_ext_autodoc_private_members: test_private_attributes and test_private_attributes_and_private_members. Both are modeled analog to existing test cases for `:meta private:` and `:meta public:` for functions and module variables.
- About the fix: Currently the decision logic in `autodoc.Documenter.filter_members` does not see the docstring of class attributes. Therefore the fix must make the docstring available. For variables of a module ("global variables") the docstring is stored in `ObjectMember.docstring` (see `ModuleDocumenter.get_module_members()`). `autodoc.Documenter.filter_members` retrieves the docstring from the ObjectMember object. For class attributes, the ObjectMember does not contain the docstring, because `autodoc.importer.get_class_members` does not set it, when it creates the ObjectMember object. My fix changes `autodoc.importer.get_class_members` to set the docstring.
- Rejected alternatives: Issue #8180 contains a patch, that modifies `autodoc.Documenter.filter_members`. This patch also fixes the bug, but is makes the information flow more complicated. Currently `autodoc.Documenter.filter_members` uses just two ways to get the docstring of a member: as the result of `sphinx.util.inspect.getdoc` or from ObjectMember.docstring. The patch would add a third way: using `analyzer.find_attr_docs()`.

### Relates
- #8180 fixed by this pull request.
- #8700 and #8922: autosummary also uses `autodoc.importer.get_class_members`. Therefore, if autosummary shall respect metadata, it needs the docstring.
- Same as pull request #10445, but rebased to branch 5.x.
