### PR TITLE
Prefer ``importlib.metadata`` from Python 3.10 onwards

### DIFF
--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import traceback
 import warnings
 from importlib import import_module
@@ -15,10 +16,10 @@ from docutils.parsers import Parser
 from docutils.parsers.rst import Directive
 from docutils.transforms import Transform
 
-try:  # Python < 3.10 (backport)
-    from importlib_metadata import entry_points
-except ImportError:
+if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 from sphinx.builders import Builder
 from sphinx.config import Config

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -14,10 +14,7 @@ from zipfile import ZipFile
 if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
 else:
-    try:
-        from importlib_metadata import entry_points
-    except ImportError:
-        from importlib.metadata import entry_points
+    from importlib_metadata import entry_points
 
 from sphinx import package_dir
 from sphinx.errors import ThemeError
@@ -192,11 +189,7 @@ class HTMLThemeFactory:
         Sphinx refers to ``sphinx_themes`` entry_points.
         """
         # look up for new styled entry_points at first
-        try:
-            theme_entry_points = entry_points(group='sphinx.html_themes')
-        except TypeError:
-            _theme_entry_points = entry_points().get('sphinx.html_themes', ())
-            theme_entry_points = {ep.name: ep for ep in _theme_entry_points}
+        theme_entry_points = entry_points(group='sphinx.html_themes')
         try:
             entry_point = theme_entry_points[name]
             self.app.registry.load_extension(self.app, entry_point.module)

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import configparser
 import os
 import shutil
+import sys
 import tempfile
 from os import path
 from typing import TYPE_CHECKING, Any
 from zipfile import ZipFile
 
-try:  # Python < 3.10 (backport)
-    from importlib_metadata import entry_points
-except ImportError:
+if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
+else:
+    try:
+        from importlib_metadata import entry_points
+    except ImportError:
+        from importlib.metadata import entry_points
 
 from sphinx import package_dir
 from sphinx.errors import ThemeError

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -188,7 +188,11 @@ class HTMLThemeFactory:
         Sphinx refers to ``sphinx_themes`` entry_points.
         """
         # look up for new styled entry_points at first
-        theme_entry_points = entry_points(group='sphinx.html_themes')
+        try:
+            theme_entry_points = entry_points(group='sphinx.html_themes')
+        except TypeError:
+            _theme_entry_points = entry_points().get('sphinx.html_themes', ())
+            theme_entry_points = {ep.name: ep for ep in _theme_entry_points}
         try:
             entry_point = theme_entry_points[name]
             self.app.registry.load_extension(self.app, entry_point.module)


### PR DESCRIPTION
Subject: Fix #10479 

### Feature or Bugfix
- Bugfix

### Purpose
- Fix the bug and import logic, `importlib` is considered before `importlib-metadata` in new python version
- Env: `importlib-metadata<3.6`, `importlib-metadata==1.7.0` in particular.

### Detail
- sphinx-build fails if `importlib-metadata<3.6` is installed, no matter what Python version is.
- it may also fail if Python version < 3.10.
- In these environment, the imported `entry_points` accepts no parameter, while `sphinx` calls it with `group`
