### PR TITLE
search: use both title and subtitle only if different

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -286,7 +286,7 @@ const Search = {
           let score = Math.round(100 * queryLower.length / title.length)
           results.push([
             docNames[file],
-            `${titles[file]} > ${title}`,
+            titles[file] !== title ? `${titles[file]} > ${title}` : title,
             id !== null ? "#" + id : "",
             null,
             score,


### PR DESCRIPTION
Fixes: #10824.

Fixes problem seen here:
https://sphinx--10824.org.readthedocs.build/en/10824/search.html?q=getting+started

where one sees entries like 'Getting Started > Getting Started', fixes as:
https://sphinx--10848.org.readthedocs.build/en/10848/search.html?q=getting+started


