### PR TITLE
Fix HTML Search

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ Bugs fixed
   ``-``, ``~``, and ``**``). Patch by Adam Turner.
 * #10460: logging: Always show node source locations as absolute paths.
 * HTML Search: HTML tags are displayed as a part of object name
+* HTML Search: search snipets should not be folded
 * #10520: HTML Theme: Fix use of sidebar classes in ``agogo.css_t``.
 * #6679: HTML Theme: Fix inclusion of hidden toctrees in the agogo theme.
 * #10566: HTML Theme: Fix enable_search_shortcuts does not work

--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Bugs fixed
 * HTML Search: HTML tags are displayed as a part of object name
 * HTML Search: search snipets should not be folded
 * HTML Search: Minor errors are emitted on fetching search snipets
+* HTML Search: The markers for header links are shown in the search result
 * #10520: HTML Theme: Fix use of sidebar classes in ``agogo.css_t``.
 * #6679: HTML Theme: Fix inclusion of hidden toctrees in the agogo theme.
 * #10566: HTML Theme: Fix enable_search_shortcuts does not work

--- a/CHANGES
+++ b/CHANGES
@@ -46,6 +46,7 @@ Bugs fixed
 * #10031: py domain: Fix spurious whitespace in unparsing various operators (``+``,
   ``-``, ``~``, and ``**``). Patch by Adam Turner.
 * #10460: logging: Always show node source locations as absolute paths.
+* HTML Search: HTML tags are displayed as a part of object name
 * #10520: HTML Theme: Fix use of sidebar classes in ``agogo.css_t``.
 * #6679: HTML Theme: Fix inclusion of hidden toctrees in the agogo theme.
 * #10566: HTML Theme: Fix enable_search_shortcuts does not work

--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ Bugs fixed
 * #10460: logging: Always show node source locations as absolute paths.
 * HTML Search: HTML tags are displayed as a part of object name
 * HTML Search: search snipets should not be folded
+* HTML Search: Minor errors are emitted on fetching search snipets
 * #10520: HTML Theme: Fix use of sidebar classes in ``agogo.css_t``.
 * #6679: HTML Theme: Fix inclusion of hidden toctrees in the agogo theme.
 * #10566: HTML Theme: Fix enable_search_shortcuts does not work

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -88,7 +88,7 @@ const _displayItem = (item, highlightTerms, searchTerms) => {
   linkEl.href = linkUrl + "?" + params.toString() + anchor;
   linkEl.innerHTML = title;
   if (descr)
-    listItem.appendChild(document.createElement("span")).innerText =
+    listItem.appendChild(document.createElement("span")).innerHTML =
       " (" + descr + ")";
   else if (showSearchSummary)
     fetch(requestUrl)

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -155,9 +155,7 @@ const Search = {
   _pulse_status: -1,
 
   htmlToText: (htmlString) => {
-    const htmlElement = document
-      .createRange()
-      .createContextualFragment(htmlString);
+    const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
     htmlElement.querySelectorAll(".headerlink").forEach((el) => el.parentNode.removeChild(el));
     const docContent = htmlElement.querySelector('[role="main"]');
     if (docContent !== undefined) return docContent.textContent;

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -519,7 +519,7 @@ const Search = {
 
     let summary = document.createElement("p");
     summary.classList.add("context");
-    summary.innerText = top + text.substr(startWithContext, 240).trim() + tail;
+    summary.textContent = top + text.substr(startWithContext, 240).trim() + tail;
 
     highlightWords.forEach((highlightWord) =>
       _highlightText(summary, highlightWord, "highlighted")

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -156,7 +156,7 @@ const Search = {
 
   htmlToText: (htmlString) => {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
-    htmlElement.querySelectorAll(".headerlink").forEach((el) => el.parentNode.removeChild(el));
+    htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
     const docContent = htmlElement.querySelector('[role="main"]');
     if (docContent !== undefined) return docContent.textContent;
     console.warn(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
* HTML Search: HTML tags are displayed as a part of object name
* HTML Search: search snipets should not be folded
* HTML Search: The markers for header links are shown in the search result
* HTML Search: Minor errors are emitted on fetching search snipets
* 