### PR TITLE
LaTeX writer: add \label's for all index keys, not just first

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -687,10 +687,10 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.append('}')
 
     def visit_desc_signature(self, node: Element) -> None:
+        hyper = ''
         if node.parent['objtype'] != 'describe' and node['ids']:
-            hyper = self.hypertarget(node['ids'][0])
-        else:
-            hyper = ''
+            for id in node['ids']:
+                hyper += self.hypertarget(id)
         self.body.append(hyper)
         if not self.in_desc_signature:
             self.in_desc_signature = True


### PR DESCRIPTION
Subject: Add `\label`'s for all index keys, not just first

### Feature or Bugfix
- Bugfix

### Purpose
Please see coq/coq#12361 for the issue description. I won't describe it better than it's written there.

This change was originally a monkey-patch in coq, but I am forwarding it here as requested by the patch author @cpitclaudel (in https://github.com/coq/coq/pull/16193#issuecomment-1174746768)