### PR TITLE
LaTeX: refactor sphinxShadowBox to allow colors for frame and shadow

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -846,7 +846,7 @@ Do not use quotes to enclose values, whether numerical or strings.
     Default: ``5pt``
 
 ``shadowsize``
-    The width of the lateral "shadow" to the right.
+    The width of the lateral "shadow" to the right and bottom.
 
     Default: ``4pt``
 
@@ -854,6 +854,20 @@ Do not use quotes to enclose values, whether numerical or strings.
     The width of the frame around :dudir:`topic` boxes.
 
     Default: ``\fboxrule``
+
+``shadowBorderColor``
+    The color of the frame around :dudir:`topic` boxes.
+
+    Default: ``{rgb}{0,0,0}`` (black)
+
+    .. versionadded:: 5.1.0
+
+``shadowShadowColor``
+    The color of the lateral "shadow" to the right and bottom.
+
+    Default: ``{rgb}{0,0,0}`` (black)
+
+    .. versionadded:: 5.1.0
 
 |notebdcolors|
     The colour for the two horizontal rules used by Sphinx in LaTeX for styling

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -6,7 +6,7 @@
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
-\ProvidesPackage{sphinx}[2021/01/27 v4.0.0 LaTeX package (Sphinx markup)]
+\ProvidesPackage{sphinx}[2022/06/30 v5.1.0 LaTeX package (Sphinx markup)]
 
 % provides \ltx@ifundefined
 % (many packages load ltxcmds: graphicx does for pdftex and lualatex but
@@ -154,6 +154,9 @@
 }%
 % Default color chosen to be as in minted.sty LaTeX package!
 \sphinxDeclareSphinxColorOption{VerbatimHighlightColor}{{rgb}{0.878,1,1}}
+% topic and contents boxes
+\sphinxDeclareSphinxColorOption{shadowBorderColor}{{rgb}{0,0,0}}
+\sphinxDeclareSphinxColorOption{shadowShadowColor}{{rgb}{0,0,0}}
 % admonition boxes, "light" style
 \sphinxDeclareSphinxColorOption{noteBorderColor}{{rgb}{0,0,0}}
 \sphinxDeclareSphinxColorOption{hintBorderColor}{{rgb}{0,0,0}}

--- a/sphinx/texinputs/sphinxlatexshadowbox.sty
+++ b/sphinx/texinputs/sphinxlatexshadowbox.sty
@@ -21,7 +21,9 @@
 % to avoid problems with some pdf viewers.
 \long\def\spx@ShadowFBox#1{%
   \leavevmode\begingroup
-  % first we prepare a box with the contents in an invisible frame
+  % First we prepare a box with the contents and some reserved space for the
+  % frame and inner separation; with more parameters we could allow various
+  % border widths for top, bottom, left, right, but here all are equal.
   \setbox\@tempboxa
    \hbox{\kern\sphinxshadowrule
          \vbox{\kern\sphinxshadowrule
@@ -30,25 +32,41 @@
                \kern\sphinxshadowsep
                \kern\sphinxshadowrule}%
          \kern\sphinxshadowrule}%
-  % now we unbox the previous one, drawing contents first, then
-  % we frame it with a color
+  % Now we rebox, adding the colored frame for which space was reserved.
   \setbox\@tempboxa
-   \hbox{\unhcopy\@tempboxa
+   \hbox{\unhcopy\@tempboxa % not \unhbox to be able to refer to \ht, \wd later
          \kern-\wd\@tempboxa
-         {\color{sphinxshadowBorderColor}%
-         \vrule\@width\sphinxshadowrule
-         \vbox{\hrule\@height\sphinxshadowrule
-               \kern\dimexpr\ht\@tempboxa-\sphinxshadowrule\relax
-               \hbox{\kern\dimexpr\wd\@tempboxa-2\sphinxshadowrule\relax}%
-               \kern\dimexpr\dp\@tempboxa-\sphinxshadowrule\relax
-               \hrule\@height\sphinxshadowrule}%
-         \vrule\@width\sphinxshadowrule}%
-         }%
-  % Now we add the shadow, like \shadowbox from fancybox.sty would do
-  % Formerly, shadow was drawn partly on top of frame, but this was
-  % before both frame and shadow acquired colors.
+         {\color{sphinxshadowBorderColor}% color push here
+          \vrule\@width\sphinxshadowrule% TeX auto-computes the height
+          \vbox{\hrule\@height\sphinxshadowrule% TeX auto-computes the width
+                \kern\dimexpr\ht\@tempboxa-\sphinxshadowrule\relax
+                % This empty \hbox is here to give width used by \hrule
+                % As \dp\@tempboxa is zero, the \hbox location is at the
+                % bottom of frame.
+                \hbox{\kern\dimexpr\wd\@tempboxa-2\sphinxshadowrule\relax}%
+                \kern\dimexpr\dp\@tempboxa-\sphinxshadowrule\relax
+                \hrule\@height\sphinxshadowrule% TeX auto-computes the width
+                }%
+          \vrule\@width\sphinxshadowrule% TeX auto-computes the height
+         }% color pop will happen here
+        }%
+  % Now we add the shadow.
+  %
+  % Formerly, shadow was drawn partly on top of frame, but this was before
+  % both frame and shadow acquired colors.  The width of the part of the
+  % shadow on the right is hidden, so it will stick into the right page
+  % margin.
+  %
+  % The frame borders are included into this final \hbox, which is sent back
+  % to \MakeFramed/\endMakeFramed measurements and then finally to page
+  % shipout.  As \advance\hsize-\width appears in \MakeFramed, where \width is
+  % the computed extra width added by the framing plus inner separation (so
+  % actually 2\sphinxshadowrule+2\sphinxshadowsep), this all means that
+  % horizontally the frame will be perfectly adjusted to the *total* text
+  % width limits (i.e. independent of current list nesting; but anyhow
+  % Docutils does not allow nesting of topic within topics or body elements).
   \hbox{\vbox{\offinterlineskip
-              \hbox{\copy\@tempboxa
+              \hbox{\copy\@tempboxa % not \box as we need \wd and \ht next
                     % add shadow on right side
                     \lower\sphinxshadowsize
                           \hbox{{\color{sphinxshadowShadowColor}%
@@ -60,17 +78,32 @@
                     \vbox{{\color{sphinxshadowShadowColor}%
                            \hrule\@width\wd\@tempboxa \@height\sphinxshadowsize}}%
               }%
-        % move left by the size of right shadow so shadow adds no width
+        % move left by the size of right shadow so shadow adds no width, and
+        % will stick into right margin
+        % (we did not conceal of course from TeX the depth)
         \kern-\sphinxshadowsize
        }%
   \endgroup
 }
 
-% Again based on use of "framed.sty", this allows breakable framed boxes.
-% use framed.sty to allow page breaks in frame+shadow
-% works well inside Lists and Quote-like environments
-% produced by ``topic'' directive (or local contents)
-% could nest if LaTeX writer authorized it
+% Use framed.sty \MakeFramed/\endMakeFramed to allow page breaks for topic
+% boxes.  Originally Sphinx used \shadowbox from fancybox.sty but it did not
+% allow pagebreaks (which was problematic for "contents" directive if there
+% are many subsections).
+%
+% Docutils does not allow topic to be nested within topics or other body
+% elements.  But the LaTeX code here does allow it:
+%
+% - a topic inside another topic would be rendered in a minipage (thus not
+%   allowing pagebreaks).  Its external frame would adapt perfectly to
+%   the *current (smaller) width for text*.
+%
+% - a topic inside (nested) lists or quote environments would have its frame
+%   take the *full width* of the page, but its text contents on the other hand
+%   would obey exactly the current indentation plus inner separation.  This is
+%   in contrast with the framing used for literal blocks, also based, but in a
+%   more sophisticated way on usage of \MakeFramed/\endMakeFramed, and
+%   adjusting to current text indentation.
 \newenvironment{sphinxShadowBox}
   {\def\FrameCommand {\spx@ShadowFBox }%
    \advance\spx@image@maxheight

--- a/sphinx/texinputs/sphinxlatexshadowbox.sty
+++ b/sphinx/texinputs/sphinxlatexshadowbox.sty
@@ -1,7 +1,7 @@
 %% TOPIC AND CONTENTS BOXES
 %
 % change this info string if making any custom modification
-\ProvidesFile{sphinxlatexshadowbox.sty}[2021/01/27 sphinxShadowBox]
+\ProvidesFile{sphinxlatexshadowbox.sty}[2022/06/30 sphinxShadowBox]
 
 % Provides support for this output mark-up from Sphinx latex writer:
 %
@@ -17,30 +17,48 @@
 % Requires:
 \RequirePackage{framed}
 
-% Again based on use of "framed.sty", this allows breakable framed boxes.
+% Let's draw the contents first, then the frame and the shadow last,
+% to avoid problems with some pdf viewers.
 \long\def\spx@ShadowFBox#1{%
   \leavevmode\begingroup
-  % first we frame the box #1
+  % first we prepare a box with the contents in an invisible frame
   \setbox\@tempboxa
-   \hbox{\vrule\@width\sphinxshadowrule
-         \vbox{\hrule\@height\sphinxshadowrule
+   \hbox{\kern\sphinxshadowrule
+         \vbox{\kern\sphinxshadowrule
                \kern\sphinxshadowsep
                \hbox{\kern\sphinxshadowsep #1\kern\sphinxshadowsep}%
                \kern\sphinxshadowsep
+               \kern\sphinxshadowrule}%
+         \kern\sphinxshadowrule}%
+  % now we unbox the previous one, drawing contents first, then
+  % we frame it with a color
+  \setbox\@tempboxa
+   \hbox{\unhcopy\@tempboxa
+         \kern-\wd\@tempboxa
+         {\color{sphinxshadowBorderColor}%
+         \vrule\@width\sphinxshadowrule
+         \vbox{\hrule\@height\sphinxshadowrule
+               \kern\dimexpr\ht\@tempboxa-\sphinxshadowrule\relax
+               \hbox{\kern\dimexpr\wd\@tempboxa-2\sphinxshadowrule\relax}%
+               \kern\dimexpr\dp\@tempboxa-\sphinxshadowrule\relax
                \hrule\@height\sphinxshadowrule}%
          \vrule\@width\sphinxshadowrule}%
+         }%
   % Now we add the shadow, like \shadowbox from fancybox.sty would do
-  \dimen@\dimexpr.5\sphinxshadowrule+\sphinxshadowsize\relax
+  % Formerly, shadow was drawn partly on top of frame, but this was
+  % before both frame and shadow acquired colors.
   \hbox{\vbox{\offinterlineskip
-              \hbox{\copy\@tempboxa\kern-.5\sphinxshadowrule
+              \hbox{\copy\@tempboxa
                     % add shadow on right side
                     \lower\sphinxshadowsize
-                          \hbox{\vrule\@height\ht\@tempboxa \@width\dimen@}%
+                          \hbox{{\color{sphinxshadowShadowColor}%
+                                 \vrule\@height\ht\@tempboxa \@width\sphinxshadowsize}}%
                     }%
-              \kern-\dimen@ % shift back vertically to bottom of frame
+              \kern-\sphinxshadowsize % shift back vertically to bottom of frame
               % and add shadow at bottom
               \moveright\sphinxshadowsize
-                    \vbox{\hrule\@width\wd\@tempboxa \@height\dimen@}%
+                    \vbox{{\color{sphinxshadowShadowColor}%
+                           \hrule\@width\wd\@tempboxa \@height\sphinxshadowsize}}%
               }%
         % move left by the size of right shadow so shadow adds no width
         \kern-\sphinxshadowsize
@@ -48,6 +66,7 @@
   \endgroup
 }
 
+% Again based on use of "framed.sty", this allows breakable framed boxes.
 % use framed.sty to allow page breaks in frame+shadow
 % works well inside Lists and Quote-like environments
 % produced by ``topic'' directive (or local contents)


### PR DESCRIPTION
This adds possibility of colors for the "shadowed" box used for the ``topic`` and ``contents`` directives.

No change to existing output, as default colors left to black.

Here is an example of use:
![Capture d’écran 2022-06-30 à 19 51 33](https://user-images.githubusercontent.com/2589111/176744546-90fe8042-6228-475b-ac1d-5add84fc8d96.png)

(the box allows pagebreaks as formerly, this is not shown here)

The example uses: 
```
latex_elements = {
    'sphinxsetup': """%
  shadowrule=2pt,%
  shadowsize=6pt,%
  shadowShadowColor={RGB}{170,170,170},%
""",
}
```
in `conf.py`.

edit. I messed up horizontal width, will fix later to maintain behaviour as current. Well I wll never understood what went wrong, so I redid it entirely, and the code is much closer to current one.

Here is an example of use with a page break, to show no color leaks:
![Capture d’écran 2022-06-30 à 22 34 04](https://user-images.githubusercontent.com/2589111/176775093-5d3da8ba-bc13-4698-9901-fef5cbdf42b9.png)

```
Topics
------

Hello

.. raw:: latex

   \rule{1cm}{1cm} \hrulefill \rule{1cm}{1cm}

.. topic:: Some topic

   .. raw:: latex

      \begingroup\color{blue}

   Some contents possibly very long, we added color via raw latex, to check
   nothing bad happen even at at page break. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. Some contents possibly very long. Some
   contents possibly very long. 

   .. raw:: latex

      \endgroup

.. raw:: latex

   \rule{1cm}{1cm} \hrulefill \rule{1cm}{1cm}
```

with `conf.py`:

```
latex_elements = {
    'sphinxsetup': """%
  shadowrule=10pt,%
  shadowsize=20pt,%
  shadowShadowColor={RGB}{170,170,170},%
  shadowBorderColor={RGB}{255,0,0},%
""",
}
```