### PR TITLE
Address inconsistently localized entries in objects.inv

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Features added
 Bugs fixed
 ----------
 
+* #9778: Address inconsistently localized entries in ``objects.inv`` by removing translation lazy-loader proxy class.
+
 Testing
 --------
 

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -6,90 +6,6 @@ from os import path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 
-class _TranslationProxy:
-    """
-    Class for proxy strings from gettext translations. This is a helper for the
-    lazy_* functions from this module.
-
-    The proxy implementation attempts to be as complete as possible, so that
-    the lazy objects should mostly work as expected, for example for sorting.
-    """
-    __slots__ = ('_func', '_args')
-
-    def __new__(cls, func: Callable, *args: str) -> '_TranslationProxy':
-        if not args:
-            # not called with "function" and "arguments", but a plain string
-            return str(func)  # type: ignore[return-value]
-        return object.__new__(cls)
-
-    def __getnewargs__(self) -> Tuple[str]:
-        return (self._func,) + self._args  # type: ignore
-
-    def __init__(self, func: Callable, *args: str) -> None:
-        self._func = func
-        self._args = args
-
-    def __str__(self) -> str:
-        return str(self._func(*self._args))
-
-    def __dir__(self) -> List[str]:
-        return dir(str)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self.__str__(), name)
-
-    def __getstate__(self) -> Tuple[Callable, Tuple[str, ...]]:
-        return self._func, self._args
-
-    def __setstate__(self, tup: Tuple[Callable, Tuple[str]]) -> None:
-        self._func, self._args = tup
-
-    def __copy__(self) -> '_TranslationProxy':
-        return _TranslationProxy(self._func, *self._args)
-
-    def __repr__(self) -> str:
-        try:
-            return 'i' + repr(str(self.__str__()))
-        except Exception:
-            return f'<{self.__class__.__name__} broken>'
-
-    def __add__(self, other: str) -> str:
-        return self.__str__() + other
-
-    def __radd__(self, other: str) -> str:
-        return other + self.__str__()
-
-    def __mod__(self, other: str) -> str:
-        return self.__str__() % other
-
-    def __rmod__(self, other: str) -> str:
-        return other % self.__str__()
-
-    def __mul__(self, other: Any) -> str:
-        return self.__str__() * other
-
-    def __rmul__(self, other: Any) -> str:
-        return other * self.__str__()
-
-    def __hash__(self):
-        return hash(self.__str__())
-
-    def __eq__(self, other):
-        return self.__str__() == other
-
-    def __lt__(self, string):
-        return self.__str__() < string
-
-    def __contains__(self, char):
-        return char in self.__str__()
-
-    def __len__(self):
-        return len(self.__str__())
-
-    def __getitem__(self, index):
-        return self.__str__()[index]
-
-
 translators: Dict[Tuple[str, str], NullTranslations] = {}
 
 
@@ -181,18 +97,6 @@ def get_translator(catalog: str = 'sphinx', namespace: str = 'general') -> NullT
     return translators.get((namespace, catalog), NullTranslations())
 
 
-def is_translator_registered(catalog: str = 'sphinx', namespace: str = 'general') -> bool:
-    return (namespace, catalog) in translators
-
-
-def _lazy_translate(catalog: str, namespace: str, message: str) -> str:
-    """Used instead of _ when creating TranslationProxy, because _ is
-    not bound yet at that time.
-    """
-    translator = get_translator(catalog, namespace)
-    return translator.gettext(message)
-
-
 def get_translation(catalog: str, namespace: str = 'general') -> Callable[[str], str]:
     """Get a translation function based on the *catalog* and *namespace*.
 
@@ -219,15 +123,11 @@ def get_translation(catalog: str, namespace: str = 'general') -> Callable[[str],
     .. versionadded:: 1.8
     """
     def gettext(message: str, *args: Any) -> str:
-        if not is_translator_registered(catalog, namespace):
-            # not initialized yet
-            return _TranslationProxy(_lazy_translate, catalog, namespace, message)  # type: ignore  # NOQA
-        else:
-            translator = get_translator(catalog, namespace)
-            if len(args) <= 1:
-                return translator.gettext(message)
-            else:  # support pluralization
-                return translator.ngettext(message, args[0], args[1])
+        translator = get_translator(catalog, namespace)
+        if len(args) <= 1:
+            return translator.gettext(message)
+        else:  # support pluralization
+            return translator.ngettext(message, args[0], args[1])
 
     return gettext
 

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -5,7 +5,6 @@ from gettext import NullTranslations, translation
 from os import path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
-
 translators: Dict[Tuple[str, str], NullTranslations] = {}
 
 


### PR DESCRIPTION
Subject: Address inconsistently localized entries in `objects.inv` by removing translation lazy-loader proxy class

### Feature or Bugfix
- Bugfix

### Purpose
Numerous packages within Debian are identified as non-reproducible during parallel builds that are performed side-by-side using builds with English-language and Estonian-language locale configurations (among other environmental differences).

One recurring cause for these appears to be that the `objects.inv` file generated by Sphinx contains some (often only one, or a small number) localized display names for entries.

This behaviour appears to be inconsistent as documented in #9778.

Removing the lazy-loader `_TranslationProxy` class mechanism appears to help based on some local testing - although I'm yet to figure out why that is precisely.

### Detail
- example `diffoscope` link for differences from a `python-psutil` package build (at the time-of-writing, this displays an example `objects.inv` localization issue) - https://tests.reproducible-builds.org/debian/dbd/unstable/amd64/python-psutil_5.9.2-1.diffoscope.html#python-psutil-doc_-.-.---_all.deb---data.tar.xz---data.tar---.-usr-share-doc-python-psutil-doc-html-objects.inv
- I've confirmed by performing a documentation build for `language=et` configured via `sphinx/config.py` (perhaps not the correct place...) that the resulting HTML documentation build _does_ continue to be localized as expected (naive regression test)

### Relates
May resolve #9778.