### PR TITLE
use fully-qualified name when registering node

### DIFF
--- a/tests/roots/test-ext-duplicate-node/_ext/hello_world/__init__.py
+++ b/tests/roots/test-ext-duplicate-node/_ext/hello_world/__init__.py
@@ -1,7 +1,7 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive
-
 from hello_world import module_a, module_b
+
 from sphinx.application import Sphinx
 
 

--- a/tests/roots/test-ext-duplicate-node/_ext/hello_world/__init__.py
+++ b/tests/roots/test-ext-duplicate-node/_ext/hello_world/__init__.py
@@ -1,0 +1,24 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+from hello_world import module_a, module_b
+from sphinx.application import Sphinx
+
+
+class HelloWorld(Directive):
+
+    def run(self):
+        paragraph_node = nodes.paragraph(text='Hello World!')
+        return [paragraph_node]
+
+
+def setup(app: Sphinx):  # type: ignore[no-untyped-def]
+    app.add_directive("helloworld", HelloWorld)
+    module_a.register(app)
+    module_b.register(app)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/tests/roots/test-ext-duplicate-node/_ext/hello_world/module_a.py
+++ b/tests/roots/test-ext-duplicate-node/_ext/hello_world/module_a.py
@@ -1,0 +1,26 @@
+from docutils import nodes
+
+from sphinx.application import Sphinx
+
+__all__ = [
+    "register",
+]
+
+
+def visit_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
+    pass
+
+def depart_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
+    pass
+
+class Node(nodes.General, nodes.Element):
+    pass
+
+
+def register(app: Sphinx) -> None:
+    app.add_node(
+        Node,
+        html=(visit_node, depart_node),
+        latex=(visit_node, depart_node),
+        text=(visit_node, depart_node),
+    )

--- a/tests/roots/test-ext-duplicate-node/_ext/hello_world/module_b.py
+++ b/tests/roots/test-ext-duplicate-node/_ext/hello_world/module_b.py
@@ -1,0 +1,26 @@
+from docutils import nodes
+
+from sphinx.application import Sphinx
+
+__all__ = [
+    "register",
+]
+
+
+def visit_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
+    pass
+
+def depart_node(_self: nodes.GenericNodeVisitor, _node: nodes.Node) -> None:
+    pass
+
+class Node(nodes.General, nodes.Element):
+    pass
+
+
+def register(app: Sphinx) -> None:
+    app.add_node(
+        Node,
+        html=(visit_node, depart_node),
+        latex=(visit_node, depart_node),
+        text=(visit_node, depart_node),
+    )

--- a/tests/roots/test-ext-duplicate-node/conf.py
+++ b/tests/roots/test-ext-duplicate-node/conf.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("./_ext"))
+
+extensions = ['hello_world']

--- a/tests/roots/test-ext-duplicate-node/index.rst
+++ b/tests/roots/test-ext-duplicate-node/index.rst
@@ -1,0 +1,4 @@
+test for sphinx.ext.todo
+========================
+
+this is intentionally empty

--- a/tests/test_ext_duplicate_node.py
+++ b/tests/test_ext_duplicate_node.py
@@ -1,0 +1,11 @@
+"""Test sphinx.ext.todo extension."""
+
+import pytest
+
+from sphinx.application import Sphinx
+
+
+@pytest.mark.sphinx('html', testroot='ext-duplicate-node', freshenv=True)
+def test_duplicate_node(app: Sphinx) -> None:
+    app.warningiserror = True
+    app.build()


### PR DESCRIPTION
closes #11219

i've tried to create a failing test here, but the test passes..

if i create the same structure outside of pytest and attempt to run a build it fails. I'm not sure why the behaviour is different.

see this reproduction that shows the build error - https://github.com/danieleades/sphinx-bug-11220