### PR TITLE
Suppress lint failures from Ruff 0.0.211

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ ignore = [
     # flake8-bandit
     "S101",  # assert used
     "S105",  # possible hardcoded password
+    # flake8-simplify
+    "SIM102", # nested 'if' statements
+    "SIM105", # use contextlib.suppress
+    "SIM117", # use single 'with' statement
 ]
 external = [  # Whitelist for RUF100 unkown code warnings
     "E704",


### PR DESCRIPTION
ruff fails for me locally, since ruff has added new SIM lints which sphinx has not implemented

this PR suppresses those lints (matching the flake8-simplify config)