### PR TITLE
fix flake8 warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+      - id: yesqa
+        additional_dependencies:
+          - flake8-comprehensions
+          - flake8-bugbear
+          - flake8-simplify

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -153,8 +153,8 @@ def augment_descriptions_with_types(
     force_rtype: bool
 ) -> None:
     fields = cast(Iterable[nodes.field], node)
-    has_description = set()  # type: Set[str]
-    has_type = set()  # type: Set[str]
+    has_description: Set[str] = set()
+    has_type: Set[str] = set()
     for field in fields:
         field_name = field[0].astext()
         parts = re.split(' +', field_name)

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -5,7 +5,7 @@ The todolist directive collects all todos of your project and lists them along
 with a backlink to the original location.
 """
 
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, cast
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -55,7 +55,7 @@ class Todo(BaseAdmonition, SphinxDirective):
         if not self.options.get('class'):
             self.options['class'] = ['admonition-todo']
 
-        (todo,) = super().run()  # type: Tuple[Node]
+        (todo,) = super().run()
         if isinstance(todo, nodes.system_message):
             return [todo]
         elif isinstance(todo, todo_node):

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -5,7 +5,8 @@ import unicodedata
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, cast
 
 from docutils import nodes
-from docutils.nodes import Element, Node, Text
+from docutils.nodes import Element  # noqa: F401 (used for type comments only)
+from docutils.nodes import Node, Text
 from docutils.transforms import Transform, Transformer
 from docutils.transforms.parts import ContentsFilter
 from docutils.transforms.universal import SmartQuotes

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -3,7 +3,8 @@
 from typing import Any, Dict, Iterable, cast
 
 from docutils import nodes
-from docutils.nodes import Element, TextElement
+from docutils.nodes import TextElement  # noqa: F401 (used for type comments only)
+from docutils.nodes import Element
 from docutils.writers.manpage import Translator as BaseTranslator
 from docutils.writers.manpage import Writer
 

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -557,7 +557,7 @@ def test_too_many_requests_user_timeout(app, capsys):
 
 
 class FakeResponse:
-    headers = {}  # type: Dict[str, str]
+    headers: Dict[str, str] = {}
     url = "http://localhost/"
 
 


### PR DESCRIPTION
Looks like there's a few flake8 warnings on master. This PR aims to address those.

The errors stem from the use of type comments. These comments are non-standard syntax, though they are supported by the PyCharm IDE.
Unfortunately pylance, mypy, and flake8 don't like them.
*without* type comments, it's not possible to type annotate 'for' loops on untyped iterators, so in these instances I've suppressed warnings rather than removing the type comments. Possibly there's a better long term solution, but hopefully this gets the CI working again and starts putting some nice green ticks next to the pull requests.