### PR TITLE
continuous integration: resolve docutils installation step build failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
       env:
-        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning"
+        PYTHONWARNINGS: "error,default::DeprecationWarning"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
       env:
-        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning"
+        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning,default:pkg_resources.declare_namespace:DeprecationWarning"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
       env:
-        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning::,default:deprecated call.*pkg_resources.declare_namespace:DeprecationWarning::"
+        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning::,default:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning::"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
       env:
-        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning::,default:pkg_resources.declare_namespace:DeprecationWarning::"
+        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning::,default:deprecated call.*pkg_resources.declare_namespace:DeprecationWarning::"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
       env:
-        PYTHONWARNINGS: "error,default::DeprecationWarning"
+        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,8 @@ jobs:
     - name: Install Docutils ${{ matrix.docutils }}
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
+      env:
+        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   FORCE_COLOR: "1"
   PYTHONDEVMODE: "1"  # -X dev
   PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
-  PYTHONWARNINGS: "error,always:unclosed:ResourceWarning"
+  PYTHONWARNINGS: "error,always:unclosed:ResourceWarning"  # default: all warnings as errors, except ResourceWarnings about unclosed items
 
 jobs:
   ubuntu:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   FORCE_COLOR: "1"
   PYTHONDEVMODE: "1"  # -X dev
   PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
-  PYTHONWARNINGS: "error,always:unclosed:ResourceWarning"  # default: all warnings as errors, except ResourceWarnings about unclosed items
+  PYTHONWARNINGS: "error,always:unclosed:ResourceWarning::"  # default: all warnings as errors, except ResourceWarnings about unclosed items
 
 jobs:
   ubuntu:
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "!endsWith(matrix.python, '-dev')"
       env:
-        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning,default:pkg_resources.declare_namespace:DeprecationWarning"
+        PYTHONWARNINGS: "error,default:pkg_resources is deprecated:DeprecationWarning::,default:pkg_resources.declare_namespace:DeprecationWarning::"
     - name: Install Docutils ${{ matrix.docutils }} (ignore warnings)
       run: python -m pip install --upgrade "docutils==${{ matrix.docutils }}.*"
       if: "endsWith(matrix.python, '-dev')"


### PR DESCRIPTION
### Feature or Bugfix
- Maintenance

### Purpose
- Restore continuous integration test success.

### Detail
- `pip`'s vendored libraries have begun warning about the deprecation of `pkg_resources`
- Our build stages intentionally treat warnings as errors by default
- This change temporarily permits ~~this specific warning~~ deprecation warnings to occur and be reported-but-not-considered-failure.
- The first commit on this branch will attempt to replicate the problem, and the second commit will attempt to resolve it.

### Relates
- Resolves #11330.