### PR TITLE
Keep "translated" attribute on translated nodes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@ Deprecated
 Features added
 --------------
 
+* #11157: Keep ``translated: True`` attribute on translated nodes.
 * #11415: Add a checksum to JavaScript and CSS asset URIs included within
   generated HTML, using the CRC32 algorithm.
 * :meth:`~sphinx.application.Sphinx.require_sphinx` now allows the version

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -512,11 +512,6 @@ class Locale(SphinxTransform):
                 node['raw_entries'] = entries
                 node['entries'] = new_entries
 
-        # remove translated attribute that is used for avoiding double translation.
-        matcher = NodeMatcher(translated=Any)
-        for translated in self.document.findall(matcher):  # type: nodes.Element
-            translated.delattr('translated')
-
 
 class RemoveTranslatableInline(SphinxTransform):
     """

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -616,7 +616,6 @@ def test_gettext_buildr_ignores_only_directive(app):
 
 
 @sphinx_intl
-@pytest.mark.test_params(shared_result='test_intl_gettext')
 def test_node_translated_attribute(app):
     app.build()
 

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -616,6 +616,21 @@ def test_gettext_buildr_ignores_only_directive(app):
 
 
 @sphinx_intl
+@pytest.mark.test_params(shared_result='test_intl_gettext')
+def test_node_translated_attribute(app):
+    app.build()
+
+    expected = 23
+    translated_nodes = 0
+
+    doctree = app.env.get_doctree('admonitions')
+    for node in doctree.traverse():
+        if hasattr(node, 'get') and node.get('translated', False):
+            translated_nodes += 1
+    assert translated_nodes == expected
+
+
+@sphinx_intl
 # use individual shared_result directory to avoid "incompatible doctree" error
 @pytest.mark.sphinx(testroot='builder-gettext-dont-rebuild-mo')
 def test_gettext_dont_rebuild_mo(make_app, app_params):


### PR DESCRIPTION
### Feature or Bugfix
Feature

### Purpose
`sphinx.transforms.Locale` iterates over all the nodes to replace its content with the translated version of the text if found. Since the process works in two phases, it adds an "internal" `translated: True` attribute to the docutils node when the translated text is found in phase 1, allowing phase 2 to skip this nodes and avoid re-processing them. Finally, this "internal" `translated` attribute is removed from all the nodes.

This particular commit deletes the code that removes the `translated` attribute from the nodes so developers can use it to improve the experience on translations. This attribute can be useful to calculate the translated percentage of a particular document, to visually mark paragraphs as not translated and many other applications.

### Example

I created a minimal example of how developers can use this `translated` attribute to develop Sphinx extensions: https://github.com/humitos/sphinx-translated-node-example

![Screenshot_2023-07-23_16-32-46](https://github.com/sphinx-doc/sphinx/assets/244656/89a1c61a-b08a-4deb-a179-2126886096ef)

### Detail
- #11157 

### Relates
- #1246

