### PR TITLE
Update ``test_captioned_code_block`` for latest Docutils

### DIFF
--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -53,9 +53,9 @@ def test_captioned_code_block(app, status, warning):
     content = (app.outdir / 'python.1').read_text(encoding='utf8')
 
     if docutils.__version_info__[:2] < (0, 21):
-        expected = r"""\
+        expected = """\
 .sp
-caption \fItest\fP rb
+caption \\fItest\\fP rb
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -70,9 +70,9 @@ end
 .UNINDENT
 """
     else:
-        expected = r"""\
+        expected = """\
 .sp
-caption \fItest\fP rb
+caption \\fItest\\fP rb
 .INDENT 0.0
 .INDENT 3.5
 .sp

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -1,7 +1,6 @@
 """Test the build process with manpage builder with the test root."""
 
-from textwrap import dedent
-
+import docutils
 import pytest
 
 from sphinx.builders.manpage import default_man_pages
@@ -53,26 +52,40 @@ def test_captioned_code_block(app, status, warning):
     app.builder.build_all()
     content = (app.outdir / 'python.1').read_text(encoding='utf8')
 
-    expected = dedent("""\
-    .sp
-    caption \\fItest\\fP rb
-    .INDENT 0.0
-    .INDENT 3.5
-    .sp
-    .EX
-    def ruby?
-        false
-    end
-    .EE
-    .UNINDENT
-    .UNINDENT
-    """)
+    if docutils.__version_info__[:2] < (0, 21):
+        expected = """\
+.sp
+caption \\fItest\\fP rb
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+def ruby?
+    false
+end
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+"""
+    else:
+        expected = """\
+.sp
+caption \\fItest\\fP rb
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+def ruby?
+    false
+end
+.EE
+.UNINDENT
+.UNINDENT
+"""
 
-    expected_docutils_pre_0_21 = (
-        expected.replace('.EX', '.nf\n.ft C').replace('.EE', '.ft P\n.fi')
-    )
-
-    assert (expected in content) or (expected_docutils_pre_0_21 in content)
+    assert expected in content
 
 
 def test_default_man_pages():

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -53,9 +53,9 @@ def test_captioned_code_block(app, status, warning):
     content = (app.outdir / 'python.1').read_text(encoding='utf8')
 
     if docutils.__version_info__[:2] < (0, 21):
-        expected = """\
+        expected = r"""\
 .sp
-caption \\fItest\\fP rb
+caption \fItest\fP rb
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -70,9 +70,9 @@ end
 .UNINDENT
 """
     else:
-        expected = """\
+        expected = r"""\
 .sp
-caption \\fItest\\fP rb
+caption \fItest\fP rb
 .INDENT 0.0
 .INDENT 3.5
 .sp

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -1,5 +1,7 @@
 """Test the build process with manpage builder with the test root."""
 
+from textwrap import dedent
+
 import pytest
 
 from sphinx.builders.manpage import default_man_pages
@@ -51,20 +53,26 @@ def test_captioned_code_block(app, status, warning):
     app.builder.build_all()
     content = (app.outdir / 'python.1').read_text(encoding='utf8')
 
-    assert ('.sp\n'
-            'caption \\fItest\\fP rb\n'
-            '.INDENT 0.0\n'
-            '.INDENT 3.5\n'
-            '.sp\n'
-            '.nf\n'
-            '.ft C\n'
-            'def ruby?\n'
-            '    false\n'
-            'end\n'
-            '.ft P\n'
-            '.fi\n'
-            '.UNINDENT\n'
-            '.UNINDENT\n' in content)
+    expected = dedent("""\
+    .sp
+    caption \\fItest\\fP rb
+    .INDENT 0.0
+    .INDENT 3.5
+    .sp
+    .EX
+    def ruby?
+        false
+    end
+    .EE
+    .UNINDENT
+    .UNINDENT
+    """)
+
+    expected_docutils_pre_0_21 = (
+        expected.replace('.EX', '.nf\n.ft C').replace('.EE', '.ft P\n.fi')
+    )
+
+    assert (expected in content) or (expected_docutils_pre_0_21 in content)
 
 
 def test_default_man_pages():


### PR DESCRIPTION
Subject: Make `test_build_manpage` pass with docutils HEAD

### Feature or Bugfix
- Bugfix

### Purpose
Docutils changed the tags used for literal blocks in manpages. This can be seen in CI: https://github.com/sphinx-doc/sphinx/actions/runs/5740649194/job/15558960493.

### Detail
- https://sourceforge.net/p/docutils/code/9430/

### Relates
- https://bugs.debian.org/1041809

