### PR TITLE
Make ``--jobs`` a synonym for ``-j``

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -138,7 +138,7 @@ Options
    the build directory; with this option you can select a different cache
    directory (the doctrees can be shared between all builders).
 
-.. option:: -j N
+.. option:: -j N, --jobs N
 
    Distribute the build over *N* processes in parallel, to make building on
    multiprocessor machines more effective.  Note that not all parts and not all
@@ -150,6 +150,9 @@ Options
 
    .. versionchanged:: 1.7
       Support ``auto`` argument.
+
+   .. versionchanged:: 6.2
+      Add ``--jobs`` long option.
 
 .. option:: -c path
 

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -142,7 +142,8 @@ files can be built by specifying individual filenames.
     group.add_argument('-d', metavar='PATH', dest='doctreedir',
                        help=__('path for the cached environment and doctree '
                                'files (default: OUTPUTDIR/.doctrees)'))
-    group.add_argument('-j', metavar='N', default=1, type=jobs_argument, dest='jobs',
+    group.add_argument('-j', '--jobs', metavar='N', default=1, type=jobs_argument,
+                       dest='jobs',
                        help=__('build in parallel with N processes where '
                                'possible (special value "auto" will set N to cpu-count)'))
     group = parser.add_argument_group('build configuration options')


### PR DESCRIPTION
Subject: Add `--jobs` to the Sphinx command-line options

### Feature or Bugfix
<!-- please choose -->
- Feature


### Purpose
- Add the command-line option `--jobs` as a synonym for the `-j` flag.

### Detail
- Add the usual long option `--jobs`. Compare with `make --help`:

```
 -j [N], --jobs[=N]          Allow N jobs at once; infinite jobs with no arg.
```

## Before

```console
$ sphinx-build --help
...
  -j N              build in parallel with N processes where possible (special
                    value "auto" will set N to cpu-count)
...
```

## After

```console
$ sphinx-build --help
...
  -j N, --jobs N    build in parallel with N processes where possible (special
                    value "auto" will set N to cpu-count)
...
```


### Relates
- Alternative to and closes https://github.com/sphinx-doc/sphinx/pull/11169
- https://github.com/python/devguide/pull/1038#discussion_r1088601323

