### PR TITLE
Compatibility issue: pin to 'urllib3<2.0.0' pending support in 'requests'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,11 @@ Release 7.1.0 (in development)
 Dependencies
 ------------
 
+* #11419: Pin the ``urllib3`` dependency to versions lower than 2.0.0 - it is
+  `not yet supported`_ by current ``requests`` library versions.
+
+.. _not yet supported: https://github.com/psf/requests/issues/6432
+
 Incompatible changes
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "alabaster>=0.7,<0.8",
     "imagesize>=1.3",
     "requests>=2.25.0",
+    "urllib3>=1.26.15,<2.0.0",
     "packaging>=21.0",
     "importlib-metadata>=4.8; python_version < '3.10'",
     "colorama>=0.4.5; sys_platform == 'win32'",


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Ensure dependency compatibility between `requests` and `urllib3` versions in `pyproject.toml`.
- Limitation: may not ensure compatibility when `sphinx` itself is installed as a Python package dependency.

### Relates
- Resolves #11419.