### PR TITLE
Coerce `language = None` in `conf.py` to Engligh

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Dependencies
 Incompatible changes
 --------------------
 
+* #10474: :confval:`language` does not accept ``None`` as it value.  The default
+  value of ``language`` becomes to ``'en'`` now.
+
 Deprecated
 ----------
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -725,13 +725,15 @@ documentation on :ref:`intl` for details.
    (e.g. the German version of ``myfigure.png`` will be ``myfigure.de.png``
    by default setting) and substitute them for original figures.  In the LaTeX
    builder, a suitable language will be selected as an option for the *Babel*
-   package.  Default is ``None``, which means that no translation will be done.
+   package.  Default is ``'en'``.
 
    .. versionadded:: 0.5
 
    .. versionchanged:: 1.4
 
       Support figure substitution
+
+   .. versionchanged:: 5.0
 
    Currently supported languages by Sphinx are:
 
@@ -745,7 +747,7 @@ documentation on :ref:`intl` for details.
    * ``da`` -- Danish
    * ``de`` -- German
    * ``el`` -- Greek
-   * ``en`` -- English
+   * ``en`` -- English (default)
    * ``eo`` -- Esperanto
    * ``es`` -- Spanish
    * ``et`` -- Estonian

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -166,7 +166,7 @@ class Config:
 
         # Resolve https://github.com/sphinx-doc/sphinx/issues/10474 where conf.py
         # explicitly sets language to None, by coercing it to English.
-        if namespace["language"] is None:
+        if namespace.get("language", ...) is None:
             namespace["language"] = "en"
 
         return cls(namespace, overrides or {})

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -163,6 +163,12 @@ class Config:
             raise ConfigError(__("config directory doesn't contain a conf.py file (%s)") %
                               confdir)
         namespace = eval_config_file(filename, tags)
+
+        # Resolve https://github.com/sphinx-doc/sphinx/issues/10474 where conf.py
+        # explicitly sets language to None, by coercing it to English.
+        if namespace["language"] is None:
+            namespace["language"] = "en"
+
         return cls(namespace, overrides or {})
 
     def convert_overrides(self, name: str, value: Any) -> Any:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -168,6 +168,9 @@ class Config:
         # Resolve https://github.com/sphinx-doc/sphinx/issues/10474 where conf.py
         # explicitly sets language to None, by coercing it to English.
         if namespace.get("language", ...) is None:
+            logging.warning(__("Invalid configuration found: 'language = None'. "
+                               "Now it takes only a string. Please update your configuration. "
+                               "Fallback to 'en' (English)."))
             namespace["language"] = "en"
             warnings.warn("'None' is not a valid value for 'language', coercing to 'en'. "
                           "Update 'conf.py' to a valid language code to silence this "

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -165,8 +165,10 @@ class Config:
                               confdir)
         namespace = eval_config_file(filename, tags)
 
-        # Resolve https://github.com/sphinx-doc/sphinx/issues/10474 where conf.py
-        # explicitly sets language to None, by coercing it to English.
+        # Note: Old sphinx projects has been configured as "langugae = None" because
+        #       sphinx-quickstart had generated the configuration by default formerly.
+        #       To keep compatibility, they should be fallback to 'en' for a while
+        #       (At least 2 years or more since v5.0 release).
         if namespace.get("language", ...) is None:
             logging.warning(__("Invalid configuration found: 'language = None'. "
                                "Now it takes only a string. Please update your configuration. "

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -3,6 +3,7 @@
 import re
 import traceback
 import types
+import warnings
 from collections import OrderedDict
 from os import getenv, path
 from typing import (TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List, NamedTuple,
@@ -168,6 +169,9 @@ class Config:
         # explicitly sets language to None, by coercing it to English.
         if namespace.get("language", ...) is None:
             namespace["language"] = "en"
+            warnings.warn("'None' is not a valid value for 'language', coercing to 'en'. "
+                          "Update 'conf.py' to a valid language code to silence this "
+                          "warning.", RuntimeWarning, stacklevel=4)
 
         return cls(namespace, overrides or {})
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -165,18 +165,15 @@ class Config:
                               confdir)
         namespace = eval_config_file(filename, tags)
 
-        # Note: Old sphinx projects has been configured as "langugae = None" because
-        #       sphinx-quickstart had generated the configuration by default formerly.
+        # Note: Old sphinx projects have been configured as "langugae = None" because
+        #       sphinx-quickstart previously generated this by default.
         #       To keep compatibility, they should be fallback to 'en' for a while
-        #       (At least 2 years or more since v5.0 release).
+        #       (This conversion should not be removed before 2025-01-01).
         if namespace.get("language", ...) is None:
-            logging.warning(__("Invalid configuration found: 'language = None'. "
-                               "Now it takes only a string. Please update your configuration. "
-                               "Fallback to 'en' (English)."))
+            logger.warning(__("Invalid configuration value found: 'language = None'. "
+                              "Update your configuration to a valid langauge code. "
+                              "Falling back to 'en' (English)."))
             namespace["language"] = "en"
-            warnings.warn("'None' is not a valid value for 'language', coercing to 'en'. "
-                          "Update 'conf.py' to a valid language code to silence this "
-                          "warning.", RuntimeWarning, stacklevel=4)
 
         return cls(namespace, overrides or {})
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -3,7 +3,6 @@
 import re
 import traceback
 import types
-import warnings
 from collections import OrderedDict
 from os import getenv, path
 from typing import (TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List, NamedTuple,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -381,3 +381,17 @@ def test_nitpick_ignore_regex_fullmatch(app, status, warning):
     assert len(warning) == len(nitpick_warnings)
     for actual, expected in zip(warning, nitpick_warnings):
         assert expected in actual
+
+
+def test_conf_py_language_none(tempdir):
+    """Regression test for #10474."""
+
+    # Given a conf.py file with language = None
+    (tempdir / 'conf.py').write_text("language = None", encoding='utf-8')
+
+    # When we load conf.py into a Config object
+    cfg = Config.read(tempdir, {}, None)
+    cfg.init_values()
+
+    # Then the language is coerced to English
+    assert cfg.language == "en"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -395,3 +395,17 @@ def test_conf_py_language_none(tempdir):
 
     # Then the language is coerced to English
     assert cfg.language == "en"
+
+
+def test_conf_py_no_language(tempdir):
+    """Regression test for #10474."""
+
+    # Given a conf.py file with no language attribute
+    (tempdir / 'conf.py').write_text("", encoding='utf-8')
+
+    # When we load conf.py into a Config object
+    cfg = Config.read(tempdir, {}, None)
+    cfg.init_values()
+
+    # Then the language is coerced to English
+    assert cfg.language == "en"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -397,7 +397,8 @@ def test_conf_py_language_none(tempdir):
     assert cfg.language == "en"
 
 
-def test_conf_py_language_none_warning(tempdir, caplog):
+@mock.patch("sphinx.config.logger")
+def test_conf_py_language_none_warning(logger, tempdir):
     """Regression test for #10474."""
 
     # Given a conf.py file with language = None
@@ -407,12 +408,11 @@ def test_conf_py_language_none_warning(tempdir, caplog):
     Config.read(tempdir, {}, None)
 
     # Then a warning is raised
-    assert len(caplog.messages) == 1
-    assert caplog.messages[0] == (
+    assert logger.warning.called
+    assert logger.warning.call_args[0][0] == (
         "Invalid configuration value found: 'language = None'. "
         "Update your configuration to a valid langauge code. "
         "Falling back to 'en' (English).")
-    assert caplog.records[0].levelname == "WARNING"
 
 
 def test_conf_py_no_language(tempdir):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -397,6 +397,22 @@ def test_conf_py_language_none(tempdir):
     assert cfg.language == "en"
 
 
+def test_conf_py_language_none_warning(tempdir):
+    """Regression test for #10474."""
+
+    # Given a conf.py file with language = None
+    (tempdir / 'conf.py').write_text("language = None", encoding='utf-8')
+
+    # Then a warning is raised
+    with pytest.warns(
+            RuntimeWarning,
+            match="'None' is not a valid value for 'language', coercing to 'en'. "
+                  "Update 'conf.py' to a valid language code to silence this "
+                  "warning."):
+        # When we load conf.py into a Config object
+        Config.read(tempdir, {}, None)
+
+
 def test_conf_py_no_language(tempdir):
     """Regression test for #10474."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -397,20 +397,22 @@ def test_conf_py_language_none(tempdir):
     assert cfg.language == "en"
 
 
-def test_conf_py_language_none_warning(tempdir):
+def test_conf_py_language_none_warning(tempdir, caplog):
     """Regression test for #10474."""
 
     # Given a conf.py file with language = None
     (tempdir / 'conf.py').write_text("language = None", encoding='utf-8')
 
+    # When we load conf.py into a Config object
+    Config.read(tempdir, {}, None)
+
     # Then a warning is raised
-    with pytest.warns(
-            RuntimeWarning,
-            match="'None' is not a valid value for 'language', coercing to 'en'. "
-                  "Update 'conf.py' to a valid language code to silence this "
-                  "warning."):
-        # When we load conf.py into a Config object
-        Config.read(tempdir, {}, None)
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0] == (
+        "Invalid configuration value found: 'language = None'. "
+        "Update your configuration to a valid langauge code. "
+        "Falling back to 'en' (English).")
+    assert caplog.records[0].levelname == "WARNING"
 
 
 def test_conf_py_no_language(tempdir):


### PR DESCRIPTION
Closes #10474.

@tk0miya this needs to go into 5.0.0 according to the bug report.

### Feature or Bugfix
- Bugfix

A
