### PR TITLE
Add missing quotes in html 4 deprecation text

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1316,7 +1316,7 @@ def deprecate_html_4(_app: Sphinx, config: Config) -> None:
     # RemovedInSphinx70Warning
     if config.html4_writer:
         logger.warning(_('Support for emitting HTML 4 output is deprecated and '
-                         'will be removed in Sphinx 7. ("html4_writer=True '
+                         'will be removed in Sphinx 7. ("html4_writer=True" '
                          'detected in configuration options)'))
 
 


### PR DESCRIPTION
Subject: Just a missing closing double-quote in html 4 deprecation warning that I spotted when translating.
