### PR TITLE
doc: add note on unsupported include directive for source-read event content modification

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -260,6 +260,9 @@ Here is a more detailed list of these events.
 
    .. versionadded:: 0.5
 
+   .. note:: Content of files included with the :dudir:`include` directive will
+             be accessible but cannot be modified from within this event.
+
 .. event:: object-description-transform (app, domain, objtype, contentnode)
 
    Emitted when an object description directive has run.  The *domain* and


### PR DESCRIPTION
Subject: doc: add note on unsupported include directive for source-read event content modification

### Purpose
- Files included with the `include` directive have their content available
in the source-read event but modifications will not make it to the
output, so let's document it.
### Relates
- #10678 

### Note
Does this need to be sent to master and/or 4.x branch too?
