### PR TITLE
linkcheck builder: close streamed HTTP response objects when no content reads are required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   FORCE_COLOR: "1"
   PYTHONDEVMODE: "1"  # -X dev
   PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
-  PYTHONWARNINGS: "error,always:unclosed:ResourceWarning::"  # default: all warnings as errors, except ResourceWarnings about unclosed items
+  PYTHONWARNINGS: "error"
 
 jobs:
   ubuntu:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   FORCE_COLOR: "1"
   PYTHONDEVMODE: "1"  # -X dev
   PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
-  PYTHONWARNINGS: "error"
+  PYTHONWARNINGS: "error"  # default: all warnings as errors
 
 jobs:
   ubuntu:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -316,21 +316,20 @@ class HyperlinkAvailabilityCheckWorker(Thread):
             try:
                 if anchor and self.config.linkcheck_anchors:
                     # Read the whole document and see if #anchor exists
-                    response = requests.get(req_url, stream=True, config=self.config,
-                                            auth=auth_info, **kwargs)
-                    response.raise_for_status()
-                    found = check_anchor(response, unquote(anchor))
+                    with requests.get(req_url, stream=True, config=self.config, auth=auth_info,
+                                      **kwargs) as response:
+                        response.raise_for_status()
+                        found = check_anchor(response, unquote(anchor))
 
-                    if not found:
-                        raise Exception(__("Anchor '%s' not found") % anchor)
+                        if not found:
+                            raise Exception(__("Anchor '%s' not found") % anchor)
                 else:
                     try:
                         # try a HEAD request first, which should be easier on
                         # the server and the network
-                        response = requests.head(req_url, allow_redirects=True,
-                                                 config=self.config, auth=auth_info,
-                                                 **kwargs)
-                        response.raise_for_status()
+                        with requests.head(req_url, allow_redirects=True, config=self.config,
+                                           auth=auth_info, **kwargs) as response:
+                            response.raise_for_status()
                     # Servers drop the connection on HEAD requests, causing
                     # ConnectionError.
                     except (ConnectionError, HTTPError, TooManyRedirects) as err:
@@ -338,10 +337,9 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                             raise
                         # retry with GET request if that fails, some servers
                         # don't like HEAD requests.
-                        response = requests.get(req_url, stream=True,
-                                                config=self.config,
-                                                auth=auth_info, **kwargs)
-                        response.raise_for_status()
+                        with requests.get(req_url, stream=True, config=self.config,
+                                          auth=auth_info, **kwargs) as response:
+                            response.raise_for_status()
             except HTTPError as err:
                 if err.response.status_code == 401:
                     # We'll take "Unauthorized" as working.

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -321,8 +321,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                         response.raise_for_status()
                         found = check_anchor(response, unquote(anchor))
 
-                        if not found:
-                            raise Exception(__("Anchor '%s' not found") % anchor)
+                    if not found:
+                        raise Exception(__("Anchor '%s' not found") % anchor)
                 else:
                     try:
                         # try a HEAD request first, which should be easier on

--- a/tests/roots/test-linkcheck-anchors-ignore/conf.py
+++ b/tests/roots/test-linkcheck-anchors-ignore/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-documents_exclude/conf.py
+++ b/tests/roots/test-linkcheck-documents_exclude/conf.py
@@ -3,4 +3,4 @@ linkcheck_exclude_documents = [
     '^broken_link$',
     'br[0-9]ken_link',
 ]
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-localserver-anchor/conf.py
+++ b/tests/roots/test-linkcheck-localserver-anchor/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-localserver-https/conf.py
+++ b/tests/roots/test-linkcheck-localserver-https/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-localserver-warn-redirects/conf.py
+++ b/tests/roots/test-linkcheck-localserver-warn-redirects/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-localserver/conf.py
+++ b/tests/roots/test-linkcheck-localserver/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-raw-node/conf.py
+++ b/tests/roots/test-linkcheck-raw-node/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck-too-many-retries/conf.py
+++ b/tests/roots/test-linkcheck-too-many-retries/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck/conf.py
+++ b/tests/roots/test-linkcheck/conf.py
@@ -1,4 +1,4 @@
 root_doc = 'links'
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.075
+linkcheck_timeout = 0.05

--- a/tests/roots/test-linkcheck/links.rst
+++ b/tests/roots/test-linkcheck/links.rst
@@ -11,3 +11,4 @@ Some additional anchors to exercise ignore code
 .. image:: http://localhost:7777/image.png
 .. figure:: http://localhost:7777/image2.png
 
+* `Valid anchored url <http://localhost:7777/anchor.html#found>`_


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Intended to reduce warning noise (`ResourceWarning` output) during linkcheck build tests

### Detail
- The linkchecker makes HTTP requests in a couple of places in streaming mode to minimize the amount of traffic/data required
- Since `requests` doesn't know whether the caller may intend to read content from a streamed HTTP response object, it holds the socket open
- We can ~~explicitly close~~ invoke each request using a [context manager](https://docs.python.org/3/reference/datamodel.html#context-managers), ~~since we know for certain that we are not going to read data from it in these cases~~ to allow the [corresponding `__exit__` method](https://github.com/psf/requests/blob/61c324da43dd8b775d3930d76265538b3ca27bc1/requests/models.py#L709-L710) to perform cleanup

### Relates
- Resolves #11317 