### PR TITLE
`ifconfig`: Add a meta node to fix iteration

### DIFF
--- a/sphinx/ext/ifconfig.py
+++ b/sphinx/ext/ifconfig.py
@@ -20,6 +20,7 @@ from docutils import nodes
 from docutils.nodes import Node
 
 import sphinx
+from sphinx import addnodes
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import nested_parse_with_titles
@@ -64,7 +65,7 @@ def process_ifconfig_nodes(app: Sphinx, doctree: nodes.document, docname: str) -
             node.replace_self(newnode)
         else:
             if not res:
-                node.replace_self([])
+                node.replace_self(addnodes.meta())
             else:
                 node.replace_self(node.children)
 

--- a/sphinx/ext/ifconfig.py
+++ b/sphinx/ext/ifconfig.py
@@ -20,7 +20,6 @@ from docutils import nodes
 from docutils.nodes import Node
 
 import sphinx
-from sphinx import addnodes
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import nested_parse_with_titles
@@ -52,7 +51,7 @@ def process_ifconfig_nodes(app: Sphinx, doctree: nodes.document, docname: str) -
     ns = {confval.name: confval.value for confval in app.config}
     ns.update(app.config.__dict__.copy())
     ns['builder'] = app.builder.name
-    for node in doctree.findall(ifconfig):
+    for node in list(doctree.findall(ifconfig)):
         try:
             res = eval(node['expr'], ns)
         except Exception as err:
@@ -65,7 +64,7 @@ def process_ifconfig_nodes(app: Sphinx, doctree: nodes.document, docname: str) -
             node.replace_self(newnode)
         else:
             if not res:
-                node.replace_self(addnodes.meta())
+                node.replace_self([])
             else:
                 node.replace_self(node.children)
 

--- a/tests/roots/test-ext-ifconfig/conf.py
+++ b/tests/roots/test-ext-ifconfig/conf.py
@@ -7,3 +7,4 @@ confval1 = True
 def setup(app):
     app.add_config_value('confval1', False, None)
     app.add_config_value('confval2', False, None)
+    app.add_config_value('false_config', False, None)

--- a/tests/roots/test-ext-ifconfig/index.rst
+++ b/tests/roots/test-ext-ifconfig/index.rst
@@ -18,4 +18,4 @@ Issue 10496 regression test
 
 .. ifconfig:: false_config
 
-   `Link 2 <https://link2example>`__
+   `Link 2 <https://link2.example>`__

--- a/tests/roots/test-ext-ifconfig/index.rst
+++ b/tests/roots/test-ext-ifconfig/index.rst
@@ -9,3 +9,13 @@ ifconfig
 
    egg
 
+Issue 10496 regression test
+===========================
+
+.. ifconfig:: false_config
+
+   `Link 1 <https://link1.example>`__
+
+.. ifconfig:: false_config
+
+   `Link 2 <https://link2example>`__


### PR DESCRIPTION
Fixes #10496

This issue arose due to the change from `.traverse` to `.findall`, which moved from a precompiled list to a generator.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

A