### PR TITLE
Remove support for pluralisation during ``gettext`` resource translation

### DIFF
--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -221,16 +221,13 @@ def get_translation(catalog: str, namespace: str = 'general') -> Callable[[str],
 
     .. versionadded:: 1.8
     """
-    def gettext(message: str, *args: Any) -> str:
+    def gettext(message: str) -> str:
         if not is_translator_registered(catalog, namespace):
             # not initialized yet
             return _TranslationProxy(_lazy_translate, catalog, namespace, message)  # type: ignore[return-value]  # noqa: E501
         else:
             translator = get_translator(catalog, namespace)
-            if len(args) <= 1:
-                return translator.gettext(message)
-            else:  # support pluralization
-                return translator.ngettext(message, args[0], args[1])
+            return translator.gettext(message)
 
     return gettext
 


### PR DESCRIPTION
### Change type
- Cleanup

### Purpose
- During development of #10949, code related to `ngettext` (support for n-ary / plural forms of translated text) was modified in the codebase, and following on from that, I spent some time investigating whether that's used.  It [doesn't appear to be](https://github.com/sphinx-doc/sphinx/pull/10949#discussion_r1009589074), so this pull request offers a possible cleanup by removing the `ngettext` reference

### Detail
- `ngettext` allows an application to provide a dynamic number (often a count of items, like '5' in `the linter produced 5 warnings`) to the translation query so that a plurality-relevant message can be retrieved from the catalog
- `sphinx` has previously used this within its own codebase, but no longer does -- [`babel` command-line extraction](https://babel.pocoo.org/en/latest/cmdline.html#extract) is used to retrieve translatable resources from the codebase, and extraction of plural-form keywords is not [configured](https://github.com/sphinx-doc/sphinx/blob/cd3f2e435000835dd98a11497440bc16a79ec31c/utils/babel_runner.py#L121) (nor easy to enable, as far as I could tell)
- As a result it seems like it may make sense to remove the code

### Relates
- #10949 