### PR TITLE
Fix autodoc for `typing.TypedDict` inheritance

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -13,7 +13,7 @@ import re
 import sys
 import warnings
 from inspect import Parameter, Signature
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypedDict, TypeVar
 
 from docutils.statemachine import StringList
 
@@ -34,6 +34,14 @@ from sphinx.util.inspect import (
     stringify_signature,
 )
 from sphinx.util.typing import OptionSpec, get_type_hints, restify, stringify_annotation
+
+try:
+    from typing import is_typeddict  # type: ignore[attr-defined]
+except ImportError:
+    # Python <3.10
+    def is_typeddict(obj: Any) -> bool:
+        original_bases = safe_getattr(obj, '__orig_bases__', ())
+        return any(base is TypedDict for base in original_bases)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -723,7 +731,7 @@ class Documenter:
                 # workaround for `TypedDict` subclassing; does not work with
                 # `typing_extensions.TypedDict` and requires explicitly passing
                 # `TypedDict` to subclasses
-                if not doc and inspect.isclass(self.object):
+                if not doc and is_typeddict(self.object):
                     __annotations__ = self.get_attr(self.object, '__annotations__', {})
                     if membername in __annotations__:
                         original_bases = safe_getattr(self.object, '__orig_bases__', ())

--- a/tests/roots/test-ext-autodoc/target/typed_dict.py
+++ b/tests/roots/test-ext-autodoc/target/typed_dict.py
@@ -1,0 +1,11 @@
+from typing import TypedDict
+
+
+class Parent(TypedDict):
+    #: parent attr1 doc
+    p_attr1: int
+
+
+class Child(Parent, TypedDict):
+    #: child attr1 doc
+    c_attr1: int

--- a/tests/test_extensions/test_ext_autodoc_autoclass.py
+++ b/tests/test_extensions/test_ext_autodoc_autoclass.py
@@ -240,6 +240,33 @@ def test_properties(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_properties_typed_dict_inherited(app):
+    options = {'members': None,
+               'inherited-members': 'dict'}
+    actual = do_autodoc(app, 'class', 'target.typed_dict.Child', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: Child',
+        '   :module: target.typed_dict',
+        '',
+        '',
+        '   .. py:attribute:: Child.c_attr1',
+        '      :module: target.typed_dict',
+        '      :type: int',
+        '',
+        '      child attr1 doc',
+        '',
+        '',
+        '   .. py:attribute:: Child.p_attr1',
+        '      :module: target.typed_dict',
+        '      :type: int',
+        '',
+        '      parent attr1 doc',
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_slots_attribute(app):
     options = {"members": None}
     actual = do_autodoc(app, 'class', 'target.slots.Bar', options)


### PR DESCRIPTION
Subject: enable listing inherited members of `TypedDict` subclasses

### Feature or Bugfix
- Bugfix

### Purpose
- fix inherited members not showing up for subclasses of `TypedDict`

### Detail
- Workarounds the problem of MRO not including parent classes for `TypedDict` (there does not seem to be a clear reason for that as for [this BDFL comment](https://github.com/python/cpython/issues/85421#issuecomment-1093876783) and subsequent comments - probably someone wanted to make the TypedDict as lightweight as possible, but it seems it was never documented)
- Uses convenient fact that classes directly inheriting from `typing.TypedDict` include `__orig_bases__` from [PEP560](https://peps.python.org/pep-0560/#dynamic-class-creation-and-types-resolve-bases).
- unfortunately does not work with `typing_extensions.TypedDict` which does not implement `__orig_bases__` as of now

### Relates
- fixes #9290