### PR TITLE
linkcheck builder: begin using session-based HTTP requests

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -350,7 +350,9 @@ class HyperlinkAvailabilityCheckWorker(Thread):
 
         return status, info, code
 
-    def _retrieval_methods(self, check_anchors: bool, anchor: str) -> Iterator[tuple[Callable, dict]]:
+    def _retrieval_methods(self,
+                           check_anchors: bool,
+                           anchor: str) -> Iterator[tuple[Callable, dict]]:
         if not check_anchors or not anchor:
             yield self._session.head, {'allow_redirects': True}
         yield self._session.get, {'stream': True}

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -68,9 +68,9 @@ class _Session(requests.Session):
 
         This sets up User-Agent header and TLS verification automatically."""
         headers = kwargs.setdefault('headers', {})
-        headers.setdefault('User-Agent', kwargs.pop('_user_agent', _USER_AGENT))
-        if '_tls_info' in kwargs:
-            tls_verify, tls_cacerts = kwargs.pop('_tls_info')
+        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
+        if _tls_info:
+            tls_verify, tls_cacerts = _tls_info
             verify = bool(kwargs.get('verify', tls_verify))
             kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
         else:
@@ -90,9 +90,9 @@ class _Session(requests.Session):
 
         This sets up User-Agent header and TLS verification automatically."""
         headers = kwargs.setdefault('headers', {})
-        headers.setdefault('User-Agent', kwargs.pop('_user_agent', _USER_AGENT))
-        if '_tls_info' in kwargs:
-            tls_verify, tls_cacerts = kwargs.pop('_tls_info')
+        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
+        if _tls_info:
+            tls_verify, tls_cacerts = _tls_info
             verify = bool(kwargs.get('verify', tls_verify))
             kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
         else:

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -50,7 +50,7 @@ class _Session(requests.Session):
         self, method: str, url: str,
         _user_agent: str = '',
         _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-        **kwargs: Any
+        **kwargs: Any,
     ) -> requests.Response:
         """Sends a request with an HTTP verb and url.
 

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -57,7 +57,13 @@ def head(url: str, **kwargs: Any) -> requests.Response:
 
 class _Session(requests.Session):
 
-    def get(self, url: str, **kwargs: Any) -> requests.Response:  # type: ignore[override]
+    def get(  # type: ignore[override]
+        self,
+        url: str,
+        _user_agent: str = '',
+        _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
+        **kwargs: Any
+    ) -> requests.Response:
         """Sends a GET request like requests.get().
 
         This sets up User-Agent header and TLS verification automatically."""
@@ -73,7 +79,13 @@ class _Session(requests.Session):
         with ignore_insecure_warning(verify):
             return super().get(url, **kwargs)
 
-    def head(self, url: str, **kwargs: Any) -> requests.Response:  # type: ignore[override]
+    def head(  # type: ignore[override]
+        self,
+        url: str,
+        _user_agent: str = '',
+        _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
+        **kwargs: Any
+    ) -> requests.Response:
         """Sends a HEAD request like requests.head().
 
         This sets up User-Agent header and TLS verification automatically."""

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -81,7 +81,7 @@ def head(url: str,
 
 class _Session(requests.Session):
 
-    def get(self, url: str, **kwargs: Any) -> requests.Response:
+    def get(self, url: str, **kwargs: Any) -> requests.Response:  # type: ignore[override]
         """Sends a GET request like requests.get().
 
         This sets up User-Agent header and TLS verification automatically."""
@@ -97,7 +97,7 @@ class _Session(requests.Session):
         with ignore_insecure_warning(verify):
             return super().get(url, **kwargs)
 
-    def head(self, url: str, **kwargs: Any) -> requests.Response:
+    def head(self, url: str, **kwargs: Any) -> requests.Response:  # type: ignore[override]
         """Sends a HEAD request like requests.head().
 
         This sets up User-Agent header and TLS verification automatically."""

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -77,3 +77,46 @@ def head(url: str,
 
     with ignore_insecure_warning(verify):
         return requests.head(url, **kwargs)
+
+
+class _Session(requests.Session):
+
+    def get(self,
+            url: str,
+            _user_agent: str = '',
+            _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
+            **kwargs: Any) -> requests.Response:
+        """Sends a GET request like requests.get().
+
+        This sets up User-Agent header and TLS verification automatically."""
+        headers = kwargs.setdefault('headers', {})
+        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
+        if _tls_info:
+            tls_verify, tls_cacerts = _tls_info
+            verify = bool(kwargs.get('verify', tls_verify))
+            kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
+        else:
+            verify = kwargs.get('verify', True)
+
+        with ignore_insecure_warning(verify):
+            return super().get(url, **kwargs)
+
+    def head(self,
+            url: str,
+            _user_agent: str = '',
+            _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
+            **kwargs: Any) -> requests.Response:
+        """Sends a HEAD request like requests.head().
+
+        This sets up User-Agent header and TLS verification automatically."""
+        headers = kwargs.setdefault('headers', {})
+        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
+        if _tls_info:
+            tls_verify, tls_cacerts = _tls_info
+            verify = bool(kwargs.get('verify', tls_verify))
+            kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
+        else:
+            verify = kwargs.get('verify', True)
+
+        with ignore_insecure_warning(verify):
+            return super().head(url, **kwargs)

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -81,18 +81,14 @@ def head(url: str,
 
 class _Session(requests.Session):
 
-    def get(self,
-            url: str,
-            _user_agent: str = '',
-            _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-            **kwargs: Any) -> requests.Response:
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
         """Sends a GET request like requests.get().
 
         This sets up User-Agent header and TLS verification automatically."""
         headers = kwargs.setdefault('headers', {})
-        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
-        if _tls_info:
-            tls_verify, tls_cacerts = _tls_info
+        headers.setdefault('User-Agent', kwargs.pop('_user_agent', _USER_AGENT))
+        if '_tls_info' in kwargs:
+            tls_verify, tls_cacerts = kwargs.pop('_tls_info')
             verify = bool(kwargs.get('verify', tls_verify))
             kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
         else:
@@ -101,18 +97,14 @@ class _Session(requests.Session):
         with ignore_insecure_warning(verify):
             return super().get(url, **kwargs)
 
-    def head(self,
-             url: str,
-             _user_agent: str = '',
-             _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-             **kwargs: Any) -> requests.Response:
+    def head(self, url: str, **kwargs: Any) -> requests.Response:
         """Sends a HEAD request like requests.head().
 
         This sets up User-Agent header and TLS verification automatically."""
         headers = kwargs.setdefault('headers', {})
-        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
-        if _tls_info:
-            tls_verify, tls_cacerts = _tls_info
+        headers.setdefault('User-Agent', kwargs.pop('_user_agent', _USER_AGENT))
+        if '_tls_info' in kwargs:
+            tls_verify, tls_cacerts = kwargs.pop('_tls_info')
             verify = bool(kwargs.get('verify', tls_verify))
             kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
         else:

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -39,44 +39,20 @@ def _get_tls_cacert(url: str, certs: str | dict[str, str] | None) -> str | bool:
         return certs.get(hostname, True)
 
 
-def get(url: str,
-        _user_agent: str = '',
-        _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-        **kwargs: Any) -> requests.Response:
+def get(url: str, **kwargs: Any) -> requests.Response:
     """Sends a HEAD request like requests.head().
 
     This sets up User-Agent header and TLS verification automatically."""
-    headers = kwargs.setdefault('headers', {})
-    headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
-    if _tls_info:
-        tls_verify, tls_cacerts = _tls_info
-        verify = bool(kwargs.get('verify', tls_verify))
-        kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
-    else:
-        verify = kwargs.get('verify', True)
-
-    with ignore_insecure_warning(verify):
-        return requests.get(url, **kwargs)
+    with _Session() as session:
+        return session.get(url, **kwargs)
 
 
-def head(url: str,
-         _user_agent: str = '',
-         _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-         **kwargs: Any) -> requests.Response:
+def head(url: str, **kwargs: Any) -> requests.Response:
     """Sends a HEAD request like requests.head().
 
     This sets up User-Agent header and TLS verification automatically."""
-    headers = kwargs.setdefault('headers', {})
-    headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
-    if _tls_info:
-        tls_verify, tls_cacerts = _tls_info
-        verify = bool(kwargs.get('verify', tls_verify))
-        kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
-    else:
-        verify = kwargs.get('verify', True)
-
-    with ignore_insecure_warning(verify):
-        return requests.head(url, **kwargs)
+    with _Session() as session:
+        return session.head(url, **kwargs)
 
 
 class _Session(requests.Session):

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -102,10 +102,10 @@ class _Session(requests.Session):
             return super().get(url, **kwargs)
 
     def head(self,
-            url: str,
-            _user_agent: str = '',
-            _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-            **kwargs: Any) -> requests.Response:
+             url: str,
+             _user_agent: str = '',
+             _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
+             **kwargs: Any) -> requests.Response:
         """Sends a HEAD request like requests.head().
 
         This sets up User-Agent header and TLS verification automatically."""

--- a/sphinx/util/requests.py
+++ b/sphinx/util/requests.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any
 from urllib.parse import urlsplit
 
 import requests
@@ -14,15 +13,6 @@ import sphinx
 
 _USER_AGENT = (f'Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 '
                f'Sphinx/{sphinx.__version__}')
-
-
-@contextmanager
-def ignore_insecure_warning(verify: bool) -> Iterator[None]:
-    with warnings.catch_warnings():
-        if not verify:
-            # ignore InsecureRequestWarning if verify=False
-            warnings.filterwarnings("ignore", category=InsecureRequestWarning)
-        yield
 
 
 def _get_tls_cacert(url: str, certs: str | dict[str, str] | None) -> str | bool:
@@ -40,7 +30,7 @@ def _get_tls_cacert(url: str, certs: str | dict[str, str] | None) -> str | bool:
 
 
 def get(url: str, **kwargs: Any) -> requests.Response:
-    """Sends a HEAD request like requests.head().
+    """Sends a GET request like requests.get().
 
     This sets up User-Agent header and TLS verification automatically."""
     with _Session() as session:
@@ -56,15 +46,13 @@ def head(url: str, **kwargs: Any) -> requests.Response:
 
 
 class _Session(requests.Session):
-
-    def get(  # type: ignore[override]
-        self,
-        url: str,
+    def request(  # type: ignore[override]
+        self, method: str, url: str,
         _user_agent: str = '',
         _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
         **kwargs: Any
     ) -> requests.Response:
-        """Sends a GET request like requests.get().
+        """Sends a request with an HTTP verb and url.
 
         This sets up User-Agent header and TLS verification automatically."""
         headers = kwargs.setdefault('headers', {})
@@ -76,27 +64,10 @@ class _Session(requests.Session):
         else:
             verify = kwargs.get('verify', True)
 
-        with ignore_insecure_warning(verify):
-            return super().get(url, **kwargs)
+        if verify:
+            return super().request(method, url, **kwargs)
 
-    def head(  # type: ignore[override]
-        self,
-        url: str,
-        _user_agent: str = '',
-        _tls_info: tuple[bool, str | dict[str, str] | None] = (),  # type: ignore[assignment]
-        **kwargs: Any
-    ) -> requests.Response:
-        """Sends a HEAD request like requests.head().
-
-        This sets up User-Agent header and TLS verification automatically."""
-        headers = kwargs.setdefault('headers', {})
-        headers.setdefault('User-Agent', _user_agent or _USER_AGENT)
-        if _tls_info:
-            tls_verify, tls_cacerts = _tls_info
-            verify = bool(kwargs.get('verify', tls_verify))
-            kwargs.setdefault('verify', verify and _get_tls_cacert(url, tls_cacerts))
-        else:
-            verify = kwargs.get('verify', True)
-
-        with ignore_insecure_warning(verify):
-            return super().head(url, **kwargs)
+        with warnings.catch_warnings():
+            # ignore InsecureRequestWarning if verify=False
+            warnings.filterwarnings("ignore", category=InsecureRequestWarning)
+            return super().request(method, url, **kwargs)

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -104,7 +104,7 @@ def test_defaults(app):
     with http_server(DefaultsHandler):
         with ConnectionMeasurement() as m:
             app.build()
-        assert m.connection_count <= 10
+        assert m.connection_count <= 5
 
     # Text output
     assert (app.outdir / 'output.txt').exists()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
- Refactoring

### Purpose
- Reduce the number of HTTP connections used during linkchecking, reducing network resource usage.

### Detail
- Resolves #11324.

### Relates
- Re-spin of #11340 following some interim refactors and cleanups of the `linkcheck` builder.