### PR TITLE
Allow parallel execution of tests in ``test_search``

### DIFF
--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -456,7 +456,7 @@ def test_literalinclude_file_whole_of_emptyline(app, status, warning):
 
 @pytest.mark.sphinx('html', testroot='directive-code')
 def test_literalinclude_caption_html(app, status, warning):
-    app.builder.build('index')
+    app.builder.build_all()
     html = (app.outdir / 'caption.html').read_text(encoding='utf8')
     caption = ('<div class="code-block-caption">'
                '<span class="caption-number">Listing 2 </span>'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -105,11 +105,12 @@ def test_meta_keys_are_handled_for_language_de(app, status, warning):
 def test_stemmer_does_not_remove_short_words(app, status, warning):
     app.builder.build_all()
     searchindex = (app.outdir / 'searchindex.js').read_text(encoding='utf8')
-    assert 'zfs' in searchindex
+    assert '"zf"' in searchindex
 
 
 @pytest.mark.sphinx(testroot='search')
 def test_stemmer(app, status, warning):
+    app.builder.build_all()
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
     print(searchindex)
     assert is_registered_term(searchindex, 'findthisstemmedkei')
@@ -118,6 +119,7 @@ def test_stemmer(app, status, warning):
 
 @pytest.mark.sphinx(testroot='search')
 def test_term_in_heading_and_section(app, status, warning):
+    app.builder.build_all()
     searchindex = (app.outdir / 'searchindex.js').read_text(encoding='utf8')
     # if search term is in the title of one doc and in the text of another
     # both documents should be a hit in the search index as a title,
@@ -128,6 +130,7 @@ def test_term_in_heading_and_section(app, status, warning):
 
 @pytest.mark.sphinx(testroot='search')
 def test_term_in_raw_directive(app, status, warning):
+    app.builder.build_all()
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
     assert not is_registered_term(searchindex, 'raw')
     assert is_registered_term(searchindex, 'rawword')


### PR DESCRIPTION
Add various `app.builder.build_all` calls and for
`test_stemmer_does_not_remove_short_words` for not relly on the `'html_search_language': 'de'`.

Link: #11291