### PR TITLE
Fix syntax in ``:manpage:`` role example

### DIFF
--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -411,7 +411,7 @@ different style:
 .. rst:role:: manpage
 
    A reference to a Unix manual page including the section, e.g.
-   ``:manpage:`ls(1)``` displays :manpage:`ls(1). Creates a hyperlink to an
+   ``:manpage:`ls(1)``` displays :manpage:`ls(1)`. Creates a hyperlink to an
    external site rendering the manpage if :confval:`manpages_url` is defined.
 
 .. rst:role:: menuselection


### PR DESCRIPTION
Subject: Add missing backtick I accidentally left out of https://github.com/sphinx-doc/sphinx/pull/11226.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail

# Before

<img width="832" alt="image" src="https://user-images.githubusercontent.com/1324225/226140848-43013233-12c1-4680-8e55-8cc300a9e70e.png">

https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-manpage

# After

<img width="821" alt="image" src="https://user-images.githubusercontent.com/1324225/226140834-b38e181f-df83-4efe-ab75-cde86bd2a6a4.png">

https://sphinx--11249.org.readthedocs.build/en/11249/usage/restructuredtext/roles.html#role-manpage

### Relates
- https://github.com/sphinx-doc/sphinx/pull/11226

