### PR TITLE
Remove obsolete HTML keyword ``link rel="shortcut"``

### DIFF
--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -137,7 +137,7 @@
           href="{{ pathto('_static/opensearch.xml', 1) }}"/>
     {%- endif %}
     {%- if favicon_url %}
-    <link rel="shortcut icon" href="{{ favicon_url|e }}"/>
+    <link rel="icon" href="{{ favicon_url|e }}"/>
     {%- endif %}
     {%- endif %}
 {%- block linktags %}

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1370,7 +1370,7 @@ def test_html_remote_logo(app, status, warning):
 
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
     assert ('<img class="logo" src="https://www.python.org/static/img/python-logo.png" alt="Logo"/>' in result)
-    assert ('<link rel="shortcut icon" href="https://www.python.org/static/favicon.ico"/>' in result)
+    assert ('<link rel="icon" href="https://www.python.org/static/favicon.ico"/>' in result)
     assert not (app.outdir / 'python-logo.png').exists()
 
 


### PR DESCRIPTION
Subject: The keyword `shortcut` was used by historic browsers. It is not required anymore by the HTML5 specification.

### Feature or Bugfix
- Refactoring

### Purpose
- Remove outdated HTML keyword

### Detail
- The keyword `shortcut` was used by historic browsers (e.g. Internet Explorer 6).
- This browsers are not supported anymore by sphinx.
- It is not required anymore by the HTML5 specification.

### Relates
- **HTML5 Specification**, 4.6.7.8 Link type "icon", https://html.spec.whatwg.org/#rel-icon
- **Sphinx**: Release 1.5 (released Dec 5, 2016)
  - Internet Explorer 6-8, Opera 12.1x or Safari 5.1+ support is dropped
  because jQuery version is updated from 1.11.0 to 3.1.0 (ref: #2634, #2773)

