### PR TITLE
Fix LaTeX output of line-block

### DIFF
--- a/sphinx/texinputs/sphinxlatexobjects.sty
+++ b/sphinx/texinputs/sphinxlatexobjects.sty
@@ -351,13 +351,13 @@
 \DUprovidelength{\DUlineblockindent}{2.5em}
 \ifdefined\DUlineblock\else
   \newenvironment{DUlineblock}[1]{%
-    \list{}{\setlength{\partopsep}{\parskip}
-            \addtolength{\partopsep}{\baselineskip}
-            \setlength{\topsep}{0pt}
-            \setlength{\itemsep}{0.15\baselineskip}
-            \setlength{\parsep}{0pt}
-            \setlength{\leftmargin}{#1}}
-    \raggedright
+    \list{}{\setlength{\partopsep}{\parskip}%
+            \addtolength{\partopsep}{\baselineskip}%
+            \setlength{\topsep}{0pt}%
+            \setlength{\itemsep}{0.15\baselineskip}%
+            \setlength{\parsep}{0pt}%
+            \setlength{\leftmargin}{#1}}%
+    \raggedright%
   }
   {\endlist}
 \fi


### PR DESCRIPTION
Subject: Fix LaTeX output of line-block

### Feature or Bugfix

- Bugfix


### Purpose
- Because the newlines are not commented out, this leaves an empty token at the beginning of the block. This empty token manifests as a spurious empty line in certain contexts, for example when using the line block inside a definition list.

### Relates
- This closes #11529.

