### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: "If you use Sphinx, please cite it as below."
 authors:
 - family-names: Brandl
   given-names: Georg
@@ -26,7 +26,7 @@ authors:
   alias: TimKam
   orcid: "https://orcid.org/0000-0002-6458-2252"
   website: "people.cs.umu.se/tkampik"
-title: "Sphinx: Python Documentation Generator"
+title: "The Sphinx documentation builder"
 version: 5.0.1
 date-released: 2022-06-02
-url: "https://github.com/sphinx-doc/sphinx"
+url: "https://www.sphinx-doc.org/en/master/"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: Brandl
+  given-names: Georg
+  alias: birkenfeld
+  email: georg@python.org
+  affiliation: FZ Jülich
+  city: München
+  country: DE
+- family-names: Shimizukawa
+  given-names: Takayuki
+  alias: shimizukawa
+  email: shimizukawa@gmail.com
+  website: "http://about.me/shimizukawa"
+  city: Tokyo
+  country: JP
+- family-names: Komiya
+  given-names: Takeshi
+  alias: tk0miya
+  email: i.tkomiya@gmail.com
+  city: Saitama
+  country: JP
+- family-names: Kampik
+  given-names: Timotheus
+  alias: TimKam
+  orcid: "https://orcid.org/0000-0002-6458-2252"
+  website: "people.cs.umu.se/tkampik"
+title: "Sphinx: Python Documentation Generator"
+version: 5.0.1
+date-released: 2022-06-02
+url: "https://github.com/sphinx-doc/sphinx"


### PR DESCRIPTION
Add CITATION.cff file. Closes #10543.

I have tried to add all public members of the sphinx org as authors, with all the information in their Github profile, although most of it is not necessary. Some additional fields could also be added, such as the license type or an abstract.

The version and date-released are optional and could be removed.

Please, check that there is no missing author that should be credited. It is also possible to credit an entity. If there is an additional article or book that should be cited instead it is also possible to add it as a preferred citation.

Subject: Add standard citation.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
- Feature

### Purpose
- Solves #10543.

### Detail
- Add standard citation.

### Relates
-  #10543.

