### PR TITLE
Don't use attribute type annotation for constructor parameters

### DIFF
--- a/tests/ext_napoleon_pep526_data_numpy.py
+++ b/tests/ext_napoleon_pep526_data_numpy.py
@@ -18,3 +18,18 @@ class PEP526NumpyClass:
     """
     attr1: int
     attr2: str
+
+
+class PEP526NumpyDontUseAttrTypeForParam:
+    """
+    A Class
+
+    Parameters
+    ----------
+    blah:
+        Description of parameter blah
+    """
+    def __init__(self, blah: int):
+        pass
+
+    blah: bool

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -20,7 +20,10 @@ from sphinx.ext.napoleon.docstring import (
 )
 
 from .ext_napoleon_pep526_data_google import PEP526GoogleClass
-from .ext_napoleon_pep526_data_numpy import PEP526NumpyClass
+from .ext_napoleon_pep526_data_numpy import (
+    PEP526NumpyClass,
+    PEP526NumpyDontUseAttrTypeForParam,
+)
 
 
 class NamedtupleSubclass(namedtuple('NamedtupleSubclass', ('attr1', 'attr2'))):
@@ -2641,6 +2644,20 @@ Sample class with PEP 526 annotations and numpy docstring
 """
         print(actual)
         assert expected == actual
+
+    def test_pep526_annotations_dont_use_attr_type_for_param(self):
+        # test class attributes annotations
+        config = Config(
+            napoleon_attr_annotations=True
+        )
+        actual = str(NumpyDocstring(cleandoc(PEP526NumpyDontUseAttrTypeForParam.__doc__), config, app=None, what="class",
+                                    obj=PEP526NumpyDontUseAttrTypeForParam))
+        assert actual == """\
+A Class
+
+:param blah: Description of parameter blah
+:type blah: int
+"""
 
 
 @pytest.mark.sphinx('text', testroot='ext-napoleon',


### PR DESCRIPTION
Fix a bug where if a class has an attribute and a constructor parameter with the same name, napoleon will use the type annotation from the attribute for the constructor argument.

### Feature or Bugfix
- Bugfix

### Detail
Suppose we have a class that looks like 
```py
class Example:
    """
    A Class

    Parameters
    ----------
    blah:
        Description of parameter blah
    """
    def __init__(self, blah: int):
        pass

    blah: bool
```
The processed docstring looks like:
```rst
A Class
       
:param blah: Description of parameter blah
:type blah: bool
```
Note that the parameter has type `int` but Napoleon took the type from the attribute which has type `bool`. 
A more practical reason this would happen is that the parameter has type `Optional[dict]` and this is stored into an attribute of type `dict` where if `None` is passed a default dictionary is created.

I added a new parameter `is_attribute` to `_lookup_annotation` and `_consume_field`(s) which defaults to `False`. If `is_attribute` is `False` and `what` is `"class"` then we look up the type from the constructor arguments instead. With these changes it produces the correct output:
```rst
:param blah: Description of parameter blah
:type blah: int
```
