### PR TITLE
LaTeX: get aligned longtable obey current list indent

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -85,6 +85,8 @@ Bugs fixed
   leak to the shadow and border at a page break
 * #11264: LaTeX: missing space before colon after "Voir aussi" for :rst:dir:`seealso`
   directive in French
+* #11268: LaTeX: longtable with left alignment breaks out of current list
+  indentation context in PDF.  Thanks to picnixz.
 * #11274: LaTeX: external links are not properly escaped for ``\sphinxupquote``
   compatibility
 * #11147: Fix source file/line number info in object description content and in

--- a/sphinx/templates/latex/longtable.tex.jinja
+++ b/sphinx/templates/latex/longtable.tex.jinja
@@ -22,15 +22,19 @@
 <% if 'nocolorrows' in table.styles -%>
 \sphinxthistablewithnocolorrowsstyle
 <% endif -%>
-\begin{longtable}
-<%- if table.align in ('center', 'default') -%>
-  [c]
-<%- elif table.align == 'left' -%>
-  [l]
-<%- elif table.align == 'right' -%>
-  [r]
-<%- endif -%>
-<%= table.get_colspec() %>
+\makeatletter
+<%- if table.align in ('center', 'default') %>
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+<%- elif table.align == 'left' %>
+  \setlength\LTleft{\@totalleftmargin}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+<%- elif table.align == 'right' %>
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax}
+<%- endif %>
+\makeatother
+\begin{longtable}<%= table.get_colspec() %>
 <%- if table.caption -%>
 \sphinxthelongtablecaptionisattop
 \caption{<%= ''.join(table.caption) %>\strut}<%= labels %>\\*[\sphinxlongtablecapskipadjust]

--- a/tests/roots/test-latex-table/expects/longtable.tex
+++ b/tests/roots/test-latex-table/expects/longtable.tex
@@ -4,7 +4,11 @@
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
 \sphinxthistablewithborderlessstyle
-\begin{longtable}[c]{ll}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{ll}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/roots/test-latex-table/expects/longtable_having_align.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_align.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[r]{|l|l|}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax}
+\makeatother
+\begin{longtable}{|l|l|}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/roots/test-latex-table/expects/longtable_having_caption.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_caption.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[c]{|l|l|}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|l|l|}
 \sphinxthelongtablecaptionisattop
 \caption{caption for longtable\strut}\label{\detokenize{longtable:id1}}\\*[\sphinxlongtablecapskipadjust]
 \sphinxtoprule

--- a/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_problematic_cell.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[c]{|*{2}{\X{1}{2}|}}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|*{2}{\X{1}{2}|}}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_stub_columns_and_problematic_cell.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[c]{|*{3}{\X{1}{3}|}}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|*{3}{\X{1}{3}|}}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_verbatim.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[c]{|*{2}{\X{1}{2}|}}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|*{2}{\X{1}{2}|}}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[c]{|\X{30}{100}|\X{70}{100}|}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
 \noalign{\phantomsection\label{\detokenize{longtable:namedlongtable}}\label{\detokenize{longtable:mylongtable}}}%
 \sphinxtoprule
 \sphinxstyletheadfamily 

--- a/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths_and_problematic_cell.tex
@@ -3,7 +3,11 @@
 \begin{savenotes}
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
-\begin{longtable}[c]{|\X{30}{100}|\X{70}{100}|}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|\X{30}{100}|\X{70}{100}|}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/longtable_with_tabularcolumn.tex
@@ -4,7 +4,11 @@
 \sphinxatlongtablestart
 \sphinxthistablewithglobalstyle
 \sphinxthistablewithvlinesstyle
-\begin{longtable}[c]{|c|c|}
+\makeatletter
+  \setlength\LTleft{\@totalleftmargin plus1fill}
+  \setlength\LTright{\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill}
+\makeatother
+\begin{longtable}{|c|c|}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1364,10 +1364,10 @@ def test_latex_table_with_booktabs_and_colorrows(app, status, warning):
     assert r'\PassOptionsToPackage{booktabs}{sphinx}' in result
     assert r'\PassOptionsToPackage{colorrows}{sphinx}' in result
     # tabularcolumns
-    assert r'\begin{longtable}[c]{|c|c|}' in result
+    assert r'\begin{longtable}{|c|c|}' in result
     # class: standard
     assert r'\begin{tabulary}{\linewidth}[t]{|T|T|T|T|T|}' in result
-    assert r'\begin{longtable}[c]{ll}' in result
+    assert r'\begin{longtable}{ll}' in result
     assert r'\begin{tabular}[t]{*{2}{\X{1}{2}}}' in result
     assert r'\begin{tabular}[t]{\X{30}{100}\X{70}{100}}' in result
 

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -538,7 +538,7 @@ def test_autosummary_latex_table_colspec(app, status, warning):
     result = (app.outdir / 'python.tex').read_text(encoding='utf8')
     print(status.getvalue())
     print(warning.getvalue())
-    assert r'\begin{longtable}[c]{\X{1}{2}\X{1}{2}}' in result
+    assert r'\begin{longtable}{\X{1}{2}\X{1}{2}}' in result
     assert r'p{0.5\linewidth}' not in result
 
 


### PR DESCRIPTION
Fix #11268.

Thanks to @picnixz!

Using this test input

```rest
.. raw:: latex

   \rule{\linewidth}{1pt}

This is quoted:

  Quoted paragraph (somehow no "quoting" if the list starts
  immediately in place of this text paragraph).

  - More text styling:

    - this is more indented

      .. raw:: latex

         \rule{\linewidth}{1pt}

      .. csv-table::
         :header: Name, ``maps argument #1 to:``
         :align: left
         :class: longtable

         foo, bar

      .. csv-table::
         :header: Name, ``maps argument #1 to:``
         :align: right
         :class: longtable

         foo, bar

      .. csv-table::
         :header: Name, ``maps argument #1 to:``
         :align: center
         :class: longtable

         foo, bar

      .. csv-table::
         :header: Name, ``maps argument #1 to:``
         :align: center
         :class: longtable

         foo, bar

The above is supposedly quoted
```

here is the output

With this PR:

![Capture d’écran 2023-04-11 à 20 17 22](https://user-images.githubusercontent.com/2589111/231254134-0f90336c-520a-4d41-90ad-05c565cd4853.png)

Prior to this PR:

![Capture d’écran 2023-04-11 à 20 18 06](https://user-images.githubusercontent.com/2589111/231254197-b0acd515-9257-4b8c-a775-f1b441cc6c49.png)

### Feature or Bugfix
<!-- please choose -->
- Bugfix

Remark: I resisted against using core TeX for skip register assignment in place of `\setlength`, which adds the LaTeX overhead.  Hmm, maybe I will in the end use leaner TeX syntax but let's go with this.
