### PR TITLE
sphinx13.css: add left padding to the footer

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -226,7 +226,7 @@ div.footer {
     background-image: url(footerbg.png);
     color: #ccc;
     text-shadow: 0 0 .2px rgba(255, 255, 255, 0.8);
-    padding: 3px 8px 3px 0;
+    padding: 3px 8px 3px 8px;
     clear: both;
     font-size: 0.8em;
     text-align: right;


### PR DESCRIPTION
Before, the text started directly at the window edge:

![grafik](https://user-images.githubusercontent.com/2836374/187043218-745f3691-7391-438e-83d1-17de7c7fbd74.png)

after:

![grafik](https://user-images.githubusercontent.com/2836374/187043281-59a5eebf-e7ee-4134-a6f8-1d24d449c632.png)

The 8px padding equals the document padding and thus the text is aligned with the text in the sidebar.
