### PR TITLE
Fix copying images under parallel execution

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -401,8 +401,11 @@ class EpubBuilder(StandaloneHTMLBuilder):
         the format and resizing the image if necessary/possible.
         """
         ensuredir(path.join(self.outdir, self.imagedir))
+        converted_images = {*self.env.original_image_uri.values()}
         for src in status_iterator(self.env.images, __('copying images... '), "brown",
                                    len(self.env.images), self.app.verbosity):
+            if src in converted_images:
+                continue
             _docnames, dest = self.env.images[src]
             try:
                 img = Image.open(path.join(self.srcdir, src))

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -401,9 +401,9 @@ class EpubBuilder(StandaloneHTMLBuilder):
         the format and resizing the image if necessary/possible.
         """
         ensuredir(path.join(self.outdir, self.imagedir))
-        for src in status_iterator(self.images, __('copying images... '), "brown",
-                                   len(self.images), self.app.verbosity):
-            dest = self.images[src]
+        for src in status_iterator(self.env.images, __('copying images... '), "brown",
+                                   len(self.env.images), self.app.verbosity):
+            _docnames, dest = self.env.images[src]
             try:
                 img = Image.open(path.join(self.srcdir, src))
             except OSError:
@@ -438,7 +438,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """Copy image files to destination directory.
         This overwritten method can use Pillow to convert image files.
         """
-        if self.images:
+        if self.env.images:
             if self.config.epub_fix_images or self.config.epub_max_image_width:
                 if not Image:
                     logger.warning(__('Pillow not found - copying image files'))

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -764,13 +764,13 @@ class StandaloneHTMLBuilder(Builder):
             self.handle_page(indexname, indexcontext, 'domainindex.html')
 
     def copy_image_files(self) -> None:
-        if self.images:
+        if self.env.images:
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
             ensuredir(path.join(self.outdir, self.imagedir))
-            for src in status_iterator(self.images, __('copying images... '), "brown",
-                                       len(self.images), self.app.verbosity,
+            for src in status_iterator(self.env.images, __('copying images... '), "brown",
+                                       len(self.env.images), self.app.verbosity,
                                        stringify_func=stringify_func):
-                dest = self.images[src]
+                _docnames, dest = self.env.images[src]
                 try:
                     copyfile(path.join(self.srcdir, src),
                              path.join(self.outdir, self.imagedir, dest))

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -765,11 +765,14 @@ class StandaloneHTMLBuilder(Builder):
 
     def copy_image_files(self) -> None:
         if self.env.images:
+            converted_images = {*self.env.original_image_uri.values()}
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
             ensuredir(path.join(self.outdir, self.imagedir))
             for src in status_iterator(self.env.images, __('copying images... '), "brown",
                                        len(self.env.images), self.app.verbosity,
                                        stringify_func=stringify_func):
+                if src in converted_images:
+                    continue
                 _docnames, dest = self.env.images[src]
                 try:
                     copyfile(path.join(self.srcdir, src),

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -414,10 +414,13 @@ class LaTeXBuilder(Builder):
 
     def copy_image_files(self) -> None:
         if self.env.images:
+            converted_images = {*self.env.original_image_uri.values()}
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
             for src in status_iterator(self.env.images, __('copying images... '), "brown",
                                        len(self.env.images), self.app.verbosity,
                                        stringify_func=stringify_func):
+                if src in converted_images:
+                    continue
                 _docnames, dest = self.env.images[src]
                 try:
                     copy_asset_file(path.join(self.srcdir, src),

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -413,12 +413,12 @@ class LaTeXBuilder(Builder):
             copy_asset_file(path.join(self.confdir, filename), self.outdir)
 
     def copy_image_files(self) -> None:
-        if self.images:
+        if self.env.images:
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
-            for src in status_iterator(self.images, __('copying images... '), "brown",
-                                       len(self.images), self.app.verbosity,
+            for src in status_iterator(self.env.images, __('copying images... '), "brown",
+                                       len(self.env.images), self.app.verbosity,
                                        stringify_func=stringify_func):
-                dest = self.images[src]
+                _docnames, dest = self.env.images[src]
                 try:
                     copy_asset_file(path.join(self.srcdir, src),
                                     path.join(self.outdir, dest))

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -174,10 +174,13 @@ class TexinfoBuilder(Builder):
 
     def copy_image_files(self, targetname: str) -> None:
         if self.env.images:
+            converted_images = {*self.env.original_image_uri.values()}
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
             for src in status_iterator(self.env.images, __('copying images... '), "brown",
                                        len(self.env.images), self.app.verbosity,
                                        stringify_func=stringify_func):
+                if src in converted_images:
+                    continue
                 _docnames, dest = self.env.images[src]
                 try:
                     imagedir = path.join(self.outdir, targetname + '-figures')

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -173,12 +173,12 @@ class TexinfoBuilder(Builder):
         self.copy_support_files()
 
     def copy_image_files(self, targetname: str) -> None:
-        if self.images:
+        if self.env.images:
             stringify_func = ImageAdapter(self.app.env).get_original_image_uri
-            for src in status_iterator(self.images, __('copying images... '), "brown",
-                                       len(self.images), self.app.verbosity,
+            for src in status_iterator(self.env.images, __('copying images... '), "brown",
+                                       len(self.env.images), self.app.verbosity,
                                        stringify_func=stringify_func):
-                dest = self.images[src]
+                _docnames, dest = self.env.images[src]
                 try:
                     imagedir = path.join(self.outdir, targetname + '-figures')
                     ensuredir(imagedir)

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -403,6 +403,7 @@ def test_copy_images(app, status, warning):
         'img.gif',
         'img.pdf',
         'img.png',
+        'python-logo.png',
         'rimg.png',
         'rimg1.png',
         'svgimg.pdf',

--- a/tests/test_build_epub.py
+++ b/tests/test_build_epub.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from pathlib import Path
 from subprocess import CalledProcessError
 from xml.etree import ElementTree
 
@@ -390,3 +391,21 @@ def test_xml_name_pattern_check():
     assert _XML_NAME_PATTERN.match('id-pub')
     assert _XML_NAME_PATTERN.match('webpage')
     assert not _XML_NAME_PATTERN.match('1bfda21')
+
+
+@pytest.mark.sphinx('epub', testroot='images')
+def test_copy_images(app, status, warning):
+    app.build()
+
+    images_dir = Path(app.outdir) / '_images'
+    images = {image.name for image in images_dir.rglob('*')}
+    assert images == {
+        'img.gif',
+        'img.pdf',
+        'img.png',
+        'rimg.png',
+        'rimg1.png',
+        'svgimg.pdf',
+        'svgimg.svg',
+        'testimäge.png',
+    }

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -3,6 +3,7 @@
 import os
 import re
 from itertools import chain, cycle
+from pathlib import Path
 from unittest.mock import ANY, call, patch
 
 import pytest
@@ -1770,3 +1771,21 @@ def test_theme_having_multiple_stylesheets(app):
 
     assert '<link rel="stylesheet" type="text/css" href="_static/mytheme.css" />' in content
     assert '<link rel="stylesheet" type="text/css" href="_static/extra.css" />' in content
+
+
+@pytest.mark.sphinx('html', testroot='images')
+def test_copy_images(app, status, warning):
+    app.build()
+
+    images_dir = Path(app.outdir) / '_images'
+    images = {image.name for image in images_dir.rglob('*')}
+    assert images == {
+        'img.gif',
+        'img.pdf',
+        'img.png',
+        'rimg.png',
+        'rimg1.png',
+        'svgimg.pdf',
+        'svgimg.svg',
+        'testimäge.png',
+    }

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 from itertools import product
+from pathlib import Path
 from shutil import copyfile
 from subprocess import CalledProcessError
 
@@ -1670,3 +1671,21 @@ def test_latex_code_role(app):
             common_content + '%\n}} code block') in content
     assert (r'\begin{sphinxVerbatim}[commandchars=\\\{\}]' +
             '\n' + common_content + '\n' + r'\end{sphinxVerbatim}') in content
+
+
+@pytest.mark.sphinx('latex', testroot='images')
+def test_copy_images(app, status, warning):
+    app.build()
+
+    images_dir = Path(app.outdir) / '_images'
+    images = {image.name for image in images_dir.rglob('*')}
+    assert images == {
+        'img.gif',
+        'img.pdf',
+        'img.png',
+        'rimg.png',
+        'rimg1.png',
+        'svgimg.pdf',
+        'svgimg.svg',
+        'testimäge.png',
+    }

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1677,12 +1677,16 @@ def test_latex_code_role(app):
 def test_copy_images(app, status, warning):
     app.build()
 
-    images_dir = Path(app.outdir) / '_images'
-    images = {image.name for image in images_dir.rglob('*')}
+    test_dir = Path(app.outdir)
+    images = {
+        image.name for image in test_dir.rglob('*')
+        if image.suffix in {'.gif', '.pdf', '.png', '.svg'}
+    }
     assert images == {
         'img.gif',
         'img.pdf',
         'img.png',
+        'python-logo.png',
         'rimg.png',
         'rimg1.png',
         'svgimg.pdf',

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -144,12 +144,13 @@ def test_texinfo_samp_with_variable(app, status, warning):
 def test_copy_images(app, status, warning):
     app.build()
 
-    images_dir = Path(app.outdir) / '_images'
+    images_dir = Path(app.outdir) / 'python-figures'
     images = {image.name for image in images_dir.rglob('*')}
     assert images == {
         'img.gif',
         'img.pdf',
         'img.png',
+        'python-logo.png',
         'rimg.png',
         'rimg1.png',
         'svgimg.pdf',

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+from pathlib import Path
 from subprocess import CalledProcessError
 from unittest.mock import Mock
 
@@ -137,3 +138,21 @@ def test_texinfo_samp_with_variable(app, status, warning):
     assert '@code{@var{variable_only}}' in output
     assert '@code{@var{variable} and text}' in output
     assert '@code{Show @var{variable} in the middle}' in output
+
+
+@pytest.mark.sphinx('texinfo', testroot='images')
+def test_copy_images(app, status, warning):
+    app.build()
+
+    images_dir = Path(app.outdir) / '_images'
+    images = {image.name for image in images_dir.rglob('*')}
+    assert images == {
+        'img.gif',
+        'img.pdf',
+        'img.png',
+        'rimg.png',
+        'rimg1.png',
+        'svgimg.pdf',
+        'svgimg.svg',
+        'testimäge.png',
+    }


### PR DESCRIPTION
cc @hugovk @CAM-Gerlach; xref https://github.com/python/peps/pull/2950

This (hopefully) fixes copying images when running Sphinx under parallel-mode.

A