### PR TITLE
Update removal note for logo and favicon variables

### DIFF
--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -144,12 +144,12 @@ The following is a list of deprecated interfaces.
 
    * - ``favicon`` variable in HTML templates
      - 4.0
-     - TBD
+     - 6.0
      - ``favicon_url``
 
    * - ``logo`` variable in HTML templates
      - 4.0
-     - TBD
+     - 6.0
      - ``logo_url``
 
    * - ``sphinx.directives.patches.ListTable``


### PR DESCRIPTION
Subject: Update removal note for logo and favicon variables

### Feature or Bugfix
- Bugfix

### Purpose
Support for `logo` and `favicon` variables were removed as of 6.0.0 release; documentation for Deprecated APIs needs updating accordingly.

### Detail
Updates

### Relates
- #11062 

