### PR TITLE
Improve support for deprecated builders without env arg

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -89,10 +89,11 @@ class Builder:
             self.env: BuildEnvironment = env
             self.env.set_versioning_method(self.versioning_method,
                                            self.versioning_compare)
-        elif env is not Ellipsis:
+        else:
             # ... is passed by SphinxComponentRegistry.create_builder to not show two warnings.
             warnings.warn("The 'env' argument to Builder will be required from Sphinx 7.",
                           RemovedInSphinx70Warning, stacklevel=2)
+            self.env = Optional[BuildEnvironment]  # type: ignore[assignment]
         self.events: EventManager = app.events
         self.config: Config = app.config
         self.tags: Tags = app.tags

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -93,7 +93,7 @@ class Builder:
             # ... is passed by SphinxComponentRegistry.create_builder to not show two warnings.
             warnings.warn("The 'env' argument to Builder will be required from Sphinx 7.",
                           RemovedInSphinx70Warning, stacklevel=2)
-            self.env = Optional[BuildEnvironment]  # type: ignore[assignment]
+            self.env: Optional[BuildEnvironment] = None  # type: ignore[assignment]
         self.events: EventManager = app.events
         self.config: Config = app.config
         self.tags: Tags = app.tags

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -93,7 +93,7 @@ class Builder:
             # ... is passed by SphinxComponentRegistry.create_builder to not show two warnings.
             warnings.warn("The 'env' argument to Builder will be required from Sphinx 7.",
                           RemovedInSphinx70Warning, stacklevel=2)
-            self.env: Optional[BuildEnvironment] = None  # type: ignore[assignment]
+            self.env = None  # type: ignore[assignment]
         self.events: EventManager = app.events
         self.config: Config = app.config
         self.tags: Tags = app.tags

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -93,7 +93,7 @@ class Builder:
             # ... is passed by SphinxComponentRegistry.create_builder to not show two warnings.
             warnings.warn("The 'env' argument to Builder will be required from Sphinx 7.",
                           RemovedInSphinx70Warning, stacklevel=2)
-            self.env = None  # type: ignore[assignment]
+            self.env = None
         self.events: EventManager = app.events
         self.config: Config = app.config
         self.tags: Tags = app.tags

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -166,7 +166,7 @@ class SphinxComponentRegistry:
                 f"'env'argument. Report this bug to the developers of your custom builder, "
                 f"this is likely not a issue with Sphinx. The 'env' argument will be required "
                 f"from Sphinx 7.", RemovedInSphinx70Warning, stacklevel=2)
-            builder = self.builders[name](app, env=...)  # type: ignore[arg-type]
+            builder = self.builders[name](app)
             if env is not None:
                 builder.set_environment(env)
             return builder


### PR DESCRIPTION

### Feature or Bugfix
- Bugfix

### Purpose

After upgrading to Sphinx 5.1.x, some third-party builders may fail to load. For example:

```
$ python -m sphinx -b confluence . _build/confluence -E -a
Running Sphinx v5.1.0

Exception occurred:
  File "C:\Users\...\AppData\Roaming\Python\Python38\site-packages\sphinx\registry.py", line 169, in create_builder
    builder = self.builders[name](app, env=...)  # type: ignore[arg-type]
TypeError: __init__() got an unexpected keyword argument 'env'
The full traceback has been saved in C:\Users\...\AppData\Local\Temp\sphinx-err-nvacn3g4.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```
It appears the `env` change (6ef22d261303ec07890305b300135c34952ca327) for builders using the older cannot handle the new Sphinx engine.

These changes help support the older environment initialization, for builders that have yet to upgrade their definitions.

### Relates
- https://github.com/sphinx-contrib/confluencebuilder/pull/691

