### PR TITLE
linkcheck builder: don't retry with HTTP GET after SSLError on HTTP HEAD

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -334,6 +334,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     break
 
                 except SSLError as err:
+                    # SSL failure; report that the link is broken.
                     return 'broken', str(err), 0
 
                 except (ConnectionError, TooManyRedirects) as err:
@@ -364,7 +365,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     continue
 
                 except Exception as err:
-                    # Unhandled exception (intermittent or permanent); report that the
+                    # Unhandled exception (intermittent or permanent); report that
                     # the link is broken.
                     return 'broken', str(err), 0
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -18,7 +18,7 @@ from urllib.parse import unquote, urlparse, urlunparse
 
 from docutils import nodes
 from requests import Response
-from requests.exceptions import ConnectionError, HTTPError, TooManyRedirects
+from requests.exceptions import ConnectionError, HTTPError, SSLError, TooManyRedirects
 
 from sphinx.application import Sphinx
 from sphinx.builders.dummy import DummyBuilder
@@ -330,6 +330,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                         with requests.head(req_url, allow_redirects=True, config=self.config,
                                            auth=auth_info, **kwargs) as response:
                             response.raise_for_status()
+                    except SSLError as err:
+                        return 'broken', str(err), 0
                     # Servers drop the connection on HEAD requests, causing
                     # ConnectionError.
                     except (ConnectionError, HTTPError, TooManyRedirects) as err:

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -18,8 +18,8 @@ import pytest
 
 from sphinx.builders.linkcheck import HyperlinkAvailabilityCheckWorker, RateLimit
 from sphinx.testing.util import strip_escseq
-from sphinx.util.console import strip_colors
 from sphinx.util import requests
+from sphinx.util.console import strip_colors
 
 from .utils import CERT_FILE, http_server, https_server
 

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -391,7 +391,7 @@ class OKHandler(http.server.BaseHTTPRequestHandler):
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
-def test_invalid_ssl(app):
+def test_invalid_ssl(app, capsys):
     # Link indicates SSL should be used (https) but the server does not handle it.
     with http_server(OKHandler):
         app.build()
@@ -403,6 +403,8 @@ def test_invalid_ssl(app):
     assert content["lineno"] == 1
     assert content["uri"] == "https://localhost:7777/"
     assert "SSLError" in content["info"]
+    _stdout, stderr = capsys.readouterr()
+    assert len(stderr.splitlines()) == 2  # each HTTPS request results in two junk HTTP requests
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- If an `SSLError` occurs following an HTTP HEAD operation, it seems unlikely that a subsequent HTTP GET will succeed, so don't attempt one.

### Detail
- The `SSLError` exception that can be raised by `requests` [is a subclass of `ConnectionError`](https://github.com/psf/requests/blob/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29/requests/exceptions.py#L57-L58), so [our logic to handle HTTP HEAD request failures has allowed an HTTP GET to occur as a fallback](https://github.com/sphinx-doc/sphinx/blob/d3c91f951255c6729a53e38c895ddc0af036b5b9/sphinx/builders/linkcheck.py#L335-L341).
- My understanding is that [TLS operates at a protocol layer below HTTP](https://en.wikipedia.org/wiki/HTTPS#Network_layers), and so if there is a TLS-related error from a host, it seems unlikely that retrying with a different higher-layer protocol request (HTTP GET instead of HTTP HEAD) could succeed.
- We shouldn't make additional HTTP requests that we do not believe will succeed.

### Relates
- Partially addresses #9592.
- See also #9306 (could invalidate this approach?).