### PR TITLE
Remove setup_command from pyproject.toml

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,9 @@ Features added
 Bugs fixed
 ----------
 
+* #11418: Remove distutils entry point and any other references to
+  ``setup_command`` from pyproject.toml
+
 Testing
 --------
 

--- a/CHANGES
+++ b/CHANGES
@@ -20,8 +20,9 @@ Features added
 Bugs fixed
 ----------
 
-* #11418: Remove distutils entry point and any other references to
-  ``setup_command`` from pyproject.toml
+* #11418: Clean up remaining references to ``sphinx.setup_command``
+  following the removal of support for setuptools.
+  Patch by Willem Mulder.
 
 Testing
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,9 +105,6 @@ sphinx-quickstart = "sphinx.cmd.quickstart:main"
 sphinx-apidoc = "sphinx.ext.apidoc:main"
 sphinx-autogen = "sphinx.ext.autosummary.generate:main"
 
-[project.entry-points."distutils.commands"]
-build_sphinx = 'sphinx.setup_command:BuildDoc'
-
 [tool.flit.module]
 name = "sphinx"
 
@@ -344,7 +341,6 @@ module = [
     "sphinx.ext.napoleon.docstring",
     "sphinx.pycode.parser",
     "sphinx.registry",
-    "sphinx.setup_command",
     "sphinx.testing.util",
     "sphinx.transforms.i18n",
     "sphinx.transforms.post_transforms.images",
@@ -391,7 +387,6 @@ filterwarnings = [
 ]
 markers = [
     "apidoc",
-    "setup_command",
 ]
 testpaths = ["tests"]
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- pyproject.toml is still referencing `setup_command` in places, including as entry point for `distutils.commands`. This breaks any invocation of setuptools involving getting information from entry points.

### Detail
- Running e.g. `python setup.py --help-commands` will raise `ModuleNotFoundError: No module named 'sphinx.setup_command'`

### Relates
- colcon/colcon-core#556
- #11363 

