### PR TITLE
[Quickstart] Allow calling the Makefile using `make -f path/to/Makefile <target>`

### DIFF
--- a/sphinx/templates/quickstart/Makefile.new_t
+++ b/sphinx/templates/quickstart/Makefile.new_t
@@ -12,10 +12,13 @@ BUILDDIR      = {{ rbuilddir }}
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+# The Makefile itself, referenced either by a relative or absolute path
+MAKEFILE = Makefile $(shell pwd)/Makefile
+
+.PHONY: help $(MAKEFILE)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: $(MAKEFILE)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 


### PR DESCRIPTION
Subject: Allow calling the quickstart Makefile with `make -f`
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- This PR modifies the default Makefile so that it can be called using `make -f`. Otherwise it would call it with a target that is the path to the Makefile itself, this would result in a weird "path/to/Makefile is not a directory" error.
- This PR does impacts people using the quickstart setup. It relies on the shell having the `pwd` command.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/10706

