### PR TITLE
Docs: Add a link to sphinx-extensions

### DIFF
--- a/doc/usage/extensions/index.rst
+++ b/doc/usage/extensions/index.rst
@@ -50,8 +50,9 @@ You can find several extensions contributed by users in the `sphinx-contrib`__
 organization. If you wish to include your extension in this organization,
 simply follow the instructions provided in the `github-administration`__
 project. This is optional and there are several extensions hosted elsewhere.
-The `awesome-sphinxdoc`__ and `sphinx-extensions`__ projects are both curated lists of Sphinx packages,
-and many packages use the `Framework :: Sphinx :: Extension`__ and
+The `awesome-sphinxdoc`__ and `sphinx-extensions`__ projects are both curated
+lists of Sphinx packages, and many packages use the
+`Framework :: Sphinx :: Extension`__ and
 `Framework :: Sphinx :: Theme`__ trove classifiers for Sphinx extensions and
 themes, respectively.
 

--- a/doc/usage/extensions/index.rst
+++ b/doc/usage/extensions/index.rst
@@ -50,7 +50,7 @@ You can find several extensions contributed by users in the `sphinx-contrib`__
 organization. If you wish to include your extension in this organization,
 simply follow the instructions provided in the `github-administration`__
 project. This is optional and there are several extensions hosted elsewhere.
-The `awesome-sphinxdoc`__ project contains a curated list of Sphinx packages,
+The `awesome-sphinxdoc`__ and `sphinx-extensions`__ projects are both curated lists of Sphinx packages,
 and many packages use the `Framework :: Sphinx :: Extension`__ and
 `Framework :: Sphinx :: Theme`__ trove classifiers for Sphinx extensions and
 themes, respectively.
@@ -58,6 +58,7 @@ themes, respectively.
 .. __: https://github.com/sphinx-contrib/
 .. __: https://github.com/sphinx-contrib/github-administration
 .. __: https://github.com/yoloseem/awesome-sphinxdoc
+.. __: https://sphinx-extensions.readthedocs.io/en/latest/
 .. __: https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension
 .. __: https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Theme
 


### PR DESCRIPTION
Subject: Hi :wave:  I was thinking that [sphinx-extensions](https://sphinx-extensions.readthedocs.io/en/latest/) is a nice list that deserves a link.

### Feature or Bugfix

nay

### Purpose

The Awesome List has many outdated projects, so as a resource it's good but for some people a much smaller list might be a better place to start.

### Detail

nay

### Relates

also nay

