### PR TITLE
Fixes missing and broken links in inheritance diagrams

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,9 @@ Bugs fixed
 * #11529: Line Block in LaTeX builder outputs spurious empty token.
   Patch by Adrian Vollmer.
 * #11196: autosummary: Summary line extraction failed with "e.g."
+* #10614: Fixed a number of bugs in inheritance diagrams that resulted in
+  missing or broken links.
+  Patch by Albert Shih.
 
 Testing
 -------

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -413,10 +413,10 @@ def html_visit_inheritance_diagram(self: HTML5Translator, node: inheritance_diag
     for child in pending_xrefs:
         if child.get('refuri') is not None:
             # Construct the name from the URI if the reference is external via intersphinx
-            if child.get('internal', True):
-                refname = child['reftitle']
-            else:
+            if not child.get('internal', True):
                 refname = child['refuri'].rsplit('#', 1)[-1]
+            else:
+                refname = child['reftitle']
 
             urls[refname] = child.get('refuri')
         elif child.get('refid') is not None:

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import builtins
 import hashlib
 import inspect
-import pathlib
+import posixpath
 import re
 from collections.abc import Iterable
 from importlib import import_module
@@ -410,21 +410,21 @@ def html_visit_inheritance_diagram(self: HTML5Translator, node: inheritance_diag
     # Create a mapping from fully-qualified class names to URLs.
     graphviz_output_format = self.builder.env.config.graphviz_output_format.upper()
     current_filename = self.builder.current_docname + self.builder.out_suffix
-    current_dir = pathlib.PurePath(current_filename).parent
+    current_dir = posixpath.dirname(current_filename)
     urls = {}
     pending_xrefs = cast(Iterable[addnodes.pending_xref], node)
     for child in pending_xrefs:
         if child.get('refuri') is not None:
             # Construct the name from the URI if the reference is external via intersphinx
-            if not child.get('internal', True):
-                refname = child['refuri'].rsplit('#', 1)[-1]
-            else:
+            if child.get('internal', True):
                 refname = child['reftitle']
+            else:
+                refname = child['refuri'].rsplit('#', 1)[-1]
 
             # For SVG output, relative URIs need to be re-pathed to where the SVG file will be
             if graphviz_output_format == 'SVG' and '://' not in child['refuri']:
                 # URI relative to src dir (typically equivalent to stripping all leading ../)
-                uri_rel_to_srcdir = (current_dir / child['refuri']).as_posix()
+                uri_rel_to_srcdir = posixpath.join(current_dir, child['refuri'])
                 # URI relative to image dir (typically equivalent to prepending ../)
                 uri_rel_to_imagedir = relpath(uri_rel_to_srcdir, self.builder.imagedir)
                 urls[refname] = canon_path(uri_rel_to_imagedir)
@@ -434,8 +434,8 @@ def html_visit_inheritance_diagram(self: HTML5Translator, node: inheritance_diag
             if graphviz_output_format == 'SVG':
                 # URI relative to image dir (typically equivalent to prepending ../)
                 uri_rel_to_imagedir = relpath(current_filename, self.builder.imagedir)
-                urls[child['reftitle']] = canon_path(uri_rel_to_imagedir) +\
-                                          '#' + child.get('refid')
+                urls[child['reftitle']] = (canon_path(uri_rel_to_imagedir) +
+                                           '#' + child.get('refid'))
             else:
                 urls[child['reftitle']] = '#' + child.get('refid')
 

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -415,14 +415,21 @@ def html_visit_inheritance_diagram(self: HTML5Translator, node: inheritance_diag
     pending_xrefs = cast(Iterable[addnodes.pending_xref], node)
     for child in pending_xrefs:
         if child.get('refuri') is not None:
-            if graphviz_output_format == 'SVG':
+            # Construct the name from the URI if the reference is external via intersphinx
+            if not child.get('internal', True):
+                refname = child['refuri'].rsplit('#', 1)[-1]
+            else:
+                refname = child['reftitle']
+
+            # For SVG output, relative URIs need to be re-pathed to where the SVG file will be
+            if graphviz_output_format == 'SVG' and '://' not in child['refuri']:
                 # URI relative to src dir (typically equivalent to stripping all leading ../)
-                uri_rel_to_srcdir = (current_dir / child.get('refuri')).as_posix()
+                uri_rel_to_srcdir = (current_dir / child['refuri']).as_posix()
                 # URI relative to image dir (typically equivalent to prepending ../)
                 uri_rel_to_imagedir = relpath(uri_rel_to_srcdir, self.builder.imagedir)
-                urls[child['reftitle']] = canon_path(uri_rel_to_imagedir)
+                urls[refname] = canon_path(uri_rel_to_imagedir)
             else:
-                urls[child['reftitle']] = child.get('refuri')
+                urls[refname] = child['refuri']
         elif child.get('refid') is not None:
             if graphviz_output_format == 'SVG':
                 # URI relative to image dir (typically equivalent to prepending ../)

--- a/tests/roots/test-ext-inheritance_diagram/conf.py
+++ b/tests/roots/test-ext-inheritance_diagram/conf.py
@@ -3,4 +3,4 @@ import sys
 
 sys.path.insert(0, os.path.abspath('.'))
 
-extensions = ['sphinx.ext.inheritance_diagram']
+extensions = ['sphinx.ext.inheritance_diagram', 'sphinx.ext.intersphinx']

--- a/tests/roots/test-ext-inheritance_diagram/index.rst
+++ b/tests/roots/test-ext-inheritance_diagram/index.rst
@@ -18,6 +18,3 @@ test-ext-inheritance_diagram
 .. inheritance-diagram:: subdir.other.Bob
 
 .. py:class:: test.Alice
-
-.. toctree::
-   subdir/index

--- a/tests/roots/test-ext-inheritance_diagram/index.rst
+++ b/tests/roots/test-ext-inheritance_diagram/index.rst
@@ -7,13 +7,11 @@ test-ext-inheritance_diagram
 .. inheritance-diagram:: test.Foo
    :caption: Test Foo!
 
-.. inheritance-diagram:: test.Baz
+.. inheritance-diagram:: test.DocLowerLevel
 
-.. py:class:: test.Bar
+.. py:class:: test.DocHere
 
-.. py:class:: test.Baz
-
-.. py:class:: test.Qux
+.. py:class:: test.DocMainLevel
 
 .. inheritance-diagram:: subdir.other.Bob
 

--- a/tests/roots/test-ext-inheritance_diagram/index.rst
+++ b/tests/roots/test-ext-inheritance_diagram/index.rst
@@ -8,3 +8,16 @@ test-ext-inheritance_diagram
    :caption: Test Foo!
 
 .. inheritance-diagram:: test.Baz
+
+.. py:class:: test.Bar
+
+.. py:class:: test.Baz
+
+.. py:class:: test.Qux
+
+.. inheritance-diagram:: subdir.other.Bob
+
+.. py:class:: test.Alice
+
+.. toctree::
+   subdir/index

--- a/tests/roots/test-ext-inheritance_diagram/subdir/index.rst
+++ b/tests/roots/test-ext-inheritance_diagram/subdir/index.rst
@@ -1,0 +1,5 @@
+=========================================
+test-ext-inheritance_diagram subdirectory
+=========================================
+
+.. inheritance-diagram:: test.Qux

--- a/tests/roots/test-ext-inheritance_diagram/subdir/index.rst
+++ b/tests/roots/test-ext-inheritance_diagram/subdir/index.rst
@@ -2,4 +2,6 @@
 test-ext-inheritance_diagram subdirectory
 =========================================
 
-.. inheritance-diagram:: test.Qux
+.. inheritance-diagram:: test.DocMainLevel
+
+.. py:class:: test.DocLowerLevel

--- a/tests/roots/test-ext-inheritance_diagram/subdir/other.py
+++ b/tests/roots/test-ext-inheritance_diagram/subdir/other.py
@@ -1,0 +1,5 @@
+from test import Alice
+
+
+class Bob(Alice):
+    pass

--- a/tests/roots/test-ext-inheritance_diagram/test.py
+++ b/tests/roots/test-ext-inheritance_diagram/test.py
@@ -2,15 +2,15 @@ class Foo:
     pass
 
 
-class Bar(Foo):
+class DocHere(Foo):
     pass
 
 
-class Baz(Bar):
+class DocLowerLevel(DocHere):
     pass
 
 
-class Qux(Foo):
+class DocMainLevel(Foo):
     pass
 
 

--- a/tests/roots/test-ext-inheritance_diagram/test.py
+++ b/tests/roots/test-ext-inheritance_diagram/test.py
@@ -12,3 +12,7 @@ class Baz(Bar):
 
 class Qux(Foo):
     pass
+
+
+class Alice(object):
+    pass

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -269,8 +269,8 @@ def test_inheritance_diagram_latex_alias(app, status, warning):
     doc = app.env.get_and_resolve_doctree('index', app)
     aliased_graph = doc.children[0].children[3]['graph'].class_info
     assert len(aliased_graph) == 3
-    assert ('test.Baz', 'test.Baz', ['test.Bar'], None) in aliased_graph
-    assert ('test.Bar', 'test.Bar', ['alias.Foo'], None) in aliased_graph
+    assert ('test.DocLowerLevel', 'test.DocLowerLevel', ['test.DocHere'], None) in aliased_graph
+    assert ('test.DocHere', 'test.DocHere', ['alias.Foo'], None) in aliased_graph
     assert ('alias.Foo', 'alias.Foo', [], None) in aliased_graph
 
     content = (app.outdir / 'index.html').read_text(encoding='utf8')

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -11,6 +11,7 @@ from sphinx.ext.inheritance_diagram import (
     InheritanceException,
     import_classes,
 )
+from sphinx.ext.intersphinx import load_mappings, normalize_intersphinx_mapping
 
 
 @pytest.mark.sphinx(buildername="html", testroot="inheritance")
@@ -135,12 +136,31 @@ def test_inheritance_diagram(app, status, warning):
         ]
 
 
+# An external inventory to test intersphinx links in inheritance diagrams
+subdir_inventory = b'''\
+# Sphinx inventory version 1
+# Project: subdir
+# Version: 1.0
+subdir.other.Bob class foo.html
+'''
+
+
 @pytest.mark.sphinx('html', testroot='ext-inheritance_diagram')
 @pytest.mark.usefixtures('if_graphviz_found')
-def test_inheritance_diagram_png_html(app, status, warning):
+def test_inheritance_diagram_png_html(tempdir, app, status, warning):
+    inv_file = tempdir / 'inventory'
+    inv_file.write_bytes(subdir_inventory)
+    app.config.intersphinx_mapping = {
+        'https://example.org': inv_file,
+    }
+    app.config.intersphinx_cache_limit = 0
+    normalize_intersphinx_mapping(app, app.config)
+    load_mappings(app)
+
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    base_maps = re.findall('<map .+\n.+\n</map>', content)
 
     pattern = ('<figure class="align-default" id="id1">\n'
                '<div class="graphviz">'
@@ -150,14 +170,44 @@ def test_inheritance_diagram_png_html(app, status, warning):
                'title="Permalink to this image">\xb6</a></p>\n</figcaption>\n</figure>\n')
     assert re.search(pattern, content, re.M)
 
+    subdir_content = (app.outdir / 'subdir/index.html').read_text(encoding='utf8')
+    subdir_maps = re.findall('<map .+\n.+\n</map>', subdir_content)
+    subdir_maps = [re.sub('href="(\\S+)"', 'href="subdir/\\g<1>"', s) for s in subdir_maps]
+
+    # Go through the clickmap for every PNG inheritance diagram
+    for diagram_content in base_maps + subdir_maps:
+        # Verify that an intersphinx link was created via the external inventory
+        if 'subdir.' in diagram_content:
+            assert "https://example.org" in diagram_content
+
+        # Extract every link in the inheritance diagram
+        for href in re.findall('href="(\\S+?)"', diagram_content):
+            if '://' in href:
+                # Verify that absolute URLs are not prefixed with ../
+                assert href.startswith("https://example.org/")
+            else:
+                # Verify that relative URLs point to existing documents
+                reluri = href.rsplit('#', 1)[0]  # strip the anchor at the end
+                assert (app.outdir / reluri).exists()
+
 
 @pytest.mark.sphinx('html', testroot='ext-inheritance_diagram',
                     confoverrides={'graphviz_output_format': 'svg'})
 @pytest.mark.usefixtures('if_graphviz_found')
-def test_inheritance_diagram_svg_html(app, status, warning):
+def test_inheritance_diagram_svg_html(tempdir, app, status, warning):
+    inv_file = tempdir / 'inventory'
+    inv_file.write_bytes(subdir_inventory)
+    app.config.intersphinx_mapping = {
+        "subdir": ('https://example.org', inv_file),
+    }
+    app.config.intersphinx_cache_limit = 0
+    normalize_intersphinx_mapping(app, app.config)
+    load_mappings(app)
+
     app.builder.build_all()
 
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    base_svgs = re.findall('<object data="(_images/inheritance-\\w+.svg?)"', content)
 
     pattern = ('<figure class="align-default" id="id1">\n'
                '<div class="graphviz">'
@@ -169,6 +219,27 @@ def test_inheritance_diagram_svg_html(app, status, warning):
                'title="Permalink to this image">\xb6</a></p>\n</figcaption>\n</figure>\n')
 
     assert re.search(pattern, content, re.M)
+
+    subdir_content = (app.outdir / 'subdir/index.html').read_text(encoding='utf8')
+    subdir_svgs = re.findall('<object data="../(_images/inheritance-\\w+.svg?)"', subdir_content)
+
+    # Go through every SVG inheritance diagram
+    for diagram in base_svgs + subdir_svgs:
+        diagram_content = (app.outdir / diagram).read_text(encoding='utf8')
+
+        # Verify that an intersphinx link was created via the external inventory
+        if 'subdir.' in diagram_content:
+            assert "https://example.org" in diagram_content
+
+        # Extract every link in the inheritance diagram
+        for href in re.findall('href="(\\S+?)"', diagram_content):
+            if '://' in href:
+                # Verify that absolute URLs are not prefixed with ../
+                assert href.startswith("https://example.org/")
+            else:
+                # Verify that relative URLs point to existing documents
+                reluri = href.rsplit('#', 1)[0]  # strip the anchor at the end
+                assert (app.outdir / app.builder.imagedir / reluri).exists()
 
 
 @pytest.mark.sphinx('latex', testroot='ext-inheritance_diagram')

--- a/tests/test_ext_inheritance_diagram.py
+++ b/tests/test_ext_inheritance_diagram.py
@@ -144,7 +144,7 @@ subdir_inventory = b'''\
 # Version: 1.0
 # The remainder of this file is compressed using zlib.
 ''' + zlib.compress(b'''\
-subdir.other.Bob class 1 foo.html -
+subdir.other.Bob py:class 1 foo.html#subdir.other.Bob -
 ''')
 
 


### PR DESCRIPTION
Subject: Fixes missing and broken links in inheritance diagrams

### Feature or Bugfix
- Bugfix

### Purpose
There are multiple bugs that result in missing or broken links in inheritance diagrams.  The missing links are due to bugs that break the correct association of external classes with URLs.  The broken links are specific to SVG output where the relative paths are not correctly re-pathed.  This PR has been rewritten given #11078.

### Detail
- Missing links
  - For `intersphinx` references where a class is found in an external inventory, `reftitle` does not contain the name of the class – instead, it is `"(in <project> <version)"` – so the actual name of the class must be separately constructed to build the class<->URL mapping (see #865)
- Broken links
  - Fixed a relative-path bug in `ext.inheritance_diagram` given the modifications to `ext.graphviz` in #11078

### Relates
- Closes #865
- Closes #3176
- Closes #10570

