### PR TITLE
Fix broken changelog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,24 +1,3 @@
-Release 5.1.0 (in development)
-==============================
-
-Dependencies
-------------
-
-Incompatible changes
---------------------
-
-Deprecated
-----------
-
-Features added
---------------
-
-Bugs fixed
-----------
-
-Testing
---------
-
 Release 5.0.2 (in development)
 ==============================
 


### PR DESCRIPTION
Subject: I believe the Changelog is currently broken with 2 `5.0.1` sections (one above and one below the 5.0.2)

### Feature or Bugfix
Neither

