### PR TITLE
Update deploying.rst

### DIFF
--- a/doc/tutorial/deploying.rst
+++ b/doc/tutorial/deploying.rst
@@ -192,7 +192,7 @@ contents:
        steps:
        - uses: actions/checkout@v3
        - name: Build HTML
-         uses: ammaraskar/sphinx-action@0.4
+         uses: ammaraskar/sphinx-action@master
        - name: Upload artifacts
          uses: actions/upload-artifact@v3
          with:


### PR DESCRIPTION
Version 0.4 of sphinx-action contains a problem investigated and documented here: https://github.com/ammaraskar/sphinx-action/issues/5. The action throws an error claiming it can't write the log file. The problem is fixed in `master` and since this is a tutorial, it is more or less expected that it should work off the bat, so I thinking pinning the `master` version for now, and the next release when it comes out, might be the best way to help beginners.

Subject: Update github workflow `.yml` file in tutorial.

### Feature or Bugfix
- Feature: docs update

### Purpose
- `.yml` file in tutorial should work as is to better help newbies familiarize themselves with sphinx.

### Detail
- Github Workflow in tutorial won't work due to bug in `sphinx-action@0.4`; pin `sphinx-action@master` instead.

### Relates
https://github.com/ammaraskar/sphinx-action/issues/5

