### PR TITLE
Support for Glossary Identifiers

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -830,6 +830,25 @@ Glossary
    The whole characters in "key" is used instead of a first character; it is
    used for "Combining Character Sequence" and "Surrogate Pairs" grouping key.
 
+   If you want to specify a "glossary key" to make glossaries unique even if
+   they have terms with the same names, you can put a "key" as
+   ".. glossary:: key". For example::
+
+      .. glossary::
+
+         term 1
+            Definition
+      
+      .. glossary:: second
+
+         term 1
+            Different Definition
+
+   This "glossary key" makes is so that you can properly reference glossaries as::
+      
+      The syntax to reference the first glossary is :term:`term 1` and to reference
+      the second glossary the syntax is :term:`second:term 1`.
+
    In i18n situation, you can specify "localized term : key" even if original
    text only have "term" part. In this case, translated "localized term" will be
    categorized in "key" group.

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -264,8 +264,9 @@ def split_term_classifiers(line: str) -> List[Optional[str]]:
     return parts
 
 
-def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], key: str, index_key: str,
-                       source: str, lineno: int, node_id: str, document: nodes.document
+def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], key: str,
+                       index_key: str, source: str, lineno: int, node_id: str,
+                       document: nodes.document
                        ) -> nodes.term:
     # get a text-only representation of the term and register it
     # as a cross-reference target with the proper key.
@@ -313,7 +314,7 @@ class Glossary(SphinxDirective):
             key = self.arguments[0].strip() + ":"
         else:
             key = ''
-        
+
         node = addnodes.glossary()
         node.document = self.state.document
         node['sorted'] = ('sorted' in self.options)

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -264,30 +264,30 @@ def split_term_classifiers(line: str) -> List[Optional[str]]:
     return parts
 
 
-def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], index_key: str,
+def make_glossary_term(env: "BuildEnvironment", textnodes: Iterable[Node], key: str, index_key: str,
                        source: str, lineno: int, node_id: str, document: nodes.document
                        ) -> nodes.term:
     # get a text-only representation of the term and register it
-    # as a cross-reference target
+    # as a cross-reference target with the proper key.
     term = nodes.term('', '', *textnodes)
     term.source = source
     term.line = lineno
-    termtext = term.astext()
+    term_reference = key + term.astext()
 
     if node_id:
         # node_id is given from outside (mainly i18n module), use it forcedly
         term['ids'].append(node_id)
     else:
-        node_id = make_id(env, document, 'term', termtext)
+        node_id = make_id(env, document, 'term', term_reference)
         term['ids'].append(node_id)
         document.note_explicit_target(term)
 
     std = cast(StandardDomain, env.get_domain('std'))
-    std._note_term(termtext, node_id, location=term)
+    std._note_term(term_reference, node_id, location=term)
 
     # add an index entry too
     indexnode = addnodes.index()
-    indexnode['entries'] = [('single', termtext, node_id, 'main', index_key)]
+    indexnode['entries'] = [('single', term_reference, node_id, 'main', index_key)]
     indexnode.source, indexnode.line = term.source, term.line
     term.append(indexnode)
 
@@ -302,13 +302,18 @@ class Glossary(SphinxDirective):
 
     has_content = True
     required_arguments = 0
-    optional_arguments = 0
+    optional_arguments = 1
     final_argument_whitespace = False
     option_spec: OptionSpec = {
         'sorted': directives.flag,
     }
 
     def run(self) -> List[Node]:
+        if self.arguments:
+            key = self.arguments[0].strip() + ":"
+        else:
+            key = ''
+        
         node = addnodes.glossary()
         node.document = self.state.document
         node['sorted'] = ('sorted' in self.options)
@@ -387,7 +392,7 @@ class Glossary(SphinxDirective):
                 textnodes, sysmsg = self.state.inline_text(parts[0], lineno)
 
                 # use first classifier as a index key
-                term = make_glossary_term(self.env, textnodes, parts[1], source, lineno,
+                term = make_glossary_term(self.env, textnodes, key, parts[1], source, lineno,
                                           node_id=None, document=self.state.document)
                 term.rawsource = line
                 system_messages.extend(sysmsg)

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -220,7 +220,7 @@ class Locale(SphinxTransform):
                     parts = split_term_classifiers(msgstr)
                     patch = publish_msgstr(self.app, parts[0], source,
                                            node.line, self.config, settings)
-                    patch = make_glossary_term(self.env, patch, parts[1],
+                    patch = make_glossary_term(self.env, patch, '', parts[1],
                                                source, node.line, _id,
                                                self.document)
                     processed = True

--- a/tests/roots/test-glossary/index.rst
+++ b/tests/roots/test-glossary/index.rst
@@ -20,3 +20,23 @@ test-glossary
 
    ähnlich
       Dinge
+
+.. glossary:: ID
+   :sorted:
+
+   boson
+      Particle with integer spin.
+
+   *fermion*
+      Particle with half-integer spin.
+
+   tauon
+   myon
+   electron
+      Examples for fermions.
+
+   über
+      Gewisse
+
+   ähnlich
+      Dinge

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -355,6 +355,26 @@ This tests :CLASS:`role names in uppercase`.
    ähnlich
       Dinge
 
+.. glossary:: ID
+   :sorted:
+
+   boson
+      Particle with integer spin.
+
+   *fermion*
+      Particle with half-integer spin.
+
+   tauon
+   myon
+   electron
+      Examples for fermions.
+
+   über
+      Gewisse
+
+   ähnlich
+      Dinge
+
 .. productionlist::
    try_stmt: `try1_stmt` | `try2_stmt`
    try1_stmt: "try" ":" `suite`

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1450,20 +1450,48 @@ def test_latex_glossary(app, status, warning):
     assert (r'\sphinxlineitem{ähnlich\index{ähnlich@\spxentry{ähnlich}|spxpagem}'
             r'\phantomsection'
             r'\label{\detokenize{index:term-ahnlich}}}' in result)
-    assert (r'\sphinxlineitem{boson\index{boson@\spxentry{boson}|spxpagem}\phantomsection'
+    assert (r'\sphinxlineitem{boson\index{boson@\spxentry{boson}|spxpagem}'
+            r'\phantomsection'
             r'\label{\detokenize{index:term-boson}}}' in result)
     assert (r'\sphinxlineitem{\sphinxstyleemphasis{fermion}'
             r'\index{fermion@\spxentry{fermion}|spxpagem}'
             r'\phantomsection'
             r'\label{\detokenize{index:term-fermion}}}' in result)
-    assert (r'\sphinxlineitem{tauon\index{tauon@\spxentry{tauon}|spxpagem}\phantomsection'
+    assert (r'\sphinxlineitem{tauon\index{tauon@\spxentry{tauon}|spxpagem}'
+            r'\phantomsection'
             r'\label{\detokenize{index:term-tauon}}}'
-            r'\sphinxlineitem{myon\index{myon@\spxentry{myon}|spxpagem}\phantomsection'
+            r'\sphinxlineitem{myon\index{myon@\spxentry{myon}|spxpagem}'
+            r'\phantomsection'
             r'\label{\detokenize{index:term-myon}}}'
-            r'\sphinxlineitem{electron\index{electron@\spxentry{electron}|spxpagem}\phantomsection'
+            r'\sphinxlineitem{electron\index{electron@\spxentry{electron}|spxpagem}'
+            r'\phantomsection'
             r'\label{\detokenize{index:term-electron}}}' in result)
-    assert (r'\sphinxlineitem{über\index{über@\spxentry{über}|spxpagem}\phantomsection'
+    assert (r'\sphinxlineitem{über\index{über@\spxentry{über}|spxpagem}'
+            r'\phantomsection'
             r'\label{\detokenize{index:term-uber}}}' in result)
+
+    assert (r'\sphinxlineitem{ähnlich\index{ID:ähnlich@\spxentry{ID:ähnlich}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-ahnlich}}}' in result)
+    assert (r'\sphinxlineitem{boson\index{ID:boson@\spxentry{ID:boson}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-boson}}}' in result)
+    assert (r'\sphinxlineitem{\sphinxstyleemphasis{fermion}'
+            r'\index{ID:fermion@\spxentry{ID:fermion}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-fermion}}}' in result)
+    assert (r'\sphinxlineitem{tauon\index{ID:tauon@\spxentry{ID:tauon}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-tauon}}}'
+            r'\sphinxlineitem{myon\index{ID:myon@\spxentry{ID:myon}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-myon}}}'
+            r'\sphinxlineitem{electron\index{ID:electron@\spxentry{ID:electron}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-electron}}}' in result)
+    assert (r'\sphinxlineitem{über\index{ID:über@\spxentry{ID:über}|spxpagem}'
+            r'\phantomsection'
+            r'\label{\detokenize{index:term-ID-uber}}}' in result)
 
 
 @pytest.mark.sphinx('latex', testroot='latex-labels')

--- a/tests/test_domain_std.py
+++ b/tests/test_domain_std.py
@@ -170,6 +170,7 @@ def test_glossary(app):
                                   pending_xref(), nodes.paragraph())
     assert_node(refnode, nodes.reference, refid="term-TERM2")
 
+
 def test_glossary_with_glossary_identifier(app):
     text = (".. glossary:: ID\n"
             "\n"
@@ -232,6 +233,7 @@ def test_glossary_with_glossary_identifier(app):
     refnode = domain.resolve_xref(app.env, 'index', app.builder, 'term', 'ID:term2',
                                   pending_xref(), nodes.paragraph())
     assert_node(refnode, nodes.reference, refid="term-ID-TERM2")
+
 
 def test_glossary_warning(app, status, warning):
     # empty line between terms

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -382,7 +382,7 @@ def get_verifier(verify, verify_re):
          '<dd>description</dd>\n</dl>'),
         None,
     ),
-        (
+    (
         # glossary (description list): multiple terms with identifier
         'verify',
         '.. glossary:: ID\n\n   term1\n   term2\n       description',

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -382,6 +382,18 @@ def get_verifier(verify, verify_re):
          '<dd>description</dd>\n</dl>'),
         None,
     ),
+        (
+        # glossary (description list): multiple terms with identifier
+        'verify',
+        '.. glossary:: ID\n\n   term1\n   term2\n       description',
+        ('<dl class="glossary docutils">\n'
+         '<dt id="term-ID-term1">term1<a class="headerlink" href="#term-ID-term1"'
+         ' title="Permalink to this term">¶</a></dt>'
+         '<dt id="term-ID-term2">term2<a class="headerlink" href="#term-ID-term2"'
+         ' title="Permalink to this term">¶</a></dt>'
+         '<dd>description</dd>\n</dl>'),
+        None,
+    ),
 ])
 def test_inline(get_verifier, type, rst, html_expected, latex_expected):
     verifier = get_verifier(type)


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Currently, Sphinx supports multiple glossaries, but the same term cannot appear twice. This is improved by adding an identifier to glossaries so that the correct glossary can be referenced.

### Detail
- Added the identifier to the glossary directive
- Added documentation
- Added testing

### Relates
-  Closes #1399 

