### PR TITLE
fix: ensure stringify mode is passed to all child calls when type is `types.Union` 

### DIFF
--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -446,6 +446,9 @@ def test_stringify_type_union_operator():
     assert stringify_annotation(int | str | None) == "int | str | None"  # type: ignore
     assert stringify_annotation(int | str | None, "smart") == "int | str | None"  # type: ignore
 
+    assert stringify(int | Struct) == "int | struct.Struct"  # type: ignore
+    assert stringify(int | Struct, "smart") == "int | ~struct.Struct"  # type: ignore
+
 
 def test_stringify_broken_type_hints():
     assert stringify_annotation(BrokenType, 'fully-qualified-except-typing') == 'tests.test_util_typing.BrokenType'

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -446,8 +446,8 @@ def test_stringify_type_union_operator():
     assert stringify_annotation(int | str | None) == "int | str | None"  # type: ignore
     assert stringify_annotation(int | str | None, "smart") == "int | str | None"  # type: ignore
 
-    assert stringify(int | Struct) == "int | struct.Struct"  # type: ignore
-    assert stringify(int | Struct, "smart") == "int | ~struct.Struct"  # type: ignore
+    assert stringify_annotation(int | Struct) == "int | struct.Struct"  # type: ignore
+    assert stringify_annotation(int | Struct, "smart") == "int | ~struct.Struct"  # type: ignore
 
 
 def test_stringify_broken_type_hints():


### PR DESCRIPTION
`stringify` wasn't passing on the `mode` if the type was `types.Union` which resulted in the following behaviour: 

```py
stringify(int | Struct, "smart") 
>>> "int | struct.Struct"
```

This PR passes the mode to the following `stringify` call such that the above test prints
```py
>>> "int | ~struct.Struct"
```

Also added a testcase for this problem to `test_util_typing.py`.