### PR TITLE
Use ``time.strftime`` for date formatting in the EUPB builder

### DIFF
--- a/sphinx/builders/_epub_base.py
+++ b/sphinx/builders/_epub_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import html
 import os
 import re
+import time
 from os import path
 from typing import Any, NamedTuple
 from urllib.parse import quote
@@ -20,7 +21,6 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.display import status_iterator
 from sphinx.util.fileutil import copy_asset_file
-from sphinx.util.i18n import format_date
 from sphinx.util.osutil import copyfile, ensuredir
 
 try:
@@ -479,6 +479,12 @@ class EpubBuilder(StandaloneHTMLBuilder):
         """Create a dictionary with all metadata for the content.opf
         file properly escaped.
         """
+
+        if (source_date_epoch := os.getenv('SOURCE_DATE_EPOCH')) is not None:
+            time_tuple = time.gmtime(int(source_date_epoch))
+        else:
+            time_tuple = time.gmtime()
+
         metadata: dict[str, Any] = {}
         metadata['title'] = html.escape(self.config.epub_title)
         metadata['author'] = html.escape(self.config.epub_author)
@@ -488,7 +494,7 @@ class EpubBuilder(StandaloneHTMLBuilder):
         metadata['copyright'] = html.escape(self.config.epub_copyright)
         metadata['scheme'] = html.escape(self.config.epub_scheme)
         metadata['id'] = html.escape(self.config.epub_identifier)
-        metadata['date'] = html.escape(format_date("%Y-%m-%d", language='en'))
+        metadata['date'] = html.escape(time.strftime('%Y-%m-%d', time_tuple))
         metadata['manifest_items'] = []
         metadata['spines'] = []
         metadata['guides'] = []

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -6,7 +6,9 @@ Originally derived from epub.py.
 from __future__ import annotations
 
 import html
+import os
 import re
+import time
 from os import path
 from typing import Any, NamedTuple
 
@@ -17,7 +19,6 @@ from sphinx.config import ENUM, Config
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.fileutil import copy_asset_file
-from sphinx.util.i18n import format_date
 from sphinx.util.osutil import make_filename
 
 logger = logging.getLogger(__name__)
@@ -99,12 +100,17 @@ class Epub3Builder(_epub_base.EpubBuilder):
         """
         writing_mode = self.config.epub_writing_mode
 
+        if (source_date_epoch := os.getenv('SOURCE_DATE_EPOCH')) is not None:
+            time_tuple = time.gmtime(int(source_date_epoch))
+        else:
+            time_tuple = time.gmtime()
+
         metadata = super().content_metadata()
         metadata['description'] = html.escape(self.config.epub_description)
         metadata['contributor'] = html.escape(self.config.epub_contributor)
         metadata['page_progression_direction'] = PAGE_PROGRESSION_DIRECTIONS.get(writing_mode)
         metadata['ibook_scroll_axis'] = IBOOK_SCROLL_AXIS.get(writing_mode)
-        metadata['date'] = html.escape(format_date("%Y-%m-%dT%H:%M:%SZ", language='en'))
+        metadata['date'] = html.escape(time.strftime("%Y-%m-%dT%H:%M:%SZ", time_tuple))
         metadata['version'] = html.escape(self.config.version)
         metadata['epub_version'] = self.config.epub_version
         return metadata


### PR DESCRIPTION
When language is hardcoded to English, we can avoid the indirection of ``sphinx.util.i18n.format_date`` and Babel.

