### PR TITLE
Fix spacing of search message in french translation

### DIFF
--- a/sphinx/locale/fr/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fr/LC_MESSAGES/sphinx.po
@@ -3452,7 +3452,7 @@ msgstr "Préparation de la recherche..."
 
 #: sphinx/themes/basic/static/searchtools.js:413
 msgid ", in "
-msgstr ", dans"
+msgstr ", dans "
 
 #: sphinx/themes/basic/static/sphinx_highlight.js:107
 msgid "Hide Search Matches"


### PR DESCRIPTION
Subject: Add a space to match spacing of source message and display a correct sentence.


### Feature or Bugfix
- Bugfix

### Purpose

Should fix the following situation:

![2023-03-18-180032_637x211_scrot](https://user-images.githubusercontent.com/23519418/226121701-209d880b-e31e-4161-b5d0-3c085cbc8ebb.png)

