### PR TITLE
general code quality improvements

### DIFF
--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -67,10 +67,8 @@ class KeyboardTransform(SphinxPostTransform):
     def is_multiwords_key(self, parts: List[str]) -> bool:
         if len(parts) >= 3 and parts[1].strip() == '':
             name = parts[0].lower(), parts[2].lower()
-            if name in self.multiwords_keys:
-                return True
-            else:
-                return False
+            return name in self.multiwords_keys
+
         else:
             return False
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -99,7 +99,7 @@ class TocTree(SphinxDirective):
                     toctree['entries'].append((None, docname))
                     toctree['includefiles'].append(docname)
                 if not docnames:
-                    logger.warning(__('toctree glob pattern %r didn\'t match any documents'),
+                    logger.warning(__("toctree glob pattern %r didn't match any documents"),
                                    entry, location=toctree)
             else:
                 if explicit:

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1959,7 +1959,7 @@ class Symbol:
             if Symbol.debug_lookup:
                 Symbol.debug_print(
                     "no match, but fill an empty declaration, candSybmol is not None?:",
-                    candSymbol is not None)  # NOQA
+                    candSymbol is not None)
                 Symbol.debug_indent -= 2
             if candSymbol is not None:
                 candSymbol.remove()

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -4,6 +4,7 @@ Gracefully adapted from the TextPress system by Armin.
 """
 
 from collections import defaultdict
+from contextlib import suppress
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Tuple, Type
 
@@ -80,12 +81,10 @@ class EventManager:
     def emit(self, name: str, *args: Any,
              allowed_exceptions: Tuple[Type[Exception], ...] = ()) -> List:
         """Emit a Sphinx event."""
-        try:
-            logger.debug('[app] emitting event: %r%s', name, repr(args)[:100])
-        except Exception:
+        with suppress(Exception):
             # not every object likes to be repr()'d (think
             # random stuff coming via autodoc)
-            pass
+            logger.debug('[app] emitting event: %r%s', name, repr(args)[:100])
 
         results = []
         listeners = sorted(self.listeners[name], key=attrgetter("priority"))

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -4,6 +4,7 @@ import importlib
 import traceback
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional
+from contextlib import suppress
 
 from sphinx.ext.autodoc.mock import ismock, undecorate
 from sphinx.pycode import ModuleAnalyzer, PycodeError
@@ -19,18 +20,16 @@ logger = logging.getLogger(__name__)
 
 def mangle(subject: Any, name: str) -> str:
     """Mangle the given name."""
-    try:
+    with suppress(AttributeError):
         if isclass(subject) and name.startswith('__') and not name.endswith('__'):
             return "_%s%s" % (subject.__name__, name)
-    except AttributeError:
-        pass
 
     return name
 
 
 def unmangle(subject: Any, name: str) -> Optional[str]:
     """Unmangle the given name."""
-    try:
+    with suppress(AttributeError):
         if isclass(subject) and not name.endswith('__'):
             prefix = "_%s__" % subject.__name__
             if name.startswith(prefix):
@@ -41,8 +40,6 @@ def unmangle(subject: Any, name: str) -> Optional[str]:
                     if name.startswith(prefix):
                         # mangled attribute defined in parent class
                         return None
-    except AttributeError:
-        pass
 
     return name
 
@@ -252,7 +249,7 @@ def get_class_members(subject: Any, objpath: List[str], attrgetter: Callable,
         except AttributeError:
             continue
 
-    try:
+    with suppress(AttributeError):
         for cls in getmro(subject):
             try:
                 modname = safe_getattr(cls, '__module__')
@@ -295,7 +292,5 @@ def get_class_members(subject: Any, objpath: List[str], attrgetter: Callable,
                         # attribute is already known, because dir(subject) enumerates it.
                         # But it has no docstring yet
                         members[name].docstring = '\n'.join(docstring)
-    except AttributeError:
-        pass
 
     return members

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -2,6 +2,7 @@
 
 import re
 from collections import OrderedDict
+from contextlib import suppress
 from typing import Any, Dict, Iterable, Set, cast
 
 from docutils import nodes
@@ -20,7 +21,7 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
     else:
         mode = 'fully-qualified'
 
-    try:
+    with suppress(TypeError, ValueError):
         if callable(obj):
             annotations = app.env.temp_data.setdefault('annotations', {})
             annotation = annotations.setdefault(name, OrderedDict())
@@ -30,8 +31,6 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
                     annotation[param.name] = typing.stringify(param.annotation, mode)
             if sig.return_annotation is not sig.empty:
                 annotation['return'] = typing.stringify(sig.return_annotation, mode)
-    except (TypeError, ValueError):
-        pass
 
 
 def merge_typehints(app: Sphinx, domain: str, objtype: str, contentnode: Element) -> None:

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -74,7 +74,6 @@ from sphinx.ext.autodoc import INSTANCEATTR, Documenter
 from sphinx.ext.autodoc.directive import DocumenterBridge, Options
 from sphinx.ext.autodoc.importer import import_module
 from sphinx.ext.autodoc.mock import mock
-from sphinx.extension import Extension
 from sphinx.locale import __
 from sphinx.project import Project
 from sphinx.pycode import ModuleAnalyzer, PycodeError

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -74,6 +74,7 @@ from sphinx.ext.autodoc import INSTANCEATTR, Documenter
 from sphinx.ext.autodoc.directive import DocumenterBridge, Options
 from sphinx.ext.autodoc.importer import import_module
 from sphinx.ext.autodoc.mock import mock
+from sphinx.extension import Extension
 from sphinx.locale import __
 from sphinx.project import Project
 from sphinx.pycode import ModuleAnalyzer, PycodeError

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -224,7 +224,7 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict, format: str,
         return relfn, outfn
 
     if (hasattr(self.builder, '_graphviz_warned_dot') and
-       self.builder._graphviz_warned_dot.get(graphviz_dot)):  # type: ignore  # NOQA
+       self.builder._graphviz_warned_dot.get(graphviz_dot)):  # type: ignore
         return None, None
 
     ensuredir(path.dirname(outfn))

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -31,6 +31,7 @@ LaTeX.
 import builtins
 import inspect
 import re
+from contextlib import suppress
 from importlib import import_module
 from typing import Any, Dict, Iterable, List, Tuple, cast
 
@@ -184,13 +185,11 @@ class InheritanceGraph:
 
             # Use first line of docstring as tooltip, if available
             tooltip = None
-            try:
+            with suppress(AttributeError):  # might raise AttributeError for strange classes
                 if cls.__doc__:
                     doc = cls.__doc__.strip().split("\n")[0]
                     if doc:
                         tooltip = '"%s"' % doc.replace('"', '\\"')
-            except Exception:  # might raise AttributeError for strange classes
-                pass
 
             baselist: List[str] = []
             all_classes[cls] = (nodename, fullname, baselist, tooltip)

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -389,7 +389,7 @@ class ManpageLink(SphinxTransform):
         for node in self.document.findall(addnodes.manpage):
             manpage = ' '.join([str(x) for x in node.children
                                 if isinstance(x, nodes.Text)])
-            pattern = r'^(?P<path>(?P<page>.+)[\(\.](?P<section>[1-9]\w*)?\)?)$'  # noqa
+            pattern = r'^(?P<path>(?P<page>.+)[\(\.](?P<section>[1-9]\w*)?\)?)$'
             info = {'path': manpage,
                     'page': manpage,
                     'section': ''}

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -180,7 +180,7 @@ class TexinfoTranslator(SphinxTranslator):
         self.escape_newlines = 0
         self.escape_hyphens = 0
         self.curfilestack: List[str] = []
-        self.footnotestack: List[Dict[str, List[Union[collected_footnote, bool]]]] = []  # NOQA
+        self.footnotestack: List[Dict[str, List[Union[collected_footnote, bool]]]] = []
         self.in_footnote = 0
         self.in_samp = 0
         self.handled_abbrs: Set[str] = set()

--- a/tests/roots/test-ext-autodoc/autodoc_dummy_module.py
+++ b/tests/roots/test-ext-autodoc/autodoc_dummy_module.py
@@ -1,6 +1,6 @@
-from dummy import *  # NOQA
+from dummy import *
 
 
 def test():
     """Dummy function using dummy.*"""
-    dummy_function()   # NOQA
+    dummy_function()

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -1,7 +1,7 @@
 import enum
 from io import StringIO
 
-from sphinx.util import save_traceback  # NOQA
+from sphinx.util import save_traceback
 
 __all__ = ['Class']
 

--- a/tests/roots/test-ext-autodoc/target/coroutine.py
+++ b/tests/roots/test-ext-autodoc/target/coroutine.py
@@ -5,7 +5,7 @@ from functools import wraps
 class AsyncClass:
     async def do_coroutine(self):
         """A documented coroutine function"""
-        attr_coro_result = await _other_coro_func()  # NOQA
+        attr_coro_result = await _other_coro_func()
 
     @classmethod
     async def do_coroutine2(cls):

--- a/tests/roots/test-ext-autodoc/target/need_mocks.py
+++ b/tests/roots/test-ext-autodoc/target/need_mocks.py
@@ -1,12 +1,12 @@
 
-import missing_module  # NOQA
-import missing_package1.missing_module1  # NOQA
-from missing_module import missing_name  # NOQA
-from missing_package2 import missing_module2  # NOQA
-from missing_package3.missing_module3 import missing_name  # NOQA
+import missing_module
+import missing_package1.missing_module1
+from missing_module import missing_name
+from missing_package2 import missing_module2
+from missing_package3.missing_module3 import missing_name
 
-import sphinx.missing_module4  # NOQA
-from sphinx.missing_module4 import missing_name2  # NOQA
+import sphinx.missing_module4
+from sphinx.missing_module4 import missing_name2
 
 
 @missing_name(int)

--- a/tests/roots/test-ext-autosummary-filename-map/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary-filename-map/autosummary_dummy_module.py
@@ -1,4 +1,4 @@
-from os import path  # NOQA
+from os import path
 from typing import Union
 
 

--- a/tests/roots/test-ext-autosummary-recursive/package/module.py
+++ b/tests/roots/test-ext-autosummary-recursive/package/module.py
@@ -1,4 +1,4 @@
-from os import *  # NOQA
+from os import *
 
 
 class Foo:

--- a/tests/roots/test-ext-autosummary-recursive/package/package/module.py
+++ b/tests/roots/test-ext-autosummary-recursive/package/package/module.py
@@ -1,4 +1,4 @@
-from os import *  # NOQA
+from os import *
 
 
 class Foo:

--- a/tests/roots/test-ext-autosummary-recursive/package2/module.py
+++ b/tests/roots/test-ext-autosummary-recursive/package2/module.py
@@ -1,4 +1,4 @@
-from os import *  # NOQA
+from os import *
 
 
 class Foo:

--- a/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
+++ b/tests/roots/test-ext-autosummary/autosummary_dummy_module.py
@@ -1,4 +1,4 @@
-from os import path  # NOQA
+from os import path
 from typing import Union
 
 from autosummary_class_module import Class

--- a/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
+++ b/tests/roots/test-ext-viewcode-find/not_a_package/__init__.py
@@ -1,1 +1,1 @@
-from .submodule import Class1, func1  # NOQA
+from .submodule import Class1, func1

--- a/tests/roots/test-ext-viewcode/conf.py
+++ b/tests/roots/test-ext-viewcode/conf.py
@@ -8,7 +8,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
 exclude_patterns = ['_build']
 
 
-if 'test_linkcode' in tags:  # NOQA
+if 'test_linkcode' in tags:
     extensions.remove('sphinx.ext.viewcode')
     extensions.append('sphinx.ext.linkcode')
 

--- a/tests/roots/test-ext-viewcode/spam/__init__.py
+++ b/tests/roots/test-ext-viewcode/spam/__init__.py
@@ -1,2 +1,2 @@
-from .mod1 import Class1, func1  # NOQA
-from .mod2 import Class2, func2  # NOQA
+from .mod1 import Class1, func1
+from .mod2 import Class2, func2

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -46,7 +46,7 @@ extlinks = {'issue': ('http://bugs.python.org/issue%s', 'issue %s'),
             'pyurl': ('http://python.org/%s', None)}
 
 # modify tags from conf.py
-tags.add('confpytag')  # NOQA
+tags.add('confpytag')
 
 
 # -- extension API

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1520,7 +1520,7 @@ def test_html_math_renderer_is_duplicated(make_app, app_params):
     try:
         args, kwargs = app_params
         make_app(*args, **kwargs)
-        assert False
+        raise AssertionError()
     except ConfigError as exc:
         assert str(exc) == ('Many math_renderers are registered. '
                             'But no math_renderer is selected.')
@@ -1550,7 +1550,7 @@ def test_html_math_renderer_is_mismatched(make_app, app_params):
     try:
         args, kwargs = app_params
         make_app(*args, **kwargs)
-        assert False
+        raise AssertionError()
     except ConfigError as exc:
         assert str(exc) == "Unknown math_renderer 'imgmath' is given."
 

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -1270,8 +1270,8 @@ def test_module_index(app):
     assert index.generate() == (
         [('d', [IndexEntry('docutils', 0, 'index', 'module-docutils', '', '', '')]),
          ('s', [IndexEntry('sphinx', 1, 'index', 'module-sphinx', '', '', ''),
-                IndexEntry('sphinx.builders', 2, 'index', 'module-sphinx.builders', '', '', ''),  # NOQA
-                IndexEntry('sphinx.builders.html', 2, 'index', 'module-sphinx.builders.html', '', '', ''),  # NOQA
+                IndexEntry('sphinx.builders', 2, 'index', 'module-sphinx.builders', '', '', ''),
+                IndexEntry('sphinx.builders.html', 2, 'index', 'module-sphinx.builders.html', '', '', ''),
                 IndexEntry('sphinx.config', 2, 'index', 'module-sphinx.config', '', '', ''),
                 IndexEntry('sphinx_intl', 0, 'index', 'module-sphinx_intl', '', '', '')])],
         False
@@ -1314,8 +1314,8 @@ def test_modindex_common_prefix(app):
     restructuredtext.parse(app, text)
     index = PythonModuleIndex(app.env.get_domain('py'))
     assert index.generate() == (
-        [('b', [IndexEntry('sphinx.builders', 1, 'index', 'module-sphinx.builders', '', '', ''),  # NOQA
-                IndexEntry('sphinx.builders.html', 2, 'index', 'module-sphinx.builders.html', '', '', '')]),  # NOQA
+        [('b', [IndexEntry('sphinx.builders', 1, 'index', 'module-sphinx.builders', '', '', ''),
+                IndexEntry('sphinx.builders.html', 2, 'index', 'module-sphinx.builders.html', '', '', '')]),
          ('c', [IndexEntry('sphinx.config', 0, 'index', 'module-sphinx.config', '', '', '')]),
          ('d', [IndexEntry('docutils', 0, 'index', 'module-docutils', '', '', '')]),
          ('s', [IndexEntry('sphinx', 0, 'index', 'module-sphinx', '', '', ''),

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -363,7 +363,7 @@ def test_get_doc(app):
 
     # verify that method docstrings get extracted in both normal case
     # and in case of bound method posing as a function
-    class J:  # NOQA
+    class J:
         def foo(self):
             """Method docstring"""
     assert getdocl('method', J.foo) == ['Method docstring']

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -649,12 +649,12 @@ def test_isattributedescriptor(app):
     assert inspect.isattributedescriptor(Base.meth) is False                   # method
     assert inspect.isattributedescriptor(Base.staticmeth) is False             # staticmethod
     assert inspect.isattributedescriptor(Base.classmeth) is False              # classmetho
-    assert inspect.isattributedescriptor(Descriptor) is False                  # custom descriptor class    # NOQA
-    assert inspect.isattributedescriptor(str.join) is False                    # MethodDescriptorType       # NOQA
-    assert inspect.isattributedescriptor(object.__init__) is False             # WrapperDescriptorType      # NOQA
-    assert inspect.isattributedescriptor(dict.__dict__['fromkeys']) is False   # ClassMethodDescriptorType  # NOQA
-    assert inspect.isattributedescriptor(types.FrameType.f_locals) is True     # GetSetDescriptorType       # NOQA
-    assert inspect.isattributedescriptor(datetime.timedelta.days) is True      # MemberDescriptorType       # NOQA
+    assert inspect.isattributedescriptor(Descriptor) is False                  # custom descriptor class
+    assert inspect.isattributedescriptor(str.join) is False                    # MethodDescriptorType
+    assert inspect.isattributedescriptor(object.__init__) is False             # WrapperDescriptorType
+    assert inspect.isattributedescriptor(dict.__dict__['fromkeys']) is False   # ClassMethodDescriptorType
+    assert inspect.isattributedescriptor(types.FrameType.f_locals) is True     # GetSetDescriptorType
+    assert inspect.isattributedescriptor(datetime.timedelta.days) is True      # MemberDescriptorType
 
     try:
         # _testcapi module cannot be importable in some distro
@@ -662,7 +662,7 @@ def test_isattributedescriptor(app):
         import _testcapi
 
         testinstancemethod = _testcapi.instancemethod(str.__repr__)
-        assert inspect.isattributedescriptor(testinstancemethod) is False      # instancemethod (C-API)     # NOQA
+        assert inspect.isattributedescriptor(testinstancemethod) is False      # instancemethod (C-API)
     except ImportError:
         pass
 


### PR DESCRIPTION
fixes a number of warnings generated by flake8 plugins not currently used in this project

These fixes address code quality, but not code *correctness*

in particular, it removes a number of blanket `# NOQA` comments that don't appear to be necessary
