### PR TITLE
Fix #11274: external links are not properly escaped for ``\sphinxupquote``   compatibility

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,7 @@ Bugs fixed
   leak to the shadow and border at a page break
 * #11264: LaTeX: missing space before colon after "Voir aussi" for :rst:dir:`seealso`
   directive in French
+* #11274: LaTeX: external links may break PDF build if under ``\sphinxupquote``
 * #11147: Fix source file/line number info in object description content and in
   other uses of ``nested_parse_with_titles``.  Patch by Jeremy Maitin-Shepard.
 * #11192: Restore correct parallel search index building.

--- a/sphinx/texinputs/sphinxlatexliterals.sty
+++ b/sphinx/texinputs/sphinxlatexliterals.sty
@@ -1,7 +1,7 @@
 %% LITERAL BLOCKS
 %
 % change this info string if making any custom modification
-\ProvidesFile{sphinxlatexliterals.sty}[2023/03/19 code-blocks and parsed literals]
+\ProvidesFile{sphinxlatexliterals.sty}[2023/04/01 code-blocks and parsed literals]
 
 % Provides support for this output mark-up from Sphinx latex writer:
 %
@@ -264,7 +264,8 @@
 \def\sphinx@verbatim@nolig@list {\do \`}%
 % Some characters . , ; ? ! / are neither pygmentized nor "tex-escaped".
 % This macro makes them "active" and they will insert potential linebreaks.
-% Not compatible with math mode (cf \sphinxunactivateextras).
+% Not compatible with math mode (cf \sphinxunactivateextras, which uses
+% these lists to make sure activated characters get de-activated).
 \newcommand*\sphinxbreaksbeforeactivelist {}% none
 \newcommand*\sphinxbreaksafteractivelist  {\do\.\do\,\do\;\do\?\do\!\do\/}
 \newcommand*\sphinxbreaksviaactive {%
@@ -984,6 +985,12 @@
 % Hence \sphinx@do@noligs will be removed, or rather replaced  with code
 % inserting discretionaries, as they allow a continuation symbol on start of
 % next line to achieve common design with code-blocks.
+% TODO: do the above TODO!
+% Extend \sphinxunactivateextras for \sphinxhref as the latter may
+% actually be in the scope of \sphinxupquote and does a \scantokens
+% of its own.
+   \expandafter\def\expandafter\sphinxunactivateextras\expandafter
+      {\sphinxunactivateextras\verbatim@nolig@list}%
    \let\do@noligs\sphinx@do@noligs
    \@noligs\endlinechar\m@ne\everyeof{}% (<- in case inside \sphinxhref)
    \expandafter\scantokens

--- a/tests/roots/test-root/objects.txt
+++ b/tests/roots/test-root/objects.txt
@@ -103,6 +103,12 @@ Referring to :func:`nothing <>`.
    :type hour: DuplicateType
    :param .Cls extcls: A class from another module.
 
+.. class:: MyClass
+
+   .. attribute:: config
+      :type: sphinx.config.Config
+
+      A configuration object.
 
 C items
 =======

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -13,6 +13,8 @@ import pytest
 from sphinx.builders.latex import default_latex_documents
 from sphinx.config import Config
 from sphinx.errors import SphinxError
+from sphinx.ext.intersphinx import load_mappings, normalize_intersphinx_mapping
+from sphinx.ext.intersphinx import setup as intersphinx_setup
 from sphinx.testing.util import strip_escseq
 from sphinx.util.osutil import ensuredir
 from sphinx.writers.latex import LaTeXTranslator
@@ -95,12 +97,18 @@ def skip_if_stylefiles_notfound(testfunc):
 )
 @pytest.mark.sphinx('latex')
 def test_build_latex_doc(app, status, warning, engine, docclass):
+    app.config.intersphinx_mapping = {
+        'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+    }
+    intersphinx_setup(app)
     app.config.latex_engine = engine
     app.config.latex_documents = [app.config.latex_documents[0][:4] + (docclass,)]
     if engine == 'xelatex':
         app.config.latex_table_style = ['booktabs']
     elif engine == 'lualatex':
         app.config.latex_table_style = ['colorrows']
+    normalize_intersphinx_mapping(app, app.config)
+    load_mappings(app)
     app.builder.init()
 
     LaTeXTranslator.ignore_missing_images = True


### PR DESCRIPTION
Fix #11274