### PR TITLE
LaTeX: partially fix color issues for wrapped code lines with pagebreak

### DIFF
--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -1,7 +1,7 @@
 %% LITERAL BLOCKS
 %
 % change this info string if making any custom modification
-\ProvidesFile{sphinxlatexliterals.sty}[2022/06/18 code-blocks and parsed literals]
+\ProvidesFile{sphinxlatexliterals.sty}[2022/06/29 code-blocks and parsed literals]
 
 % Provides support for this output mark-up from Sphinx latex writer:
 %
@@ -99,37 +99,48 @@
 %  - frame is \fboxsep separated from the contents,
 %  - the contents use the full available text width,
 %  - #1 = color of frame, #2 = color of background,
-%  - #3 = above frame, #4 = below frame, #5 = within frame,
-%  - #3 and #4 must be already typeset boxes; they must issue \normalcolor
-%    or similar, else, they are under scope of color #1
+%  - #3 = will be typeset above frame,
+%  - #4 = will be typeset below frame,
+%  - #5 = will be typeset within frame,
+% #3 and #4 must be already typeset boxes.
+% #5 are the contents, and in the context of usage of fancyvrb+framed by
+% Sphinx, it will arrive here already transformed into horizontal
+% boxes.  The \normalcolor is a preventive measure to some color issues
+% when a pagebreak occurs in the middle of a wrapped long code line.
 \long\def\spx@fcolorbox #1#2#3#4#5{%
   \hskip\@totalleftmargin
   \hskip-\fboxsep\hskip-\fboxrule
   % MEMO: \color@b@x from xcolor.sty is identical with the one from color.sty
-  \color@b@x {\color{#1}\spx@CustomFBox{#3}{#4}}{\color{#2}}{#5}%
+  \color@b@x {\spx@CustomFBox{#1}{#3}{#4}}{\color{#2}}{{\normalcolor#5}}%
   \hskip-\fboxsep\hskip-\fboxrule
   \hskip-\linewidth \hskip-\@totalleftmargin \hskip\columnwidth
 }%
-% #1 = for material above frame, such as a caption or a "continued" hint
-% #2 = for material below frame, such as a caption or "continues on next page"
-% #3 = actual contents, which will be typeset with a background color
-\long\def\spx@CustomFBox#1#2#3{%
+% #1 = color of frame
+% #2 = for material above frame, such as a caption or a "continued" hint
+% #3 = for material below frame, such as a caption or "continues on next page"
+% #4 = contents; or rather if called from \spx@fcolorbox (only use case here),
+%      the contents are in \box\z@ and #4 is
+%      \color{<bgcolor>}\color@block {\wd \z@ }{\ht \z@ }{\dp \z@ }\box \z@
+\long\def\spx@CustomFBox#1#2#3#4{%
   \begingroup
-  \setbox\@tempboxa\hbox{{#3}}% inner braces to avoid color leaks
-  \vbox{#1% above frame
+  \setbox\@tempboxa\hbox{{#4}}% inner braces to avoid background color leak
+  \vbox{#2% above frame
             % draw frame border _latest_ to avoid pdf viewer issue
             \kern\fboxrule
             \hbox{\kern\fboxrule
                   \copy\@tempboxa
+                  {\color{#1}% frame color
                   \kern-\wd\@tempboxa\kern-\fboxrule
                   \vrule\@width\fboxrule
                   \kern\wd\@tempboxa
                   \vrule\@width\fboxrule}%
+                 }%
+            {\color{#1}% frame color
             \kern-\dimexpr\ht\@tempboxa+\dp\@tempboxa+\fboxrule\relax
             \hrule\@height\fboxrule
             \kern\dimexpr\ht\@tempboxa+\dp\@tempboxa\relax
-            \hrule\@height\fboxrule
-        #2% below frame
+            \hrule\@height\fboxrule}%
+        #3% below frame
        }%
   \endgroup
 }%
@@ -145,10 +156,10 @@
 %
 \def\sphinxVerbatim@Continued
    {\csname spx@fcolorbox@put@\spx@opt@verbatimcontinuedalign\endcsname
-    {\normalcolor\sphinxstylecodecontinued\literalblockcontinuedname}}%
+    {{\normalcolor\sphinxstylecodecontinued\literalblockcontinuedname}}}%
 \def\sphinxVerbatim@Continues
    {\csname spx@fcolorbox@put@\spx@opt@verbatimcontinuesalign\endcsname
-    {\normalcolor\sphinxstylecodecontinues\literalblockcontinuesname}}%
+    {{\normalcolor\sphinxstylecodecontinues\literalblockcontinuesname}}}%
 \def\sphinxVerbatim@Title
    {\spx@fcolorbox@put@c{\unhcopy\sphinxVerbatim@TitleBox}}%
 \let\sphinxVerbatim@Before\@empty

--- a/sphinx/texinputs/sphinxlatexstyletext.sty
+++ b/sphinx/texinputs/sphinxlatexstyletext.sty
@@ -1,7 +1,7 @@
 %% TEXT STYLING
 %
 % change this info string if making any custom modification
-\ProvidesFile{sphinxlatexstyletext.sty}[2021/12/06 text styling]
+\ProvidesFile{sphinxlatexstyletext.sty}[2022/06/29 text styling]
 
 % Basically everything here consists of macros which are part of the latex
 % markup produced by the Sphinx latex writer
@@ -39,6 +39,7 @@
 \protected\def\sphinxstyleothertitle   #1{\textbf{#1}}
 \protected\def\sphinxstylesidebarsubtitle #1{~\\\textbf{#1} \smallskip}
 % \text.. commands do not allow multiple paragraphs
+% attention, this one is not self-delimiting
 \protected\def\sphinxstyletheadfamily    {\sffamily}
 \protected\def\sphinxstyleemphasis     #1{\emph{#1}}
 \protected\def\sphinxstyleliteralemphasis#1{\emph{\sphinxcode{#1}}}
@@ -46,8 +47,8 @@
 \protected\def\sphinxstyleliteralstrong#1{\sphinxbfcode{#1}}
 \protected\def\sphinxstyleabbreviation #1{\textsc{#1}}
 \protected\def\sphinxstyleliteralintitle#1{\sphinxcode{#1}}
-\newcommand*\sphinxstylecodecontinued[1]{\footnotesize(#1)}%
-\newcommand*\sphinxstylecodecontinues[1]{\footnotesize(#1)}%
+\newcommand*\sphinxstylecodecontinued[1]{{\footnotesize(#1)}}%
+\newcommand*\sphinxstylecodecontinues[1]{{\footnotesize(#1)}}%
 % figure legend comes after caption and may contain arbitrary body elements
 \newenvironment{sphinxlegend}{\par\small}{\par}
 % reduce hyperref "Token not allowed in a PDF string" warnings on PDF builds


### PR DESCRIPTION
This does not fix entirely #10610 but it does sufficiently for it not to
require reverting #10577 which tried to solve #8686 conundrum.  In
extreme cases, the #8686 problem meant that some contents disappeared
at page bottom, so it is probably better to maintain #10577 which
will avoid any such overflow of code beyond its frame, even though in
some specific cases (a colored entity such as a long string is partly on
both pages), some syntax highlighting gets lost.

There are anyhow other issues with colors for wrapped code lines, even
with no pagebreaks involved, such as #10615.  This patch does not change
the situation there.

Prior to this patch (but after #10577):
![Capture d’écran 2022-06-29 à 18 42 36](https://user-images.githubusercontent.com/2589111/176491347-be491e7e-4831-46c6-b2f6-5cf63f5c40bc.png)

With this patch
![Capture d’écran 2022-06-29 à 18 41 36](https://user-images.githubusercontent.com/2589111/176491397-91b2bafb-adc9-4dcc-9d41-d639e9390f8d.png)

This patch does some change to private Sphinx LaTeX macro `\spx@fcolorbox` and `\spx@CustomFBox`.

There is no CHANGES entry because it fixes issues with #10577 which has been merged but not released yet.

test done with
```rest
Test
----


.. raw:: latex

   \vspace*{15cm}%\showoutput

.. code-block:: python

   A = [x for x in range(10)]
   print("a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line a very long line")
   A = [x for x in range(10)]


ABC
```
