### PR TITLE
Fix #10574: Failed to search on sphinx-doc.org

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,6 +178,10 @@ def setup(app):
     app.add_object_type('event', 'event', 'pair: %s; event', parse_event,
                         doc_field_types=[fdesc])
 
+    # Load jQuery to make readthedocs-doc-embed.js available (refs: #10574)
+    app.add_js_file('https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js',
+                    priority=100)
+
     # workaround for RTD
     from sphinx.util import logging
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Since 6.0, jQuery has not been loaded by default.  It affects to the
search feature of RtD.  This loads jQuery again to make it available.

