### PR TITLE
Fix #11407: adjust the spelling in the example.

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -718,7 +718,7 @@ __ https://pygments.org/docs/lexers
          var_in_third=true
 
       Useful cases of these option is working with tag comments.
-      ``:start-after: [initialized]`` and ``:end-before: [initialized]`` options
+      ``:start-after: [initialize]`` and ``:end-before: [initialized]`` options
       keep lines between comments:
 
       .. code-block:: py
@@ -726,7 +726,7 @@ __ https://pygments.org/docs/lexers
          if __name__ == "__main__":
              # [initialize]
              app.start(":8000")
-             # [initialize]
+             # [initialized]
 
 
    When lines have been selected in any of the ways described above, the line


### PR DESCRIPTION
Subject: Fix Issue #11407 
### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Purpose
- The spelling in the example is incorrect, this PR fixes that. There is also a question of reducing ambiguity. The intention of the example is to show a string to indicate the beginning of a block and another string to match the end of the block.

### Detail
```
      Useful cases of these option is working with tag comments.
      ``:start-after: [initialize]`` and ``:end-before: [initialized]`` options
      keep lines between comments:

      .. code-block:: py

         if __name__ == "__main__":
             # [initialize]
             app.start(":8000")
             # [initialized]
```

### Relates
- [<URL or Ticket>](https://github.com/sphinx-doc/sphinx/issues/11407)

