### PR TITLE
Correct `is_allowed_version()`'s example tests

### DIFF
--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -45,11 +45,11 @@ def is_allowed_version(spec: str, version: str) -> bool:
 
     Some examples:
 
-        >>> is_allowed_version('3.3', '<=3.5')
+        >>> is_allowed_version('<=3.5', '3.3')
         True
-        >>> is_allowed_version('3.3', '<=3.2')
+        >>> is_allowed_version('<=3.2', '3.3')
         False
-        >>> is_allowed_version('3.3', '>3.2, <4.0')
+        >>> is_allowed_version('>3.2, <4.0', '3.3')
         True
     """
     return Version(version) in SpecifierSet(spec)


### PR DESCRIPTION
Params were reversed, Fixes #10801.

Subject: Assure doc example has right param order

### Feature or Bugfix
Bugfix

### Purpose
- Documentation

### Detail
- See #10801 for details

### Relates
- #10801
- sphinx.ext.doctest

Note for later: `sphinx.ext.doctest` itself won't run in `python -m doctest sphinx/ext/doctest.py` due to imports. You have to extract the function to get the error.