### PR TITLE
Remove support for parsing pre-v3 syntax in the C domain

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,9 @@ Incompatible changes
   Patch by Adam Turner.
 * #10471, #10565: Removed deprecated APIs scheduled for removal in Sphinx 6.0. See
   :ref:`dev-deprecated-apis` for details. Patch by Adam Turner.
+* XXXXXX: C Domain: Remove support for parsing pre-v3 style type directives and
+  roles. Also remove associated configuration variables ``c_allow_pre_v3`` and
+  ``c_warn_on_allowed_pre_v3``.
 
 Deprecated
 ----------

--- a/CHANGES
+++ b/CHANGES
@@ -33,9 +33,9 @@ Incompatible changes
   Patch by Adam Turner.
 * #10471, #10565: Removed deprecated APIs scheduled for removal in Sphinx 6.0. See
   :ref:`dev-deprecated-apis` for details. Patch by Adam Turner.
-* XXXXXX: C Domain: Remove support for parsing pre-v3 style type directives and
+* #10901: C Domain: Remove support for parsing pre-v3 style type directives and
   roles. Also remove associated configuration variables ``c_allow_pre_v3`` and
-  ``c_warn_on_allowed_pre_v3``.
+  ``c_warn_on_allowed_pre_v3``. Patch by Adam Turner.
 
 Deprecated
 ----------

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3048,23 +3048,6 @@ class DefinitionParser(BaseParser):
             init = ASTInitializer(initVal)
         return ASTEnumerator(name, init, attrs)
 
-    def parse_pre_v3_type_definition(self) -> ASTDeclaration:
-        self.skip_ws()
-        declaration: DeclarationType = None
-        if self.skip_word('struct'):
-            typ = 'struct'
-            declaration = self._parse_struct()
-        elif self.skip_word('union'):
-            typ = 'union'
-            declaration = self._parse_union()
-        elif self.skip_word('enum'):
-            typ = 'enum'
-            declaration = self._parse_enum()
-        else:
-            self.fail("Could not parse pre-v3 type directive."
-                      " Must start with 'struct', 'union', or 'enum'.")
-        return ASTDeclaration(typ, typ, declaration, False)
-
     def parse_declaration(self, objectType: str, directiveType: str) -> ASTDeclaration:
         if objectType not in ('function', 'member',
                               'macro', 'struct', 'union', 'enum', 'enumerator', 'type'):
@@ -3229,9 +3212,6 @@ class CObject(ObjectDescription[ASTDeclaration]):
     def parse_definition(self, parser: DefinitionParser) -> ASTDeclaration:
         return parser.parse_declaration(self.object_type, self.objtype)
 
-    def parse_pre_v3_type_definition(self, parser: DefinitionParser) -> ASTDeclaration:
-        return parser.parse_pre_v3_type_definition()
-
     def describe_signature(self, signode: TextElement, ast: ASTDeclaration,
                            options: Dict) -> None:
         ast.describe_signature(signode, 'lastIsName', self.env, options)
@@ -3254,27 +3234,8 @@ class CObject(ObjectDescription[ASTDeclaration]):
 
         parser = DefinitionParser(sig, location=signode, config=self.env.config)
         try:
-            try:
-                ast = self.parse_definition(parser)
-                parser.assert_end()
-            except DefinitionError as eOrig:
-                if not self.env.config['c_allow_pre_v3']:
-                    raise
-                if self.objtype != 'type':
-                    raise
-                try:
-                    ast = self.parse_pre_v3_type_definition(parser)
-                    parser.assert_end()
-                except DefinitionError:
-                    raise eOrig
-                self.object_type = ast.objectType  # type: ignore
-                if self.env.config['c_warn_on_allowed_pre_v3']:
-                    msg = "{}: Pre-v3 C type directive '.. c:type:: {}' converted to " \
-                          "'.. c:{}:: {}'." \
-                          "\nThe original parsing error was:\n{}"
-                    msg = msg.format(RemovedInSphinx70Warning.__name__,
-                                     sig, ast.objectType, ast, eOrig)
-                    logger.warning(msg, location=signode)
+            ast = self.parse_definition(parser)
+            parser.assert_end()
         except DefinitionError as e:
             logger.warning(e, location=signode)
             # It is easier to assume some phony name than handling the error in
@@ -3675,39 +3636,6 @@ class CXRefRole(XRefRole):
                     title = title[dot + 1:]
         return title, target
 
-    def run(self) -> Tuple[List[Node], List[system_message]]:
-        if not self.env.config['c_allow_pre_v3']:
-            return super().run()
-
-        text = self.text.replace('\n', ' ')
-        parser = DefinitionParser(text, location=self.get_location(),
-                                  config=self.env.config)
-        try:
-            parser.parse_xref_object()
-            # it succeeded, so let it through
-            return super().run()
-        except DefinitionError as eOrig:
-            # try as if it was an c:expr
-            parser.pos = 0
-            try:
-                ast = parser.parse_expression()
-            except DefinitionError:
-                # that didn't go well, just default back
-                return super().run()
-            classes = ['xref', 'c', 'c-texpr']
-            parentSymbol = self.env.temp_data.get('cpp:parent_symbol', None)
-            if parentSymbol is None:
-                parentSymbol = self.env.domaindata['c']['root_symbol']
-            signode = nodes.inline(classes=classes)
-            ast.describe_signature(signode, 'markType', self.env, parentSymbol)
-
-            if self.env.config['c_warn_on_allowed_pre_v3']:
-                msg = "{}: Pre-v3 C type role ':c:type:`{}`' converted to ':c:expr:`{}`'."
-                msg += "\nThe original parsing error was:\n{}"
-                msg = msg.format(RemovedInSphinx70Warning.__name__, text, text, eOrig)
-                logger.warning(msg, location=self.get_location())
-            return [signode], []
-
 
 class CExprRole(SphinxRole):
     def __init__(self, asCode: bool) -> None:
@@ -3916,9 +3844,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("c_paren_attributes", [], 'env')
     app.add_config_value("c_extra_keywords", _macroKeywords, 'env')
     app.add_post_transform(AliasTransform)
-
-    app.add_config_value("c_allow_pre_v3", False, 'env')
-    app.add_config_value("c_warn_on_allowed_pre_v3", True, 'env')
 
     return {
         'version': 'builtin',

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -12,7 +12,6 @@ from sphinx import addnodes
 from sphinx.addnodes import pending_xref
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
-from sphinx.deprecation import RemovedInSphinx70Warning
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.environment import BuildEnvironment


### PR DESCRIPTION
With the completion of https://github.com/python/cpython/issues/93738, we are now free to remove support for pre-v3 syntax in the C domain. Note previously we had confirmed the Linux kernel does not require the variable either (https://github.com/sphinx-doc/sphinx/pull/10471#discussion_r899419814, https://lore.kernel.org/linux-doc/LO3P123MB26810D190462B6BBBF1305F6C2A19@LO3P123MB2681.GBRP123.PROD.OUTLOOK.COM/T/#u).

cc: @jakobandersen 

A
