### PR TITLE
Add missing default arguments in sphinx-apidoc.rst

### DIFF
--- a/doc/man/sphinx-apidoc.rst
+++ b/doc/man/sphinx-apidoc.rst
@@ -62,7 +62,7 @@ Options
 
 .. option:: -d <MAXDEPTH>
 
-   Maximum depth for the generated table of contents file. Defaults to ``4``. 
+   Maximum depth for the generated table of contents file. Defaults to ``4``.
 
 .. option:: --tocfile
 

--- a/doc/man/sphinx-apidoc.rst
+++ b/doc/man/sphinx-apidoc.rst
@@ -50,7 +50,7 @@ Options
 
 .. option:: -l, --follow-links
 
-   Follow symbolic links.
+   Follow symbolic links. Defaults to ``False``.
 
 .. option:: -n, --dry-run
 
@@ -62,7 +62,7 @@ Options
 
 .. option:: -d <MAXDEPTH>
 
-   Maximum depth for the generated table of contents file.
+   Maximum depth for the generated table of contents file. Defaults to ``4``. 
 
 .. option:: --tocfile
 


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix

- Bugfix


### Purpose

This PR adds the missing default arguments to two CLI flags, `-l` and `-d`, from `sphinx-apidoc` in the documentation.


