### PR TITLE
Update `requests` links

### DIFF
--- a/EXAMPLES
+++ b/EXAMPLES
@@ -40,7 +40,7 @@ Documentation using the alabaster theme
 * `pytest <https://docs.pytest.org/>`__ (customized)
 * `python-apt <https://apt-team.pages.debian.net/python-apt/>`__
 * `PyVisfile <https://documen.tician.de/pyvisfile/>`__
-* `Requests <https://docs.python-requests.org/>`__
+* `Requests <https://requests.readthedocs.io/>`__
 * `searx <https://asciimoo.github.io/searx/>`__
 * `Spyder <https://docs.spyder-ide.org/>`__ (customized)
 * `Tablib <http://docs.python-tablib.org/>`__

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -109,7 +109,6 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'requests': ('https://docs.python-requests.org/en/latest/', None),
     'readthedocs': ('https://docs.readthedocs.io/en/stable', None),
 }
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2670,8 +2670,8 @@ Options for the linkcheck builder
      A regular expression that matches a URI.
    *auth_info*
      Authentication information to use for that URI. The value can be anything
-     that is understood by the ``requests`` library (see :ref:`requests
-     Authentication <requests:authentication>` for details).
+     that is understood by the ``requests`` library (see `requests Authentication
+     <https://requests.readthedocs.io/en/master/user/authentication>`__ for details).
 
    The ``linkcheck`` builder will use the first matching ``auth_info`` value
    it can find in the :confval:`linkcheck_auth` list, so values earlier in the

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2670,8 +2670,10 @@ Options for the linkcheck builder
      A regular expression that matches a URI.
    *auth_info*
      Authentication information to use for that URI. The value can be anything
-     that is understood by the ``requests`` library (see `requests Authentication
-     <https://requests.readthedocs.io/en/master/user/authentication>`__ for details).
+     that is understood by the ``requests`` library (see `requests Authentication`__
+     for details).
+
+   __ https://requests.readthedocs.io/en/master/user/authentication
 
    The ``linkcheck`` builder will use the first matching ``auth_info`` value
    it can find in the :confval:`linkcheck_auth` list, so values earlier in the


### PR DESCRIPTION
Fixes CI due to the `python-requests` domain no longer working.

@tk0miya please can this go into 5.0.0 to fix CI / for correct docs?

### Feature or Bugfix
- Bugfix

A