### PR TITLE
Set permissions for GitHub Actions

### DIFF
--- a/.github/workflows/builddoc.yml
+++ b/.github/workflows/builddoc.yml
@@ -2,6 +2,9 @@ name: Build document
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,9 @@ name: Coverage
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,8 +5,13 @@ on:
     tags:
     - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   create-release:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docutils-latest.yml
+++ b/.github/workflows/docutils-latest.yml
@@ -5,6 +5,9 @@ on:
   - cron: "0 0 * * SUN"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: github.repository_owner == 'sphinx-doc'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint source code
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -5,6 +5,9 @@ on:
   - cron: "0 0 * * SUN"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   push:
     if: github.repository_owner == 'sphinx-doc'
@@ -30,6 +33,9 @@ jobs:
         TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
   pull:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository_owner == 'sphinx-doc'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
