### PR TITLE
incremental adoption of 'strict optional'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,75 @@ ignore_missing_imports = True
 follow_imports = skip
 check_untyped_defs = True
 warn_unused_ignores = True
-strict_optional = False
+strict_optional = True
 no_implicit_optional = True
 warn_redundant_casts = True
+
+[mypy-sphinx.application]
+strict_optional = False
+
+[mypy-sphinx.builders]
+strict_optional = False
+
+[mypy-sphinx.builders.gettext]
+strict_optional = False
+
+[mypy-sphinx.builders.html]
+strict_optional = False
+
+[mypy-sphinx.builders.latex.*]
+strict_optional = False
+
+[mypy-sphinx.builders.linkcheck]
+strict_optional = False
+
+[mypy-sphinx.builders.singlehtml]
+strict_optional = False
+
+[mypy-sphinx.cmd.*]
+strict_optional = False
+
+[mypy-sphinx.directives]
+strict_optional = False
+
+[mypy-sphinx.directives.code]
+strict_optional = False
+
+[mypy-sphinx.domains.*]
+strict_optional = False
+
+[mypy-sphinx.environment.*]
+strict_optional = False
+
+[mypy-sphinx.ext.*]
+strict_optional = False
+
+[mypy-sphinx.locale]
+strict_optional = False
+
+[mypy-sphinx.pycode.parser]
+strict_optional = False
+
+[mypy-sphinx.registry.*]
+strict_optional = False
+
+[mypy-sphinx.search]
+strict_optional = False
+
+[mypy-sphinx.setup_command]
+strict_optional = False
+
+[mypy-sphinx.testing.util]
+strict_optional = False
+
+[mypy-sphinx.transforms.*]
+strict_optional = False
+
+[mypy-sphinx.util.*]
+strict_optional = False
+
+[mypy-sphinx.writers.*]
+strict_optional = False
 
 [tool:pytest]
 filterwarnings =

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -1,6 +1,6 @@
 """Additional docutils nodes."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 import docutils
 from docutils import nodes
@@ -27,7 +27,7 @@ class document(nodes.document):
                    in your extensions.  It will be removed without deprecation period.
     """
 
-    def set_id(self, node: Element, msgnode: Element = None,
+    def set_id(self, node: Element, msgnode: Optional[Element] = None,
                suggested_prefix: str = '') -> str:
         if docutils.__version_info__ >= (0, 16):
             ret = super().set_id(node, msgnode, suggested_prefix)  # type: ignore

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1023,7 +1023,7 @@ class StandaloneHTMLBuilder(Builder):
         return quote(docname) + self.link_suffix
 
     def handle_page(self, pagename: str, addctx: Dict, templatename: str = 'page.html',
-                    outfilename: str = None, event_arg: Any = None) -> None:
+                    outfilename: Optional[str] = None, event_arg: Any = None) -> None:
         ctx = self.globalcontext.copy()
         # current_page_name is backwards compatibility
         ctx['pagename'] = ctx['current_page_name'] = pagename

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -424,7 +424,7 @@ def correct_copyright_year(app: "Sphinx", config: Config) -> None:
                 config[k] = copyright_year_re.sub(replace, config[k])
 
 
-def check_confval_types(app: "Sphinx", config: Config) -> None:
+def check_confval_types(app: Optional["Sphinx"], config: Config) -> None:
     """Check all values for deviation from the default value's type, since
     that can result in TypeErrors all over the place NB.
     """

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -182,7 +182,7 @@ def read_doc(app: "Sphinx", env: BuildEnvironment, filename: str) -> nodes.docum
                     writer=SphinxDummyWriter(),
                     source_class=SphinxFileInput,
                     destination=NullOutput())
-    pub.process_programmatic_settings(None, env.settings, None)
+    pub.process_programmatic_settings(None, env.settings, None)  # type: ignore[arg-type]
     pub.set_source(source_path=filename)
     pub.publish()
     return pub.document

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -3,7 +3,7 @@
 import pathlib
 from os import path
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from jinja2 import BaseLoader, FileSystemLoader, TemplateNotFound
 from jinja2.environment import Environment
@@ -142,7 +142,12 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
 
     # TemplateBridge interface
 
-    def init(self, builder: "Builder", theme: Theme = None, dirs: List[str] = None) -> None:
+    def init(
+        self,
+        builder: "Builder",
+        theme: Optional[Theme] = None,
+        dirs: Optional[List[str]] = None
+    ) -> None:
         # create a chain of paths to search
         if theme:
             # the theme's own dir and its bases' dirs

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -5,7 +5,7 @@ import sys
 from collections import namedtuple
 from io import StringIO
 from subprocess import PIPE
-from typing import Any, Callable, Dict, Generator, Tuple
+from typing import Any, Callable, Dict, Generator, Optional, Tuple
 
 import pytest
 
@@ -28,7 +28,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope='session')
-def rootdir() -> str:
+def rootdir() -> Optional[str]:
     return None
 
 

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -2,7 +2,7 @@ import builtins
 import os
 import shutil
 import sys
-from typing import IO, Any, Callable, List
+from typing import IO, Any, Callable, List, Optional
 
 FILESYSTEMENCODING = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
@@ -69,7 +69,7 @@ class path(str):
         """
         return os.path.ismount(self)
 
-    def rmtree(self, ignore_errors: bool = False, onerror: Callable = None) -> None:
+    def rmtree(self, ignore_errors: bool = False, onerror: Optional[Callable] = None) -> None:
         """
         Removes the file or directory and any files or directories it may
         contain.


### PR DESCRIPTION
This PR adds a mypy 'whitelist' such that strict optional is applied to all modules that currently have no errors. The idea is that this whitelist shrinks over time, never gets any bigger, and can eventually be removed when `strict optional` has been fully-implemented. This means that no new strict optional type errors can be reintroduced to modules that have been completely cleared.

The downside is that it makes the mypy config file quite noisy until it's fully adopted

there's also still quite a lot of globbing in the whitelist. This could get more verbose before it gets less verbose when those globs are broken down further