### PR TITLE
Add option to skip sphinx logger setup

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -138,7 +138,7 @@ class Sphinx:
                  freshenv: bool = False, warningiserror: bool = False,
                  tags: list[str] | None = None,
                  verbosity: int = 0, parallel: int = 0, keep_going: bool = False,
-                 pdb: bool = False) -> None:
+                 pdb: bool = False, skip_logging_setup: bool = False) -> None:
         self.phase = BuildPhase.INITIALIZATION
         self.verbosity = verbosity
         self.extensions: dict[str, Extension] = {}
@@ -181,7 +181,8 @@ class Sphinx:
         else:
             self.warningiserror = warningiserror
         self.pdb = pdb
-        logging.setup(self, self._status, self._warning)
+        if not skip_logging_setup:
+            logging.setup(self, self._status, self._warning)
 
         self.events = EventManager(self)
 

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -189,7 +189,8 @@ files can be built by specifying individual filenames.
                        help=__('show full traceback on exception'))
     group.add_argument('-P', action='store_true', dest='pdb',
                        help=__('run Pdb on exception'))
-
+    group.add_argument('--skip-logging-setup', action='store_true', dest='skip_logging_setup',
+                       help=__('skip setup of sphinx custom logger'))
     return parser
 
 
@@ -281,7 +282,7 @@ def build_main(argv: list[str] = sys.argv[1:]) -> int:
                          args.doctreedir, args.builder, args.confoverrides, args.status,
                          args.warning, args.freshenv, args.warningiserror,
                          args.tags, args.verbosity, args.jobs, args.keep_going,
-                         args.pdb)
+                         args.pdb, args.skip_logging_setup)
             app.build(args.force_all, args.filenames)
             return app.statuscode
     except (Exception, KeyboardInterrupt) as exc:


### PR DESCRIPTION
Subject: Add the ability to skip sphinx logging formatted so third-party libs that wrap sphinx can use their logger instead

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose

- Add the ability to skip sphinx logging formatted so third-party libs that wrap sphinx can use their logger instead

### Detail

- today sphinx removes any existing python loggers when `build_main` is called
- this is extremely undesirable since it limits 3rd parties from wrapping the sphinx build command with their own logger


### Relates
- <URL or Ticket>

