### PR TITLE
Fix relpath on Windows when path is None

### DIFF
--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -123,7 +123,7 @@ def relpath(path: str, start: str | None = os.curdir) -> str:
     """
     try:
         return os.path.relpath(path, start)
-    except ValueError:
+    except (ValueError, TypeError):
         return path
 
 


### PR DESCRIPTION
Subject: Fix bug on Windows when using sphinx-needs in combination with sphinxcontrib.spelling

### Feature or Bugfix
Bugfix

### How to reproduce
* Install sphinxcontrib.spelling
* Install sphinx-needs (and sphinxcontrib.plantuml as required)
* Create a new project with sphinx-quickstart
* Replace index.rst with the following contents:
```
Test
====

.. needtable:: 
```
* Run 'make spelling'
* Observe sphinx crashing
```
Exception occurred:
  File "C:\Python310\lib\ntpath.py", line 695, in relpath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

The stacktrace in the log:
```
Traceback (most recent call last):
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\cmd\build.py", line 281, in build_main
    app.build(args.force_all, args.filenames)
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\application.py", line 347, in build
    self.builder.build_update()
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\builders\__init__.py", line 307, in build_update
    self.build(['__all__'], to_build)
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\builders\__init__.py", line 376, in build
    self.write(docnames, list(updated_docnames), method)
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\builders\__init__.py", line 571, in write
    self._write_serial(sorted(docnames))
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\builders\__init__.py", line 581, in _write_serial
    self.write_doc(docname, doctree)
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinxcontrib\spelling\builder.py", line 191, in write_doc
    lines = list(self._find_misspellings(docname, doctree))
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinxcontrib\spelling\builder.py", line 228, in _find_misspellings
    source = osutil.relpath(source)
  File "C:\Temp\.virtualenvs\test-Mr90davp\lib\site-packages\sphinx\util\osutil.py", line 123, in relpath
    return os.path.relpath(path, start)
  File "C:\Python310\lib\ntpath.py", line 695, in relpath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

### Analysis

The invocation of `osutil.relpath()` in https://github.com/sphinx-contrib/spelling/blob/19902955ad703fe60a242eebbb53258282b22713/sphinxcontrib/spelling/builder.py#L229 might pass `None` as an argument because `docutils.utils.get_source_line(node)` returns `None`.

I am not familiar with the codebase of Sphinx, but because of the above it seems that `osutil.relpath()` must be able to handle `None`. However, on Windows passing `None` will result in the above exception, because `os.path.relpath()` raises an `TypeError` on Windows instead of a `ValueError`.
