### PR TITLE
Fixed path bug with links in SVG inheritance diagrams

### DIFF
--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -30,6 +30,7 @@ LaTeX.
 
 import builtins
 import inspect
+import pathlib
 import re
 from importlib import import_module
 from typing import Any, Dict, Iterable, List, Tuple, cast
@@ -46,6 +47,7 @@ from sphinx.ext.graphviz import (figure_wrapper, graphviz, render_dot_html, rend
                                  render_dot_texinfo)
 from sphinx.util import md5
 from sphinx.util.docutils import SphinxDirective
+from sphinx.util.osutil import canon_path, relpath
 from sphinx.util.typing import OptionSpec
 from sphinx.writers.html import HTMLTranslator
 from sphinx.writers.latex import LaTeXTranslator
@@ -396,17 +398,25 @@ def html_visit_inheritance_diagram(self: HTMLTranslator, node: inheritance_diagr
     # Create a mapping from fully-qualified class names to URLs.
     graphviz_output_format = self.builder.env.config.graphviz_output_format.upper()
     current_filename = self.builder.current_docname + self.builder.out_suffix
+    current_dir = pathlib.PurePath(current_filename).parent
     urls = {}
     pending_xrefs = cast(Iterable[addnodes.pending_xref], node)
     for child in pending_xrefs:
         if child.get('refuri') is not None:
             if graphviz_output_format == 'SVG':
-                urls[child['reftitle']] = "../" + child.get('refuri')
+                # URI relative to src dir (typically equivalent to stripping all leading ../)
+                uri_rel_to_srcdir = (current_dir / child.get('refuri')).as_posix()
+                # URI relative to image dir (typically equivalent to prepending ../)
+                uri_rel_to_imagedir = relpath(uri_rel_to_srcdir, self.builder.imagedir)
+                urls[child['reftitle']] = canon_path(uri_rel_to_imagedir)
             else:
                 urls[child['reftitle']] = child.get('refuri')
         elif child.get('refid') is not None:
             if graphviz_output_format == 'SVG':
-                urls[child['reftitle']] = '../' + current_filename + '#' + child.get('refid')
+                # URI relative to image dir (typically equivalent to prepending ../)
+                uri_rel_to_imagedir = relpath(current_filename, self.builder.imagedir)
+                urls[child['reftitle']] = canon_path(uri_rel_to_imagedir) +\
+                                          '#' + child.get('refid')
             else:
                 urls[child['reftitle']] = '#' + child.get('refid')
 


### PR DESCRIPTION
Subject: Fixes links in SVG inheritance diagrams when those diagrams are in documents not at the base level

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Currently, links in SVG inheritance diagrams only work when the documents are at the base level.  That's because the URIs supplied to the diagram are relative to the document (as is appropriate for PNG output), but the SVGs live in the `/_images` folder, so the URIs need to be relative to that location.  There is a hard-coded `'../'` that gets prepended to the URIs, which fixes only base-level documents.  Documents in sub-directories result in SVG links that have one or more extraneous `'../'` that break the links.

### Detail
This PR fixes the URIs to be relative to the image directory prior to making the SVG inheritance diagrams.

### Relates
Fixes #10570