### PR TITLE
Use a shared file-system lock in ``create_server``

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ test = [
     "pytest>=4.6",
     "html5lib",
     "cython",
+    "filelock"
 ]
 
 [[project.authors]]

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -99,7 +99,8 @@ def test_defaults(app):
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-too-many-retries', freshenv=True)
 def test_too_many_retries(app):
-    app.build()
+    with http_server(DefaultsHandler):
+        app.build()
 
     # Text output
     assert (app.outdir / 'output.txt').exists()
@@ -688,7 +689,8 @@ def test_get_after_head_raises_connection_error(app):
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-documents_exclude', freshenv=True)
 def test_linkcheck_exclude_documents(app):
-    app.build()
+    with http_server(DefaultsHandler):
+        app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:
         content = [json.loads(record) for record in fp]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,11 +9,11 @@ import filelock
 # Generated with:
 # $ openssl req -new -x509 -days 3650 -nodes -out cert.pem \
 #     -keyout cert.pem -addext "subjectAltName = DNS:localhost"
-FILE_DIR = pathlib.Path(__file__).parent
-CERT_FILE = str(FILE_DIR / "certs" / "cert.pem")
+TESTS_ROOT = pathlib.Path(__file__).parent
+CERT_FILE = str(TESTS_ROOT / "certs" / "cert.pem")
 
 # File lock for tests
-LOCK_PATH = str(FILE_DIR / 'test-server.lock')
+LOCK_PATH = str(TESTS_ROOT / 'test-server.lock')
 
 
 class HttpServerThread(threading.Thread):


### PR DESCRIPTION
With a parallel run of tests, one gets "Address already in use" errors as all tests attempt to bind to the same port. Fix it with a shared file-system lock.

@AA-Turner 