### PR TITLE
test_intl: resolve test flakiness by using integer nanosecond timestamps during file modification detection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,8 @@ Features added
 
 Bugs fixed
 ----------
+* #440: Fix coarse timestamp resolution in some filesystem generating a wrong
+  list of outdated files. (reverted)
 
 Testing
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -34,8 +34,6 @@ Features added
 
 Bugs fixed
 ----------
-* #440: Fix coarse timestamp resolution in some filesystem generating a wrong
-  list of outdated files. (reverted)
 
 Testing
 --------

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -496,7 +496,7 @@ class Builder:
             doctree = publisher.document
 
         # store time of reading, for outdated files detection
-        self.env.all_docs[docname] = time.time_ns()
+        self.env.all_docs[docname] = time.time_ns() // 1_000
 
         # cleanup
         self.env.temp_data.clear()

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -496,7 +496,7 @@ class Builder:
             doctree = publisher.document
 
         # store time of reading, for outdated files detection
-        self.env.all_docs[docname] = time.time()
+        self.env.all_docs[docname] = time.time_ns()
 
         # cleanup
         self.env.temp_data.clear()

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -496,11 +496,7 @@ class Builder:
             doctree = publisher.document
 
         # store time of reading, for outdated files detection
-        # (Some filesystems have coarse timestamp resolution;
-        # therefore time.time() can be older than filesystem's timestamp.
-        # For example, FAT32 has 2sec timestamp resolution.)
-        self.env.all_docs[docname] = max(time.time(),
-                                         path.getmtime(self.env.doc2path(docname)))
+        self.env.all_docs[docname] = time.time()
 
         # cleanup
         self.env.temp_data.clear()

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -8,7 +8,7 @@ import pickle
 from collections import defaultdict
 from copy import copy
 from datetime import datetime
-from os import path, stat
+from os import path
 from typing import TYPE_CHECKING, Any, Callable, Generator, Iterator
 
 from docutils import nodes
@@ -481,7 +481,7 @@ class BuildEnvironment:
                     continue
                 # check the mtime of the document
                 mtime = self.all_docs[docname]
-                newmtime = stat(self.doc2path(docname)).st_mtime_ns
+                newmtime = os.stat(self.doc2path(docname)).st_mtime_ns
                 if newmtime > mtime:
                     logger.debug('[build target] outdated %r: %s -> %s',
                                  docname,
@@ -497,7 +497,7 @@ class BuildEnvironment:
                         if not path.isfile(deppath):
                             changed.add(docname)
                             break
-                        depmtime = stat(deppath).st_mtime_ns
+                        depmtime = os.stat(deppath).st_mtime_ns
                         if depmtime > mtime:
                             changed.add(docname)
                             break

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -732,7 +732,7 @@ class BuildEnvironment:
         self.events.emit('env-check-consistency', self)
 
 
-def _last_modified_time(filename: str) -> int:
+def _last_modified_time(filename: str | os.PathLike[str]) -> int:
     """Return the last modified time of ``filename``.
 
     The time is returned as integer microseconds.

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -55,7 +55,7 @@ default_settings: dict[str, Any] = {
 
 # This is increased every time an environment attribute is added
 # or changed to properly invalidate pickle files.
-ENV_VERSION = 57
+ENV_VERSION = 58
 
 # config status
 CONFIG_OK = 1

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -166,7 +166,7 @@ class BuildEnvironment:
         # All "docnames" here are /-separated and relative and exclude
         # the source suffix.
 
-        # docname -> time of reading (in integer nanoseconds)
+        # docname -> time of reading (in integer microseconds)
         # contains all read docnames
         self.all_docs: dict[str, int] = {}
         # docname -> set of dependent file
@@ -480,7 +480,7 @@ class BuildEnvironment:
                     changed.add(docname)
                     continue
                 # check the mtime of the document
-                mtime = self.all_docs[docname] // 1_000  # convert ns to μs
+                mtime = self.all_docs[docname]
                 newmtime = _last_modified_time(self.doc2path(docname))
                 if newmtime > mtime:
                     # convert integer microseconds to floating-point seconds,
@@ -735,7 +735,7 @@ class BuildEnvironment:
 def _last_modified_time(filename: str) -> int:
     """Return the last modified time of ``filename``.
 
-    The time is returned as integer milliseconds.
+    The time is returned as integer microseconds.
     The lowest common denominator of modern file-systems seems to be
     microsecond-level precision.
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -8,7 +8,7 @@ import pickle
 from collections import defaultdict
 from copy import copy
 from datetime import datetime
-from os import path
+from os import path, stat
 from typing import TYPE_CHECKING, Any, Callable, Generator, Iterator
 
 from docutils import nodes
@@ -481,12 +481,12 @@ class BuildEnvironment:
                     continue
                 # check the mtime of the document
                 mtime = self.all_docs[docname]
-                newmtime = path.getmtime(self.doc2path(docname))
+                newmtime = stat(self.doc2path(docname)).st_mtime_ns
                 if newmtime > mtime:
                     logger.debug('[build target] outdated %r: %s -> %s',
                                  docname,
-                                 datetime.utcfromtimestamp(mtime),
-                                 datetime.utcfromtimestamp(newmtime))
+                                 datetime.utcfromtimestamp(mtime / 1_000_000_000),
+                                 datetime.utcfromtimestamp(newmtime / 1_000_000_000))
                     changed.add(docname)
                     continue
                 # finally, check the mtime of dependencies
@@ -497,7 +497,7 @@ class BuildEnvironment:
                         if not path.isfile(deppath):
                             changed.add(docname)
                             break
-                        depmtime = path.getmtime(deppath)
+                        depmtime = stat(deppath).st_mtime_ns
                         if depmtime > mtime:
                             changed.add(docname)
                             break


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The intent here is to improve the reliability of the tests within the `test_intl` module, and in particular to resolve #11232.

### Detail
- The flaky test assertions relate to the detection of modified files during application builds; and it seems to be message catalog files (`.mo`) that are relevant.
- Timestamp detection had been using floating-point seconds-since-the-epoch.
- Based on a small sample size of testing from jayaddison/sphinx#3, I believe that integer-based nanoseconds-since-the-epoch may be more reliable (but I'm not 100% confident).
- At the same time, revert commit 718993afc8e0e61c689a7681aa27f0f6dfbbcb7e that I believe should be unnecessary -- and maybe-cause-related -- simplifying the code and retrieving the current-time as nanoseconds-since-epoch.

### Relates
- May resolve #11232.