### PR TITLE
Avoid failure when config.language is None

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Bugs fixed
 
 * #10723: LaTeX: 5.1.0 has made the 'sphinxsetup' ``verbatimwithframe=false``
   become without effect.
+* #10768: Avoid failure when config.language is None.
 
 Testing
 --------

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -463,6 +463,8 @@ def install_packages_for_ja(app: Sphinx) -> None:
 
 def default_latex_engine(config: Config) -> str:
     """ Better default latex_engine settings for specific languages. """
+    if config.language is None:
+        return 'pdflatex'
     if config.language == 'ja':
         return 'uplatex'
     elif config.language.startswith('zh'):


### PR DESCRIPTION
Help resolve https://github.com/executablebooks/jupyter-book/issues/1806

Subject:

Despite <https://github.com/sphinx-doc/sphinx/issues/10062> that aims to set a default language to English config.language may have a value of `None`, which breaks downstream execution of jupyter-book (see <https://github.com/executablebooks/jupyter-book/issues/1806>).

Suggested bugfix allows to pass execution of jupyter-book with Sphinx 5.1+.

### Feature or Bugfix
- Bugfix

### Purpose

As above

### Detail

As above

### Relates

As above

