### PR TITLE
Correct typo

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -170,7 +170,7 @@ class Config:
         #       (This conversion should not be removed before 2025-01-01).
         if namespace.get("language", ...) is None:
             logger.warning(__("Invalid configuration value found: 'language = None'. "
-                              "Update your configuration to a valid langauge code. "
+                              "Update your configuration to a valid language code. "
                               "Falling back to 'en' (English)."))
             namespace["language"] = "en"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -411,7 +411,7 @@ def test_conf_py_language_none_warning(logger, tempdir):
     assert logger.warning.called
     assert logger.warning.call_args[0][0] == (
         "Invalid configuration value found: 'language = None'. "
-        "Update your configuration to a valid langauge code. "
+        "Update your configuration to a valid language code. "
         "Falling back to 'en' (English).")
 
 


### PR DESCRIPTION
Fix a small typo in a warning.
