### PR TITLE
[C++] Ensure consistent non-specialization template argument representation, rebased and updated

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Bugs fixed
 
 - #10257: C++, ensure consistent non-specialization template argument
   representation.
+- #10729: C++, fix parsing of certain non-type template parameter packs.
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,9 @@ Features added
 Bugs fixed
 ----------
 
+- #10257: C++, ensure consistent non-specialization template argument
+  representation.
+
 Testing
 --------
 

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -4850,7 +4850,7 @@ class Symbol:
                     if symbol.declaration is None:
                         if Symbol.debug_lookup:
                             Symbol.debug_print("empty candidate")
-                        # if in the end we have non matching, but have an empty one,
+                        # if in the end we have non-matching, but have an empty one,
                         # then just continue with that
                         ourChild = symbol
                         continue
@@ -4880,10 +4880,10 @@ class Symbol:
                     if (otherChild.declaration.objectType ==
                             ourChild.declaration.objectType and
                             otherChild.declaration.objectType in
-                            ('templateParam', 'functionParam')):
-                        # `ourChild` was presumably just created during mergging
-                        # by the call to `_fill_empty` on the parent and can be
-                        # ignored.
+                            ('templateParam', 'functionParam') and
+                            ourChild.parent.declaration == otherChild.parent.declaration):
+                        # `ourChild` was just created during merging by the call
+                        # to `_fill_empty` on the parent and can be ignored.
                         pass
                     else:
                         # Both have declarations, and in the same docname.
@@ -5153,6 +5153,7 @@ class Symbol:
                 res.append(": ")
                 if self.isRedeclaration:
                     res.append('!!duplicate!! ')
+                res.append("{" + self.declaration.objectType + "} ")
                 res.append(str(self.declaration))
         if self.docname:
             res.append('\t(')

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -8149,7 +8149,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
 
     return {
         'version': 'builtin',
-        'env_version': 7,
+        'env_version': 8,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -841,9 +841,9 @@ def test_domain_cpp_ast_templates():
     check('class', 'abc::ns::foo{{id_0, id_1, ...id_2}} {key}xyz::bar',
           {2: 'I00DpEXN3abc2ns3fooEI4id_04id_1sp4id_2EEN3xyz3barE'})
     check('class', 'abc::ns::foo{{id_0, id_1, id_2}} {key}xyz::bar<id_0, id_1, id_2>',
-          {2: 'I000EXN3abc2ns3fooEI4id_04id_14id_2EEN3xyz3barI4id_04id_14id_2EE'})
+          {2: 'I000EXN3abc2ns3fooEI4id_04id_14id_2EEN3xyz3barE'})
     check('class', 'abc::ns::foo{{id_0, id_1, ...id_2}} {key}xyz::bar<id_0, id_1, id_2...>',
-          {2: 'I00DpEXN3abc2ns3fooEI4id_04id_1sp4id_2EEN3xyz3barI4id_04id_1Dp4id_2EE'})
+          {2: 'I00DpEXN3abc2ns3fooEI4id_04id_1sp4id_2EEN3xyz3barE'})
 
     check('class', 'template<> Concept{{U}} {key}A<int>::B', {2: 'IEI0EX7ConceptI1UEEN1AIiE1BE'})
 
@@ -901,7 +901,7 @@ def test_domain_cpp_ast_requires_clauses():
           'template<typename T> requires R<T> ' +
           'template<typename U> requires S<T> ' +
           'void A<T>::f() requires B',
-          {4: 'I0EIQ1RI1TEEI0EIQaa1SI1TE1BEN1AI1TE1fEvv'})
+          {4: 'I0EIQ1RI1TEEI0EIQaa1SI1TE1BEN1A1fEvv'})
     check('function',
           'template<template<typename T> requires R<T> typename X> ' +
           'void f()',
@@ -1395,3 +1395,89 @@ def test_domain_cpp_parse_mix_decl_duplicate(app, warning):
     assert "index.rst:3: WARNING: Duplicate C++ declaration, also defined at index:1." in ws[2]
     assert "Declaration is '.. cpp:struct:: A'." in ws[3]
     assert ws[4] == ""
+
+
+# For some reason, using the default testroot of "root" leads to the contents of
+# `test-root/objects.txt` polluting the symbol table depending on the test
+# execution order.  Using a testroot of "config" seems to avoid that problem.
+@pytest.mark.sphinx(testroot='config')
+def test_domain_cpp_normalize_unspecialized_template_args(make_app, app_params):
+    args, kwargs = app_params
+
+    text1 = (".. cpp:class:: template <typename T> A\n")
+    text2 = (".. cpp:class:: template <typename T> template <typename U> A<T>::B\n")
+
+    app1 = make_app(*args, **kwargs)
+    restructuredtext.parse(app=app1, text=text1, docname='text1')
+    root1 = app1.env.domaindata['cpp']['root_symbol']
+
+    assert root1.dump(1) == (
+        '  ::\n'
+        '    template<typename T> \n'
+        '    A: template<typename T> A\t(text1)\n'
+        '      T: typename T\t(text1)\n'
+    )
+
+    app2 = make_app(*args, **kwargs)
+    restructuredtext.parse(app=app2, text=text2, docname='text2')
+    root2 = app2.env.domaindata['cpp']['root_symbol']
+
+    assert root2.dump(1) == (
+        '  ::\n'
+        '    template<typename T> \n'
+        '    A\n'
+        '      T\n'
+        '      template<typename U> \n'
+        '      B: template<typename T> template<typename U> A<T>::B\t(text2)\n'
+        '        U: typename U\t(text2)\n'
+    )
+
+    root2.merge_with(root1, ['text1'], app2.env)
+
+    assert root2.dump(1) == (
+        '  ::\n'
+        '    template<typename T> \n'
+        '    A: template<typename T> A\t(text1)\n'
+        '      T: typename T\t(text1)\n'
+        '      template<typename U> \n'
+        '      B: template<typename T> template<typename U> A<T>::B\t(text2)\n'
+        '        U: typename U\t(text2)\n'
+    )
+    warning = app2._warning.getvalue()
+    assert 'Internal C++ domain error during symbol merging' not in warning
+
+
+def parse_template_parameter(param: str):
+    ast = parse('type', 'template<' + param + '> X')
+    return ast.templatePrefix.templates[0].params[0]
+
+
+@pytest.mark.parametrize(
+    'param,is_pack',
+    [('typename', False),
+     ('typename T', False),
+     ('typename...', True),
+     ('typename... T', True),
+     ('int', False),
+     ('int N', False),
+     ('int* N', False),
+     ('int& N', False),
+     ('int&... N', True),
+     ('int*... N', True),
+     ('int...', True),
+     ('int... N', True),
+     ('auto', False),
+     ('auto...', True),
+     ('int X::*', False),
+     ('int X::*...', True),
+     ('int (X::*)(bool)', False),
+     ('int (X::*x)(bool)', False),
+     # TODO: the following two declarations cannot currently be parsed
+     # ('int (X::*)(bool)...', True),
+     # ('int (X::*x...)(bool)', True),
+     ('template<typename> class', False),
+     ('template<typename> class...', True),
+     ])
+def test_domain_cpp_template_parameters_is_pack(param: str, is_pack: bool):
+    ast = parse_template_parameter(param)
+    assert ast.isPack == is_pack

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -1414,8 +1414,8 @@ def test_domain_cpp_normalize_unspecialized_template_args(make_app, app_params):
     assert root1.dump(1) == (
         '  ::\n'
         '    template<typename T> \n'
-        '    A: template<typename T> A\t(text1)\n'
-        '      T: typename T\t(text1)\n'
+        '    A: {class} template<typename T> A\t(text1)\n'
+        '      T: {templateParam} typename T\t(text1)\n'
     )
 
     app2 = make_app(*args, **kwargs)
@@ -1428,8 +1428,8 @@ def test_domain_cpp_normalize_unspecialized_template_args(make_app, app_params):
         '    A\n'
         '      T\n'
         '      template<typename U> \n'
-        '      B: template<typename T> template<typename U> A<T>::B\t(text2)\n'
-        '        U: typename U\t(text2)\n'
+        '      B: {class} template<typename T> template<typename U> A<T>::B\t(text2)\n'
+        '        U: {templateParam} typename U\t(text2)\n'
     )
 
     root2.merge_with(root1, ['text1'], app2.env)
@@ -1437,11 +1437,11 @@ def test_domain_cpp_normalize_unspecialized_template_args(make_app, app_params):
     assert root2.dump(1) == (
         '  ::\n'
         '    template<typename T> \n'
-        '    A: template<typename T> A\t(text1)\n'
-        '      T: typename T\t(text1)\n'
+        '    A: {class} template<typename T> A\t(text1)\n'
+        '      T: {templateParam} typename T\t(text1)\n'
         '      template<typename U> \n'
-        '      B: template<typename T> template<typename U> A<T>::B\t(text2)\n'
-        '        U: typename U\t(text2)\n'
+        '      B: {class} template<typename T> template<typename U> A<T>::B\t(text2)\n'
+        '        U: {templateParam} typename U\t(text2)\n'
     )
     warning = app2._warning.getvalue()
     assert 'Internal C++ domain error during symbol merging' not in warning

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -1043,6 +1043,38 @@ def test_domain_cpp_ast_xref_parsing():
     check('T f()')
 
 
+@pytest.mark.parametrize(
+    'param,is_pack',
+    [('typename', False),
+     ('typename T', False),
+     ('typename...', True),
+     ('typename... T', True),
+     ('int', False),
+     ('int N', False),
+     ('int* N', False),
+     ('int& N', False),
+     ('int&... N', True),
+     ('int*... N', True),
+     ('int...', True),
+     ('int... N', True),
+     ('auto', False),
+     ('auto...', True),
+     ('int X::*', False),
+     ('int X::*...', True),
+     ('int (X::*)(bool)', False),
+     ('int (X::*x)(bool)', False),
+     ('int (X::*)(bool)...', True),
+     ('template<typename> class', False),
+     ('template<typename> class...', True),
+     ])
+def test_domain_cpp_template_parameters_is_pack(param: str, is_pack: bool):
+    def parse_template_parameter(param: str):
+        ast = parse('type', 'template<' + param + '> X')
+        return ast.templatePrefix.templates[0].params[0]
+    ast = parse_template_parameter(param)
+    assert ast.isPack == is_pack
+
+
 # def test_print():
 #     # used for getting all the ids out for checking
 #     for a in ids:
@@ -1448,37 +1480,3 @@ def test_domain_cpp_normalize_unspecialized_template_args(make_app, app_params):
     )
     warning = app2._warning.getvalue()
     assert 'Internal C++ domain error during symbol merging' not in warning
-
-
-def parse_template_parameter(param: str):
-    ast = parse('type', 'template<' + param + '> X')
-    return ast.templatePrefix.templates[0].params[0]
-
-
-@pytest.mark.parametrize(
-    'param,is_pack',
-    [('typename', False),
-     ('typename T', False),
-     ('typename...', True),
-     ('typename... T', True),
-     ('int', False),
-     ('int N', False),
-     ('int* N', False),
-     ('int& N', False),
-     ('int&... N', True),
-     ('int*... N', True),
-     ('int...', True),
-     ('int... N', True),
-     ('auto', False),
-     ('auto...', True),
-     ('int X::*', False),
-     ('int X::*...', True),
-     ('int (X::*)(bool)', False),
-     ('int (X::*x)(bool)', False),
-     ('int (X::*)(bool)...', True),
-     ('template<typename> class', False),
-     ('template<typename> class...', True),
-     ])
-def test_domain_cpp_template_parameters_is_pack(param: str, is_pack: bool):
-    ast = parse_template_parameter(param)
-    assert ast.isPack == is_pack

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -876,6 +876,9 @@ def test_domain_cpp_ast_templates():
     # defaulted constrained type parameters
     check('type', 'template<C T = int&> {key}A', {2: 'I_1CE1A'}, key='using')
 
+    # pack expansion after non-type template parameter
+    check('type', 'template<int (X::*)(bool)...> {key}A', {2: 'I_DpM1XFibEE1A'}, key='using')
+
 
 def test_domain_cpp_ast_placeholder_types():
     check('function', 'void f(Sortable auto &v)', {1: 'f__SortableR', 2: '1fR8Sortable'})
@@ -1472,9 +1475,7 @@ def parse_template_parameter(param: str):
      ('int X::*...', True),
      ('int (X::*)(bool)', False),
      ('int (X::*x)(bool)', False),
-     # TODO: the following two declarations cannot currently be parsed
-     # ('int (X::*)(bool)...', True),
-     # ('int (X::*x...)(bool)', True),
+     ('int (X::*)(bool)...', True),
      ('template<typename> class', False),
      ('template<typename> class...', True),
      ])


### PR DESCRIPTION
Rebased and updated version of #10257.
In addition the parameter pack parsing is fixed for one of the noted cases, while the other case is not valid C++ code anyway.