### PR TITLE
setuptools are used in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ test = [
     "pytest>=4.6",
     "html5lib",
     "cython",
+    "setuptools",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
See e.g.:

    ______________________________ test_build_sphinx _______________________________

    setup_command = setup(pkgroot=path('/tmp/pytest-of-mockbuild/pytest-0/test_build_sphinx0/test-setup'), proc=<Popen: returncode: 1 args: ['/usr/bin/python3', 'setup.py', 'build_sphinx']>)

        def test_build_sphinx(setup_command):
            proc = setup_command.proc
            out, err = proc.communicate()
            print(out.decode())
            print(err.decode())
    >       assert proc.returncode == 0
    E       AssertionError: assert 1 == 0
    E        +  where 1 = <Popen: returncode: 1 args: ['/usr/bin/python3', 'setup.py', 'build_sphinx']>.returncode

    /builddir/build/BUILD/Sphinx-5.3.0/tests/test_setup_command.py:47: AssertionError
    ----------------------------- Captured stdout call -----------------------------

    Traceback (most recent call last):
      File "/tmp/pytest-of-mockbuild/pytest-0/test_build_sphinx0/test-setup/setup.py", line 1, in <module>
        from setuptools import setup
    ModuleNotFoundError: No module named 'setuptools'

Subject: Requrie setuptools for tests

### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Purpose
- make the tests run in environment where setuptools are not installed by default

