### PR TITLE
Test with Docutils 0.19 prereleases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   ubuntu:
     runs-on: ubuntu-18.04
-    name: Python ${{ matrix.python }}
+    name: Python ${{ matrix.python }} (${{ matrix.docutils }})
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +20,8 @@ jobs:
           docutils: du17
         - python: "3.10"
           docutils: du18
+        - python: "3.10"
+          docutils: du19pre
         - python: "3.11-dev"
           docutils: py311
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4.0
-envlist = docs,flake8,mypy,twine,py{36,37,38,39,310},du{14,15,16,17,18}
+envlist = docs,flake8,mypy,twine,py{36,37,38,39,310},du{14,15,16,17,18,19}
 
 [testenv]
 usedevelop = True
@@ -16,13 +16,14 @@ passenv =
     TERM
 description =
     py{36,37,38,39,310}: Run unit tests against {envname}.
-    du{14,15,16,17,18}: Run unit tests with the given version of docutils.
+    du{14,15,16,17,18,19}: Run unit tests with the given version of docutils.
 deps =
     du14: docutils==0.14.*
     du15: docutils==0.15.*
     du16: docutils==0.16.*
     du17: docutils==0.17.*
     du18: docutils==0.18.*
+    du19: docutils==0.19.*
 extras =
     test
 setenv =
@@ -34,6 +35,11 @@ commands=
 [testenv:du-latest]
 commands =
     python -m pip install "git+https://repo.or.cz/docutils.git#subdirectory=docutils"
+    {[testenv]commands}
+
+[testenv:du19pre]
+commands =
+    python -m pip install --pre "docutils==0.19.*"
     {[testenv]commands}
 
 [testenv:flake8]


### PR DESCRIPTION
Start testing on Docutils 0.19. Note this doesn't change declared support.

A