### PR TITLE
Make --parallel a synonym for -j

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -142,7 +142,8 @@ files can be built by specifying individual filenames.
     group.add_argument('-d', metavar='PATH', dest='doctreedir',
                        help=__('path for the cached environment and doctree '
                                'files (default: OUTPUTDIR/.doctrees)'))
-    group.add_argument('-j', metavar='N', default=1, type=jobs_argument, dest='jobs',
+    group.add_argument('-j', '--parallel', metavar='N', default=1,
+                       type=jobs_argument, dest='jobs',
                        help=__('build in parallel with N processes where '
                                'possible (special value "auto" will set N to cpu-count)'))
     group = parser.add_argument_group('build configuration options')


### PR DESCRIPTION
Subject: Add `--parallel` to the sphinx command-line options

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Add the (relatively self-documenting) command-line option `--parallel`, as a synonym for the (comparatively-inscrutable) `-j` flag.

### Detail
- It was pointed out that `-j auto` (or any other use of `-j`) isn't particularly self-documenting, as command-line arguments go.
- Also appears in the `--help` summary generated by `argparse`:
  ```console
  $ PYTHONPATH=`pwd` python3 -m sphinx --help
  usage: __main__.py [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]

  [...]
  
  general options:
    -b BUILDER          builder to use (default: html)
    -a                  write all files (default: only write new and changed
                        files)
    -E                  don't use a saved environment, always read all files
    -d PATH             path for the cached environment and doctree files
                        (default: OUTPUTDIR/.doctrees)
    -j N, --parallel N  build in parallel with N processes where possible
                        (special value "auto" will set N to cpu-count)
  ```

### Relates
- https://github.com/python/devguide/pull/1038#discussion_r1088601323
