### PR TITLE
Re-allow localisation when SOURCE_DATE_EPOCH is set (follow-up to #10949)

### DIFF
--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -105,22 +105,10 @@ def init(
     if translator.__class__ is NullTranslations:
         translator = None
 
-    if getenv('SOURCE_DATE_EPOCH') is not None:
-        # Disable localization during reproducible source builds
-        # See https://reproducible-builds.org/docs/source-date-epoch/
-        #
-        # Note: Providing an empty/none value to gettext.translation causes
-        # it to consult various language-related environment variables to find
-        # locale(s).  We don't want that during a reproducible build; we want
-        # to run through the same code path, but to return NullTranslations.
-        #
-        # To achieve that, specify the ISO-639-3 'undetermined' language code,
-        # which should not match any translation catalogs.
-        languages: list[str] | None = ['und']
-    elif language:
+    if language:
         if '_' in language:
             # for language having country code (like "de_AT")
-            languages = [language, language.split('_')[0]]
+            languages: list[str] | None = [language, language.split('_')[0]]
         else:
             languages = [language]
     else:

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import locale
 from gettext import NullTranslations, translation
-from os import getenv, path
+from os import path
 from typing import Any, Callable
 
 

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -94,5 +94,5 @@ def test_init_reproducible_build_language(rootdir, monkeypatch):
         _ = _empty_language_translation(rootdir)
         loc_et_translation = str(_('Hello world'))  # str cast to evaluate lazy method
 
-    assert sde_en_translation == sde_et_translation
-    assert sde_et_translation != loc_et_translation
+    assert sde_en_translation != sde_et_translation
+    assert sde_et_translation == loc_et_translation

--- a/tests/test_util_inventory.py
+++ b/tests/test_util_inventory.py
@@ -134,8 +134,8 @@ def test_inventory_reproducible(tempdir, monkeypatch):
     srcdir_et = _write_appconfig(tempdir, "et", prefix="localized")
     localized_inventory_et = _build_inventory(srcdir_et)
 
-    # Ensure that the reproducible inventory contents are identical
-    assert reproducible_inventory_et.read_bytes() == reproducible_inventory_en.read_bytes()
+    # Ensure that each (reproducible) localized inventory is different
+    assert reproducible_inventory_et.read_bytes() != reproducible_inventory_en.read_bytes()
 
-    # Ensure that inventory contents are different between a localized and non-localized build
-    assert reproducible_inventory_et.read_bytes() != localized_inventory_et.read_bytes()
+    # Ensure that inventory contents are the same between a reproducible and non-reproducible build
+    assert reproducible_inventory_et.read_bytes() == localized_inventory_et.read_bytes()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- I may have take an entirely incorrect (basically, inverted) approach to solving #9778
- The approach - disabling localisation entirely for reproducible builds (#10949) is likely not a good idea
- I'd really appreciate sanity-checking on this

### Detail
- #10949 fixed an unusual behaviour around lazy-loading of localised resources
  - > During investigation, it turned out that many gettext-localized values -- particularly in Python modules under sphinx.domains -- were being translated at module-load-time (in other words, when each Python module was import'ed) -- and would not subsequently be re-localized.
- However, #10949 also completely disabled localisation during reproducible builds (detected by a non-empty `SOURCE_DATE_EPOCH` environment variable)
- Disabling localisation may not have been necessary: as mentioned in the [original bug description](https://github.com/sphinx-doc/sphinx/issues/9778#issue-1036427985), the `objects.inv` file -- where reproducibility problems were occurring -- was already being requested in a single language (English-only); so localisation of the rest of the package-under-build should be irrelevant

### Relates
- Original bug report: #9778
- Previous fix attempt: #10949 