### PR TITLE
Introduce a gate/check GHA job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,20 @@ jobs:
       run:  python -m pip install -U pip tox
     - name: Run Tox
       run:  tox -e py -- -vv
+
+  # https://github.com/marketplace/actions/alls-green#why
+  check:  # This job does nothing and is only used for the branch protection
+
+    if: always()
+
+    needs:
+    - ubuntu
+    - windows
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
_**Subject:**_ Add a branch protection-ready `check` job to the main GHA workflow

### Feature or Bugfix
<!-- please choose -->
- Maintenance
- Testing

### What does it do?

This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It also allows to reduce the list of required branch protection CI statuses to just one — `check`. This reduces the maintenance burden by a lot and have been battle-tested across a small bunch of projects in its action form and in-house implementations of other people.

It is now in use in aiohttp (and other aio-libs projects), CherryPy, conda, coveragepy, Open edX, some of the Ansible repositories, pip-tools, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some of hynek's projects (like `attrs`, `structlog`), some PyCQA, PyCA, PyPA and pytest projects, a few AWS Labs projects (to my surprise). Admittedly, I maintain a few of these but it seems to address some of the pain folks have: https://github.com/jaraco/skeleton/pull/55#issuecomment-1106638475. The rest of the action users are listed here: https://github.com/re-actors/alls-green/network/dependents.

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.
