### PR TITLE
Add shell completions by shtab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ test = [
     "typed_ast; python_version < '3.8'",
     "cython",
 ]
+completion = [
+    "shtab",
+]
 
 [[project.authors]]
 name = "Georg Brandl"

--- a/sphinx/_shtab.py
+++ b/sphinx/_shtab.py
@@ -1,0 +1,8 @@
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser, *args, **kwargs):
+    from argparse import Action
+    Action.complete = None  # type: ignore
+    return parser

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -9,6 +9,12 @@ from collections import OrderedDict
 from os import path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
+try:
+    import shtab
+except ImportError:
+    from .. import _shtab as shtab
+
+
 # try to import readline, unix specific enhancement
 try:
     import readline
@@ -464,9 +470,11 @@ def get_parser() -> argparse.ArgumentParser:
         "Makefile to be used with sphinx-build.\n"
     )
     parser = argparse.ArgumentParser(
+        'sphinx-quickstart',
         usage='%(prog)s [OPTIONS] <PROJECT_DIR>',
         epilog=__("For more information, visit <https://www.sphinx-doc.org/>."),
         description=description)
+    shtab.add_argument_to(parser)
 
     parser.add_argument('-q', '--quiet', action='store_true', dest='quiet',
                         default=None,
@@ -475,7 +483,8 @@ def get_parser() -> argparse.ArgumentParser:
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('path', metavar='PROJECT_DIR', default='.', nargs='?',
-                        help=__('project root'))
+                        help=__('project root')
+                        ).complete = shtab.DIR
 
     group = parser.add_argument_group(__('Structure options'))
     group.add_argument('--sep', action='store_true', dest='sep', default=None,
@@ -531,7 +540,8 @@ def get_parser() -> argparse.ArgumentParser:
     group = parser.add_argument_group(__('Project templating'))
     group.add_argument('-t', '--templatedir', metavar='TEMPLATEDIR',
                        dest='templatedir',
-                       help=__('template directory for template files'))
+                       help=__('template directory for template files')
+                        ).complete = shtab.DIR
     group.add_argument('-d', metavar='NAME=VALUE', action='append',
                        dest='variables',
                        help=__('define a template variable'))

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -27,6 +27,12 @@ from sphinx.locale import __
 from sphinx.util.osutil import FileAvoidWrite, ensuredir
 from sphinx.util.template import ReSTRenderer
 
+try:
+    import shtab
+except ImportError:
+    from .. import _shtab as shtab
+
+
 # automodule options
 if 'SPHINX_APIDOC_OPTIONS' in os.environ:
     OPTIONS = os.environ['SPHINX_APIDOC_OPTIONS'].split(',')
@@ -299,6 +305,7 @@ def is_excluded(root: str, excludes: List[str]) -> bool:
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        'sphinx-apidoc',
         usage='%(prog)s [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> '
               '[EXCLUDE_PATTERN, ...]',
         epilog=__('For more information, visit <https://www.sphinx-doc.org/>.'),
@@ -310,19 +317,22 @@ The <EXCLUDE_PATTERN>s can be file and/or directory patterns that will be
 excluded from generation.
 
 Note: By default this script will not overwrite already created files."""))
+    shtab.add_argument_to(parser)
 
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('module_path',
-                        help=__('path to module to document'))
+                        help=__('path to module to document')
+                        ).complete = shtab.FILE
     parser.add_argument('exclude_pattern', nargs='*',
                         help=__('fnmatch-style file and/or directory patterns '
                                 'to exclude from generation'))
 
     parser.add_argument('-o', '--output-dir', action='store', dest='destdir',
                         required=True,
-                        help=__('directory to place all output'))
+                        help=__('directory to place all output')
+                        ).complete = shtab.DIR
     parser.add_argument('-q', action='store_true', dest='quiet',
                         help=__('no output on stdout, just warnings on stderr'))
     parser.add_argument('-d', '--maxdepth', action='store', dest='maxdepth',
@@ -389,7 +399,8 @@ Note: By default this script will not overwrite already created files."""))
     group = parser.add_argument_group(__('Project templating'))
     group.add_argument('-t', '--templatedir', metavar='TEMPLATEDIR',
                        dest='templatedir',
-                       help=__('template directory for template files'))
+                       help=__('template directory for template files')
+                       ).complete = shtab.DIR
 
     return parser
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -44,6 +44,12 @@ from sphinx.util.inspect import getall, safe_getattr
 from sphinx.util.osutil import ensuredir
 from sphinx.util.template import SphinxTemplateLoader
 
+try:
+    import shtab
+except ImportError:
+    from ... import _shtab as shtab
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -591,16 +597,19 @@ The format of the autosummary directive is documented in the
 
   pydoc sphinx.ext.autosummary
 """))
+    shtab.add_argument_to(parser)
 
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
 
     parser.add_argument('source_file', nargs='+',
-                        help=__('source files to generate rST files for'))
+                        help=__('source files to generate rST files for')
+                        ).complete = shtab.FILE
 
     parser.add_argument('-o', '--output-dir', action='store',
                         dest='output_dir',
-                        help=__('directory to place all output in'))
+                        help=__('directory to place all output in')
+                        ).complete = shtab.DIR
     parser.add_argument('-s', '--suffix', action='store', dest='suffix',
                         default='rst',
                         help=__('default suffix for files (default: '


### PR DESCRIPTION
Subject: Add shell completions by shtab

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Install

```sh
cmds=(apidoc autogen build quickstart)
for cmd in $cmds; do
 sphinx-$cmd --print-completion bash | sudo tee /usr/share/bash-completion/completions/sphinx-$cmd
 sphinx-$cmd --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_sphinx-$cmd
 sphinx-$cmd --print-completion tcsh | sudo tee /etc/profile.d/sphinx-$cmd.completion.csh
done
```

### Result

```sh
❯ sphinx-quickstart -<TAB>
option
-a                   author names
--author             author names
--batchfile          create batchfile
-d                   define a template variable
--dot                replacement for dot in _templates etc.
...
❯ sphinx-quickstart --templatedir <TAB>
templatedir
doc/     sphinx/  tests/   utils/
```
