### PR TITLE
Fix `findall` usage in `KeyboardTransform`

### DIFF
--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -42,8 +42,7 @@ class KeyboardTransform(SphinxPostTransform):
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])
         # this list must be pre-created as during iteration new nodes
         # are added which match the condition in the NodeMatcher.
-        nodes_to_expand: List[nodes.literal] = list(self.document.findall(matcher))
-        for node in nodes_to_expand:  # type: nodes.literal
+        for node in list(self.document.findall(matcher)):  # type: nodes.literal
             parts = self.pattern.split(node[-1].astext())
             if len(parts) == 1 or self.is_multiwords_key(parts):
                 continue

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -42,7 +42,7 @@ class KeyboardTransform(SphinxPostTransform):
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])
         # this list must be pre-created as during iteration new nodes
         # are added which match the condition in the NodeMatcher.
-        nodes_to_expand = list(self.document.findall(matcher))
+        nodes_to_expand: List[nodes.literal] = list(self.document.findall(matcher))
         for node in nodes_to_expand:  # type: nodes.literal
             parts = self.pattern.split(node[-1].astext())
             if len(parts) == 1 or self.is_multiwords_key(parts):

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -40,7 +40,10 @@ class KeyboardTransform(SphinxPostTransform):
 
     def run(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])
-        for node in self.document.findall(matcher):  # type: nodes.literal
+        # this list must be pre-created as during iteration new nodes
+        # are added which match the condition in the NodeMatcher.
+        nodes_to_expand = list(self.document.findall(matcher))
+        for node in nodes_to_expand:  # type: nodes.literal
             parts = self.pattern.split(node[-1].astext())
             if len(parts) == 1 or self.is_multiwords_key(parts):
                 continue
@@ -61,6 +64,7 @@ class KeyboardTransform(SphinxPostTransform):
                     node += nodes.Text(sep)
                 except IndexError:
                     pass
+                _a = 1
 
     def is_multiwords_key(self, parts: List[str]) -> bool:
         if len(parts) >= 3 and parts[1].strip() == '':

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -64,7 +64,6 @@ class KeyboardTransform(SphinxPostTransform):
                     node += nodes.Text(sep)
                 except IndexError:
                     pass
-                _a = 1
 
     def is_multiwords_key(self, parts: List[str]) -> bool:
         if len(parts) >= 3 and parts[1].strip() == '':

--- a/tests/roots/test-transforms-post_transforms-keyboard/index.rst
+++ b/tests/roots/test-transforms-post_transforms-keyboard/index.rst
@@ -1,4 +1,4 @@
 Regression test for issue 10495
 ===============================
 
-:kbd:`test - test`
+:kbd:`spanish - inquisition`

--- a/tests/roots/test-transforms-post_transforms-keyboard/index.rst
+++ b/tests/roots/test-transforms-post_transforms-keyboard/index.rst
@@ -1,0 +1,4 @@
+Regression test for issue 10495
+===============================
+
+:kbd:`test - test`

--- a/tests/test_transforms_post_transforms.py
+++ b/tests/test_transforms_post_transforms.py
@@ -55,4 +55,5 @@ def test_missing_reference_conditional_pending_xref(app, status, warning):
 def test_keyboard_issue_10495(app):
     """Regression test for issue 10495, we want no crash."""
     app.build()
-    assert "blah" in (app.outdir / 'index.html').read_text(encoding='utf8')
+    assert "spanish" in (app.outdir / 'index.html').read_text(encoding='utf8')
+    assert "inquisition" in (app.outdir / 'index.html').read_text(encoding='utf8')

--- a/tests/test_transforms_post_transforms.py
+++ b/tests/test_transforms_post_transforms.py
@@ -52,7 +52,7 @@ def test_missing_reference_conditional_pending_xref(app, status, warning):
 
 @pytest.mark.sphinx('html', testroot='transforms-post_transforms-keyboard',
                     freshenv=True)
-def test_keyboard_issue_10495(app):
+def test_keyboard_hyphen_spaces(app):
     """Regression test for issue 10495, we want no crash."""
     app.build()
     assert "spanish" in (app.outdir / 'index.html').read_text(encoding='utf8')

--- a/tests/test_transforms_post_transforms.py
+++ b/tests/test_transforms_post_transforms.py
@@ -48,3 +48,11 @@ def test_missing_reference_conditional_pending_xref(app, status, warning):
 
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
     assert '<span class="n"><span class="pre">Age</span></span>' in content
+
+
+@pytest.mark.sphinx('html', testroot='transforms-post_transforms-keyboard',
+                    freshenv=True)
+def test_keyboard_issue_10495(app):
+    """Regression test for issue 10495, we want no crash."""
+    app.build()
+    assert "blah" in (app.outdir / 'index.html').read_text(encoding='utf8')


### PR DESCRIPTION
Fixes #10495. 

The bug was introduced to to using `.findall` which is a generator -- as the transform adds new nodes which match the condition in NodeMatcher, these are erroneously iterated over.

### Feature or Bugfix
- Bugfix

A

cc: @cyring @aaime please could you test this patch to see if it solves your issues?

