### PR TITLE
Docs: Update devguide link

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -240,7 +240,7 @@ as long as the text::
 Normally, there are no heading levels assigned to certain characters as the
 structure is determined from the succession of headings.  However, this
 convention is used in `Python's Style Guide for documenting
-<https://docs.python.org/devguide/documenting.html#style-guide>`_ which you may
+<https://devguide.python.org/documentation/style-guide/>`_ which you may
 follow:
 
 * ``#`` with overline, for parts


### PR DESCRIPTION
<!--
  Before posting a pull request, please choose a appropriate branch:

  - Breaking changes: master
  - Critical or severe bugs: X.Y.Z
  - Others: X.Y

  For more details, see https://www.sphinx-doc.org/en/master/internals/release-process.html#branch-model
-->

### Feature or Bugfix

- Refactoring

https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections links to "Python’s Style Guide for documenting" at https://docs.python.org/devguide/documenting.html#style-guide

The Python devguide has been re-organised, the new link is at https://devguide.python.org/documentation/style-guide/

The old page links to the new one, so let's go directly to the new one.

### Purpose
- Fix a link

### Detail
- Link directly to style guide

### Relates
- https://github.com/python/devguide/pull/901
