### PR TITLE
linkcheck tests: use thread-safe collections.deque for client header recording

### DIFF
--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import base64
-from collections import deque
 import http.server
 import json
 import re
 import textwrap
 import time
 import wsgiref.handlers
+from collections import deque
 from datetime import datetime
 from os import path
 from queue import Queue

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from collections import deque
 import http.server
 import json
 import re
@@ -199,7 +200,7 @@ def capture_headers_handler(records):
         (r'.*local.*', ('user2', 'hunter2')),
     ]})
 def test_auth_header_uses_first_match(app):
-    records = []
+    records = deque()
     with http_server(capture_headers_handler(records)):
         app.build()
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- When threaded test HTTP servers are in use, as in #11340, then client header related tests have been failing intermittently.
- This pull request attempts to address that by using a thread-safe collection that is shared between the unit test (object owner) and server handler (object recipient/producer thread).

### Detail
- [`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque) is thread-safe and supports `append` and iteration, similar to the `list` object currently in-use.
- Tested as part of jayaddison/sphinx#2.

### Relates
- Resolves #11348.
