### PR TITLE
Increase timeout threshold for ``linkcheck`` tests

### DIFF
--- a/tests/roots/test-linkcheck-anchors-ignore/conf.py
+++ b/tests/roots/test-linkcheck-anchors-ignore/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-documents_exclude/conf.py
+++ b/tests/roots/test-linkcheck-documents_exclude/conf.py
@@ -3,4 +3,4 @@ linkcheck_exclude_documents = [
     '^broken_link$',
     'br[0-9]ken_link',
 ]
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-localserver-anchor/conf.py
+++ b/tests/roots/test-linkcheck-localserver-anchor/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-localserver-https/conf.py
+++ b/tests/roots/test-linkcheck-localserver-https/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-localserver-warn-redirects/conf.py
+++ b/tests/roots/test-linkcheck-localserver-warn-redirects/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-localserver/conf.py
+++ b/tests/roots/test-linkcheck-localserver/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-raw-node/conf.py
+++ b/tests/roots/test-linkcheck-raw-node/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck-too-many-retries/conf.py
+++ b/tests/roots/test-linkcheck-too-many-retries/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075

--- a/tests/roots/test-linkcheck/conf.py
+++ b/tests/roots/test-linkcheck/conf.py
@@ -1,4 +1,4 @@
 root_doc = 'links'
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.075


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (for flaky tests)

### Purpose
- Increases the timeout threshold for the `linkcheck` builder tests from 0.05s to 0.075s
- Resolves #11299 

### Detail
- The performance of the linkcheck tests was improved a few weeks ago (97f07ca83c70bba55fe1c1cb25993e5240e4187d)
- That introduced some improved (lower) timeout thresholds that had to be adjusted a little (7d928b3e7910d9bd5b232548a2d5998331c29b59)
- A few failures remained, and that resulted in me opening issue #11299 
- I think that the changes here should allow the flaky tests to pass consistently
- I haven't been able to find any other reason that performance would have degraded for these tests recently

### Relates
- Should fix #11299.