### PR TITLE
Revert "Fix detection for out of date files (#9360)"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,8 +17,6 @@ Features added
   ``:option:`--module[=foobar]``` or ``:option:`--module foobar```.
   Patch by Martin Liska.
 * #10881: autosectionlabel: Record the generated section label to the debug log.
-* #9360: Fix caching for now-outdated files for some builders (e.g. manpage)
-  when there is no change in source files. Patch by Martin Liska.
 
 Bugs fixed
 ----------

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -347,7 +347,7 @@ class Builder:
             with progress_message(__('checking consistency')):
                 self.env.check_consistency()
         else:
-            if method == 'update' and (not docnames or docnames == ['__all__']):
+            if method == 'update' and not docnames:
                 logger.info(bold(__('no targets are out of date.')))
                 return
 

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -633,6 +633,7 @@ def test_tocdepth(app, cached_etree_parse, fname, expect):
     ],
 }))
 @pytest.mark.sphinx('singlehtml', testroot='tocdepth')
+@pytest.mark.test_params(shared_result='test_build_html_tocdepth')
 def test_tocdepth_singlehtml(app, cached_etree_parse, fname, expect):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
@@ -1137,6 +1138,7 @@ def test_numfig_with_secnum_depth(app, cached_etree_parse, fname, expect):
     ],
 }))
 @pytest.mark.sphinx('singlehtml', testroot='numfig', confoverrides={'numfig': True})
+@pytest.mark.test_params(shared_result='test_build_html_numfig_on')
 def test_numfig_with_singlehtml(app, cached_etree_parse, fname, expect):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1604,7 +1604,7 @@ def test_latex_container(app, status, warning):
 
 @pytest.mark.sphinx('latex', testroot='reST-code-role')
 def test_latex_code_role(app):
-    app.build(force_all=True)
+    app.build()
     content = (app.outdir / 'python.tex').read_text()
 
     common_content = (

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -42,7 +42,7 @@ def test_man_pages_empty_description(app, status, warning):
 @pytest.mark.sphinx('man', testroot='basic',
                     confoverrides={'man_make_section_directory': True})
 def test_man_make_section_directory(app, status, warning):
-    app.build(force_all=True)
+    app.build()
     assert (app.outdir / 'man1' / 'python.1').exists()
 
 

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -60,7 +60,7 @@ def test_texinfo(app, status, warning):
 
 @pytest.mark.sphinx('texinfo', testroot='markup-rubric')
 def test_texinfo_rubric(app, status, warning):
-    app.build(force_all=True)
+    app.build()
 
     output = (app.outdir / 'python.texi').read_text(encoding='utf8')
     assert '@heading This is a rubric' in output


### PR DESCRIPTION
This reverts commit b1390c4191319e75d14ce3e6e73ef43c31d981b4.

The change is reverted because some Builders don't have more fine-grained support for outdated docs:
https://github.com/sphinx-doc/sphinx/issues/10903#issuecomment-1273199352
