### PR TITLE
Fix lookup table for multi-word key names (``kbd`` role)

### DIFF
--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -31,12 +31,12 @@ class KeyboardTransform(SphinxPostTransform):
     formats = ('html',)
     pattern = re.compile(r'(?<=.)(-|\+|\^|\s+)(?=.)')
     multiwords_keys = (('caps', 'lock'),
-                       ('page' 'down'),
+                       ('page', 'down'),
                        ('page', 'up'),
-                       ('scroll' 'lock'),
+                       ('scroll', 'lock'),
                        ('num', 'lock'),
-                       ('sys' 'rq'),
-                       ('back' 'space'))
+                       ('sys', 'rq'),
+                       ('back', 'space'))
 
     def run(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])


### PR DESCRIPTION
It seems the original PR adding multi word key support forgot to add commas and python helpfully just concatenated the strings instead of building the required tuples.