### PR TITLE
Declare support for Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Framework :: Setuptools Plugin",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4.0
-envlist = docs,flake8,mypy,twine,py{36,37,38,39,310},du{14,15,16,17,18,19}
+envlist = docs,flake8,mypy,twine,py{36,37,38,39,310,311},du{14,15,16,17,18,19}
 isolated_build = True
 
 [testenv]
@@ -16,7 +16,7 @@ passenv =
     EPUBCHECK_PATH
     TERM
 description =
-    py{36,37,38,39,310}: Run unit tests against {envname}.
+    py{36,37,38,39,310,311}: Run unit tests against {envname}.
     du{14,15,16,17,18,19}: Run unit tests with the given version of docutils.
 deps =
     du14: docutils==0.14.*


### PR DESCRIPTION
Subject: <short purpose of this pull request>

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Add Trove classifier for Python 3.11
- Add `py311` to `tox.ini`

### Detail
- Shows that 3.11 is supported on PyPI and its API
- Helps make 3.11 testable via tox. It's already tested on the CI 👍 

