### PR TITLE
Only use ``_write_doc_doctree_cache`` in serial mode

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -452,7 +452,7 @@ class Builder:
             # remove all inventory entries for that file
             self.events.emit('env-purge-doc', self.env, docname)
             self.env.clear_doc(docname)
-            self.read_doc(docname)
+            self.read_doc(docname, False)
 
     def _read_parallel(self, docnames: list[str], nproc: int) -> None:
         chunks = make_chunks(docnames, nproc)
@@ -470,7 +470,7 @@ class Builder:
         def read_process(docs: list[str]) -> bytes:
             self.env.app = self.app
             for docname in docs:
-                self.read_doc(docname)
+                self.read_doc(docname, True)
             # allow pickling self to send it back
             return pickle.dumps(self.env, pickle.HIGHEST_PROTOCOL)
 
@@ -488,7 +488,7 @@ class Builder:
         tasks.join()
         logger.info('')
 
-    def read_doc(self, docname: str) -> None:
+    def read_doc(self, docname: str, parallel: bool) -> None:
         """Parse a file and add/update inventory entries for the doctree."""
         self.env.prepare_settings(docname)
 
@@ -522,9 +522,9 @@ class Builder:
         self.env.temp_data.clear()
         self.env.ref_context.clear()
 
-        self.write_doctree(docname, doctree)
+        self.write_doctree(docname, doctree, parallel)
 
-    def write_doctree(self, docname: str, doctree: nodes.document) -> None:
+    def write_doctree(self, docname: str, doctree: nodes.document, parallel: bool) -> None:
         """Write the doctree to a file."""
         # make it picklable
         doctree.reporter = None
@@ -542,7 +542,11 @@ class Builder:
         with open(doctree_filename, 'wb') as f:
             pickle.dump(doctree, f, pickle.HIGHEST_PROTOCOL)
 
-        self.env._write_doc_doctree_cache[docname] = doctree
+        # in parallel mode, this function is invoked in a context of a process
+        # worker and thus it does not make sense to pickle it and send it
+        # to the main process
+        if not parallel:
+            self.env._write_doc_doctree_cache[docname] = doctree
 
     def write(
         self,


### PR DESCRIPTION
As shown in #11124, if the reading operation is using multiple processes, then the content of self.env._write_doc_doctree_cache is not synchronized with the main process. Thus use it only in serial mode.

For cpython documentation I get to the following numbers before this revision:
-j1 + caching of _write_doc_doctree_cache: **95 s**
-j1 + not caching of _write_doc_doctree_cache: **86 s**
-j32 + caching of _write_doc_doctree_cache: **57 s**
-j32 + no caching of _write_doc_doctree_cache: **48 s**

Related: #11124