### PR TITLE
Deprecate legacy ``intersphinx_mapping`` format

### DIFF
--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -63,7 +63,7 @@ linking:
    When fetching remote inventory files, proxy settings will be read from
    the ``$HTTP_PROXY`` environment variable.
 
-   **Format of the mapping**
+   **Format**
 
    .. versionadded:: 1.0
 

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -63,17 +63,7 @@ linking:
    When fetching remote inventory files, proxy settings will be read from
    the ``$HTTP_PROXY`` environment variable.
 
-   **Old format for this config value**
-
-   This is the format used before Sphinx 1.0.  It is still recognized.
-
-   A dictionary mapping URIs to either ``None`` or an URI.  The keys are the
-   base URI of the foreign Sphinx documentation sets and can be local paths or
-   HTTP URIs.  The values indicate where the inventory file can be found: they
-   can be ``None`` (at the same location as the base URI) or another local or
-   HTTP URI.
-
-   **New format for this config value**
+   **Format of the mapping**
 
    .. versionadded:: 1.0
 
@@ -135,6 +125,28 @@ linking:
               ('https://myproj.readthedocs.io/projects/otherbook/en/latest',
                   ('../../otherbook/build/html/objects.inv', None)),
       }
+
+   **Old format for this config value**
+
+   .. deprecated:: 6.2
+
+   .. RemovedInSphinx80Warning
+
+   .. caution:: This is the format used before Sphinx 1.0.
+                It is deprecated and will be removed in Sphinx 8.0.
+
+   A dictionary mapping URIs to either ``None`` or an URI.  The keys are the
+   base URI of the foreign Sphinx documentation sets and can be local paths or
+   HTTP URIs.  The values indicate where the inventory file can be found: they
+   can be ``None`` (at the same location as the base URI) or another local or
+   HTTP URI.
+
+   Example:
+
+   .. code:: python
+
+      intersphinx_mapping = {'https://docs.python.org/': None}
+
 
 .. confval:: intersphinx_cache_limit
 

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -617,6 +617,7 @@ def normalize_intersphinx_mapping(app: Sphinx, config: Config) -> None:
                     continue
             else:
                 # old format, no name
+                # xref RemovedInSphinx80Warning
                 name, uri, inv = None, key, value
                 logger.warning(
                     "The pre-Sphinx 1.0 'intersphinx_mapping' format is "

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -618,6 +618,13 @@ def normalize_intersphinx_mapping(app: Sphinx, config: Config) -> None:
             else:
                 # old format, no name
                 name, uri, inv = None, key, value
+                logger.warning(
+                    "The pre-Sphinx 1.0 'intersphinx_mapping' format is "
+                    "deprecated and will be removed in Sphinx 8. Update to the "
+                    "current format as described in the documentation. "
+                    f"Hint: \"intersphinx_mapping = {{'<name>': {(uri, inv)!r}}}\"."
+                    "https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping",  # NoQA: E501
+                )
 
             if not isinstance(inv, tuple):
                 config.intersphinx_mapping[key] = (name, (uri, (inv,)))

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -390,7 +390,10 @@ def test_load_mappings_warnings(tempdir, app, status, warning):
     # load the inventory and check if it's done correctly
     normalize_intersphinx_mapping(app, app.config)
     load_mappings(app)
-    assert warning.getvalue().count('\n') == 1
+    warnings = warning.getvalue().splitlines()
+    assert len(warnings) == 2
+    assert "The pre-Sphinx 1.0 'intersphinx_mapping' format is " in warnings[0]
+    assert 'intersphinx identifier 12345 is not string. Ignored' in warnings[1]
 
 
 def test_load_mappings_fallback(tempdir, app, status, warning):


### PR DESCRIPTION
This format was deprecated in documentation in Sphinx 1.0, but never in code.