### PR TITLE
Remove obsolete workarounds in ``doc/conf.py``

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,19 +181,3 @@ def setup(app):
                          names=['param'], can_collapse=True)
     app.add_object_type('event', 'event', 'pair: %s; event', parse_event,
                         doc_field_types=[fdesc])
-
-    # Load jQuery and patches to make readthedocs-doc-embed.js available (refs: #10574)
-    app.add_js_file('https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js',
-                    priority=100)
-    app.add_js_file(
-        'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.1/underscore-min.js',
-        priority=100,
-    )
-    app.add_js_file('_sphinx_javascript_frameworks_compat.js', priority=105)
-
-    # workaround for RTD
-    from sphinx.util import logging
-    logger = logging.getLogger(__name__)
-    app.info = lambda *args, **kwargs: logger.info(*args, **kwargs)
-    app.warn = lambda *args, **kwargs: logger.warning(*args, **kwargs)
-    app.debug = lambda *args, **kwargs: logger.debug(*args, **kwargs)


### PR DESCRIPTION
- The workaround for setting `app.info`, `app.warn`, `app.debug` was from times when Read the Docs didn't support Sphinx 2.0 (!) yet. So we exposed some Sphinx 1.x APIs to them. readthedocs/readthedocs-sphinx-ext#51 was merged in 2018, so this is no longer needed since then.

- Loading jQuery and underscore libraries is also not needed now: this is handled on Read the Docs side by readthedocs/readthedocs.org#9861 and other changes.