### PR TITLE
Remove `sphinx.builders.gettext` module from whitelist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,6 @@ strict_optional = False
 [mypy-sphinx.builders]
 strict_optional = False
 
-[mypy-sphinx.builders.gettext]
-strict_optional = False
-
 [mypy-sphinx.builders.html]
 strict_optional = False
 

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -120,7 +120,6 @@ class I18nBuilder(Builder):
     """
     name = 'i18n'
     versioning_method = 'text'
-    versioning_compare: bool = None  # be set by `gettext_uuid`
     use_message_catalog = False
 
     def init(self) -> None:


### PR DESCRIPTION
shrink the mypy 'strict optional' white list