### PR TITLE
Correct the Python Developer Guide markup style advice link

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -239,8 +239,8 @@ as long as the text::
 
 Normally, there are no heading levels assigned to certain characters as the
 structure is determined from the succession of headings.  However, this
-convention is used in `Python's Style Guide for documenting
-<https://devguide.python.org/documentation/style-guide/>`_ which you may
+convention is used in `Python Developer's Guide for documenting
+<https://devguide.python.org/documentation/markup/#sections>`_ which you may
 follow:
 
 * ``#`` with overline, for parts


### PR DESCRIPTION
Subject: Update link to Python devguide's advice on section markup

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- The Python Developer's Guide has moved the recommendation on section headers to another page
- Let's update the link

### Detail
- Change: https://devguide.python.org/documentation/style-guide/
- To: https://devguide.python.org/documentation/markup/#sections

### Relates
- https://github.com/python/devguide/pull/901
- 

