### PR TITLE
agogo theme: revert CSS changes related to sidebar

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Bugs fixed
 - #10257: C++, ensure consistent non-specialization template argument
   representation.
 - #10729: C++, fix parsing of certain non-type template parameter packs.
+- #10715: Revert #10520: "Fix" use of sidebar classes in ``agogo.css_t``
 
 Testing
 --------

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -273,6 +273,7 @@ div.document ol {
 
 div.sidebar,
 aside.sidebar {
+  width: {{ theme_sidebarwidth|todim }};
   {%- if theme_rightsidebar|tobool %}
   float: right;
   {%- else %}

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -273,6 +273,11 @@ div.document ol {
 
 div.sidebar,
 aside.sidebar {
+  {%- if theme_rightsidebar|tobool %}
+  float: right;
+  {%- else %}
+  float: left;
+  {%- endif %}
   font-size: .9em;
 }
 


### PR DESCRIPTION
As an alternative to #10716, this fully reverts #10520 and should fix #10715.

### Feature or Bugfix
- Bugfix