### PR TITLE
Document autosummary template variable "objtype"

### DIFF
--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -235,7 +235,7 @@ Autosummary uses the following Jinja template files:
 - :file:`autosummary/attribute.rst` -- template for class attributes
 - :file:`autosummary/method.rst` -- template for class methods
 
-The following variables available in the templates:
+The following variables are available in the templates:
 
 .. currentmodule:: None
 
@@ -250,6 +250,12 @@ The following variables available in the templates:
 .. data:: fullname
 
    Full name of the documented object, including module and class parts.
+
+.. data:: objtype
+
+   Type of the documented object, one of ``"module"``, ``"function"``,
+   ``"class"``, ``"method"``, ``"attribute"``, ``"data"``, ``"object"``,
+   ``"exception"``, ``"newvarattribute"``, ``"newtypedata"``, ``"property"``.
 
 .. data:: module
 


### PR DESCRIPTION
The variable was missing in the documentation, but it clearly exists:

https://github.com/sphinx-doc/sphinx/blob/984416247370a87ad947d89f334a8ce2d8ea6558/sphinx/ext/autosummary/generate.py#L346

Note: I've not listed the objtype values used by the deprecated Documenters in `sphinx/ext/autodoc/depreacted.py`. Since they are deprecated, I assume users should not use them anymore.