### PR TITLE
Remove redundant static typing casts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ follow_imports = skip
 check_untyped_defs = True
 warn_unused_ignores = True
 strict_optional = False
+no_implicit_optional = True
 warn_redundant_casts = True
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ follow_imports = skip
 check_untyped_defs = True
 warn_unused_ignores = True
 strict_optional = False
-no_implicit_optional = True
+warn_redundant_casts = True
 
 [tool:pytest]
 filterwarnings =

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3552,7 +3552,6 @@ class AliasTransform(SphinxTransform):
 
     def apply(self, **kwargs: Any) -> None:
         for node in self.document.findall(AliasNode):
-            node = cast(AliasNode, node)
             sig = node.sig
             parentKey = node.parentKey
             try:

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -76,7 +76,7 @@ class VersionChange(SphinxDirective):
                 content += node[0].children
                 node[0].replace_self(nodes.paragraph('', '', content, translatable=False))
 
-            para = cast(nodes.paragraph, node[0])
+            para = node[0]
             para.insert(0, nodes.inline('', '%s: ' % text, classes=classes))
         elif len(node) > 0:
             # the contents do not starts with a paragraph

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -2,7 +2,7 @@
 
 import re
 from typing import (Any, Callable, Dict, Generator, Iterator, List, Optional, Tuple, TypeVar,
-                    Union, cast)
+                    Union)
 
 from docutils import nodes
 from docutils.nodes import Element, Node, TextElement, system_message
@@ -7519,7 +7519,6 @@ class AliasTransform(SphinxTransform):
 
     def apply(self, **kwargs: Any) -> None:
         for node in self.document.findall(AliasNode):
-            node = cast(AliasNode, node)
             sig = node.sig
             parentKey = node.parentKey
             try:

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -3,7 +3,7 @@
 import re
 import unicodedata
 from typing import (TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Set, Tuple, Type,
-                    Union, cast)
+                    Union)
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -412,7 +412,7 @@ def inline_all_toctrees(builder: "Builder", docnameset: Set[str], docname: str,
 
     Record all docnames in *docnameset*, and output docnames with *colorfunc*.
     """
-    tree = cast(nodes.document, tree.deepcopy())
+    tree = tree.deepcopy()
     for toctreenode in list(tree.findall(addnodes.toctree)):
         newnodes = []
         includefiles = map(str, toctreenode['includefiles'])


### PR DESCRIPTION
remove redundant `typing.cast`s and updates mypy config to prevent these in future.

type casts should only be used as a last resort, as they can mask errors if refactoring later changes the type of an object.
