### PR TITLE
Fix sphinx-doc#10104: gettext: Duplicated locations are output to pot file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Bugs fixed
 * #9648: autodoc: ``*args`` and ``**kwargs`` entries are duplicated when
   ``autodoc_typehints="description"``
 * #10443: epub: EPUB builder can't detect the mimetype of .webp file
+* #10104: gettext: Duplicated locations are shown if 3rd party extension does
+  not provide correct information
 * #10456: py domain: ``:meta:`` fields are displayed if docstring contains two
   or more meta-field
 * #9096: sphinx-build: the value of progress bar for paralle build is wrong

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -57,7 +57,8 @@ class Catalog:
 
     def __iter__(self) -> Generator[Message, None, None]:
         for message in self.messages:
-            positions = [(source, line) for source, line, uuid in self.metadata[message]]
+            positions = sorted(set((source, line) for source, line, uuid
+                                   in self.metadata[message]))
             uuids = [uuid for source, line, uuid in self.metadata[message]]
             yield Message(message, positions, uuids)
 

--- a/tests/test_build_gettext.py
+++ b/tests/test_build_gettext.py
@@ -8,7 +8,27 @@ from subprocess import PIPE, CalledProcessError
 
 import pytest
 
+from sphinx.builders.gettext import Catalog, MsgOrigin
 from sphinx.util.osutil import cd
+
+
+def test_Catalog_duplicated_message():
+    catalog = Catalog()
+    catalog.add('hello', MsgOrigin('/path/to/filename', 1))
+    catalog.add('hello', MsgOrigin('/path/to/filename', 1))
+    catalog.add('hello', MsgOrigin('/path/to/filename', 2))
+    catalog.add('hello', MsgOrigin('/path/to/yetanother', 1))
+    catalog.add('world', MsgOrigin('/path/to/filename', 1))
+
+    assert len(list(catalog)) == 2
+
+    msg1, msg2 = list(catalog)
+    assert msg1.text == 'hello'
+    assert msg1.locations == [('/path/to/filename', 1),
+                              ('/path/to/filename', 2),
+                              ('/path/to/yetanother', 1)]
+    assert msg2.text == 'world'
+    assert msg2.locations == [('/path/to/filename', 1)]
 
 
 @pytest.mark.sphinx('gettext', srcdir='root-gettext')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- When 3rd party extension does not provide line number for each message,
duplicated locations are output to pot file unexpectedly.  This filters
duplicated locations before generationg pot file.
- gettext builder has already called `relpath` inside template. So I don't call it on this PR.
- refs: #10104 
