### PR TITLE
improve type annotations

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -151,7 +151,7 @@ class Builder:
             from sphinx.jinja2glue import BuiltinTemplateLoader
             self.templates = BuiltinTemplateLoader()
 
-    def get_target_uri(self, docname: str, typ: str = None) -> str:
+    def get_target_uri(self, docname: str, typ: Optional[str] = None) -> str:
         """Return the target URI for a document name.
 
         *typ* can be used to qualify the link characteristic for individual
@@ -159,7 +159,7 @@ class Builder:
         """
         raise NotImplementedError
 
-    def get_relative_uri(self, from_: str, to: str, typ: str = None) -> str:
+    def get_relative_uri(self, from_: str, to: str, typ: Optional[str] = None) -> str:
         """Return a relative URI between two source filenames.
 
         May raise environment.NoUri if there's no way to return a sensible URI.
@@ -312,7 +312,10 @@ class Builder:
                        len(to_build))
 
     def build(
-        self, docnames: Iterable[str], summary: Optional[str] = None, method: str = 'update'
+        self,
+        docnames: Optional[Iterable[str]],
+        summary: Optional[str] = None,
+        method: str = 'update',
     ) -> None:
         """Main build method.
 

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -252,7 +252,10 @@ class MessageCatalogBuilder(I18nBuilder):
                 raise ThemeError('%s: %r' % (template, exc)) from exc
 
     def build(
-        self, docnames: Iterable[str], summary: Optional[str] = None, method: str = 'update'
+        self,
+        docnames: Optional[Iterable[str]],
+        summary: Optional[str] = None,
+        method: str = 'update',
     ) -> None:
         self._extract_from_template()
         super().build(docnames, summary, method)

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -96,9 +96,9 @@ class Stylesheet(str):
     its filename (str).
     """
 
-    attributes: Dict[str, str] = None
-    filename: str = None
-    priority: int = None
+    attributes: Dict[str, str]
+    filename: str
+    priority: int
 
     def __new__(cls, filename: str, *args: str, priority: int = 500, **attributes: Any
                 ) -> "Stylesheet":
@@ -122,9 +122,9 @@ class JavaScript(str):
     its filename (str).
     """
 
-    attributes: Dict[str, str] = None
-    filename: str = None
-    priority: int = None
+    attributes: Dict[str, str]
+    filename: str
+    priority: int
 
     def __new__(cls, filename: str, priority: int = 500, **attributes: str) -> "JavaScript":
         self = str.__new__(cls, filename)
@@ -158,7 +158,10 @@ class BuildInfo:
             raise ValueError(__('build info file is broken: %r') % exc) from exc
 
     def __init__(
-        self, config: Config = None, tags: Tags = None, config_categories: List[str] = []
+        self,
+        config: Optional[Config] = None,
+        tags: Optional[Tags] = None,
+        config_categories: List[str] = [],
     ) -> None:
         self.config_hash = ''
         self.tags_hash = ''
@@ -1018,7 +1021,7 @@ class StandaloneHTMLBuilder(Builder):
 
     # --------- these are overwritten by the serialization builder
 
-    def get_target_uri(self, docname: str, typ: str = None) -> str:
+    def get_target_uri(self, docname: str, typ: Optional[str] = None) -> str:
         return quote(docname) + self.link_suffix
 
     def handle_page(self, pagename: str, addctx: Dict, templatename: str = 'page.html',

--- a/sphinx/domains/__init__.py
+++ b/sphinx/domains/__init__.py
@@ -94,8 +94,10 @@ class Index(ABC):
         self.domain = domain
 
     @abstractmethod
-    def generate(self, docnames: Iterable[str] = None
-                 ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
+    def generate(
+        self,
+        docnames: Optional[Iterable[str]] = None,
+    ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         """Get entries for the index.
 
         If ``docnames`` is given, restrict to entries referring to these

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -1285,7 +1285,7 @@ class ASTMacroParameter(ASTBase):
 
 
 class ASTMacro(ASTBase):
-    def __init__(self, ident: ASTNestedName, args: List[ASTMacroParameter]) -> None:
+    def __init__(self, ident: ASTNestedName, args: Optional[List[ASTMacroParameter]]) -> None:
         self.ident = ident
         self.args = args
 
@@ -2887,8 +2887,11 @@ class DefinitionParser(BaseParser):
             header = "Error in declarator or parameters"
             raise self._make_multi_error(prevErrors, header) from e
 
-    def _parse_initializer(self, outer: str = None, allowFallback: bool = True
-                           ) -> ASTInitializer:
+    def _parse_initializer(
+        self,
+        outer: Optional[str] = None,
+        allowFallback: bool = True
+    ) -> Optional[ASTInitializer]:
         self.skip_ws()
         if outer == 'member' and False:  # TODO
             bracedInit = self._parse_braced_init_list()

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -669,7 +669,7 @@ class ASTIdentifier(ASTBase):
 
 class ASTNestedNameElement(ASTBase):
     def __init__(self, identOrOp: Union[ASTIdentifier, "ASTOperator"],
-                 templateArgs: "ASTTemplateArgs") -> None:
+                 templateArgs: Optional["ASTTemplateArgs"]) -> None:
         self.identOrOp = identOrOp
         self.templateArgs = templateArgs
 
@@ -2000,7 +2000,12 @@ class ASTFunctionParameter(ASTBase):
         self.arg = arg
         self.ellipsis = ellipsis
 
-    def get_id(self, version: int, objectType: str = None, symbol: "Symbol" = None) -> str:
+    def get_id(
+        self,
+        version: int,
+        objectType: Optional[str] = None,
+        symbol: Optional["Symbol"] = None
+    ) -> str:
         # this is not part of the normal name mangling in C++
         if symbol:
             # the anchor will be our parent
@@ -3192,7 +3197,12 @@ class ASTTemplateParamConstrainedTypeWithInit(ASTBase):
     def isPack(self) -> bool:
         return self.type.isPack
 
-    def get_id(self, version: int, objectType: str = None, symbol: "Symbol" = None) -> str:
+    def get_id(
+        self,
+        version: int,
+        objectType: Optional[str] = None,
+        symbol: Optional["Symbol"] = None
+    ) -> str:
         # this is not part of the normal name mangling in C++
         assert version >= 2
         if symbol:
@@ -3231,8 +3241,12 @@ class ASTTypeWithInit(ASTBase):
     def isPack(self) -> bool:
         return self.type.isPack
 
-    def get_id(self, version: int, objectType: str = None,
-               symbol: "Symbol" = None) -> str:
+    def get_id(
+        self,
+        version: int,
+        objectType: Optional[str] = None,
+        symbol: Optional["Symbol"] = None,
+    ) -> str:
         if objectType != 'member':
             return self.type.get_id(version, objectType)
         if version == 1:
@@ -3260,8 +3274,12 @@ class ASTTypeUsing(ASTBase):
         self.name = name
         self.type = type
 
-    def get_id(self, version: int, objectType: str = None,
-               symbol: "Symbol" = None) -> str:
+    def get_id(
+        self,
+        version: int,
+        objectType: Optional[str] = None,
+        symbol: Optional["Symbol"] = None,
+    ) -> str:
         if version == 1:
             raise NoOldIdError()
         return symbol.get_full_nested_name().get_id(version)
@@ -3300,8 +3318,12 @@ class ASTConcept(ASTBase):
     def name(self) -> ASTNestedName:
         return self.nestedName
 
-    def get_id(self, version: int, objectType: str = None,
-               symbol: "Symbol" = None) -> str:
+    def get_id(
+        self,
+        version: int,
+        objectType: Optional[str] = None,
+        symbol: Optional["Symbol"] = None,
+    ) -> str:
         if version == 1:
             raise NoOldIdError()
         return symbol.get_full_nested_name().get_id(version)
@@ -4501,11 +4523,11 @@ class Symbol:
         onMissingQualifiedSymbol: Callable[
             ["Symbol", Union[ASTIdentifier, ASTOperator], Any, ASTTemplateArgs], "Symbol"
         ],
-        strictTemplateParamArgLists: bool, ancestorLookupType: str,
+        strictTemplateParamArgLists: bool, ancestorLookupType: Optional[str],
         templateShorthand: bool, matchSelf: bool,
         recurseInAnon: bool, correctPrimaryTemplateArgs: bool,
         searchInSiblings: bool
-    ) -> SymbolLookupResult:
+    ) -> Optional[SymbolLookupResult]:
         # ancestorLookupType: if not None, specifies the target type of the lookup
         if Symbol.debug_lookup:
             Symbol.debug_indent += 1
@@ -4629,8 +4651,14 @@ class Symbol:
         return SymbolLookupResult(symbols, parentSymbol,
                                   identOrOp, templateParams, templateArgs)
 
-    def _add_symbols(self, nestedName: ASTNestedName, templateDecls: List[Any],
-                     declaration: ASTDeclaration, docname: str, line: int) -> "Symbol":
+    def _add_symbols(
+        self,
+        nestedName: ASTNestedName,
+        templateDecls: List[Any],
+        declaration: Optional[ASTDeclaration],
+        docname: Optional[str],
+        line: Optional[int],
+    ) -> "Symbol":
         # Used for adding a whole path of symbols, where the last may or may not
         # be an actual declaration.
 
@@ -4955,7 +4983,7 @@ class Symbol:
 
     def find_identifier(self, identOrOp: Union[ASTIdentifier, ASTOperator],
                         matchSelf: bool, recurseInAnon: bool, searchInSiblings: bool
-                        ) -> "Symbol":
+                        ) -> Optional["Symbol"]:
         if Symbol.debug_lookup:
             Symbol.debug_indent += 1
             Symbol.debug_print("find_identifier:")
@@ -4984,7 +5012,7 @@ class Symbol:
             current = current.siblingAbove
         return None
 
-    def direct_lookup(self, key: "LookupKey") -> "Symbol":
+    def direct_lookup(self, key: "LookupKey") -> Optional["Symbol"]:
         if Symbol.debug_lookup:
             Symbol.debug_indent += 1
             Symbol.debug_print("direct_lookup:")
@@ -5025,9 +5053,16 @@ class Symbol:
             Symbol.debug_indent -= 2
         return s
 
-    def find_name(self, nestedName: ASTNestedName, templateDecls: List[Any],
-                  typ: str, templateShorthand: bool, matchSelf: bool,
-                  recurseInAnon: bool, searchInSiblings: bool) -> Tuple[List["Symbol"], str]:
+    def find_name(
+        self,
+        nestedName: ASTNestedName,
+        templateDecls: List[Any],
+        typ: str,
+        templateShorthand: bool,
+        matchSelf: bool,
+        recurseInAnon: bool,
+        searchInSiblings: bool
+    ) -> Tuple[Optional[List["Symbol"]], Optional[str]]:
         # templateShorthand: missing template parameter lists for templates is ok
         # If the first component is None,
         # then the second component _may_ be a string explaining why.


### PR DESCRIPTION
this is sisyphean, but i feel like i'm slowly reducing the local entropy in the universe.

There's definitely a chronic overuse of argument defaults in this repo.... if only there was a way to lint for functions with default arguments, where the arguments are always fully-specified in usage. I think there'd be a lot of examples in this repo