### PR TITLE
Restore correct parallel search index building

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -655,10 +655,6 @@ class StandaloneHTMLBuilder(Builder):
         }
 
     def write_doc(self, docname: str, doctree: nodes.document) -> None:
-        title_node = self.env.longtitles.get(docname)
-        title = self.render_partial(title_node)['title'] if title_node else ''
-        self.index_page(docname, doctree, title)
-
         destination = StringOutput(encoding='utf-8')
         doctree.settings = self.docsettings
 
@@ -678,6 +674,9 @@ class StandaloneHTMLBuilder(Builder):
     def write_doc_serialized(self, docname: str, doctree: nodes.document) -> None:
         self.imgpath = relative_uri(self.get_target_uri(docname), self.imagedir)
         self.post_process_images(doctree)
+        title_node = self.env.longtitles.get(docname)
+        title = self.render_partial(title_node)['title'] if title_node else ''
+        self.index_page(docname, doctree, title)
 
     def finish(self) -> None:
         self.finish_tasks.add_task(self.gen_indices)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -286,3 +286,10 @@ def test_nosearch(app):
     assert 'latex' not in index['terms']
     assert 'zfs' in index['terms']
     assert index['terms']['zfs'] == []  # zfs on nosearch.rst is not registered to index
+
+
+@pytest.mark.sphinx(testroot='search', parallel=3, freshenv=True)
+def test_parallel(app):
+    app.build()
+    index = load_searchindex(app.outdir / 'searchindex.js')
+    assert index['docnames'] == ['index', 'nosearch', 'tocitem']


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Reverts the remaining changes from b32841e153431ec02de31e9ec32e79ab3ac7d1c2.

The image-related changes were already reverted in 2a7c40d07f4b0e0fd2a4bc942e74634c2df24dee, but the search index changes also need to be reverted.

It would be nice to support parallel search index building, but the necessary support for merging the search indices produced by each process needs to be added first.

Fixes #11163.