### PR TITLE
Fix `get_terminal_width` on Windows

### DIFF
--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import sys
 from typing import Dict, Pattern
 
@@ -22,21 +23,8 @@ def terminal_safe(s: str) -> str:
 
 
 def get_terminal_width() -> int:
-    """Borrowed from the py lib."""
-    if sys.platform == "win32":
-        # For static typing, as fcntl & termios never exist on Windows.
-        return int(os.environ.get('COLUMNS', 80)) - 1
-    try:
-        import fcntl
-        import struct
-        import termios
-        call = fcntl.ioctl(0, termios.TIOCGWINSZ, struct.pack('hhhh', 0, 0, 0, 0))
-        height, width = struct.unpack('hhhh', call)[:2]
-        terminal_width = width
-    except Exception:
-        # FALLBACK
-        terminal_width = int(os.environ.get('COLUMNS', 80)) - 1
-    return terminal_width
+    """Get number of columns of the terminal."""
+    return shutil.get_terminal_size().columns - 1
 
 
 _tw: int = get_terminal_width()

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -23,7 +23,7 @@ def terminal_safe(s: str) -> str:
 
 
 def get_terminal_width() -> int:
-    """Get number of columns of the terminal."""
+    """Return the width of the terminal in columns."""
     return shutil.get_terminal_size().columns - 1
 
 


### PR DESCRIPTION
### Subject: Get actual terminal width on Windows

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix
- Refactoring

### Purpose
[`shutil.get_terminal_size`](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size) is available since Python 3.3: it first checks for a COLUMNS environment variable, then queries the terminal and eventually falls back to 80 columns if none of the above works. So it's a drop-in replacement for `get_terminal_width()` that works on Windows too to get the actual terminal width.


### Relates
- closes #10841