### PR TITLE
Add missing documentation for `--no-color` and `--color` options to `sphinx-build` man page

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -201,9 +201,19 @@ Options
    references.  See the config value :confval:`nitpick_ignore` for a way to
    exclude some references as "known missing".
 
-.. option:: -N
+.. option:: -N, --no-color
 
    Do not emit colored output.
+
+   .. versionchanged:: 1.6
+      Add ``--no-color`` long option.
+
+
+.. option:: --color
+
+   Do emit colored output. Auto-detected by default.
+
+   .. versionadded:: 1.6
 
 .. option:: -v
 

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -208,7 +208,6 @@ Options
    .. versionchanged:: 1.6
       Add ``--no-color`` long option.
 
-
 .. option:: --color
 
    Do emit colored output. Auto-detected by default.

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -210,7 +210,7 @@ Options
 
 .. option:: --color
 
-   Do emit colored output. Auto-detected by default.
+   Emit colored output. Auto-detected by default.
 
    .. versionadded:: 1.6
 


### PR DESCRIPTION
Subject: Add missing documentation for `--no-color` and `--color` options to `sphinx-build` man page

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
- The `--color` and `--no-color` to `sphinx-build` were added in the linked PR. They are included in the short help message, but lack documentation on `sphinx-build`'s manual page. 


### Detail

### Relates
- #3397

