### PR TITLE
Fix HTML specification mandates value for attribute defer

### DIFF
--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -15,7 +15,7 @@
     <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
-  <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
+  <script src="{{ pathto('searchindex.js', 1) }}" defer="defer"></script>
   {{ super() }}
 {% endblock %}
 {% block body %}


### PR DESCRIPTION
## Bugfix

### Purpose

fixes xmllint warning:
```
Build finished. The HTML pages are in _build/html.
./search.html:20: parser error : Specification mandates value for attribute defer
  <script src="searchindex.js" defer></script>
                                    ^
-:1: parser error : Document is empty
```

there are more `defer` attributes across the repo, but they have values, thus the fixed file/line is the only one which needs a fix

let me know if the PR should be retargetted as it is bugfix