### PR TITLE
Compatibility: pycode parser: adjust dedent-token handling to maintain py3.12+ compatibility

### DIFF
--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -528,11 +528,9 @@ class DefinitionFinder(TokenProcessor):
             end_pos, end_col = self.current.end
 
             def is_implicit_dedent():
-                # EOF
                 if end_pos == len(self.buffers) + 1 and end_col == 0:
                     return True
-                # Non-empty code line
-                if self.get_line(end_pos):
+                if end_col < len(self.get_line(end_pos)):
                     return True
                 return False
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -532,6 +532,7 @@ class DefinitionFinder(TokenProcessor):
                     return True
                 if end_col < len(self.get_line(end_pos)):
                     return True
+                return False
 
             # Remove empty lines starting from the line _before_ implicit dedents
             # refs: https://github.com/sphinx-doc/sphinx/issues/11436

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -532,7 +532,7 @@ class DefinitionFinder(TokenProcessor):
                 if end_pos == len(self.buffers) + 1 and end_col == 0:
                     return True
                 # Non-empty code line
-                if self.get_line(end_pos):
+                if not emptyline_re.match(self.get_line(end_pos)):
                     return True
                 return False
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -528,9 +528,11 @@ class DefinitionFinder(TokenProcessor):
             end_pos, end_col = self.current.end
 
             def is_implicit_dedent():
+                # EOF
                 if end_pos == len(self.buffers) + 1 and end_col == 0:
                     return True
-                if end_col < len(self.get_line(end_pos)):
+                # Non-empty code line
+                if self.get_line(end_pos):
                     return True
                 return False
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -525,7 +525,20 @@ class DefinitionFinder(TokenProcessor):
         definition = self.indents.pop()
         if definition[0] != 'other':
             typ, funcname, start_pos = definition
-            end_pos = self.current.end[0] - 1
+            end_pos, end_col = self.current.end
+
+            def is_implicit_dedent():
+                if end_pos == len(self.buffers) + 1 and end_col == 0:
+                    return True
+                if end_col < len(self.get_line(end_pos)):
+                    return True
+
+            # Remove empty lines starting from the line _before_ implicit dedents
+            # refs: https://github.com/sphinx-doc/sphinx/issues/11436
+            if is_implicit_dedent():
+                end_pos -= 1
+
+            # Omit empty dedenting lines from the definition's line range
             while emptyline_re.match(self.get_line(end_pos)):
                 end_pos -= 1
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -528,8 +528,10 @@ class DefinitionFinder(TokenProcessor):
             end_pos, end_col = self.current.end
 
             def is_implicit_dedent():
+                # EOF
                 if end_pos == len(self.buffers) + 1 and end_col == 0:
                     return True
+                # Dedent on the same line as code
                 if end_col < len(self.get_line(end_pos)):
                     return True
                 return False

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -532,7 +532,7 @@ class DefinitionFinder(TokenProcessor):
                 if end_pos == len(self.buffers) + 1 and end_col == 0:
                     return True
                 # Non-empty code line
-                if not emptyline_re.match(self.get_line(end_pos)):
+                if self.get_line(end_pos):
                     return True
                 return False
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -527,7 +527,7 @@ class DefinitionFinder(TokenProcessor):
             typ, funcname, start_pos = definition
             end_pos, end_col = self.current.end
 
-            def is_implicit_dedent():
+            def is_beyond_dedent():
                 # EOF
                 if end_pos == len(self.buffers) + 1 and end_col == 0:
                     return True
@@ -536,12 +536,13 @@ class DefinitionFinder(TokenProcessor):
                     return True
                 return False
 
-            # Remove empty lines starting from the line _before_ implicit dedents
+            # Dedent tokens may appear past the end-of-file, or alongside
+            # subsequent lines of code
             # refs: https://github.com/sphinx-doc/sphinx/issues/11436
-            if is_implicit_dedent():
+            if is_beyond_dedent():
                 end_pos -= 1
 
-            # Omit empty dedenting lines from the definition's line range
+            # Omit empty lines that follow the definition
             while emptyline_re.match(self.get_line(end_pos)):
                 end_pos -= 1
 

--- a/tests/roots/test-directive-code/literal-compact.inc
+++ b/tests/roots/test-directive-code/literal-compact.inc
@@ -1,0 +1,4 @@
+# Compact representation of a class and method
+class Bar:
+    def baz(): pass
+def bar(): pass

--- a/tests/test_directive_code.py
+++ b/tests/test_directive_code.py
@@ -23,6 +23,11 @@ def literal_inc_path(testroot):
     return testroot / 'literal.inc'
 
 
+@pytest.fixture(scope='module')
+def literal_compact_inc_path(testroot):
+    return testroot / 'literal-compact.inc'
+
+
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_LiteralIncludeReader(literal_inc_path):
     options = {'lineno-match': True}
@@ -71,6 +76,31 @@ def test_LiteralIncludeReader_pyobject3(literal_inc_path):
     content, lines = reader.read()
     assert content == ("    def baz():\n"
                        "        pass\n")
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_pyobject4(literal_compact_inc_path):
+    options = {'pyobject': 'Bar'}
+    reader = LiteralIncludeReader(literal_compact_inc_path, options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == ("class Bar:\n"
+                       "    def baz(): pass\n")
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_pyobject5(literal_compact_inc_path):
+    options = {'pyobject': 'bar'}
+    reader = LiteralIncludeReader(literal_compact_inc_path, options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == "def bar(): pass\n"
+
+
+@pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
+def test_LiteralIncludeReader_pyobject6(literal_compact_inc_path):
+    options = {'pyobject': 'bar'}
+    reader = LiteralIncludeReader(literal_compact_inc_path, options, DUMMY_CONFIG)
+    content, lines = reader.read()
+    assert content == "def bar(): pass\n"
 
 
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Resolves test failures in Python code parsing (particularly for named definitions within indented code blocks).

### Detail
- From version 3.12.0a7 of Python, the line positions included on DEDENT tokens (encountered during Sphinx's Python code parsing logic, to determine the line-positioning of definitions) are always within the bounds of the number of lines in the source file.
- This means that we should not decrement that line position when we encounter it at the end-of-file for version 3.12+ of Python.

### Relates
- Resolves #11436.

Thank you, @mgmacias95 for guidance on the fix.