### PR TITLE
Add type info to version and project config keys

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -82,11 +82,11 @@ class Config:
 
     config_values: Dict[str, Tuple] = {
         # general options
-        'project': ('Python', 'env', []),
+        'project': ('Python', 'env', [str]),
         'author': ('unknown', 'env', []),
         'project_copyright': ('', 'html', [str]),
         'copyright': (lambda c: c.project_copyright, 'html', [str]),
-        'version': ('', 'env', []),
+        'version': ('', 'env', [str]),
         'release': ('', 'env', []),
         'today': ('', 'env', []),
         # the real default is locale-dependent


### PR DESCRIPTION
Add type information for "version" and "project" configuration keys.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Bugfix

### Purpose
This shows a warning if they are set to something other than a str. In both cases, ```sphinx/util/inventory.py``` will throw a ```TypeError```.

This fixes #10544.

### Detail
### Relates
- #10544 

