### PR TITLE
apply ruff using pre-commit hook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,28 +13,14 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  ruff:
+  pre-commits:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3
-    - name: Install pip
-      run: python -m pip install --upgrade pip
-
-    - name: Install known good Ruff
-      run: python -m pip install ruff==0.0.261
-    - name: Lint with known good Ruff
-      run: ruff . --diff --format github
-
-    - name: Install latest Ruff
-      run: python -m pip install --upgrade ruff
-    - name: Lint with Ruff
-      continue-on-error: true
-      run: ruff . --diff --format github
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.0
 
   flake8:
     runs-on: ubuntu-latest
@@ -101,7 +87,7 @@ jobs:
       run: >
         sphinx-lint
         --enable line-too-long
-        --max-line-length 85 
+        --max-line-length 85
         CHANGES
         CONTRIBUTING.rst
         README.rst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+default_install_hook_types: [pre-commit]
+
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.263"
+    hooks:
+      - id: ruff
+        stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,3 @@ repos:
     rev: "v0.0.263"
     hooks:
       - id: ruff
-        stages: [commit]

--- a/doc/internals/contributing.rst
+++ b/doc/internals/contributing.rst
@@ -105,7 +105,7 @@ These are the basic steps needed to start developing on Sphinx.
        . ~/.venv/bin/activate
        pip install -e .
 
-#. install `pre-commit hooks <https://pre-commit.com/>`__::
+#. Install `pre-commit hooks <https://pre-commit.com/>`__::
 
        pre-commit install
 

--- a/doc/internals/contributing.rst
+++ b/doc/internals/contributing.rst
@@ -105,6 +105,10 @@ These are the basic steps needed to start developing on Sphinx.
        . ~/.venv/bin/activate
        pip install -e .
 
+#. install `pre-commit hooks <https://pre-commit.com/>`__::
+
+       pre-commit install
+
 #. Create a new working branch. Choose any name you like. ::
 
        git checkout -b feature-xyz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,10 +236,10 @@ ignore = [
     "Q000",  # double quotes found but single quotes preferred
     "Q001",  # single quote docstring found but double quotes preferred
     # flake8-return
-    "RET503",  # Missing explicit `return` at the end of function able to return value
+    "RET503",  # missing explicit `return` at the end of function able to return value
     "RET504",  # unnecessary variable assignment before `return` statement
     "RET505",  # unnecessary `else` after `return` statement
-    "RET506",  # Unnecessary `else` after `raise` statement
+    "RET506",  # unnecessary `else` after `raise` statement
     # flake8-raise
     "RSE102",
     # Ruff-specific rules
@@ -254,14 +254,14 @@ ignore = [
     "S301",  # 'pickle' unsafe when loading untrusted data
     "S324",  # probable use of insecure hash functions
     "S603",  # `subprocess` call: check for execution of untrusted input
-    "S607",  # Starting a process with a partial executable path
+    "S607",  # starting a process with a partial executable path
     "S701",  # use autoescape=True for Jinja
     # flake8-simplify
     "SIM102", # nested 'if' statements
     "SIM103", # return condition directly
     "SIM105", # use contextlib.suppress
     "SIM108", # use ternary operator
-    "SIM114", # Combine `if` branches using logical `or` operator
+    "SIM114", # combine `if` branches using logical `or` operator
     "SIM115", # use context handler for opening files
     "SIM117", # use single 'with' statement
     # flake8-self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,7 @@ ignore = [
     "SIM103", # return condition directly
     "SIM105", # use contextlib.suppress
     "SIM108", # use ternary operator
+    "SIM114", # Combine `if` branches using logical `or` operator
     "SIM115", # use context handler for opening files
     "SIM117", # use single 'with' statement
     # flake8-self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
     "sphinxcontrib-websupport",
 ]
 lint = [
+    "pre-commit",
     "flake8>=3.5.0",
     "flake8-simplify",
     "isort",
@@ -235,8 +236,10 @@ ignore = [
     "Q000",  # double quotes found but single quotes preferred
     "Q001",  # single quote docstring found but double quotes preferred
     # flake8-return
+    "RET503",  # Missing explicit `return` at the end of function able to return value
     "RET504",  # unnecessary variable assignment before `return` statement
     "RET505",  # unnecessary `else` after `return` statement
+    "RET506",  # Unnecessary `else` after `raise` statement
     # flake8-raise
     "RSE102",
     # Ruff-specific rules
@@ -250,6 +253,8 @@ ignore = [
     "S113",  # probable use of requests call without timeout
     "S301",  # 'pickle' unsafe when loading untrusted data
     "S324",  # probable use of insecure hash functions
+    "S603",  # `subprocess` call: check for execution of untrusted input
+    "S607",  # Starting a process with a partial executable path
     "S701",  # use autoescape=True for Jinja
     # flake8-simplify
     "SIM102", # nested 'if' statements

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -2980,7 +2980,7 @@ class DefinitionParser(BaseParser):
                         header = "Type must be either just a name or a "
                         header += "typedef-like declaration."
                         raise self._make_multi_error(prevErrors, header) from exTyped
-                    else:  # NoQA: RET506
+                    else:
                         # For testing purposes.
                         # do it again to get the proper traceback (how do you
                         # reliably save a traceback when an exception is

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -6647,7 +6647,7 @@ class DefinitionParser(BaseParser):
                         else:
                             raise AssertionError()
                         raise self._make_multi_error(prevErrors, header) from exTyped
-                    else:  # NoQA: RET506
+                    else:
                         # For testing purposes.
                         # do it again to get the proper traceback (how do you
                         # reliably save a traceback when an exception is

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -181,7 +181,7 @@ class TocTreeCollector(EnvironmentCollector):
                     _walk_toc(subnode, secnums, depth - 1, titlenode)
                     numstack.pop()
                     titlenode = None
-                elif isinstance(subnode, nodes.list_item):  # NoQA: SIM114
+                elif isinstance(subnode, nodes.list_item):
                     _walk_toc(subnode, secnums, depth, titlenode)
                     titlenode = None
                 elif isinstance(subnode, addnodes.only):

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -724,7 +724,7 @@ class Documenter:
                     # special __methods__
                     if (self.options.special_members and
                             membername in self.options.special_members):
-                        if membername == '__doc__':  # NoQA: SIM114
+                        if membername == '__doc__':
                             keep = False
                         elif is_filtered_inherited_member(membername, obj):
                             keep = False
@@ -743,7 +743,7 @@ class Documenter:
                         keep = True
                 elif want_all and isprivate:
                     if has_doc or self.options.undoc_members:
-                        if self.options.private_members is None:  # NoQA: SIM114
+                        if self.options.private_members is None:
                             keep = False
                         elif is_filtered_inherited_member(membername, obj):
                             keep = False

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -188,7 +188,7 @@ class ModuleScanner:
             try:
                 if ('', name) in attr_docs:
                     imported = False
-                elif inspect.ismodule(value):  # NoQA: SIM114
+                elif inspect.ismodule(value):
                     imported = True
                 elif safe_getattr(value, '__module__') != self.object.__name__:
                     imported = True

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -189,7 +189,7 @@ class AfterCommentParser(TokenProcessor):
                 tokens += self.fetch_until([OP, ']'])
             elif self.current == INDENT:
                 tokens += self.fetch_until(DEDENT)
-            elif self.current == [OP, ';']:  # NoQA: SIM114
+            elif self.current == [OP, ';']:
                 break
             elif self.current.kind not in (OP, NAME, NUMBER, STRING):
                 break

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -491,7 +491,7 @@ class SphinxComponentRegistry:
 def merge_source_suffix(app: Sphinx, config: Config) -> None:
     """Merge any user-specified source_suffix with any added by extensions."""
     for suffix, filetype in app.registry.source_suffix.items():
-        if suffix not in app.config.source_suffix:  # NoQA: SIM114
+        if suffix not in app.config.source_suffix:
             app.config.source_suffix[suffix] = filetype
         elif app.config.source_suffix[suffix] is None:
             # filetype is not specified (default filetype).

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -173,7 +173,7 @@ def restify(cls: type | None, mode: str = 'fully-qualified-except-typing') -> st
                 text = restify(cls.__origin__, mode)  # type: ignore[attr-defined]
 
             origin = getattr(cls, '__origin__', None)
-            if not hasattr(cls, '__args__'):  # NoQA: SIM114
+            if not hasattr(cls, '__args__'):
                 pass
             elif all(is_system_TypeVar(a) for a in cls.__args__):
                 # Suppress arguments if all system defined TypeVars (ex. Dict[KT, VT])

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -223,7 +223,7 @@ class Table:
                 for colno, cell in enumerate(line):
                     if cell.col != colno:
                         continue
-                    if lineno != cell.row:  # NoQA: SIM114
+                    if lineno != cell.row:
                         physical_text = ""
                     elif physical_line >= len(cell.wrapped):
                         physical_text = ""


### PR DESCRIPTION
I'm proposing to execute linting operation using pre-commit to make sure that people don't get bad surprises when creating a PR. 

### Feature or Bugfix
- Feature

### Detail

### Relates
related to #11205 

Instead of getting hard stop as for blakc I would like to itterate on this one. First thing first here is a proposal on running ruff within pre-commits to make sure it's run everytime. 

proposal following commits:
- [ ] use a pre-commit action to run ruff in the lint CI 
- [ ] drop ruff from requirements (as it's living in the pre-commit env)
- [ ] drop isort and flake8 as they are meant to be replaced by ruff

@AA-Turner let me know which one you want to see and which you don't and I'll commit accordingly

