### PR TITLE
Add the ``SIM300`` lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,6 @@ ignore =
     SIM115,
     SIM117,
     SIM223,
-    SIM300,
     SIM401,
     SIM904,
     SIM905,


### PR DESCRIPTION
SIM300 is 'yoda conditions'. These have already been fixed in this repo, but we might as well add the lint to prevent them being inadvertently re-added