### PR TITLE
Use ``overwrite_file`` context manager in ``test_ext_autodoc_configs``

### DIFF
--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -2,6 +2,7 @@
 
 import platform
 import sys
+from contextlib import contextmanager
 
 import pytest
 
@@ -10,6 +11,19 @@ from sphinx.testing import restructuredtext
 from .test_ext_autodoc import do_autodoc
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
+
+
+@contextmanager
+def overwrite_file(path, content):
+    current_content = path.read_text() if path.exists() else None
+    try:
+        path.write_text(content)
+        yield
+    finally:
+        if current_content is not None:
+            path.write_text(current_content)
+        else:
+            path.unlink()
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
@@ -947,7 +961,8 @@ def test_autodoc_typehints_none_for_overload(app):
 
 
 @pytest.mark.sphinx('text', testroot='ext-autodoc',
-                    confoverrides={'autodoc_typehints': "description"})
+                    confoverrides={'autodoc_typehints': "description"},
+                    freshenv=True)
 def test_autodoc_typehints_description(app):
     app.build()
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
@@ -986,20 +1001,19 @@ def test_autodoc_typehints_description_no_undoc(app):
     # No :type: or :rtype: will be injected for `incr`, which does not have
     # a description for its parameters or its return. `tuple_args` does
     # describe them, so :type: and :rtype: will be added.
-    (app.srcdir / 'index.rst').write_text(
-        '.. autofunction:: target.typehints.incr\n'
-        '\n'
-        '.. autofunction:: target.typehints.decr\n'
-        '\n'
-        '   :returns: decremented number\n'
-        '\n'
-        '.. autofunction:: target.typehints.tuple_args\n'
-        '\n'
-        '   :param x: arg\n'
-        '   :return: another tuple\n',
-        encoding='utf8',
-    )
-    app.build()
+    with overwrite_file(app.srcdir / 'index.rst',
+                        '.. autofunction:: target.typehints.incr\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.decr\n'
+                        '\n'
+                        '   :returns: decremented number\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.tuple_args\n'
+                        '\n'
+                        '   :param x: arg\n'
+                        '   :return: another tuple\n'):
+        app.build()
+    # Restore the original content of the file
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
     assert ('target.typehints.incr(a, b=1)\n'
             '\n'
@@ -1033,26 +1047,24 @@ def test_autodoc_typehints_description_no_undoc_doc_rtype(app):
     # autodoc_typehints_description_target. `tuple_args` does describe both, so
     # :type: and :rtype: will be added. `nothing` has no parameters but a return
     # type of None, which will be added.
-    (app.srcdir / 'index.rst').write_text(
-        '.. autofunction:: target.typehints.incr\n'
-        '\n'
-        '.. autofunction:: target.typehints.decr\n'
-        '\n'
-        '   :returns: decremented number\n'
-        '\n'
-        '.. autofunction:: target.typehints.tuple_args\n'
-        '\n'
-        '   :param x: arg\n'
-        '   :return: another tuple\n'
-        '\n'
-        '.. autofunction:: target.typehints.Math.nothing\n'
-        '\n'
-        '.. autofunction:: target.typehints.Math.horse\n'
-        '\n'
-        '   :return: nothing\n',
-        encoding='utf8',
-    )
-    app.build()
+    with overwrite_file(app.srcdir / 'index.rst',
+                        '.. autofunction:: target.typehints.incr\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.decr\n'
+                        '\n'
+                        '   :returns: decremented number\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.tuple_args\n'
+                        '\n'
+                        '   :param x: arg\n'
+                        '   :return: another tuple\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.Math.nothing\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.Math.horse\n'
+                        '\n'
+                        '   :return: nothing\n'):
+        app.build()
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
     assert context == (
         'target.typehints.incr(a, b=1)\n'
@@ -1094,12 +1106,10 @@ def test_autodoc_typehints_description_no_undoc_doc_rtype(app):
 @pytest.mark.sphinx('text', testroot='ext-autodoc',
                     confoverrides={'autodoc_typehints': "description"})
 def test_autodoc_typehints_description_with_documented_init(app):
-    (app.srcdir / 'index.rst').write_text(
-        '.. autoclass:: target.typehints._ClassWithDocumentedInit\n'
-        '   :special-members: __init__\n',
-        encoding='utf8',
-    )
-    app.build()
+    with overwrite_file(app.srcdir / 'index.rst',
+                        '.. autoclass:: target.typehints._ClassWithDocumentedInit\n'
+                        '   :special-members: __init__\n'):
+        app.build()
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
     assert context == (
         'class target.typehints._ClassWithDocumentedInit(x, *args, **kwargs)\n'
@@ -1133,12 +1143,10 @@ def test_autodoc_typehints_description_with_documented_init(app):
                     confoverrides={'autodoc_typehints': "description",
                                    'autodoc_typehints_description_target': 'documented'})
 def test_autodoc_typehints_description_with_documented_init_no_undoc(app):
-    (app.srcdir / 'index.rst').write_text(
-        '.. autoclass:: target.typehints._ClassWithDocumentedInit\n'
-        '   :special-members: __init__\n',
-        encoding='utf8',
-    )
-    app.build()
+    with overwrite_file(app.srcdir / 'index.rst',
+                        '.. autoclass:: target.typehints._ClassWithDocumentedInit\n'
+                        '   :special-members: __init__\n'):
+        app.build()
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
     assert context == (
         'class target.typehints._ClassWithDocumentedInit(x, *args, **kwargs)\n'
@@ -1165,12 +1173,10 @@ def test_autodoc_typehints_description_with_documented_init_no_undoc_doc_rtype(a
     # see test_autodoc_typehints_description_with_documented_init_no_undoc
     # returnvalue_and_documented_params should not change class or method
     # docstring.
-    (app.srcdir / 'index.rst').write_text(
-        '.. autoclass:: target.typehints._ClassWithDocumentedInit\n'
-        '   :special-members: __init__\n',
-        encoding='utf8',
-    )
-    app.build()
+    with overwrite_file(app.srcdir / 'index.rst',
+                        '.. autoclass:: target.typehints._ClassWithDocumentedInit\n'
+                        '   :special-members: __init__\n'):
+        app.build()
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
     assert context == (
         'class target.typehints._ClassWithDocumentedInit(x, *args, **kwargs)\n'
@@ -1200,15 +1206,13 @@ def test_autodoc_typehints_description_for_invalid_node(app):
 @pytest.mark.sphinx('text', testroot='ext-autodoc',
                     confoverrides={'autodoc_typehints': "both"})
 def test_autodoc_typehints_both(app):
-    (app.srcdir / 'index.rst').write_text(
-        '.. autofunction:: target.typehints.incr\n'
-        '\n'
-        '.. autofunction:: target.typehints.tuple_args\n'
-        '\n'
-        '.. autofunction:: target.overload.sum\n',
-        encoding='utf8',
-    )
-    app.build()
+    with overwrite_file(app.srcdir / 'index.rst',
+                        '.. autofunction:: target.typehints.incr\n'
+                        '\n'
+                        '.. autofunction:: target.typehints.tuple_args\n'
+                        '\n'
+                        '.. autofunction:: target.overload.sum\n'):
+        app.build()
     context = (app.outdir / 'index.txt').read_text(encoding='utf8')
     assert ('target.typehints.incr(a: int, b: int = 1) -> int\n'
             '\n'
@@ -1387,8 +1391,9 @@ def test_autodoc_type_aliases(app):
                     confoverrides={'autodoc_typehints': "description",
                                    'autodoc_type_aliases': {'myint': 'myint'}})
 def test_autodoc_typehints_description_and_type_aliases(app):
-    (app.srcdir / 'autodoc_type_aliases.rst').write_text('.. autofunction:: target.autodoc_type_aliases.sum', encoding='utf8')
-    app.build()
+    with overwrite_file(app.srcdir / 'autodoc_type_aliases.rst',
+                        '.. autofunction:: target.autodoc_type_aliases.sum'):
+        app.build()
     context = (app.outdir / 'autodoc_type_aliases.txt').read_text(encoding='utf8')
     assert context == (
         'target.autodoc_type_aliases.sum(x, y)\n'

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -15,13 +15,13 @@ IS_PYPY = platform.python_implementation() == 'PyPy'
 
 @contextmanager
 def overwrite_file(path, content):
-    current_content = path.read_text() if path.exists() else None
+    current_content = path.read_bytes() if path.exists() else None
     try:
-        path.write_text(content)
+        path.write_text(content, encoding='utf-8')
         yield
     finally:
         if current_content is not None:
-            path.write_text(current_content)
+            path.write_bytes(current_content)
         else:
             path.unlink()
 


### PR DESCRIPTION
The tests modify source files (index.rst), that is not restored and thus another test can reach a modified source file and it leads to unexpected test results.

Related: #11285 

@AA-Turner