### PR TITLE
Differentiate the colour of previously-visited hyperlinks

### DIFF
--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -41,6 +41,10 @@ a {
   color: {{ theme_linkcolor }};
 }
 
+a:visited {
+  color: #551a8b;
+}
+
 div.bodywrapper a, div.footer a {
   text-decoration: underline;
 }

--- a/sphinx/themes/basic/static/basic.css_t
+++ b/sphinx/themes/basic/static/basic.css_t
@@ -237,6 +237,10 @@ a.headerlink {
     visibility: hidden;
 }
 
+a:visited {
+    color: #551A8B;
+}
+
 h1:hover > a.headerlink,
 h2:hover > a.headerlink,
 h3:hover > a.headerlink,

--- a/sphinx/themes/bizstyle/static/bizstyle.css_t
+++ b/sphinx/themes/bizstyle/static/bizstyle.css_t
@@ -181,6 +181,10 @@ a:hover {
     text-decoration: underline;
 }
 
+a:visited {
+    color: #551a8b;
+}
+
 div.body a {
     text-decoration: underline;
 }

--- a/sphinx/themes/classic/theme.conf
+++ b/sphinx/themes/classic/theme.conf
@@ -24,7 +24,7 @@ headbgcolor      = #f2f2f2
 headtextcolor    = #20435c
 headlinkcolor    = #c60f0f
 linkcolor        = #355f7c
-visitedlinkcolor = #355f7c
+visitedlinkcolor = #551a8b
 codebgcolor      = unset
 codetextcolor    = unset
 

--- a/sphinx/themes/epub/static/epub.css_t
+++ b/sphinx/themes/epub/static/epub.css_t
@@ -26,10 +26,15 @@ div.clearer {
     clear: both;
 }
 
-a:link, a:visited {
+a:link {
     color: #3333ff;
     text-decoration: underline;
 }
+
+a:visited {
+    color: #551a8b;
+    text-decoration: underline;
+} 
 
 img {
     border: 0;

--- a/sphinx/themes/haiku/theme.conf
+++ b/sphinx/themes/haiku/theme.conf
@@ -10,5 +10,5 @@ body_max_width    = 70em
 textcolor         = #333333
 headingcolor      = #0c3762
 linkcolor         = #dc3c01
-visitedlinkcolor  = #892601
+visitedlinkcolor  = #551a8b
 hoverlinkcolor    = #ff4500

--- a/sphinx/themes/nature/static/nature.css_t
+++ b/sphinx/themes/nature/static/nature.css_t
@@ -142,6 +142,10 @@ a:hover {
     text-decoration: underline;
 }
 
+a:visited {
+    color: #551A8B;
+}
+
 div.body h1,
 div.body h2,
 div.body h3,

--- a/sphinx/themes/nonav/static/nonav.css_t
+++ b/sphinx/themes/nonav/static/nonav.css_t
@@ -15,8 +15,13 @@ div.clearer {
     clear: both;
 }
 
-a:link, a:visited {
+a:link {
     color: #3333ff;
+    text-decoration: underline;
+}
+
+a:visited {
+    color: #551a8b;
     text-decoration: underline;
 }
 

--- a/sphinx/themes/pyramid/static/pyramid.css_t
+++ b/sphinx/themes/pyramid/static/pyramid.css_t
@@ -181,6 +181,10 @@ a:hover, a:hover .pre {
     text-decoration: underline;
 }
 
+a:visited {
+    color: #551a8b;
+}
+
 div.body h1,
 div.body h2,
 div.body h3,

--- a/sphinx/themes/scrolls/static/scrolls.css_t
+++ b/sphinx/themes/scrolls/static/scrolls.css_t
@@ -187,6 +187,10 @@ a:hover {
     color: {{ theme_visitedlinkcolor }};
 }
 
+a:visited {
+    color: {{ theme_visitedlinkcolor }};
+}
+
 pre {
     background-image: url(metal.png);
     border-top: 1px solid #ccc;

--- a/sphinx/themes/scrolls/theme.conf
+++ b/sphinx/themes/scrolls/theme.conf
@@ -9,5 +9,5 @@ body_max_width = 680
 headerbordercolor = #1752b4
 subheadlinecolor  = #0d306b
 linkcolor         = #1752b4
-visitedlinkcolor  = #444
+visitedlinkcolor  = #551a8b
 admonitioncolor   = #28437f

--- a/sphinx/themes/sphinxdoc/static/sphinxdoc.css_t
+++ b/sphinx/themes/sphinxdoc/static/sphinxdoc.css_t
@@ -151,6 +151,10 @@ a:hover {
     color: #2491CF;
 }
 
+a:visited {
+    color: #551A8B;
+}
+
 div.body a {
     text-decoration: underline;
 }


### PR DESCRIPTION
Subject: Make visited links default color different

### Feature or Bugfix

- Feature

### Purpose

- Make it easier to tell which pages you have visited

### Detail

- Updates the visited link color in all the themes to the [HTML5 reference color](https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3) per [suggestion](https://github.com/sphinx-doc/sphinx/issues/1708#issuecomment-609018269) from @septatrix 
- Fix #1708 

### Relates

- https://github.com/sphinx-doc/sphinx/issues/1708
- https://github.com/sphinx-doc/sphinx/pull/9027

### Screenshots

All are ordered before and then after.

#### agogo

![agogo-before](https://user-images.githubusercontent.com/4713486/235532714-6cfd407e-e615-4a91-9353-71757fead22e.png)

![agogo-after](https://user-images.githubusercontent.com/4713486/235532747-414c65d2-fd1e-46ec-8143-1d2cb4c924d5.png)

#### basic

![basic-before](https://user-images.githubusercontent.com/4713486/235532911-808200af-0a75-4d2f-8ea6-469b3e564765.png)

![basic-after](https://user-images.githubusercontent.com/4713486/235532940-47af7ba1-538b-4a92-b0ab-842669ba6534.png)

#### bizstyle

![bizstyle-before](https://user-images.githubusercontent.com/4713486/235532959-44de8725-246e-455f-9be7-4cc6b19879c6.png)

![bizstyle-after](https://user-images.githubusercontent.com/4713486/235532990-febf10c6-0154-45a6-ba5b-fd52fd068bc3.png)

#### classic

![classic-before](https://user-images.githubusercontent.com/4713486/235533045-596af5db-9c94-43b7-8b7c-c97c10f04dbc.png)

![classic-after](https://user-images.githubusercontent.com/4713486/235533062-0adebb27-9f81-456d-a05e-a10c8152eb3e.png)

#### default

![default-before](https://user-images.githubusercontent.com/4713486/235533109-4d73006c-ceeb-48fb-8455-204267b9f966.png)

![default-after](https://user-images.githubusercontent.com/4713486/235533124-f8c158db-372e-4ea4-bfad-f1286e74bdad.png)

#### epub

![epub-before](https://user-images.githubusercontent.com/4713486/235533196-8edff845-64a1-4f75-8224-0220f1bc8152.png)

![epub-after](https://user-images.githubusercontent.com/4713486/235533217-4427d337-0300-4aaf-bb79-0badac392b33.png)

#### haiku

![haiku-before](https://user-images.githubusercontent.com/4713486/235533244-0cbe6770-589b-41e5-ae02-f4702fa42005.png)

![haiku-after](https://user-images.githubusercontent.com/4713486/235533260-0bcc6997-4eaa-49e9-931f-f96c07f105d2.png)

#### nature

![nature-before](https://user-images.githubusercontent.com/4713486/235533308-23791d5c-302e-4276-bd58-116d62268548.png)

![nature-after](https://user-images.githubusercontent.com/4713486/235533334-7c609f8e-928c-4554-a2aa-0aa6faee4523.png)

#### nonav

![nonav-before](https://user-images.githubusercontent.com/4713486/235533362-35ab2736-dcc4-4a64-97d3-d199c945690f.png)

![nonav-after](https://user-images.githubusercontent.com/4713486/235533379-13c737af-5733-4bee-a0d8-2e18aa5bb5cc.png)

#### pyramid

![pyramid-before](https://user-images.githubusercontent.com/4713486/235533413-0cb1ef84-1920-4256-87fe-c172c902158a.png)

![pyramid-after](https://user-images.githubusercontent.com/4713486/235533424-ee684d6d-167a-431f-a3e2-81aa1fa95028.png)

#### scrolls

![scrolls-before](https://user-images.githubusercontent.com/4713486/235533492-663d624e-f028-4dc1-bf07-d90c9adad9ec.png)

![scrolls-after](https://user-images.githubusercontent.com/4713486/235533516-53acaaa1-a6c7-44cf-ab87-b62c5beaf818.png)

#### sphinxdoc


![sphinxdoc-before](https://user-images.githubusercontent.com/4713486/235533539-21663a9d-fe15-40b6-a255-beb5747b7095.png)

![sphinxdoc-after](https://user-images.githubusercontent.com/4713486/235533589-7696b06c-6fa2-484c-9b8e-0b671524715c.png)

#### traditional

![traditional-before](https://user-images.githubusercontent.com/4713486/235533625-b9de7d32-1d03-413c-b1fe-614f8ee216df.png)

![traditional-after](https://user-images.githubusercontent.com/4713486/235533663-5c180aab-3738-43fd-b4fe-4dcb727509ca.png)