### PR TITLE
Fix #10695: old LaTeX does not allow \@ifpackageloaded usage in body

### DIFF
--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -685,6 +685,27 @@
 %% FRAMED ENVIRONMENTS
 %
 \RequirePackage{sphinxpackageboxes}
+% This macro is possibly executed at begin document if the check
+% whether radii setting options have been used turns out positive
+\def\spx@RequirePackage@PictIIe{%
+\IfFileExists{pict2e.sty}
+   {\RequirePackage{pict2e}}
+   {\PackageWarningNoLine{sphinx}{%
+       The package pict2e is required for rounded boxes.\MessageBreak
+       It does not seem to be available on your system.\MessageBreak
+       Options for setting radii will thus be ignored}%
+    \AtEndDocument{\PackageWarningNoLine{sphinx}{%
+       I issued a warning which may have gotten lost in the\MessageBreak
+       gigantic console output: pict2e.sty was not found,\MessageBreak
+       and radii setting options have been ignored}}%
+    \def\spx@boxes@fcolorbox@rounded{\spx@boxes@fcolorbox}%
+   }%
+}%
+% This at begin document will be executed after \spx@RequirePackage@PictIIe
+\AtBeginDocument{%
+    \@ifpackageloaded{pict2e}{\let\spx@ifpackageloaded@pictiie\@firstoftwo}%
+                             {\let\spx@ifpackageloaded@pictiie\@secondoftwo}%
+}%
 \input{sphinxlatexadmonitions.sty}
 \input{sphinxlatexliterals.sty}
 \input{sphinxlatexshadowbox.sty}

--- a/sphinx/texinputs/sphinxlatexadmonitions.sty
+++ b/sphinx/texinputs/sphinxlatexadmonitions.sty
@@ -162,7 +162,7 @@
           \ifdim\spx@boxes@radius@bottomleft >\z@0\fi
           1\spx@boxes@fcolorbox{##1}%
         \else
-          \@ifpackageloaded{pict2e}%
+          \spx@ifpackageloaded@pictiie
              {\ifspx@boxes@insetshadow
                 \spx@boxes@fcolorbox{##1}%
               \else

--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -164,7 +164,7 @@
           \ifdim\spx@pre@radius@bottomleft >\z@0\fi
           1\spx@boxes@fcolorbox{\box\z@}%
         \else
-          \@ifpackageloaded{pict2e}%
+          \spx@ifpackageloaded@pictiie
              {\ifspx@pre@insetshadow
                 \spx@boxes@fcolorbox{\box\z@}%
               \else

--- a/sphinx/texinputs/sphinxlatexshadowbox.sty
+++ b/sphinx/texinputs/sphinxlatexshadowbox.sty
@@ -79,7 +79,7 @@
           \ifdim\spx@topic@radius@bottomleft >\z@0\fi
           1\spx@boxes@fcolorbox{\box\z@}%
         \else
-          \@ifpackageloaded{pict2e}%
+          \spx@ifpackageloaded@pictiie
              {\ifspx@topic@insetshadow
                 \spx@boxes@fcolorbox{\box\z@}%
               \else

--- a/sphinx/texinputs/sphinxpackageboxes.sty
+++ b/sphinx/texinputs/sphinxpackageboxes.sty
@@ -362,16 +362,16 @@
      \dimexpr\dp\spx@tempboxa+\spx@boxes@padding@bottom+\spx@boxes@border\relax
      \hbox{%
    \begin{picture}%
-      % \strip@pt\dimexpr fot work around "old" LaTeX picture limitation
+      % \strip@pt\dimexpr to work around "old" LaTeX picture limitation
       % (we could use the "picture" package, this would add another dependency)
-      (\strip@pt\wd\spx@tempboxa,\strip@pt\dimexpr\ht\spx@tempboxa+\dp\spx@tempboxa)%
-      (\strip@pt\dimexpr-.5\spx@boxes@border,\strip@pt\dimexpr-.5\spx@boxes@border)%
+      (\strip@pt\wd\spx@tempboxa,\strip@pt\dimexpr\ht\spx@tempboxa+\dp\spx@tempboxa\relax)%
+      (\strip@pt\dimexpr-.5\spx@boxes@border\relax,\strip@pt\dimexpr-.5\spx@boxes@border\relax)%
 \ifspx@boxes@withshadow
               \color{spx@boxes@shadowcolor}%
-              \put(\dimexpr\ifdim\spx@boxes@shadow@xoffset<\z@-\fi
-                           0.5\spx@boxes@border+\spx@boxes@shadow@xoffset,%
-                   \dimexpr\ifdim\spx@boxes@shadow@yoffset<\z@\else-\fi
-                           0.5\spx@boxes@border-\spx@boxes@shadow@yoffset)
+              \put(\strip@pt\dimexpr\ifdim\spx@boxes@shadow@xoffset<\z@-\fi
+                           0.5\spx@boxes@border+\spx@boxes@shadow@xoffset\relax,%
+                   \strip@pt\dimexpr\ifdim\spx@boxes@shadow@yoffset<\z@\else-\fi
+                           0.5\spx@boxes@border-\spx@boxes@shadow@yoffset\relax)
                    {\spx@boxes@borderpath\fillpath}%
               {\ifspx@boxes@withbackgroundcolor\else
                    \color{white}% or rather try to use page color?

--- a/sphinx/texinputs/sphinxpackageboxes.sty
+++ b/sphinx/texinputs/sphinxpackageboxes.sty
@@ -72,22 +72,6 @@
 % if nothing else is changed (perhaps in future the title itself could be also
 % rendered in a rounded box?)
 
-\def\spx@RequirePackage@PictIIe{%
-\IfFileExists{pict2e.sty}
-   {\RequirePackage{pict2e}}
-   {\PackageWarningNoLine{sphinx}{%
-       The package pict2e is required for rounded boxes.\MessageBreak
-       It does not seem to be available on your system.\MessageBreak
-       Options for setting radii will thus be ignored}%
-    \AtEndDocument{\PackageWarningNoLine{sphinx}{%
-       I issued a warning which may have gotten lost in the\MessageBreak
-       gigantic console output: pict2e.sty was not found,\MessageBreak
-       and radii setting options have been ignored}}%
-   \def\spx@boxes@fcolorbox@rounded{\spx@boxes@fcolorbox}%
-   }%
-}%
-
-
 %//// \spx@boxes@fcolorbox
 % This box will have the same baseline as its argument (which is typeset in
 % horizontal mode).  It takes into account four border widths parameters, four


### PR DESCRIPTION
Fix #10695 
Sorry for oversight, I thought I had tested with a TL2019, but perhaps this was before I added code which uses `\@ifpackageloaded` in document body.  It worked with more recent LaTeX but creates problems with older ones.