### PR TITLE
Fix encoding of LatinRules.xdy (now UTF-8)

### DIFF
--- a/sphinx/texinputs/LatinRules.xdy
+++ b/sphinx/texinputs/LatinRules.xdy
@@ -2,12 +2,12 @@
 ;; filename: LatinRules.xdy
 ;;
 ;; Please note that this data file deliberately uses strings
-;; with single non-ascii bytes. This is intentional and
+;; with single non-ascii bytes.  This is intentional and
 ;; follows the usage observed in similar xindy support files.
 ;;
 ;; It is based upon xindy's files lang/general/utf8.xdy and
 ;; lang/general/utf8-lang.xdy which implement
-;; "a general sorting order for Western European languages"
+;; "a general sorting order for Western European languages".
 ;;
 ;; The aim for Sphinx is to be able to index in a Cyrillic document
 ;; also terms using the Latin alphabets, inclusive of letters
@@ -18,7 +18,7 @@
 ;;
 ;; So here we use only 0o266 or higher bytes.
 ;; (Ŋ, ŋ, Ĳ, and ĳ are absent from
-;; lang/general/utf8.xdy and not included here)
+;; lang/general/utf8.xdy and not included here.)
 ;; Contributed by the Sphinx team, 2018.
 
 (define-letter-group "A" :prefixes ("�"))

--- a/sphinx/texinputs/LatinRules.xdy
+++ b/sphinx/texinputs/LatinRules.xdy
@@ -1,5 +1,9 @@
-;; style file for xindy
+;; Common Lisp style file for xindy
 ;; filename: LatinRules.xdy
+;;
+;; Please note that this data file deliberately uses strings
+;; with single non-ascii bytes. This is intentional and
+;; follows the usage observed in similar xindy support files.
 ;;
 ;; It is based upon xindy's files lang/general/utf8.xdy and
 ;; lang/general/utf8-lang.xdy which implement


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
At the moment, sphinx/texinputs/LatinRules.xdy is encoded as
(as reported by `file LatinRules.xdy`):

  > Non-ISO extended-ASCII text, with LF, NEL line terminators

This has at least two consequences:
1. More basic text readers display the file incorrectly. This includes
   the file's own [raw view](https://raw.githubusercontent.com/sphinx-doc/sphinx/31eba1a76dd485dc633cae48227b46879eda5df4/sphinx/texinputs/LatinRules.xdy) on GitHub.
2. Certain pipelines may automatically convert this to UTF-8 (ostensibly
   a good thing), which causes headaches with diff and version control
   (500 spurious line changes every time the document is rebuilt).

This commit simply re-encodes the file to UTF-8. (Compare [raw view after change](https://raw.githubusercontent.com/alcrene/sphinx/fix-LatinRules-encoding/sphinx/texinputs/LatinRules.xdy).)

