### PR TITLE
Fix disabling cross-references in pre-v3 C domain

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3676,7 +3676,8 @@ class CXRefRole(XRefRole):
         return title, target
 
     def run(self) -> Tuple[List[Node], List[system_message]]:
-        if not self.env.config['c_allow_pre_v3']:
+        if not self.env.config['c_allow_pre_v3'] or self.disabled:
+            # workaround, remove entire method with c_allow_pre_v3 code
             return super().run()
 
         text = self.text.replace('\n', ' ')


### PR DESCRIPTION
Previously, ``:c:var:`!spam` `` failed when `c_allow_pre_v3` was true and `sphinx-build` was run in nitpicky mode.

### Feature or Bugfix
- Bugfix

### Relates
- https://github.com/python/cpython/pull/96016

A

