### PR TITLE
Clarify licence in Sphinx's metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ urls.Code = "https://github.com/sphinx-doc/sphinx"
 urls.Download = "https://pypi.org/project/Sphinx/"
 urls.Homepage = "https://www.sphinx-doc.org/"
 urls."Issue tracker" = "https://github.com/sphinx-doc/sphinx/issues"
-license.text = "BSD"
+license.text = "BSD-2-Clause"
 requires-python = ">=3.8"
 
 # Classifiers list: https://pypi.org/classifiers/


### PR DESCRIPTION
Subject: Clarify which BSD license is used in a parsable form

<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix
<!-- please choose -->

Metadata change

### Purpose

As a downstream user it is desirable to be able to programmatically determine the precise licenses used by our dependencies. The emerging convention for this is the [SPDX License List](https://spdx.org/licenses/). SPDX License Expressions are already used in the JavaScript (npm) and Rust (crates.io) ecosystems, for example.

In Python, there is [PEP 639](https://peps.python.org/pep-0639/) which would add a standard 'License-Expression' metadata field. The discussion around this PEP seems to have gone stale in 2021.

This merge request is in lieu of that PEP coming soon. Unless you as project maintainers think the proposed change in this PR has downsides (which you are entitled to!), I would ask that you accept this change so that it's possible for users to attempt to parse your license metadata as an SPDX License Expression.

In particular, it disambiguates which BSD license it is.


