### PR TITLE
tests: linkcheck: refactor to remove variable sharing between tests and test webservers

### DIFF
--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -194,7 +194,7 @@ def test_raises_for_invalid_status(app):
     )
 
 
-def custom_handler(valid_credentials=None, success_criteria=lambda _: True):
+def custom_handler(valid_credentials=(), success_criteria=lambda _: True):
     """
     Returns an HTTP request handler that authenticates the client and then determines
     an appropriate HTTP response code, based on caller-provided credentials and optional
@@ -225,8 +225,10 @@ def custom_handler(valid_credentials=None, success_criteria=lambda _: True):
 
         @authenticated
         def do_GET(self):
-            response = (200, "OK") if success_criteria(self) else (400, "Bad Request")
-            self.send_response(*response)
+            if success_criteria(self):
+                self.send_response(200, "OK")
+            else:
+                self.send_response(400, "Bad Request")
             self.end_headers()
 
     return CustomHandler

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -299,8 +299,6 @@ def test_linkcheck_request_headers_no_slash(app):
     def check_headers(self):
         if "X-Secret" in self.headers:
             return False
-        if "sesami" in self.headers.as_string():
-            return False
         if self.headers["Accept"] != "application/json":
             return False
         return True

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -276,8 +276,6 @@ def test_linkcheck_request_headers(app):
     def check_headers(self):
         if "X-Secret" in self.headers:
             return False
-        if "sesami" in self.headers.as_string():
-            return False
         if self.headers["Accept"] != "text/html":
             return False
         return True

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -259,6 +259,9 @@ def test_auth_header_no_match(app):
     with open(app.outdir / "output.json", encoding="utf-8") as fp:
         content = json.load(fp)
 
+    # TODO: should this test's webserver return HTTP 401 here?
+    # https://github.com/sphinx-doc/sphinx/issues/11433
+    assert content["info"] == "403 Client Error: Forbidden for url: http://localhost:7777/"
     assert content["status"] == "broken"
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Tests for #11324 will benefit from the use of threaded webservers during unit tests.
  - The `test_auth_header_uses_first_match` test appears flaky when threaded test webservers are used (see #11348).
    - My working theory is that sharing of the `records` variable -- used to capture request header values within the server, and then assert on their values in the unit test -- across threads is somehow unsafe/unreliable (and could be the cause of the test flakiness).

### Detail
- Refactor to remove the sharing of the `records` variable between unit tests and their corresponding webserver request handler threads.
- Allow each test to provide a callable that declares the success criteria, and have the webserver thread evaluate that and communicate a resulting success/failure code using HTTP status codes.

### Relates
- May resolve #11348.
- Could be tested in combination with #11392.