### PR TITLE
Regression fixup: respect anchor-check configuration setting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,10 @@ Features added
 Bugs fixed
 ----------
 
+* #11542: linkcheck builder: regression: URL anchors were reported as missing
+  when the 'linkcheck_anchors' configuration setting was set to 'False'.
+  Patch by James Addison.
+
 Testing
 -------
 

--- a/CHANGES
+++ b/CHANGES
@@ -16,8 +16,8 @@ Features added
 Bugs fixed
 ----------
 
-* #11542: linkcheck builder: regression: URL anchors were reported as missing
-  when the 'linkcheck_anchors' configuration setting was set to 'False'.
+* #11542: linkcheck: Properly respect :confval:`linkcheck_anchors`
+  and do not spuriously report failures to validate anchors.
   Patch by James Addison.
 
 Testing

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -406,8 +406,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     _user_agent=self.user_agent,
                     _tls_info=(self.tls_verify, self.tls_cacerts),
                 ) as response:
-                    if response.ok and self.check_anchors:
-                        if anchor and not contains_anchor(response, anchor):
+                    if (self.check_anchors and response.ok and anchor
+                        and not contains_anchor(response, anchor)):
                             raise Exception(__(f'Anchor {anchor!r} not found'))
 
                 # Copy data we need from the (closed) response

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -406,8 +406,9 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     _user_agent=self.user_agent,
                     _tls_info=(self.tls_verify, self.tls_cacerts),
                 ) as response:
-                    if response.ok and self.check_anchors and anchor and not contains_anchor(response, anchor):
-                        raise Exception(__(f'Anchor {anchor!r} not found'))
+                    if response.ok and self.check_anchors:
+                        if anchor and not contains_anchor(response, anchor):
+                            raise Exception(__(f'Anchor {anchor!r} not found'))
 
                 # Copy data we need from the (closed) response
                 status_code = response.status_code

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -407,8 +407,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     _tls_info=(self.tls_verify, self.tls_cacerts),
                 ) as response:
                     if (self.check_anchors and response.ok and anchor
-                        and not contains_anchor(response, anchor)):
-                            raise Exception(__(f'Anchor {anchor!r} not found'))
+                            and not contains_anchor(response, anchor)):
+                        raise Exception(__(f'Anchor {anchor!r} not found'))
 
                 # Copy data we need from the (closed) response
                 status_code = response.status_code

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -406,7 +406,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     _user_agent=self.user_agent,
                     _tls_info=(self.tls_verify, self.tls_cacerts),
                 ) as response:
-                    if response.ok and anchor and not contains_anchor(response, anchor):
+                    if response.ok and self.check_anchors and anchor and not contains_anchor(response, anchor):
                         raise Exception(__(f'Anchor {anchor!r} not found'))
 
                 # Copy data we need from the (closed) response

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -152,6 +152,7 @@ def test_defaults(app):
     }
     # looking for '#top' and '#does-not-exist' not found should fail
     assert rowsby["http://localhost:7777/#top"]["info"] == "Anchor 'top' not found"
+    assert rowsby["http://localhost:7777/#top"]["status"] == "broken"
     assert rowsby["http://localhost:7777#does-not-exist"]["info"] == "Anchor 'does-not-exist' not found"
     # images should fail
     assert "Not Found for url: http://localhost:7777/image.png" in rowsby["http://localhost:7777/image.png"]["info"]
@@ -164,6 +165,21 @@ def test_defaults(app):
         'uri': 'http://localhost:7777/anchor.html#found',
         'info': '',
     }
+
+
+@pytest.mark.sphinx('linkcheck', testroot='linkcheck', freshenv=True, confoverrides={'linkcheck_anchors': False})
+def test_check_link_response_only(app):
+    with http_server(DefaultsHandler):
+        app.build()
+
+    # JSON output
+    assert (app.outdir / 'output.json').exists()
+    content = (app.outdir / 'output.json').read_text(encoding='utf8')
+
+    rows = [json.loads(x) for x in content.splitlines()]
+    row = rows[0]
+    rowsby = {row["uri"]: row for row in rows}
+    assert rowsby["http://localhost:7777/#top"]["status"] == "working"
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-too-many-retries', freshenv=True)

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -167,7 +167,9 @@ def test_defaults(app):
     }
 
 
-@pytest.mark.sphinx('linkcheck', testroot='linkcheck', freshenv=True, confoverrides={'linkcheck_anchors': False})
+@pytest.mark.sphinx(
+    'linkcheck', testroot='linkcheck', freshenv=True,
+    confoverrides={'linkcheck_anchors': False})
 def test_check_link_response_only(app):
     with http_server(DefaultsHandler):
         app.build()
@@ -177,7 +179,6 @@ def test_check_link_response_only(app):
     content = (app.outdir / 'output.json').read_text(encoding='utf8')
 
     rows = [json.loads(x) for x in content.splitlines()]
-    row = rows[0]
     rowsby = {row["uri"]: row for row in rows}
     assert rowsby["http://localhost:7777/#top"]["status"] == "working"
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fixes a regression introduced by refactoring in #11432 : the `linkcheck_anchors` setting was not being respected.

### Detail
- When anchor checking is disabled, the client uses an HTTP HEAD request instead of an HTTP GET request, to reduce network traffic optimization.
- A response to an HTTP HEAD request should not contain response content, but since #11432 the `linkcheck` builder code has been attempting to read content from these responses.

### Relates
- May resolve #11542.