### PR TITLE
Use subtitle name in search results

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -378,7 +378,7 @@ class IndexBuilder:
         alltitles: Dict[str, List[Tuple[int, str]]] = {}
         for docname, titlelist in self._all_titles.items():
             for title, titleid in titlelist:
-                alltitles.setdefault(title.lower(), []).append((fn2index[docname],  titleid))
+                alltitles.setdefault(title, []).append((fn2index[docname],  titleid))
 
         return dict(docnames=docnames, filenames=filenames, titles=titles, terms=terms,
                     objects=objects, objtypes=objtypes, objnames=objnames,

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -280,12 +280,12 @@ const Search = {
 
     const queryLower = query.toLowerCase();
     for (const [title, foundTitles] of Object.entries(allTitles)) {
-      if (title.includes(queryLower) && (queryLower.length >= title.length/2)) {
+      if (title.toLowerCase().includes(queryLower) && (queryLower.length >= title.length/2)) {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
           results.push([
             docNames[file],
-            titles[file],
+            title,
             id !== null ? "#" + id : "",
             null,
             score,


### PR DESCRIPTION
When displaying a search result for a sub-title (not title document), use its name instead of the page title name.