### PR TITLE
Bump required requests version to 2.25.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "babel>=2.9",
     "alabaster>=0.7,<0.8",
     "imagesize>=1.3",
-    "requests>=2.5.0",
+    "requests>=2.25.0",
     "packaging>=21.0",
     "importlib-metadata>=4.8; python_version < '3.10'",
     "colorama>=0.4.5; sys_platform == 'win32'",


### PR DESCRIPTION
Subject: Bump required `requests` version to 2.25.0.

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- We encountered an issue early that Sphinx failed with missing `urllib3` dependency, `urlib3` should be installed by `requests`, but since the current required version of `requests` is too low, `urllib3` is embedded rather than required by `reuquests`, this PR is intended to bump the required `requests` version so that `urllib3` will be installed along with `requests` and Sphinx.

### Detail
- Bump required `requests` version to 2.25.0.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/10927

