### PR TITLE
Fix parsing of options with enabled option_emphasise_placeholders

### DIFF
--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -186,23 +186,22 @@ class Cmdoption(ObjectDescription[str]):
             signode += addnodes.desc_name(optname, optname)
             if self.env.config.option_emphasise_placeholders:
                 add_end_bracket = False
-                if not args:
-                    continue
-                if args[0] == '[' and args[-1] == ']':
-                    add_end_bracket = True
-                    signode += addnodes.desc_sig_punctuation('[', '[')
-                    args = args[1:-1]
-                if args[0] == ' ':
-                    signode += addnodes.desc_sig_space()
-                    args = args.strip()
-                if args[0] == '=':
-                    signode += addnodes.desc_sig_punctuation('=', '=')
-                    args = args[1:]
-                for part in samp_role.parse(args):
-                    if isinstance(part, nodes.Text):
-                        signode += nodes.Text(part.astext())
-                    else:
-                        signode += part
+                if args:
+                    if args[0] == '[' and args[-1] == ']':
+                        add_end_bracket = True
+                        signode += addnodes.desc_sig_punctuation('[', '[')
+                        args = args[1:-1]
+                    elif args[0] == ' ':
+                        signode += addnodes.desc_sig_space()
+                        args = args.strip()
+                    elif args[0] == '=':
+                        signode += addnodes.desc_sig_punctuation('=', '=')
+                        args = args[1:]
+                    for part in samp_role.parse(args):
+                        if isinstance(part, nodes.Text):
+                            signode += nodes.Text(part.astext())
+                        else:
+                            signode += part
                 if add_end_bracket:
                     signode += addnodes.desc_sig_punctuation(']', ']')
             else:

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1748,6 +1748,8 @@ def test_option_emphasise_placeholders(app, status, warning):
             '<span class="pre">-</span>'
             '<em><span class="pre">COUNT</span></em>' in content)
     assert '<span class="pre">{{value}}</span>' in content
+    assert ('<span class="pre">--plugin.option</span></span>'
+            '<a class="headerlink" href="#cmdoption-perl-plugin.option" title="Permalink to this definition">¶</a></dt>') in content
 
 
 @pytest.mark.sphinx('html', testroot='root')
@@ -1757,6 +1759,9 @@ def test_option_emphasise_placeholders_default(app, status, warning):
     assert '<span class="pre">={TYPE}</span>' in content
     assert '<span class="pre">={WHERE}-{COUNT}</span></span>' in content
     assert '<span class="pre">{client_name}</span>' in content
+    assert ('<span class="pre">--plugin.option</span></span>'
+            '<span class="sig-prename descclassname"></span>'
+            '<a class="headerlink" href="#cmdoption-perl-plugin.option" title="Permalink to this definition">¶</a></dt>') in content
 
 
 @pytest.mark.sphinx('html', testroot='theming')


### PR DESCRIPTION
If the option is enabled, the current code wrongly uses

```python
if not args:
  continue
```

which skips adjustement of signode and firstname
at the very of the loop.

Fixes: #10366.