### PR TITLE
Add parallel_batchsize config variable

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -755,6 +755,17 @@ General configuration
 
    .. versionadded:: 5.1
 
+.. confval:: parallel_batchsize
+
+   Sets the preferred batchsize for parallel builds.
+   Ideally, Sphinx will try to distribute the processing of documentation files equally among the available processors.
+   However, if the number of documents allocated to each process exceeds the configured value, Sphinx will adjust the batches accordingly.
+
+   Default is ``10``.
+
+   .. versionadded:: 6.0
+      Previously, Sphinx always set this to ``10``, which lead to performance issues in bigger documentation builds.
+
 .. _intl-options:
 
 Options for internationalization

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -109,6 +109,8 @@ class Builder:
         self.imagedir = ""
         # relative path to image directory from current docname (used at writing docs)
         self.imgpath = ""
+        # set batchsize preference for parallel builds
+        self.batchsize = env.config.batchsize
 
         # these get set later
         self.parallel_ok = False
@@ -454,7 +456,7 @@ class Builder:
             self.read_doc(docname)
 
     def _read_parallel(self, docnames: List[str], nproc: int) -> None:
-        chunks = make_chunks(docnames, nproc)
+        chunks = make_chunks(docnames, nproc, self.batchsize)
 
         # create a status_iterator to step progressbar after reading a document
         # (see: ``merge()`` function)
@@ -595,7 +597,7 @@ class Builder:
         self.write_doc(firstname, doctree)
 
         tasks = ParallelTasks(nproc)
-        chunks = make_chunks(docnames, nproc)
+        chunks = make_chunks(docnames, nproc, self.batchsize)
 
         # create a status_iterator to step progressbar after writing a document
         # (see: ``on_chunk_done()`` function)

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -110,7 +110,7 @@ class Builder:
         # relative path to image directory from current docname (used at writing docs)
         self.imgpath = ""
         # set batchsize preference for parallel builds
-        self.batchsize = env.config.batchsize
+        self.parallel_batchsize = env.config.parallel_batchsize
 
         # these get set later
         self.parallel_ok = False
@@ -456,7 +456,7 @@ class Builder:
             self.read_doc(docname)
 
     def _read_parallel(self, docnames: List[str], nproc: int) -> None:
-        chunks = make_chunks(docnames, nproc, self.batchsize)
+        chunks = make_chunks(docnames, nproc, self.parallel_batchsize)
 
         # create a status_iterator to step progressbar after reading a document
         # (see: ``merge()`` function)
@@ -597,7 +597,7 @@ class Builder:
         self.write_doc(firstname, doctree)
 
         tasks = ParallelTasks(nproc)
-        chunks = make_chunks(docnames, nproc, self.batchsize)
+        chunks = make_chunks(docnames, nproc, self.parallel_batchsize)
 
         # create a status_iterator to step progressbar after writing a document
         # (see: ``on_chunk_done()`` function)

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -145,7 +145,7 @@ class Config:
                                   'builders': ['man', 'text']},
                                  'env', []),
         'option_emphasise_placeholders': (False, 'env', []),
-        'batchsize': (10, 'env', [int]),
+        'parallel_batchsize': (10, 'env', [int]),
     }
 
     def __init__(self, config: Dict[str, Any] = {}, overrides: Dict[str, Any] = {}) -> None:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -145,6 +145,7 @@ class Config:
                                   'builders': ['man', 'text']},
                                  'env', []),
         'option_emphasise_placeholders': (False, 'env', []),
+        'batchsize': (10, 'env', [int]),
     }
 
     def __init__(self, config: Dict[str, Any] = {}, overrides: Dict[str, Any] = {}) -> None:

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -134,7 +134,7 @@ class ParallelTasks:
         return joined_any
 
 
-def make_chunks(arguments: Sequence[str], nproc: int, maxbatch: int = 10) -> List[Any]:
+def make_chunks(arguments: Sequence[str], nproc: int, maxbatch) -> List[Any]:
     # determine how many documents to read in one go
     nargs = len(arguments)
     chunksize = nargs // nproc


### PR DESCRIPTION
Subject: Add configuration variable for setting the batchsize in parallel builds

### Feature or Bugfix
- Feature

### Purpose

- Add a new config variable `parallel_batchsize` to allow users to adjust the preferred batchsize in parallel builds.

### Detail

- When chunking the documents to generate tasks for parallel builds, the [`make_chunks`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/util/parallel.py#L137) function is used.
This function tries to set a batchsize to `nargs // nproc`.
However, if the result exceeds `maxbatch` (current default is 10), a recalculation is done:
`int(sqrt(nargs / nproc * maxbatch))`
This leads to batches that are way too small in larger builds (e.g. 22,000 docs, 16 cores -> batchsize = 111) and therefore many merge operations, which may ultimately lead to memory overflows.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/10967

