### PR TITLE
Fix minor search summary issues

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -158,7 +158,7 @@ const Search = {
     const htmlElement = document
       .createRange()
       .createContextualFragment(htmlString);
-    _removeChildren(htmlElement.querySelectorAll(".headerlink"));
+    htmlElement.querySelectorAll(".headerlink").forEach((el) => el.parentNode.removeChild(el));
     const docContent = htmlElement.querySelector('[role="main"]');
     if (docContent !== undefined) return docContent.textContent;
     console.warn(

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -516,7 +516,7 @@ const Search = {
     const top = startWithContext === 0 ? "" : "...";
     const tail = startWithContext + 240 < text.length ? "..." : "";
 
-    let summary = document.createElement("div");
+    let summary = document.createElement("p");
     summary.classList.add("context");
     summary.innerText = top + text.substr(startWithContext, 240).trim() + tail;
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -504,11 +504,12 @@ const Search = {
    * latter for highlighting it.
    */
   makeSearchSummary: (htmlText, keywords, highlightWords) => {
-    const text = Search.htmlToText(htmlText).toLowerCase();
+    const text = Search.htmlToText(htmlText);
     if (text === "") return null;
 
+    const textLower = text.toLowerCase();
     const actualStartPosition = [...keywords]
-      .map((k) => text.indexOf(k.toLowerCase()))
+      .map((k) => textLower.indexOf(k.toLowerCase()))
       .filter((i) => i > -1)
       .slice(-1)[0];
     const startWithContext = Math.max(actualStartPosition - 120, 0);


### PR DESCRIPTION
Subject: Fix minor search summary issues

### Feature or Bugfix
- Bugfix

### Purpose
I believe all of these are mainly cosmetic minor regressions from #10028.
See [5.x](https://sphinx-test-stuff.readthedocs.io/en/tmp-5.x/search.html?q=gettext) vs [this branch](https://sphinx-test-stuff.readthedocs.io/en/tmp-fix-searchtools/search.html?q=gettext) for comparison (with rtd's server-side search disabled as it's not an issue when that's used).

### Details
- Summary element type should be `<p>` instead of `<div>`, fixes styling (originally changed in 339cab76579ee2b9b0c6ed85cdf3f89afe589067)
- The lowercase text should only be used for context matching, not for the final output
- Removal of header links was broken

