### PR TITLE
Create a 'search field' component for themes

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -32,7 +32,7 @@
 {%- block content %}
 <div class="document">
   <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
-    {%- include "searchbox.html" %}
+    {%- include "searchfield.html" %}
     <div class="sphinxsidebar-navigation__contents">
       <h3>{{ _('On this page') }}</h3>
       {{ toc }}

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -68,6 +68,7 @@ div.sphinxsidebar {
     overflow-wrap: break-word;
     margin: 0;
     padding-right: 15px;
+    padding-top: 0.5em;
     font-size: 1em;
 }
 
@@ -125,6 +126,10 @@ div.sphinxsidebar li.current > a {
 
 .sphinxsidebar-navigation__contents > ul > li > a {
     display: none;
+}
+
+div.sphinxsidebar #searchbox {
+    margin: 12px 0 20px 0;
 }
 
 div.footer {

--- a/sphinx/themes/basic/searchfield.html
+++ b/sphinx/themes/basic/searchfield.html
@@ -1,0 +1,23 @@
+{#
+    basic/searchfield.html
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    Sphinx sidebar template: search field.
+    This component is similar to searchbox.html but does not include an
+    extra heading ("Quick search"). Instead, it uses a placeholder text
+    in the search field.
+
+    :copyright: Copyright 2007-2022 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- if pagename != "search" and builder != "singlehtml" %}
+<div id="searchbox" style="display: none" role="search">
+    <div class="searchformwrapper">
+    <form class="search" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search"/>
+      <input type="submit" value="{{ _('Go') }}" />
+    </form>
+    </div>
+</div>
+<script>document.getElementById('searchbox').style.display = "block"</script>
+{%- endif %}


### PR DESCRIPTION
### Feature or Bugfix
- Feature. Closes #10791.

### Purpose
searchfield.html is similar to the existing searchbox.html, but does not have the heading "Quick Search". Instead, it uses "Search" as a placeholder text. This gives a cleaner and less cluttered appearance.

Before:
![image](https://user-images.githubusercontent.com/2836374/209028523-43a7773b-9c45-4f9f-8c9d-d39b73b16982.png)

After:
![image](https://user-images.githubusercontent.com/2836374/209028538-04cc0201-833f-4910-840c-3d5b55fef64b.png)


### Detail
The searchfield component is added to the basic theme and thus can be used in any derivative theme. It is not used by default for backward compatibility. Also searchbox.html was deliberately not modified for backward compatibility.

The searchfield component is made the default in the new sphinx13 theme.

CSS adaptions ensure that the top of the search field is aligned with the top of the main content.
