### PR TITLE
Fix build failure for Docutils 0.18.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #10596: Build failure if Docutils version is 0.18 (not 0.18.1) due
+  to missing ``Node.findall()``
+
 Testing
 --------
 

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -550,9 +550,9 @@ class SphinxTranslator(nodes.NodeVisitor):
 
 
 # Node.findall() is a new interface to traverse a doctree since docutils-0.18.
-# This applies a patch docutils-0.17 or older to be available Node.findall()
+# This applies a patch to docutils up to 0.18 inclusive to provide Node.findall()
 # method to use it from our codebase.
-if docutils.__version_info__ < (0, 18):
+if docutils.__version_info__ <= (0, 18):
     def findall(self, *args, **kwargs):
         return iter(self.traverse(*args, **kwargs))
 


### PR DESCRIPTION
Node.findall() was added only at Docutils 0.18.1, here is extract from [Docutils HISTORY](https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/HISTORY.txt)

```rst
Release 0.18.1
==============

* docutils/nodes.py

  - `Node.traverse()` returns a list again to restore backwards
    compatibility. Fixes bug #431.

  - New method `Node.findall()`: like `Node.traverse()` but returns an
    iterator. Obsoletes `Node.traverse()`.
```

Fix #10596 

### Relates
- #10044 

