### PR TITLE
fix #11446: linkcheck should split url only if # part of anchor

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -287,8 +287,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
 
         def check_uri() -> tuple[str, str, int]:
             # split off anchor
-            pattern = r"(.+/[^/]*)#([^/]*?/?$)"
-            match = re.search(pattern, uri)
+            uri_pattern = r"(.+/[^/]*)#([^/]*?/?$)"
+            match = re.search(uri_pattern, uri)
             if match:
                 req_url, anchor = match.groups()
             else:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -287,15 +287,17 @@ class HyperlinkAvailabilityCheckWorker(Thread):
 
         def check_uri() -> tuple[str, str, int]:
             # split off anchor
-            if '#' in uri:
-                req_url, anchor = uri.split('#', 1)
-                for rex in self.anchors_ignore:
-                    if rex.match(anchor):
-                        anchor = None
-                        break
+            pattern = r"(.+/[^/]*)#([^/]*?/?$)"
+            match = re.search(pattern, uri)
+            if match:
+                req_url, anchor = match.groups()
             else:
-                req_url = uri
-                anchor = None
+                req_url, anchor = uri, None
+
+            for rex in self.anchors_ignore:
+                if anchor and rex.match(anchor):
+                    anchor = None
+                    break
 
             # handle non-ASCII URIs
             try:

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -734,6 +734,7 @@ def test_linkcheck_exclude_documents(app):
         },
     ]
 
+
 urls = [
     "https://www.example.com/path/to/resource#123",
     "https://www.example.com/path/to/#/resource#123",


### PR DESCRIPTION
fixes #11446

as described in the issue, the link checker incorrectly processes URLs that have a `#` that is part of the directory path, rather than designating the anchor. 

This pull request fixes this by splitting the URL using a regexp `(.+/[^/]*)#([^/]*?/?$)`, which is a complicated way of saying we want to split the URL by `#` only if it is not followed by more forward slashes. 

I've tested the implementation by hand on the URL `https://microsoft.github.io/pyright/#/type-concepts-advanced` as described in the issue and it works. So that nothing breaks in the future, I added a test that ensures that the following two URLs:

-     "https://www.example.com/path/to/resource#123"
-     "https://www.example.com/path/to/#/resource#123"
    
the anchor "123" is split off correctly. Although the test works, it's quite technical with the mockers that I used. If you guys have suggestions on how to improve, I'm all ears. 