### PR TITLE
Fix #10594: HTML: field term colons are doubled if using Docutils 0.18+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+#10594: HTML: field term colons are doubled if using Docutils 0.18+
+
 Testing
 --------
 

--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,7 @@ Features added
 Bugs fixed
 ----------
 
-#10594: HTML Theme: field term colons are doubled if using Docutils 0.18+
+* #10594: HTML Theme: field term colons are doubled if using Docutils 0.18+
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,7 @@ Features added
 Bugs fixed
 ----------
 
-#10594: HTML: field term colons are doubled if using Docutils 0.18+
+#10594: HTML Theme: field term colons are doubled if using Docutils 0.18+
 
 Testing
 --------

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -686,15 +686,11 @@ dl.field-list > dt {
     padding-right: 5px;
 }
 
-/* Compatibility patch for Docutils 0.18+ */
-dl.field-list > dt .colon {
-    display: none;
-}
-
-/* Docutils 0.17 and older */
+{%- if docutils_version_info[:2] < (0, 18) %}
 dl.field-list > dt:after {
     content: ":";
 }
+{% endif %}
 
 dl.field-list > dd {
     padding-left: 0.5em;

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -686,6 +686,12 @@ dl.field-list > dt {
     padding-right: 5px;
 }
 
+/* Compatibility patch for Docutils 0.18+ */
+dl.field-list > dt .colon {
+    display: none;
+}
+
+/* Docutils 0.17 and older */
 dl.field-list > dt:after {
     content: ":";
 }


### PR DESCRIPTION

### Relates
- #10523 

The Docutils commit responsible for the change at 0.18 is [rev8734](https://sourceforge.net/p/docutils/code/8734/)

Nota bene:
- our test suite did not detect the added `<span class="colon">:</span>` at Docutils 0.18. As I am not competent enough to add a test conditional on Docutils version I did not (remember I am only LaTeX guru here).
- I guess the `docinfo` class for `<dl>` is not involved at Sphinx level