### PR TITLE
RST roles in titles render properly with ``rst_prolog``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,9 +35,16 @@ Features added
 Bugs fixed
 ----------
 
-* #11437: Top-level headings with RST roles at the beginning of an RST file
-  render properly when :confval:`rst_prolog` is set. Users are not longer
-  required to put an empty line at the beginning of the file.
+* #11437: Top-level headings starting with an RST role reference now render
+  properly when :confval:`rst_prolog` is set. Users are not longer required
+  to put an empty line at the beginning of the file, i.e., the following
+  construction is now properly rendered.
+
+  .. code-block:: rst
+
+     :mod:`foo` -- The foo module
+     ============================
+
   Patch by Bénédikt Tran.
 
 Testing

--- a/CHANGES
+++ b/CHANGES
@@ -35,15 +35,18 @@ Features added
 Bugs fixed
 ----------
 
-* #11437: Top-level headings starting with an RST role reference now render
-  properly when :confval:`rst_prolog` is set. Users are not longer required
-  to put an empty line at the beginning of the file, i.e., the following
-  construction is now properly rendered.
+* #11437: Top-level headings starting with a reStructuredText role
+  now render properly when :confval:`rst_prolog` is set.
+  Previously, a file starting with the below would have
+  improperly rendered due to where the prologue text
+  was inserted into the document.
 
-  .. code-block:: rst
+  .. code:: rst
 
-     :mod:`foo` -- The foo module
-     ============================
+     :mod:`lobster` -- The lobster module
+     ====================================
+
+     ...
 
   Patch by Bénédikt Tran.
 

--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,11 @@ Features added
 Bugs fixed
 ----------
 
+* #11437: Top-level headings with RST roles at the beginning of an RST file
+  render properly when :confval:`rst_prolog` is set. Users are not longer
+  required to put an empty line at the beginning of the file.
+  Patch by Bénédikt Tran.
+
 Testing
 --------
 

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -13,16 +13,10 @@ from docutils.parsers.rst.languages import en as english
 from docutils.parsers.rst.states import Body
 from docutils.statemachine import StringList
 from docutils.utils import Reporter
-from jinja2 import Environment
+from jinja2 import Environment, pass_environment
 
 from sphinx.locale import __
 from sphinx.util import docutils, logging
-
-try:
-    from jinja2.utils import pass_environment
-except ImportError:
-    from jinja2 import environmentfilter as pass_environment
-
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/util/rst.py
+++ b/sphinx/util/rst.py
@@ -86,9 +86,17 @@ def prepend_prolog(content: StringList, prolog: str) -> None:
                 break
 
         if pos > 0:
-            # insert a blank line after docinfo
-            content.insert(pos, '', '<generated>', 0)
-            pos += 1
+            if pos < len(content) and len(content[pos]) >= 6 and len(set(content[pos])) == 1:
+                # This was actually a title starting with :role:`...` and not a docinfo,
+                # in which case the prolog will be put at the beginning of the file.
+                #
+                # Note that the smallest "role-like" title requires at least 6 characters
+                # and the sectioning characters must be repeated at least 6 times as well.
+                pos = 0
+            else:
+                # insert a blank line after docinfo
+                content.insert(pos, '', '<generated>', 0)
+                pos += 1
 
         # insert prolog (after docinfo if exists)
         for lineno, line in enumerate(prolog.splitlines()):

--- a/tests/test_util_rst.py
+++ b/tests/test_util_rst.py
@@ -78,6 +78,61 @@ def test_prepend_prolog_without_CR(app):
                                       ('dummy.rst', 1, 'Sphinx is a document generator')]
 
 
+def test_prepend_prolog_with_roles_in_sections(app):
+    prolog = 'this is rst_prolog\nhello reST!'
+    content = StringList([':title: test of SphinxFileInput',
+                          ':author: Sphinx team',
+                          '',  # this newline is required
+                          ':mod:`foo`',
+                          '----------',
+                          '',
+                          'hello'],
+                         'dummy.rst')
+    prepend_prolog(content, prolog)
+
+    assert list(content.xitems()) == [('dummy.rst', 0, ':title: test of SphinxFileInput'),
+                                      ('dummy.rst', 1, ':author: Sphinx team'),
+                                      ('<generated>', 0, ''),
+                                      ('<rst_prolog>', 0, 'this is rst_prolog'),
+                                      ('<rst_prolog>', 1, 'hello reST!'),
+                                      ('<generated>', 0, ''),
+                                      ('dummy.rst', 2, ''),
+                                      ('dummy.rst', 3, ':mod:`foo`'),
+                                      ('dummy.rst', 4, '----------'),
+                                      ('dummy.rst', 5, ''),
+                                      ('dummy.rst', 6, 'hello')]
+
+
+def test_prepend_prolog_with_roles_in_sections_with_CR(app):
+    # prolog having CR at tail
+    prolog = 'this is rst_prolog\nhello reST!\n'
+    content = StringList([':mod:`foo`', '-' * 10, '', 'hello'], 'dummy.rst')
+    prepend_prolog(content, prolog)
+
+    assert list(content.xitems()) == [('<rst_prolog>', 0, 'this is rst_prolog'),
+                                      ('<rst_prolog>', 1, 'hello reST!'),
+                                      ('<generated>', 0, ''),
+                                      ('dummy.rst', 0, ':mod:`foo`'),
+                                      ('dummy.rst', 1, '----------'),
+                                      ('dummy.rst', 2, ''),
+                                      ('dummy.rst', 3, 'hello')]
+
+
+def test_prepend_prolog_with_roles_in_sections_without_CR(app):
+    # prolog not having CR at tail
+    prolog = 'this is rst_prolog\nhello reST!'
+    content = StringList([':mod:`foo`', '-' * 10, '', 'hello'], 'dummy.rst')
+    prepend_prolog(content, prolog)
+
+    assert list(content.xitems()) == [('<rst_prolog>', 0, 'this is rst_prolog'),
+                                      ('<rst_prolog>', 1, 'hello reST!'),
+                                      ('<generated>', 0, ''),
+                                      ('dummy.rst', 0, ':mod:`foo`'),
+                                      ('dummy.rst', 1, '----------'),
+                                      ('dummy.rst', 2, ''),
+                                      ('dummy.rst', 3, 'hello')]
+
+
 def test_textwidth():
     assert textwidth('Hello') == 5
     assert textwidth('русский язык') == 12

--- a/tests/test_util_rst.py
+++ b/tests/test_util_rst.py
@@ -103,8 +103,8 @@ def test_prepend_prolog_with_roles_in_sections(app):
                                       ('dummy.rst', 6, 'hello')]
 
 
-def test_prepend_prolog_with_roles_in_sections_with_CR(app):
-    # prolog having CR at tail
+def test_prepend_prolog_with_roles_in_sections_with_newline(app):
+    # prologue with trailing line break
     prolog = 'this is rst_prolog\nhello reST!\n'
     content = StringList([':mod:`foo`', '-' * 10, '', 'hello'], 'dummy.rst')
     prepend_prolog(content, prolog)
@@ -118,8 +118,8 @@ def test_prepend_prolog_with_roles_in_sections_with_CR(app):
                                       ('dummy.rst', 3, 'hello')]
 
 
-def test_prepend_prolog_with_roles_in_sections_without_CR(app):
-    # prolog not having CR at tail
+def test_prepend_prolog_with_roles_in_sections_without_newline(app):
+    # prologue with no trailing line break
     prolog = 'this is rst_prolog\nhello reST!'
     content = StringList([':mod:`foo`', '-' * 10, '', 'hello'], 'dummy.rst')
     prepend_prolog(content, prolog)


### PR DESCRIPTION
When an RST file contains a section starting with an RST role and when ``rst_prolog`` is set, the prolog is inserted betweeen the title and the heading, causing the title to be incorrectly rendered.

For instance, if `rst_epilog = ".. |foo| replace:: The foo"`, then

```rst
:mod:`foo` - |foo|
------------------
The foo module.
```

was actually transformed into

```rst
:mod:`foo` - |foo|

.. |foo| replace:: The foo

------------------
The foo module.
```

instead of 

```rst
.. |foo| replace:: The foo

:mod:`foo` - |foo|
------------------
The foo module.
```

Fix #11437.

