### PR TITLE
fix: warning on Python 3.12 about deprecated utcfromtimestamp

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from codecs import open
 from collections import defaultdict
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from os import getenv, path, walk
 from time import time
 from typing import Any, Generator, Iterable
@@ -164,7 +164,7 @@ class I18nBuilder(Builder):
 # determine tzoffset once to remain unaffected by DST change during build
 timestamp = time()
 local_time = datetime.fromtimestamp(timestamp)
-utc_time = datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+utc_time = datetime.fromtimestamp(timestamp, timezone.utc)
 tzdelta = localtime - utc_time
     
 

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -165,7 +165,7 @@ class I18nBuilder(Builder):
 timestamp = time()
 local_time = datetime.fromtimestamp(timestamp)
 utc_time = datetime.fromtimestamp(timestamp, timezone.utc)
-tzdelta = localtime - utc_time
+tzdelta = local_time - utc_time
     
 
 # set timestamp from SOURCE_DATE_EPOCH if set

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -164,7 +164,7 @@ class I18nBuilder(Builder):
 # determine tzoffset once to remain unaffected by DST change during build
 timestamp = time()
 local_time = datetime.fromtimestamp(timestamp)
-utc_time = datetime.fromtimestamp(timestamp, timezone.utc)
+utc_time = datetime.fromtimestamp(timestamp, tz=timezone.utc)
 tzdelta = local_time - utc_time.replace(tzinfo=None)
 
 # set timestamp from SOURCE_DATE_EPOCH if set

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -163,8 +163,11 @@ class I18nBuilder(Builder):
 
 # determine tzoffset once to remain unaffected by DST change during build
 timestamp = time()
-tzdelta = datetime.fromtimestamp(timestamp) - \
-    datetime.utcfromtimestamp(timestamp)
+local_time = datetime.fromtimestamp(timestamp)
+utc_time = datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+tzdelta = localtime - utc_time
+    
+
 # set timestamp from SOURCE_DATE_EPOCH if set
 # see https://reproducible-builds.org/specs/source-date-epoch/
 source_date_epoch = getenv('SOURCE_DATE_EPOCH')

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -166,7 +166,6 @@ timestamp = time()
 local_time = datetime.fromtimestamp(timestamp)
 utc_time = datetime.fromtimestamp(timestamp, timezone.utc)
 tzdelta = local_time - utc_time.replace(tzinfo=None)
-    
 
 # set timestamp from SOURCE_DATE_EPOCH if set
 # see https://reproducible-builds.org/specs/source-date-epoch/

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -165,7 +165,7 @@ class I18nBuilder(Builder):
 timestamp = time()
 local_time = datetime.fromtimestamp(timestamp)
 utc_time = datetime.fromtimestamp(timestamp, timezone.utc)
-tzdelta = local_time - utc_time
+tzdelta = local_time - utc_time.replace(tzinfo=None)
     
 
 # set timestamp from SOURCE_DATE_EPOCH if set


### PR DESCRIPTION
See https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp

Subject: fix a warning when running on Python 3.12's betas.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- fix a warning when running on Python 3.12's betas.


Should be backward compatible (3.12's suggestion to use `datetime.UTC` was added in 3.11, so isn't that helpful - but that's just an alias for `datetime.timezone.utc`)