### PR TITLE
use pyupgrade on codebase

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -163,7 +163,7 @@ def linkify_issues_in_changelog(app, docname, source):
 
         def linkify(match):
             url = 'https://github.com/sphinx-doc/sphinx/issues/' + match[1]
-            return '`{} <{}>`_'.format(match[0], url)
+            return f'`{match[0]} <{url}>`_'
 
         linkified_changelog = re.sub(r'(?:PR)?#([0-9]+)\b', linkify, changelog)
 

--- a/doc/development/tutorials/examples/recipe.py
+++ b/doc/development/tutorials/examples/recipe.py
@@ -120,8 +120,7 @@ class RecipeDomain(Domain):
         return '{}.{}'.format('recipe', node.arguments[0])
 
     def get_objects(self):
-        for obj in self.data['recipes']:
-            yield(obj)
+        yield from self.data['recipes']
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node,
                      contnode):
@@ -142,7 +141,7 @@ class RecipeDomain(Domain):
     def add_recipe(self, signature, ingredients):
         """Add a new recipe to the domain."""
         name = '{}.{}'.format('recipe', signature)
-        anchor = 'recipe-{}'.format(signature)
+        anchor = f'recipe-{signature}'
 
         self.data['recipe_ingredients'][name] = ingredients
         # name, dispname, type, docname, anchor, priority

--- a/doc/usage/extensions/example_google.py
+++ b/doc/usage/extensions/example_google.py
@@ -142,8 +142,7 @@ def example_generator(n):
         [0, 1, 2, 3]
 
     """
-    for i in range(n):
-        yield i
+    yield from range(n)
 
 
 class ExampleError(Exception):

--- a/doc/usage/extensions/example_numpy.py
+++ b/doc/usage/extensions/example_numpy.py
@@ -180,8 +180,7 @@ def example_generator(n):
     [0, 1, 2, 3]
 
     """
-    for i in range(n):
-        yield i
+    yield from range(n)
 
 
 class ExampleError(Exception):

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -250,7 +250,7 @@ class desc_parameterlist(nodes.Part, nodes.Inline, nodes.FixedTextElement):
     child_text_separator = ', '
 
     def astext(self):
-        return '({})'.format(super().astext())
+        return f'({super().astext()})'
 
 
 class desc_parameter(nodes.Part, nodes.Inline, nodes.FixedTextElement):

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -644,8 +644,8 @@ class Builder:
         # At the moment, only XXX_use_index is looked up this way.
         # Every new builder variant must be registered in Config.config_values.
         try:
-            optname = '{}_{}'.format(self.name, option)
+            optname = f'{self.name}_{option}'
             return getattr(self.config, optname)
         except AttributeError:
-            optname = '{}_{}'.format(default, option)
+            optname = f'{default}_{option}'
             return getattr(self.config, optname)

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -644,8 +644,8 @@ class Builder:
         # At the moment, only XXX_use_index is looked up this way.
         # Every new builder variant must be registered in Config.config_values.
         try:
-            optname = '%s_%s' % (self.name, option)
+            optname = '{}_{}'.format(self.name, option)
             return getattr(self.config, optname)
         except AttributeError:
-            optname = '%s_%s' % (default, option)
+            optname = '{}_{}'.format(default, option)
             return getattr(self.config, optname)

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -64,7 +64,7 @@ class ChangesBuilder(Builder):
                     entry = '<b>{}</b>: <i>{}:</i> {}'.format(descname, ttext,
                                                           context)
                 else:
-                    entry = '<b>{}</b>: <i>{}</i>.'.format(descname, ttext)
+                    entry = f'<b>{descname}</b>: <i>{ttext}</i>.'
                 apichanges.append((entry, changeset.docname, changeset.lineno))
             elif descname or changeset.module:
                 module = changeset.module or _('Builtins')
@@ -74,13 +74,13 @@ class ChangesBuilder(Builder):
                     entry = '<b>{}</b>: <i>{}:</i> {}'.format(descname, ttext,
                                                           context)
                 else:
-                    entry = '<b>{}</b>: <i>{}</i>.'.format(descname, ttext)
+                    entry = f'<b>{descname}</b>: <i>{ttext}</i>.'
                 libchanges.setdefault(module, []).append((entry, changeset.docname,
                                                           changeset.lineno))
             else:
                 if not context:
                     continue
-                entry = '<i>{}:</i> {}'.format(ttext.capitalize(), context)
+                entry = f'<i>{ttext.capitalize()}:</i> {context}'
                 title = self.env.titles[changeset.docname].astext()
                 otherchanges.setdefault((changeset.docname, title), []).append(
                     (entry, changeset.docname, changeset.lineno))
@@ -141,8 +141,8 @@ class ChangesBuilder(Builder):
     def hl(self, text: str, version: str) -> str:
         text = html.escape(text)
         for directive in ('versionchanged', 'versionadded', 'deprecated'):
-            text = text.replace('.. {}:: {}'.format(directive, version),
-                                '<b>.. {}:: {}</b>'.format(directive, version))
+            text = text.replace(f'.. {directive}:: {version}',
+                                f'<b>.. {directive}:: {version}</b>')
         return text
 
     def finish(self) -> None:

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -61,8 +61,7 @@ class ChangesBuilder(Builder):
             context = changeset.content.replace('\n', ' ')
             if descname and changeset.docname.startswith('c-api'):
                 if context:
-                    entry = '<b>{}</b>: <i>{}:</i> {}'.format(descname, ttext,
-                                                          context)
+                    entry = f'<b>{descname}</b>: <i>{ttext}:</i> {context}'
                 else:
                     entry = f'<b>{descname}</b>: <i>{ttext}</i>.'
                 apichanges.append((entry, changeset.docname, changeset.lineno))
@@ -71,8 +70,11 @@ class ChangesBuilder(Builder):
                 if not descname:
                     descname = _('Module level')
                 if context:
-                    entry = '<b>{}</b>: <i>{}:</i> {}'.format(descname, ttext,
-                                                          context)
+                    entry = '<b>{}</b>: <i>{}:</i> {}'.format(
+                        descname,
+                        ttext,
+                        context
+                    )
                 else:
                     entry = f'<b>{descname}</b>: <i>{ttext}</i>.'
                 libchanges.setdefault(module, []).append((entry, changeset.docname,

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -61,26 +61,26 @@ class ChangesBuilder(Builder):
             context = changeset.content.replace('\n', ' ')
             if descname and changeset.docname.startswith('c-api'):
                 if context:
-                    entry = '<b>%s</b>: <i>%s:</i> %s' % (descname, ttext,
+                    entry = '<b>{}</b>: <i>{}:</i> {}'.format(descname, ttext,
                                                           context)
                 else:
-                    entry = '<b>%s</b>: <i>%s</i>.' % (descname, ttext)
+                    entry = '<b>{}</b>: <i>{}</i>.'.format(descname, ttext)
                 apichanges.append((entry, changeset.docname, changeset.lineno))
             elif descname or changeset.module:
                 module = changeset.module or _('Builtins')
                 if not descname:
                     descname = _('Module level')
                 if context:
-                    entry = '<b>%s</b>: <i>%s:</i> %s' % (descname, ttext,
+                    entry = '<b>{}</b>: <i>{}:</i> {}'.format(descname, ttext,
                                                           context)
                 else:
-                    entry = '<b>%s</b>: <i>%s</i>.' % (descname, ttext)
+                    entry = '<b>{}</b>: <i>{}</i>.'.format(descname, ttext)
                 libchanges.setdefault(module, []).append((entry, changeset.docname,
                                                           changeset.lineno))
             else:
                 if not context:
                     continue
-                entry = '<i>%s:</i> %s' % (ttext.capitalize(), context)
+                entry = '<i>{}:</i> {}'.format(ttext.capitalize(), context)
                 title = self.env.titles[changeset.docname].astext()
                 otherchanges.setdefault((changeset.docname, title), []).append(
                     (entry, changeset.docname, changeset.lineno))
@@ -141,8 +141,8 @@ class ChangesBuilder(Builder):
     def hl(self, text: str, version: str) -> str:
         text = html.escape(text)
         for directive in ('versionchanged', 'versionadded', 'deprecated'):
-            text = text.replace('.. %s:: %s' % (directive, version),
-                                '<b>.. %s:: %s</b>' % (directive, version))
+            text = text.replace('.. {}:: {}'.format(directive, version),
+                                '<b>.. {}:: {}</b>'.format(directive, version))
         return text
 
     def finish(self) -> None:

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -250,7 +250,7 @@ class MessageCatalogBuilder(I18nBuilder):
                     origin = MsgOrigin(template, line)
                     self.catalogs['sphinx'].add(msg, origin)
             except Exception as exc:
-                raise ThemeError('{}: {!r}'.format(template, exc)) from exc
+                raise ThemeError(f'{template}: {exc!r}') from exc
 
     def build(
         self, docnames: Iterable[str], summary: Optional[str] = None, method: str = 'update'

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -250,7 +250,7 @@ class MessageCatalogBuilder(I18nBuilder):
                     origin = MsgOrigin(template, line)
                     self.catalogs['sphinx'].add(msg, origin)
             except Exception as exc:
-                raise ThemeError('%s: %r' % (template, exc)) from exc
+                raise ThemeError('{}: {!r}'.format(template, exc)) from exc
 
     def build(
         self, docnames: Iterable[str], summary: Optional[str] = None, method: str = 'update'

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -488,7 +488,7 @@ class StandaloneHTMLBuilder(Builder):
             for domain_name in sorted(self.env.domains):
                 domain: Domain = self.env.domains[domain_name]
                 for indexcls in domain.indices:
-                    indexname = '%s-%s' % (domain.name, indexcls.name)
+                    indexname = '{}-{}'.format(domain.name, indexcls.name)
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
                             continue
@@ -1194,7 +1194,7 @@ def setup_css_tag_helper(app: Sphinx, pagename: str, templatename: str,
         for key in sorted(css.attributes):
             value = css.attributes[key]
             if value is not None:
-                attrs.append('%s="%s"' % (key, html.escape(value, True)))
+                attrs.append('{}="{}"'.format(key, html.escape(value, True)))
         attrs.append('href="%s"' % pathto(css.filename, resource=True))
         return '<link %s />' % ' '.join(attrs)
 
@@ -1221,7 +1221,7 @@ def setup_js_tag_helper(app: Sphinx, pagename: str, templatename: str,
                     elif key == 'data_url_root':
                         attrs.append('data-url_root="%s"' % pathto('', resource=True))
                     else:
-                        attrs.append('%s="%s"' % (key, html.escape(value, True)))
+                        attrs.append('{}="{}"'.format(key, html.escape(value, True)))
             if js.filename:
                 attrs.append('src="%s"' % pathto(js.filename, resource=True))
         else:
@@ -1229,7 +1229,7 @@ def setup_js_tag_helper(app: Sphinx, pagename: str, templatename: str,
             attrs.append('src="%s"' % pathto(js, resource=True))
 
         if attrs:
-            return '<script %s>%s</script>' % (' '.join(attrs), body)
+            return '<script {}>{}</script>'.format(' '.join(attrs), body)
         else:
             return '<script>%s</script>' % body
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -488,7 +488,7 @@ class StandaloneHTMLBuilder(Builder):
             for domain_name in sorted(self.env.domains):
                 domain: Domain = self.env.domains[domain_name]
                 for indexcls in domain.indices:
-                    indexname = '{}-{}'.format(domain.name, indexcls.name)
+                    indexname = f'{domain.name}-{indexcls.name}'
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
                             continue
@@ -1194,7 +1194,7 @@ def setup_css_tag_helper(app: Sphinx, pagename: str, templatename: str,
         for key in sorted(css.attributes):
             value = css.attributes[key]
             if value is not None:
-                attrs.append('{}="{}"'.format(key, html.escape(value, True)))
+                attrs.append(f'{key}="{html.escape(value, True)}"')
         attrs.append('href="%s"' % pathto(css.filename, resource=True))
         return '<link %s />' % ' '.join(attrs)
 
@@ -1221,7 +1221,7 @@ def setup_js_tag_helper(app: Sphinx, pagename: str, templatename: str,
                     elif key == 'data_url_root':
                         attrs.append('data-url_root="%s"' % pathto('', resource=True))
                     else:
-                        attrs.append('{}="{}"'.format(key, html.escape(value, True)))
+                        attrs.append(f'{key}="{html.escape(value, True)}"')
             if js.filename:
                 attrs.append('src="%s"' % pathto(js.filename, resource=True))
         else:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -233,11 +233,11 @@ class LaTeXBuilder(Builder):
             self.context['classoptions'] += ',' + self.babel.get_language()
             options = self.babel.get_mainlanguage_options()
             if options:
-                language = r'\setmainlanguage[%s]{%s}' % (options, self.babel.get_language())
+                language = r'\setmainlanguage[{}]{{{}}}'.format(options, self.babel.get_language())
             else:
                 language = r'\setmainlanguage{%s}' % self.babel.get_language()
 
-            self.context['multilingual'] = '%s\n%s' % (self.context['polyglossia'], language)
+            self.context['multilingual'] = '{}\n{}'.format(self.context['polyglossia'], language)
 
     def write_stylesheet(self) -> None:
         highlighter = highlighting.PygmentsBridge('latex', self.config.pygments_style)

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -233,7 +233,7 @@ class LaTeXBuilder(Builder):
             self.context['classoptions'] += ',' + self.babel.get_language()
             options = self.babel.get_mainlanguage_options()
             if options:
-                language = r'\setmainlanguage[{}]{{{}}}'.format(options, self.babel.get_language())
+                language = fr'\setmainlanguage[{options}]{{{self.babel.get_language()}}}'
             else:
                 language = r'\setmainlanguage{%s}' % self.babel.get_language()
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -237,7 +237,10 @@ class LaTeXBuilder(Builder):
             else:
                 language = r'\setmainlanguage{%s}' % self.babel.get_language()
 
-            self.context['multilingual'] = '{}\n{}'.format(self.context['polyglossia'], language)
+            self.context['multilingual'] = '{}\n{}'.format(
+                self.context['polyglossia'],
+                language
+            )
 
     def write_stylesheet(self) -> None:
         highlighter = highlighting.PygmentsBridge('latex', self.config.pygments_style)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -175,7 +175,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
 
     def write_entry(self, what: str, docname: str, filename: str, line: int,
                     uri: str) -> None:
-        self.txt_outfile.write("%s:%s: [%s] %s\n" % (filename, line, what, uri))
+        self.txt_outfile.write("{}:{}: [{}] {}\n".format(filename, line, what, uri))
 
     def write_linkstat(self, data: dict) -> None:
         self.json_outfile.write(json.dumps(data))
@@ -270,8 +270,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
 
         def get_request_headers() -> Dict[str, str]:
             url = urlparse(uri)
-            candidates = ["%s://%s" % (url.scheme, url.netloc),
-                          "%s://%s/" % (url.scheme, url.netloc),
+            candidates = ["{}://{}".format(url.scheme, url.netloc),
+                          "{}://{}/".format(url.scheme, url.netloc),
                           uri,
                           "*"]
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -175,7 +175,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
 
     def write_entry(self, what: str, docname: str, filename: str, line: int,
                     uri: str) -> None:
-        self.txt_outfile.write("{}:{}: [{}] {}\n".format(filename, line, what, uri))
+        self.txt_outfile.write(f"{filename}:{line}: [{what}] {uri}\n")
 
     def write_linkstat(self, data: dict) -> None:
         self.json_outfile.write(json.dumps(data))
@@ -270,8 +270,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
 
         def get_request_headers() -> Dict[str, str]:
             url = urlparse(uri)
-            candidates = ["{}://{}".format(url.scheme, url.netloc),
-                          "{}://{}/".format(url.scheme, url.netloc),
+            candidates = [f"{url.scheme}://{url.netloc}",
+                          f"{url.scheme}://{url.netloc}/",
                           uri,
                           "*"]
 

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -75,9 +75,9 @@ class ManualPageBuilder(Builder):
             if self.config.man_make_section_directory:
                 dirname = 'man%s' % section
                 ensuredir(path.join(self.outdir, dirname))
-                targetname = '{}/{}.{}'.format(dirname, name, section)
+                targetname = f'{dirname}/{name}.{section}'
             else:
-                targetname = '{}.{}'.format(name, section)
+                targetname = f'{name}.{section}'
 
             logger.info(darkgreen(targetname) + ' { ', nonl=True)
             destination = FileOutput(
@@ -104,7 +104,7 @@ class ManualPageBuilder(Builder):
 def default_man_pages(config: Config) -> List[Tuple[str, str, str, List[str], int]]:
     """ Better default man_pages settings. """
     filename = make_filename_from_project(config.project)
-    return [(config.root_doc, filename, '{} {}'.format(config.project, config.release),
+    return [(config.root_doc, filename, f'{config.project} {config.release}',
              [config.author], 1)]
 
 

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -75,9 +75,9 @@ class ManualPageBuilder(Builder):
             if self.config.man_make_section_directory:
                 dirname = 'man%s' % section
                 ensuredir(path.join(self.outdir, dirname))
-                targetname = '%s/%s.%s' % (dirname, name, section)
+                targetname = '{}/{}.{}'.format(dirname, name, section)
             else:
-                targetname = '%s.%s' % (name, section)
+                targetname = '{}.{}'.format(name, section)
 
             logger.info(darkgreen(targetname) + ' { ', nonl=True)
             destination = FileOutput(
@@ -104,7 +104,7 @@ class ManualPageBuilder(Builder):
 def default_man_pages(config: Config) -> List[Tuple[str, str, str, List[str], int]]:
     """ Better default man_pages settings. """
     filename = make_filename_from_project(config.project)
-    return [(config.root_doc, filename, '%s %s' % (config.project, config.release),
+    return [(config.root_doc, filename, '{} {}'.format(config.project, config.release),
              [config.author], 1)]
 
 

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -87,7 +87,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         new_secnumbers: Dict[str, Tuple[int, ...]] = {}
         for docname, secnums in self.env.toc_secnumbers.items():
             for id, secnum in secnums.items():
-                alias = "%s/%s" % (docname, id)
+                alias = "{}/{}".format(docname, id)
                 new_secnumbers[alias] = secnum
 
         return {self.config.root_doc: new_secnumbers}
@@ -106,7 +106,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         # {'foo': {'figure': {'id2': (2,), 'id1': (1,)}}, 'bar': {'figure': {'id1': (3,)}}}
         for docname, fignumlist in self.env.toc_fignumbers.items():
             for figtype, fignums in fignumlist.items():
-                alias = "%s/%s" % (docname, figtype)
+                alias = "{}/{}".format(docname, figtype)
                 new_fignumbers.setdefault(alias, {})
                 for id, fignum in fignums.items():
                     new_fignumbers[alias][id] = fignum

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -87,7 +87,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         new_secnumbers: Dict[str, Tuple[int, ...]] = {}
         for docname, secnums in self.env.toc_secnumbers.items():
             for id, secnum in secnums.items():
-                alias = "{}/{}".format(docname, id)
+                alias = f"{docname}/{id}"
                 new_secnumbers[alias] = secnum
 
         return {self.config.root_doc: new_secnumbers}
@@ -106,7 +106,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         # {'foo': {'figure': {'id2': (2,), 'id1': (1,)}}, 'bar': {'figure': {'id1': (3,)}}}
         for docname, fignumlist in self.env.toc_fignumbers.items():
             for figtype, fignums in fignumlist.items():
-                alias = "{}/{}".format(docname, figtype)
+                alias = f"{docname}/{figtype}"
                 new_fignumbers.setdefault(alias, {})
                 for id, fignum in fignums.items():
                     new_fignumbers[alias][id] = fignum

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -84,7 +84,7 @@ class Make:
         print("Please use `make %s' where %s is one of" % ((blue('target'),) * 2))
         for osname, bname, description in BUILDERS:
             if not osname or os.name == osname:
-                print('  %s  %s' % (blue(bname.ljust(10)), description))
+                print('  {}  {}'.format(blue(bname.ljust(10)), description))
 
     def build_latexpdf(self) -> int:
         if self.run_generic_build('latex') > 0:

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -84,7 +84,7 @@ class Make:
         print("Please use `make %s' where %s is one of" % ((blue('target'),) * 2))
         for osname, bname, description in BUILDERS:
             if not osname or os.name == osname:
-                print('  {}  {}'.format(blue(bname.ljust(10)), description))
+                print(f'  {blue(bname.ljust(10))}  {description}')
 
     def build_latexpdf(self) -> int:
         if self.run_generic_build('latex') > 0:

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -133,7 +133,7 @@ def ok(x: str) -> str:
 def do_prompt(text: str, default: str = None, validator: Callable[[str], Any] = nonempty) -> Union[str, bool]:  # NOQA
     while True:
         if default is not None:
-            prompt = PROMPT_PREFIX + '%s [%s]: ' % (text, default)
+            prompt = PROMPT_PREFIX + '{} [{}]: '.format(text, default)
         else:
             prompt = PROMPT_PREFIX + text + ': '
         if USE_LIBEDIT:
@@ -300,7 +300,7 @@ def ask_user(d: Dict[str, Any]) -> None:
         print(__('Indicate which of the following Sphinx extensions should be enabled:'))
         d['extensions'] = []
         for name, description in EXTENSIONS.items():
-            if do_prompt('%s: %s (y/n)' % (name, description), 'n', boolean):
+            if do_prompt('{}: {} (y/n)'.format(name, description), 'n', boolean):
                 d['extensions'].append('sphinx.ext.%s' % name)
 
         # Handle conflicting options

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -133,7 +133,7 @@ def ok(x: str) -> str:
 def do_prompt(text: str, default: str = None, validator: Callable[[str], Any] = nonempty) -> Union[str, bool]:  # NOQA
     while True:
         if default is not None:
-            prompt = PROMPT_PREFIX + '{} [{}]: '.format(text, default)
+            prompt = PROMPT_PREFIX + f'{text} [{default}]: '
         else:
             prompt = PROMPT_PREFIX + text + ': '
         if USE_LIBEDIT:
@@ -300,7 +300,7 @@ def ask_user(d: Dict[str, Any]) -> None:
         print(__('Indicate which of the following Sphinx extensions should be enabled:'))
         d['extensions'] = []
         for name, description in EXTENSIONS.items():
-            if do_prompt('{}: {} (y/n)'.format(name, description), 'n', boolean):
+            if do_prompt(f'{name}: {description} (y/n)', 'n', boolean):
                 d['extensions'].append('sphinx.ext.%s' % name)
 
         # Handle conflicting options

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -461,7 +461,7 @@ def check_confval_types(app: Optional["Sphinx"], config: Config) -> None:
             if annotations:
                 msg = __("The config value `{name}' has type `{current.__name__}'; "
                          "expected {permitted}.")
-                wrapped_annotations = ["`{}'".format(c.__name__) for c in annotations]
+                wrapped_annotations = [f"`{c.__name__}'" for c in annotations]
                 if len(wrapped_annotations) > 2:
                     permitted = "{}, or {}".format(
                         ", ".join(wrapped_annotations[:-1]),

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -232,7 +232,7 @@ class Domain:
         std = cast(StandardDomain, self.env.get_domain('std'))
         for index in self.indices:
             if index.name and index.localname:
-                docname = "{}-{}".format(self.name, index.name)
+                docname = f"{self.name}-{index.name}"
                 std.note_hyperlink_target(docname, docname, '', index.localname)
 
     def add_object_type(self, name: str, objtype: ObjType) -> None:
@@ -254,7 +254,7 @@ class Domain:
             return self._role_cache[name]
         if name not in self.roles:
             return None
-        fullname = '{}:{}'.format(self.name, name)
+        fullname = f'{self.name}:{name}'
 
         def role_adapter(typ: str, rawtext: str, text: str, lineno: int,
                          inliner: Inliner, options: Dict = {}, content: List[str] = []
@@ -272,7 +272,7 @@ class Domain:
             return self._directive_cache[name]
         if name not in self.directives:
             return None
-        fullname = '{}:{}'.format(self.name, name)
+        fullname = f'{self.name}:{name}'
         BaseDirective = self.directives[name]
 
         class DirectiveAdapter(BaseDirective):  # type: ignore

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -232,7 +232,7 @@ class Domain:
         std = cast(StandardDomain, self.env.get_domain('std'))
         for index in self.indices:
             if index.name and index.localname:
-                docname = "%s-%s" % (self.name, index.name)
+                docname = "{}-{}".format(self.name, index.name)
                 std.note_hyperlink_target(docname, docname, '', index.localname)
 
     def add_object_type(self, name: str, objtype: ObjType) -> None:
@@ -254,7 +254,7 @@ class Domain:
             return self._role_cache[name]
         if name not in self.roles:
             return None
-        fullname = '%s:%s' % (self.name, name)
+        fullname = '{}:{}'.format(self.name, name)
 
         def role_adapter(typ: str, rawtext: str, text: str, lineno: int,
                          inliner: Inliner, options: Dict = {}, content: List[str] = []
@@ -272,7 +272,7 @@ class Domain:
             return self._directive_cache[name]
         if name not in self.directives:
             return None
-        fullname = '%s:%s' % (self.name, name)
+        fullname = '{}:{}'.format(self.name, name)
         BaseDirective = self.directives[name]
 
         class DirectiveAdapter(BaseDirective):  # type: ignore

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1142,7 +1142,7 @@ class ASTBracedInitList(ASTBase):
     def _stringify(self, transform: StringifyTransform) -> str:
         exprs = [transform(e) for e in self.exprs]
         trailingComma = ',' if self.trailingComma else ''
-        return '{%s%s}' % (', '.join(exprs), trailingComma)
+        return '{{{}{}}}'.format(', '.join(exprs), trailingComma)
 
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:
@@ -1827,7 +1827,7 @@ class Symbol:
             Symbol.debug_indent += 1
             Symbol.debug_print("nn:       ", nestedName)
             Symbol.debug_print("decl:     ", declaration)
-            Symbol.debug_print("location: {}:{}".format(docname, line))
+            Symbol.debug_print(f"location: {docname}:{line}")
 
         def onMissingQualifiedSymbol(parentSymbol: "Symbol", ident: ASTIdentifier) -> "Symbol":
             if Symbol.debug_lookup:
@@ -1853,7 +1853,7 @@ class Symbol:
                 Symbol.debug_indent += 1
                 Symbol.debug_print("ident:       ", lookupResult.ident)
                 Symbol.debug_print("declaration: ", declaration)
-                Symbol.debug_print("location:    {}:{}".format(docname, line))
+                Symbol.debug_print(f"location:    {docname}:{line}")
                 Symbol.debug_indent -= 1
             symbol = Symbol(parent=lookupResult.parentSymbol,
                             ident=lookupResult.ident,
@@ -2268,7 +2268,7 @@ class DefinitionParser(BaseParser):
             if self.skip_string(close):
                 break
             if not self.skip_string_and_ws(','):
-                self.fail("Error in %s, expected ',' or '%s'." % (name, close))
+                self.fail("Error in {}, expected ',' or '{}'.".format(name, close))
             if self.current_char == close and close == '}':
                 self.pos += 1
                 trailingComma = True

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -2268,7 +2268,7 @@ class DefinitionParser(BaseParser):
             if self.skip_string(close):
                 break
             if not self.skip_string_and_ws(','):
-                self.fail("Error in {}, expected ',' or '{}'.".format(name, close))
+                self.fail(f"Error in {name}, expected ',' or '{close}'.")
             if self.current_char == close and close == '}':
                 self.pos += 1
                 trailingComma = True

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -5322,7 +5322,7 @@ class DefinitionParser(BaseParser):
             if self.skip_string(close):
                 break
             if not self.skip_string_and_ws(','):
-                self.fail("Error in {}, expected ',' or '{}'.".format(name, close))
+                self.fail(f"Error in {name}, expected ',' or '{close}'.")
             if self.current_char == close and close == '}':
                 self.pos += 1
                 trailingComma = True
@@ -7962,7 +7962,7 @@ class CPPDomain(Domain):
             objtypes = self.objtypes_for_role(typ)
             if objtypes:
                 return declTyp in objtypes
-            print("Type is {}, declaration type is {}".format(typ, declTyp))
+            print(f"Type is {typ}, declaration type is {declTyp}")
             raise AssertionError()
         if not checkType():
             logger.warning("cpp:%s targets a %s (%s).",

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -954,7 +954,7 @@ class ASTUserDefinedLiteral(ASTLiteral):
 
     def get_id(self, version: int) -> str:
         # mangle as if it was a function call: ident(literal)
-        return 'clL_Zli{}E{}E'.format(self.ident.get_id(version), self.literal.get_id(version))
+        return f'clL_Zli{self.ident.get_id(version)}E{self.literal.get_id(version)}E'
 
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:
@@ -1569,7 +1569,7 @@ class ASTBracedInitList(ASTBase):
     def _stringify(self, transform: StringifyTransform) -> str:
         exprs = [transform(e) for e in self.exprs]
         trailingComma = ',' if self.trailingComma else ''
-        return '{%s%s}' % (', '.join(exprs), trailingComma)
+        return '{{{}{}}}'.format(', '.join(exprs), trailingComma)
 
     def describe_signature(self, signode: TextElement, mode: str,
                            env: "BuildEnvironment", symbol: "Symbol") -> None:
@@ -4584,7 +4584,7 @@ class Symbol:
             Symbol.debug_print("tdecls:", ",".join(str(t) for t in templateDecls))
             Symbol.debug_print("nn:       ", nestedName)
             Symbol.debug_print("decl:     ", declaration)
-            Symbol.debug_print("location: {}:{}".format(docname, line))
+            Symbol.debug_print(f"location: {docname}:{line}")
 
         def onMissingQualifiedSymbol(parentSymbol: "Symbol",
                                      identOrOp: Union[ASTIdentifier, ASTOperator],
@@ -4622,7 +4622,7 @@ class Symbol:
                 Symbol.debug_print("identOrOp:     ", lookupResult.identOrOp)
                 Symbol.debug_print("templateArgs:  ", lookupResult.templateArgs)
                 Symbol.debug_print("declaration:   ", declaration)
-                Symbol.debug_print("location:      {}:{}".format(docname, line))
+                Symbol.debug_print(f"location:      {docname}:{line}")
                 Symbol.debug_indent -= 1
             symbol = Symbol(parent=lookupResult.parentSymbol,
                             identOrOp=lookupResult.identOrOp,
@@ -5322,7 +5322,7 @@ class DefinitionParser(BaseParser):
             if self.skip_string(close):
                 break
             if not self.skip_string_and_ws(','):
-                self.fail("Error in %s, expected ',' or '%s'." % (name, close))
+                self.fail("Error in {}, expected ',' or '{}'.".format(name, close))
             if self.current_char == close and close == '}':
                 self.pos += 1
                 trailingComma = True
@@ -5964,23 +5964,23 @@ class DefinitionParser(BaseParser):
                      'float', 'double',
                      '__float80', '_Float64x', '__float128', '_Float128'):
                 if typ is not None:
-                    self.fail("Can not have both {} and {}.".format(t, typ))
+                    self.fail(f"Can not have both {t} and {typ}.")
                 typ = t
             elif t in ('signed', 'unsigned'):
                 if signedness is not None:
-                    self.fail("Can not have both {} and {}.".format(t, signedness))
+                    self.fail(f"Can not have both {t} and {signedness}.")
                 signedness = t
             elif t == 'short':
                 if len(width) != 0:
-                    self.fail("Can not have both {} and {}.".format(t, width[0]))
+                    self.fail(f"Can not have both {t} and {width[0]}.")
                 width.append(t)
             elif t == 'long':
                 if len(width) != 0 and width[0] != 'long':
-                    self.fail("Can not have both {} and {}.".format(t, width[0]))
+                    self.fail(f"Can not have both {t} and {width[0]}.")
                 width.append(t)
             elif t in ('_Imaginary', '_Complex'):
                 if modifier is not None:
-                    self.fail("Can not have both {} and {}.".format(t, modifier))
+                    self.fail(f"Can not have both {t} and {modifier}.")
                 modifier = t
             self.skip_ws()
         if len(names) == 0:
@@ -5990,41 +5990,41 @@ class DefinitionParser(BaseParser):
                    'wchar_t', 'char8_t', 'char16_t', 'char32_t',
                    '__float80', '_Float64x', '__float128', '_Float128'):
             if modifier is not None:
-                self.fail("Can not have both {} and {}.".format(typ, modifier))
+                self.fail(f"Can not have both {typ} and {modifier}.")
             if signedness is not None:
-                self.fail("Can not have both {} and {}.".format(typ, signedness))
+                self.fail(f"Can not have both {typ} and {signedness}.")
             if len(width) != 0:
                 self.fail("Can not have both {} and {}.".format(typ, ' '.join(width)))
         elif typ == 'char':
             if modifier is not None:
-                self.fail("Can not have both {} and {}.".format(typ, modifier))
+                self.fail(f"Can not have both {typ} and {modifier}.")
             if len(width) != 0:
                 self.fail("Can not have both {} and {}.".format(typ, ' '.join(width)))
         elif typ == 'int':
             if modifier is not None:
-                self.fail("Can not have both {} and {}.".format(typ, modifier))
+                self.fail(f"Can not have both {typ} and {modifier}.")
         elif typ in ('__int64', '__int128'):
             if modifier is not None:
-                self.fail("Can not have both {} and {}.".format(typ, modifier))
+                self.fail(f"Can not have both {typ} and {modifier}.")
             if len(width) != 0:
                 self.fail("Can not have both {} and {}.".format(typ, ' '.join(width)))
         elif typ == 'float':
             if signedness is not None:
-                self.fail("Can not have both {} and {}.".format(typ, signedness))
+                self.fail(f"Can not have both {typ} and {signedness}.")
             if len(width) != 0:
                 self.fail("Can not have both {} and {}.".format(typ, ' '.join(width)))
         elif typ == 'double':
             if signedness is not None:
-                self.fail("Can not have both {} and {}.".format(typ, signedness))
+                self.fail(f"Can not have both {typ} and {signedness}.")
             if len(width) > 1:
                 self.fail("Can not have both {} and {}.".format(typ, ' '.join(width)))
             if len(width) == 1 and width[0] != 'long':
                 self.fail("Can not have both {} and {}.".format(typ, ' '.join(width)))
         elif typ is None:
             if modifier is not None:
-                self.fail("Can not have {} without a floating point type.".format(modifier))
+                self.fail(f"Can not have {modifier} without a floating point type.")
         else:
-            raise AssertionError("Unhandled type {}".format(typ))
+            raise AssertionError(f"Unhandled type {typ}")
 
         canonNames: List[str] = []
         if modifier is not None:
@@ -7962,7 +7962,7 @@ class CPPDomain(Domain):
             objtypes = self.objtypes_for_role(typ)
             if objtypes:
                 return declTyp in objtypes
-            print("Type is %s, declaration type is %s" % (typ, declTyp))
+            print("Type is {}, declaration type is {}".format(typ, declTyp))
             raise AssertionError()
         if not checkType():
             logger.warning("cpp:%s targets a %s (%s).",

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -129,7 +129,7 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
     """Parse type annotation."""
     def unparse(node: ast.AST) -> List[Node]:
         if isinstance(node, ast.Attribute):
-            return [nodes.Text("%s.%s" % (unparse(node.value)[0], node.attr))]
+            return [nodes.Text("{}.{}".format(unparse(node.value)[0], node.attr))]
         elif isinstance(node, ast.BinOp):
             result: List[Node] = unparse(node.left)
             result.extend(unparse(node.op))
@@ -671,7 +671,7 @@ class PyFunction(PyObject):
                 text = _('%s() (in module %s)') % (name, modname)
                 self.indexnode['entries'].append(('single', text, node_id, '', None))
             else:
-                text = '%s; %s()' % (pairindextypes['builtin'], name)
+                text = '{}; {}()'.format(pairindextypes['builtin'], name)
                 self.indexnode['entries'].append(('pair', text, node_id, '', None))
 
     def get_index_text(self, modname: str, name_cls: Tuple[str, str]) -> str:
@@ -1002,7 +1002,7 @@ class PyModule(SphinxDirective):
             # the platform and synopsis aren't printed; in fact, they are only
             # used in the modindex currently
             ret.append(target)
-            indextext = '%s; %s' % (pairindextypes['module'], modname)
+            indextext = '{}; {}'.format(pairindextypes['module'], modname)
             inode = addnodes.index(entries=[('pair', indextext, node_id, '', None)])
             ret.append(inode)
         return ret

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -129,7 +129,7 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> List[Node]:
     """Parse type annotation."""
     def unparse(node: ast.AST) -> List[Node]:
         if isinstance(node, ast.Attribute):
-            return [nodes.Text("{}.{}".format(unparse(node.value)[0], node.attr))]
+            return [nodes.Text(f"{unparse(node.value)[0]}.{node.attr}")]
         elif isinstance(node, ast.BinOp):
             result: List[Node] = unparse(node.left)
             result.extend(unparse(node.op))

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -508,7 +508,7 @@ class ProductionList(SphinxDirective):
                 self.state.document.note_implicit_target(subnode, subnode)
 
                 if len(productionGroup) != 0:
-                    objName = "%s:%s" % (productionGroup, name)
+                    objName = "{}:{}".format(productionGroup, name)
                 else:
                     objName = name
                 domain.note_object('token', objName, node_id, location=node)

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -508,7 +508,7 @@ class ProductionList(SphinxDirective):
                 self.state.document.note_implicit_target(subnode, subnode)
 
                 if len(productionGroup) != 0:
-                    objName = "{}:{}".format(productionGroup, name)
+                    objName = f"{productionGroup}:{name}"
                 else:
                     objName = name
                 domain.note_object('token', objName, node_id, location=node)

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -240,14 +240,14 @@ class BuildEnvironment:
                 extension = extensions[0]
             else:
                 extension = '%d' % (len(extensions),)
-            self.config_status_extra = ' ({!r})'.format(extension)
+            self.config_status_extra = f' ({extension!r})'
         else:
             # check if a config value was changed that affects how
             # doctrees are read
             for item in config.filter('env'):
                 if self.config[item.name] != item.value:
                     self.config_status = CONFIG_CHANGED
-                    self.config_status_extra = ' ({!r})'.format(item.name)
+                    self.config_status_extra = f' ({item.name!r})'
                     break
 
         self.config = config

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -240,14 +240,14 @@ class BuildEnvironment:
                 extension = extensions[0]
             else:
                 extension = '%d' % (len(extensions),)
-            self.config_status_extra = ' (%r)' % (extension,)
+            self.config_status_extra = ' ({!r})'.format(extension)
         else:
             # check if a config value was changed that affects how
             # doctrees are read
             for item in config.filter('env'):
                 if self.config[item.name] != item.value:
                     self.config_status = CONFIG_CHANGED
-                    self.config_status_extra = ' (%r)' % (item.name,)
+                    self.config_status_extra = ' ({!r})'.format(item.name)
                     break
 
         self.config = config

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -56,14 +56,14 @@ class ExtensionError(SphinxError):
 
     def __repr__(self) -> str:
         if self.orig_exc:
-            return '%s(%r, %r)' % (self.__class__.__name__,
+            return '{}({!r}, {!r})'.format(self.__class__.__name__,
                                    self.message, self.orig_exc)
-        return '%s(%r)' % (self.__class__.__name__, self.message)
+        return '{}({!r})'.format(self.__class__.__name__, self.message)
 
     def __str__(self) -> str:
         parent_str = super().__str__()
         if self.orig_exc:
-            return '%s (exception: %s)' % (parent_str, self.orig_exc)
+            return '{} (exception: {})'.format(parent_str, self.orig_exc)
         return parent_str
 
 

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -56,8 +56,10 @@ class ExtensionError(SphinxError):
 
     def __repr__(self) -> str:
         if self.orig_exc:
-            return '{}({!r}, {!r})'.format(self.__class__.__name__,
-                                   self.message, self.orig_exc)
+            return '{}({!r}, {!r})'.format(
+                self.__class__.__name__,
+                self.message, self.orig_exc
+            )
         return f'{self.__class__.__name__}({self.message!r})'
 
     def __str__(self) -> str:

--- a/sphinx/errors.py
+++ b/sphinx/errors.py
@@ -58,12 +58,12 @@ class ExtensionError(SphinxError):
         if self.orig_exc:
             return '{}({!r}, {!r})'.format(self.__class__.__name__,
                                    self.message, self.orig_exc)
-        return '{}({!r})'.format(self.__class__.__name__, self.message)
+        return f'{self.__class__.__name__}({self.message!r})'
 
     def __str__(self) -> str:
         parent_str = super().__str__()
         if self.orig_exc:
-            return '{} (exception: {})'.format(parent_str, self.orig_exc)
+            return f'{parent_str} (exception: {self.orig_exc})'
         return parent_str
 
 

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -72,7 +72,7 @@ def write_file(name: str, text: str, opts: Any) -> None:
     """Write the output file for module/package <name>."""
     quiet = getattr(opts, 'quiet', None)
 
-    fname = path.join(opts.destdir, '{}.{}'.format(name, opts.suffix))
+    fname = path.join(opts.destdir, f'{name}.{opts.suffix}')
     if opts.dryrun:
         if not quiet:
             print(__('Would create file %s.') % fname)

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -72,7 +72,7 @@ def write_file(name: str, text: str, opts: Any) -> None:
     """Write the output file for module/package <name>."""
     quiet = getattr(opts, 'quiet', None)
 
-    fname = path.join(opts.destdir, '%s.%s' % (name, opts.suffix))
+    fname = path.join(opts.destdir, '{}.{}'.format(name, opts.suffix))
     if opts.dryrun:
         if not quiet:
             print(__('Would create file %s.') % fname)

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -512,9 +512,9 @@ class Documenter:
         sourcename = self.get_sourcename()
 
         # one signature per line, indented by column
-        prefix = '.. {}:{}:: '.format(domain, directive)
+        prefix = f'.. {domain}:{directive}:: '
         for i, sig_line in enumerate(sig.split("\n")):
-            self.add_line('{}{}{}'.format(prefix, name, sig_line),
+            self.add_line(f'{prefix}{name}{sig_line}',
                           sourcename)
             if i == 0:
                 prefix = " " * len(prefix)
@@ -559,12 +559,12 @@ class Documenter:
                 inspect.safe_getattr(self.object, '__qualname__', None)):
             # Get the correct location of docstring from self.object
             # to support inherited methods
-            fullname = '{}.{}'.format(self.object.__module__, self.object.__qualname__)
+            fullname = f'{self.object.__module__}.{self.object.__qualname__}'
         else:
             fullname = self.fullname
 
         if self.analyzer:
-            return '{}:docstring of {}'.format(self.analyzer.srcname, fullname)
+            return f'{self.analyzer.srcname}:docstring of {fullname}'
         else:
             return 'docstring of %s' % fullname
 
@@ -1204,7 +1204,7 @@ class DocstringSignatureMixin:
                     result = args, retann
                 else:
                     # subsequent signatures
-                    self._signatures.append("({}) -> {}".format(args, retann))
+                    self._signatures.append(f"({args}) -> {retann}")
 
             if result:
                 # finish the loop when signature found

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -512,9 +512,9 @@ class Documenter:
         sourcename = self.get_sourcename()
 
         # one signature per line, indented by column
-        prefix = '.. %s:%s:: ' % (domain, directive)
+        prefix = '.. {}:{}:: '.format(domain, directive)
         for i, sig_line in enumerate(sig.split("\n")):
-            self.add_line('%s%s%s' % (prefix, name, sig_line),
+            self.add_line('{}{}{}'.format(prefix, name, sig_line),
                           sourcename)
             if i == 0:
                 prefix = " " * len(prefix)
@@ -559,12 +559,12 @@ class Documenter:
                 inspect.safe_getattr(self.object, '__qualname__', None)):
             # Get the correct location of docstring from self.object
             # to support inherited methods
-            fullname = '%s.%s' % (self.object.__module__, self.object.__qualname__)
+            fullname = '{}.{}'.format(self.object.__module__, self.object.__qualname__)
         else:
             fullname = self.fullname
 
         if self.analyzer:
-            return '%s:docstring of %s' % (self.analyzer.srcname, fullname)
+            return '{}:docstring of {}'.format(self.analyzer.srcname, fullname)
         else:
             return 'docstring of %s' % fullname
 
@@ -1204,7 +1204,7 @@ class DocstringSignatureMixin:
                     result = args, retann
                 else:
                     # subsequent signatures
-                    self._signatures.append("(%s) -> %s" % (args, retann))
+                    self._signatures.append("({}) -> {}".format(args, retann))
 
             if result:
                 # finish the loop when signature found

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -21,7 +21,7 @@ def mangle(subject: Any, name: str) -> str:
     """Mangle the given name."""
     try:
         if isclass(subject) and name.startswith('__') and not name.endswith('__'):
-            return "_{}{}".format(subject.__name__, name)
+            return f"_{subject.__name__}{name}"
     except AttributeError:
         pass
 
@@ -115,7 +115,7 @@ def import_object(modname: str, objpath: List[str], objtype: str = '',
             errmsg = ('autodoc: failed to import %s %r from module %r' %
                       (objtype, '.'.join(objpath), modname))
         else:
-            errmsg = 'autodoc: failed to import {} {!r}'.format(objtype, modname)
+            errmsg = f'autodoc: failed to import {objtype} {modname!r}'
 
         if isinstance(exc, ImportError):
             # import_module() raises ImportError having real exception obj and

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -21,7 +21,7 @@ def mangle(subject: Any, name: str) -> str:
     """Mangle the given name."""
     try:
         if isclass(subject) and name.startswith('__') and not name.endswith('__'):
-            return "_%s%s" % (subject.__name__, name)
+            return "_{}{}".format(subject.__name__, name)
     except AttributeError:
         pass
 
@@ -115,7 +115,7 @@ def import_object(modname: str, objpath: List[str], objtype: str = '',
             errmsg = ('autodoc: failed to import %s %r from module %r' %
                       (objtype, '.'.join(objpath), modname))
         else:
-            errmsg = 'autodoc: failed to import %s %r' % (objtype, modname)
+            errmsg = 'autodoc: failed to import {} {!r}'.format(objtype, modname)
 
         if isinstance(exc, ImportError):
             # import_module() raises ImportError having real exception obj and

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -316,7 +316,7 @@ class Autosummary(SphinxDirective):
             try:
                 real_name, obj, parent, modname = self.import_by_name(name, prefixes=prefixes)
             except ImportExceptionGroup as exc:
-                errors = list({"* {}: {}".format(type(e).__name__, e) for e in exc.exceptions})
+                errors = list({f"* {type(e).__name__}: {e}" for e in exc.exceptions})
                 logger.warning(__('autosummary: failed to import %s.\nPossible hints:\n%s'),
                                name, '\n'.join(errors), location=self.get_location())
                 continue
@@ -414,9 +414,9 @@ class Autosummary(SphinxDirective):
         for name, sig, summary, real_name in items:
             qualifier = 'obj'
             if 'nosignatures' not in self.options:
-                col1 = ':py:{}:`{} <{}>`\\ {}'.format(qualifier, name, real_name, rst.escape(sig))
+                col1 = f':py:{qualifier}:`{name} <{real_name}>`\\ {rst.escape(sig)}'
             else:
-                col1 = ':py:{}:`{} <{}>`'.format(qualifier, name, real_name)
+                col1 = f':py:{qualifier}:`{name} <{real_name}>`'
             col2 = summary
             append_row(col1, col2)
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -316,7 +316,7 @@ class Autosummary(SphinxDirective):
             try:
                 real_name, obj, parent, modname = self.import_by_name(name, prefixes=prefixes)
             except ImportExceptionGroup as exc:
-                errors = list({"* %s: %s" % (type(e).__name__, e) for e in exc.exceptions})
+                errors = list({"* {}: {}".format(type(e).__name__, e) for e in exc.exceptions})
                 logger.warning(__('autosummary: failed to import %s.\nPossible hints:\n%s'),
                                name, '\n'.join(errors), location=self.get_location())
                 continue
@@ -414,9 +414,9 @@ class Autosummary(SphinxDirective):
         for name, sig, summary, real_name in items:
             qualifier = 'obj'
             if 'nosignatures' not in self.options:
-                col1 = ':py:%s:`%s <%s>`\\ %s' % (qualifier, name, real_name, rst.escape(sig))
+                col1 = ':py:{}:`{} <{}>`\\ {}'.format(qualifier, name, real_name, rst.escape(sig))
             else:
-                col1 = ':py:%s:`%s <%s>`' % (qualifier, name, real_name)
+                col1 = ':py:{}:`{} <{}>`'.format(qualifier, name, real_name)
             col2 = summary
             append_row(col1, col2)
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -404,7 +404,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
                 else:
                     exceptions = exc.exceptions + [exc2]
 
-                errors = list({"* {}: {}".format(type(e).__name__, e) for e in exceptions})
+                errors = list({f"* {type(e).__name__}: {e}" for e in exceptions})
                 logger.warning(__('[autosummary] failed to import %s.\nPossible hints:\n%s'),
                                entry.name, '\n'.join(errors))
                 continue
@@ -468,7 +468,7 @@ def find_autosummary_in_docstring(name: str, filename: str = None) -> List[Autos
     except AttributeError:
         pass
     except ImportExceptionGroup as exc:
-        errors = list({"* {}: {}".format(type(e).__name__, e) for e in exc.exceptions})
+        errors = list({f"* {type(e).__name__}: {e}" for e in exc.exceptions})
         print('Failed to import {}.\nPossible hints:\n{}'.format(name, '\n'.join(errors)))
     except SystemExit:
         print("Failed to import '%s'; the module executes module level "
@@ -537,7 +537,7 @@ def find_autosummary_in_lines(lines: List[str], module: str = None, filename: st
                     name = name[1:]
                 if current_module and \
                    not name.startswith(current_module + '.'):
-                    name = "{}.{}".format(current_module, name)
+                    name = f"{current_module}.{name}"
                 documented.append(AutosummaryEntry(name, toctree, template, recursive))
                 continue
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -404,7 +404,7 @@ def generate_autosummary_docs(sources: List[str], output_dir: str = None,
                 else:
                     exceptions = exc.exceptions + [exc2]
 
-                errors = list({"* %s: %s" % (type(e).__name__, e) for e in exceptions})
+                errors = list({"* {}: {}".format(type(e).__name__, e) for e in exceptions})
                 logger.warning(__('[autosummary] failed to import %s.\nPossible hints:\n%s'),
                                entry.name, '\n'.join(errors))
                 continue
@@ -468,8 +468,8 @@ def find_autosummary_in_docstring(name: str, filename: str = None) -> List[Autos
     except AttributeError:
         pass
     except ImportExceptionGroup as exc:
-        errors = list({"* %s: %s" % (type(e).__name__, e) for e in exc.exceptions})
-        print('Failed to import %s.\nPossible hints:\n%s' % (name, '\n'.join(errors)))
+        errors = list({"* {}: {}".format(type(e).__name__, e) for e in exc.exceptions})
+        print('Failed to import {}.\nPossible hints:\n{}'.format(name, '\n'.join(errors)))
     except SystemExit:
         print("Failed to import '%s'; the module executes module level "
               "statement and it might call sys.exit()." % name)
@@ -537,7 +537,7 @@ def find_autosummary_in_lines(lines: List[str], module: str = None, filename: st
                     name = name[1:]
                 if current_module and \
                    not name.startswith(current_module + '.'):
-                    name = "%s.%s" % (current_module, name)
+                    name = "{}.{}".format(current_module, name)
                 documented.append(AutosummaryEntry(name, toctree, template, recursive))
                 continue
 

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -170,7 +170,7 @@ class CoverageBuilder(Builder):
                     # is not defined in this module
                     continue
 
-                full_name = '{}.{}'.format(mod_name, name)
+                full_name = f'{mod_name}.{name}'
                 if self.ignore_pyobj(full_name):
                     continue
 
@@ -213,7 +213,7 @@ class CoverageBuilder(Builder):
                             if skip_undoc and not attr.__doc__:
                                 # skip methods without docstring if wished
                                 continue
-                            full_attr_name = '{}.{}'.format(full_name, attr_name)
+                            full_attr_name = f'{full_name}.{attr_name}'
                             if self.ignore_pyobj(full_attr_name):
                                 continue
                             if full_attr_name not in objects:

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -170,7 +170,7 @@ class CoverageBuilder(Builder):
                     # is not defined in this module
                     continue
 
-                full_name = '%s.%s' % (mod_name, name)
+                full_name = '{}.{}'.format(mod_name, name)
                 if self.ignore_pyobj(full_name):
                     continue
 
@@ -213,7 +213,7 @@ class CoverageBuilder(Builder):
                             if skip_undoc and not attr.__doc__:
                                 # skip methods without docstring if wished
                                 continue
-                            full_attr_name = '%s.%s' % (full_name, attr_name)
+                            full_attr_name = '{}.{}'.format(full_name, attr_name)
                             if self.ignore_pyobj(full_attr_name):
                                 continue
                             if full_attr_name not in objects:

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -487,7 +487,7 @@ Doctest summary
                 return True
             # simulate a doctest with the code
             sim_doctest = doctest.DocTest(examples, {},
-                                          '{} ({} code)'.format(group.name, what),
+                                          f'{group.name} ({what} code)',
                                           testcodes[0].filename, 0, None)
             sim_doctest.globs = ns
             old_f = runner.failures

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -219,7 +219,7 @@ class TestGroup:
             raise RuntimeError(__('invalid TestCode type'))
 
     def __repr__(self) -> str:
-        return 'TestGroup(name=%r, setup=%r, cleanup=%r, tests=%r)' % (
+        return 'TestGroup(name={!r}, setup={!r}, cleanup={!r}, tests={!r})'.format(
             self.name, self.setup, self.cleanup, self.tests)
 
 
@@ -233,7 +233,7 @@ class TestCode:
         self.options = options or {}
 
     def __repr__(self) -> str:
-        return 'TestCode(%r, %r, filename=%r, lineno=%r, options=%r)' % (
+        return 'TestCode({!r}, {!r}, filename={!r}, lineno={!r}, options={!r})'.format(
             self.code, self.type, self.filename, self.lineno, self.options)
 
 
@@ -487,7 +487,7 @@ Doctest summary
                 return True
             # simulate a doctest with the code
             sim_doctest = doctest.DocTest(examples, {},
-                                          '%s (%s code)' % (group.name, what),
+                                          '{} ({} code)'.format(group.name, what),
                                           testcodes[0].filename, 0, None)
             sim_doctest.globs = ns
             old_f = runner.failures

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -216,7 +216,7 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict, format: str,
     hashkey = (code + str(options) + str(graphviz_dot) +
                str(self.builder.config.graphviz_dot_args)).encode()
 
-    fname = '%s-%s.%s' % (prefix, sha1(hashkey).hexdigest(), format)
+    fname = '{}-{}.{}'.format(prefix, sha1(hashkey).hexdigest(), format)
     relfn = posixpath.join(self.builder.imgpath, fname)
     outfn = path.join(self.builder.outdir, self.builder.imagedir, fname)
 

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -216,7 +216,7 @@ def render_dot(self: SphinxTranslator, code: str, options: Dict, format: str,
     hashkey = (code + str(options) + str(graphviz_dot) +
                str(self.builder.config.graphviz_dot_args)).encode()
 
-    fname = '{}-{}.{}'.format(prefix, sha1(hashkey).hexdigest(), format)
+    fname = f'{prefix}-{sha1(hashkey).hexdigest()}.{format}'
     relfn = posixpath.join(self.builder.imgpath, fname)
     outfn = path.join(self.builder.outdir, self.builder.imagedir, fname)
 

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -227,7 +227,7 @@ def render_math(self: HTMLTranslator, math: str) -> Tuple[str, int]:
                                  self.builder.config,
                                  self.builder.confdir)
 
-    filename = "%s.%s" % (sha1(latex.encode()).hexdigest(), image_format)
+    filename = "{}.{}".format(sha1(latex.encode()).hexdigest(), image_format)
     relfn = posixpath.join(self.builder.imgpath, 'math', filename)
     outfn = path.join(self.builder.outdir, self.builder.imagedir, 'math', filename)
     if path.isfile(outfn):

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -227,7 +227,7 @@ def render_math(self: HTMLTranslator, math: str) -> Tuple[str, int]:
                                  self.builder.config,
                                  self.builder.confdir)
 
-    filename = "{}.{}".format(sha1(latex.encode()).hexdigest(), image_format)
+    filename = f"{sha1(latex.encode()).hexdigest()}.{image_format}"
     relfn = posixpath.join(self.builder.imgpath, 'math', filename)
     outfn = path.join(self.builder.outdir, self.builder.imagedir, 'math', filename)
     if path.isfile(outfn):

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -225,7 +225,7 @@ class InheritanceGraph:
         if module in ('__builtin__', 'builtins'):
             fullname = cls.__name__
         else:
-            fullname = '%s.%s' % (module, cls.__qualname__)
+            fullname = '{}.{}'.format(module, cls.__qualname__)
         if parts == 0:
             result = fullname
         else:

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -225,7 +225,7 @@ class InheritanceGraph:
         if module in ('__builtin__', 'builtins'):
             fullname = cls.__name__
         else:
-            fullname = '{}.{}'.format(module, cls.__qualname__)
+            fullname = f'{module}.{cls.__qualname__}'
         if parts == 0:
             result = fullname
         else:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -141,9 +141,9 @@ def _get_safe_url(url: str) -> str:
     else:
         frags = list(parts)
         if parts.port:
-            frags[1] = '{}@{}:{}'.format(parts.username, parts.hostname, parts.port)
+            frags[1] = f'{parts.username}@{parts.hostname}:{parts.port}'
         else:
-            frags[1] = '{}@{}'.format(parts.username, parts.hostname)
+            frags[1] = f'{parts.username}@{parts.hostname}'
 
         return urlunsplit(frags)
 
@@ -334,7 +334,7 @@ def _resolve_reference_in_domain(env: BuildEnvironment,
         objtypes.append('method')
 
     # the inventory contains domain:type as objtype
-    objtypes = ["{}:{}".format(domain.name, t) for t in objtypes]
+    objtypes = [f"{domain.name}:{t}" for t in objtypes]
 
     # now that the objtypes list is complete we can remove the disabled ones
     if honor_disabled_refs:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -401,7 +401,7 @@ class GoogleDocstring:
     def _format_admonition(self, admonition: str, lines: List[str]) -> List[str]:
         lines = self._strip_empty(lines)
         if len(lines) == 1:
-            return ['.. {}:: {}'.format(admonition, lines[0].strip()), '']
+            return [f'.. {admonition}:: {lines[0].strip()}', '']
         elif lines:
             lines = self._indent(self._dedent(lines), 3)
             return ['.. %s::' % admonition, ''] + lines + ['']
@@ -432,13 +432,13 @@ class GoogleDocstring:
             _desc = self._strip_empty(_desc)
             if any(_desc):
                 _desc = self._fix_field_desc(_desc)
-                field = ':{} {}: '.format(field_role, _name)
+                field = f':{field_role} {_name}: '
                 lines.extend(self._format_block(field, _desc))
             else:
-                lines.append(':{} {}:'.format(field_role, _name))
+                lines.append(f':{field_role} {_name}:')
 
             if _type:
-                lines.append(':{} {}: {}'.format(type_role, _name, _type))
+                lines.append(f':{type_role} {_name}: {_type}')
         return lines + ['']
 
     def _format_field(self, _name: str, _type: str, _desc: List[str]) -> List[str]:
@@ -448,16 +448,16 @@ class GoogleDocstring:
         if _name:
             if _type:
                 if '`' in _type:
-                    field = '**{}** ({}){}'.format(_name, _type, separator)
+                    field = f'**{_name}** ({_type}){separator}'
                 else:
-                    field = '**{}** (*{}*){}'.format(_name, _type, separator)
+                    field = f'**{_name}** (*{_type}*){separator}'
             else:
-                field = '**{}**{}'.format(_name, separator)
+                field = f'**{_name}**{separator}'
         elif _type:
             if '`' in _type:
-                field = '{}{}'.format(_type, separator)
+                field = f'{_type}{separator}'
             else:
-                field = '*{}*{}'.format(_type, separator)
+                field = f'*{_type}*{separator}'
         else:
             field = ''
 
@@ -648,7 +648,7 @@ class GoogleDocstring:
                 field = ':ivar %s: ' % _name
                 lines.extend(self._format_block(field, _desc))
                 if _type:
-                    lines.append(':vartype {}: {}'.format(_name, _type))
+                    lines.append(f':vartype {_name}: {_type}')
             else:
                 lines.append('.. attribute:: ' + _name)
                 if self._opt and 'noindex' in self._opt:
@@ -761,7 +761,7 @@ class GoogleDocstring:
             _type = ' ' + _type if _type else ''
             _desc = self._strip_empty(_desc)
             _descs = ' ' + '\n    '.join(_desc) if any(_desc) else ''
-            lines.append(':raises{}:{}'.format(_type, _descs))
+            lines.append(f':raises{_type}:{_descs}')
         if lines:
             lines.append('')
         return lines
@@ -847,7 +847,7 @@ class GoogleDocstring:
                 q = klass.__qualname__
             except AttributeError:
                 q = klass.__name__
-            return '~{}.{}'.format(q, attr_name)
+            return f'~{q}.{attr_name}'
         return attr_name
 
     def _strip_empty(self, lines: List[str]) -> List[str]:
@@ -1333,7 +1333,7 @@ class NumpyDocstring(GoogleDocstring):
         last_had_desc = True
         for name, desc, role in items:
             if role:
-                link = ':{}:`{}`'.format(role, name)
+                link = f':{role}:`{name}`'
             else:
                 link = ':obj:`%s`' % name
             if desc or last_had_desc:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -401,7 +401,7 @@ class GoogleDocstring:
     def _format_admonition(self, admonition: str, lines: List[str]) -> List[str]:
         lines = self._strip_empty(lines)
         if len(lines) == 1:
-            return ['.. %s:: %s' % (admonition, lines[0].strip()), '']
+            return ['.. {}:: {}'.format(admonition, lines[0].strip()), '']
         elif lines:
             lines = self._indent(self._dedent(lines), 3)
             return ['.. %s::' % admonition, ''] + lines + ['']
@@ -432,13 +432,13 @@ class GoogleDocstring:
             _desc = self._strip_empty(_desc)
             if any(_desc):
                 _desc = self._fix_field_desc(_desc)
-                field = ':%s %s: ' % (field_role, _name)
+                field = ':{} {}: '.format(field_role, _name)
                 lines.extend(self._format_block(field, _desc))
             else:
-                lines.append(':%s %s:' % (field_role, _name))
+                lines.append(':{} {}:'.format(field_role, _name))
 
             if _type:
-                lines.append(':%s %s: %s' % (type_role, _name, _type))
+                lines.append(':{} {}: {}'.format(type_role, _name, _type))
         return lines + ['']
 
     def _format_field(self, _name: str, _type: str, _desc: List[str]) -> List[str]:
@@ -448,16 +448,16 @@ class GoogleDocstring:
         if _name:
             if _type:
                 if '`' in _type:
-                    field = '**%s** (%s)%s' % (_name, _type, separator)
+                    field = '**{}** ({}){}'.format(_name, _type, separator)
                 else:
-                    field = '**%s** (*%s*)%s' % (_name, _type, separator)
+                    field = '**{}** (*{}*){}'.format(_name, _type, separator)
             else:
-                field = '**%s**%s' % (_name, separator)
+                field = '**{}**{}'.format(_name, separator)
         elif _type:
             if '`' in _type:
-                field = '%s%s' % (_type, separator)
+                field = '{}{}'.format(_type, separator)
             else:
-                field = '*%s*%s' % (_type, separator)
+                field = '*{}*{}'.format(_type, separator)
         else:
             field = ''
 
@@ -648,7 +648,7 @@ class GoogleDocstring:
                 field = ':ivar %s: ' % _name
                 lines.extend(self._format_block(field, _desc))
                 if _type:
-                    lines.append(':vartype %s: %s' % (_name, _type))
+                    lines.append(':vartype {}: {}'.format(_name, _type))
             else:
                 lines.append('.. attribute:: ' + _name)
                 if self._opt and 'noindex' in self._opt:
@@ -761,7 +761,7 @@ class GoogleDocstring:
             _type = ' ' + _type if _type else ''
             _desc = self._strip_empty(_desc)
             _descs = ' ' + '\n    '.join(_desc) if any(_desc) else ''
-            lines.append(':raises%s:%s' % (_type, _descs))
+            lines.append(':raises{}:{}'.format(_type, _descs))
         if lines:
             lines.append('')
         return lines
@@ -847,7 +847,7 @@ class GoogleDocstring:
                 q = klass.__qualname__
             except AttributeError:
                 q = klass.__name__
-            return '~%s.%s' % (q, attr_name)
+            return '~{}.{}'.format(q, attr_name)
         return attr_name
 
     def _strip_empty(self, lines: List[str]) -> List[str]:
@@ -1333,7 +1333,7 @@ class NumpyDocstring(GoogleDocstring):
         last_had_desc = True
         for name, desc, role in items:
             if role:
-                link = ':%s:`%s`' % (role, name)
+                link = ':{}:`{}`'.format(role, name)
             else:
                 link = ':obj:`%s`' % name
             if desc or last_had_desc:

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -213,7 +213,7 @@ def should_generate_module_page(app: Sphinx, modname: str) -> bool:
         if path.getmtime(module_filename) <= path.getmtime(page_filename):
             # generation is not needed if the HTML page is newer than module file.
             return False
-    except IOError:
+    except OSError:
         pass
 
     return True
@@ -305,7 +305,7 @@ def collect_pages(app: Sphinx) -> Generator[Tuple[str, Dict[str, Any], str], Non
                 stack.pop()
                 html.append('</ul>')
             stack.append(modname + '.')
-        html.append('<li><a href="%s">%s</a></li>\n' % (
+        html.append('<li><a href="{}">{}</a></li>\n'.format(
             urito(posixpath.join(OUTPUT_DIRNAME, 'index'),
                   posixpath.join(OUTPUT_DIRNAME, modname.replace('.', '/'))),
             modname))

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -103,7 +103,7 @@ class idgen:
 def warning(context: Dict, message: str, *args: Any, **kwargs: Any) -> str:
     if 'pagename' in context:
         filename = context.get('pagename') + context.get('file_suffix', '')
-        message = 'in rendering %s: %s' % (filename, message)
+        message = 'in rendering {}: {}'.format(filename, message)
     logger = logging.getLogger('sphinx.themes')
     logger.warning(message, *args, **kwargs)
     return ''  # return empty string not to output any values

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -103,7 +103,7 @@ class idgen:
 def warning(context: Dict, message: str, *args: Any, **kwargs: Any) -> str:
     if 'pagename' in context:
         filename = context.get('pagename') + context.get('file_suffix', '')
-        message = 'in rendering {}: {}'.format(filename, message)
+        message = f'in rendering {filename}: {message}'
     logger = logging.getLogger('sphinx.themes')
     logger.warning(message, *args, **kwargs)
     return ''  # return empty string not to output any values

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -156,7 +156,7 @@ class ModuleAnalyzer:
             self.tagorder = parser.deforders
             self._analyzed = True
         except Exception as exc:
-            raise PycodeError('parsing {!r} failed: {!r}'.format(self.srcname, exc)) from exc
+            raise PycodeError(f'parsing {self.srcname!r} failed: {exc!r}') from exc
 
     def find_attr_docs(self) -> Dict[Tuple[str, str], List[str]]:
         """Find class and module-level attributes and their documentation."""

--- a/sphinx/pycode/__init__.py
+++ b/sphinx/pycode/__init__.py
@@ -156,7 +156,7 @@ class ModuleAnalyzer:
             self.tagorder = parser.deforders
             self._analyzed = True
         except Exception as exc:
-            raise PycodeError('parsing %r failed: %r' % (self.srcname, exc)) from exc
+            raise PycodeError('parsing {!r} failed: {!r}'.format(self.srcname, exc)) from exc
 
     def find_attr_docs(self) -> Dict[Tuple[str, str], List[str]]:
         """Find class and module-level attributes and their documentation."""

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -81,11 +81,11 @@ class _UnparseVisitor(ast.NodeVisitor):
     def _visit_op(self, node: ast.AST) -> str:
         return OPERATORS[node.__class__]
     for _op in OPERATORS:
-        locals()['visit_{}'.format(_op.__name__)] = _visit_op
+        locals()[f'visit_{_op.__name__}'] = _visit_op
 
     def visit_arg(self, node: ast.arg) -> str:
         if node.annotation:
-            return "%s: %s" % (node.arg, self.visit(node.annotation))
+            return "{}: {}".format(node.arg, self.visit(node.annotation))
         else:
             return node.arg
 
@@ -138,7 +138,7 @@ class _UnparseVisitor(ast.NodeVisitor):
         return ", ".join(args)
 
     def visit_Attribute(self, node: ast.Attribute) -> str:
-        return "%s.%s" % (self.visit(node.value), node.attr)
+        return "{}.{}".format(self.visit(node.value), node.attr)
 
     def visit_BinOp(self, node: ast.BinOp) -> str:
         # Special case ``**`` to not have surrounding spaces.
@@ -152,8 +152,8 @@ class _UnparseVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> str:
         args = ([self.visit(e) for e in node.args] +
-                ["%s=%s" % (k.arg, self.visit(k.value)) for k in node.keywords])
-        return "%s(%s)" % (self.visit(node.func), ", ".join(args))
+                ["{}={}".format(k.arg, self.visit(k.value)) for k in node.keywords])
+        return "{}({})".format(self.visit(node.func), ", ".join(args))
 
     def visit_Constant(self, node: ast.Constant) -> str:  # type: ignore
         if node.value is Ellipsis:
@@ -197,19 +197,19 @@ class _UnparseVisitor(ast.NodeVisitor):
 
         if is_simple_tuple(node.slice):
             elts = ", ".join(self.visit(e) for e in node.slice.elts)  # type: ignore
-            return "%s[%s]" % (self.visit(node.value), elts)
+            return "{}[{}]".format(self.visit(node.value), elts)
         elif isinstance(node.slice, ast.Index) and is_simple_tuple(node.slice.value):
             elts = ", ".join(self.visit(e) for e in node.slice.value.elts)  # type: ignore
-            return "%s[%s]" % (self.visit(node.value), elts)
+            return "{}[{}]".format(self.visit(node.value), elts)
         else:
-            return "%s[%s]" % (self.visit(node.value), self.visit(node.slice))
+            return "{}[{}]".format(self.visit(node.value), self.visit(node.slice))
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> str:
         # UnaryOp is one of {UAdd, USub, Invert, Not}, which refer to ``+x``,
         # ``-x``, ``~x``, and ``not x``. Only Not needs a space.
         if isinstance(node.op, ast.Not):
-            return "%s %s" % (self.visit(node.op), self.visit(node.operand))
-        return "%s%s" % (self.visit(node.op), self.visit(node.operand))
+            return "{} {}".format(self.visit(node.op), self.visit(node.operand))
+        return "{}{}".format(self.visit(node.op), self.visit(node.operand))
 
     def visit_Tuple(self, node: ast.Tuple) -> str:
         if len(node.elts) == 0:

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -85,7 +85,7 @@ class _UnparseVisitor(ast.NodeVisitor):
 
     def visit_arg(self, node: ast.arg) -> str:
         if node.annotation:
-            return "{}: {}".format(node.arg, self.visit(node.annotation))
+            return f"{node.arg}: {self.visit(node.annotation)}"
         else:
             return node.arg
 
@@ -138,7 +138,7 @@ class _UnparseVisitor(ast.NodeVisitor):
         return ", ".join(args)
 
     def visit_Attribute(self, node: ast.Attribute) -> str:
-        return "{}.{}".format(self.visit(node.value), node.attr)
+        return f"{self.visit(node.value)}.{node.attr}"
 
     def visit_BinOp(self, node: ast.BinOp) -> str:
         # Special case ``**`` to not have surrounding spaces.
@@ -152,7 +152,7 @@ class _UnparseVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> str:
         args = ([self.visit(e) for e in node.args] +
-                ["{}={}".format(k.arg, self.visit(k.value)) for k in node.keywords])
+                [f"{k.arg}={self.visit(k.value)}" for k in node.keywords])
         return "{}({})".format(self.visit(node.func), ", ".join(args))
 
     def visit_Constant(self, node: ast.Constant) -> str:  # type: ignore
@@ -197,19 +197,19 @@ class _UnparseVisitor(ast.NodeVisitor):
 
         if is_simple_tuple(node.slice):
             elts = ", ".join(self.visit(e) for e in node.slice.elts)  # type: ignore
-            return "{}[{}]".format(self.visit(node.value), elts)
+            return f"{self.visit(node.value)}[{elts}]"
         elif isinstance(node.slice, ast.Index) and is_simple_tuple(node.slice.value):
             elts = ", ".join(self.visit(e) for e in node.slice.value.elts)  # type: ignore
-            return "{}[{}]".format(self.visit(node.value), elts)
+            return f"{self.visit(node.value)}[{elts}]"
         else:
-            return "{}[{}]".format(self.visit(node.value), self.visit(node.slice))
+            return f"{self.visit(node.value)}[{self.visit(node.slice)}]"
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> str:
         # UnaryOp is one of {UAdd, USub, Invert, Not}, which refer to ``+x``,
         # ``-x``, ``~x``, and ``not x``. Only Not needs a space.
         if isinstance(node.op, ast.Not):
-            return "{} {}".format(self.visit(node.op), self.visit(node.operand))
-        return "{}{}".format(self.visit(node.op), self.visit(node.operand))
+            return f"{self.visit(node.op)} {self.visit(node.operand)}"
+        return f"{self.visit(node.op)}{self.visit(node.operand)}"
 
     def visit_Tuple(self, node: ast.Tuple) -> str:
         if len(node.elts) == 0:

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -112,7 +112,7 @@ class Token:
         return any(self == candidate for candidate in conditions)
 
     def __repr__(self) -> str:
-        return '<Token kind=%r value=%r>' % (tokenize.tok_name[self.kind],
+        return '<Token kind={!r} value={!r}>'.format(tokenize.tok_name[self.kind],
                                              self.value.strip())
 
 
@@ -346,7 +346,7 @@ class VariableCommentPicker(ast.NodeVisitor):
         """Handles Assign node and pick up a variable comment."""
         try:
             targets = get_assign_targets(node)
-            varnames: List[str] = sum([get_lvar_names(t, self=self.get_self()) for t in targets], [])  # NOQA
+            varnames: List[str] = sum((get_lvar_names(t, self=self.get_self()) for t in targets), [])  # NOQA
             current_line = self.get_line(node.lineno)
         except TypeError:
             return  # this assignment is not new definition!

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -112,8 +112,10 @@ class Token:
         return any(self == candidate for candidate in conditions)
 
     def __repr__(self) -> str:
-        return '<Token kind={!r} value={!r}>'.format(tokenize.tok_name[self.kind],
-                                             self.value.strip())
+        return '<Token kind={!r} value={!r}>'.format(
+            tokenize.tok_name[self.kind],
+            self.value.strip()
+        )
 
 
 class TokenProcessor:

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -96,7 +96,7 @@ class XRefRole(ReferenceRole):
             self.classes = ['xref', self.reftype]
         else:
             self.refdomain, self.reftype = self.name.split(':', 1)
-            self.classes = ['xref', self.refdomain, '%s-%s' % (self.refdomain, self.reftype)]
+            self.classes = ['xref', self.refdomain, '{}-{}'.format(self.refdomain, self.reftype)]
 
         if self.disabled:
             return self.create_non_xref_node()

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -96,7 +96,7 @@ class XRefRole(ReferenceRole):
             self.classes = ['xref', self.reftype]
         else:
             self.refdomain, self.reftype = self.name.split(':', 1)
-            self.classes = ['xref', self.refdomain, '{}-{}'.format(self.refdomain, self.reftype)]
+            self.classes = ['xref', self.refdomain, f'{self.refdomain}-{self.reftype}']
 
         if self.disabled:
             return self.create_non_xref_node()

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -369,7 +369,7 @@ class IndexBuilder:
                     titleterms=title_terms, envversion=self.env.version)
 
     def label(self) -> str:
-        return "{} (code: {})".format(self.lang.language_name, self.lang.lang)
+        return f"{self.lang.language_name} (code: {self.lang.lang})"
 
     def prune(self, docnames: Iterable[str]) -> None:
         """Remove data for all docnames not in the list."""

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -351,7 +351,7 @@ class IndexBuilder:
                     if fn in fn2index:
                         rv[k] = fn2index[fn]
                 else:
-                    rv[k] = sorted([fn2index[fn] for fn in v if fn in fn2index])
+                    rv[k] = sorted(fn2index[fn] for fn in v if fn in fn2index)
         return rvs
 
     def freeze(self) -> Dict[str, Any]:
@@ -369,7 +369,7 @@ class IndexBuilder:
                     titleterms=title_terms, envversion=self.env.version)
 
     def label(self) -> str:
-        return "%s (code: %s)" % (self.lang.language_name, self.lang.lang)
+        return "{} (code: {})".format(self.lang.language_name, self.lang.lang)
 
     def prune(self, docnames: Iterable[str]) -> None:
         """Remove data for all docnames not in the list."""

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -205,4 +205,4 @@ class path(str):
     __div__ = __truediv__ = joinpath
 
     def __repr__(self) -> str:
-        return '%s(%s)' % (self.__class__.__name__, super().__repr__())
+        return '{}({})'.format(self.__class__.__name__, super().__repr__())

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -205,4 +205,4 @@ class path(str):
     __div__ = __truediv__ = joinpath
 
     def __repr__(self) -> str:
-        return '{}({})'.format(self.__class__.__name__, super().__repr__())
+        return f'{self.__class__.__name__}({super().__repr__()})'

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -24,17 +24,17 @@ __all__ = [
 
 def assert_re_search(regex: Pattern, text: str, flags: int = 0) -> None:
     if not re.search(regex, text, flags):
-        raise AssertionError('{!r} did not match {!r}'.format(regex, text))
+        raise AssertionError(f'{regex!r} did not match {text!r}')
 
 
 def assert_not_re_search(regex: Pattern, text: str, flags: int = 0) -> None:
     if re.search(regex, text, flags):
-        raise AssertionError('{!r} did match {!r}'.format(regex, text))
+        raise AssertionError(f'{regex!r} did match {text!r}')
 
 
 def assert_startswith(thing: str, prefix: str) -> None:
     if not thing.startswith(prefix):
-        raise AssertionError('{!r} does not start with {!r}'.format(thing, prefix))
+        raise AssertionError(f'{thing!r} does not start with {prefix!r}')
 
 
 def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> None:
@@ -59,10 +59,10 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
                 path = xpath + "[%d]" % i
                 assert_node(node[i], nodecls, xpath=path, **kwargs)
         elif isinstance(cls, str):
-            assert node == cls, 'The node {!r} is not {!r}: {!r}'.format(xpath, cls, node)
+            assert node == cls, f'The node {xpath!r} is not {cls!r}: {node!r}'
         else:
             assert isinstance(node, cls), \
-                'The node{} is not subclass of {!r}: {!r}'.format(xpath, cls, node)
+                f'The node{xpath} is not subclass of {cls!r}: {node!r}'
 
     if kwargs:
         assert isinstance(node, nodes.Element), \
@@ -70,9 +70,9 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
 
         for key, value in kwargs.items():
             assert key in node, \
-                'The node{} does not have {!r} attribute: {!r}'.format(xpath, key, node)
+                f'The node{xpath} does not have {key!r} attribute: {node!r}'
             assert node[key] == value, \
-                'The node{}[{}] is not {!r}: {!r}'.format(xpath, key, value, node[key])
+                f'The node{xpath}[{key}] is not {value!r}: {node[key]!r}'
 
 
 def etree_parse(path: str) -> Any:
@@ -143,7 +143,7 @@ class SphinxTestApp(application.Sphinx):
                 delattr(nodes.GenericNodeVisitor, 'depart_' + method[6:])
 
     def __repr__(self) -> str:
-        return '<{} buildername={!r}>'.format(self.__class__.__name__, self.builder.name)
+        return f'<{self.__class__.__name__} buildername={self.builder.name!r}>'
 
 
 class SphinxTestAppWrapperForSkipBuilding:

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -24,17 +24,17 @@ __all__ = [
 
 def assert_re_search(regex: Pattern, text: str, flags: int = 0) -> None:
     if not re.search(regex, text, flags):
-        raise AssertionError('%r did not match %r' % (regex, text))
+        raise AssertionError('{!r} did not match {!r}'.format(regex, text))
 
 
 def assert_not_re_search(regex: Pattern, text: str, flags: int = 0) -> None:
     if re.search(regex, text, flags):
-        raise AssertionError('%r did match %r' % (regex, text))
+        raise AssertionError('{!r} did match {!r}'.format(regex, text))
 
 
 def assert_startswith(thing: str, prefix: str) -> None:
     if not thing.startswith(prefix):
-        raise AssertionError('%r does not start with %r' % (thing, prefix))
+        raise AssertionError('{!r} does not start with {!r}'.format(thing, prefix))
 
 
 def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> None:
@@ -59,10 +59,10 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
                 path = xpath + "[%d]" % i
                 assert_node(node[i], nodecls, xpath=path, **kwargs)
         elif isinstance(cls, str):
-            assert node == cls, 'The node %r is not %r: %r' % (xpath, cls, node)
+            assert node == cls, 'The node {!r} is not {!r}: {!r}'.format(xpath, cls, node)
         else:
             assert isinstance(node, cls), \
-                'The node%s is not subclass of %r: %r' % (xpath, cls, node)
+                'The node{} is not subclass of {!r}: {!r}'.format(xpath, cls, node)
 
     if kwargs:
         assert isinstance(node, nodes.Element), \
@@ -70,9 +70,9 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
 
         for key, value in kwargs.items():
             assert key in node, \
-                'The node%s does not have %r attribute: %r' % (xpath, key, node)
+                'The node{} does not have {!r} attribute: {!r}'.format(xpath, key, node)
             assert node[key] == value, \
-                'The node%s[%s] is not %r: %r' % (xpath, key, value, node[key])
+                'The node{}[{}] is not {!r}: {!r}'.format(xpath, key, value, node[key])
 
 
 def etree_parse(path: str) -> Any:
@@ -143,7 +143,7 @@ class SphinxTestApp(application.Sphinx):
                 delattr(nodes.GenericNodeVisitor, 'depart_' + method[6:])
 
     def __repr__(self) -> str:
-        return '<%s buildername=%r>' % (self.__class__.__name__, self.builder.name)
+        return '<{} buildername={!r}>'.format(self.__class__.__name__, self.builder.name)
 
 
 class SphinxTestAppWrapperForSkipBuilding:

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -62,7 +62,7 @@ def publish_msgstr(app: "Sphinx", source: str, source_path: str, source_line: in
         parser = app.registry.create_source_parser(app, filetype)
         doc = reader.read(
             source=StringInput(source=source,
-                               source_path="{}:{}:<translated>".format(source_path, source_line)),
+                               source_path=f"{source_path}:{source_line}:<translated>"),
             parser=parser,
             settings=settings,
         )

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -62,7 +62,7 @@ def publish_msgstr(app: "Sphinx", source: str, source_path: str, source_line: in
         parser = app.registry.create_source_parser(app, filetype)
         doc = reader.read(
             source=StringInput(source=source,
-                               source_path="%s:%s:<translated>" % (source_path, source_line)),
+                               source_path="{}:{}:<translated>".format(source_path, source_line)),
             parser=parser,
             settings=settings,
         )

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -138,14 +138,14 @@ class ReferencesResolver(SphinxPostTransform):
                     res = domain.resolve_xref(self.env, refdoc, self.app.builder,
                                               role, target, node, contnode)
                     if res and len(res) > 0 and isinstance(res[0], nodes.Element):
-                        results.append(('%s:%s' % (domain.name, role), res))
+                        results.append(('{}:{}'.format(domain.name, role), res))
         # now, see how many matches we got...
         if not results:
             return None
         if len(results) > 1:
             def stringify(name: str, node: Element) -> str:
                 reftitle = node.get('reftitle', node.astext())
-                return ':%s:`%s`' % (name, reftitle)
+                return ':{}:`{}`'.format(name, reftitle)
             candidates = ' or '.join(stringify(name, role) for name, role in results)
             logger.warning(__('more than one target found for \'any\' cross-'
                               'reference %r: could be %s'), target, candidates,
@@ -166,7 +166,7 @@ class ReferencesResolver(SphinxPostTransform):
         warn = node.get('refwarn')
         if self.config.nitpicky:
             warn = True
-            dtype = '%s:%s' % (domain.name, typ) if domain else typ
+            dtype = '{}:{}'.format(domain.name, typ) if domain else typ
             if self.config.nitpick_ignore:
                 if (dtype, target) in self.config.nitpick_ignore:
                     warn = False

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -138,14 +138,14 @@ class ReferencesResolver(SphinxPostTransform):
                     res = domain.resolve_xref(self.env, refdoc, self.app.builder,
                                               role, target, node, contnode)
                     if res and len(res) > 0 and isinstance(res[0], nodes.Element):
-                        results.append(('{}:{}'.format(domain.name, role), res))
+                        results.append((f'{domain.name}:{role}', res))
         # now, see how many matches we got...
         if not results:
             return None
         if len(results) > 1:
             def stringify(name: str, node: Element) -> str:
                 reftitle = node.get('reftitle', node.astext())
-                return ':{}:`{}`'.format(name, reftitle)
+                return f':{name}:`{reftitle}`'
             candidates = ' or '.join(stringify(name, role) for name, role in results)
             logger.warning(__('more than one target found for \'any\' cross-'
                               'reference %r: could be %s'), target, candidates,
@@ -166,7 +166,7 @@ class ReferencesResolver(SphinxPostTransform):
         warn = node.get('refwarn')
         if self.config.nitpicky:
             warn = True
-            dtype = '{}:{}'.format(domain.name, typ) if domain else typ
+            dtype = f'{domain.name}:{typ}' if domain else typ
             if self.config.nitpick_ignore:
                 if (dtype, target) in self.config.nitpick_ignore:
                     warn = False

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -119,7 +119,7 @@ class FilenameUniqDict(dict):
         i = 0
         while uniquename in self._existing:
             i += 1
-            uniquename = '%s%s%s' % (base, i, ext)
+            uniquename = '{}{}{}'.format(base, i, ext)
         self[newfile] = ({docname}, uniquename)
         self._existing.add(uniquename)
         return uniquename
@@ -183,7 +183,7 @@ class DownloadFiles(dict):
     def add_file(self, docname: str, filename: str) -> str:
         if filename not in self:
             digest = md5(filename.encode()).hexdigest()
-            dest = '%s/%s' % (digest, os.path.basename(filename))
+            dest = '{}/{}'.format(digest, os.path.basename(filename))
             self[filename] = (set(), dest)
 
         self[filename][0].add(docname)
@@ -342,7 +342,7 @@ def split_into(n: int, type: str, value: str) -> List[str]:
     """Split an index entry into a given number of parts at semicolons."""
     parts = [x.strip() for x in value.split(';', n - 1)]
     if sum(1 for part in parts if part) < n:
-        raise ValueError('invalid %s index entry %r' % (type, value))
+        raise ValueError('invalid {} index entry {!r}'.format(type, value))
     return parts
 
 
@@ -362,7 +362,7 @@ def split_index_msg(type: str, value: str) -> List[str]:
     elif type == 'seealso':
         result = split_into(2, 'see', value)
     else:
-        raise ValueError('invalid %s index entry %r' % (type, value))
+        raise ValueError('invalid {} index entry {!r}'.format(type, value))
 
     return result
 
@@ -451,7 +451,7 @@ def display_chunk(chunk: Any) -> str:
     if isinstance(chunk, (list, tuple)):
         if len(chunk) == 1:
             return str(chunk[0])
-        return '%s .. %s' % (chunk[0], chunk[-1])
+        return '{} .. {}'.format(chunk[0], chunk[-1])
     return str(chunk)
 
 
@@ -567,5 +567,5 @@ def xmlname_checker() -> Pattern:
 
     start_chars_regex = convert(name_start_chars)
     name_chars_regex = convert(name_chars)
-    return re.compile('(%s)(%s|%s)*' % (
+    return re.compile('({})({}|{})*'.format(
         start_chars_regex, start_chars_regex, name_chars_regex))

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -119,7 +119,7 @@ class FilenameUniqDict(dict):
         i = 0
         while uniquename in self._existing:
             i += 1
-            uniquename = '{}{}{}'.format(base, i, ext)
+            uniquename = f'{base}{i}{ext}'
         self[newfile] = ({docname}, uniquename)
         self._existing.add(uniquename)
         return uniquename
@@ -183,7 +183,7 @@ class DownloadFiles(dict):
     def add_file(self, docname: str, filename: str) -> str:
         if filename not in self:
             digest = md5(filename.encode()).hexdigest()
-            dest = '{}/{}'.format(digest, os.path.basename(filename))
+            dest = f'{digest}/{os.path.basename(filename)}'
             self[filename] = (set(), dest)
 
         self[filename][0].add(docname)
@@ -342,7 +342,7 @@ def split_into(n: int, type: str, value: str) -> List[str]:
     """Split an index entry into a given number of parts at semicolons."""
     parts = [x.strip() for x in value.split(';', n - 1)]
     if sum(1 for part in parts if part) < n:
-        raise ValueError('invalid {} index entry {!r}'.format(type, value))
+        raise ValueError(f'invalid {type} index entry {value!r}')
     return parts
 
 
@@ -362,7 +362,7 @@ def split_index_msg(type: str, value: str) -> List[str]:
     elif type == 'seealso':
         result = split_into(2, 'see', value)
     else:
-        raise ValueError('invalid {} index entry {!r}'.format(type, value))
+        raise ValueError(f'invalid {type} index entry {value!r}')
 
     return result
 
@@ -451,7 +451,7 @@ def display_chunk(chunk: Any) -> str:
     if isinstance(chunk, (list, tuple)):
         if len(chunk) == 1:
             return str(chunk[0])
-        return '{} .. {}'.format(chunk[0], chunk[-1])
+        return f'{chunk[0]} .. {chunk[-1]}'
     return str(chunk)
 
 

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -278,7 +278,7 @@ class BaseParser:
     def status(self, msg: str) -> None:
         # for debugging
         indicator = '-' * self.pos + '^'
-        print("{}\n{}\n{}".format(msg, self.definition, indicator))
+        print(f"{msg}\n{self.definition}\n{indicator}")
 
     def fail(self, msg: str) -> None:
         errors = []

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -278,7 +278,7 @@ class BaseParser:
     def status(self, msg: str) -> None:
         # for debugging
         indicator = '-' * self.pos + '^'
-        print("%s\n%s\n%s" % (msg, self.definition, indicator))
+        print("{}\n{}\n{}".format(msg, self.definition, indicator))
 
     def fail(self, msg: str) -> None:
         errors = []

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -420,7 +420,7 @@ def object_description(object: Any) -> str:
             return "frozenset({%s})" % ", ".join(object_description(x)
                                                  for x in sorted_values)
     elif isinstance(object, enum.Enum):
-        return "{}.{}".format(object.__class__.__name__, object.name)
+        return f"{object.__class__.__name__}.{object.name}"
 
     try:
         s = repr(object)

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -420,7 +420,7 @@ def object_description(object: Any) -> str:
             return "frozenset({%s})" % ", ".join(object_description(x)
                                                  for x in sorted_values)
     elif isinstance(object, enum.Enum):
-        return "%s.%s" % (object.__class__.__name__, object.name)
+        return "{}.{}".format(object.__class__.__name__, object.name)
 
     try:
         s = repr(object)
@@ -728,7 +728,7 @@ def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
         return '(%s)' % ', '.join(args)
     else:
         annotation = stringify_annotation(sig.return_annotation, mode)
-        return '(%s) -> %s' % (', '.join(args), annotation)
+        return '({}) -> {}'.format(', '.join(args), annotation)
 
 
 def signature_from_str(signature: str) -> inspect.Signature:

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -40,13 +40,13 @@ def encode_string(s: str) -> str:
         except KeyError:
             n = ord(s)
             if n < 0x10000:
-                return '\\u{:04x}'.format(n)
+                return f'\\u{n:04x}'
             else:
                 # surrogate pair
                 n -= 0x10000
                 s1 = 0xd800 | ((n >> 10) & 0x3ff)
                 s2 = 0xdc00 | (n & 0x3ff)
-                return '\\u{:04x}\\u{:04x}'.format(s1, s2)
+                return f'\\u{s1:04x}\\u{s2:04x}'
     return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'
 
 

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -40,13 +40,13 @@ def encode_string(s: str) -> str:
         except KeyError:
             n = ord(s)
             if n < 0x10000:
-                return '\\u%04x' % (n,)
+                return '\\u{:04x}'.format(n)
             else:
                 # surrogate pair
                 n -= 0x10000
                 s1 = 0xd800 | ((n >> 10) & 0x3ff)
                 s2 = 0xdc00 | (n & 0x3ff)
-                return '\\u%04x\\u%04x' % (s1, s2)
+                return '\\u{:04x}\\u{:04x}'.format(s1, s2)
     return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'
 
 
@@ -87,7 +87,7 @@ def dumps(obj: Any, key: bool = False) -> str:
     elif isinstance(obj, (int, float)):
         return str(obj)
     elif isinstance(obj, dict):
-        return '{%s}' % ','.join(sorted('%s:%s' % (
+        return '{%s}' % ','.join(sorted('{}:{}'.format(
             dumps(key, True),
             dumps(value)
         ) for key, value in obj.items()))

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -90,7 +90,7 @@ class SphinxLogRecord(logging.LogRecord):
         message = super().getMessage()
         location = getattr(self, 'location', None)
         if location:
-            message = '%s: %s%s' % (location, self.prefix, message)
+            message = '{}: {}{}'.format(location, self.prefix, message)
         elif self.prefix not in message:
             message = self.prefix + message
 
@@ -490,7 +490,7 @@ class SphinxLogRecordTranslator(logging.Filter):
         if isinstance(location, tuple):
             docname, lineno = location
             if docname and lineno:
-                record.location = '%s:%s' % (self.app.env.doc2path(docname), lineno)
+                record.location = '{}:{}'.format(self.app.env.doc2path(docname), lineno)
             elif docname:
                 record.location = '%s' % self.app.env.doc2path(docname)
             else:
@@ -518,7 +518,7 @@ def get_node_location(node: Node) -> Optional[str]:
     if source:
         source = abspath(source)
     if source and line:
-        return "%s:%s" % (source, line)
+        return "{}:{}".format(source, line)
     elif source:
         return "%s:" % source
     elif line:

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -90,7 +90,7 @@ class SphinxLogRecord(logging.LogRecord):
         message = super().getMessage()
         location = getattr(self, 'location', None)
         if location:
-            message = '{}: {}{}'.format(location, self.prefix, message)
+            message = f'{location}: {self.prefix}{message}'
         elif self.prefix not in message:
             message = self.prefix + message
 
@@ -490,7 +490,7 @@ class SphinxLogRecordTranslator(logging.Filter):
         if isinstance(location, tuple):
             docname, lineno = location
             if docname and lineno:
-                record.location = '{}:{}'.format(self.app.env.doc2path(docname), lineno)
+                record.location = f'{self.app.env.doc2path(docname)}:{lineno}'
             elif docname:
                 record.location = '%s' % self.app.env.doc2path(docname)
             else:
@@ -518,7 +518,7 @@ def get_node_location(node: Node) -> Optional[str]:
     if source:
         source = abspath(source)
     if source and line:
-        return "{}:{}".format(source, line)
+        return f"{source}:{line}"
     elif source:
         return "%s:" % source
     elif line:

--- a/sphinx/util/matching.py
+++ b/sphinx/util/matching.py
@@ -47,7 +47,7 @@ def _translate_pattern(pat: str) -> str:
                     stuff = '^/' + stuff[1:]
                 elif stuff[0] == '^':
                     stuff = '\\' + stuff
-                res = '%s[%s]' % (res, stuff)
+                res = '{}[{}]'.format(res, stuff)
         else:
             res += re.escape(c)
     return res + '$'

--- a/sphinx/util/matching.py
+++ b/sphinx/util/matching.py
@@ -47,7 +47,7 @@ def _translate_pattern(pat: str) -> str:
                     stuff = '^/' + stuff[1:]
                 elif stuff[0] == '^':
                     stuff = '\\' + stuff
-                res = '{}[{}]'.format(res, stuff)
+                res = f'{res}[{stuff}]'
         else:
             res += re.escape(c)
     return res + '$'

--- a/sphinx/util/math.py
+++ b/sphinx/util/math.py
@@ -11,7 +11,7 @@ def get_node_equation_number(writer: HTMLTranslator, node: nodes.math_block) -> 
     if writer.builder.config.math_numfig and writer.builder.config.numfig:
         figtype = 'displaymath'
         if writer.builder.name == 'singlehtml':
-            key = "{}/{}".format(writer.docnames[-1], figtype)
+            key = f"{writer.docnames[-1]}/{figtype}"
         else:
             key = figtype
 

--- a/sphinx/util/math.py
+++ b/sphinx/util/math.py
@@ -11,7 +11,7 @@ def get_node_equation_number(writer: HTMLTranslator, node: nodes.math_block) -> 
     if writer.builder.config.math_numfig and writer.builder.config.numfig:
         figtype = 'displaymath'
         if writer.builder.name == 'singlehtml':
-            key = "%s/%s" % (writer.docnames[-1], figtype)
+            key = "{}/{}".format(writer.docnames[-1], figtype)
         else:
             key = figtype
 
@@ -54,4 +54,4 @@ def wrap_displaymath(text: str, label: Optional[str], numbering: bool) -> str:
         for part in parts:
             equations.append('%s\\\\\n' % part.strip())
 
-    return '%s\n%s%s' % (begin, ''.join(equations), end)
+    return '{}\n{}{}'.format(begin, ''.join(equations), end)

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -88,7 +88,7 @@ def get_full_module_name(node: Node) -> str:
     :param nodes.Node node: target node
     :return: full module dotted path
     """
-    return '{}.{}'.format(node.__module__, node.__class__.__name__)
+    return f'{node.__module__}.{node.__class__.__name__}'
 
 
 def repr_domxml(node: Node, length: int = 80) -> str:

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -55,7 +55,7 @@ def heading(env: Environment, text: str, level: int = 1) -> str:
     assert level <= 3
     width = textwidth(text, WIDECHARS[env.language])
     sectioning_char = SECTIONING_CHARS[level - 1]
-    return '{}\n{}'.format(text, sectioning_char * width)
+    return f'{text}\n{sectioning_char * width}'
 
 
 @contextmanager

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -55,7 +55,7 @@ def heading(env: Environment, text: str, level: int = 1) -> str:
     assert level <= 3
     width = textwidth(text, WIDECHARS[env.language])
     sectioning_char = SECTIONING_CHARS[level - 1]
-    return '%s\n%s' % (text, sectioning_char * width)
+    return '{}\n{}'.format(text, sectioning_char * width)
 
 
 @contextmanager

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -146,8 +146,8 @@ def educateQuotes(text: str, language: str = 'en') -> str:
     # Special case if the very first character is a quote
     # followed by punctuation at a non-word-break.
     # Close the quotes by brute force:
-    text = re.sub(r"""^'(?={}\\B)""".format(punct_class), smart.csquote, text)
-    text = re.sub(r"""^"(?={}\\B)""".format(punct_class), smart.cpquote, text)
+    text = re.sub(fr"""^'(?={punct_class}\\B)""", smart.csquote, text)
+    text = re.sub(fr"""^"(?={punct_class}\\B)""", smart.cpquote, text)
 
     # Special case for double sets of quotes, e.g.:
     #   <p>He said, "'Quoted' words in a larger quote."</p>

--- a/sphinx/util/smartypants.py
+++ b/sphinx/util/smartypants.py
@@ -146,8 +146,8 @@ def educateQuotes(text: str, language: str = 'en') -> str:
     # Special case if the very first character is a quote
     # followed by punctuation at a non-word-break.
     # Close the quotes by brute force:
-    text = re.sub(r"""^'(?=%s\\B)""" % (punct_class,), smart.csquote, text)
-    text = re.sub(r"""^"(?=%s\\B)""" % (punct_class,), smart.cpquote, text)
+    text = re.sub(r"""^'(?={}\\B)""".format(punct_class), smart.csquote, text)
+    text = re.sub(r"""^"(?={}\\B)""".format(punct_class), smart.cpquote, text)
 
     # Special case for double sets of quotes, e.g.:
     #   <p>He said, "'Quoted' words in a larger quote."</p>
@@ -168,12 +168,12 @@ def educateQuotes(text: str, language: str = 'en') -> str:
                             &nbsp;      |   # a non-breaking space entity, or
                             --          |   # dashes, or
                             &[mn]dash;  |   # named dash entities
-                            %s          |   # or decimal entities
+                            {}          |   # or decimal entities
                             &\#x201[34];    # or hex
                     )
                     '                 # the quote
                     (?=\w)            # followed by a word character
-                    """ % (dec_dashes,), re.VERBOSE | re.UNICODE)
+                    """.format(dec_dashes), re.VERBOSE | re.UNICODE)
     text = opening_single_quotes_regex.sub(r'\1' + smart.osquote, text)
 
     # In many locales, single closing quotes are different from apostrophe:
@@ -184,20 +184,20 @@ def educateQuotes(text: str, language: str = 'en') -> str:
     # "Ich fass' es nicht."
 
     closing_single_quotes_regex = re.compile(r"""
-                    (%s)
+                    ({})
                     '
                     (?!\s  |       # whitespace
                        s\b |
                         \d         # digits   ('80s)
                     )
-                    """ % (close_class,), re.VERBOSE | re.UNICODE)
+                    """.format(close_class), re.VERBOSE | re.UNICODE)
     text = closing_single_quotes_regex.sub(r'\1' + smart.csquote, text)
 
     closing_single_quotes_regex = re.compile(r"""
-                    (%s)
+                    ({})
                     '
                     (\s | s\b)
-                    """ % (close_class,), re.VERBOSE | re.UNICODE)
+                    """.format(close_class), re.VERBOSE | re.UNICODE)
     text = closing_single_quotes_regex.sub(r'\1%s\2' % smart.csquote, text)
 
     # Any remaining single quotes should be opening ones:
@@ -210,26 +210,26 @@ def educateQuotes(text: str, language: str = 'en') -> str:
                             &nbsp;      |   # a non-breaking space entity, or
                             --          |   # dashes, or
                             &[mn]dash;  |   # named dash entities
-                            %s          |   # or decimal entities
+                            {}          |   # or decimal entities
                             &\#x201[34];    # or hex
                     )
                     "                 # the quote
                     (?=\w)            # followed by a word character
-                    """ % (dec_dashes,), re.VERBOSE)
+                    """.format(dec_dashes), re.VERBOSE)
     text = opening_double_quotes_regex.sub(r'\1' + smart.opquote, text)
 
     # Double closing quotes:
     closing_double_quotes_regex = re.compile(r"""
-                    #(%s)?   # character that indicates the quote should be closing
+                    #({})?   # character that indicates the quote should be closing
                     "
                     (?=\s)
-                    """ % (close_class,), re.VERBOSE)
+                    """.format(close_class), re.VERBOSE)
     text = closing_double_quotes_regex.sub(smart.cpquote, text)
 
     closing_double_quotes_regex = re.compile(r"""
-                    (%s)   # character that indicates the quote should be closing
+                    ({})   # character that indicates the quote should be closing
                     "
-                    """ % (close_class,), re.VERBOSE)
+                    """.format(close_class), re.VERBOSE)
     text = closing_double_quotes_regex.sub(r'\1' + smart.cpquote, text)
 
     # Any remaining quotes should be opening ones.

--- a/sphinx/util/tags.py
+++ b/sphinx/util/tags.py
@@ -30,7 +30,7 @@ class BooleanParser(Parser):
             node = self.parse_expression()
             self.stream.expect('rparen')
         else:
-            self.fail("unexpected token '%s'" % (token,), token.lineno)
+            self.fail("unexpected token '{}'".format(token), token.lineno)
         return node
 
 

--- a/sphinx/util/tags.py
+++ b/sphinx/util/tags.py
@@ -30,7 +30,7 @@ class BooleanParser(Parser):
             node = self.parse_expression()
             self.stream.expect('rparen')
         else:
-            self.fail("unexpected token '{}'".format(token), token.lineno)
+            self.fail(f"unexpected token '{token}'", token.lineno)
         return node
 
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -129,15 +129,15 @@ def restify(cls: Optional[Type], mode: str = 'fully-qualified-except-typing') ->
         elif isinstance(cls, str):
             return cls
         elif ismockmodule(cls):
-            return ':py:class:`{}{}`'.format(modprefix, cls.__name__)
+            return f':py:class:`{modprefix}{cls.__name__}`'
         elif ismock(cls):
-            return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
+            return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
         elif is_invalid_builtin_class(cls):
-            return ':py:class:`{}{}`'.format(modprefix, INVALID_BUILTIN_CLASSES[cls])
+            return f':py:class:`{modprefix}{INVALID_BUILTIN_CLASSES[cls]}`'
         elif inspect.isNewType(cls):
             if sys.version_info > (3, 10):
                 # newtypes have correct module info since Python 3.10+
-                return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
+                return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
             else:
                 return ':py:class:`%s`' % cls.__name__
         elif UnionType and isinstance(cls, UnionType):
@@ -189,9 +189,9 @@ def _restify_py37(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
             text = restify(cls.__origin__, mode)  # type: ignore
         elif getattr(cls, '_name', None):
             if cls.__module__ == 'typing':
-                text = ':py:class:`~{}.{}`'.format(cls.__module__, cls._name)
+                text = f':py:class:`~{cls.__module__}.{cls._name}`'
             else:
-                text = ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls._name)
+                text = f':py:class:`{modprefix}{cls.__module__}.{cls._name}`'
         else:
             text = restify(cls.__origin__, mode)
 
@@ -203,7 +203,7 @@ def _restify_py37(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
             pass
         elif cls.__module__ == 'typing' and cls._name == 'Callable':
             args = ', '.join(restify(a, mode) for a in cls.__args__[:-1])
-            text += r"\ [[{}], {}]".format(args, restify(cls.__args__[-1], mode))
+            text += fr"\ [[{args}], {restify(cls.__args__[-1], mode)}]"
         elif cls.__module__ == 'typing' and getattr(origin, '_name', None) == 'Literal':
             text += r"\ [%s]" % ', '.join(repr(a) for a in cls.__args__)
         elif cls.__args__:
@@ -211,23 +211,23 @@ def _restify_py37(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
 
         return text
     elif isinstance(cls, typing._SpecialForm):
-        return ':py:obj:`~{}.{}`'.format(cls.__module__, cls._name)
+        return f':py:obj:`~{cls.__module__}.{cls._name}`'
     elif sys.version_info >= (3, 11) and cls is typing.Any:
         # handle bpo-46998
         return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
     elif hasattr(cls, '__qualname__'):
         if cls.__module__ == 'typing':
-            return ':py:class:`~{}.{}`'.format(cls.__module__, cls.__qualname__)
+            return f':py:class:`~{cls.__module__}.{cls.__qualname__}`'
         else:
-            return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__qualname__)
+            return f':py:class:`{modprefix}{cls.__module__}.{cls.__qualname__}`'
     elif isinstance(cls, ForwardRef):
         return ':py:class:`%s`' % cls.__forward_arg__
     else:
         # not a class (ex. TypeVar)
         if cls.__module__ == 'typing':
-            return ':py:obj:`~{}.{}`'.format(cls.__module__, cls.__name__)
+            return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
         else:
-            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
+            return f':py:obj:`{modprefix}{cls.__module__}.{cls.__name__}`'
 
 
 def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typing') -> str:
@@ -249,7 +249,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         else:
             qualname = repr(cls).replace('typing.', '')
     elif hasattr(cls, '__qualname__'):
-        qualname = '{}{}.{}'.format(modprefix, module, cls.__qualname__)
+        qualname = f'{modprefix}{module}.{cls.__qualname__}'
     else:
         qualname = repr(cls)
 
@@ -258,7 +258,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         if module == 'typing':
             reftext = ':py:class:`~typing.%s`' % qualname
         else:
-            reftext = ':py:class:`{}{}`'.format(modprefix, qualname)
+            reftext = f':py:class:`{modprefix}{qualname}`'
 
         params = cls.__args__
         if params:
@@ -270,7 +270,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         if module == 'typing':
             reftext = ':py:class:`~typing.%s`' % qualname
         else:
-            reftext = ':py:class:`{}{}`'.format(modprefix, qualname)
+            reftext = f':py:class:`{modprefix}{qualname}`'
 
         if cls.__args__ is None or len(cls.__args__) <= 2:
             params = cls.__args__
@@ -279,7 +279,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         else:  # typing.Callable
             args = ', '.join(restify(arg, mode) for arg in cls.__args__[:-1])
             result = restify(cls.__args__[-1], mode)
-            return reftext + '\\ [[{}], {}]'.format(args, result)
+            return reftext + f'\\ [[{args}], {result}]'
 
         if params:
             param_str = ', '.join(restify(p, mode) for p in params)
@@ -304,27 +304,27 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
             return ':py:obj:`Union`'
     elif hasattr(cls, '__qualname__'):
         if cls.__module__ == 'typing':
-            return ':py:class:`~{}.{}`'.format(cls.__module__, cls.__qualname__)
+            return f':py:class:`~{cls.__module__}.{cls.__qualname__}`'
         else:
-            return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__qualname__)
+            return f':py:class:`{modprefix}{cls.__module__}.{cls.__qualname__}`'
     elif hasattr(cls, '_name'):
         # SpecialForm
         if cls.__module__ == 'typing':
-            return ':py:obj:`~{}.{}`'.format(cls.__module__, cls._name)
+            return f':py:obj:`~{cls.__module__}.{cls._name}`'
         else:
-            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, cls._name)
+            return f':py:obj:`{modprefix}{cls.__module__}.{cls._name}`'
     elif hasattr(cls, '__name__'):
         # not a class (ex. TypeVar)
         if cls.__module__ == 'typing':
-            return ':py:obj:`~{}.{}`'.format(cls.__module__, cls.__name__)
+            return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
         else:
-            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
+            return f':py:obj:`{modprefix}{cls.__module__}.{cls.__name__}`'
     else:
         # others (ex. Any)
         if cls.__module__ == 'typing':
-            return ':py:obj:`~{}.{}`'.format(cls.__module__, qualname)
+            return f':py:obj:`~{cls.__module__}.{qualname}`'
         else:
-            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, qualname)
+            return f':py:obj:`{modprefix}{cls.__module__}.{qualname}`'
 
 
 def stringify(annotation: Any, mode: str = 'fully-qualified-except-typing') -> str:
@@ -363,7 +363,7 @@ def stringify(annotation: Any, mode: str = 'fully-qualified-except-typing') -> s
     elif inspect.isNewType(annotation):
         if sys.version_info > (3, 10):
             # newtypes have correct module info since Python 3.10+
-            return modprefix + '{}.{}'.format(annotation.__module__, annotation.__name__)
+            return modprefix + f'{annotation.__module__}.{annotation.__name__}'
         else:
             return annotation.__name__
     elif not annotation:
@@ -373,7 +373,7 @@ def stringify(annotation: Any, mode: str = 'fully-qualified-except-typing') -> s
     elif ismockmodule(annotation):
         return modprefix + annotation.__name__
     elif ismock(annotation):
-        return modprefix + '{}.{}'.format(annotation.__module__, annotation.__name__)
+        return modprefix + f'{annotation.__module__}.{annotation.__name__}'
     elif is_invalid_builtin_class(annotation):
         return modprefix + INVALID_BUILTIN_CLASSES[annotation]
     elif str(annotation).startswith('typing.Annotated'):  # for py310+
@@ -435,26 +435,26 @@ def _stringify_py37(annotation: Any, mode: str = 'fully-qualified-except-typing'
             if len(annotation.__args__) > 1 and annotation.__args__[-1] is NoneType:
                 if len(annotation.__args__) > 2:
                     args = ', '.join(stringify(a, mode) for a in annotation.__args__[:-1])
-                    return '{}Optional[{}Union[{}]]'.format(modprefix, modprefix, args)
+                    return f'{modprefix}Optional[{modprefix}Union[{args}]]'
                 else:
                     return '{}Optional[{}]'.format(modprefix,
                                                stringify(annotation.__args__[0], mode))
             else:
                 args = ', '.join(stringify(a, mode) for a in annotation.__args__)
-                return '{}Union[{}]'.format(modprefix, args)
+                return f'{modprefix}Union[{args}]'
         elif qualname == 'types.Union':
             if len(annotation.__args__) > 1 and None in annotation.__args__:
                 args = ' | '.join(stringify(a) for a in annotation.__args__ if a)
-                return '{}Optional[{}]'.format(modprefix, args)
+                return f'{modprefix}Optional[{args}]'
             else:
                 return ' | '.join(stringify(a) for a in annotation.__args__)
         elif qualname == 'Callable':
             args = ', '.join(stringify(a, mode) for a in annotation.__args__[:-1])
             returns = stringify(annotation.__args__[-1], mode)
-            return '{}{}[[{}], {}]'.format(modprefix, qualname, args, returns)
+            return f'{modprefix}{qualname}[[{args}], {returns}]'
         elif qualname == 'Literal':
             args = ', '.join(repr(a) for a in annotation.__args__)
-            return '{}{}[{}]'.format(modprefix, qualname, args)
+            return f'{modprefix}{qualname}[{args}]'
         elif str(annotation).startswith('typing.Annotated'):  # for py39+
             return stringify(annotation.__args__[0], mode)
         elif all(is_system_TypeVar(a) for a in annotation.__args__):
@@ -462,7 +462,7 @@ def _stringify_py37(annotation: Any, mode: str = 'fully-qualified-except-typing'
             return modprefix + qualname
         else:
             args = ', '.join(stringify(a, mode) for a in annotation.__args__)
-            return '{}{}[{}]'.format(modprefix, qualname, args)
+            return f'{modprefix}{qualname}[{args}]'
 
     return modprefix + qualname
 
@@ -501,7 +501,7 @@ def _stringify_py36(annotation: Any, mode: str = 'fully-qualified-except-typing'
         params = annotation.__args__
         if params:
             param_str = ', '.join(stringify(p, mode) for p in params)
-            return '{}{}[{}]'.format(modprefix, qualname, param_str)
+            return f'{modprefix}{qualname}[{param_str}]'
         else:
             return modprefix + qualname
     elif isinstance(annotation, typing.GenericMeta):
@@ -514,10 +514,10 @@ def _stringify_py36(annotation: Any, mode: str = 'fully-qualified-except-typing'
             args = ', '.join(stringify(arg, mode) for arg
                              in annotation.__args__[:-1])  # type: ignore
             result = stringify(annotation.__args__[-1])  # type: ignore
-            return '{}{}[[{}], {}]'.format(modprefix, qualname, args, result)
+            return f'{modprefix}{qualname}[[{args}], {result}]'
         if params is not None:
             param_str = ', '.join(stringify(p, mode) for p in params)
-            return '{}{}[{}]'.format(modprefix, qualname, param_str)
+            return f'{modprefix}{qualname}[{param_str}]'
     elif (hasattr(annotation, '__origin__') and
           annotation.__origin__ is typing.Union):
         params = annotation.__args__
@@ -525,12 +525,12 @@ def _stringify_py36(annotation: Any, mode: str = 'fully-qualified-except-typing'
             if len(params) > 1 and params[-1] is NoneType:
                 if len(params) > 2:
                     param_str = ", ".join(stringify(p, mode) for p in params[:-1])
-                    return '{}Optional[{}Union[{}]]'.format(modprefix, modprefix, param_str)
+                    return f'{modprefix}Optional[{modprefix}Union[{param_str}]]'
                 else:
-                    return '{}Optional[{}]'.format(modprefix, stringify(params[0], mode))
+                    return f'{modprefix}Optional[{stringify(params[0], mode)}]'
             else:
                 param_str = ', '.join(stringify(p, mode) for p in params)
-                return '{}Union[{}]'.format(modprefix, param_str)
+                return f'{modprefix}Union[{param_str}]'
 
     return modprefix + qualname
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -437,8 +437,10 @@ def _stringify_py37(annotation: Any, mode: str = 'fully-qualified-except-typing'
                     args = ', '.join(stringify(a, mode) for a in annotation.__args__[:-1])
                     return f'{modprefix}Optional[{modprefix}Union[{args}]]'
                 else:
-                    return '{}Optional[{}]'.format(modprefix,
-                                               stringify(annotation.__args__[0], mode))
+                    return '{}Optional[{}]'.format(
+                        modprefix,
+                        stringify(annotation.__args__[0], mode)
+                    )
             else:
                 args = ', '.join(stringify(a, mode) for a in annotation.__args__)
                 return f'{modprefix}Union[{args}]'

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -129,15 +129,15 @@ def restify(cls: Optional[Type], mode: str = 'fully-qualified-except-typing') ->
         elif isinstance(cls, str):
             return cls
         elif ismockmodule(cls):
-            return ':py:class:`%s%s`' % (modprefix, cls.__name__)
+            return ':py:class:`{}{}`'.format(modprefix, cls.__name__)
         elif ismock(cls):
-            return ':py:class:`%s%s.%s`' % (modprefix, cls.__module__, cls.__name__)
+            return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
         elif is_invalid_builtin_class(cls):
-            return ':py:class:`%s%s`' % (modprefix, INVALID_BUILTIN_CLASSES[cls])
+            return ':py:class:`{}{}`'.format(modprefix, INVALID_BUILTIN_CLASSES[cls])
         elif inspect.isNewType(cls):
             if sys.version_info > (3, 10):
                 # newtypes have correct module info since Python 3.10+
-                return ':py:class:`%s%s.%s`' % (modprefix, cls.__module__, cls.__name__)
+                return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
             else:
                 return ':py:class:`%s`' % cls.__name__
         elif UnionType and isinstance(cls, UnionType):
@@ -148,7 +148,7 @@ def restify(cls: Optional[Type], mode: str = 'fully-qualified-except-typing') ->
                 return ' | '.join(restify(a, mode) for a in cls.__args__)
         elif cls.__module__ in ('__builtin__', 'builtins'):
             if hasattr(cls, '__args__'):
-                return ':py:class:`%s`\\ [%s]' % (
+                return ':py:class:`{}`\\ [{}]'.format(
                     cls.__name__,
                     ', '.join(restify(arg, mode) for arg in cls.__args__),
                 )
@@ -189,9 +189,9 @@ def _restify_py37(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
             text = restify(cls.__origin__, mode)  # type: ignore
         elif getattr(cls, '_name', None):
             if cls.__module__ == 'typing':
-                text = ':py:class:`~%s.%s`' % (cls.__module__, cls._name)
+                text = ':py:class:`~{}.{}`'.format(cls.__module__, cls._name)
             else:
-                text = ':py:class:`%s%s.%s`' % (modprefix, cls.__module__, cls._name)
+                text = ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls._name)
         else:
             text = restify(cls.__origin__, mode)
 
@@ -203,7 +203,7 @@ def _restify_py37(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
             pass
         elif cls.__module__ == 'typing' and cls._name == 'Callable':
             args = ', '.join(restify(a, mode) for a in cls.__args__[:-1])
-            text += r"\ [[%s], %s]" % (args, restify(cls.__args__[-1], mode))
+            text += r"\ [[{}], {}]".format(args, restify(cls.__args__[-1], mode))
         elif cls.__module__ == 'typing' and getattr(origin, '_name', None) == 'Literal':
             text += r"\ [%s]" % ', '.join(repr(a) for a in cls.__args__)
         elif cls.__args__:
@@ -211,23 +211,23 @@ def _restify_py37(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
 
         return text
     elif isinstance(cls, typing._SpecialForm):
-        return ':py:obj:`~%s.%s`' % (cls.__module__, cls._name)
+        return ':py:obj:`~{}.{}`'.format(cls.__module__, cls._name)
     elif sys.version_info >= (3, 11) and cls is typing.Any:
         # handle bpo-46998
         return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
     elif hasattr(cls, '__qualname__'):
         if cls.__module__ == 'typing':
-            return ':py:class:`~%s.%s`' % (cls.__module__, cls.__qualname__)
+            return ':py:class:`~{}.{}`'.format(cls.__module__, cls.__qualname__)
         else:
-            return ':py:class:`%s%s.%s`' % (modprefix, cls.__module__, cls.__qualname__)
+            return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__qualname__)
     elif isinstance(cls, ForwardRef):
         return ':py:class:`%s`' % cls.__forward_arg__
     else:
         # not a class (ex. TypeVar)
         if cls.__module__ == 'typing':
-            return ':py:obj:`~%s.%s`' % (cls.__module__, cls.__name__)
+            return ':py:obj:`~{}.{}`'.format(cls.__module__, cls.__name__)
         else:
-            return ':py:obj:`%s%s.%s`' % (modprefix, cls.__module__, cls.__name__)
+            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
 
 
 def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typing') -> str:
@@ -249,7 +249,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         else:
             qualname = repr(cls).replace('typing.', '')
     elif hasattr(cls, '__qualname__'):
-        qualname = '%s%s.%s' % (modprefix, module, cls.__qualname__)
+        qualname = '{}{}.{}'.format(modprefix, module, cls.__qualname__)
     else:
         qualname = repr(cls)
 
@@ -258,7 +258,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         if module == 'typing':
             reftext = ':py:class:`~typing.%s`' % qualname
         else:
-            reftext = ':py:class:`%s%s`' % (modprefix, qualname)
+            reftext = ':py:class:`{}{}`'.format(modprefix, qualname)
 
         params = cls.__args__
         if params:
@@ -270,7 +270,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         if module == 'typing':
             reftext = ':py:class:`~typing.%s`' % qualname
         else:
-            reftext = ':py:class:`%s%s`' % (modprefix, qualname)
+            reftext = ':py:class:`{}{}`'.format(modprefix, qualname)
 
         if cls.__args__ is None or len(cls.__args__) <= 2:
             params = cls.__args__
@@ -279,7 +279,7 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
         else:  # typing.Callable
             args = ', '.join(restify(arg, mode) for arg in cls.__args__[:-1])
             result = restify(cls.__args__[-1], mode)
-            return reftext + '\\ [[%s], %s]' % (args, result)
+            return reftext + '\\ [[{}], {}]'.format(args, result)
 
         if params:
             param_str = ', '.join(restify(p, mode) for p in params)
@@ -304,27 +304,27 @@ def _restify_py36(cls: Optional[Type], mode: str = 'fully-qualified-except-typin
             return ':py:obj:`Union`'
     elif hasattr(cls, '__qualname__'):
         if cls.__module__ == 'typing':
-            return ':py:class:`~%s.%s`' % (cls.__module__, cls.__qualname__)
+            return ':py:class:`~{}.{}`'.format(cls.__module__, cls.__qualname__)
         else:
-            return ':py:class:`%s%s.%s`' % (modprefix, cls.__module__, cls.__qualname__)
+            return ':py:class:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__qualname__)
     elif hasattr(cls, '_name'):
         # SpecialForm
         if cls.__module__ == 'typing':
-            return ':py:obj:`~%s.%s`' % (cls.__module__, cls._name)
+            return ':py:obj:`~{}.{}`'.format(cls.__module__, cls._name)
         else:
-            return ':py:obj:`%s%s.%s`' % (modprefix, cls.__module__, cls._name)
+            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, cls._name)
     elif hasattr(cls, '__name__'):
         # not a class (ex. TypeVar)
         if cls.__module__ == 'typing':
-            return ':py:obj:`~%s.%s`' % (cls.__module__, cls.__name__)
+            return ':py:obj:`~{}.{}`'.format(cls.__module__, cls.__name__)
         else:
-            return ':py:obj:`%s%s.%s`' % (modprefix, cls.__module__, cls.__name__)
+            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, cls.__name__)
     else:
         # others (ex. Any)
         if cls.__module__ == 'typing':
-            return ':py:obj:`~%s.%s`' % (cls.__module__, qualname)
+            return ':py:obj:`~{}.{}`'.format(cls.__module__, qualname)
         else:
-            return ':py:obj:`%s%s.%s`' % (modprefix, cls.__module__, qualname)
+            return ':py:obj:`{}{}.{}`'.format(modprefix, cls.__module__, qualname)
 
 
 def stringify(annotation: Any, mode: str = 'fully-qualified-except-typing') -> str:
@@ -363,7 +363,7 @@ def stringify(annotation: Any, mode: str = 'fully-qualified-except-typing') -> s
     elif inspect.isNewType(annotation):
         if sys.version_info > (3, 10):
             # newtypes have correct module info since Python 3.10+
-            return modprefix + '%s.%s' % (annotation.__module__, annotation.__name__)
+            return modprefix + '{}.{}'.format(annotation.__module__, annotation.__name__)
         else:
             return annotation.__name__
     elif not annotation:
@@ -373,7 +373,7 @@ def stringify(annotation: Any, mode: str = 'fully-qualified-except-typing') -> s
     elif ismockmodule(annotation):
         return modprefix + annotation.__name__
     elif ismock(annotation):
-        return modprefix + '%s.%s' % (annotation.__module__, annotation.__name__)
+        return modprefix + '{}.{}'.format(annotation.__module__, annotation.__name__)
     elif is_invalid_builtin_class(annotation):
         return modprefix + INVALID_BUILTIN_CLASSES[annotation]
     elif str(annotation).startswith('typing.Annotated'):  # for py310+
@@ -435,26 +435,26 @@ def _stringify_py37(annotation: Any, mode: str = 'fully-qualified-except-typing'
             if len(annotation.__args__) > 1 and annotation.__args__[-1] is NoneType:
                 if len(annotation.__args__) > 2:
                     args = ', '.join(stringify(a, mode) for a in annotation.__args__[:-1])
-                    return '%sOptional[%sUnion[%s]]' % (modprefix, modprefix, args)
+                    return '{}Optional[{}Union[{}]]'.format(modprefix, modprefix, args)
                 else:
-                    return '%sOptional[%s]' % (modprefix,
+                    return '{}Optional[{}]'.format(modprefix,
                                                stringify(annotation.__args__[0], mode))
             else:
                 args = ', '.join(stringify(a, mode) for a in annotation.__args__)
-                return '%sUnion[%s]' % (modprefix, args)
+                return '{}Union[{}]'.format(modprefix, args)
         elif qualname == 'types.Union':
             if len(annotation.__args__) > 1 and None in annotation.__args__:
                 args = ' | '.join(stringify(a) for a in annotation.__args__ if a)
-                return '%sOptional[%s]' % (modprefix, args)
+                return '{}Optional[{}]'.format(modprefix, args)
             else:
                 return ' | '.join(stringify(a) for a in annotation.__args__)
         elif qualname == 'Callable':
             args = ', '.join(stringify(a, mode) for a in annotation.__args__[:-1])
             returns = stringify(annotation.__args__[-1], mode)
-            return '%s%s[[%s], %s]' % (modprefix, qualname, args, returns)
+            return '{}{}[[{}], {}]'.format(modprefix, qualname, args, returns)
         elif qualname == 'Literal':
             args = ', '.join(repr(a) for a in annotation.__args__)
-            return '%s%s[%s]' % (modprefix, qualname, args)
+            return '{}{}[{}]'.format(modprefix, qualname, args)
         elif str(annotation).startswith('typing.Annotated'):  # for py39+
             return stringify(annotation.__args__[0], mode)
         elif all(is_system_TypeVar(a) for a in annotation.__args__):
@@ -462,7 +462,7 @@ def _stringify_py37(annotation: Any, mode: str = 'fully-qualified-except-typing'
             return modprefix + qualname
         else:
             args = ', '.join(stringify(a, mode) for a in annotation.__args__)
-            return '%s%s[%s]' % (modprefix, qualname, args)
+            return '{}{}[{}]'.format(modprefix, qualname, args)
 
     return modprefix + qualname
 
@@ -501,7 +501,7 @@ def _stringify_py36(annotation: Any, mode: str = 'fully-qualified-except-typing'
         params = annotation.__args__
         if params:
             param_str = ', '.join(stringify(p, mode) for p in params)
-            return '%s%s[%s]' % (modprefix, qualname, param_str)
+            return '{}{}[{}]'.format(modprefix, qualname, param_str)
         else:
             return modprefix + qualname
     elif isinstance(annotation, typing.GenericMeta):
@@ -514,10 +514,10 @@ def _stringify_py36(annotation: Any, mode: str = 'fully-qualified-except-typing'
             args = ', '.join(stringify(arg, mode) for arg
                              in annotation.__args__[:-1])  # type: ignore
             result = stringify(annotation.__args__[-1])  # type: ignore
-            return '%s%s[[%s], %s]' % (modprefix, qualname, args, result)
+            return '{}{}[[{}], {}]'.format(modprefix, qualname, args, result)
         if params is not None:
             param_str = ', '.join(stringify(p, mode) for p in params)
-            return '%s%s[%s]' % (modprefix, qualname, param_str)
+            return '{}{}[{}]'.format(modprefix, qualname, param_str)
     elif (hasattr(annotation, '__origin__') and
           annotation.__origin__ is typing.Union):
         params = annotation.__args__
@@ -525,12 +525,12 @@ def _stringify_py36(annotation: Any, mode: str = 'fully-qualified-except-typing'
             if len(params) > 1 and params[-1] is NoneType:
                 if len(params) > 2:
                     param_str = ", ".join(stringify(p, mode) for p in params[:-1])
-                    return '%sOptional[%sUnion[%s]]' % (modprefix, modprefix, param_str)
+                    return '{}Optional[{}Union[{}]]'.format(modprefix, modprefix, param_str)
                 else:
-                    return '%sOptional[%s]' % (modprefix, stringify(params[0], mode))
+                    return '{}Optional[{}]'.format(modprefix, stringify(params[0], mode))
             else:
                 param_str = ', '.join(stringify(p, mode) for p in params)
-                return '%sUnion[%s]' % (modprefix, param_str)
+                return '{}Union[{}]'.format(modprefix, param_str)
 
     return modprefix + qualname
 

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -40,7 +40,7 @@ def multiply_length(length: str, scale: int) -> str:
     else:
         amount, unit = matched.groups()
         result = float(amount) * scale / 100
-        return "%s%s" % (int(result), unit)
+        return "{}{}".format(int(result), unit)
 
 
 class HTMLWriter(Writer):
@@ -175,8 +175,8 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.first_param = 1
         self.optional_param_level = 0
         # How many required parameters are left.
-        self.required_params_left = sum([isinstance(c, addnodes.desc_parameter)
-                                         for c in node.children])
+        self.required_params_left = sum(isinstance(c, addnodes.desc_parameter)
+                                         for c in node.children)
         self.param_separator = node.child_text_separator
 
     def depart_desc_parameterlist(self, node: Element) -> None:
@@ -288,7 +288,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         elif isinstance(node.parent, nodes.section):
             if self.builder.name == 'singlehtml':
                 docname = self.docnames[-1]
-                anchorname = "%s/#%s" % (docname, node.parent['ids'][0])
+                anchorname = "{}/#{}".format(docname, node.parent['ids'][0])
                 if anchorname not in self.builder.secnumbers:
                     anchorname = "%s/" % docname  # try first heading which has no anchor
             else:
@@ -310,7 +310,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
     def add_fignumber(self, node: Element) -> None:
         def append_fignumber(figtype: str, figure_id: str) -> None:
             if self.builder.name == 'singlehtml':
-                key = "%s/%s" % (self.docnames[-1], figtype)
+                key = "{}/{}".format(self.docnames[-1], figtype)
             else:
                 key = figtype
 
@@ -429,7 +429,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
             elif close_tag.startswith('</a></h'):
                 self.body.append('</a><a class="headerlink" href="#%s" ' %
                                  node.parent['ids'][0] +
-                                 'title="%s">%s' % (
+                                 'title="{}">{}'.format(
                                      _('Permalink to this heading'),
                                      self.config.html_permalinks_icon))
             elif isinstance(node.parent, nodes.table):

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -175,8 +175,10 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
         self.first_param = 1
         self.optional_param_level = 0
         # How many required parameters are left.
-        self.required_params_left = sum(isinstance(c, addnodes.desc_parameter)
-                                         for c in node.children)
+        self.required_params_left = sum(
+            isinstance(c, addnodes.desc_parameter)
+            for c in node.children
+        )
         self.param_separator = node.child_text_separator
 
     def depart_desc_parameterlist(self, node: Element) -> None:

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -40,7 +40,7 @@ def multiply_length(length: str, scale: int) -> str:
     else:
         amount, unit = matched.groups()
         result = float(amount) * scale / 100
-        return "{}{}".format(int(result), unit)
+        return f"{int(result)}{unit}"
 
 
 class HTMLWriter(Writer):
@@ -310,7 +310,7 @@ class HTMLTranslator(SphinxTranslator, BaseTranslator):
     def add_fignumber(self, node: Element) -> None:
         def append_fignumber(figtype: str, figure_id: str) -> None:
             if self.builder.name == 'singlehtml':
-                key = "{}/{}".format(self.docnames[-1], figtype)
+                key = f"{self.docnames[-1]}/{figtype}"
             else:
                 key = figtype
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -39,7 +39,7 @@ def multiply_length(length: str, scale: int) -> str:
     else:
         amount, unit = matched.groups()
         result = float(amount) * scale / 100
-        return "%s%s" % (int(result), unit)
+        return "{}{}".format(int(result), unit)
 
 
 class HTML5Translator(SphinxTranslator, BaseTranslator):
@@ -154,8 +154,8 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.first_param = 1
         self.optional_param_level = 0
         # How many required parameters are left.
-        self.required_params_left = sum([isinstance(c, addnodes.desc_parameter)
-                                         for c in node.children])
+        self.required_params_left = sum(isinstance(c, addnodes.desc_parameter)
+                                         for c in node.children)
         self.param_separator = node.child_text_separator
 
     def depart_desc_parameterlist(self, node: Element) -> None:
@@ -267,7 +267,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         if isinstance(node.parent, nodes.section):
             if self.builder.name == 'singlehtml':
                 docname = self.docnames[-1]
-                anchorname = "%s/#%s" % (docname, node.parent['ids'][0])
+                anchorname = "{}/#{}".format(docname, node.parent['ids'][0])
                 if anchorname not in self.builder.secnumbers:
                     anchorname = "%s/" % docname  # try first heading which has no anchor
             else:
@@ -289,7 +289,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     def add_fignumber(self, node: Element) -> None:
         def append_fignumber(figtype: str, figure_id: str) -> None:
             if self.builder.name == 'singlehtml':
-                key = "%s/%s" % (self.docnames[-1], figtype)
+                key = "{}/{}".format(self.docnames[-1], figtype)
             else:
                 key = figtype
 
@@ -388,7 +388,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             elif close_tag.startswith('</a></h'):
                 self.body.append('</a><a class="headerlink" href="#%s" ' %
                                  node.parent['ids'][0] +
-                                 'title="%s">%s' % (
+                                 'title="{}">{}'.format(
                                      _('Permalink to this heading'),
                                      self.config.html_permalinks_icon))
             elif isinstance(node.parent, nodes.table):

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -39,7 +39,7 @@ def multiply_length(length: str, scale: int) -> str:
     else:
         amount, unit = matched.groups()
         result = float(amount) * scale / 100
-        return "{}{}".format(int(result), unit)
+        return f"{int(result)}{unit}"
 
 
 class HTML5Translator(SphinxTranslator, BaseTranslator):
@@ -289,7 +289,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
     def add_fignumber(self, node: Element) -> None:
         def append_fignumber(figtype: str, figure_id: str) -> None:
             if self.builder.name == 'singlehtml':
-                key = "{}/{}".format(self.docnames[-1], figtype)
+                key = f"{self.docnames[-1]}/{figtype}"
             else:
                 key = figtype
 

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -154,8 +154,10 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
         self.first_param = 1
         self.optional_param_level = 0
         # How many required parameters are left.
-        self.required_params_left = sum(isinstance(c, addnodes.desc_parameter)
-                                         for c in node.children)
+        self.required_params_left = sum(
+            isinstance(c, addnodes.desc_parameter)
+            for c in node.children
+        )
         self.param_separator = node.child_text_separator
 
     def depart_desc_parameterlist(self, node: Element) -> None:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -254,7 +254,7 @@ def rstdim_to_latexdim(width_str: str, scale: int = 100) -> str:
         elif unit == "%":
             res = r"%.5f\linewidth" % (amount_float / 100.0)
         else:
-            res = "{:.5f}{}".format(amount_float, unit)
+            res = f"{amount_float:.5f}{unit}"
     return res
 
 
@@ -446,7 +446,7 @@ class LaTeXTranslator(SphinxTranslator):
             prefix = ''
             suffix = ''
 
-        return r'{}\renewcommand{{{}}}{{{}}}{}'.format(prefix, command, definition, suffix) + CR
+        return fr'{prefix}\renewcommand{{{command}}}{{{definition}}}{suffix}' + CR
 
     def generate_indices(self) -> str:
         def generate(content: List[Tuple[str, List[IndexEntry]]], collapsed: bool) -> None:
@@ -474,7 +474,7 @@ class LaTeXTranslator(SphinxTranslator):
         if indices_config:
             for domain in self.builder.env.domains.values():
                 for indexcls in domain.indices:
-                    indexname = '{}-{}'.format(domain.name, indexcls.name)
+                    indexname = f'{domain.name}-{indexcls.name}'
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
                             continue
@@ -609,10 +609,10 @@ class LaTeXTranslator(SphinxTranslator):
                     short = ('[%s]' % self.escape(' '.join(clean_astext(node).split())))
 
                 try:
-                    self.body.append(r'\{}{}{{'.format(self.sectionnames[self.sectionlevel], short))
+                    self.body.append(fr'\{self.sectionnames[self.sectionlevel]}{short}{{')
                 except IndexError:
                     # just use "subparagraph", it's not numbered anyway
-                    self.body.append(r'\{}{}{{'.format(self.sectionnames[-1], short))
+                    self.body.append(fr'\{self.sectionnames[-1]}{short}{{')
                 self.context.append('}' + CR + self.hypertarget_to(node.parent))
         elif isinstance(parent, nodes.topic):
             self.body.append(r'\sphinxstyletopictitle{')
@@ -1475,11 +1475,11 @@ class LaTeXTranslator(SphinxTranslator):
                     try:
                         p1, p2 = (escape(x) for x in split_into(2, 'single', string))
                         P1, P2 = style(p1), style(p2)
-                        self.body.append(r'\index{{{}@{}!{}@{}{}}}'.format(p1, P1, p2, P2, m))
+                        self.body.append(fr'\index{{{p1}@{P1}!{p2}@{P2}{m}}}')
                     except ValueError:
                         p = escape(split_into(1, 'single', string)[0])
                         P = style(p)
-                        self.body.append(r'\index{{{}@{}{}}}'.format(p, P, m))
+                        self.body.append(fr'\index{{{p}@{P}{m}}}')
                 elif type == 'pair':
                     p1, p2 = (escape(x) for x in split_into(2, 'pair', string))
                     P1, P2 = style(p1), style(p2)
@@ -1498,11 +1498,11 @@ class LaTeXTranslator(SphinxTranslator):
                 elif type == 'see':
                     p1, p2 = (escape(x) for x in split_into(2, 'see', string))
                     P1 = style(p1)
-                    self.body.append(r'\index{{{}@{}|see{{{}}}}}'.format(p1, P1, p2))
+                    self.body.append(fr'\index{{{p1}@{P1}|see{{{p2}}}}}')
                 elif type == 'seealso':
                     p1, p2 = (escape(x) for x in split_into(2, 'seealso', string))
                     P1 = style(p1)
-                    self.body.append(r'\index{{{}@{}|see{{{}}}}}'.format(p1, P1, p2))
+                    self.body.append(fr'\index{{{p1}@{P1}|see{{{p2}}}}}')
                 else:
                     logger.warning(__('unknown index entry type %s found'), type)
             except ValueError as err:
@@ -1596,7 +1596,7 @@ class LaTeXTranslator(SphinxTranslator):
         else:
             # old style format (cf. "Fig.%{number}")
             text = escape_abbr(title) % (r'\ref{%s}' % self.idescape(id))
-        hyperref = r'\hyperref[{}]{{{}}}'.format(self.idescape(id), text)
+        hyperref = fr'\hyperref[{self.idescape(id)}]{{{text}}}'
         self.body.append(hyperref)
 
         raise nodes.SkipNode

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -254,7 +254,7 @@ def rstdim_to_latexdim(width_str: str, scale: int = 100) -> str:
         elif unit == "%":
             res = r"%.5f\linewidth" % (amount_float / 100.0)
         else:
-            res = "%.5f%s" % (amount_float, unit)
+            res = "{:.5f}{}".format(amount_float, unit)
     return res
 
 
@@ -446,7 +446,7 @@ class LaTeXTranslator(SphinxTranslator):
             prefix = ''
             suffix = ''
 
-        return r'%s\renewcommand{%s}{%s}%s' % (prefix, command, definition, suffix) + CR
+        return r'{}\renewcommand{{{}}}{{{}}}{}'.format(prefix, command, definition, suffix) + CR
 
     def generate_indices(self) -> str:
         def generate(content: List[Tuple[str, List[IndexEntry]]], collapsed: bool) -> None:
@@ -474,7 +474,7 @@ class LaTeXTranslator(SphinxTranslator):
         if indices_config:
             for domain in self.builder.env.domains.values():
                 for indexcls in domain.indices:
-                    indexname = '%s-%s' % (domain.name, indexcls.name)
+                    indexname = '{}-{}'.format(domain.name, indexcls.name)
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
                             continue
@@ -609,10 +609,10 @@ class LaTeXTranslator(SphinxTranslator):
                     short = ('[%s]' % self.escape(' '.join(clean_astext(node).split())))
 
                 try:
-                    self.body.append(r'\%s%s{' % (self.sectionnames[self.sectionlevel], short))
+                    self.body.append(r'\{}{}{{'.format(self.sectionnames[self.sectionlevel], short))
                 except IndexError:
                     # just use "subparagraph", it's not numbered anyway
-                    self.body.append(r'\%s%s{' % (self.sectionnames[-1], short))
+                    self.body.append(r'\{}{}{{'.format(self.sectionnames[-1], short))
                 self.context.append('}' + CR + self.hypertarget_to(node.parent))
         elif isinstance(parent, nodes.topic):
             self.body.append(r'\sphinxstyletopictitle{')
@@ -1473,20 +1473,20 @@ class LaTeXTranslator(SphinxTranslator):
             try:
                 if type == 'single':
                     try:
-                        p1, p2 = [escape(x) for x in split_into(2, 'single', string)]
+                        p1, p2 = (escape(x) for x in split_into(2, 'single', string))
                         P1, P2 = style(p1), style(p2)
-                        self.body.append(r'\index{%s@%s!%s@%s%s}' % (p1, P1, p2, P2, m))
+                        self.body.append(r'\index{{{}@{}!{}@{}{}}}'.format(p1, P1, p2, P2, m))
                     except ValueError:
                         p = escape(split_into(1, 'single', string)[0])
                         P = style(p)
-                        self.body.append(r'\index{%s@%s%s}' % (p, P, m))
+                        self.body.append(r'\index{{{}@{}{}}}'.format(p, P, m))
                 elif type == 'pair':
-                    p1, p2 = [escape(x) for x in split_into(2, 'pair', string)]
+                    p1, p2 = (escape(x) for x in split_into(2, 'pair', string))
                     P1, P2 = style(p1), style(p2)
                     self.body.append(r'\index{%s@%s!%s@%s%s}\index{%s@%s!%s@%s%s}' %
                                      (p1, P1, p2, P2, m, p2, P2, p1, P1, m))
                 elif type == 'triple':
-                    p1, p2, p3 = [escape(x) for x in split_into(3, 'triple', string)]
+                    p1, p2, p3 = (escape(x) for x in split_into(3, 'triple', string))
                     P1, P2, P3 = style(p1), style(p2), style(p3)
                     self.body.append(
                         r'\index{%s@%s!%s %s@%s %s%s}'
@@ -1496,13 +1496,13 @@ class LaTeXTranslator(SphinxTranslator):
                          p2, P2, p3, p1, P3, P1, m,
                          p3, P3, p1, p2, P1, P2, m))
                 elif type == 'see':
-                    p1, p2 = [escape(x) for x in split_into(2, 'see', string)]
+                    p1, p2 = (escape(x) for x in split_into(2, 'see', string))
                     P1 = style(p1)
-                    self.body.append(r'\index{%s@%s|see{%s}}' % (p1, P1, p2))
+                    self.body.append(r'\index{{{}@{}|see{{{}}}}}'.format(p1, P1, p2))
                 elif type == 'seealso':
-                    p1, p2 = [escape(x) for x in split_into(2, 'seealso', string)]
+                    p1, p2 = (escape(x) for x in split_into(2, 'seealso', string))
                     P1 = style(p1)
-                    self.body.append(r'\index{%s@%s|see{%s}}' % (p1, P1, p2))
+                    self.body.append(r'\index{{{}@{}|see{{{}}}}}'.format(p1, P1, p2))
                 else:
                     logger.warning(__('unknown index entry type %s found'), type)
             except ValueError as err:
@@ -1596,7 +1596,7 @@ class LaTeXTranslator(SphinxTranslator):
         else:
             # old style format (cf. "Fig.%{number}")
             text = escape_abbr(title) % (r'\ref{%s}' % self.idescape(id))
-        hyperref = r'\hyperref[%s]{%s}' % (self.idescape(id), text)
+        hyperref = r'\hyperref[{}]{{{}}}'.format(self.idescape(id), text)
         self.body.append(hyperref)
 
         raise nodes.SkipNode
@@ -1678,7 +1678,7 @@ class LaTeXTranslator(SphinxTranslator):
 
     def visit_citation(self, node: Element) -> None:
         label = cast(nodes.label, node[0])
-        self.body.append(r'\bibitem[%s]{%s:%s}' % (self.encode(label.astext()),
+        self.body.append(r'\bibitem[{}]{{{}:{}}}'.format(self.encode(label.astext()),
                                                    node['docname'], node['ids'][0]))
 
     def depart_citation(self, node: Element) -> None:
@@ -1688,7 +1688,7 @@ class LaTeXTranslator(SphinxTranslator):
         if self.in_title:
             pass
         else:
-            self.body.append(r'\sphinxcite{%s:%s}' % (node['docname'], node['refname']))
+            self.body.append(r'\sphinxcite{{{}:{}}}'.format(node['docname'], node['refname']))
             raise nodes.SkipNode
 
     def depart_citation_reference(self, node: Element) -> None:
@@ -2017,7 +2017,7 @@ class LaTeXTranslator(SphinxTranslator):
 
     def visit_math_block(self, node: Element) -> None:
         if node.get('label'):
-            label = "equation:%s:%s" % (node['docname'], node['label'])
+            label = "equation:{}:{}".format(node['docname'], node['label'])
         else:
             label = None
 
@@ -2032,7 +2032,7 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_math_reference(self, node: Element) -> None:
-        label = "equation:%s:%s" % (node['docname'], node['target'])
+        label = "equation:{}:{}".format(node['docname'], node['target'])
         eqref_format = self.config.math_eqref_format
         if eqref_format:
             try:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1678,8 +1678,10 @@ class LaTeXTranslator(SphinxTranslator):
 
     def visit_citation(self, node: Element) -> None:
         label = cast(nodes.label, node[0])
-        self.body.append(r'\bibitem[{}]{{{}:{}}}'.format(self.encode(label.astext()),
-                                                   node['docname'], node['ids'][0]))
+        self.body.append(r'\bibitem[{}]{{{}:{}}}'.format(
+            self.encode(label.astext()),
+            node['docname'], node['ids'][0]),
+        )
 
     def depart_citation(self, node: Element) -> None:
         pass

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -193,7 +193,7 @@ class TexinfoTranslator(SphinxTranslator):
             name, content = index
             pointers = tuple([name] + self.rellinks[name])
             self.body.append('\n@node %s,%s,%s,%s\n' % pointers)
-            self.body.append('@unnumbered {}\n\n{}\n'.format(name, content))
+            self.body.append(f'@unnumbered {name}\n\n{content}\n')
 
         while self.referenced_ids:
             # handle xrefs with missing anchors
@@ -382,9 +382,9 @@ class TexinfoTranslator(SphinxTranslator):
 
     def format_menu_entry(self, name: str, node_name: str, desc: str) -> str:
         if name == node_name:
-            s = '* {}:: '.format(name)
+            s = f'* {name}:: '
         else:
-            s = '* {}: {}. '.format(name, node_name)
+            s = f'* {name}: {node_name}. '
         offset = max((24, (len(name) + 4) % 78))
         wdesc = '\n'.join(' ' * offset + l for l in
                           textwrap.wrap(desc, width=78 - offset))
@@ -459,7 +459,7 @@ class TexinfoTranslator(SphinxTranslator):
                     if not entry[3]:
                         continue
                     name = self.escape_menu(entry[0])
-                    sid = self.get_short_id('{}:{}'.format(entry[2], entry[3]))
+                    sid = self.get_short_id(f'{entry[2]}:{entry[3]}')
                     desc = self.escape_arg(entry[6])
                     me = self.format_menu_entry(name, sid, desc)
                     ret.append(me)
@@ -470,7 +470,7 @@ class TexinfoTranslator(SphinxTranslator):
         if indices_config:
             for domain in self.builder.env.domains.values():
                 for indexcls in domain.indices:
-                    indexname = '{}-{}'.format(domain.name, indexcls.name)
+                    indexname = f'{domain.name}-{indexcls.name}'
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
                             continue
@@ -535,7 +535,7 @@ class TexinfoTranslator(SphinxTranslator):
         name = self.escape_menu(name)
         sid = self.get_short_id(id)
         if self.config.texinfo_cross_references:
-            self.body.append('@ref{{{},,{}}}'.format(sid, name))
+            self.body.append(f'@ref{{{sid},,{name}}}')
             self.referenced_ids.add(sid)
             self.referenced_ids.add(self.escape_id(id))
         else:
@@ -693,7 +693,7 @@ class TexinfoTranslator(SphinxTranslator):
             if not name or name == uri:
                 self.body.append('@email{%s}' % uri)
             else:
-                self.body.append('@email{{{},{}}}'.format(uri, name))
+                self.body.append(f'@email{{{uri},{name}}}')
         elif uri.startswith('#'):
             # references to labels in the same document
             id = self.curfilestack[-1] + ':' + uri[1:]
@@ -718,9 +718,9 @@ class TexinfoTranslator(SphinxTranslator):
             id = self.escape_id(id)
             name = self.escape_menu(name)
             if name == id:
-                self.body.append('@ref{{{},,,{}}}'.format(id, uri))
+                self.body.append(f'@ref{{{id},,,{uri}}}')
             else:
-                self.body.append('@ref{{{},,{},{}}}'.format(id, name, uri))
+                self.body.append(f'@ref{{{id},,{name},{uri}}}')
         else:
             uri = self.escape_arg(uri)
             name = self.escape_arg(name)
@@ -730,11 +730,11 @@ class TexinfoTranslator(SphinxTranslator):
             if not name or uri == name:
                 self.body.append('@indicateurl{%s}' % uri)
             elif show_urls == 'inline':
-                self.body.append('@uref{{{},{}}}'.format(uri, name))
+                self.body.append(f'@uref{{{uri},{name}}}')
             elif show_urls == 'no':
-                self.body.append('@uref{{{},,{}}}'.format(uri, name))
+                self.body.append(f'@uref{{{uri},,{name}}}')
             else:
-                self.body.append('{}@footnote{{{}}}'.format(name, uri))
+                self.body.append(f'{name}@footnote{{{uri}}}')
         raise nodes.SkipNode
 
     def depart_reference(self, node: Element) -> None:
@@ -1402,7 +1402,7 @@ class TexinfoTranslator(SphinxTranslator):
             name = objtype
         # by convention, the deffn category should be capitalized like a title
         category = self.escape_arg(smart_capwords(name))
-        self.body.append('\n{} {{{}}} '.format(self.at_deffnx, category))
+        self.body.append(f'\n{self.at_deffnx} {{{category}}} ')
         self.at_deffnx = '@deffnx'
         self.desc_type_name = name
 

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -193,13 +193,13 @@ class TexinfoTranslator(SphinxTranslator):
             name, content = index
             pointers = tuple([name] + self.rellinks[name])
             self.body.append('\n@node %s,%s,%s,%s\n' % pointers)
-            self.body.append('@unnumbered %s\n\n%s\n' % (name, content))
+            self.body.append('@unnumbered {}\n\n{}\n'.format(name, content))
 
         while self.referenced_ids:
             # handle xrefs with missing anchors
             r = self.referenced_ids.pop()
             if r not in self.written_ids:
-                self.body.append('@anchor{%s}@w{%s}\n' % (r, ' ' * 30))
+                self.body.append('@anchor{{{}}}@w{{{}}}\n'.format(r, ' ' * 30))
         self.ensure_eol()
         self.fragment = ''.join(self.body)
         self.elements['body'] = self.fragment
@@ -382,9 +382,9 @@ class TexinfoTranslator(SphinxTranslator):
 
     def format_menu_entry(self, name: str, node_name: str, desc: str) -> str:
         if name == node_name:
-            s = '* %s:: ' % (name,)
+            s = '* {}:: '.format(name)
         else:
-            s = '* %s: %s. ' % (name, node_name)
+            s = '* {}: {}. '.format(name, node_name)
         offset = max((24, (len(name) + 4) % 78))
         wdesc = '\n'.join(' ' * offset + l for l in
                           textwrap.wrap(desc, width=78 - offset))
@@ -459,7 +459,7 @@ class TexinfoTranslator(SphinxTranslator):
                     if not entry[3]:
                         continue
                     name = self.escape_menu(entry[0])
-                    sid = self.get_short_id('%s:%s' % (entry[2], entry[3]))
+                    sid = self.get_short_id('{}:{}'.format(entry[2], entry[3]))
                     desc = self.escape_arg(entry[6])
                     me = self.format_menu_entry(name, sid, desc)
                     ret.append(me)
@@ -470,7 +470,7 @@ class TexinfoTranslator(SphinxTranslator):
         if indices_config:
             for domain in self.builder.env.domains.values():
                 for indexcls in domain.indices:
-                    indexname = '%s-%s' % (domain.name, indexcls.name)
+                    indexname = '{}-{}'.format(domain.name, indexcls.name)
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
                             continue
@@ -535,7 +535,7 @@ class TexinfoTranslator(SphinxTranslator):
         name = self.escape_menu(name)
         sid = self.get_short_id(id)
         if self.config.texinfo_cross_references:
-            self.body.append('@ref{%s,,%s}' % (sid, name))
+            self.body.append('@ref{{{},,{}}}'.format(sid, name))
             self.referenced_ids.add(sid)
             self.referenced_ids.add(self.escape_id(id))
         else:
@@ -693,7 +693,7 @@ class TexinfoTranslator(SphinxTranslator):
             if not name or name == uri:
                 self.body.append('@email{%s}' % uri)
             else:
-                self.body.append('@email{%s,%s}' % (uri, name))
+                self.body.append('@email{{{},{}}}'.format(uri, name))
         elif uri.startswith('#'):
             # references to labels in the same document
             id = self.curfilestack[-1] + ':' + uri[1:]
@@ -718,9 +718,9 @@ class TexinfoTranslator(SphinxTranslator):
             id = self.escape_id(id)
             name = self.escape_menu(name)
             if name == id:
-                self.body.append('@ref{%s,,,%s}' % (id, uri))
+                self.body.append('@ref{{{},,,{}}}'.format(id, uri))
             else:
-                self.body.append('@ref{%s,,%s,%s}' % (id, name, uri))
+                self.body.append('@ref{{{},,{},{}}}'.format(id, name, uri))
         else:
             uri = self.escape_arg(uri)
             name = self.escape_arg(name)
@@ -730,11 +730,11 @@ class TexinfoTranslator(SphinxTranslator):
             if not name or uri == name:
                 self.body.append('@indicateurl{%s}' % uri)
             elif show_urls == 'inline':
-                self.body.append('@uref{%s,%s}' % (uri, name))
+                self.body.append('@uref{{{},{}}}'.format(uri, name))
             elif show_urls == 'no':
-                self.body.append('@uref{%s,,%s}' % (uri, name))
+                self.body.append('@uref{{{},,{}}}'.format(uri, name))
             else:
-                self.body.append('%s@footnote{%s}' % (name, uri))
+                self.body.append('{}@footnote{{{}}}'.format(name, uri))
         raise nodes.SkipNode
 
     def depart_reference(self, node: Element) -> None:
@@ -1207,7 +1207,7 @@ class TexinfoTranslator(SphinxTranslator):
         width = self.tex_image_length(node.get('width', ''))
         height = self.tex_image_length(node.get('height', ''))
         alt = self.escape_arg(node.get('alt', ''))
-        filename = "%s-figures/%s" % (self.elements['filename'][:-5], name)  # type: ignore
+        filename = "{}-figures/{}".format(self.elements['filename'][:-5], name)  # type: ignore
         self.body.append('\n@image{%s,%s,%s,%s,%s}\n' %
                          (filename, width, height, alt, ext[1:]))
 
@@ -1402,7 +1402,7 @@ class TexinfoTranslator(SphinxTranslator):
             name = objtype
         # by convention, the deffn category should be capitalized like a title
         category = self.escape_arg(smart_capwords(name))
-        self.body.append('\n%s {%s} ' % (self.at_deffnx, category))
+        self.body.append('\n{} {{{}}} '.format(self.at_deffnx, category))
         self.at_deffnx = '@deffnx'
         self.desc_type_name = name
 

--- a/tests/roots/test-apidoc-toc/mypackage/main.py
+++ b/tests/roots/test-apidoc-toc/mypackage/main.py
@@ -6,10 +6,10 @@ import mod_resource
 import mod_something
 
 if __name__ == "__main__":
-    print("Hello, world! -> something returns: {}".format(mod_something.something()))
+    print(f"Hello, world! -> something returns: {mod_something.something()}")
 
     res_path = \
         os.path.join(os.path.dirname(mod_resource.__file__), 'resource.txt')
     with open(res_path, encoding='utf-8') as f:
         text = f.read()
-    print("From mod_resource:resource.txt -> {}".format(text))
+    print(f"From mod_resource:resource.txt -> {text}")

--- a/tests/roots/test-autosummary/underscore_module_.py
+++ b/tests/roots/test-autosummary/underscore_module_.py
@@ -3,7 +3,7 @@ module with trailing underscores everywhere
 """
 
 
-class class_(object):
+class class_:
     """ Class """
     def method_(_arg):
         """ Method """

--- a/tests/roots/test-changes/conf.py
+++ b/tests/roots/test-changes/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 project = 'Sphinx ChangesBuilder tests'
 copyright = '2007-2022 by the Sphinx team, see AUTHORS'
 version = '0.6'

--- a/tests/roots/test-correct-year/conf.py
+++ b/tests/roots/test-correct-year/conf.py
@@ -1,2 +1,1 @@
-
 copyright = '2006-2009, Author'

--- a/tests/roots/test-directive-only/conf.py
+++ b/tests/roots/test-directive-only/conf.py
@@ -1,3 +1,2 @@
-
 project = 'test-directive-only'
 exclude_patterns = ['_build']

--- a/tests/roots/test-ext-autodoc/autodoc_dummy_bar.py
+++ b/tests/roots/test-ext-autodoc/autodoc_dummy_bar.py
@@ -1,6 +1,6 @@
 from bug2437.autodoc_dummy_foo import Foo
 
 
-class Bar(object):
+class Bar:
     """Dummy class Bar with alias."""
     my_name = Foo

--- a/tests/roots/test-ext-autodoc/bug2437/autodoc_dummy_foo.py
+++ b/tests/roots/test-ext-autodoc/bug2437/autodoc_dummy_foo.py
@@ -1,3 +1,3 @@
-class Foo(object):
+class Foo:
     """Dummy class Foo."""
     pass

--- a/tests/roots/test-ext-autodoc/target/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/__init__.py
@@ -33,7 +33,7 @@ def _funky_classmethod(name, b, c, d, docstring=None):
     return classmethod(function)
 
 
-class Class(object):
+class Class:
     """Class to document."""
 
     def meth(self):
@@ -96,10 +96,10 @@ def function(foo, *args, **kwds):
     pass
 
 
-class Outer(object):
+class Outer:
     """Foo"""
 
-    class Inner(object):
+    class Inner:
         """Foo"""
 
         def meth(self):
@@ -113,7 +113,7 @@ class InnerChild(Outer.Inner):
     """InnerChild docstring"""
 
 
-class DocstringSig(object):
+class DocstringSig:
     def __new__(cls, *new_args, **new_kwargs):
         """__new__(cls, d, e=1) -> DocstringSig
 First line of docstring
@@ -164,12 +164,12 @@ class StrRepr(str):
         return self
 
 
-class AttCls(object):
+class AttCls:
     a1 = StrRepr('hello\nworld')
     a2 = None
 
 
-class InstAttCls(object):
+class InstAttCls:
     """Class with documented class and instance attributes."""
 
     #: Doc comment for class attribute InstAttCls.ca1.
@@ -189,7 +189,7 @@ class InstAttCls(object):
         """Docstring for instance attribute InstAttCls.ia2."""
 
 
-class CustomIter(object):
+class CustomIter:
     def __init__(self):
         """Create a new `CustomIter`."""
         self.values = range(10)

--- a/tests/roots/test-ext-autodoc/target/autodoc_type_aliases.py
+++ b/tests/roots/test-ext-autodoc/target/autodoc_type_aliases.py
@@ -12,7 +12,7 @@ variable: myint
 variable2 = None  # type: myint
 
 #: docstring
-variable3: Optional[myint]
+variable3: myint | None
 
 
 def read(r: io.BytesIO) -> io.StringIO:

--- a/tests/roots/test-ext-autodoc/target/descriptor.py
+++ b/tests/roots/test-ext-autodoc/target/descriptor.py
@@ -1,4 +1,4 @@
-class CustomDataDescriptor(object):
+class CustomDataDescriptor:
     """Descriptor class docstring."""
 
     def __init__(self, doc):

--- a/tests/roots/test-ext-autodoc/target/inheritance.py
+++ b/tests/roots/test-ext-autodoc/target/inheritance.py
@@ -1,4 +1,4 @@
-class Base(object):
+class Base:
     #: docstring
     inheritedattr = None
 

--- a/tests/roots/test-ext-autodoc/target/need_mocks.py
+++ b/tests/roots/test-ext-autodoc/target/need_mocks.py
@@ -1,4 +1,3 @@
-
 import missing_module  # NOQA
 import missing_package1.missing_module1  # NOQA
 from missing_module import missing_name  # NOQA
@@ -20,7 +19,7 @@ def func(arg: missing_module.Class):
     pass
 
 
-class TestAutodoc(object):
+class TestAutodoc:
     """TestAutodoc docstring."""
 
     #: docstring

--- a/tests/roots/test-ext-autodoc/target/partialmethod.py
+++ b/tests/roots/test-ext-autodoc/target/partialmethod.py
@@ -2,7 +2,7 @@
 from functools import partialmethod
 
 
-class Cell(object):
+class Cell:
     """An example for partialmethod.
 
     refs: https://docs.python.jp/3/library/functools.html#functools.partialmethod

--- a/tests/roots/test-ext-autodoc/target/typed_vars.py
+++ b/tests/roots/test-ext-autodoc/target/typed_vars.py
@@ -8,7 +8,7 @@ attr3 = ''  # type: str
 
 class _Descriptor:
     def __init__(self, name):
-        self.__doc__ = "This is {}".format(name)
+        self.__doc__ = f"This is {name}"
     def __get__(self):
         pass
 

--- a/tests/roots/test-ext-inheritance_diagram/example/sphinx.py
+++ b/tests/roots/test-ext-inheritance_diagram/example/sphinx.py
@@ -1,5 +1,5 @@
 # example.sphinx
 
 
-class DummyClass(object):
+class DummyClass:
     pass

--- a/tests/roots/test-ext-inheritance_diagram/test.py
+++ b/tests/roots/test-ext-inheritance_diagram/test.py
@@ -1,4 +1,4 @@
-class Foo(object):
+class Foo:
     pass
 
 

--- a/tests/roots/test-ext-viewcode-find/not_a_package/submodule.py
+++ b/tests/roots/test-ext-viewcode-find/not_a_package/submodule.py
@@ -17,13 +17,13 @@ def func1(a, b):
 
 
 @decorator
-class Class1(object):
+class Class1:
     """
     this is Class1
     """
 
 
-class Class3(object):
+class Class3:
     """
     this is Class3
     """

--- a/tests/roots/test-ext-viewcode/conf.py
+++ b/tests/roots/test-ext-viewcode/conf.py
@@ -19,6 +19,6 @@ if 'test_linkcode' in tags:  # NOQA
         elif domain == "js":
             return "http://foobar/js/" + info['fullname']
         elif domain in ("c", "cpp"):
-            return "http://foobar/%s/%s" % (domain,  "".join(info['names']))
+            return "http://foobar/{}/{}".format(domain,  "".join(info['names']))
         else:
             raise AssertionError()

--- a/tests/roots/test-ext-viewcode/spam/mod1.py
+++ b/tests/roots/test-ext-viewcode/spam/mod1.py
@@ -16,13 +16,13 @@ def func1(a, b):
 
 
 @decorator
-class Class1(object):
+class Class1:
     """
     this is Class1
     """
 
 
-class Class3(object):
+class Class3:
     """
     this is Class3
     """

--- a/tests/roots/test-ext-viewcode/spam/mod2.py
+++ b/tests/roots/test-ext-viewcode/spam/mod2.py
@@ -16,7 +16,7 @@ def func2(a, b):
 
 
 @decorator
-class Class2(object):
+class Class2:
     """
     this is Class2
     """

--- a/tests/roots/test-inheritance/dummy/test.py
+++ b/tests/roots/test-inheritance/dummy/test.py
@@ -11,7 +11,7 @@ r"""
 """
 
 
-class A(object):
+class A:
     pass
 
 

--- a/tests/roots/test-inheritance/dummy/test_nested.py
+++ b/tests/roots/test-inheritance/dummy/test_nested.py
@@ -2,8 +2,8 @@
 """
 
 
-class A(object):
-    class B(object):
+class A:
+    class B:
         pass
 
 

--- a/tests/roots/test-root/autodoc_target.py
+++ b/tests/roots/test-root/autodoc_target.py
@@ -19,7 +19,7 @@ class CustomEx(Exception):
         """Exception method."""
 
 
-class CustomDataDescriptor(object):
+class CustomDataDescriptor:
     """Descriptor class docstring."""
 
     def __init__(self, doc):
@@ -56,7 +56,7 @@ def _funky_classmethod(name, b, c, d, docstring=None):
     return classmethod(function)
 
 
-class Base(object):
+class Base:
     def inheritedmeth(self):
         """Inherited function."""
 
@@ -136,10 +136,10 @@ def function(foo, *args, **kwds):
     pass
 
 
-class Outer(object):
+class Outer:
     """Foo"""
 
-    class Inner(object):
+    class Inner:
         """Foo"""
 
         def meth(self):
@@ -149,7 +149,7 @@ class Outer(object):
     factory = dict
 
 
-class DocstringSig(object):
+class DocstringSig:
     def meth(self):
         """meth(FOO, BAR=1) -> BAZ
 First line of docstring
@@ -184,12 +184,12 @@ class StrRepr(str):
         return self
 
 
-class AttCls(object):
+class AttCls:
     a1 = StrRepr('hello\nworld')
     a2 = None
 
 
-class InstAttCls(object):
+class InstAttCls:
     """Class with documented class and instance attributes."""
 
     #: Doc comment for class attribute InstAttCls.ca1.

--- a/tests/roots/test-warnings/autodoc_fodder.py
+++ b/tests/roots/test-warnings/autodoc_fodder.py
@@ -1,5 +1,4 @@
-
-class MarkupError(object):
+class MarkupError:
     """
     .. note:: This is a docstring with a
     small markup error which should have

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -43,8 +43,8 @@ def nonascii_srcdir(request, rootdir, sphinx_test_tempdir):
         root_doc.write_text(root_doc.read_text(encoding='utf8') + dedent("""
                             .. toctree::
 
-                               %(test_name)s/%(test_name)s
-                            """ % {'test_name': test_name}), encoding='utf8')
+                               {test_name}/{test_name}
+                            """.format(test_name=test_name)), encoding='utf8')
     return srcdir
 
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -79,7 +79,7 @@ def tail_check(check):
         for node in nodes:
             if node.tail and rex.search(node.tail):
                 return True
-        raise AssertionError('%r not found in tail of any nodes %s' % (check, nodes))
+        raise AssertionError('{!r} not found in tail of any nodes {}'.format(check, nodes))
     return checker
 
 
@@ -114,9 +114,9 @@ def check_xpath(etree, fname, path, check, be_found=True):
             if all(not rex.search(get_text(node)) for node in nodes):
                 return
 
-        raise AssertionError(('%r not found in any node matching '
+        raise AssertionError('%r not found in any node matching '
                               'path %s in %s: %r' % (check, path, fname,
-                                                     [node.text for node in nodes])))
+                                                     [node.text for node in nodes]))
 
 
 @pytest.mark.sphinx('html', testroot='warnings')

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -79,7 +79,7 @@ def tail_check(check):
         for node in nodes:
             if node.tail and rex.search(node.tail):
                 return True
-        raise AssertionError('{!r} not found in tail of any nodes {}'.format(check, nodes))
+        raise AssertionError(f'{check!r} not found in tail of any nodes {nodes}')
     return checker
 
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -114,9 +114,13 @@ def check_xpath(etree, fname, path, check, be_found=True):
             if all(not rex.search(get_text(node)) for node in nodes):
                 return
 
-        raise AssertionError('%r not found in any node matching '
-                              'path %s in %s: %r' % (check, path, fname,
-                                                     [node.text for node in nodes]))
+        raise AssertionError(
+            '%r not found in any node matching '
+            'path %s in %s: %r' % (
+                check, path, fname,
+                [node.text for node in nodes]
+            )
+        )
 
 
 @pytest.mark.sphinx('html', testroot='warnings')

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -60,7 +60,7 @@ def compile_latex_document(app, filename='python.tex'):
     except CalledProcessError as exc:
         print(exc.stdout)
         print(exc.stderr)
-        raise AssertionError('%s exited with return code %s' % (app.config.latex_engine,
+        raise AssertionError('{} exited with return code {}'.format(app.config.latex_engine,
                                                                 exc.returncode))
 
 

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -60,8 +60,7 @@ def compile_latex_document(app, filename='python.tex'):
     except CalledProcessError as exc:
         print(exc.stdout)
         print(exc.stderr)
-        raise AssertionError('{} exited with return code {}'.format(app.config.latex_engine,
-                                                                exc.returncode))
+        raise AssertionError(f'{app.config.latex_engine} exited with return code {exc.returncode}')
 
 
 def skip_if_requested(testfunc):

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -470,12 +470,12 @@ def test_domain_c_ast_function_definitions():
     cvrs = ['', 'const', 'volatile', 'restrict', 'restrict volatile const']
     for cvr in cvrs:
         space = ' ' if len(cvr) != 0 else ''
-        check('function', 'void f(int arr[{}*])'.format(cvr), {1: 'f'})
-        check('function', 'void f(int arr[{}])'.format(cvr), {1: 'f'})
-        check('function', 'void f(int arr[{}{}42])'.format(cvr, space), {1: 'f'})
-        check('function', 'void f(int arr[static{}{} 42])'.format(space, cvr), {1: 'f'})
-        check('function', 'void f(int arr[{}{}static 42])'.format(cvr, space), {1: 'f'},
-              output='void f(int arr[static{}{} 42])'.format(space, cvr))
+        check('function', f'void f(int arr[{cvr}*])', {1: 'f'})
+        check('function', f'void f(int arr[{cvr}])', {1: 'f'})
+        check('function', f'void f(int arr[{cvr}{space}42])', {1: 'f'})
+        check('function', f'void f(int arr[static{space}{cvr} 42])', {1: 'f'})
+        check('function', f'void f(int arr[{cvr}{space}static 42])', {1: 'f'},
+              output=f'void f(int arr[static{space}{cvr} 42])')
     check('function', 'void f(int arr[const static volatile 42])', {1: 'f'},
           output='void f(int arr[static volatile const 42])')
 
@@ -611,9 +611,9 @@ def split_warnigns(warning):
 
 def filter_warnings(warning, file):
     lines = split_warnigns(warning)
-    res = [l for l in lines if "domain-c" in l and "{}.rst".format(file) in l and
+    res = [l for l in lines if "domain-c" in l and f"{file}.rst" in l and
            "WARNING: document isn't included in any toctree" not in l]
-    print("Filtered warnings for file '{}':".format(file))
+    print(f"Filtered warnings for file '{file}':")
     for w in res:
         print(w)
     return res
@@ -652,7 +652,7 @@ def test_domain_c_build_namespace(app, status, warning):
     assert len(ws) == 0
     t = (app.outdir / "namespace.html").read_text(encoding='utf8')
     for id_ in ('NS.NSVar', 'NULLVar', 'ZeroVar', 'NS2.NS3.NS2NS3Var', 'PopVar'):
-        assert 'id="c.{}"'.format(id_) in t
+        assert f'id="c.{id_}"' in t
 
 
 @pytest.mark.sphinx(testroot='domain-c', confoverrides={'nitpicky': True})

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -1164,7 +1164,7 @@ def test_domain_cpp_build_with_add_function_parentheses_is_True(app, status, war
         pattern = '<li><p>%s<a .*?><code .*?><span .*?>%s</span></code></a></p></li>' % spec
         res = re.search(pattern, text)
         if not res:
-            print("Pattern\n\t{}\nnot found in {}".format(pattern, file))
+            print(f"Pattern\n\t{pattern}\nnot found in {file}")
             raise AssertionError()
     rolePatterns = [
         ('', 'Sphinx'),
@@ -1205,7 +1205,7 @@ def test_domain_cpp_build_with_add_function_parentheses_is_False(app, status, wa
         pattern = '<li><p>%s<a .*?><code .*?><span .*?>%s</span></code></a></p></li>' % spec
         res = re.search(pattern, text)
         if not res:
-            print("Pattern\n\t{}\nnot found in {}".format(pattern, file))
+            print(f"Pattern\n\t{pattern}\nnot found in {file}")
             raise AssertionError()
     rolePatterns = [
         ('', 'Sphinx'),

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -218,7 +218,7 @@ def test_domain_cpp_ast_expressions():
              ('\\U0001f34c', '127820'), ('\\U0001F34C', '127820')]
     for p, t in charPrefixAndIds:
         for c, val in chars:
-            exprCheck("{}'{}'".format(p, c), t + val)
+            exprCheck(f"{p}'{c}'", t + val)
     # user-defined literals
     for i in ints:
         exprCheck(i + '_udl', 'clL_Zli4_udlEL' + i.replace("'", "") + 'EE')
@@ -230,7 +230,7 @@ def test_domain_cpp_ast_expressions():
         exprCheck('0x' + f + '_udl', 'clL_Zli4_udlEL0x' + f.replace("'", "") + 'EE')
     for p, t in charPrefixAndIds:
         for c, val in chars:
-            exprCheck("{}'{}'_udl".format(p, c), 'clL_Zli4_udlE' + t + val + 'E')
+            exprCheck(f"{p}'{c}'_udl", 'clL_Zli4_udlE' + t + val + 'E')
     exprCheck('"abc"_udl', 'clL_Zli4_udlELA3_KcEE')
     # from issue #7294
     exprCheck('6.62607015e-34q_J', 'clL_Zli3q_JEL6.62607015e-34EE')
@@ -1049,9 +1049,9 @@ def test_domain_cpp_ast_xref_parsing():
 
 def filter_warnings(warning, file):
     lines = warning.getvalue().split("\n")
-    res = [l for l in lines if "domain-cpp" in l and "{}.rst".format(file) in l and
+    res = [l for l in lines if "domain-cpp" in l and f"{file}.rst" in l and
            "WARNING: document isn't included in any toctree" not in l]
-    print("Filtered warnings for file '{}':".format(file))
+    print(f"Filtered warnings for file '{file}':")
     for w in res:
         print(w)
     return res
@@ -1134,10 +1134,10 @@ def test_domain_cpp_build_misuse_of_roles(app, status, warning):
         txtTargetType = "function" if targetType == "func" else targetType
         for r in allRoles:
             if r not in roles:
-                warn.append("WARNING: cpp:{} targets a {} (".format(r, txtTargetType))
+                warn.append(f"WARNING: cpp:{r} targets a {txtTargetType} (")
                 if targetType == 'templateParam':
-                    warn.append("WARNING: cpp:{} targets a {} (".format(r, txtTargetType))
-                    warn.append("WARNING: cpp:{} targets a {} (".format(r, txtTargetType))
+                    warn.append(f"WARNING: cpp:{r} targets a {txtTargetType} (")
+                    warn.append(f"WARNING: cpp:{r} targets a {txtTargetType} (")
     warn = sorted(warn)
     for w in ws:
         assert "targets a" in w
@@ -1164,7 +1164,7 @@ def test_domain_cpp_build_with_add_function_parentheses_is_True(app, status, war
         pattern = '<li><p>%s<a .*?><code .*?><span .*?>%s</span></code></a></p></li>' % spec
         res = re.search(pattern, text)
         if not res:
-            print("Pattern\n\t%s\nnot found in %s" % (pattern, file))
+            print("Pattern\n\t{}\nnot found in {}".format(pattern, file))
             raise AssertionError()
     rolePatterns = [
         ('', 'Sphinx'),
@@ -1205,7 +1205,7 @@ def test_domain_cpp_build_with_add_function_parentheses_is_False(app, status, wa
         pattern = '<li><p>%s<a .*?><code .*?><span .*?>%s</span></code></a></p></li>' % spec
         res = re.search(pattern, text)
         if not res:
-            print("Pattern\n\t%s\nnot found in %s" % (pattern, file))
+            print("Pattern\n\t{}\nnot found in {}".format(pattern, file))
             raise AssertionError()
     rolePatterns = [
         ('', 'Sphinx'),
@@ -1291,7 +1291,7 @@ not found in `{test}`
 
     for role in (expr_role, texpr_role):
         name = role.name
-        expect = '`{name}` puts the domain and role classes at its root'.format(name=name)
+        expect = f'`{name}` puts the domain and role classes at its root'
         assert {'sig', 'sig-inline', 'cpp', name} <= role.classes, expect
 
     # reference classes

--- a/tests/test_ext_apidoc.py
+++ b/tests/test_ext_apidoc.py
@@ -318,7 +318,7 @@ def test_toc_all_references_should_exist_pep420_enabled(make_app, apidoc):
         if ref and ref[0] in (':', '#'):
             continue
         found_refs.append(ref)
-        filename = "{}.rst".format(ref)
+        filename = f"{ref}.rst"
         if not (outdir / filename).isfile():
             missing_files.append(filename)
 
@@ -347,7 +347,7 @@ def test_toc_all_references_should_exist_pep420_disabled(make_app, apidoc):
     for ref in refs:
         if ref and ref[0] in (':', '#'):
             continue
-        filename = "{}.rst".format(ref)
+        filename = f"{ref}.rst"
         found_refs.append(ref)
         if not (outdir / filename).isfile():
             missing_files.append(filename)

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -62,7 +62,7 @@ def test_mangle_signature():
             if '::' in x]
     for inp, outp in TEST:
         res = mangle_signature(inp).strip().replace("\u00a0", " ")
-        assert res == outp, ("'%s' -> '%s' != '%s'" % (inp, res, outp))
+        assert res == outp, ("'{}' -> '{}' != '{}'".format(inp, res, outp))
 
 
 def test_extract_summary(capsys):

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -62,7 +62,7 @@ def test_mangle_signature():
             if '::' in x]
     for inp, outp in TEST:
         res = mangle_signature(inp).strip().replace("\u00a0", " ")
-        assert res == outp, ("'{}' -> '{}' != '{}'".format(inp, res, outp))
+        assert res == outp, (f"'{inp}' -> '{res}' != '{outp}'")
 
 
 def test_extract_summary(capsys):

--- a/tests/test_ext_doctest.py
+++ b/tests/test_ext_doctest.py
@@ -117,7 +117,7 @@ def test_skipif(app, status, warning):
 def record(directive, part, should_skip):
     global recorded_calls
     recorded_calls[(directive, part, should_skip)] += 1
-    return 'Recorded {} {} {}'.format(directive, part, should_skip)
+    return f'Recorded {directive} {part} {should_skip}'
 
 
 @pytest.mark.sphinx('doctest', testroot='ext-doctest-with-autodoc')

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -708,12 +708,12 @@ def test_html_index_entries(app):
     def wrap(tag, keyword):
         start_tag = "<%s[^>]*>" % tag
         end_tag = "</%s>" % tag
-        return r"%s\s*%s\s*%s" % (start_tag, keyword, end_tag)
+        return r"{}\s*{}\s*{}".format(start_tag, keyword, end_tag)
 
     def wrap_nest(parenttag, childtag, keyword):
         start_tag1 = "<%s[^>]*>" % parenttag
         start_tag2 = "<%s[^>]*>" % childtag
-        return r"%s\s*%s\s*%s" % (start_tag1, keyword, start_tag2)
+        return r"{}\s*{}\s*{}".format(start_tag1, keyword, start_tag2)
     expected_exprs = [
         wrap('a', 'NEWSLETTER'),
         wrap('a', 'MAILING LIST'),

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -708,12 +708,12 @@ def test_html_index_entries(app):
     def wrap(tag, keyword):
         start_tag = "<%s[^>]*>" % tag
         end_tag = "</%s>" % tag
-        return r"{}\s*{}\s*{}".format(start_tag, keyword, end_tag)
+        return fr"{start_tag}\s*{keyword}\s*{end_tag}"
 
     def wrap_nest(parenttag, childtag, keyword):
         start_tag1 = "<%s[^>]*>" % parenttag
         start_tag2 = "<%s[^>]*>" % childtag
-        return r"{}\s*{}\s*{}".format(start_tag1, keyword, start_tag2)
+        return fr"{start_tag1}\s*{keyword}\s*{start_tag2}"
     expected_exprs = [
         wrap('a', 'NEWSLETTER'),
         wrap('a', 'MAILING LIST'),

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -67,18 +67,18 @@ def test_js_source(app, status, warning):
     app.builder.build(['contents'])
 
     v = '3.6.0'
-    msg = 'jquery.js version does not match to {v}'.format(v=v)
+    msg = f'jquery.js version does not match to {v}'
     jquery_min = (app.outdir / '_static' / 'jquery.js').read_text(encoding='utf8')
-    assert 'jQuery v{v}'.format(v=v) in jquery_min, msg
-    jquery_src = (app.outdir / '_static' / 'jquery-{v}.js'.format(v=v)).read_text(encoding='utf8')
-    assert 'jQuery JavaScript Library v{v}'.format(v=v) in jquery_src, msg
+    assert f'jQuery v{v}' in jquery_min, msg
+    jquery_src = (app.outdir / '_static' / f'jquery-{v}.js').read_text(encoding='utf8')
+    assert f'jQuery JavaScript Library v{v}' in jquery_src, msg
 
     v = '1.13.1'
-    msg = 'underscore.js version does not match to {v}'.format(v=v)
+    msg = f'underscore.js version does not match to {v}'
     underscore_min = (app.outdir / '_static' / 'underscore.js').read_text(encoding='utf8')
-    assert 'Underscore.js {v}'.format(v=v) in underscore_min, msg
-    underscore_src = (app.outdir / '_static' / 'underscore-{v}.js'.format(v=v)).read_text(encoding='utf8')
-    assert 'Underscore.js {v}'.format(v=v) in underscore_src, msg
+    assert f'Underscore.js {v}' in underscore_min, msg
+    underscore_src = (app.outdir / '_static' / f'underscore-{v}.js').read_text(encoding='utf8')
+    assert f'Underscore.js {v}' in underscore_src, msg
 
 
 @pytest.mark.sphinx(testroot='double-inheriting-theme')

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -103,7 +103,7 @@ class Changes:
 
     def finalize_release_date(self):
         release_date = datetime.now().strftime('%b %d, %Y')
-        heading = 'Release {} (released {})'.format(self.version, release_date)
+        heading = f'Release {self.version} (released {release_date})'
 
         with open(self.path, 'r+', encoding='utf-8') as f:
             f.readline()  # skip first two lines

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -103,7 +103,7 @@ class Changes:
 
     def finalize_release_date(self):
         release_date = datetime.now().strftime('%b %d, %Y')
-        heading = 'Release %s (released %s)' % (self.version, release_date)
+        heading = 'Release {} (released {})'.format(self.version, release_date)
 
         with open(self.path, 'r+', encoding='utf-8') as f:
             f.readline()  # skip first two lines
@@ -121,7 +121,7 @@ class Changes:
             version = stringify_version(version_info)
         else:
             reltype = version_info[3]
-            version = '%s %s%s' % (stringify_version(version_info),
+            version = '{} {}{}'.format(stringify_version(version_info),
                                    RELEASE_TYPE.get(reltype, reltype),
                                    version_info[4] or '')
         heading = 'Release %s (in development)' % version

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -121,9 +121,11 @@ class Changes:
             version = stringify_version(version_info)
         else:
             reltype = version_info[3]
-            version = '{} {}{}'.format(stringify_version(version_info),
-                                   RELEASE_TYPE.get(reltype, reltype),
-                                   version_info[4] or '')
+            version = '{} {}{}'.format(
+                stringify_version(version_info),
+                RELEASE_TYPE.get(reltype, reltype),
+                version_info[4] or ''
+            )
         heading = 'Release %s (in development)' % version
 
         with open(os.path.join(script_dir, 'CHANGES_template'), encoding='utf-8') as f:


### PR DESCRIPTION
this an experimental run of using `pyupgrade` on this code-base.

This will need to be reviewed carefully. I can imagine some whitelisting might be required, for example if a test is deliberately using an older python syntax for a test or similar, then pyupgrade would blindly update it to new syntax and invalidate the test.