### PR TITLE
Add ``tests/test-server.lock`` to ``.gitignore``

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ doc/_build/
 doc/locale/
 tests/.coverage
 tests/build/
+tests/test-server.lock
 utils/regression_test.js
 
 node_modules/


### PR DESCRIPTION
I'm a bit tired to always skip this file when using git so... let's add it to the `.gitignore`. 

By the way, this file is only created when running tests and must *not* be deleted (see https://github.com/sphinx-doc/sphinx/pull/11294#discussion_r1159460449). 