### PR TITLE
Fix #11074: Can't change sphinxnote to use sphinxheavybox

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Bugs fixed
 
 * #6744: LaTeX: support for seealso directive should be via an environment
   to allow styling.
+* #11074: LaTeX: Can't change sphinxnote to use sphinxheavybox starting with
+  5.1.0
 
 Testing
 --------

--- a/sphinx/texinputs/sphinxlatexadmonitions.sty
+++ b/sphinx/texinputs/sphinxlatexadmonitions.sty
@@ -126,10 +126,49 @@
   \fi\@nameuse{fi}%
   \sphinxcolorlet{spx@boxes@shadowcolor}{sphinx\spx@noticetype ShadowColor}%
 }
+% rescue code in case sphinxheavybox is used for note-like notices
+% (executed if there is no radius.topleft associated macro)
+\def\spx@admonitions@boxes@fcolorbox@setup@fallback{%
+  \spx@boxes@border@top   \spx@notice@border
+  \spx@boxes@border@right \spx@notice@border
+  \spx@boxes@border@bottom\spx@notice@border
+  \spx@boxes@border@left  \spx@notice@border
+  \spx@boxes@border       \spx@notice@border
+% legacy behavior for padding
+  \spx@boxes@padding@top   \dimexpr.6\baselineskip-\spx@notice@border\relax
+  \spx@boxes@padding@right \spx@boxes@padding@top
+  \spx@boxes@padding@bottom\spx@boxes@padding@top
+  \spx@boxes@padding@left  \spx@boxes@padding@top
+% straight corners
+  \spx@boxes@radius@topleft     \z@
+  \spx@boxes@radius@topright    \z@
+  \spx@boxes@radius@bottomright \z@
+  \spx@boxes@radius@bottomleft  \z@
+% legacy has no shadow
+  \spx@boxes@withshadowfalse
+  \spx@boxes@insetshadowfalse
+  \spx@boxes@withshadowcolorfalse
+% assume background color although there is no public interface,
+% sphinxnoteBgColor et al. are defined above and let to white
+  \spx@boxes@withbackgroundcolortrue
+  \sphinxcolorlet{spx@boxes@backgroundcolor}{spx@notice@bgcolor}%
+% assume always with border color (for simplicity sake, again, and this
+% time there is a public interface)
+  \spx@boxes@withbordercolortrue
+  \sphinxcolorlet{spx@boxes@bordercolor}{spx@notice@bordercolor}%
+}
 % Code adapted from framed.sty's "snugshade" environment.
 % Nesting works (inner frames do not allow page breaks).
 \newenvironment{sphinxheavybox}{\par
+   \ifcsname spx@\spx@noticetype @radius@topleft\endcsname
+     \expandafter\@firstoftwo
+   \else
+     % attempt to use sphinxheavybox without the circa 20 needed style
+     % parameters, i.e., for one of the light notice types
+     \expandafter\@secondoftwo
+   \fi
    \spx@admonitions@boxes@fcolorbox@setup
+   \spx@admonitions@boxes@fcolorbox@setup@fallback
    % Those are used by sphinxVerbatim if the \ifspx@inframed boolean is true
    \setlength{\FrameRule}{0.5\dimexpr\spx@boxes@border@top+\spx@boxes@border@bottom\relax}%
    % MEMO: prior to 5.1.0 \FrameSep was determined as 0.6\baselineskip -


### PR DESCRIPTION
I have made an entry in Bugfixes, but as I commened in #11074 I did not consider the changed behavior at 5.1.0 as a bug (it would have been a regression), as it was never said explicitly one could use `sphinxheavybox` without precautions directly.

Memo: this allows to let `sphinxnote` etc... use `sphinxheavybox` but do not deduce one can wrap arbitrarily this way for a new environment unrelated to admonitions: under the hood there is `sphinxadmonition` dispatch which does some preparatory steps before the `sphinxnote` etc... are actually executed.

Fixes #11074

