### PR TITLE
Add test coverage for 'today_fmt' reference substitution

### DIFF
--- a/tests/roots/test-intl/refs.txt
+++ b/tests/roots/test-intl/refs.txt
@@ -45,3 +45,4 @@ D-5. Link to `Translation Tips`_ and `Next Section`_ section.
 
 Next Section
 -------------
+Last updated |today|.

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -1383,3 +1383,13 @@ def test_customize_system_message(make_app, app_params, sphinx_test_tempdir):
         assert 'QUICK SEARCH' in content
     finally:
         locale.translators.clear()
+
+
+@pytest.mark.sphinx('html', testroot='intl', confoverrides={'today_fmt': '%Y-%m-%d'})
+def test_customize_today_date_format(app, monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('SOURCE_DATE_EPOCH', '1439131307')
+        app.build()
+        content = (app.outdir / 'refs.html').read_text(encoding='utf8')
+
+    assert '2015-08-09' in content


### PR DESCRIPTION
### Type of change
- Additional test coverage

### Purpose
- During some self-review of #10949 using `pytest`, `coverage` and `diff-cover`, I noticed that one of the lines affected by the changeset that didn't have any test coverage is [this code](https://github.com/sphinx-doc/sphinx/blob/cd3f2e435000835dd98a11497440bc16a79ec31c/sphinx/transforms/__init__.py#L105-L108) to substitute named references to 'today' in source documentation with a `today_fmt`-formatted date.  This pull request offers basic test coverage for that part of the code.

### Detail
- The `DefaultSubstitution` class is added as part of a chain of default transformers [during app setup](https://github.com/sphinx-doc/sphinx/blob/cd3f2e435000835dd98a11497440bc16a79ec31c/sphinx/transforms/__init__.py#L399).  It can substitute named references in a source document with configured text replacements, and has a special case to handle `|today|` when it appears as a reference with no direct text substitute (but instead a date format substitute) is configured.
- Indirectly this also adds test coverage for the [handling of `SOURCE_DATE_EPOCH` within `util.i18n.format_date`](https://github.com/sphinx-doc/sphinx/blob/cd3f2e435000835dd98a11497440bc16a79ec31c/sphinx/util/i18n.py#L199), although that wasn't the initial intent of this changeset

### Relates
- #10949 