### PR TITLE
Cleanup: remove 'noqa' comment from a statement that is never visited

### DIFF
--- a/sphinx/util/display.py
+++ b/sphinx/util/display.py
@@ -8,7 +8,7 @@ from sphinx.util import logging
 from sphinx.util.console import bold, colorize, term_width_line  # type: ignore
 
 if False:
-    from types import TracebackType  # NoQA: TCH003
+    from types import TracebackType
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Removes a `noqa` (linter ignore statement) from a Python statement that is never visited at runtime

### Detail
- Versions of `ruff` prior to charliermarsh/ruff#2408 suggested the `noqa` statement, and more recent versions no longer suggest it (in fact, they suggest removing it)

### Relates
- https://github.com/charliermarsh/ruff/issues/2408