### PR TITLE
Footnote & citation display for Docutils 0.18

### DIFF
--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -428,10 +428,6 @@ table.docutils td, table.docutils th {
     border-bottom: 1px solid #aaa;
 }
 
-table.footnote td, table.footnote th {
-    border: 0 !important;
-}
-
 th {
     text-align: left;
     padding-right: 5px;
@@ -615,6 +611,7 @@ ul.simple p {
     margin-bottom: 0;
 }
 
+/* Docutils 0.17 and older (footnotes & citations) */
 dl.footnote > dt,
 dl.citation > dt {
     float: left;
@@ -631,6 +628,33 @@ dl.citation > dd:after {
     content: "";
     clear: both;
 }
+
+/* Docutils 0.18+ (footnotes & citations) */
+aside.footnote > span,
+div.citation > span {
+    float: left;
+}
+aside.footnote > span:last-of-type,
+div.citation > span:last-of-type {
+  padding-right: 0.5em;
+}
+aside.footnote > p {
+  margin-left: 2em;
+}
+div.citation > p {
+  margin-left: 4em;
+}
+aside.footnote > p:last-of-type,
+div.citation > p:last-of-type {
+    margin-bottom: 0em;
+}
+aside.footnote > p:last-of-type:after,
+div.citation > p:last-of-type:after {
+    content: "";
+    clear: both;
+}
+
+/* Footnotes & citations ends */
 
 dl.field-list {
     display: grid;


### PR DESCRIPTION
Docutils 0.18 moved away from `<dl>` et al for footnotes and definition lists. This PR ensures that Sphinx 5 will have consistent formatting. Closes #10415

[Preview (Docutils 0.17)](https://aa-turner.github.io/sphinx/sphinx13_docutils-17.1/demo.html#references)  
[Preview (Docutils 0.18)](https://aa-turner.github.io/sphinx/sphinx13_docutils-18.1/demo.html#references)  

@tk0miya please could this go into 5.0.0? As @stsewd noted it is a (visual) regression from Sphinx 4.5.0.


### Feature or Bugfix
- Bugfix

A
