### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -93,9 +93,9 @@ def make_link_role(name: str, base_url: str, caption: str) -> RoleFunction:
     try:
         base_url % 'dummy'
     except (TypeError, ValueError):
-        logger.warn(__('extlinks: Sphinx-6.0 will require base URL to '
-                       'contain exactly one \'%s\' and all other \'%\' need '
-                       'to be escaped as \'%%\'.'))  # RemovedInSphinx60Warning
+        logger.warning(__('extlinks: Sphinx-6.0 will require base URL to '
+                          'contain exactly one \'%s\' and all other \'%\' need '
+                          'to be escaped as \'%%\'.'))  # RemovedInSphinx60Warning
         base_url = base_url.replace('%', '%%') + '%s'
     if caption is not None:
         try:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -396,7 +396,7 @@ class SphinxComponentRegistry:
 
     def add_latex_package(self, name: str, options: str, after_hyperref: bool = False) -> None:
         if self.has_latex_package(name):
-            logger.warn("latex package '%s' already included" % name)
+            logger.warning("latex package '%s' already included", name)
 
         logger.debug('[app] adding latex package: %r', name)
         if after_hyperref:


### PR DESCRIPTION
Subject: Replace deprecated logging.warn with logging.warning

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).


### Relates
* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444

