### PR TITLE
Restrict permissions in GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,11 @@ name: CI
 
 on: [push, pull_request]
 
-permissions: {} # none
+permissions:
+  contents: read
 
 jobs:
   ubuntu:
-    permissions:
-      contents: read
     runs-on: ubuntu-18.04
     name: Python ${{ matrix.python }} (${{ matrix.docutils }})
     strategy:
@@ -51,8 +50,6 @@ jobs:
       run: tox -e ${{ matrix.docutils }} -- -vv
 
   windows:
-    permissions:
-      contents: read
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,12 @@ name: CI
 
 on: [push, pull_request]
 
+permissions: {} # none
+
 jobs:
   ubuntu:
+    permissions:
+      contents: read
     runs-on: ubuntu-18.04
     name: Python ${{ matrix.python }} (${{ matrix.docutils }})
     strategy:
@@ -47,6 +51,8 @@ jobs:
       run: tox -e ${{ matrix.docutils }} -- -vv
 
   windows:
+    permissions:
+      contents: read
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,12 +2,11 @@ name: CI (node.js)
 
 on: [push, pull_request]
 
-permissions: {} # none
+permissions:
+  contents: read
 
 jobs:
   build:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     env:
       node-version: 16

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,8 +2,12 @@ name: CI (node.js)
 
 on: [push, pull_request]
 
+permissions: {} # none
+
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       node-version: 16


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.