### PR TITLE
Update test_config.py::test_needs_sphinx for Alabaster 0.7.13 compat

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,20 +163,20 @@ def make_app_with_empty_project(make_app, tempdir):
     return _make_app
 
 
-@mock.patch.object(sphinx, '__display_version__', '1.3.4')
+@mock.patch.object(sphinx, '__display_version__', '1.6.4')
 def test_needs_sphinx(make_app_with_empty_project):
     make_app = make_app_with_empty_project
     # micro version
-    make_app(confoverrides={'needs_sphinx': '1.3.3'})  # OK: less
-    make_app(confoverrides={'needs_sphinx': '1.3.4'})  # OK: equals
+    make_app(confoverrides={'needs_sphinx': '1.6.3'})  # OK: less
+    make_app(confoverrides={'needs_sphinx': '1.6.4'})  # OK: equals
     with pytest.raises(VersionRequirementError):
-        make_app(confoverrides={'needs_sphinx': '1.3.5'})  # NG: greater
+        make_app(confoverrides={'needs_sphinx': '1.6.5'})  # NG: greater
 
     # minor version
-    make_app(confoverrides={'needs_sphinx': '1.2'})  # OK: less
-    make_app(confoverrides={'needs_sphinx': '1.3'})  # OK: equals
+    make_app(confoverrides={'needs_sphinx': '1.5'})  # OK: less
+    make_app(confoverrides={'needs_sphinx': '1.6'})  # OK: equals
     with pytest.raises(VersionRequirementError):
-        make_app(confoverrides={'needs_sphinx': '1.4'})  # NG: greater
+        make_app(confoverrides={'needs_sphinx': '1.7'})  # NG: greater
 
     # major version
     make_app(confoverrides={'needs_sphinx': '0'})  # OK: less


### PR DESCRIPTION
Relates #11145

Makes CI pass.