### PR TITLE
Consistently name the object description options

### DIFF
--- a/doc/development/overview.rst
+++ b/doc/development/overview.rst
@@ -12,7 +12,7 @@ project's :file:`conf.py` file, but this is not available to you as an
 extension developer.
 
 .. module:: sphinx.application
-    :noindex:
+   :no-index:
 
 To ensure that another extension is activated as a part of your own extension,
 use the :meth:`sphinx.application.Sphinx.setup_extension` method. This will

--- a/doc/development/templating.rst
+++ b/doc/development/templating.rst
@@ -226,7 +226,7 @@ them to generate links or output multiply used elements.
    documents.
 
 .. function:: pathto(file, 1)
-   :noindex:
+   :no-index:
 
    Return the path to a *file* which is a filename relative to the root of the
    generated output.  Use this to refer to static files.

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -105,7 +105,7 @@ Emitting events
 ---------------
 
 .. class:: Sphinx
-   :noindex:
+   :no-index:
 
    .. automethod:: emit
 

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -303,7 +303,7 @@ inserting them into the page source under a suitable :rst:dir:`py:module`,
 
      .. versionadded:: 0.4
 
-   * All autodoc directives support the ``noindex`` flag option that has the
+   * All autodoc directives support the ``no-index`` flag option that has the
      same effect as for standard :rst:dir:`py:function` etc. directives: no
      index entries are generated for the documented object (and all
      autodocumented members).
@@ -724,7 +724,7 @@ There are also config values that you can set:
    .. versionadded:: 1.7
 
 .. confval:: suppress_warnings
-   :noindex:
+   :no-index:
 
    :mod:`autodoc` supports to suppress warning messages via
    :confval:`suppress_warnings`.  It allows following warnings types in
@@ -755,7 +755,7 @@ autodoc provides the following additional events:
    :param obj: the object itself
    :param options: the options given to the directive: an object with attributes
       ``inherited_members``, ``undoc_members``, ``show_inheritance`` and
-      ``noindex`` that are true if the flag option of same name was given to the
+      ``no-index`` that are true if the flag option of same name was given to the
       auto directive
    :param lines: the lines of the docstring, see above
 
@@ -786,7 +786,7 @@ autodoc provides the following additional events:
    :param obj: the object itself
    :param options: the options given to the directive: an object with attributes
       ``inherited_members``, ``undoc_members``, ``show_inheritance`` and
-      ``noindex`` that are true if the flag option of same name was given to the
+      ``no-index`` that are true if the flag option of same name was given to the
       auto directive
    :param signature: function signature, as a string of the form
       ``"(parameter_1, parameter_2)"``, or ``None`` if introspection didn't
@@ -849,5 +849,5 @@ member should be included in the documentation by using the following event:
       user handler does not override the decision
    :param options: the options given to the directive: an object with attributes
       ``inherited_members``, ``undoc_members``, ``show_inheritance`` and
-      ``noindex`` that are true if the flag option of same name was given to the
+      ``no-index`` that are true if the flag option of same name was given to the
       auto directive

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -349,7 +349,7 @@ Additionally, the following filters are available
    replaces the builtin Jinja `escape filter`_ that does html-escaping.
 
 .. function:: underline(s, line='=')
-   :noindex:
+   :no-index:
 
    Add a title underline to a piece of text.
 

--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -132,7 +132,7 @@ part (``sphinx``) from all names::
    :parts: -1
 
 .. py:class:: sphinx.ext.inheritance_diagram.InheritanceDiagram
-   :nocontentsentry:
+   :no-contents-entry:
    :noindexentry:
 
    The internal class that implements the ``inheritance-diagram`` directive.

--- a/doc/usage/extensions/inheritance.rst
+++ b/doc/usage/extensions/inheritance.rst
@@ -133,7 +133,7 @@ part (``sphinx``) from all names::
 
 .. py:class:: sphinx.ext.inheritance_diagram.InheritanceDiagram
    :no-contents-entry:
-   :noindexentry:
+   :no-index-entry:
 
    The internal class that implements the ``inheritance-diagram`` directive.
 

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -50,7 +50,7 @@ Typically it will also add entries in the shown general index.
 If you want to suppress the addition of an entry in the shown index, you can
 give the directive option flag ``:noindexentry:``.
 If you want to exclude the object description from the table of contents, you
-can give the directive option flag ``:nocontentsentry:``.
+can give the directive option flag ``:no-contents-entry:``.
 If you want to typeset an object description, without even making it available
 for cross-referencing, you can give the directive option flag ``:noindex:``
 (which implies ``:noindexentry:``).
@@ -71,6 +71,11 @@ options.
 .. versionadded:: 7.2
    The directive option ``no-typesetting`` in the Python, C, C++, Javascript,
    and reStructuredText domains.
+
+.. versionchanged:: 7.2
+   The directive option ``:nocontentsentry:`` was renamed to ``:no-contents-entry:``.
+   The previous name is retained as an alias, but will be deprecated and removed in
+   a future version of Sphinx.
 
 An example using a Python domain directive::
 
@@ -1021,19 +1026,19 @@ Example::
 This will be rendered as:
 
 .. c:struct:: Data
-   :nocontentsentry:
+   :no-contents-entry:
    :noindexentry:
 
    .. c:union:: @data
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
       .. c:var:: int a
-         :nocontentsentry:
+         :no-contents-entry:
          :noindexentry:
 
       .. c:var:: double b
-         :nocontentsentry:
+         :no-contents-entry:
          :noindexentry:
 
 Explicit ref: :c:var:`Data.@data.a`. Short-hand ref: :c:var:`Data.a`.
@@ -1116,11 +1121,11 @@ Inline Expressions and Types
    will be rendered as follows:
 
    .. c:var:: int a = 42
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
    .. c:function:: int f(int i)
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
    An expression: :c:expr:`a * f(a)` (or as text: :c:texpr:`a * f(a)`).
@@ -1340,26 +1345,26 @@ visibility statement (``public``, ``private`` or ``protected``).
    The example are rendered as follows.
 
    .. cpp:type:: std::vector<int> MyList
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
       A typedef-like declaration of a type.
 
    .. cpp:type:: MyContainer::const_iterator
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
       Declaration of a type alias with unspecified type.
 
    .. cpp:type:: MyType = std::unordered_map<int, std::string>
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
       Declaration of a type alias.
 
    .. cpp:type:: template<typename T> \
                  MyContainer = std::vector<T>
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
 .. rst:directive:: .. cpp:enum:: unscoped enum declaration
@@ -1455,7 +1460,7 @@ Options
 
 Some directives support options:
 
-- ``:noindexentry:`` and ``:nocontentsentry:``, see :ref:`basic-domain-markup`.
+- ``:noindexentry:`` and ``:no-contents-entry:``, see :ref:`basic-domain-markup`.
 - ``:tparam-line-spec:``, for templated declarations.
   If specified, each template parameter will be rendered on a separate line.
 
@@ -1487,19 +1492,19 @@ Example::
 This will be rendered as:
 
 .. cpp:class:: Data
-   :nocontentsentry:
+   :no-contents-entry:
    :noindexentry:
 
    .. cpp:union:: @data
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
       .. cpp:var:: int a
-         :nocontentsentry:
+         :no-contents-entry:
          :noindexentry:
 
       .. cpp:var:: double b
-         :nocontentsentry:
+         :no-contents-entry:
          :noindexentry:
 
 Explicit ref: :cpp:var:`Data::@data::a`. Short-hand ref: :cpp:var:`Data::a`.
@@ -1606,13 +1611,13 @@ introduction` instead of a template parameter list::
 They are rendered as follows.
 
 .. cpp:function:: std::Iterator{It} void advance(It &it)
-   :nocontentsentry:
+   :no-contents-entry:
    :noindexentry:
 
    A function template with a template parameter constrained to be an Iterator.
 
 .. cpp:class:: std::LessThanComparable{T} MySortedContainer
-   :nocontentsentry:
+   :no-contents-entry:
    :noindexentry:
 
    A class template with a template parameter constrained to be
@@ -1643,11 +1648,11 @@ Inline Expressions and Types
    will be rendered as follows:
 
    .. cpp:var:: int a = 42
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
    .. cpp:function:: int f(int i)
-      :nocontentsentry:
+      :no-contents-entry:
       :noindexentry:
 
    An expression: :cpp:expr:`a * f(a)` (or as text: :cpp:texpr:`a * f(a)`).

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -52,7 +52,7 @@ give the directive option flag ``:no-index-entry:``.
 If you want to exclude the object description from the table of contents, you
 can give the directive option flag ``:no-contents-entry:``.
 If you want to typeset an object description, without even making it available
-for cross-referencing, you can give the directive option flag ``:noindex:``
+for cross-referencing, you can give the directive option flag ``:no-index:``
 (which implies ``:no-index-entry:``).
 If you do not want to typeset anything, you can give the directive option flag
 ``:no-typesetting:``.  This can for example be used to create only a target and
@@ -74,6 +74,7 @@ options.
 
 .. versionchanged:: 7.2
 
+   *  The directive option ``:noindex:`` was renamed to ``:no-index:``.
    *  The directive option ``:noindexentry:`` was renamed to ``:no-index-entry:``.
    *  The directive option ``:nocontentsentry:`` was renamed to ``:no-contents-entry:``.
 
@@ -94,9 +95,9 @@ that are continued in the next line.  Example::
 
    .. py:function:: filterwarnings(action, message='', category=Warning, \
                                    module='', lineno=0, append=False)
-      :noindex:
+      :no-index:
 
-(This example also shows how to use the ``:noindex:`` flag.)
+(This example also shows how to use the ``:no-index:`` flag.)
 
 The domains also provide roles that link back to these object descriptions.
 For example, to link to one of the functions described in the example above,
@@ -652,7 +653,7 @@ For functions with optional parameters that don't have default values
 argument support), you can use brackets to specify the optional parts:
 
 .. py:function:: compile(source[, filename[, symbol]])
-   :noindex:
+   :no-index:
 
 It is customary to put the opening bracket before the comma.
 
@@ -730,7 +731,7 @@ explained by an example::
 This will render like this:
 
 .. py:function:: send_message(sender, recipient, message_body, [priority=1])
-   :noindex:
+   :no-index:
 
    Send a message to a recipient
 
@@ -2046,7 +2047,7 @@ The JavaScript domain (name **js**) provides the following directives:
    :rst:dir:`py:class` would, for example.
 
    By default, this directive will create a linkable entity and will cause an
-   entry in the global module index, unless the ``noindex`` option is
+   entry in the global module index, unless the ``no-index`` option is
    specified.  If this option is specified, the directive will only update the
    current module name.
 
@@ -2078,7 +2079,7 @@ The JavaScript domain (name **js**) provides the following directives:
    This is rendered as:
 
    .. js:function:: $.getJSON(href, callback[, errback])
-      :noindex:
+      :no-index:
 
       :param string href: An URI to the location of the resource.
       :param callback: Gets called with the object.
@@ -2126,7 +2127,7 @@ The JavaScript domain (name **js**) provides the following directives:
    This is rendered as:
 
    .. js:class:: MyAnimal(name[, age])
-      :noindex:
+      :no-index:
 
       :param string name: The name of the animal
       :param number age: an optional age for the animal
@@ -2182,12 +2183,12 @@ The reStructuredText domain (name **rst**) provides the following directives:
    will be rendered as:
 
    .. rst:directive:: foo
-      :noindex:
+      :no-index:
 
       Foo description.
 
    .. rst:directive:: .. bar:: baz
-      :noindex:
+      :no-index:
 
       Bar description.
 
@@ -2206,13 +2207,13 @@ The reStructuredText domain (name **rst**) provides the following directives:
    will be rendered as:
 
    .. rst:directive:: toctree
-      :noindex:
+      :no-index:
 
       .. rst:directive:option:: caption: caption of ToC
-         :noindex:
+         :no-index:
 
       .. rst:directive:option:: glob
-         :noindex:
+         :no-index:
 
    .. rubric:: options
 
@@ -2241,7 +2242,7 @@ The reStructuredText domain (name **rst**) provides the following directives:
    will be rendered as:
 
    .. rst:role:: foo
-      :noindex:
+      :no-index:
 
       Foo description.
 

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -74,9 +74,12 @@ options.
 
 .. versionchanged:: 7.2
 
-   *  The directive option ``:noindex:`` was renamed to ``:no-index:``.
-   *  The directive option ``:noindexentry:`` was renamed to ``:no-index-entry:``.
-   *  The directive option ``:nocontentsentry:`` was renamed to ``:no-contents-entry:``.
+   *  The directive option ``:noindex:`` was renamed
+      to ``:no-index:``.
+   *  The directive option ``:noindexentry:`` was renamed
+      to ``:no-index-entry:``.
+   *  The directive option ``:nocontentsentry:`` was renamed
+      to ``:no-contents-entry:``.
 
    The previous names are retained as aliases,
    but will be deprecated and removed

--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -48,12 +48,12 @@ A domain will typically keep an internal index of all entities to aid
 cross-referencing.
 Typically it will also add entries in the shown general index.
 If you want to suppress the addition of an entry in the shown index, you can
-give the directive option flag ``:noindexentry:``.
+give the directive option flag ``:no-index-entry:``.
 If you want to exclude the object description from the table of contents, you
 can give the directive option flag ``:no-contents-entry:``.
 If you want to typeset an object description, without even making it available
 for cross-referencing, you can give the directive option flag ``:noindex:``
-(which implies ``:noindexentry:``).
+(which implies ``:no-index-entry:``).
 If you do not want to typeset anything, you can give the directive option flag
 ``:no-typesetting:``.  This can for example be used to create only a target and
 index entry for later reference.
@@ -73,9 +73,13 @@ options.
    and reStructuredText domains.
 
 .. versionchanged:: 7.2
-   The directive option ``:nocontentsentry:`` was renamed to ``:no-contents-entry:``.
-   The previous name is retained as an alias, but will be deprecated and removed in
-   a future version of Sphinx.
+
+   *  The directive option ``:noindexentry:`` was renamed to ``:no-index-entry:``.
+   *  The directive option ``:nocontentsentry:`` was renamed to ``:no-contents-entry:``.
+
+   The previous names are retained as aliases,
+   but will be deprecated and removed
+   in a future version of Sphinx.
 
 An example using a Python domain directive::
 
@@ -1027,19 +1031,19 @@ This will be rendered as:
 
 .. c:struct:: Data
    :no-contents-entry:
-   :noindexentry:
+   :no-index-entry:
 
    .. c:union:: @data
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
       .. c:var:: int a
          :no-contents-entry:
-         :noindexentry:
+         :no-index-entry:
 
       .. c:var:: double b
          :no-contents-entry:
-         :noindexentry:
+         :no-index-entry:
 
 Explicit ref: :c:var:`Data.@data.a`. Short-hand ref: :c:var:`Data.a`.
 
@@ -1122,11 +1126,11 @@ Inline Expressions and Types
 
    .. c:var:: int a = 42
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
    .. c:function:: int f(int i)
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
    An expression: :c:expr:`a * f(a)` (or as text: :c:texpr:`a * f(a)`).
 
@@ -1346,26 +1350,26 @@ visibility statement (``public``, ``private`` or ``protected``).
 
    .. cpp:type:: std::vector<int> MyList
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
       A typedef-like declaration of a type.
 
    .. cpp:type:: MyContainer::const_iterator
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
       Declaration of a type alias with unspecified type.
 
    .. cpp:type:: MyType = std::unordered_map<int, std::string>
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
       Declaration of a type alias.
 
    .. cpp:type:: template<typename T> \
                  MyContainer = std::vector<T>
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
 .. rst:directive:: .. cpp:enum:: unscoped enum declaration
                    .. cpp:enum-struct:: scoped enum declaration
@@ -1460,7 +1464,7 @@ Options
 
 Some directives support options:
 
-- ``:noindexentry:`` and ``:no-contents-entry:``, see :ref:`basic-domain-markup`.
+- ``:no-index-entry:`` and ``:no-contents-entry:``, see :ref:`basic-domain-markup`.
 - ``:tparam-line-spec:``, for templated declarations.
   If specified, each template parameter will be rendered on a separate line.
 
@@ -1493,19 +1497,19 @@ This will be rendered as:
 
 .. cpp:class:: Data
    :no-contents-entry:
-   :noindexentry:
+   :no-index-entry:
 
    .. cpp:union:: @data
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
       .. cpp:var:: int a
          :no-contents-entry:
-         :noindexentry:
+         :no-index-entry:
 
       .. cpp:var:: double b
          :no-contents-entry:
-         :noindexentry:
+         :no-index-entry:
 
 Explicit ref: :cpp:var:`Data::@data::a`. Short-hand ref: :cpp:var:`Data::a`.
 
@@ -1612,13 +1616,13 @@ They are rendered as follows.
 
 .. cpp:function:: std::Iterator{It} void advance(It &it)
    :no-contents-entry:
-   :noindexentry:
+   :no-index-entry:
 
    A function template with a template parameter constrained to be an Iterator.
 
 .. cpp:class:: std::LessThanComparable{T} MySortedContainer
    :no-contents-entry:
-   :noindexentry:
+   :no-index-entry:
 
    A class template with a template parameter constrained to be
    LessThanComparable.
@@ -1649,11 +1653,11 @@ Inline Expressions and Types
 
    .. cpp:var:: int a = 42
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
    .. cpp:function:: int f(int i)
       :no-contents-entry:
-      :noindexentry:
+      :no-index-entry:
 
    An expression: :cpp:expr:`a * f(a)` (or as text: :cpp:texpr:`a * f(a)`).
 

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -55,9 +55,10 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
     final_argument_whitespace = True
     option_spec: OptionSpec = {
         'noindex': directives.flag,
-        'noindexentry': directives.flag,
+        'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
     }
 
@@ -218,7 +219,11 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
         node['noindex'] = noindex = ('noindex' in self.options)
-        node['noindexentry'] = ('noindexentry' in self.options)
+        node['no-index-entry'] = node['noindexentry'] = (
+            'no-index-entry' in self.options
+            # xref RemovedInSphinx90Warning
+            # deprecate noindexentry in Sphinx 9.0
+            or 'noindexentry' in self.options)
         node['no-contents-entry'] = node['nocontentsentry'] = (
             'no-contents-entry' in self.options
             # xref RemovedInSphinx90Warning

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -219,7 +219,11 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
         node['domain'] = self.domain
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
-        node['no-index'] = no_index = ('no-index' in self.options)
+        node['no-index'] = node['noindex'] = no_index = (
+            'no-index' in self.options
+            # xref RemovedInSphinx90Warning
+            # deprecate noindex in Sphinx 9.0
+            or 'noindex' in self.options)
         node['no-index-entry'] = node['noindexentry'] = (
             'no-index-entry' in self.options
             # xref RemovedInSphinx90Warning

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -54,10 +54,11 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
     optional_arguments = 0
     final_argument_whitespace = True
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
+        'no-index': directives.flag,
         'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindex': directives.flag,
         'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
     }
@@ -188,7 +189,7 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
 
         * find out if called as a domain-specific directive, set self.domain
         * create a `desc` node to fit all description inside
-        * parse standard options, currently `noindex`
+        * parse standard options, currently `no-index`
         * create an index node if needed as self.indexnode
         * parse all given signatures (as returned by self.get_signatures())
           using self.handle_signature(), which should either return a name
@@ -218,7 +219,7 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
         node['domain'] = self.domain
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
-        node['noindex'] = noindex = ('noindex' in self.options)
+        node['no-index'] = no_index = ('no-index' in self.options)
         node['no-index-entry'] = node['noindexentry'] = (
             'no-index-entry' in self.options
             # xref RemovedInSphinx90Warning
@@ -263,7 +264,7 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
                     signode['_toc_name'] = ''
             if name not in self.names:
                 self.names.append(name)
-                if not noindex:
+                if not no_index:
                     # only add target and index entry if this is the first
                     # description of the object with this name in this desc block
                     self.add_target_and_index(name, sig, signode)
@@ -286,7 +287,7 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
         if node['no-typesetting']:
             # Attempt to return the index node, and a new target node
             # containing all the ids of this node and its children.
-            # If ``:noindex:`` is set, or there are no ids on the node
+            # If ``:no-index:`` is set, or there are no ids on the node
             # or any of its children, then just return the index node,
             # as Docutils expects a target node to have at least one id.
             if node_ids := [node_id for el in node.findall(nodes.Element)

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -56,8 +56,9 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
     option_spec: OptionSpec = {
         'noindex': directives.flag,
         'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
     }
 
     # types of doc fields that this directive handles, see sphinx.util.docfields
@@ -218,7 +219,11 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
         node['objtype'] = node['desctype'] = self.objtype
         node['noindex'] = noindex = ('noindex' in self.options)
         node['noindexentry'] = ('noindexentry' in self.options)
-        node['nocontentsentry'] = ('nocontentsentry' in self.options)
+        node['no-contents-entry'] = node['nocontentsentry'] = (
+            'no-contents-entry' in self.options
+            # xref RemovedInSphinx90Warning
+            # deprecate nocontentsentry in Sphinx 9.0
+            or 'nocontentsentry' in self.options)
         node['no-typesetting'] = ('no-typesetting' in self.options)
         if self.domain:
             node['classes'].append(self.domain)

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3164,9 +3164,10 @@ class CObject(ObjectDescription[ASTDeclaration]):
     """
 
     option_spec: OptionSpec = {
-        'noindexentry': directives.flag,
+        'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
     }
@@ -3236,7 +3237,7 @@ class CObject(ObjectDescription[ASTDeclaration]):
 
             self.state.document.note_explicit_target(signode)
 
-        if 'noindexentry' not in self.options:
+        if 'no-index-entry' not in self.options:
             indexText = self.get_index_text(name)
             self.indexnode['entries'].append(('single', indexText, newestId, '', None))
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3165,8 +3165,9 @@ class CObject(ObjectDescription[ASTDeclaration]):
 
     option_spec: OptionSpec = {
         'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
     }
 

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3544,7 +3544,7 @@ class AliasTransform(SphinxTransform):
                 desc['domain'] = 'c'
                 # 'desctype' is a backwards compatible attribute
                 desc['objtype'] = desc['desctype'] = 'alias'
-                desc['noindex'] = True
+                desc['no-index'] = True
                 childContainer = desc
 
             for sChild in s.children:
@@ -3645,7 +3645,7 @@ class CAliasObject(ObjectDescription):
         node['domain'] = self.domain
         # 'desctype' is a backwards compatible attribute
         node['objtype'] = node['desctype'] = self.objtype
-        node['noindex'] = True
+        node['no-index'] = True
 
         self.names: list[str] = []
         aliasOptions = {

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7216,8 +7216,9 @@ class CPPObject(ObjectDescription[ASTDeclaration]):
 
     option_spec: OptionSpec = {
         'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
         'tparam-line-spec': directives.flag,
         'single-line-parameter-list': directives.flag,
     }

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7669,7 +7669,7 @@ class AliasTransform(SphinxTransform):
                 desc['domain'] = 'cpp'
                 # 'desctype' is a backwards compatible attribute
                 desc['objtype'] = desc['desctype'] = 'alias'
-                desc['noindex'] = True
+                desc['no-index'] = True
                 childContainer = desc
 
             for sChild in s._children:

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -7215,9 +7215,10 @@ class CPPObject(ObjectDescription[ASTDeclaration]):
     ]
 
     option_spec: OptionSpec = {
-        'noindexentry': directives.flag,
+        'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'tparam-line-spec': directives.flag,
         'single-line-parameter-list': directives.flag,
@@ -7296,7 +7297,7 @@ class CPPObject(ObjectDescription[ASTDeclaration]):
             if decl.objectType == 'concept':
                 isInConcept = True
                 break
-        if not isInConcept and 'noindexentry' not in self.options:
+        if not isInConcept and 'no-index-entry' not in self.options:
             strippedName = name
             for prefix in self.env.config.cpp_index_common_prefix:
                 if name.startswith(prefix):

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -43,10 +43,11 @@ class JSObject(ObjectDescription[tuple[str, str]]):
     allow_nesting = False
 
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
+        'no-index': directives.flag,
         'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindex': directives.flag,
         'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
@@ -280,8 +281,8 @@ class JSModule(SphinxDirective):
     Options
     -------
 
-    noindex
-        If the ``noindex`` option is specified, no linkable elements will be
+    no-index
+        If the ``:no-index:`` option is specified, no linkable elements will be
         created, and the module won't be added to the global module index. This
         is useful for splitting up the module definition across multiple
         sections or files.
@@ -294,16 +295,17 @@ class JSModule(SphinxDirective):
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
+        'no-index': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindex': directives.flag,
         'nocontentsentry': directives.flag,
     }
 
     def run(self) -> list[Node]:
         mod_name = self.arguments[0].strip()
         self.env.ref_context['js:module'] = mod_name
-        noindex = 'noindex' in self.options
+        no_index = 'no-index' in self.options
 
         content_node: Element = nodes.section()
         # necessary so that the child nodes get the right source/line set
@@ -311,7 +313,7 @@ class JSModule(SphinxDirective):
         nested_parse_with_titles(self.state, self.content, content_node, self.content_offset)
 
         ret: list[Node] = []
-        if not noindex:
+        if not no_index:
             domain = cast(JavaScriptDomain, self.env.get_domain('js'))
 
             node_id = make_id(self.env, self.state.document, 'module', mod_name)

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -44,9 +44,10 @@ class JSObject(ObjectDescription[tuple[str, str]]):
 
     option_spec: OptionSpec = {
         'noindex': directives.flag,
-        'noindexentry': directives.flag,
+        'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
     }
@@ -147,7 +148,7 @@ class JSObject(ObjectDescription[tuple[str, str]]):
         domain = cast(JavaScriptDomain, self.env.get_domain('js'))
         domain.note_object(fullname, self.objtype, node_id, location=signode)
 
-        if 'noindexentry' not in self.options:
+        if 'no-index-entry' not in self.options:
             indextext = self.get_index_text(mod_name, name_obj)  # type: ignore[arg-type]
             if indextext:
                 self.indexnode['entries'].append(('single', indextext, node_id, '', None))

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -45,8 +45,9 @@ class JSObject(ObjectDescription[tuple[str, str]]):
     option_spec: OptionSpec = {
         'noindex': directives.flag,
         'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
     }
 
@@ -293,8 +294,9 @@ class JSModule(SphinxDirective):
     final_argument_whitespace = False
     option_spec: OptionSpec = {
         'noindex': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
     }
 
     def run(self) -> list[Node]:

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -659,10 +659,11 @@ class PyObject(ObjectDescription[tuple[str, str]]):
     :vartype allow_nesting: bool
     """
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
+        'no-index': directives.flag,
         'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindex': directives.flag,
         'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
@@ -1263,9 +1264,10 @@ class PyModule(SphinxDirective):
     option_spec: OptionSpec = {
         'platform': lambda x: x,
         'synopsis': lambda x: x,
-        'noindex': directives.flag,
+        'no-index': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindex': directives.flag,
         'nocontentsentry': directives.flag,
         'deprecated': directives.flag,
     }
@@ -1274,7 +1276,7 @@ class PyModule(SphinxDirective):
         domain = cast(PythonDomain, self.env.get_domain('py'))
 
         modname = self.arguments[0].strip()
-        noindex = 'noindex' in self.options
+        no_index = 'no-index' in self.options
         self.env.ref_context['py:module'] = modname
 
         content_node: Element = nodes.section()
@@ -1283,7 +1285,7 @@ class PyModule(SphinxDirective):
         nested_parse_with_titles(self.state, self.content, content_node, self.content_offset)
 
         ret: list[Node] = []
-        if not noindex:
+        if not no_index:
             # note module to the domain
             node_id = make_id(self.env, self.state.document, 'module', modname)
             target = nodes.target('', '', ids=[node_id], ismod=True)
@@ -1511,7 +1513,7 @@ class PythonDomain(Domain):
             else:
                 # duplicated
                 logger.warning(__('duplicate object description of %s, '
-                                  'other instance in %s, use :noindex: for one of them'),
+                                  'other instance in %s, use :no-index: for one of them'),
                                name, other.docname, location=location)
         self.objects[name] = ObjectEntry(self.env.docname, node_id, objtype, aliased)
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -660,9 +660,10 @@ class PyObject(ObjectDescription[tuple[str, str]]):
     """
     option_spec: OptionSpec = {
         'noindex': directives.flag,
-        'noindexentry': directives.flag,
+        'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
         'single-line-type-parameter-list': directives.flag,
@@ -855,7 +856,7 @@ class PyObject(ObjectDescription[tuple[str, str]]):
             domain.note_object(canonical_name, self.objtype, node_id, aliased=True,
                                location=signode)
 
-        if 'noindexentry' not in self.options:
+        if 'no-index-entry' not in self.options:
             indextext = self.get_index_text(modname, name_cls)
             if indextext:
                 self.indexnode['entries'].append(('single', indextext, node_id, '', None))
@@ -959,7 +960,7 @@ class PyFunction(PyObject):
     def add_target_and_index(self, name_cls: tuple[str, str], sig: str,
                              signode: desc_signature) -> None:
         super().add_target_and_index(name_cls, sig, signode)
-        if 'noindexentry' not in self.options:
+        if 'no-index-entry' not in self.options:
             modname = self.options.get('module', self.env.ref_context.get('py:module'))
             node_id = signode['ids'][0]
 

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -661,8 +661,9 @@ class PyObject(ObjectDescription[tuple[str, str]]):
     option_spec: OptionSpec = {
         'noindex': directives.flag,
         'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
         'single-line-parameter-list': directives.flag,
         'single-line-type-parameter-list': directives.flag,
         'module': directives.unchanged,
@@ -1262,8 +1263,9 @@ class PyModule(SphinxDirective):
         'platform': lambda x: x,
         'synopsis': lambda x: x,
         'noindex': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
         'deprecated': directives.flag,
     }
 

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -35,9 +35,10 @@ class ReSTMarkup(ObjectDescription[str]):
     """
     option_spec: OptionSpec = {
         'noindex': directives.flag,
-        'noindexentry': directives.flag,
+        'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
     }
 
@@ -49,7 +50,7 @@ class ReSTMarkup(ObjectDescription[str]):
         domain = cast(ReSTDomain, self.env.get_domain('rst'))
         domain.note_object(self.objtype, name, node_id, location=signode)
 
-        if 'noindexentry' not in self.options:
+        if 'no-index-entry' not in self.options:
             indextext = self.get_index_text(self.objtype, name)
             if indextext:
                 self.indexnode['entries'].append(('single', indextext, node_id, '', None))

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -34,10 +34,11 @@ class ReSTMarkup(ObjectDescription[str]):
     Description of generic reST markup.
     """
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
+        'no-index': directives.flag,
         'no-index-entry': directives.flag,
         'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'noindex': directives.flag,
         'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
     }

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -36,8 +36,9 @@ class ReSTMarkup(ObjectDescription[str]):
     option_spec: OptionSpec = {
         'noindex': directives.flag,
         'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
+        'no-contents-entry': directives.flag,
         'no-typesetting': directives.flag,
+        'nocontentsentry': directives.flag,
     }
 
     def add_target_and_index(self, name: str, sig: str, signode: desc_signature) -> None:

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -120,7 +120,7 @@ class TocTreeCollector(EnvironmentCollector):
                                 # Skip if explicitly disabled
                                 if sig_node.parent.get('no-contents-entry'):
                                     continue
-                                # Skip entries with no ID (e.g. with :noindex: set)
+                                # Skip entries with no ID (e.g. with :no-index: set)
                                 ids = sig_node['ids']
                                 if not ids:
                                     continue

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -118,7 +118,7 @@ class TocTreeCollector(EnvironmentCollector):
                                 if not sig_node.get('_toc_name', ''):
                                     continue
                                 # Skip if explicitly disabled
-                                if sig_node.parent.get('nocontentsentry'):
+                                if sig_node.parent.get('no-contents-entry'):
                                     continue
                                 # Skip entries with no ID (e.g. with :noindex: set)
                                 ids = sig_node['ids']

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -308,6 +308,7 @@ class Documenter:
     titles_allowed = True
 
     option_spec: OptionSpec = {
+        'no-index': bool_option,
         'noindex': bool_option,
     }
 
@@ -530,8 +531,8 @@ class Documenter:
             if i == 0:
                 prefix = " " * len(prefix)
 
-        if self.options.noindex:
-            self.add_line('   :noindex:', sourcename)
+        if self.options.no_index or self.options.noindex:
+            self.add_line('   :no-index:', sourcename)
         if self.objpath:
             # Be explicit about the module, this is necessary since .. class::
             # etc. don't support a prepended module name
@@ -953,13 +954,14 @@ class ModuleDocumenter(Documenter):
 
     option_spec: OptionSpec = {
         'members': members_option, 'undoc-members': bool_option,
-        'noindex': bool_option, 'inherited-members': inherited_members_option,
+        'no-index': bool_option, 'inherited-members': inherited_members_option,
         'show-inheritance': bool_option, 'synopsis': identity,
         'platform': identity, 'deprecated': bool_option,
         'member-order': member_order_option, 'exclude-members': exclude_members_option,
         'private-members': members_option, 'special-members': members_option,
         'imported-members': bool_option, 'ignore-module-all': bool_option,
         'no-value': bool_option,
+        'noindex': bool_option,
     }
 
     def __init__(self, *args: Any) -> None:
@@ -1425,11 +1427,12 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
     member_order = 20
     option_spec: OptionSpec = {
         'members': members_option, 'undoc-members': bool_option,
-        'noindex': bool_option, 'inherited-members': inherited_members_option,
+        'no-index': bool_option, 'inherited-members': inherited_members_option,
         'show-inheritance': bool_option, 'member-order': member_order_option,
         'exclude-members': exclude_members_option,
         'private-members': members_option, 'special-members': members_option,
         'class-doc-from': class_doc_from_option,
+        'noindex': bool_option,
     }
 
     # Must be higher than FunctionDocumenter, ClassDocumenter, and

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -367,7 +367,7 @@ def _process_docstring(app: Sphinx, what: str, name: str, obj: Any,
         The object to which the docstring belongs.
     options : sphinx.ext.autodoc.Options
         The options given to the directive: an object with attributes
-        inherited_members, undoc_members, show_inheritance and noindex that
+        inherited_members, undoc_members, show_inheritance and no_index that
         are True if the flag option of same name was given to the auto
         directive.
     lines : list of str
@@ -421,7 +421,7 @@ def _skip_member(app: Sphinx, what: str, name: str, obj: Any,
         does not override the decision
     options : sphinx.ext.autodoc.Options
         The options given to the directive: an object with attributes
-        inherited_members, undoc_members, show_inheritance and noindex that
+        inherited_members, undoc_members, show_inheritance and no_index that
         are True if the flag option of same name was given to the auto
         directive.
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -661,7 +661,7 @@ class GoogleDocstring:
             else:
                 lines.append('.. attribute:: ' + _name)
                 if self._opt:
-                    if 'no-index' in self._opt or 'noindex' in self._opt :
+                    if 'no-index' in self._opt or 'noindex' in self._opt:
                         lines.append('   :no-index:')
                 lines.append('')
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -108,7 +108,7 @@ class GoogleDocstring:
         The object to which the docstring belongs.
     options : :class:`sphinx.ext.autodoc.Options`, optional
         The options given to the directive: an object with attributes
-        inherited_members, undoc_members, show_inheritance and noindex that
+        inherited_members, undoc_members, show_inheritance and no_index that
         are True if the flag option of same name was given to the auto
         directive.
 
@@ -660,8 +660,9 @@ class GoogleDocstring:
                     lines.append(f':vartype {_name}: {_type}')
             else:
                 lines.append('.. attribute:: ' + _name)
-                if self._opt and 'noindex' in self._opt:
-                    lines.append('   :noindex:')
+                if self._opt:
+                    if 'no-index' in self._opt or 'noindex' in self._opt :
+                    lines.append('   :no-index:')
                 lines.append('')
 
                 fields = self._format_field('', '', _desc)
@@ -728,8 +729,9 @@ class GoogleDocstring:
         lines: list[str] = []
         for _name, _type, _desc in self._consume_fields(parse_type=False):
             lines.append('.. method:: %s' % _name)
-            if self._opt and 'noindex' in self._opt:
-                lines.append('   :noindex:')
+            if self._opt:
+                if 'no-index' in self._opt or 'noindex' in self._opt:
+                    lines.append('   :no-index:')
             if _desc:
                 lines.extend([''] + self._indent(_desc, 3))
             lines.append('')
@@ -1085,7 +1087,7 @@ class NumpyDocstring(GoogleDocstring):
         The object to which the docstring belongs.
     options : :class:`sphinx.ext.autodoc.Options`, optional
         The options given to the directive: an object with attributes
-        inherited_members, undoc_members, show_inheritance and noindex that
+        inherited_members, undoc_members, show_inheritance and no_index that
         are True if the flag option of same name was given to the auto
         directive.
 

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -662,7 +662,7 @@ class GoogleDocstring:
                 lines.append('.. attribute:: ' + _name)
                 if self._opt:
                     if 'no-index' in self._opt or 'noindex' in self._opt :
-                    lines.append('   :no-index:')
+                        lines.append('   :no-index:')
                 lines.append('')
 
                 fields = self._format_field('', '', _desc)

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -74,7 +74,8 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
         for key, value in kwargs.items():
             if key not in node:
                 if (key := key.replace('_', '-')) not in node:
-                    raise AssertionError(f'The node{xpath} does not have {key!r} attribute: {node!r}')
+                    raise AssertionError(f'The node{xpath} does not have {key!r}'
+                                         f' attribute: {node!r}')
             assert node[key] == value, \
                 f'The node{xpath}[{key}] is not {value!r}: {node[key]!r}'
 

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -72,8 +72,9 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
             'The node%s does not have any attributes' % xpath
 
         for key, value in kwargs.items():
-            assert key in node, \
-                f'The node{xpath} does not have {key!r} attribute: {node!r}'
+            if key not in node:
+                if (key := key.replace('_', '-')) not in node:
+                    raise AssertionError(f'The node{xpath} does not have {key!r} attribute: {node!r}')
             assert node[key] == value, \
                 f'The node{xpath}[{key}] is not {value!r}: {node[key]!r}'
 

--- a/tests/roots/test-ext-viewcode/objects.rst
+++ b/tests/roots/test-ext-viewcode/objects.rst
@@ -8,7 +8,7 @@ Testing object descriptions
 .. function:: func_without_body()
 
 .. function:: func_noindex
-   :noindex:
+   :no-index:
 
 .. function:: func_with_module
    :module: foolib

--- a/tests/roots/test-footnotes/index.rst
+++ b/tests/roots/test-footnotes/index.rst
@@ -176,7 +176,7 @@ The section with an object description
 ======================================
 
 .. py:function:: dummy(N)
-   :noindex:
+   :no-index:
 
 Footnotes referred twice
 ========================

--- a/tests/roots/test-intl/docfields.txt
+++ b/tests/roots/test-intl/docfields.txt
@@ -6,14 +6,14 @@ i18n with docfields
 .. single TypedField
 
 .. class:: Cls1
-   :noindex:
+   :no-index:
 
    :param param: description of parameter param
 
 .. grouped TypedFields
 
 .. class:: Cls2
-   :noindex:
+   :no-index:
 
    :param foo: description of parameter foo
    :param bar: description of parameter bar
@@ -22,14 +22,14 @@ i18n with docfields
 .. single GroupedField
 
 .. class:: Cls3(values)
-   :noindex:
+   :no-index:
 
    :raises ValueError: if the values are out of range
 
 .. grouped GroupedFields
 
 .. class:: Cls4(values)
-   :noindex:
+   :no-index:
 
    :raises TypeError: if the values are not valid
    :raises ValueError: if the values are out of range
@@ -38,7 +38,7 @@ i18n with docfields
 .. single Field
 
 .. class:: Cls5
-   :noindex:
+   :no-index:
 
    :returns: a new :class:`Cls3` instance
 

--- a/tests/roots/test-root/objects.txt
+++ b/tests/roots/test-root/objects.txt
@@ -34,7 +34,7 @@ Testing object descriptions
    :FIELd_name PARTial caps:
 
 .. function:: func_noindex
-   :noindex:
+   :no-index:
 
 .. function:: func_with_module
    :module: foolib

--- a/tests/roots/test-warnings/index.rst
+++ b/tests/roots/test-warnings/index.rst
@@ -2,7 +2,7 @@ test-warnings
 =============
 
 .. automodule:: autodoc_fodder
-   :noindex:
+   :no-index:
 
    .. autoclass:: MarkupError
 

--- a/tests/test_directives_no_typesetting.py
+++ b/tests/test_directives_no_typesetting.py
@@ -8,7 +8,7 @@ from sphinx.testing import restructuredtext
 from sphinx.testing.util import assert_node
 
 DOMAINS = [
-    # directive, noindex, noindexentry, signature of f, signature of g, index entry of g
+    # directive, noindex, no-index-entry, signature of f, signature of g, index entry of g
     ('c:function', False, True, 'void f()', 'void g()', ('single', 'g (C function)', 'c.g', '', None)),
     ('cpp:function', False, True, 'void f()', 'void g()', ('single', 'g (C++ function)', '_CPPv41gv', '', None)),
     ('js:function', True, True, 'f()', 'g()', ('single', 'g() (built-in function)', 'g', '', None)),
@@ -19,16 +19,16 @@ DOMAINS = [
 ]
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'),  DOMAINS)
-def test_object_description_no_typesetting(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'),  DOMAINS)
+def test_object_description_no_typesetting(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, nodes.target))
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_twice(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_twice(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'
@@ -38,8 +38,8 @@ def test_object_description_no_typesetting_twice(app, directive, noindex, noinde
     assert_node(doctree, (addnodes.index, addnodes.index, nodes.target, nodes.target))
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_noindex_orig(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_noindex_orig(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
     if not noindex:
         pytest.skip(f'{directive} does not support :noindex: option')
     text = (f'.. {directive}:: {sig_f}\n'
@@ -50,8 +50,8 @@ def test_object_description_no_typesetting_noindex_orig(app, directive, noindex,
     assert_node(doctree[2], addnodes.index, entries=[index_g])
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_noindex(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_noindex(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
     if not noindex:
         pytest.skip(f'{directive} does not support :noindex: option')
     text = (f'.. {directive}:: {sig_f}\n'
@@ -65,12 +65,12 @@ def test_object_description_no_typesetting_noindex(app, directive, noindex, noin
     assert_node(doctree[1], addnodes.index, entries=[index_g])
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_noindexentry(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
-    if not noindexentry:
-        pytest.skip(f'{directive} does not support :noindexentry: option')
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_no_index_entry(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
+    if not no_index_entry:
+        pytest.skip(f'{directive} does not support :no-index-entry: option')
     text = (f'.. {directive}:: {sig_f}\n'
-            f'   :noindexentry:\n'
+            f'   :no-index-entry:\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'
             f'   :no-typesetting:\n')
@@ -80,8 +80,8 @@ def test_object_description_no_typesetting_noindexentry(app, directive, noindex,
     assert_node(doctree[1], addnodes.index, entries=[index_g])
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_code(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_code(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'
@@ -94,8 +94,8 @@ def test_object_description_no_typesetting_code(app, directive, noindex, noindex
     assert_node(doctree, (addnodes.index, addnodes.index, nodes.target, nodes.target, nodes.literal_block))
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'noindexentry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_heading(app, directive, noindex, noindexentry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_heading(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'

--- a/tests/test_directives_no_typesetting.py
+++ b/tests/test_directives_no_typesetting.py
@@ -8,7 +8,7 @@ from sphinx.testing import restructuredtext
 from sphinx.testing.util import assert_node
 
 DOMAINS = [
-    # directive, noindex, no-index-entry, signature of f, signature of g, index entry of g
+    # directive, no-index, no-index-entry, signature of f, signature of g, index entry of g
     ('c:function', False, True, 'void f()', 'void g()', ('single', 'g (C function)', 'c.g', '', None)),
     ('cpp:function', False, True, 'void f()', 'void g()', ('single', 'g (C++ function)', '_CPPv41gv', '', None)),
     ('js:function', True, True, 'f()', 'g()', ('single', 'g() (built-in function)', 'g', '', None)),
@@ -19,16 +19,16 @@ DOMAINS = [
 ]
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'),  DOMAINS)
-def test_object_description_no_typesetting(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'),  DOMAINS)
+def test_object_description_no_typesetting(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, nodes.target))
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_twice(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_twice(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'
@@ -38,24 +38,24 @@ def test_object_description_no_typesetting_twice(app, directive, noindex, no_ind
     assert_node(doctree, (addnodes.index, addnodes.index, nodes.target, nodes.target))
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_noindex_orig(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
-    if not noindex:
-        pytest.skip(f'{directive} does not support :noindex: option')
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_noindex_orig(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
+    if not no_index:
+        pytest.skip(f'{directive} does not support :no-index: option')
     text = (f'.. {directive}:: {sig_f}\n'
-            f'   :noindex:\n'
+            f'   :no-index:\n'
             f'.. {directive}:: {sig_g}\n')
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, addnodes.desc, addnodes.index, addnodes.desc))
     assert_node(doctree[2], addnodes.index, entries=[index_g])
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_noindex(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
-    if not noindex:
-        pytest.skip(f'{directive} does not support :noindex: option')
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_noindex(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
+    if not no_index:
+        pytest.skip(f'{directive} does not support :no-index: option')
     text = (f'.. {directive}:: {sig_f}\n'
-            f'   :noindex:\n'
+            f'   :no-index:\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'
             f'   :no-typesetting:\n')
@@ -65,8 +65,8 @@ def test_object_description_no_typesetting_noindex(app, directive, noindex, no_i
     assert_node(doctree[1], addnodes.index, entries=[index_g])
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_no_index_entry(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_no_index_entry(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
     if not no_index_entry:
         pytest.skip(f'{directive} does not support :no-index-entry: option')
     text = (f'.. {directive}:: {sig_f}\n'
@@ -80,8 +80,8 @@ def test_object_description_no_typesetting_no_index_entry(app, directive, noinde
     assert_node(doctree[1], addnodes.index, entries=[index_g])
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_code(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_code(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'
@@ -94,8 +94,8 @@ def test_object_description_no_typesetting_code(app, directive, noindex, no_inde
     assert_node(doctree, (addnodes.index, addnodes.index, nodes.target, nodes.target, nodes.literal_block))
 
 
-@pytest.mark.parametrize(('directive', 'noindex', 'no-index-entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
-def test_object_description_no_typesetting_heading(app, directive, noindex, no_index_entry, sig_f, sig_g, index_g):
+@pytest.mark.parametrize(('directive', 'no_index', 'no_index_entry', 'sig_f', 'sig_g', 'index_g'), DOMAINS)
+def test_object_description_no_typesetting_heading(app, directive, no_index, no_index_entry, sig_f, sig_g, index_g):
     text = (f'.. {directive}:: {sig_f}\n'
             f'   :no-typesetting:\n'
             f'.. {directive}:: {sig_g}\n'

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -792,7 +792,7 @@ def test_domain_c_parse_cfunction(app):
             "PyType_GenericAlloc(PyTypeObject *type, Py_ssize_t nitems)")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
 
     entry = _get_obj(app, 'PyType_GenericAlloc')
     assert entry == ('index', 'c.PyType_GenericAlloc', 'function')
@@ -802,7 +802,7 @@ def test_domain_c_parse_cmember(app):
     text = ".. c:member:: PyObject* PyTypeObject.tp_bases"
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1], addnodes.desc, desctype="member",
-                domain="c", objtype="member", noindex=False)
+                domain="c", objtype="member", no_index=False)
 
     entry = _get_obj(app, 'PyTypeObject.tp_bases')
     assert entry == ('index', 'c.PyTypeObject.tp_bases', 'member')
@@ -812,7 +812,7 @@ def test_domain_c_parse_cvar(app):
     text = ".. c:var:: PyObject* PyClass_Type"
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree[1], addnodes.desc, desctype="var",
-                domain="c", objtype="var", noindex=False)
+                domain="c", objtype="var", no_index=False)
 
     entry = _get_obj(app, 'PyClass_Type')
     assert entry == ('index', 'c.PyClass_Type', 'member')
@@ -849,7 +849,7 @@ def test_cfunction_signature_with_c_maximum_signature_line_length_equal(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,
@@ -880,7 +880,7 @@ def test_cfunction_signature_with_c_maximum_signature_line_length_force_single(a
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,
@@ -910,7 +910,7 @@ def test_cfunction_signature_with_c_maximum_signature_line_length_break(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,
@@ -940,7 +940,7 @@ def test_cfunction_signature_with_maximum_signature_line_length_equal(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,
@@ -971,7 +971,7 @@ def test_cfunction_signature_with_maximum_signature_line_length_force_single(app
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,
@@ -1001,7 +1001,7 @@ def test_cfunction_signature_with_maximum_signature_line_length_break(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="c", objtype="function", noindex=False)
+                domain="c", objtype="function", no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,
@@ -1032,7 +1032,7 @@ def test_c_maximum_signature_line_length_overrides_global(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='c', objtype='function', noindex=False)
+                domain='c', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, "str"]],
         desc_sig_space,

--- a/tests/test_domain_c.py
+++ b/tests/test_domain_c.py
@@ -818,10 +818,10 @@ def test_domain_c_parse_cvar(app):
     assert entry == ('index', 'c.PyClass_Type', 'member')
 
 
-def test_domain_c_parse_noindexentry(app):
+def test_domain_c_parse_no_index_entry(app):
     text = (".. c:function:: void f()\n"
             ".. c:function:: void g()\n"
-            "   :noindexentry:\n")
+            "   :no-index-entry:\n")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C function)', 'c.f', '', None)])

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -1425,10 +1425,10 @@ _var cpp:member 1 index.html#_CPPv44$ -
     assert len(ws) == 0
 
 
-def test_domain_cpp_parse_noindexentry(app):
+def test_domain_cpp_parse_no_index_entry(app):
     text = (".. cpp:function:: void f()\n"
             ".. cpp:function:: void g()\n"
-            "   :noindexentry:\n")
+            "   :no-index-entry:\n")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f (C++ function)', '_CPPv41fv', '', None)])

--- a/tests/test_domain_cpp.py
+++ b/tests/test_domain_cpp.py
@@ -1521,7 +1521,7 @@ def test_cpp_function_signature_with_cpp_maximum_signature_line_length_equal(app
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,
@@ -1552,7 +1552,7 @@ def test_cpp_function_signature_with_cpp_maximum_signature_line_length_force_sin
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,
@@ -1582,7 +1582,7 @@ def test_cpp_function_signature_with_cpp_maximum_signature_line_length_break(app
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,
@@ -1612,7 +1612,7 @@ def test_cpp_function_signature_with_maximum_signature_line_length_equal(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,
@@ -1643,7 +1643,7 @@ def test_cpp_function_signature_with_maximum_signature_line_length_force_single(
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,
@@ -1673,7 +1673,7 @@ def test_cpp_function_signature_with_maximum_signature_line_length_break(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,
@@ -1698,7 +1698,7 @@ def test_cpp_maximum_signature_line_length_overrides_global(app):
                 desc_content)],
     ))
     assert_node(doctree[1], addnodes.desc, desctype='function',
-                domain='cpp', objtype='function', noindex=False)
+                domain='cpp', objtype='function', no_index=False)
     assert_node(doctree[1][0][0][3], [desc_parameterlist, desc_parameter, (
         [pending_xref, [desc_sig_name, 'str']],
         desc_sig_space,

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -223,10 +223,10 @@ def test_js_data(app):
     assert_node(doctree[1], addnodes.desc, domain="js", objtype="data", noindex=False)
 
 
-def test_noindexentry(app):
+def test_no_index_entry(app):
     text = (".. js:function:: f()\n"
             ".. js:function:: g()\n"
-            "   :noindexentry:\n")
+            "   :no-index-entry:\n")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f() (built-in function)', 'f', '', None)])

--- a/tests/test_domain_js.py
+++ b/tests/test_domain_js.py
@@ -195,7 +195,7 @@ def test_js_function(app):
                                                         [desc_parameter, ([desc_sig_name, "b"])])])
     assert_node(doctree[0], addnodes.index,
                 entries=[("single", "sum() (built-in function)", "sum", "", None)])
-    assert_node(doctree[1], addnodes.desc, domain="js", objtype="function", noindex=False)
+    assert_node(doctree[1], addnodes.desc, domain="js", objtype="function", no_index=False)
 
 
 def test_js_class(app):
@@ -209,7 +209,7 @@ def test_js_class(app):
                                   [desc_content, ()])]))
     assert_node(doctree[0], addnodes.index,
                 entries=[("single", "Application() (class)", "Application", "", None)])
-    assert_node(doctree[1], addnodes.desc, domain="js", objtype="class", noindex=False)
+    assert_node(doctree[1], addnodes.desc, domain="js", objtype="class", no_index=False)
 
 
 def test_js_data(app):
@@ -220,7 +220,7 @@ def test_js_data(app):
                                   [desc_content, ()])]))
     assert_node(doctree[0], addnodes.index,
                 entries=[("single", "name (global variable or constant)", "name", "", None)])
-    assert_node(doctree[1], addnodes.desc, domain="js", objtype="data", noindex=False)
+    assert_node(doctree[1], addnodes.desc, domain="js", objtype="data", no_index=False)
 
 
 def test_no_index_entry(app):
@@ -262,7 +262,7 @@ def test_jsfunction_signature_with_javascript_maximum_signature_line_length_equa
         )],
     ))
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "name"])])
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=False)
@@ -286,7 +286,7 @@ def test_jsfunction_signature_with_javascript_maximum_signature_line_length_forc
         )],
     ))
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "names"])])
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=False)
@@ -309,7 +309,7 @@ def test_jsfunction_signature_with_javascript_maximum_signature_line_length_brea
         )],
     ))
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "names"])])
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=True)
@@ -332,7 +332,7 @@ def test_jsfunction_signature_with_maximum_signature_line_length_equal(app):
         )],
     ))
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "name"])])
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=False)
@@ -356,7 +356,7 @@ def test_jsfunction_signature_with_maximum_signature_line_length_force_single(ap
         )],
     ))
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "names"])])
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=False)
@@ -379,7 +379,7 @@ def test_jsfunction_signature_with_maximum_signature_line_length_break(app):
         )],
     ))
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "names"])])
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=True)
@@ -401,7 +401,7 @@ def test_javascript_maximum_signature_line_length_overrides_global(app):
                                 desc_content)])
     assert_node(doctree, expected_doctree)
     assert_node(doctree[1], desc, desctype="function",
-                domain="js", objtype="function", noindex=False)
+                domain="js", objtype="function", no_index=False)
     expected_sig = [desc_parameterlist, desc_parameter, [desc_sig_name, "name"]]
     assert_node(doctree[1][0][1], expected_sig)
     assert_node(doctree[1][0][1], desc_parameterlist, multi_line_parameter_list=False)

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -1401,10 +1401,10 @@ def test_modindex_common_prefix(app):
     )
 
 
-def test_noindexentry(app):
+def test_no_index_entry(app):
     text = (".. py:function:: f()\n"
             ".. py:function:: g()\n"
-            "   :noindexentry:\n")
+            "   :no-index-entry:\n")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
     assert_node(doctree[0], addnodes.index, entries=[('pair', 'built-in function; f()', 'f', '', None)])
@@ -1412,7 +1412,7 @@ def test_noindexentry(app):
 
     text = (".. py:class:: f\n"
             ".. py:class:: g\n"
-            "   :noindexentry:\n")
+            "   :no-index-entry:\n")
     doctree = restructuredtext.parse(app, text)
     assert_node(doctree, (addnodes.index, desc, addnodes.index, desc))
     assert_node(doctree[0], addnodes.index, entries=[('single', 'f (built-in class)', 'f', '', None)])
@@ -1456,7 +1456,7 @@ def test_warn_missing_reference(app, status, warning):
 @pytest.mark.parametrize('include_options', (True, False))
 def test_signature_line_number(app, include_options):
     text = (".. py:function:: foo(bar : string)\n" +
-            ("   :noindexentry:\n" if include_options else ""))
+            ("   :no-index-entry:\n" if include_options else ""))
     doc = restructuredtext.parse(app, text)
     xrefs = list(doc.findall(condition=addnodes.pending_xref))
     assert len(xrefs) == 1

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -420,7 +420,7 @@ def test_pyfunction_signature(app):
                                                     [desc_returns, pending_xref, "str"])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, desc_parameter, ([desc_sig_name, "name"],
                                                       [desc_sig_punctuation, ":"],
@@ -438,7 +438,7 @@ def test_pyfunction_signature_full(app):
                                                     [desc_returns, pending_xref, "str"])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 [desc_parameterlist, ([desc_parameter, ([desc_sig_name, "a"],
                                                         [desc_sig_punctuation, ":"],
@@ -569,7 +569,7 @@ def test_optional_pyfunction_signature(app):
                                                     [desc_returns, pending_xref, "ast object"])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1],
                 ([desc_parameter, ([desc_sig_name, "source"])],
                  [desc_optional, ([desc_parameter, ([desc_sig_name, "filename"])],
@@ -585,7 +585,7 @@ def test_pyexception_signature(app):
                                                     [desc_name, "IOError"])],
                                   desc_content)]))
     assert_node(doctree[1], desc, desctype="exception",
-                domain="py", objtype="exception", noindex=False)
+                domain="py", objtype="exception", no_index=False)
 
 
 def test_pydata_signature(app):
@@ -606,7 +606,7 @@ def test_pydata_signature(app):
                                                     )],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="data",
-                domain="py", objtype="data", noindex=False)
+                domain="py", objtype="data", no_index=False)
 
 
 def test_pydata_signature_old(app):
@@ -619,7 +619,7 @@ def test_pydata_signature_old(app):
                                                                        "= 1")])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="data",
-                domain="py", objtype="data", noindex=False)
+                domain="py", objtype="data", no_index=False)
 
 
 def test_pydata_with_union_type_operator(app):
@@ -959,7 +959,7 @@ def test_pydecorator_signature(app):
                                                     [desc_name, "deco"])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
 
     assert 'deco' in domain.objects
     assert domain.objects['deco'] == ('index', 'deco', 'function', False)
@@ -974,7 +974,7 @@ def test_pydecoratormethod_signature(app):
                                                     [desc_name, "deco"])],
                                   desc_content)]))
     assert_node(doctree[1], addnodes.desc, desctype="method",
-                domain="py", objtype="method", noindex=False)
+                domain="py", objtype="method", no_index=False)
 
     assert 'deco' in domain.objects
     assert domain.objects['deco'] == ('index', 'deco', 'method', False)
@@ -1483,7 +1483,7 @@ def test_pyfunction_signature_with_python_maximum_signature_line_length_equal(ap
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1], [desc_parameterlist, desc_parameter, (
         [desc_sig_name, "name"],
         [desc_sig_punctuation, ":"],
@@ -1512,7 +1512,7 @@ def test_pyfunction_signature_with_python_maximum_signature_line_length_force_si
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1], [desc_parameterlist, desc_parameter, (
         [desc_sig_name, "names"],
         [desc_sig_punctuation, ":"],
@@ -1540,7 +1540,7 @@ def test_pyfunction_signature_with_python_maximum_signature_line_length_break(ap
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1], [desc_parameterlist, desc_parameter, (
         [desc_sig_name, "names"],
         [desc_sig_punctuation, ":"],
@@ -1568,7 +1568,7 @@ def test_pyfunction_signature_with_maximum_signature_line_length_equal(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1], [desc_parameterlist, desc_parameter, (
         [desc_sig_name, "name"],
         [desc_sig_punctuation, ":"],
@@ -1597,7 +1597,7 @@ def test_pyfunction_signature_with_maximum_signature_line_length_force_single(ap
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1], [desc_parameterlist, desc_parameter, (
         [desc_sig_name, "names"],
         [desc_sig_punctuation, ":"],
@@ -1625,7 +1625,7 @@ def test_pyfunction_signature_with_maximum_signature_line_length_break(app):
         )],
     ))
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     assert_node(doctree[1][0][1], [desc_parameterlist, desc_parameter, (
         [desc_sig_name, "names"],
         [desc_sig_punctuation, ":"],
@@ -1652,7 +1652,7 @@ def test_python_maximum_signature_line_length_overrides_global(app):
                                 desc_content)])
     assert_node(doctree, expected_doctree)
     assert_node(doctree[1], addnodes.desc, desctype="function",
-                domain="py", objtype="function", noindex=False)
+                domain="py", objtype="function", no_index=False)
     signame_node = [desc_sig_name, "name"]
     expected_sig = [desc_parameterlist, desc_parameter, (signame_node,
                                                          [desc_sig_punctuation, ":"],

--- a/tests/test_domain_rst.py
+++ b/tests/test_domain_rst.py
@@ -38,7 +38,7 @@ def test_rst_directive(app):
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="directive",
-                domain="rst", objtype="directive", noindex=False)
+                domain="rst", objtype="directive", no_index=False)
 
     # decorated
     text = ".. rst:directive:: .. toctree::"
@@ -49,7 +49,7 @@ def test_rst_directive(app):
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="directive",
-                domain="rst", objtype="directive", noindex=False)
+                domain="rst", objtype="directive", no_index=False)
 
 
 def test_rst_directive_with_argument(app):
@@ -62,7 +62,7 @@ def test_rst_directive_with_argument(app):
     assert_node(doctree[0],
                 entries=[("single", "toctree (directive)", "directive-toctree", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="directive",
-                domain="rst", objtype="directive", noindex=False)
+                domain="rst", objtype="directive", no_index=False)
 
 
 def test_rst_directive_option(app):
@@ -75,7 +75,7 @@ def test_rst_directive_option(app):
                 entries=[("single", ":foo: (directive option)",
                           "directive-option-foo", "", "F")])
     assert_node(doctree[1], addnodes.desc, desctype="directive:option",
-                domain="rst", objtype="directive:option", noindex=False)
+                domain="rst", objtype="directive:option", no_index=False)
 
 
 def test_rst_directive_option_with_argument(app):
@@ -89,7 +89,7 @@ def test_rst_directive_option_with_argument(app):
                 entries=[("single", ":foo: (directive option)",
                           "directive-option-foo", "", "F")])
     assert_node(doctree[1], addnodes.desc, desctype="directive:option",
-                domain="rst", objtype="directive:option", noindex=False)
+                domain="rst", objtype="directive:option", no_index=False)
 
 
 def test_rst_directive_option_type(app):
@@ -104,7 +104,7 @@ def test_rst_directive_option_type(app):
                 entries=[("single", ":foo: (directive option)",
                           "directive-option-foo", "", "F")])
     assert_node(doctree[1], addnodes.desc, desctype="directive:option",
-                domain="rst", objtype="directive:option", noindex=False)
+                domain="rst", objtype="directive:option", no_index=False)
 
 
 def test_rst_directive_and_directive_option(app):
@@ -122,7 +122,7 @@ def test_rst_directive_and_directive_option(app):
     assert_node(doctree[1][1][1], ([desc_signature, desc_name, ":bar:"],
                                    [desc_content, ()]))
     assert_node(doctree[1][1][1], addnodes.desc, desctype="directive:option",
-                domain="rst", objtype="directive:option", noindex=False)
+                domain="rst", objtype="directive:option", no_index=False)
 
 
 def test_rst_role(app):
@@ -134,4 +134,4 @@ def test_rst_role(app):
     assert_node(doctree[0],
                 entries=[("single", "ref (role)", "role-ref", "", None)])
     assert_node(doctree[1], addnodes.desc, desctype="role",
-                domain="rst", objtype="role", noindex=False)
+                domain="rst", objtype="role", no_index=False)

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -48,7 +48,7 @@ def make_directive_bridge(env):
         special_members = False,
         imported_members = False,
         show_inheritance = False,
-        noindex = False,
+        no_index = False,
         annotation = None,
         synopsis = '',
         platform = '',
@@ -925,22 +925,22 @@ def test_autodoc_ignore_module_all(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_noindex(app):
-    options = {"noindex": None}
+    options = {"no-index": None}
     actual = do_autodoc(app, 'module', 'target', options)
     assert list(actual) == [
         '',
         '.. py:module:: target',
-        '   :noindex:',
+        '   :no-index:',
         '',
     ]
 
-    # TODO: :noindex: should be propagated to children of target item.
+    # TODO: :no-index: should be propagated to children of target item.
 
     actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
     assert list(actual) == [
         '',
         '.. py:class:: Base()',
-        '   :noindex:',
+        '   :no-index:',
         '   :module: target.inheritance',
         '',
     ]

--- a/tests/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon_docstring.py
@@ -1162,19 +1162,19 @@ Methods:
 
         expected = """
 .. attribute:: arg
-   :noindex:
+   :no-index:
 
    description
 
 .. method:: func(i, j)
-   :noindex:
+   :no-index:
 
    
    description
 """  # noqa: W293
         config = Config()
         actual = str(GoogleDocstring(docstring, config=config, app=None, what='module',
-                                     options={'noindex': True}))
+                                     options={'no-index': True}))
         assert expected == actual
 
     def test_keywords_with_types(self):


### PR DESCRIPTION
*  The directive option ``:noindex:`` was renamed to ``:no-index:``.
*  The directive option ``:noindexentry:`` was renamed to ``:no-index-entry:``.
*  The directive option ``:nocontentsentry:`` was renamed to ``:no-contents-entry:``.

The previous names are retained as aliases, but will be deprecated and removed in a future version of Sphinx (9.0 or later).

A