### PR TITLE
Use ``finally`` to terminate parallel processes

### DIFF
--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -96,10 +96,9 @@ class ParallelTasks:
             while self._pworking:
                 if not self._join_one():
                     time.sleep(0.02)
-        except Exception:
+        finally:
             # shutdown other child processes on failure
             self.terminate()
-            raise
 
     def terminate(self) -> None:
         for tid in list(self._precvs):


### PR DESCRIPTION
Subject: Correctly terminate parallel processes.

### Feature or Bugfix

- Feature

### Purpose

While debugging an issue with parallel docs building, I encountered zombie parallel processes. This happened after I used `ctrl+c` to stop a hanging build. With this change, all parallel process will be terminated correctly regardless of the reason that terminated the build.

### Detail

The reason is simple: `except Exception` does *not* catch everything. For example, `KeyboardInterrupt` which is raised through `ctrl+c` will not be caught:

```py
try:
    raise KeyboardInterrupt
except Exception:
    print("Terminating processes", flush=True)
    raise
```

```
Traceback (most recent call last):
  File "/home/user/main.py", line 2, in <module>
    raise KeyboardInterrupt
KeyboardInterrupt
```

See the [exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy) for details.

Since we don't do anything with the caught exception other than re-raising it, we can simply use the [`finally` clause](https://docs.python.org/3/reference/compound_stmts.html#finally-clause):

```py
try:
    raise KeyboardInterrupt
finally:
    print("Terminating processes", flush=True)
```

```
Terminating processes
Traceback (most recent call last):
  File "/home/user/main.py", line 2, in <module>
    raise KeyboardInterrupt
KeyboardInterrupt
```


