### PR TITLE
Re-structure the ``linkcheck`` builder

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -12,22 +12,27 @@ from html.parser import HTMLParser
 from os import path
 from queue import PriorityQueue, Queue
 from threading import Thread
-from typing import Any, Callable, Generator, Iterator, NamedTuple, Tuple, Union, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 from urllib.parse import unquote, urlparse, urlsplit, urlunparse
 
 from docutils import nodes
-from requests import Response
 from requests.exceptions import ConnectionError, HTTPError, SSLError, TooManyRedirects
 
-from sphinx.application import Sphinx
 from sphinx.builders.dummy import DummyBuilder
-from sphinx.config import Config
-from sphinx.environment import BuildEnvironment
 from sphinx.locale import __
 from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import encode_uri, logging, requests
 from sphinx.util.console import darkgray, darkgreen, purple, red, turquoise  # type: ignore
 from sphinx.util.nodes import get_node_line
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Generator, Iterator
+
+    from requests import Response
+
+    from sphinx.application import Sphinx
+    from sphinx.config import Config
+    from sphinx.environment import BuildEnvironment
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +63,6 @@ class RateLimit(NamedTuple):
     delay: float
     next_check: float
 
-
-# Tuple is old styled CheckRequest
-CheckRequestType = Union[CheckRequest, Tuple[float, str, str, int]]
 
 DEFAULT_REQUEST_HEADERS = {
     'Accept': 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -255,19 +255,18 @@ class HyperlinkAvailabilityCheckWorker(Thread):
         self.wqueue = wqueue
 
         self.anchors_ignore = [re.compile(x)
-                               for x in self.config.linkcheck_anchors_ignore]
+                               for x in config.linkcheck_anchors_ignore]
         self.documents_exclude = [re.compile(doc)
-                                  for doc in self.config.linkcheck_exclude_documents]
+                                  for doc in config.linkcheck_exclude_documents]
         self.auth = [(re.compile(pattern), auth_info) for pattern, auth_info
-                     in self.config.linkcheck_auth]
+                     in config.linkcheck_auth]
 
-        self.timeout = self.config.linkcheck_timeout
-        self.request_headers = self.config.linkcheck_request_headers
-        self.anchors = self.config.linkcheck_anchors
-        self.allowed_redirects = self.config.linkcheck_allowed_redirects
-        self.retries = self.config.linkcheck_retries
-        self.rate_limit_timeout = self.config.linkcheck_rate_limit_timeout
-
+        self.timeout = config.linkcheck_timeout
+        self.request_headers = config.linkcheck_request_headers
+        self.anchors = config.linkcheck_anchors
+        self.allowed_redirects = config.linkcheck_allowed_redirects
+        self.retries = config.linkcheck_retries
+        self.rate_limit_timeout = config.linkcheck_rate_limit_timeout
 
         super().__init__(daemon=True)
 
@@ -341,9 +340,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
         error_message = None
         status_code = -1
         response_url = retry_after = ''
-        for retrieval_method, retrieval_kwargs in _retrieval_methods(
-                self.anchors, anchor,
-        ):
+        for retrieval_method, retrieval_kwargs in _retrieval_methods(self.anchors, anchor):
             try:
                 with retrieval_method(url=req_url, auth=auth_info, config=self.config,
                                       **retrieval_kwargs, **kwargs) as response:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -196,7 +196,8 @@ class HyperlinkAvailabilityChecker:
         self.wqueue: PriorityQueue[CheckRequest] = PriorityQueue()
         self.num_workers: int = config.linkcheck_workers
 
-        self.to_ignore = [*map(re.compile, self.config.linkcheck_ignore)]
+        self.to_ignore: list[re.Pattern[str]] = list(map(re.compile,
+                                                         self.config.linkcheck_ignore))
 
     def check(self, hyperlinks: dict[str, Hyperlink]) -> Generator[CheckResult, None, None]:
         self.invoke_threads()
@@ -259,15 +260,18 @@ class HyperlinkAvailabilityCheckWorker(Thread):
         self.rqueue = rqueue
         self.wqueue = wqueue
 
-        self.anchors_ignore = [*map(re.compile, config.linkcheck_anchors_ignore)]
-        self.documents_exclude = [*map(re.compile, config.linkcheck_exclude_documents)]
+        self.anchors_ignore: list[re.Pattern[str]] = list(
+            map(re.compile, config.linkcheck_anchors_ignore))
+        self.documents_exclude: list[re.Pattern[str]] = list(
+            map(re.compile, config.linkcheck_exclude_documents))
         self.auth = [(re.compile(pattern), auth_info) for pattern, auth_info
                      in config.linkcheck_auth]
 
         self.timeout: int | float | None = config.linkcheck_timeout
         self.request_headers: dict[str, dict[str, str]] = config.linkcheck_request_headers
         self.check_anchors: bool = config.linkcheck_anchors
-        self.allowed_redirects: dict[re.Pattern[str], re.Pattern[str]] = config.linkcheck_allowed_redirects
+        self.allowed_redirects: dict[re.Pattern[str], re.Pattern[str]]
+        self.allowed_redirects = config.linkcheck_allowed_redirects
         self.retries: int = config.linkcheck_retries
         self.rate_limit_timeout = config.linkcheck_rate_limit_timeout
 

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -696,6 +696,7 @@ def inspect_main(argv: list[str]) -> None:
     class MockConfig:
         intersphinx_timeout: int | None = None
         tls_verify = False
+        tls_cacerts = None
         user_agent = None
 
     class MockApp:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -134,11 +134,13 @@ def _read_from_url(url: str, config: Config | None = None) -> IO:
     :return: data read from resource described by *url*
     :rtype: ``file``-like object
     """
-    r = requests.get(url, stream=True, config=config, timeout=config.intersphinx_timeout)
+    r = requests.get(url, stream=True, timeout=config.intersphinx_timeout,
+                     _user_agent=config.user_agent,
+                     _tls_info=(config.tls_verify, config.tls_cacerts))
     r.raise_for_status()
     r.raw.url = r.url
     # decode content-body based on the header.
-    # ref: https://github.com/kennethreitz/requests/issues/2155
+    # ref: https://github.com/psf/requests/issues/2155
     r.raw.read = functools.partial(r.raw.read, decode_content=True)
     return r.raw
 

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -25,12 +25,12 @@ def ignore_insecure_warning(verify: bool) -> Iterator[None]:
         yield
 
 
-def _get_tls_cacert(url: str, certs: str | dict | None) -> str | bool:
+def _get_tls_cacert(url: str, certs: str | dict[str, str] | None) -> str | bool:
     """Get additional CA cert for a specific URL."""
     if not certs:
         return True
     elif isinstance(certs, (str, tuple)):
-        return certs  # type: ignore
+        return certs
     else:
         hostname = urlsplit(url).netloc
         if '@' in hostname:
@@ -41,7 +41,7 @@ def _get_tls_cacert(url: str, certs: str | dict | None) -> str | bool:
 
 def get(url: str,
         _user_agent: str = '',
-        _tls_info: tuple[bool, str | dict | None] = (),
+        _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
         **kwargs: Any) -> requests.Response:
     """Sends a HEAD request like requests.head().
 
@@ -61,7 +61,7 @@ def get(url: str,
 
 def head(url: str,
          _user_agent: str = '',
-         _tls_info: tuple[bool, str | dict | None] = (),
+         _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
          **kwargs: Any) -> requests.Response:
     """Sends a HEAD request like requests.head().
 

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -15,6 +15,10 @@ import sphinx
 
 useragent_header = [('User-Agent',
                      'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0')]
+_SPHINX_USER_AGENT = (
+    f'Sphinx/{sphinx.__version__} requests/{requests.__version__} python/'
+    + '.'.join(map(str, sys.version_info[:3]))
+)
 
 
 @contextmanager
@@ -48,17 +52,6 @@ def _get_tls_cacert(url: str, tls_verify: bool,
         return certs.get(hostname, True)
 
 
-def _get_user_agent(user_agent: str | None) -> str:
-    if user_agent:
-        return user_agent
-    else:
-        return ' '.join([
-            f'Sphinx/{sphinx.__version__}',
-            f'requests/{requests.__version__}',
-            'python/%s' % '.'.join(map(str, sys.version_info[:3])),
-        ])
-
-
 def get(url: str, **kwargs: Any) -> requests.Response:
     """Sends a GET request like requests.get().
 
@@ -69,7 +62,7 @@ def get(url: str, **kwargs: Any) -> requests.Response:
         certs = getattr(config, 'tls_cacerts', None)
 
         kwargs.setdefault('verify', _get_tls_cacert(url, config.tls_verify, certs))
-        headers.setdefault('User-Agent', _get_user_agent(config.user_agent))
+        headers.setdefault('User-Agent', config.user_agent or _SPHINX_USER_AGENT)
     else:
         headers.setdefault('User-Agent', useragent_header[0][1])
 
@@ -87,7 +80,7 @@ def head(url: str, **kwargs: Any) -> requests.Response:
         certs = getattr(config, 'tls_cacerts', None)
 
         kwargs.setdefault('verify', _get_tls_cacert(url, config.tls_verify, certs))
-        headers.setdefault('User-Agent', _get_user_agent(config.user_agent))
+        headers.setdefault('User-Agent', config.user_agent or _SPHINX_USER_AGENT)
     else:
         headers.setdefault('User-Agent', useragent_header[0][1])
 

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -731,7 +731,7 @@ class FakeResponse:
 
 
 def test_limit_rate_default_sleep(app):
-    worker = HyperlinkAvailabilityCheckWorker(app.env, app.config, Queue(), Queue(), {})
+    worker = HyperlinkAvailabilityCheckWorker(app.config, Queue(), Queue(), {})
     with mock.patch('time.time', return_value=0.0):
         next_check = worker.limit_rate(FakeResponse.url, FakeResponse.headers.get("Retry-After"))
     assert next_check == 60.0
@@ -739,15 +739,14 @@ def test_limit_rate_default_sleep(app):
 
 def test_limit_rate_user_max_delay(app):
     app.config.linkcheck_rate_limit_timeout = 0.0
-    worker = HyperlinkAvailabilityCheckWorker(app.env, app.config, Queue(), Queue(), {})
+    worker = HyperlinkAvailabilityCheckWorker(app.config, Queue(), Queue(), {})
     next_check = worker.limit_rate(FakeResponse.url, FakeResponse.headers.get("Retry-After"))
     assert next_check is None
 
 
 def test_limit_rate_doubles_previous_wait_time(app):
     rate_limits = {"localhost": RateLimit(60.0, 0.0)}
-    worker = HyperlinkAvailabilityCheckWorker(app.env, app.config, Queue(), Queue(),
-                                              rate_limits)
+    worker = HyperlinkAvailabilityCheckWorker(app.config, Queue(), Queue(), rate_limits)
     with mock.patch('time.time', return_value=0.0):
         next_check = worker.limit_rate(FakeResponse.url, FakeResponse.headers.get("Retry-After"))
     assert next_check == 120.0
@@ -756,8 +755,7 @@ def test_limit_rate_doubles_previous_wait_time(app):
 def test_limit_rate_clips_wait_time_to_max_time(app):
     app.config.linkcheck_rate_limit_timeout = 90.0
     rate_limits = {"localhost": RateLimit(60.0, 0.0)}
-    worker = HyperlinkAvailabilityCheckWorker(app.env, app.config, Queue(), Queue(),
-                                              rate_limits)
+    worker = HyperlinkAvailabilityCheckWorker(app.config, Queue(), Queue(), rate_limits)
     with mock.patch('time.time', return_value=0.0):
         next_check = worker.limit_rate(FakeResponse.url, FakeResponse.headers.get("Retry-After"))
     assert next_check == 90.0
@@ -766,8 +764,7 @@ def test_limit_rate_clips_wait_time_to_max_time(app):
 def test_limit_rate_bails_out_after_waiting_max_time(app):
     app.config.linkcheck_rate_limit_timeout = 90.0
     rate_limits = {"localhost": RateLimit(90.0, 0.0)}
-    worker = HyperlinkAvailabilityCheckWorker(app.env, app.config, Queue(), Queue(),
-                                              rate_limits)
+    worker = HyperlinkAvailabilityCheckWorker(app.config, Queue(), Queue(), rate_limits)
     next_check = worker.limit_rate(FakeResponse.url, FakeResponse.headers.get("Retry-After"))
     assert next_check is None
 

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -31,11 +31,7 @@ class DefaultsHandler(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def do_HEAD(self):
-        if self.path[1:].rstrip() == "":
-            self.send_response(200, "OK")
-            self.send_header("Content-Length", "0")
-            self.end_headers()
-        elif self.path[1:].rstrip() == "anchor.html":
+        if self.path[1:].rstrip() in {"", "anchor.html"}:
             self.send_response(200, "OK")
             self.send_header("Content-Length", "0")
             self.end_headers()
@@ -230,9 +226,8 @@ def custom_handler(valid_credentials=(), success_criteria=lambda _: True):
 
         def authenticated(method):
             def method_if_authenticated(self):
-                if expected_token is None:
-                    return method(self)
-                elif self.headers["Authorization"] == f"Basic {expected_token}":
+                if (expected_token is None
+                        or self.headers["Authorization"] == f"Basic {expected_token}"):
                     return method(self)
                 else:
                     self.send_response(403, "Forbidden")


### PR DESCRIPTION
cc: @jayaddison

This PR re-organises and re-structures the ``linkcheck`` builder.

Of note:

- All functions defined within functions are factored out into top-level functions or class methods
- Classes and methods have been re-arranged (Builder, PostTransform, Checker, Worker)
- TLS verification on ``sphinx.util.requests`` has been changed to not pass the ``Config`` object all the way down
- The ``Hyperlink`` object now stores the document path
- ``BuildEnvironment`` and ``Config`` objects are used to extract properties and are not stored as class attributes

A