### PR TITLE
test_linkcheck_allowed_redirects: enable HTTP HEAD request support

### DIFF
--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -342,7 +342,7 @@ def test_follows_redirects_on_GET(app, capsys, warning):
                         'linkcheck_allowed_redirects': {'http://localhost:7777/.*1': '.*'},
                     })
 def test_linkcheck_allowed_redirects(app, warning):
-    with http_server(make_redirect_handler(support_head=False)):
+    with http_server(make_redirect_handler(support_head=True)):
         app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:


### PR DESCRIPTION
This is intended to reduce the number of HTTP requests within this particular test to closer-to-the-norm compared to other tests within the [`test_build_linkcheck.py` module](https://github.com/sphinx-doc/sphinx/blob/509cc4533c92adae92997d63c8a7b11295f9e207/tests/test_build_linkcheck.py); this test has been [failing intermittently](https://github.com/sphinx-doc/sphinx/issues/11299) and it seems possible that timeouts due to HTTP roundtrip traffic are a contributing factor.

### Feature or Bugfix
- Bugfix (maybe)

### Purpose
- Intended to reduce flakiness in the `test_linkcheck_allowed_redirects` test -- or to rule out another potential source of that problem
- Also intended to avoid increasing the `linkcheck` request timeout thresholds for this (and other) tests

### Detail
- Should reduce the number of requests made by the unit test to the test HTTP server by half.  The server is tiny and basic, and I don't exactly understand why reducing the total request count should have any effect on the duration of the individual requests - but it's an idea to explore, and the logic expressed by the test should remain valid.

### Relates
- Relates to #11299