### PR TITLE
Ensure arguments to ``PIL.Image.resize()`` are integers

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -424,7 +424,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 (width, height) = img.size
                 nw = self.config.epub_max_image_width
                 if width > nw:
-                    nh = (height * nw) / width
+                    nh = (height * nw) // width
                     img = img.resize((nw, nh), Image.BICUBIC)
             try:
                 img.save(path.join(self.outdir, self.imagedir, dest))

--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -424,7 +424,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
                 (width, height) = img.size
                 nw = self.config.epub_max_image_width
                 if width > nw:
-                    nh = (height * nw) // width
+                    nh = round((height * nw) / width)
                     img = img.resize((nw, nh), Image.BICUBIC)
             try:
                 img.save(path.join(self.outdir, self.imagedir, dest))


### PR DESCRIPTION
Updates _epub_base.py so that the computation of nh is always an integer - otherwise some calls to resize fail (floats are not allowed)

Subject: Close issue 11286

### Feature or Bugfix
- Bugfix

### Purpose
Close issue 11286

### Detail
Close issue 11286

### Relates
https://github.com/sphinx-doc/sphinx/issues/11286

