### PR TITLE
Update CHANGES to announce LaTeX deprecation of internal \dimen's

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,16 @@ Incompatible changes
 Deprecated
 ----------
 
+* LaTeX: some internal TeX ``\dimen`` registers are since 5.1.0 either not
+  used (and assigning them some dimension value is with no effect), or used
+  via changed names.  They never were mentioned in the docs but do have usable
+  public names, hence this deprecation notice.  They are
+  ``\sphinxverbatimsep``, ``\sphinxverbatimborder``, ``\sphinxshadowsep``,
+  ``\sphinxshadowsize``, and ``\sphinxshadowrule``.  It would be complicated
+  to let their use trigger some warning during PDF builds, so this will be the
+  sole announcement.  They will get removed from LaTeX support files at 7.0.0.
+  (refs: #11105)
+
 Features added
 --------------
 


### PR DESCRIPTION
ruff linting will fail for unrelated reasons, I will merge nevertheless as ruff 0.0.213 already reported failed linting at current master tip

add to CHANGES a mention of future removal at 7.0.0 of internal LaTeX dimension registers

refs: #11105 