### PR TITLE
Ensure Ruff creates logs in colour for GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/sphinx/util/display.py
+++ b/sphinx/util/display.py
@@ -8,7 +8,7 @@ from sphinx.util import logging
 from sphinx.util.console import bold, colorize, term_width_line  # type: ignore
 
 if False:
-    from types import TracebackType  # NoQA: TCH003
+    from types import TracebackType
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Subject: Fix linting

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Ruff 0.0.245 is failing on `master` and PRs:

```diff
--- sphinx/util/display.py
+++ sphinx/util/display.py
@@ -8,7 +8,7 @@
 from sphinx.util.console import bold, colorize, term_width_line  # type: ignore
 
 if False:
-    from types import TracebackType  # NoQA: TCH003
+    from types import TracebackType
 
 logger = logging.getLogger(__name__)
 
- For example:
- https://github.com/hugovk/sphinx/actions/runs/4150982678
- https://github.com/sphinx-doc/sphinx/pull/11189

Error: Process completed with exit code 1.
```

### Detail
- Fix it

### Relates
- <URL or Ticket>

