### PR TITLE
Fix performance regression for ``imgmath`` embedding

### DIFF
--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -294,6 +294,20 @@ def cleanup_tempdir(app: Sphinx, exc: Exception) -> None:
         pass
 
 
+def cleanup_mathdir(app: Sphinx, exc: Exception) -> None:
+    if exc:
+        return
+    if not app.builder.config.imgmath_embed:
+        return
+    # in embed mode, the images are still generated in the math output dir
+    # to be shared across workers, but are not useful to the final document
+    mathdir = path.join(app.builder.outdir, app.builder.imagedir, 'math')
+    try:
+        shutil.rmtree(mathdir)
+    except Exception:
+        pass
+
+
 def get_tooltip(self: HTMLTranslator, node: Element) -> str:
     if self.builder.config.imgmath_add_tooltips:
         return ' alt="%s"' % self.encode(node.astext()).strip()
@@ -385,4 +399,5 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value('imgmath_font_size', 12, 'html')
     app.add_config_value('imgmath_embed', False, 'html', [bool])
     app.connect('build-finished', cleanup_tempdir)
+    app.connect('build-finished', cleanup_mathdir)
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}


### PR DESCRIPTION
We need the generated image files to be in one common folder to avoid having to re-generate several times the same image (the sha1 naming of the file acts as a cache to just read the depth)

The location should be possibly common to all workers, that's why I choosed to just keep the original destination folder, ie the file is just moved from tempdir to the build folder before.

This significantly drops my build time from 84min to 26min, but obviously leaves the unused image files in the output folder.

Another solution would be to use another global temporary folder shared across all the workers, or to add a delete pass after all workers have joined, but there does not seem to be an api to do that.

Bugfix: fix imgmath performance with embed=True
Follows  #10816  #10878 
