### PR TITLE
Apply ruff 0.0.213 linting advices on c40f4f904f3b053

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -362,10 +362,7 @@ class Sphinx:
                   else __('finished with problems'))
         if self._warncount:
             if self.warningiserror:
-                if self._warncount == 1:
-                    msg = __('build %s, %s warning (with warnings treated as errors).')
-                else:
-                    msg = __('build %s, %s warnings (with warnings treated as errors).')
+                msg = __("build %s, %s warning (with warnings treated as errors).") if self._warncount == 1 else __("build %s, %s warnings (with warnings treated as errors).")
             else:
                 if self._warncount == 1:
                     msg = __('build %s, %s warning.')

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -423,10 +423,7 @@ class Builder:
         self.events.emit('env-before-read-docs', self.env, docnames)
 
         # check if we should do parallel or serial read
-        if parallel_available and len(docnames) > 5 and self.app.parallel > 1:
-            par_ok = self.app.is_parallel_allowed('read')
-        else:
-            par_ok = False
+        par_ok = self.app.is_parallel_allowed("read") if parallel_available and len(docnames) > 5 and self.app.parallel > 1 else False
 
         if par_ok:
             self._read_parallel(docnames, nproc=self.app.parallel)
@@ -553,11 +550,7 @@ class Builder:
         if build_docnames is None or build_docnames == ['__all__']:
             # build_all
             build_docnames = self.env.found_docs
-        if method == 'update':
-            # build updated ones as well
-            docnames = set(build_docnames) | set(updated_docnames)
-        else:
-            docnames = set(build_docnames)
+        docnames = set(build_docnames) | set(updated_docnames) if method == "update" else set(build_docnames)
         logger.debug(__('docnames to write: %s'), ', '.join(sorted(docnames)))
 
         # add all toctree-containing files that may have changed

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -55,26 +55,17 @@ class ChangesBuilder(Builder):
             return
         logger.info(bold(__('writing summary file...')))
         for changeset in changesets:
-            if isinstance(changeset.descname, tuple):
-                descname = changeset.descname[0]
-            else:
-                descname = changeset.descname
+            descname = changeset.descname[0] if isinstance(changeset.descname, tuple) else changeset.descname
             ttext = self.typemap[changeset.type]
             context = changeset.content.replace('\n', ' ')
             if descname and changeset.docname.startswith('c-api'):
-                if context:
-                    entry = f'<b>{descname}</b>: <i>{ttext}:</i> {context}'
-                else:
-                    entry = f'<b>{descname}</b>: <i>{ttext}</i>.'
+                entry = f"<b>{descname}</b>: <i>{ttext}:</i> {context}" if context else f"<b>{descname}</b>: <i>{ttext}</i>."
                 apichanges.append((entry, changeset.docname, changeset.lineno))
             elif descname or changeset.module:
                 module = changeset.module or _('Builtins')
                 if not descname:
                     descname = _('Module level')
-                if context:
-                    entry = f'<b>{descname}</b>: <i>{ttext}:</i> {context}'
-                else:
-                    entry = f'<b>{descname}</b>: <i>{ttext}</i>.'
+                entry = f"<b>{descname}</b>: <i>{ttext}:</i> {context}" if context else f"<b>{descname}</b>: <i>{ttext}</i>."
                 libchanges.setdefault(module, []).append((entry, changeset.docname,
                                                           changeset.lineno))
             else:

--- a/sphinx/builders/dirhtml.py
+++ b/sphinx/builders/dirhtml.py
@@ -29,12 +29,7 @@ class DirectoryHTMLBuilder(StandaloneHTMLBuilder):
         return docname + SEP
 
     def get_outfilename(self, pagename: str) -> str:
-        if pagename == 'index' or pagename.endswith(SEP + 'index'):
-            outfilename = path.join(self.outdir, os_path(pagename) +
-                                    self.out_suffix)
-        else:
-            outfilename = path.join(self.outdir, os_path(pagename),
-                                    'index' + self.out_suffix)
+        outfilename = path.join(self.outdir, os_path(pagename) + self.out_suffix) if pagename == "index" or pagename.endswith(SEP + "index") else path.join(self.outdir, os_path(pagename), "index" + self.out_suffix)
 
         return outfilename
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -317,10 +317,7 @@ class StandaloneHTMLBuilder(Builder):
             style = 'sphinx'
         self.highlighter = PygmentsBridge('html', style)
 
-        if self.theme:
-            dark_style = self.theme.get_config('theme', 'pygments_dark_style', None)
-        else:
-            dark_style = None
+        dark_style = self.theme.get_config("theme", "pygments_dark_style", None) if self.theme else None
 
         if dark_style is not None:
             self.dark_highlighter = PygmentsBridge('html', dark_style)
@@ -415,10 +412,7 @@ class StandaloneHTMLBuilder(Builder):
             # ignore errors on reading
             pass
 
-        if self.templates:
-            template_mtime = self.templates.newest_template_mtime()
-        else:
-            template_mtime = 0
+        template_mtime = self.templates.newest_template_mtime() if self.templates else 0
         for docname in self.env.found_docs:
             if docname not in self.env.all_docs:
                 logger.debug('[build target] did not in env: %r', docname)

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -238,10 +238,7 @@ class LaTeXBuilder(Builder):
         elif self.context['polyglossia']:
             self.context['classoptions'] += ',' + self.babel.get_language()
             options = self.babel.get_mainlanguage_options()
-            if options:
-                language = fr'\setmainlanguage[{options}]{{{self.babel.get_language()}}}'
-            else:
-                language = r'\setmainlanguage{%s}' % self.babel.get_language()
+            language = f"\\setmainlanguage[{options}]{{{self.babel.get_language()}}}" if options else "\\setmainlanguage{%s}" % self.babel.get_language()
 
             self.context['multilingual'] = f'{self.context["polyglossia"]}\n{language}'
 
@@ -280,10 +277,7 @@ class LaTeXBuilder(Builder):
             with progress_message(__("processing %s") % targetname):
                 doctree = self.env.get_doctree(docname)
                 toctree = next(doctree.findall(addnodes.toctree), None)
-                if toctree and toctree.get('maxdepth') > 0:
-                    tocdepth = toctree.get('maxdepth')
-                else:
-                    tocdepth = None
+                tocdepth = toctree.get("maxdepth") if toctree and toctree.get("maxdepth") > 0 else None
 
                 doctree = self.assemble_doctree(
                     docname, toctree_only,

--- a/sphinx/builders/latex/theming.py
+++ b/sphinx/builders/latex/theming.py
@@ -111,10 +111,7 @@ class ThemeFactory:
 
     def get(self, name: str) -> Theme:
         """Get a theme for given *name*."""
-        if name in self.themes:
-            theme = self.themes[name]
-        else:
-            theme = self.find_user_theme(name) or Theme(name)
+        theme = self.themes[name] if name in self.themes else self.find_user_theme(name) or Theme(name)
 
         theme.update(self.config)
         return theme

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -65,10 +65,7 @@ class ManualPageBuilder(Builder):
                                   'document %s'), docname)
                 continue
             if isinstance(authors, str):
-                if authors:
-                    authors = [authors]
-                else:
-                    authors = []
+                authors = [authors] if authors else []
 
             docsettings.title = name
             docsettings.subtitle = description

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -91,10 +91,7 @@ class Make:
         if self.run_generic_build('latex') > 0:
             return 1
 
-        if sys.platform == 'win32':
-            makecmd = os.environ.get('MAKE', 'make.bat')
-        else:
-            makecmd = self.makecmd
+        makecmd = os.environ.get("MAKE", "make.bat") if sys.platform == "win32" else self.makecmd
         try:
             with cd(self.builddir_join('latex')):
                 return subprocess.call([makecmd, 'all-pdf'])
@@ -106,10 +103,7 @@ class Make:
         if self.run_generic_build('latex') > 0:
             return 1
 
-        if sys.platform == 'win32':
-            makecmd = os.environ.get('MAKE', 'make.bat')
-        else:
-            makecmd = self.makecmd
+        makecmd = os.environ.get("MAKE", "make.bat") if sys.platform == "win32" else self.makecmd
         try:
             with cd(self.builddir_join('latex')):
                 return subprocess.call([makecmd, 'all-pdf'])

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -62,11 +62,7 @@ DEFAULTS = {
 
 PROMPT_PREFIX = '> '
 
-if sys.platform == 'win32':
-    # On Windows, show questions as bold because of color scheme of PowerShell (refs: #5294).
-    COLOR_QUESTION = 'bold'
-else:
-    COLOR_QUESTION = 'purple'
+COLOR_QUESTION = "bold" if sys.platform == "win32" else "purple"
 
 
 # function to get input from terminal -- overridden by the test suite
@@ -136,10 +132,7 @@ def do_prompt(
     text: str, default: str | None = None, validator: Callable[[str], Any] = nonempty
 ) -> str | bool:
     while True:
-        if default is not None:
-            prompt = PROMPT_PREFIX + f'{text} [{default}]: '
-        else:
-            prompt = PROMPT_PREFIX + text + ': '
+        prompt = PROMPT_PREFIX + f"{text} [{default}]: " if default is not None else PROMPT_PREFIX + text + ": "
         if USE_LIBEDIT:
             # Note: libedit has a problem for combination of ``input()`` and escape
             # sequence (see #5335).  To avoid the problem, all prompts are not colored

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -466,11 +466,7 @@ def check_confval_types(app: Sphinx | None, config: Config) -> None:
                 msg = __("The config value `{name}' has type `{current.__name__}'; "
                          "expected {permitted}.")
                 wrapped_annotations = [f"`{c.__name__}'" for c in annotations]
-                if len(wrapped_annotations) > 2:
-                    permitted = (", ".join(wrapped_annotations[:-1])
-                                 + f", or {wrapped_annotations[-1]}")
-                else:
-                    permitted = " or ".join(wrapped_annotations)
+                permitted = ", ".join(wrapped_annotations[:-1]) + f", or {wrapped_annotations[-1]}" if len(wrapped_annotations) > 2 else " or ".join(wrapped_annotations)
                 logger.warning(msg.format(name=confval.name,
                                           current=type(confval.value),
                                           permitted=permitted), once=True)

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -148,10 +148,7 @@ class ASTIdentifier(ASTBaseBase):
                            prefix: str, symbol: Symbol) -> None:
         # note: slightly different signature of describe_signature due to the prefix
         verify_description_mode(mode)
-        if self.is_anon():
-            node = addnodes.desc_sig_name(text="[anonymous]")
-        else:
-            node = addnodes.desc_sig_name(self.identifier, self.identifier)
+        node = addnodes.desc_sig_name(text="[anonymous]") if self.is_anon() else addnodes.desc_sig_name(self.identifier, self.identifier)
         if mode == 'markType':
             targetText = prefix + self.identifier
             pnode = addnodes.pending_xref('', refdomain='c',
@@ -2372,10 +2369,7 @@ class DefinitionParser(BaseParser):
         self.skip_ws()
         for op in _expression_unary_ops:
             # TODO: hmm, should we be able to backtrack here?
-            if op[0] in 'cn':
-                res = self.skip_word(op)
-            else:
-                res = self.skip_string(op)
+            res = self.skip_word(op) if op[0] in "cn" else self.skip_string(op)
             if res:
                 expr = self._parse_cast_expression()
                 return ASTUnaryOpExpr(op, expr)
@@ -3454,10 +3448,7 @@ class CNamespacePopObject(SphinxDirective):
             stack = []
         else:
             stack.pop()
-        if len(stack) > 0:
-            symbol = stack[-1]
-        else:
-            symbol = self.env.domaindata['c']['root_symbol']
+        symbol = stack[-1] if len(stack) > 0 else self.env.domaindata["c"]["root_symbol"]
         self.env.temp_data['c:parent_symbol'] = symbol
         self.env.temp_data['c:namespace_stack'] = stack
         self.env.ref_context['cp:parent_key'] = symbol.get_lookup_key()

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -221,10 +221,7 @@ class JSObject(ObjectDescription[Tuple[str, str]]):
 
         config = self.env.app.config
         objtype = sig_node.parent.get('objtype')
-        if config.add_function_parentheses and objtype in {'function', 'method'}:
-            parens = '()'
-        else:
-            parens = ''
+        parens = "()" if config.add_function_parentheses and objtype in {"function", "method"} else ""
         *parents, name = sig_node['_toc_parts']
         if config.toc_object_entries_show_parents == 'domain':
             return sig_node.get('fullname', name) + parens

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -89,11 +89,7 @@ def parse_reftarget(reftarget: str, suppress_prefix: bool = False
     else:
         title = reftarget
 
-    if reftarget == 'None' or reftarget.startswith('typing.'):
-        # typing module provides non-class types.  Obj reference is good to refer them.
-        reftype = 'obj'
-    else:
-        reftype = 'class'
+    reftype = "obj" if reftarget == "None" or reftarget.startswith("typing.") else "class"
 
     return reftype, reftarget, title, refspecific
 
@@ -101,11 +97,7 @@ def parse_reftarget(reftarget: str, suppress_prefix: bool = False
 def type_to_xref(target: str, env: BuildEnvironment | None = None,
                  suppress_prefix: bool = False) -> addnodes.pending_xref:
     """Convert a type string to a cross reference node."""
-    if env:
-        kwargs = {'py:module': env.ref_context.get('py:module'),
-                  'py:class': env.ref_context.get('py:class')}
-    else:
-        kwargs = {}
+    kwargs = {'py:module': env.ref_context.get('py:module'), 'py:class': env.ref_context.get('py:class')} if env else {}
 
     reftype, target, title, refspecific = parse_reftarget(target, suppress_prefix)
 
@@ -679,10 +671,7 @@ class PyObject(ObjectDescription[Tuple[str, str]]):
 
         config = self.env.app.config
         objtype = sig_node.parent.get('objtype')
-        if config.add_function_parentheses and objtype in {'function', 'method'}:
-            parens = '()'
-        else:
-            parens = ''
+        parens = "()" if config.add_function_parentheses and objtype in {"function", "method"} else ""
         *parents, name = sig_node['_toc_parts']
         if config.toc_object_entries_show_parents == 'domain':
             return sig_node.get('fullname', name) + parens
@@ -1324,10 +1313,7 @@ class PythonDomain(Domain):
 
         newname = None
         if searchmode == 1:
-            if type is None:
-                objtypes = list(self.object_types)
-            else:
-                objtypes = self.objtypes_for_role(type)
+            objtypes = list(self.object_types) if type is None else self.objtypes_for_role(type)
             if objtypes is not None:
                 if modname and classname:
                     fullname = modname + '.' + classname + '.' + name
@@ -1402,11 +1388,7 @@ class PythonDomain(Domain):
         else:
             # determine the content of the reference by conditions
             content = find_pending_xref_condition(node, 'resolved')
-            if content:
-                children = content.children
-            else:
-                # if not found, use contnode
-                children = [contnode]
+            children = content.children if content else [contnode]
 
             return make_refnode(builder, fromdocname, obj[0], obj[1], children, name)
 
@@ -1434,11 +1416,7 @@ class PythonDomain(Domain):
             else:
                 # determine the content of the reference by conditions
                 content = find_pending_xref_condition(node, 'resolved')
-                if content:
-                    children = content.children
-                else:
-                    # if not found, use contnode
-                    children = [contnode]
+                children = content.children if content else [contnode]
 
                 results.append(('py:' + self.role_for_objtype(obj[2]),
                                 make_refnode(builder, fromdocname, obj[0], obj[1],

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -241,10 +241,7 @@ class Cmdoption(ObjectDescription[str]):
                                       self.env.docname, signode['ids'][0])
 
         # create an index entry
-        if currprogram:
-            descr = _('%s command line option') % currprogram
-        else:
-            descr = _('command line option')
+        descr = _("%s command line option") % currprogram if currprogram else _("command line option")
         for option in signode.get('allnames', []):
             entry = '; '.join([descr, option])
             self.indexnode['entries'].append(('pair', entry, signode['ids'][0], '', None))
@@ -507,10 +504,7 @@ class ProductionList(SphinxDirective):
                 subnode['ids'].append(node_id)
                 self.state.document.note_implicit_target(subnode, subnode)
 
-                if len(productionGroup) != 0:
-                    objName = f"{productionGroup}:{name}"
-                else:
-                    objName = name
+                objName = f"{productionGroup}:{name}" if len(productionGroup) != 0 else name
                 domain.note_object('token', objName, node_id, location=node)
             subnode.extend(token_xrefs(tokens, productionGroup))
             node.append(subnode)
@@ -882,25 +876,14 @@ class StandardDomain(Domain):
             return contnode
 
         try:
-            if node['refexplicit']:
-                title = contnode.astext()
-            else:
-                title = env.config.numfig_format.get(figtype, '')
+            title = contnode.astext() if node["refexplicit"] else env.config.numfig_format.get(figtype, "")
 
             if figname is None and '{name}' in title:
                 logger.warning(__('the link has no caption: %s'), title, location=node)
                 return contnode
             else:
                 fignum = '.'.join(map(str, fignumber))
-                if '{name}' in title or 'number' in title:
-                    # new style format (cf. "Fig.{number}")
-                    if figname:
-                        newtitle = title.format(name=figname, number=fignum)
-                    else:
-                        newtitle = title.format(number=fignum)
-                else:
-                    # old style format (cf. "Fig.%s")
-                    newtitle = title % fignum
+                newtitle = (title.format(name=figname, number=fignum) if figname else title.format(number=fignum)) if "{name}" in title or "number" in title else title % fignum
         except KeyError as exc:
             logger.warning(__('invalid numfig_format: %s (%r)'), title, exc, location=node)
             return contnode
@@ -932,11 +915,7 @@ class StandardDomain(Domain):
         if docname not in env.all_docs:
             return None
         else:
-            if node['refexplicit']:
-                # reference with explicit title
-                caption = node.astext()
-            else:
-                caption = clean_astext(env.titles[docname])
+            caption = node.astext() if node["refexplicit"] else clean_astext(env.titles[docname])
             innernode = nodes.inline(caption, caption, classes=['doc'])
             return make_refnode(builder, fromdocname, docname, None, innernode)
 
@@ -1134,10 +1113,7 @@ def warn_missing_reference(app: Sphinx, domain: Domain, node: pending_xref
         return None
     else:
         target = node['reftarget']
-        if target not in domain.anonlabels:  # type: ignore
-            msg = __('undefined label: %r')
-        else:
-            msg = __('Failed to create a cross reference. A title or caption not found: %r')
+        msg = __("undefined label: %r") if target not in domain.anonlabels else __("Failed to create a cross reference. A title or caption not found: %r")
 
         logger.warning(msg % target, location=node, type='ref', subtype=node['reftype'])
         return True

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -307,10 +307,7 @@ class BuildEnvironment:
             self.config_status = CONFIG_EXTENSIONS_CHANGED
             extensions = sorted(
                 set(self.config.extensions) ^ set(config.extensions))
-            if len(extensions) == 1:
-                extension = extensions[0]
-            else:
-                extension = '%d' % (len(extensions),)
+            extension = extensions[0] if len(extensions) == 1 else "%d" % (len(extensions),)
             self.config_status_extra = f' ({extension!r})'
         else:
             # check if a config value was changed that affects how

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -100,12 +100,7 @@ class IndexEntries:
             if lckey.startswith('\N{RIGHT-TO-LEFT MARK}'):
                 lckey = lckey[1:]
 
-            if lckey[0:1].isalpha() or lckey.startswith('_'):
-                # put non-symbol characters at the following group (1)
-                sortkey = (1, lckey)
-            else:
-                # put symbols at the front of the index (0)
-                sortkey = (0, lckey)
+            sortkey = (1, lckey) if lckey[0:1].isalpha() or lckey.startswith("_") else (0, lckey)
             # ensure a deterministic order *within* letters by also sorting on
             # the entry itself
             return (sortkey, entry[0])

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -161,10 +161,7 @@ class TocTree:
                         refdoc = ref
                         maxdepth = self.env.metadata[ref].get('tocdepth', 0)
                         toc = self.env.tocs[ref]
-                        if ref not in toctree_ancestors or (prune and maxdepth > 0):
-                            toc = self._toctree_copy(toc, 2, maxdepth, collapse)
-                        else:
-                            toc = toc.deepcopy()
+                        toc = self._toctree_copy(toc, 2, maxdepth, collapse) if ref not in toctree_ancestors or prune and maxdepth > 0 else toc.deepcopy()
                         process_only_nodes(toc, builder.tags)
                         if title and toc.children and len(toc.children) == 1:
                             child = toc.children[0]

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -266,10 +266,7 @@ class TocTreeCollector(EnvironmentCollector):
         def get_section_number(docname: str, section: nodes.section) -> tuple[int, ...]:
             anchorname = '#' + section['ids'][0]
             secnumbers = env.toc_secnumbers.get(docname, {})
-            if anchorname in secnumbers:
-                secnum = secnumbers.get(anchorname)
-            else:
-                secnum = secnumbers.get('')
+            secnum = secnumbers.get(anchorname) if anchorname in secnumbers else secnumbers.get("")
 
             return secnum or ()
 
@@ -330,12 +327,7 @@ class TocTreeCollector(EnvironmentCollector):
 
 
 def _make_anchor_name(ids: list[str], num_entries: list[int]) -> str:
-    if not num_entries[0]:
-        # for the very first toc entry, don't add an anchor
-        # as it is the file's title anyway
-        anchorname = ''
-    else:
-        anchorname = '#' + ids[0]
+    anchorname = "" if not num_entries[0] else "#" + ids[0]
     num_entries[0] += 1
     return anchorname
 

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -30,15 +30,7 @@ from sphinx.util.osutil import FileAvoidWrite, ensuredir
 from sphinx.util.template import ReSTRenderer
 
 # automodule options
-if 'SPHINX_APIDOC_OPTIONS' in os.environ:
-    OPTIONS = os.environ['SPHINX_APIDOC_OPTIONS'].split(',')
-else:
-    OPTIONS = [
-        'members',
-        'undoc-members',
-        # 'inherited-members', # disabled because there's a bug in sphinx
-        'show-inheritance',
-    ]
+OPTIONS = os.environ["SPHINX_APIDOC_OPTIONS"].split(",") if "SPHINX_APIDOC_OPTIONS" in os.environ else ["members", "undoc-members", "show-inheritance"]
 
 PY_SUFFIXES = ('.py', '.pyx') + tuple(EXTENSION_SUFFIXES)
 
@@ -236,11 +228,7 @@ def recurse_tree(rootpath: str, excludes: list[str], opts: Any,
     implicit_namespaces = getattr(opts, 'implicit_namespaces', False)
 
     # check if the base directory is a package and get its name
-    if is_packagedir(rootpath) or implicit_namespaces:
-        root_package = rootpath.split(path.sep)[-1]
-    else:
-        # otherwise, the base is a directory with packages
-        root_package = None
+    root_package = rootpath.split(path.sep)[-1] if is_packagedir(rootpath) or implicit_namespaces else None
 
     toplevels = []
     for root, subs, files in walk(rootpath, excludes, opts):

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -113,11 +113,7 @@ def import_object(modname: str, objpath: list[str], objtype: str = '',
             # restore ImportError
             exc = exc_on_importing
 
-        if objpath:
-            errmsg = ('autodoc: failed to import %s %r from module %r' %
-                      (objtype, '.'.join(objpath), modname))
-        else:
-            errmsg = f'autodoc: failed to import {objtype} {modname!r}'
+        errmsg = "autodoc: failed to import %s %r from module %r" % (objtype, ".".join(objpath), modname) if objpath else f"autodoc: failed to import {objtype} {modname!r}"
 
         if isinstance(exc, ImportError):
             # import_module() raises ImportError having real exception obj and
@@ -275,10 +271,7 @@ def get_class_members(subject: Any, objpath: list[str], attrgetter: Callable,
             for name in getannotations(cls):
                 name = unmangle(cls, name)
                 if name and name not in members:
-                    if analyzer and (qualname, name) in analyzer.attr_docs:
-                        docstring = '\n'.join(analyzer.attr_docs[qualname, name])
-                    else:
-                        docstring = None
+                    docstring = "\n".join(analyzer.attr_docs[qualname, name]) if analyzer and (qualname, name) in analyzer.attr_docs else None
 
                     members[name] = ObjectMember(name, INSTANCEATTR, class_=cls,
                                                  docstring=docstring)

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -167,10 +167,7 @@ def ismock(subject: Any) -> bool:
         return True
 
     # check the object is bound method
-    if isinstance(subject, MethodType) and isboundmethod(subject):
-        tmp_subject = subject.__func__
-    else:
-        tmp_subject = subject
+    tmp_subject = subject.__func__ if isinstance(subject, MethodType) and isboundmethod(subject) else subject
 
     try:
         # check the object is mocked object

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -19,10 +19,7 @@ from sphinx.util.typing import stringify_annotation
 def record_typehints(app: Sphinx, objtype: str, name: str, obj: Any,
                      options: dict, args: str, retann: str) -> None:
     """Record type hints to env object."""
-    if app.config.autodoc_typehints_format == 'short':
-        mode = 'smart'
-    else:
-        mode = 'fully-qualified'
+    mode = "smart" if app.config.autodoc_typehints_format == "short" else "fully-qualified"
 
     try:
         if callable(obj):
@@ -46,10 +43,7 @@ def merge_typehints(app: Sphinx, domain: str, objtype: str, contentnode: Element
 
     try:
         signature = cast(addnodes.desc_signature, contentnode.parent[0])
-        if signature['module']:
-            fullname = '.'.join([signature['module'], signature['fullname']])
-        else:
-            fullname = signature['fullname']
+        fullname = ".".join([signature["module"], signature["fullname"]]) if signature["module"] else signature["fullname"]
     except KeyError:
         # signature node does not have valid context info for the target object
         return

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -36,10 +36,7 @@ def register_sections_as_label(app: Sphinx, document: Node) -> None:
         docname = app.env.docname
         title = cast(nodes.title, node[0])
         ref_name = getattr(title, 'rawsource', title.astext())
-        if app.config.autosectionlabel_prefix_document:
-            name = nodes.fully_normalize_name(docname + ':' + ref_name)
-        else:
-            name = nodes.fully_normalize_name(ref_name)
+        name = nodes.fully_normalize_name(docname + ":" + ref_name) if app.config.autosectionlabel_prefix_document else nodes.fully_normalize_name(ref_name)
         sectname = clean_astext(title)
 
         logger.debug(__('section "%s" gets labeled as "%s"'),

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -175,15 +175,9 @@ def get_documenter(app: Sphinx, obj: Any, parent: Any) -> type[Documenter]:
         return ModuleDocumenter
 
     # Construct a fake documenter for *parent*
-    if parent is not None:
-        parent_doc_cls = get_documenter(app, parent, None)
-    else:
-        parent_doc_cls = ModuleDocumenter
+    parent_doc_cls = get_documenter(app, parent, None) if parent is not None else ModuleDocumenter
 
-    if hasattr(parent, '__name__'):
-        parent_doc = parent_doc_cls(FakeDirective(), parent.__name__)
-    else:
-        parent_doc = parent_doc_cls(FakeDirective(), "")
+    parent_doc = parent_doc_cls(FakeDirective(), parent.__name__) if hasattr(parent, "__name__") else parent_doc_cls(FakeDirective(), "")
 
     # Get the correct documenter class for *obj*
     classes = [cls for cls in app.registry.documenters.values()
@@ -237,11 +231,7 @@ class Autosummary(SphinxDirective):
                 docname = posixpath.join(tree_prefix, real_name)
                 docname = posixpath.normpath(posixpath.join(dirname, docname))
                 if docname not in self.env.found_docs:
-                    if excluded(self.env.doc2path(docname, False)):
-                        msg = __('autosummary references excluded document %r. Ignored.')
-                    else:
-                        msg = __('autosummary: stub file not found %r. '
-                                 'Check your autosummary_generate setting.')
+                    msg = __("autosummary references excluded document %r. Ignored.") if excluded(self.env.doc2path(docname, False)) else __("autosummary: stub file not found %r. Check your autosummary_generate setting.")
 
                     logger.warning(msg, real_name, location=self.get_location())
                     continue
@@ -411,10 +401,7 @@ class Autosummary(SphinxDirective):
 
         for name, sig, summary, real_name in items:
             qualifier = 'obj'
-            if 'nosignatures' not in self.options:
-                col1 = f':py:{qualifier}:`{name} <{real_name}>`\\ {rst.escape(sig)}'
-            else:
-                col1 = f':py:{qualifier}:`{name} <{real_name}>`'
+            col1 = f":py:{qualifier}:`{name} <{real_name}>`\\ {rst.escape(sig)}" if "nosignatures" not in self.options else f":py:{qualifier}:`{name} <{real_name}>`"
             col2 = summary
             append_row(col1, col2)
 
@@ -637,10 +624,7 @@ def import_by_name(
     errors: list[ImportExceptionGroup] = []
     for prefix in prefixes:
         try:
-            if prefix:
-                prefixed_name = '.'.join([prefix, name])
-            else:
-                prefixed_name = name
+            prefixed_name = ".".join([prefix, name]) if prefix else name
             obj, parent, modname = _import_by_name(prefixed_name, grouped_exception)
             return prefixed_name, obj, parent, modname
         except ImportError:

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -334,10 +334,7 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
     if doc.objtype in ('method', 'attribute', 'property'):
         ns['class'] = qualname.rsplit(".", 1)[0]
 
-    if doc.objtype in ('class',):
-        shortname = qualname
-    else:
-        shortname = qualname.rsplit(".", 1)[-1]
+    shortname = qualname if doc.objtype in ("class",) else qualname.rsplit(".", 1)[-1]
 
     ns['fullname'] = name
     ns['module'] = modname
@@ -377,10 +374,7 @@ def generate_autosummary_docs(sources: list[str], output_dir: str | None = None,
     # keep track of new files
     new_files = []
 
-    if app:
-        filename_map = app.config.autosummary_filename_map
-    else:
-        filename_map = {}
+    filename_map = app.config.autosummary_filename_map if app else {}
 
     # write
     for entry in sorted(set(items), key=str):

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -85,10 +85,7 @@ class TestDirective(SphinxDirective):
         nodetype: type[TextElement] = nodes.literal_block
         if self.name in ('testsetup', 'testcleanup') or 'hide' in self.options:
             nodetype = nodes.comment
-        if self.arguments:
-            groups = [x.strip() for x in self.arguments[0].split(',')]
-        else:
-            groups = ['default']
+        groups = [x.strip() for x in self.arguments[0].split(",")] if self.arguments else ["default"]
         node = nodetype(code, code, testnodetype=self.name, groups=groups)
         self.set_source_info(node)
         if test is not None:
@@ -524,10 +521,7 @@ Doctest summary
                 options[doctest.DONT_ACCEPT_BLANKLINE] = True
                 # find out if we're testing an exception
                 m = parser._EXCEPTION_RE.match(output)  # type: ignore
-                if m:
-                    exc_msg = m.group('msg')
-                else:
-                    exc_msg = None
+                exc_msg = m.group("msg") if m else None
                 example = doctest.Example(code[0].code, output, exc_msg=exc_msg,
                                           lineno=code[0].lineno, options=options)
                 test = doctest.DocTest([example], {}, group.name,

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -77,10 +77,7 @@ class ExternalLinksChecker(SphinxPostTransform):
                 msg = __('hardcoded link %r could be replaced by an extlink '
                          '(try using %r instead)')
                 value = match.groupdict().get('value')
-                if uri != title:
-                    replacement = f":{alias}:`{rst.escape(title)} <{value}>`"
-                else:
-                    replacement = f":{alias}:`{value}`"
+                replacement = f":{alias}:`{rst.escape(title)} <{value}>`" if uri != title else f":{alias}:`{value}`"
                 logger.warning(msg, uri, replacement, location=refnode)
 
 
@@ -97,10 +94,7 @@ def make_link_role(name: str, base_url: str, caption: str) -> RoleFunction:
         has_explicit_title, title, part = split_explicit_title(text)
         full_url = base_url % part
         if not has_explicit_title:
-            if caption is None:
-                title = full_url
-            else:
-                title = caption % part
+            title = full_url if caption is None else caption % part
         pnode = nodes.reference(title, title, internal=False, refuri=full_url)
         return [pnode], []
     return role

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -237,10 +237,7 @@ def render_dot(self: SphinxTranslator, code: str, options: dict, format: str,
     dot_args.extend(['-T' + format, '-o' + outfn])
 
     docname = options.get('docname', 'index')
-    if filename:
-        cwd = path.dirname(path.join(self.builder.srcdir, filename))
-    else:
-        cwd = path.dirname(path.join(self.builder.srcdir, docname))
+    cwd = path.dirname(path.join(self.builder.srcdir, filename)) if filename else path.dirname(path.join(self.builder.srcdir, docname))
 
     if format == 'png':
         dot_args.extend(['-Tcmapx', '-o%s.map' % outfn])

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -90,10 +90,7 @@ def generate_latex_macro(image_format: str,
         'math': math
     }
 
-    if config.imgmath_use_preview:
-        template_name = 'preview.tex_t'
-    else:
-        template_name = 'template.tex_t'
+    template_name = "preview.tex_t" if config.imgmath_use_preview else "template.tex_t"
 
     for template_dir in config.templates_path:
         template = path.join(confdir, template_dir, template_name)
@@ -329,10 +326,7 @@ def html_visit_math(self: HTML5Translator, node: nodes.math) -> None:
 
 
 def html_visit_displaymath(self: HTML5Translator, node: nodes.math_block) -> None:
-    if node['nowrap']:
-        latex = node.astext()
-    else:
-        latex = wrap_displaymath(node.astext(), None, False)
+    latex = node.astext() if node["nowrap"] else wrap_displaymath(node.astext(), None, False)
     try:
         rendered_path, depth = render_math(self, latex)
     except MathExtError as exc:

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -224,10 +224,7 @@ class InheritanceGraph:
         completely general.
         """
         module = cls.__module__
-        if module in ('__builtin__', 'builtins'):
-            fullname = cls.__name__
-        else:
-            fullname = f'{module}.{cls.__qualname__}'
+        fullname = cls.__name__ if module in ("__builtin__", "builtins") else f"{module}.{cls.__qualname__}"
         if parts == 0:
             result = fullname
         else:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -159,10 +159,7 @@ def fetch_inventory(app: Sphinx, uri: str, inv: Any) -> Any:
         # case: inv URI points to remote resource; strip any existing auth
         uri = _strip_basic_auth(uri)
     try:
-        if '://' in inv:
-            f = _read_from_url(inv, config=app.config)
-        else:
-            f = open(path.join(app.srcdir, inv), 'rb')
+        f = _read_from_url(inv, config=app.config) if "://" in inv else open(path.join(app.srcdir, inv), "rb")
     except Exception as err:
         err.args = ('intersphinx inventory %r not fetchable due to %s: %s',
                     inv, err.__class__, str(err))
@@ -266,10 +263,7 @@ def _create_element_from_result(domain: Domain, inv_name: str | None,
     if '://' not in uri and node.get('refdoc'):
         # get correct path in case of subdirectories
         uri = path.join(relative_path(node['refdoc'], '.'), uri)
-    if version:
-        reftitle = _('(in %s v%s)') % (proj, version)
-    else:
-        reftitle = _('(in %s)') % (proj,)
+    reftitle = _("(in %s v%s)") % (proj, version) if version else _("(in %s)") % (proj,)
     newnode = nodes.reference('', '', internal=False, refuri=uri, reftitle=reftitle)
     if node.get('refexplicit'):
         # use whatever title was given

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -177,10 +177,7 @@ class GoogleDocstring:
         self._name = name
         self._obj = obj
         self._opt = options
-        if isinstance(docstring, str):
-            lines = docstring.splitlines()
-        else:
-            lines = docstring
+        lines = docstring.splitlines() if isinstance(docstring, str) else docstring
         self._lines = Deque(map(str.rstrip, lines))
         self._parsed_lines: list[str] = []
         self._is_in_section = False
@@ -335,10 +332,7 @@ class GoogleDocstring:
             _name, _type, _desc = '', '', lines
 
             if colon:
-                if after:
-                    _desc = [after] + lines[1:]
-                else:
-                    _desc = lines[1:]
+                _desc = [after] + lines[1:] if after else lines[1:]
 
                 _type = before
 
@@ -400,10 +394,7 @@ class GoogleDocstring:
             desc_block = desc[1:]
             indent = self._get_indent(desc[0])
             block_indent = self._get_initial_indent(desc_block)
-            if block_indent > indent:
-                desc = [''] + desc
-            else:
-                desc = ['', desc[0]] + self._indent(desc_block, 4)
+            desc = [""] + desc if block_indent > indent else ["", desc[0]] + self._indent(desc_block, 4)
         return desc
 
     def _format_admonition(self, admonition: str, lines: list[str]) -> list[str]:
@@ -456,18 +447,9 @@ class GoogleDocstring:
         has_desc = any(_desc)
         separator = ' -- ' if has_desc else ''
         if _name:
-            if _type:
-                if '`' in _type:
-                    field = f'**{_name}** ({_type}){separator}'
-                else:
-                    field = f'**{_name}** (*{_type}*){separator}'
-            else:
-                field = f'**{_name}**{separator}'
+            field = (f"**{_name}** ({_type}){separator}" if "`" in _type else f"**{_name}** (*{_type}*){separator}") if _type else f"**{_name}**{separator}"
         elif _type:
-            if '`' in _type:
-                field = f'{_type}{separator}'
-            else:
-                field = f'*{_type}*{separator}'
+            field = f"{_type}{separator}" if "`" in _type else f"*{_type}*{separator}"
         else:
             field = ''
 
@@ -621,10 +603,7 @@ class GoogleDocstring:
                     section = self._consume_section_header()
                     self._is_in_section = True
                     self._section_indent = self._get_current_indent()
-                    if _directive_regex.match(section):
-                        lines = [section] + self._consume_to_next_section()
-                    else:
-                        lines = self._sections[section.lower()](section)
+                    lines = [section] + self._consume_to_next_section() if _directive_regex.match(section) else self._sections[section.lower()](section)
                 finally:
                     self._is_in_section = False
                     self._section_indent = 0
@@ -794,10 +773,7 @@ class GoogleDocstring:
         lines: list[str] = []
 
         for _name, _type, _desc in fields:
-            if use_rtype:
-                field = self._format_field(_name, '', _desc)
-            else:
-                field = self._format_field(_name, _type, _desc)
+            field = self._format_field(_name, "", _desc) if use_rtype else self._format_field(_name, _type, _desc)
 
             if multi:
                 if lines:
@@ -1337,10 +1313,7 @@ class NumpyDocstring(GoogleDocstring):
         lines: list[str] = []
         last_had_desc = True
         for name, desc, role in items:
-            if role:
-                link = f':{role}:`{name}`'
-            else:
-                link = ':obj:`%s`' % name
+            link = f":{role}:`{name}`" if role else ":obj:`%s`" % name
             if desc or last_had_desc:
                 lines += ['']
                 lines += [link]

--- a/sphinx/ext/napoleon/iterators.py
+++ b/sphinx/ext/napoleon/iterators.py
@@ -111,10 +111,7 @@ class peek_iter:
         if not n:
             if self._cache[0] == self.sentinel:
                 raise StopIteration
-            if n is None:
-                result = self._cache.popleft()
-            else:
-                result = []
+            result = self._cache.popleft() if n is None else []
         else:
             if self._cache[n - 1] == self.sentinel:
                 raise StopIteration
@@ -142,10 +139,7 @@ class peek_iter:
 
         """
         self._fillcache(n)
-        if n is None:
-            result = self._cache[0]
-        else:
-            result = [self._cache[i] for i in range(n)]
+        result = self._cache[0] if n is None else [self._cache[i] for i in range(n)]
         return result
 
 

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -151,11 +151,7 @@ class TodoListProcessor:
             node.replace_self(content)
 
     def create_todo_reference(self, todo: todo_node, docname: str) -> nodes.paragraph:
-        if self.config.todo_link_only:
-            description = _('<<original entry>>')
-        else:
-            description = (_('(The <<original entry>> is located in %s, line %d.)') %
-                           (todo.source, todo.line))
+        description = _("<<original entry>>") if self.config.todo_link_only else _("(The <<original entry>> is located in %s, line %d.)") % (todo.source, todo.line)
 
         prefix = description[:description.find('<<')]
         suffix = description[description.find('>>') + 2:]

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -247,10 +247,7 @@ def collect_pages(app: Sphinx) -> Generator[tuple[str, dict[str, Any], str], Non
         # construct a page name for the highlighted source
         pagename = posixpath.join(OUTPUT_DIRNAME, modname.replace('.', '/'))
         # highlight the source using the builder's highlighter
-        if env.config.highlight_language in {'default', 'none'}:
-            lexer = env.config.highlight_language
-        else:
-            lexer = 'python'
+        lexer = env.config.highlight_language if env.config.highlight_language in {"default", "none"} else "python"
         highlighted = highlighter.highlight_block(code, lexer, linenos=False)
         # split the code into lines
         lines = highlighted.splitlines()

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -117,11 +117,7 @@ class PygmentsBridge:
 
         # find out which lexer to use
         if lang in {'py', 'python', 'py3', 'python3', 'default'}:
-            if source.startswith('>>>'):
-                # interactive session
-                lang = 'pycon'
-            else:
-                lang = 'python'
+            lang = "pycon" if source.startswith(">>>") else "python"
         if lang == 'pycon3':
             lang = 'pycon'
 
@@ -132,10 +128,7 @@ class PygmentsBridge:
             lexer = lexer_classes[lang](**opts)
         else:
             try:
-                if lang == 'guess':
-                    lexer = guess_lexer(source, **opts)
-                else:
-                    lexer = get_lexer_by_name(lang, **opts)
+                lexer = guess_lexer(source, **opts) if lang == "guess" else get_lexer_by_name(lang, **opts)
             except ClassNotFound:
                 logger.warning(__('Pygments lexer name %r is not known'), lang,
                                location=location)

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -406,10 +406,7 @@ class VariableCommentPicker(ast.NodeVisitor):
                 targets = get_assign_targets(self.previous)
                 varnames = get_lvar_names(targets[0], self.get_self())
                 for varname in varnames:
-                    if isinstance(node.value.s, str):
-                        docstring = node.value.s
-                    else:
-                        docstring = node.value.s.decode(self.encoding or 'utf-8')
+                    docstring = node.value.s if isinstance(node.value.s, str) else node.value.s.decode(self.encoding or "utf-8")
 
                     self.add_variable_comment(varname, dedent_docstring(docstring))
                     self.add_entry(varname)

--- a/sphinx/setup_command.py
+++ b/sphinx/setup_command.py
@@ -146,10 +146,7 @@ class BuildDoc(Command):
 
         if not color_terminal():
             nocolor()
-        if not self.verbose:
-            status_stream = StringIO()
-        else:
-            status_stream = sys.stdout  # type: ignore
+        status_stream = StringIO() if not self.verbose else sys.stdout  # type: ignore
         confoverrides: dict[str, Any] = {}
         if self.project:
             confoverrides['project'] = self.project

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -169,10 +169,7 @@ class path(str):
         :param append:
             If ``True`` given `bytes` are added at the end of the file.
         """
-        if append:
-            mode = 'ab'
-        else:
-            mode = 'wb'
+        mode = "ab" if append else "wb"
         with open(self, mode=mode) as f:
             f.write(bytes)
 

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -109,10 +109,7 @@ class Theme:
 
     def get_options(self, overrides: dict[str, Any] = {}) -> dict[str, Any]:
         """Return a dictionary of theme options and their values."""
-        if self.base:
-            options = self.base.get_options()
-        else:
-            options = {}
+        options = self.base.get_options() if self.base else {}
 
         try:
             options.update(self.config.items('options'))

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -63,10 +63,7 @@ class ReferencesResolver(SphinxPostTransform):
     def run(self, **kwargs: Any) -> None:
         for node in self.document.findall(addnodes.pending_xref):
             content = self.find_pending_xref_condition(node, ("resolved", "*"))
-            if content:
-                contnode = cast(Element, content[0].deepcopy())
-            else:
-                contnode = cast(Element, node[0].deepcopy())
+            contnode = cast(Element, content[0].deepcopy()) if content else cast(Element, node[0].deepcopy())
 
             newnode = None
 

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -231,10 +231,7 @@ class ImageConverter(BaseImageConverter):
     def handle(self, node: nodes.image) -> None:
         _from, _to = self.get_conversion_rule(node)
 
-        if _from in node['candidates']:
-            srcpath = node['candidates'][_from]
-        else:
-            srcpath = node['candidates']['*']
+        srcpath = node["candidates"][_from] if _from in node["candidates"] else node["candidates"]["*"]
 
         filename = get_filename_for(srcpath, _to)
         ensuredir(self.imagedir)

--- a/sphinx/util/exceptions.py
+++ b/sphinx/util/exceptions.py
@@ -22,10 +22,7 @@ def save_traceback(app: Sphinx | None, exc: BaseException) -> str:
 
     import sphinx
 
-    if isinstance(exc, SphinxParallelError):
-        exc_format = '(Error in parallel process)\n' + exc.traceback
-    else:
-        exc_format = traceback.format_exc()
+    exc_format = "(Error in parallel process)\n" + exc.traceback if isinstance(exc, SphinxParallelError) else traceback.format_exc()
 
     if app is None:
         last_msgs = exts_list = ''

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -199,10 +199,7 @@ def format_date(
         # If time is not specified, try to use $SOURCE_DATE_EPOCH variable
         # See https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal
         source_date_epoch = os.getenv('SOURCE_DATE_EPOCH')
-        if source_date_epoch is not None:
-            date = datetime.utcfromtimestamp(float(source_date_epoch))
-        else:
-            date = datetime.now(timezone.utc).astimezone()
+        date = datetime.utcfromtimestamp(float(source_date_epoch)) if source_date_epoch is not None else datetime.now(timezone.utc).astimezone()
 
     if language is None:
         warnings.warn('The language argument for format_date() becomes required.',

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -524,10 +524,7 @@ def signature(subject: Callable, bound_method: bool = False, type_aliases: dict 
     """
 
     try:
-        if _should_unwrap(subject):
-            signature = inspect.signature(subject)
-        else:
-            signature = inspect.signature(subject, follow_wrapped=True)
+        signature = inspect.signature(subject) if _should_unwrap(subject) else inspect.signature(subject, follow_wrapped=True)
     except ValueError:
         # follow built-in wrappers up (ex. functools.lru_cache)
         signature = inspect.signature(subject)
@@ -545,10 +542,7 @@ def signature(subject: Callable, bound_method: bool = False, type_aliases: dict 
                     annotation = annotation.name
                 parameters[i] = param.replace(annotation=annotation)
         if 'return' in annotations:
-            if isinstance(annotations['return'], TypeAliasForwardRef):
-                return_annotation = annotations['return'].name
-            else:
-                return_annotation = annotations['return']
+            return_annotation = annotations["return"].name if isinstance(annotations["return"], TypeAliasForwardRef) else annotations["return"]
     except Exception:
         # ``get_type_hints()`` does not support some kind of objects like partial,
         # ForwardRef and so on.
@@ -630,10 +624,7 @@ def stringify_signature(sig: inspect.Signature, show_annotation: bool = True,
     :param unqualified_typehints: If enabled, show annotations as unqualified
                                   (ex. io.StringIO -> StringIO)
     """
-    if unqualified_typehints:
-        mode = 'smart'
-    else:
-        mode = 'fully-qualified'
+    mode = "smart" if unqualified_typehints else "fully-qualified"
 
     args = []
     last_kind = None
@@ -708,22 +699,14 @@ def signature_from_ast(node: ast.FunctionDef, code: str = '') -> inspect.Signatu
 
     if hasattr(args, "posonlyargs"):
         for i, arg in enumerate(args.posonlyargs):
-            if defaults[i] is Parameter.empty:
-                default = Parameter.empty
-            else:
-                default = DefaultValue(ast_unparse(defaults[i], code))  # type: ignore
+            default = Parameter.empty if defaults[i] is Parameter.empty else DefaultValue(ast_unparse(defaults[i], code))  # type: ignore
 
             annotation = ast_unparse(arg.annotation, code) or Parameter.empty
             params.append(Parameter(arg.arg, Parameter.POSITIONAL_ONLY,
                                     default=default, annotation=annotation))
 
     for i, arg in enumerate(args.args):
-        if defaults[i + posonlyargs] is Parameter.empty:
-            default = Parameter.empty
-        else:
-            default = DefaultValue(
-                ast_unparse(defaults[i + posonlyargs], code)  # type: ignore
-            )
+        default = Parameter.empty if defaults[i + posonlyargs] is Parameter.empty else DefaultValue(ast_unparse(defaults[i + posonlyargs], code))
 
         annotation = ast_unparse(arg.annotation, code) or Parameter.empty
         params.append(Parameter(arg.arg, Parameter.POSITIONAL_OR_KEYWORD,
@@ -735,10 +718,7 @@ def signature_from_ast(node: ast.FunctionDef, code: str = '') -> inspect.Signatu
                                 annotation=annotation))
 
     for i, arg in enumerate(args.kwonlyargs):
-        if args.kw_defaults[i] is None:
-            default = Parameter.empty
-        else:
-            default = DefaultValue(ast_unparse(args.kw_defaults[i], code))  # type: ignore
+        default = Parameter.empty if args.kw_defaults[i] is None else DefaultValue(ast_unparse(args.kw_defaults[i], code))  # type: ignore
         annotation = ast_unparse(arg.annotation, code) or Parameter.empty
         params.append(Parameter(arg.arg, Parameter.KEYWORD_ONLY, default=default,
                                 annotation=annotation))

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -417,10 +417,7 @@ class WarningIsErrorFilter(logging.Filter):
             except (TypeError, ValueError):
                 message = record.msg  # use record.msg itself
 
-            if location:
-                exc = SphinxWarning(location + ":" + str(message))
-            else:
-                exc = SphinxWarning(message)
+            exc = SphinxWarning(location + ":" + str(message)) if location else SphinxWarning(message)
             if record.exc_info is not None:
                 raise exc from record.exc_info[1]
             else:

--- a/sphinx/util/math.py
+++ b/sphinx/util/math.py
@@ -10,10 +10,7 @@ from sphinx.builders.html import HTML5Translator
 def get_node_equation_number(writer: HTML5Translator, node: nodes.math_block) -> str:
     if writer.builder.config.math_numfig and writer.builder.config.numfig:
         figtype = 'displaymath'
-        if writer.builder.name == 'singlehtml':
-            key = f"{writer.docnames[-1]}/{figtype}"
-        else:
-            key = figtype
+        key = f"{writer.docnames[-1]}/{figtype}" if writer.builder.name == "singlehtml" else figtype
 
         id = node['ids'][0]
         number = writer.builder.fignumbers.get(key, {}).get(id, ())

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -252,10 +252,7 @@ def extract_messages(doctree: Element) -> Iterable[tuple[Element, str]]:
         elif isinstance(node, nodes.image):
             if node.get('alt'):
                 yield node, node['alt']
-            if node.get('translatable'):
-                msg = '.. image:: %s' % node['uri']
-            else:
-                msg = ''
+            msg = ".. image:: %s" % node["uri"] if node.get("translatable") else ""
         elif isinstance(node, nodes.meta):  # type: ignore
             msg = node["content"]
         else:
@@ -301,10 +298,7 @@ def traverse_translatable_index(
     """Traverse translatable index node from a document tree."""
     matcher = NodeMatcher(addnodes.index, inline=False)
     for node in doctree.findall(matcher):  # type: addnodes.index
-        if 'raw_entries' in node:
-            entries = node['raw_entries']
-        else:
-            entries = node['entries']
+        entries = node["raw_entries"] if "raw_entries" in node else node["entries"]
         yield node, entries
 
 
@@ -500,10 +494,7 @@ def make_id(env: BuildEnvironment, document: nodes.document,
             prefix: str = '', term: str | None = None) -> str:
     """Generate an appropriate node_id for given *prefix* and *term*."""
     node_id = None
-    if prefix:
-        idformat = prefix + "-%s"
-    else:
-        idformat = (document.settings.id_prefix or "id") + "%s"
+    idformat = prefix + "-%s" if prefix else (document.settings.id_prefix or "id") + "%s"
 
     # try to generate node_id by *term*
     if prefix and term:

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -32,10 +32,7 @@ class SerialTasks:
     def add_task(
         self, task_func: Callable, arg: Any = None, result_func: Callable | None = None
     ) -> None:
-        if arg is not None:
-            res = task_func(arg)
-        else:
-            res = task_func()
+        res = task_func(arg) if arg is not None else task_func()
         if result_func:
             result_func(res)
 
@@ -67,10 +64,7 @@ class ParallelTasks:
         try:
             collector = logging.LogCollector()
             with collector.collect():
-                if arg is None:
-                    ret = func()
-                else:
-                    ret = func(arg)
+                ret = func() if arg is None else func(arg)
             failed = False
         except BaseException as err:
             failed = True

--- a/sphinx/util/template.py
+++ b/sphinx/util/template.py
@@ -33,11 +33,7 @@ class BaseRenderer:
 
 class FileRenderer(BaseRenderer):
     def __init__(self, search_path: str | list[str]) -> None:
-        if isinstance(search_path, str):
-            search_path = [search_path]
-        else:
-            # filter "None" paths
-            search_path = list(filter(None, search_path))
+        search_path = [search_path] if isinstance(search_path, str) else list(filter(None, search_path))
 
         loader = SphinxFileSystemLoader(search_path)
         super().__init__(loader)

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -105,10 +105,7 @@ def restify(cls: type | None, mode: str = 'fully-qualified-except-typing') -> st
     from sphinx.ext.autodoc.mock import ismock, ismockmodule  # lazy loading
     from sphinx.util import inspect  # lazy loading
 
-    if mode == 'smart':
-        modprefix = '~'
-    else:
-        modprefix = ''
+    modprefix = "~" if mode == "smart" else ""
 
     try:
         if cls is None or cls is NoneType:
@@ -162,10 +159,7 @@ def restify(cls: type | None, mode: str = 'fully-qualified-except-typing') -> st
                 text = restify(cls.__origin__, mode)  # type: ignore
             elif getattr(cls, '_name', None):
                 cls_name = cls._name  # type: ignore[attr-defined]
-                if cls.__module__ == 'typing':
-                    text = f':py:class:`~{cls.__module__}.{cls_name}`'
-                else:
-                    text = f':py:class:`{modprefix}{cls.__module__}.{cls_name}`'
+                text = f":py:class:`~{cls.__module__}.{cls_name}`" if cls.__module__ == "typing" else f":py:class:`{modprefix}{cls.__module__}.{cls_name}`"
             else:
                 text = restify(cls.__origin__, mode)  # type: ignore[attr-defined]
 
@@ -232,10 +226,7 @@ def stringify_annotation(
         raise ValueError("'mode' must be one of 'fully-qualified-except-typing', "
                          f"'fully-qualified', or 'smart'; got {mode!r}.")
 
-    if mode == 'smart':
-        module_prefix = '~'
-    else:
-        module_prefix = ''
+    module_prefix = "~" if mode == "smart" else ""
 
     annotation_qualname = getattr(annotation, '__qualname__', '')
     annotation_module = getattr(annotation, '__module__', '')

--- a/sphinx/writers/_html4.py
+++ b/sphinx/writers/_html4.py
@@ -282,10 +282,7 @@ class HTML4Translator(SphinxTranslator, BaseTranslator):
 
     def add_fignumber(self, node: Element) -> None:
         def append_fignumber(figtype: str, figure_id: str) -> None:
-            if self.builder.name == 'singlehtml':
-                key = f"{self.docnames[-1]}/{figtype}"
-            else:
-                key = figtype
+            key = f"{self.docnames[-1]}/{figtype}" if self.builder.name == "singlehtml" else figtype
 
             if figure_id in self.builder.fignumbers.get(key, {}):  # type: ignore[has-type]
                 self.body.append('<span class="caption-number">')

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -288,10 +288,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
     def add_fignumber(self, node: Element) -> None:
         def append_fignumber(figtype: str, figure_id: str) -> None:
-            if self.builder.name == 'singlehtml':
-                key = f"{self.docnames[-1]}/{figtype}"
-            else:
-                key = figtype
+            key = f"{self.docnames[-1]}/{figtype}" if self.builder.name == "singlehtml" else figtype
 
             if figure_id in self.builder.fignumbers.get(key, {}):  # type: ignore[has-type]
                 self.body.append('<span class="caption-number">')

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1258,22 +1258,13 @@ class LaTeXTranslator(SphinxTranslator):
         post: list[str] = []
         include_graphics_options = []
         has_hyperlink = isinstance(node.parent, nodes.reference)
-        if has_hyperlink:
-            is_inline = self.is_inline(node.parent)
-        else:
-            is_inline = self.is_inline(node)
+        is_inline = self.is_inline(node.parent) if has_hyperlink else self.is_inline(node)
         if 'width' in node:
-            if 'scale' in node:
-                w = self.latex_image_length(node['width'], node['scale'])
-            else:
-                w = self.latex_image_length(node['width'])
+            w = self.latex_image_length(node["width"], node["scale"]) if "scale" in node else self.latex_image_length(node["width"])
             if w:
                 include_graphics_options.append('width=%s' % w)
         if 'height' in node:
-            if 'scale' in node:
-                h = self.latex_image_length(node['height'], node['scale'])
-            else:
-                h = self.latex_image_length(node['height'])
+            h = self.latex_image_length(node["height"], node["scale"]) if "scale" in node else self.latex_image_length(node["height"])
             if h:
                 include_graphics_options.append('height=%s' % h)
         if 'scale' in node:
@@ -1323,12 +1314,7 @@ class LaTeXTranslator(SphinxTranslator):
             options = '[%s]' % ','.join(include_graphics_options)
         base, ext = path.splitext(uri)
 
-        if self.in_title and base:
-            # Lowercase tokens forcely because some fncychap themes capitalize
-            # the options of \sphinxincludegraphics unexpectedly (ex. WIDTH=...).
-            cmd = fr'\lowercase{{\sphinxincludegraphics{options}}}{{{{{base}}}{ext}}}'
-        else:
-            cmd = fr'\sphinxincludegraphics{options}{{{{{base}}}{ext}}}'
+        cmd = f"\\lowercase{{\\sphinxincludegraphics{options}}}{{{{{base}}}{ext}}}" if self.in_title and base else f"\\sphinxincludegraphics{options}{{{{{base}}}{ext}}}"
         # escape filepath for includegraphics, https://tex.stackexchange.com/a/202714/41112
         if '#' in base:
             cmd = r'{\catcode`\#=12' + cmd + '}'
@@ -1603,12 +1589,7 @@ class LaTeXTranslator(SphinxTranslator):
         elif uri.startswith('%'):
             # references to documents or labels inside documents
             hashindex = uri.find('#')
-            if hashindex == -1:
-                # reference to the document
-                id = uri[1:] + '::doc'
-            else:
-                # reference to a label
-                id = uri[1:].replace('#', ':')
+            id = uri[1:] + "::doc" if hashindex == -1 else uri[1:].replace("#", ":")
             self.body.append(self.hyperlink(id))
             if (len(node) and
                     isinstance(node[0], nodes.Element) and
@@ -1640,10 +1621,7 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(CR)
 
     def visit_number_reference(self, node: Element) -> None:
-        if node.get('refid'):
-            id = self.curfilestack[-1] + ':' + node['refid']
-        else:
-            id = node.get('refuri', '')[1:].replace('#', ':')
+        id = self.curfilestack[-1] + ":" + node["refid"] if node.get("refid") else node.get("refuri", "")[1:].replace("#", ":")
 
         title = self.escape(node.get('title', '%s')).replace(r'\%s', '%s')
         if r'\{name\}' in title or r'\{number\}' in title:
@@ -2069,10 +2047,7 @@ class LaTeXTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_math_block(self, node: Element) -> None:
-        if node.get('label'):
-            label = f"equation:{node['docname']}:{node['label']}"
-        else:
-            label = None
+        label = f'equation:{node["docname"]}:{node["label"]}' if node.get("label") else None
 
         if node.get('nowrap'):
             if label:

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -382,10 +382,7 @@ class TexinfoTranslator(SphinxTranslator):
             self.body.append('\n')
 
     def format_menu_entry(self, name: str, node_name: str, desc: str) -> str:
-        if name == node_name:
-            s = f'* {name}:: '
-        else:
-            s = f'* {name}: {node_name}. '
+        s = f"* {name}:: " if name == node_name else f"* {name}: {node_name}. "
         offset = max((24, (len(name) + 4) % 78))
         wdesc = '\n'.join(' ' * offset + l for l in
                           textwrap.wrap(desc, width=78 - offset))
@@ -707,12 +704,7 @@ class TexinfoTranslator(SphinxTranslator):
         elif uri.startswith('%'):
             # references to documents or labels inside documents
             hashindex = uri.find('#')
-            if hashindex == -1:
-                # reference to the document
-                id = uri[1:] + '::doc'
-            else:
-                # reference to a label
-                id = uri[1:].replace('#', ':')
+            id = uri[1:] + "::doc" if hashindex == -1 else uri[1:].replace("#", ":")
             self.add_xref(id, name, node)
         elif uri.startswith('info:'):
             # references to an external Info file

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -266,10 +266,7 @@ class TextWrapper(textwrap.TextWrapper):
             cur_line = []
             cur_len = 0
 
-            if lines:
-                indent = self.subsequent_indent
-            else:
-                indent = self.initial_indent
+            indent = self.subsequent_indent if lines else self.initial_indent
 
             width = self.width - column_width(indent)
 
@@ -410,10 +407,7 @@ class TextTranslator(SphinxTranslator):
         def do_format() -> None:
             if not toformat:
                 return
-            if wrap:
-                res = my_wrap(''.join(toformat), width=MAXWIDTH - maxindent)
-            else:
-                res = ''.join(toformat).splitlines()
+            res = my_wrap("".join(toformat), width=MAXWIDTH - maxindent) if wrap else "".join(toformat).splitlines()
             if end:
                 res += end
             result.append((indent, res))
@@ -499,10 +493,7 @@ class TextTranslator(SphinxTranslator):
         return ''
 
     def depart_title(self, node: Element) -> None:
-        if isinstance(node.parent, nodes.section):
-            char = self._title_char
-        else:
-            char = '^'
+        char = self._title_char if isinstance(node.parent, nodes.section) else "^"
         text = ''
         text = ''.join(x[1] for x in self.states.pop() if x[0] == -1)  # type: ignore
         if self.add_secnumbers:

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -661,10 +661,7 @@ def test_mocked_module_imports(app, warning):
 @pytest.mark.sphinx('html', testroot='ext-autodoc',
                     confoverrides={'autodoc_typehints': "signature"})
 def test_autodoc_typehints_signature(app):
-    if sys.version_info[:2] <= (3, 10):
-        type_o = "~typing.Any | None"
-    else:
-        type_o = "~typing.Any"
+    type_o = "~typing.Any | None" if sys.version_info[:2] <= (3, 10) else "~typing.Any"
 
     options = {"members": None,
                "undoc-members": None}
@@ -1408,10 +1405,7 @@ def test_autodoc_typehints_description_and_type_aliases(app):
 @pytest.mark.sphinx('html', testroot='ext-autodoc',
                     confoverrides={'autodoc_typehints_format': "fully-qualified"})
 def test_autodoc_typehints_format_fully_qualified(app):
-    if sys.version_info[:2] <= (3, 10):
-        type_o = "typing.Any | None"
-    else:
-        type_o = "typing.Any"
+    type_o = "typing.Any | None" if sys.version_info[:2] <= (3, 10) else "typing.Any"
 
     options = {"members": None,
                "undoc-members": None}


### PR DESCRIPTION
ping @AA-Turner 

is this how we are supposed to do this?

should it go to 6.1.x branch rather?

I applied `ruff` at my locale and applied the patch, this should match the one from https://github.com/sphinx-doc/sphinx/actions/runs/3861663841/jobs/6582772116

But it creates mypy failures:
```
sphinx/pycode/parser.py: note: In member "visit_Expr" of class "VariableCommentPicker":
sphinx/pycode/parser.py:409:84: error: "str" has no attribute "decode"; maybe "encode"?  [attr-defined]
sphinx/util/inspect.py:702: error: Unused "type: ignore" comment
sphinx/domains/std.py: note: In function "warn_missing_reference":
sphinx/domains/std.py:1116:58: error: "Domain" has no attribute "anonlabels"  [attr-defined]
sphinx/builders/changes.py: note: In member "write" of class "ChangesBuilder":
sphinx/builders/changes.py:58:24: error: Value of type "Optional[str]" is not indexable  [index]
sphinx/setup_command.py:149: error: Unused "type: ignore" comment
Found 5 errors in 5 files (checked 175 source files)
```

and also a whole bunch of ``E501 line too long`` flake8 errors (see https://github.com/jfbu/sphinx/actions/runs/3862012540/jobs/6583332177#step:5:23), which should be reported when I now create this PR which will activate flake8.

Thus creating this PR only as a testimonial.