### PR TITLE
support for imgmath_latex=tectonic

### DIFF
--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -130,9 +130,10 @@ def compile_math(latex: str, builder: Builder) -> str:
     # build latex command; old versions of latex don't have the
     # --output-directory option, so we have to manually chdir to the
     # temp dir to run it.
+    command = [builder.config.imgmath_latex]
     # assume that executable is on the PATH (i.e., don't handle /path/to/tectonic)
     if builder.config.imgmath_latex not in ['tectonic']:
-        command = [builder.config.imgmath_latex, '--interaction=nonstopmode']
+        command.append('--interaction=nonstopmode')
     # add custom args from the config file
     command.extend(builder.config.imgmath_latex_args)
     command.append('math.tex')

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -237,9 +237,7 @@ def render_math(
     latex = generate_latex_macro(image_format,
                                  math,
                                  self.builder.config,
-                                 self.builder.confdir,
-                                 self.builder.config.imgmath_latex in ['xelatex',
-                                                                       'tectonic'])
+                                 self.builder.confdir)
 
     filename = f"{sha1(latex.encode()).hexdigest()}.{image_format}"
     generated_path = path.join(self.builder.outdir, self.builder.imagedir, 'math', filename)

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -127,12 +127,13 @@ def compile_math(latex: str, builder: Builder) -> str:
     with open(filename, 'w', encoding='utf-8') as f:
         f.write(latex)
 
+    imgmath_latex_name = path.basename(builder.config.imgmath_latex)
+
     # build latex command; old versions of latex don't have the
     # --output-directory option, so we have to manually chdir to the
     # temp dir to run it.
     command = [builder.config.imgmath_latex]
-    # assume that executable is on the PATH (i.e., don't handle /path/to/tectonic)
-    if builder.config.imgmath_latex not in ['tectonic']:
+    if imgmath_latex_name not in ['tectonic']:
         command.append('--interaction=nonstopmode')
     # add custom args from the config file
     command.extend(builder.config.imgmath_latex_args)
@@ -141,8 +142,7 @@ def compile_math(latex: str, builder: Builder) -> str:
     try:
         subprocess.run(command, capture_output=True, cwd=tempdir, check=True,
                        encoding='ascii')
-        # FIXME: maybe it would be better to add a param: imgmath_dvi_extension?
-        if builder.config.imgmath_latex in ['xelatex', 'tectonic']:
+        if imgmath_latex_name in ['xelatex', 'tectonic']:
             return path.join(tempdir, 'math.xdv')
         else:
             return path.join(tempdir, 'math.dvi')

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -82,15 +82,15 @@ def write_svg_depth(filename: str, depth: int) -> None:
 def generate_latex_macro(image_format: str,
                          math: str,
                          config: Config,
-                         confdir: str = '',
-                         add_dvips_option: bool = False) -> str:
+                         confdir: str = '') -> str:
     """Generate LaTeX macro."""
     variables = {
         'fontsize': config.imgmath_font_size,
         'baselineskip': int(round(config.imgmath_font_size * 1.2)),
         'preamble': config.imgmath_latex_preamble,
-        'tightpage': '' if image_format == 'png' else ',tightpage',
-        'dvips': '' if not add_dvips_option else ',dvips',
+        # the dvips option is important when imgmath_latex in ["xelatex", "tectonic"],
+        # it has no impact when imgmath_latex="latex"
+        'tightpage': '' if image_format == 'png' else ',dvips,tightpage',
         'math': math,
     }
 

--- a/sphinx/templates/imgmath/preview.tex_t
+++ b/sphinx/templates/imgmath/preview.tex_t
@@ -9,7 +9,7 @@
 \pagestyle{empty}
 <%= preamble %>
 
-\usepackage[active<%= tightpage %><%= dvips %>]{preview}
+\usepackage[active<%= tightpage %>]{preview}
 
 \begin{document}
 \begin{preview}

--- a/sphinx/templates/imgmath/preview.tex_t
+++ b/sphinx/templates/imgmath/preview.tex_t
@@ -9,7 +9,7 @@
 \pagestyle{empty}
 <%= preamble %>
 
-\usepackage[active<%= tightpage %>]{preview}
+\usepackage[active<%= tightpage %><%= dvips %>]{preview}
 
 \begin{document}
 \begin{preview}


### PR DESCRIPTION
Subject: support use of tectonic in imgmath

### Feature or Bugfix
- Feature

### Purpose
- support use of tectonic and xelatex in imgmath

### Detail
Currently, using
```
imgmath_latex = "tectonic"
imgmath_latex_args = ["--outfmt", "xdv"]
```
is not possible. This PR is related to #6279
