### PR TITLE
Skip sphinx.locale.init_console when running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,20 @@ import docutils
 import pytest
 
 import sphinx
+import sphinx.locale
 from sphinx.testing import comparer
 from sphinx.testing.path import path
+
+def _init_console(locale_dir=sphinx.locale._LOCALE_DIR, catalog='sphinx'):
+    """Monkeypatch ``init_console`` to skip its action.
+
+    Some tests rely on warning messages in English. We don't want
+    CLI tests to bleed over those tests and make their warnings
+    translated.
+    """
+    return sphinx.locale.NullTranslations(), False
+
+sphinx.locale.init_console = _init_console
 
 pytest_plugins = 'sphinx.testing.fixtures'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def _init_console(locale_dir=sphinx.locale._LOCALE_DIR, catalog='sphinx'):
     """
     return sphinx.locale.NullTranslations(), False
 
+
 sphinx.locale.init_console = _init_console
 
 pytest_plugins = 'sphinx.testing.fixtures'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import sphinx.locale
 from sphinx.testing import comparer
 from sphinx.testing.path import path
 
+
 def _init_console(locale_dir=sphinx.locale._LOCALE_DIR, catalog='sphinx'):
     """Monkeypatch ``init_console`` to skip its action.
 


### PR DESCRIPTION
### Feature or Bugfix

Bugfix

### Purpose

Tests for Sphinx's CLIs, like test_apidoc, indirectly init_console to initialize translations for Sphinx's console domain, the one with Sphinx's log messages. This bleeds over subsequent tests by making warnings translated. Fix this by skipping init_console when running Sphinx's test suite.

Fixes #10500

### Relates

#10500
