### PR TITLE
Spelling (language)

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -164,13 +164,13 @@ class Config:
                               confdir)
         namespace = eval_config_file(filename, tags)
 
-        # Note: Old sphinx projects have been configured as "langugae = None" because
+        # Note: Old sphinx projects have been configured as "language = None" because
         #       sphinx-quickstart previously generated this by default.
         #       To keep compatibility, they should be fallback to 'en' for a while
         #       (This conversion should not be removed before 2025-01-01).
         if namespace.get("language", ...) is None:
             logger.warning(__("Invalid configuration value found: 'language = None'. "
-                              "Update your configuration to a valid langauge code. "
+                              "Update your configuration to a valid language code. "
                               "Falling back to 'en' (English)."))
             namespace["language"] = "en"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -411,7 +411,7 @@ def test_conf_py_language_none_warning(logger, tempdir):
     assert logger.warning.called
     assert logger.warning.call_args[0][0] == (
         "Invalid configuration value found: 'language = None'. "
-        "Update your configuration to a valid langauge code. "
+        "Update your configuration to a valid language code. "
         "Falling back to 'en' (English).")
 
 


### PR DESCRIPTION
Closes #10491.

(@tk0miya should I target `5.x` or `5.0.x` here? I don't think it's a critical issue)

### Feature or Bugfix
- Spelling

A