### PR TITLE
Bugfix: Make attribute/"thing" selector much more lax

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -60,7 +60,7 @@ MethodDescriptorType = type(type.__subclasses__)
 py_ext_sig_re = re.compile(
     r'''^ ([\w.]+::)?            # explicit module name
           ([\w.]+\.)?            # module and/or class name(s)
-          (\w+)  \s*             # thing name
+          ([^.()]+)  \s*         # thing name
           (?: \((.*)\)           # optional: arguments
            (?:\s* -> \s* (.*))?  #           return annotation
           )? $                   # and nothing more

--- a/tests/roots/test-ext-autodoc/target/enums.py
+++ b/tests/roots/test-ext-autodoc/target/enums.py
@@ -23,4 +23,10 @@ class EnumCls(enum.Enum):
         pass
 
 
-EnumClsWithSpecialCharAttrs = enum.Enum("EnumClsWithSpecialCharAttrs", "da-sh normal semi;colon")
+EnumClsWithSpecialCharAttrs = enum.Enum("EnumClsWithSpecialCharAttrs", [
+    "da-sh",
+    "normal",
+    "semi;colon",
+    "()",
+    "a()",
+])

--- a/tests/roots/test-ext-autodoc/target/enums.py
+++ b/tests/roots/test-ext-autodoc/target/enums.py
@@ -21,3 +21,6 @@ class EnumCls(enum.Enum):
     def say_goodbye(cls):
         """a classmethod says good-bye to you."""
         pass
+
+
+EnumClsWithSpecialCharAttrs = enum.Enum("EnumClsWithSpecialCharAttrs", "da-sh normal semi;colon")

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1477,12 +1477,49 @@ def test_enum_class_specialchar(app, status, warning):
     assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.normal' in actual
     assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.da-sh' in actual
     assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.semi;colon' in actual
+    assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.()' in actual
+    assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.a()' in actual
+
+    # baseline checks that everything is as expected
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.normal')
+    assert '.. py:attribute:: EnumClsWithSpecialCharAttrs.normal' in actual
+    assert '   :module: target.enums' in actual
+    assert '   :value: 2' in actual
+
+    # Check a subvalue
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.normal.name')
+    assert '.. py:attribute:: normal.name' in actual
+    assert '   :module: target.enums.EnumClsWithSpecialCharAttrs' in actual
+    assert "   :value: 'normal'" in actual
+
 
     # checks for an attribute with invalid import characters
     actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.da-sh')
     assert '.. py:attribute:: EnumClsWithSpecialCharAttrs.da-sh' in actual
     assert '   :module: target.enums' in actual
     assert '   :value: 1' in actual
+
+    # Check a subvalue
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.da-sh.name')
+    assert '.. py:attribute:: da-sh.name' in actual
+    assert '   :module: target.enums.EnumClsWithSpecialCharAttrs' in actual
+    assert "   :value: 'da-sh'" in actual
+
+    # checks for an attribute with invalid import characters
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.a()')
+    assert '.. py:attribute:: EnumClsWithSpecialCharAttrs.a()' in actual
+    assert '   :module: target.enums' in actual
+
+    # checks for an attribute with invalid import characters
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.()')
+    assert '.. py:attribute:: EnumClsWithSpecialCharAttrs.a()' in actual
+    assert '   :module: target.enums' in actual
+
+    # Check a subvalue
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.().name')
+    assert '.. py:attribute:: ().name' in actual
+    assert '   :module: target.enums.EnumClsWithSpecialCharAttrs' in actual
+    assert "   :value: '()'" in actual
 
     # confirm that no warnings have been raised
     assert warning.getvalue() == ""

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -1470,6 +1470,25 @@ def test_enum_class(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_enum_class_specialchar(app, status, warning):
+    options = {"members": None, "undoc-members": None}
+    actual = do_autodoc(app, 'class', 'target.enums.EnumClsWithSpecialCharAttrs', options)
+
+    assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.normal' in actual
+    assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.da-sh' in actual
+    assert '   .. py:attribute:: EnumClsWithSpecialCharAttrs.semi;colon' in actual
+
+    # checks for an attribute with invalid import characters
+    actual = do_autodoc(app, 'attribute', 'target.enums.EnumClsWithSpecialCharAttrs.da-sh')
+    assert '.. py:attribute:: EnumClsWithSpecialCharAttrs.da-sh' in actual
+    assert '   :module: target.enums' in actual
+    assert '   :value: 1' in actual
+
+    # confirm that no warnings have been raised
+    assert warning.getvalue() == ""
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_descriptor_class(app):
     options = {"members": 'CustomDataDescriptor,CustomDataDescriptor2'}
     actual = do_autodoc(app, 'module', 'target.descriptor', options)


### PR DESCRIPTION
Previous was expecting a regex "word", corresponding to python variable token rules but with some things like `enum.Enum`, `typing.TypedDict` & `django.models.TextChoices`, passed strings are converted to attributes and so those attributes can have arbitrary naming contents

Fixes #10322

Of note is that I've implemented this by accepting almost anything, but per the bug we could just add a few common breakage characters like `-` or `;`: `[\w;-]`, but this requires more foresight as to what might come up