### PR TITLE
Use a module level constant as best practice

### DIFF
--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -159,11 +159,11 @@ def setlocale(category: int, value: Union[str, Iterable[str], None] = None) -> N
         pass
 
 
-LOCALE_DIR = path.abspath(path.dirname(__file__))
+_LOCALE_DIR = path.abspath(path.dirname(__file__))
 
 
 def init_console(
-    locale_dir: str = LOCALE_DIR,
+    locale_dir: str = _LOCALE_DIR,
     catalog: str = 'sphinx',
 ) -> Tuple[NullTranslations, bool]:
     """Initialize locale for console.

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -4,7 +4,7 @@ import gettext
 import locale
 from collections import UserString, defaultdict
 from gettext import NullTranslations
-from os import path
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 
@@ -99,7 +99,7 @@ class _TranslationProxy(UserString):
 translators: Dict[Tuple[str, str], NullTranslations] = defaultdict(NullTranslations)
 
 
-def init(locale_dirs: List[Optional[str]], language: Optional[str],
+def init(locale_dirs: List[Optional[Path]], language: Optional[str],
          catalog: str = 'sphinx', namespace: str = 'general') -> Tuple[NullTranslations, bool]:
     """Look for message catalogs in `locale_dirs` and *ensure* that there is at
     least a NullTranslations catalog set in `translators`. If called multiple
@@ -161,8 +161,11 @@ def setlocale(category: int, value: Union[str, Iterable[str], None] = None) -> N
         pass
 
 
+LOCALE_DIR = Path(__file__).parent.absolute()
+
+
 def init_console(
-    locale_dir: str = path.abspath(path.dirname(__file__)),
+    locale_dir: Path = LOCALE_DIR,
     catalog: str = 'sphinx',
 ) -> Tuple[NullTranslations, bool]:
     """Initialize locale for console.

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -1,7 +1,6 @@
 """Locale utilities."""
 
 import locale
-from collections import UserString, defaultdict
 from gettext import NullTranslations, translation
 from os import path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union


### PR DESCRIPTION
fixes the following flake8 warnings -

```
./sphinx/locale/__init__.py:165:23: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
./sphinx/locale/__init__.py:165:36: B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
```