### PR TITLE
Fix 10605 constructor annotations in description

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+- #10286: C++, support requires clauses not just between the template
+  parameter lists and the declaration.
+
 Bugs fixed
 ----------
 

--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Bugs fixed
 
 * #10723: LaTeX: 5.1.0 has made the 'sphinxsetup' ``verbatimwithframe=false``
   become without effect.
+* #10605: Python autodoc: fix constructor argument types when
+  `autodoc_typehints` is `'description'` or `'both'`.
 
 Testing
 --------
@@ -344,7 +346,7 @@ Bugs fixed
 * #9924: LaTeX: multi-line :rst:dir:`cpp:function` directive has big vertical
   spacing in Latexpdf
 * #10158: LaTeX: excessive whitespace since v4.4.0 for undocumented
-  variables/structure members 
+  variables/structure members
 * #10175: LaTeX: named footnote reference is linked to an incorrect footnote if
   the name is also used in the different document
 * #10269: manpage: Failed to resolve the title of :rst:role:`ref` cross references
@@ -1217,7 +1219,7 @@ Bugs fixed
   inside function type signatures
 * #8780: LaTeX: long words in narrow columns may not be hyphenated
 * #8788: LaTeX: ``\titleformat`` last argument in sphinx.sty should be
-  bracketed, not braced (and is anyhow not needed) 
+  bracketed, not braced (and is anyhow not needed)
 * #8849: LaTex: code-block printed out of margin (see the opt-in LaTeX syntax
   boolean :ref:`verbatimforcewraps <latexsphinxsetupforcewraps>` for use via
   the :ref:`'sphinxsetup' <latexsphinxsetup>` key of ``latex_elements``)

--- a/doc/tutorial/deploying.rst
+++ b/doc/tutorial/deploying.rst
@@ -192,7 +192,7 @@ contents:
        steps:
        - uses: actions/checkout@v3
        - name: Build HTML
-         uses: ammaraskar/sphinx-action@0.4
+         uses: ammaraskar/sphinx-action@master
        - name: Upload artifacts
          uses: actions/upload-artifact@v3
          with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,75 @@ ignore_missing_imports = True
 follow_imports = skip
 check_untyped_defs = True
 warn_unused_ignores = True
-strict_optional = False
+strict_optional = True
 no_implicit_optional = True
 warn_redundant_casts = True
+
+[mypy-sphinx.application]
+strict_optional = False
+
+[mypy-sphinx.builders]
+strict_optional = False
+
+[mypy-sphinx.builders.gettext]
+strict_optional = False
+
+[mypy-sphinx.builders.html]
+strict_optional = False
+
+[mypy-sphinx.builders.latex.*]
+strict_optional = False
+
+[mypy-sphinx.builders.linkcheck]
+strict_optional = False
+
+[mypy-sphinx.builders.singlehtml]
+strict_optional = False
+
+[mypy-sphinx.cmd.*]
+strict_optional = False
+
+[mypy-sphinx.directives]
+strict_optional = False
+
+[mypy-sphinx.directives.code]
+strict_optional = False
+
+[mypy-sphinx.domains.*]
+strict_optional = False
+
+[mypy-sphinx.environment.*]
+strict_optional = False
+
+[mypy-sphinx.ext.*]
+strict_optional = False
+
+[mypy-sphinx.locale]
+strict_optional = False
+
+[mypy-sphinx.pycode.parser]
+strict_optional = False
+
+[mypy-sphinx.registry.*]
+strict_optional = False
+
+[mypy-sphinx.search]
+strict_optional = False
+
+[mypy-sphinx.setup_command]
+strict_optional = False
+
+[mypy-sphinx.testing.util]
+strict_optional = False
+
+[mypy-sphinx.transforms.*]
+strict_optional = False
+
+[mypy-sphinx.util.*]
+strict_optional = False
+
+[mypy-sphinx.writers.*]
+strict_optional = False
 
 [tool:pytest]
 filterwarnings =

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -1,6 +1,6 @@
 """Additional docutils nodes."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 import docutils
 from docutils import nodes
@@ -27,7 +27,7 @@ class document(nodes.document):
                    in your extensions.  It will be removed without deprecation period.
     """
 
-    def set_id(self, node: Element, msgnode: Element = None,
+    def set_id(self, node: Element, msgnode: Optional[Element] = None,
                suggested_prefix: str = '') -> str:
         if docutils.__version_info__ >= (0, 16):
             ret = super().set_id(node, msgnode, suggested_prefix)  # type: ignore

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1023,7 +1023,7 @@ class StandaloneHTMLBuilder(Builder):
         return quote(docname) + self.link_suffix
 
     def handle_page(self, pagename: str, addctx: Dict, templatename: str = 'page.html',
-                    outfilename: str = None, event_arg: Any = None) -> None:
+                    outfilename: Optional[str] = None, event_arg: Any = None) -> None:
         ctx = self.globalcontext.copy()
         # current_page_name is backwards compatibility
         ctx['pagename'] = ctx['current_page_name'] = pagename

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -424,7 +424,7 @@ def correct_copyright_year(app: "Sphinx", config: Config) -> None:
                 config[k] = copyright_year_re.sub(replace, config[k])
 
 
-def check_confval_types(app: "Sphinx", config: Config) -> None:
+def check_confval_types(app: Optional["Sphinx"], config: Config) -> None:
     """Check all values for deviation from the default value's type, since
     that can result in TypeErrors all over the place NB.
     """

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -8089,7 +8089,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     return {
         'version': 'builtin',
-        'env_version': 6,
+        'env_version': 7,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6997,7 +6997,7 @@ class DefinitionParser(BaseParser):
         if self.match(_visibility_re):
             visibility = self.matched_text
 
-        if objectType in ('type', 'concept', 'member', 'function', 'class'):
+        if objectType in ('type', 'concept', 'member', 'function', 'class', 'union'):
             templatePrefix = self._parse_template_declaration_prefix(objectType)
 
         if objectType == 'type':

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6537,7 +6537,14 @@ class DefinitionParser(BaseParser):
                 declSpecs = self._parse_decl_specs(outer=outer, typed=False)
                 decl = self._parse_declarator(named=True, paramMode=outer,
                                               typed=False)
-                self.assert_end(allowSemicolon=True)
+                must_end = True
+                if outer == 'function':
+                    # Allow trailing requires on constructors
+                    self.skip_ws()
+                    if re.compile(r'requires\b').match(self.definition, self.pos):
+                        must_end = False
+                if must_end:
+                    self.assert_end(allowSemicolon=True)
             except DefinitionError as exUntyped:
                 if outer == 'type':
                     desc = "If just a name"

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7017,8 +7017,7 @@ class DefinitionParser(BaseParser):
             declaration = self._parse_type_with_init(named=True, outer='member')
         elif objectType == 'function':
             declaration = self._parse_type(named=True, outer='function')
-            if templatePrefix is not None:
-                trailingRequiresClause = self._parse_requires_clause()
+            trailingRequiresClause = self._parse_requires_clause()
         elif objectType == 'class':
             declaration = self._parse_class()
         elif objectType == 'union':

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1272,6 +1272,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
         try:
             self.env.app.emit('autodoc-before-process-signature', self.object, False)
             sig = inspect.signature(self.object, type_aliases=self.config.autodoc_type_aliases)
+            self.env.app.emit('autodoc-after-inspection', self.object, self.fullname, sig)
             args = stringify_signature(sig, **kwargs)
         except TypeError as exc:
             logger.warning(__("Failed to get a function signature for %s: %s"),
@@ -1487,6 +1488,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             try:
                 sig = inspect.signature(call, bound_method=True,
                                         type_aliases=self.config.autodoc_type_aliases)
+                self.env.app.emit('autodoc-after-inspection', self.object, self.fullname,
+                                  sig)
                 return type(self.object), '__call__', sig
             except ValueError:
                 pass
@@ -1503,6 +1506,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             try:
                 sig = inspect.signature(new, bound_method=True,
                                         type_aliases=self.config.autodoc_type_aliases)
+                self.env.app.emit('autodoc-after-inspection', self.object, self.fullname,
+                                  sig)
                 return self.object, '__new__', sig
             except ValueError:
                 pass
@@ -1514,6 +1519,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             try:
                 sig = inspect.signature(init, bound_method=True,
                                         type_aliases=self.config.autodoc_type_aliases)
+                self.env.app.emit('autodoc-after-inspection', self.object, self.fullname,
+                                  sig)
                 return self.object, '__init__', sig
             except ValueError:
                 pass
@@ -1526,6 +1533,8 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         try:
             sig = inspect.signature(self.object, bound_method=False,
                                     type_aliases=self.config.autodoc_type_aliases)
+            self.env.app.emit('autodoc-after-inspection', self.object, self.fullname,
+                              sig)
             return None, None, sig
         except ValueError:
             pass
@@ -2824,6 +2833,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('autodoc_warningiserror', True, True)
     app.add_config_value('autodoc_inherit_docstrings', True, True)
     app.add_event('autodoc-before-process-signature')
+    app.add_event('autodoc-after-inspection')
     app.add_event('autodoc-process-docstring')
     app.add_event('autodoc-process-signature')
     app.add_event('autodoc-skip-member')

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -1,5 +1,6 @@
 """Generating content for autodoc using typehints"""
 
+import inspect
 import re
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, Set, cast
@@ -9,11 +10,10 @@ from docutils.nodes import Element
 
 from sphinx import addnodes
 from sphinx.application import Sphinx
-from sphinx.util import inspect, typing
+from sphinx.util import typing
 
 
-def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
-                     options: Dict, args: str, retann: str) -> None:
+def record_typehints(app: Sphinx, obj: Any, name: str, sig: inspect.Signature) -> None:
     """Record type hints to env object."""
     if app.config.autodoc_typehints_format == 'short':
         mode = 'smart'
@@ -24,7 +24,6 @@ def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
         if callable(obj):
             annotations = app.env.temp_data.setdefault('annotations', {})
             annotation = annotations.setdefault(name, OrderedDict())
-            sig = inspect.signature(obj, type_aliases=app.config.autodoc_type_aliases)
             for param in sig.parameters.values():
                 if param.annotation is not param.empty:
                     annotation[param.name] = typing.stringify(param.annotation, mode)
@@ -202,7 +201,7 @@ def augment_descriptions_with_types(
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.connect('autodoc-process-signature', record_typehints)
+    app.connect('autodoc-after-inspection', record_typehints)
     app.connect('object-description-transform', merge_typehints)
 
     return {

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -182,7 +182,7 @@ def read_doc(app: "Sphinx", env: BuildEnvironment, filename: str) -> nodes.docum
                     writer=SphinxDummyWriter(),
                     source_class=SphinxFileInput,
                     destination=NullOutput())
-    pub.process_programmatic_settings(None, env.settings, None)
+    pub.process_programmatic_settings(None, env.settings, None)  # type: ignore[arg-type]
     pub.set_source(source_path=filename)
     pub.publish()
     return pub.document

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -3,7 +3,7 @@
 import pathlib
 from os import path
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from jinja2 import BaseLoader, FileSystemLoader, TemplateNotFound
 from jinja2.environment import Environment
@@ -142,7 +142,12 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
 
     # TemplateBridge interface
 
-    def init(self, builder: "Builder", theme: Theme = None, dirs: List[str] = None) -> None:
+    def init(
+        self,
+        builder: "Builder",
+        theme: Optional[Theme] = None,
+        dirs: Optional[List[str]] = None
+    ) -> None:
         # create a chain of paths to search
         if theme:
             # the theme's own dir and its bases' dirs

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -5,7 +5,7 @@ import sys
 from collections import namedtuple
 from io import StringIO
 from subprocess import PIPE
-from typing import Any, Callable, Dict, Generator, Tuple
+from typing import Any, Callable, Dict, Generator, Optional, Tuple
 
 import pytest
 
@@ -28,7 +28,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope='session')
-def rootdir() -> str:
+def rootdir() -> Optional[str]:
     return None
 
 

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -2,7 +2,7 @@ import builtins
 import os
 import shutil
 import sys
-from typing import IO, Any, Callable, List
+from typing import IO, Any, Callable, List, Optional
 
 FILESYSTEMENCODING = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
@@ -69,7 +69,7 @@ class path(str):
         """
         return os.path.ismount(self)
 
-    def rmtree(self, ignore_errors: bool = False, onerror: Callable = None) -> None:
+    def rmtree(self, ignore_errors: bool = False, onerror: Optional[Callable] = None) -> None:
         """
         Removes the file or directory and any files or directories it may
         contain.

--- a/tests/roots/test-ext-autodoc/index.rst
+++ b/tests/roots/test-ext-autodoc/index.rst
@@ -13,3 +13,11 @@
 .. autofunction:: target.overload.sum
 
 .. autofunction:: target.typehints.tuple_args
+
+.. autoclass:: target.typehints_lazy.LazyGeneric
+
+.. autoclass:: target.typehints_lazy.LazyInit
+
+.. autoclass:: target.typehints_lazy.LazyInitOldStyle
+
+.. autoclass:: target.classes.CommentTypeHints

--- a/tests/roots/test-ext-autodoc/target/classes.py
+++ b/tests/roots/test-ext-autodoc/target/classes.py
@@ -33,6 +33,12 @@ class Corge(Quux):
     pass
 
 
+class CommentTypeHints:
+    def __init__(self, x):
+        # type: (Maybe[int]) -> None
+        ...
+
+
 Alias = Foo
 
 #: docstring

--- a/tests/roots/test-ext-autodoc/target/typehints_lazy.py
+++ b/tests/roots/test-ext-autodoc/target/typehints_lazy.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import (
+    Generic,
+    Optional as Opt,  # rename to test resolution
+    TypeVar,
+)
+
+
+_T = TypeVar("_T")
+
+
+class LazyGeneric(Generic[_T]):
+    """Generic docstring ;)
+
+    :param x: maybe also generic
+    """
+
+    def __init__(self, x: Opt[_T]) -> None:
+        ...
+
+
+class LazyInit:
+    """I am lazy!
+
+    :param x: this is x
+    """
+    def __init__(self, x: Opt[int]) -> None:
+        ...

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -893,6 +893,8 @@ def test_domain_cpp_ast_requires_clauses():
           {4: 'I0EIQoo1Aoo1B1CE1fvv'})
     check('function', 'void f() requires A || B || C',
           {4: 'IQoo1Aoo1B1CE1fv'})
+    check('function', 'Foo() requires A || B || C',
+          {4: 'IQoo1Aoo1B1CE3Foov'})
     check('function', 'template<typename T> requires A && B || C and D void f()',
           {4: 'I0EIQooaa1A1Baa1C1DE1fvv'})
     check('function',

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -893,6 +893,24 @@ def test_domain_cpp_ast_requires_clauses():
           {4: 'I0EIQoo1Aoo1B1CE1fvv'})
     check('function', 'template<typename T> requires A && B || C and D void f()',
           {4: 'I0EIQooaa1A1Baa1C1DE1fvv'})
+    check('function',
+          'template<typename T> requires R<T> ' +
+          'template<typename U> requires S<T> ' +
+          'void A<T>::f() requires B',
+          {4: 'I0EIQ1RI1TEEI0EIQaa1SI1TE1BEN1AI1TE1fEvv'})
+    check('function',
+          'template<template<typename T> requires R<T> typename X> ' +
+          'void f()',
+          {2: 'II0EIQ1RI1TEE0E1fv', 4: 'II0EIQ1RI1TEE0E1fvv'})
+    check('type',
+          'template<typename T> requires IsValid<T> {key}T = true_type',
+          {4: 'I0EIQ7IsValidI1TEE1T'}, key='using')
+    check('class',
+          'template<typename T> requires IsValid<T> {key}T : Base',
+          {4: 'I0EIQ7IsValidI1TEE1T'}, key='class')
+    check('member',
+          'template<typename T> requires IsValid<T> int Val = 7',
+          {4: 'I0EIQ7IsValidI1TEE3Val'})
 
 
 def test_domain_cpp_ast_template_args():

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -912,6 +912,9 @@ def test_domain_cpp_ast_requires_clauses():
     check('class',
           'template<typename T> requires IsValid<T> {key}T : Base',
           {4: 'I0EIQ7IsValidI1TEE1T'}, key='class')
+    check('union',
+          'template<typename T> requires IsValid<T> {key}T',
+          {4: 'I0EIQ7IsValidI1TEE1T'}, key='union')
     check('member',
           'template<typename T> requires IsValid<T> int Val = 7',
           {4: 'I0EIQ7IsValidI1TEE3Val'})

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -891,6 +891,8 @@ def test_domain_cpp_ast_requires_clauses():
           {4: 'I0EIQaa1A1BE1fvv'})
     check('function', 'template<typename T> requires A || B or C void f()',
           {4: 'I0EIQoo1Aoo1B1CE1fvv'})
+    check('function', 'void f() requires A || B || C',
+          {4: 'IQoo1Aoo1B1CE1fv'})
     check('function', 'template<typename T> requires A && B || C and D void f()',
           {4: 'I0EIQooaa1A1Baa1C1DE1fvv'})
     check('function',

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -970,6 +970,21 @@ def test_autodoc_typehints_description(app):
             '   Return type:\n'
             '      *Tuple*[int, int]\n'
             in context)
+    assert ('class target.typehints_lazy.LazyInit(x)\n'
+            '\n'
+            '   I am lazy!\n'
+            '\n'
+            '   Parameters:\n'
+            '      **x** (*Optional**[**int**]*) -- this is x\n'
+            in context)
+
+    assert ('class target.typehints_lazy.LazyGeneric(x)\n'
+            '\n'
+            '   Generic docstring ;)\n'
+            '\n'
+            '   Parameters:\n'
+            '      **x** (*Optional**[**_T**]*) -- maybe also generic\n'
+            in context)
 
     # Overloads still get displayed in the signature
     assert ('target.overload.sum(x: int, y: int = 0) -> int\n'


### PR DESCRIPTION
Constructor annotations where not properly detected in autodoc when
`autodoc_typehints` was `'description'` or `'both'`.

### Feature or Bugfix
- Bugfix

### Relates
- https://github.com/sphinx-doc/sphinx/issues/10605

