### PR TITLE
Update ``pygments`` CSS files checksums in tests.

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1188,7 +1188,7 @@ def test_assets_order(app):
     # css_files
     expected = [
         '_static/early.css',
-        '_static/pygments.css?v=b3523f8e',
+        '_static/pygments.css?v=4f649999',
         '_static/alabaster.css?v=039e1c02',
         'https://example.com/custom.css',
         '_static/normal.css',

--- a/tests/test_theming.py
+++ b/tests/test_theming.py
@@ -99,10 +99,10 @@ def test_dark_style(app, status, warning):
     assert (app.outdir / '_static' / 'pygments_dark.css').exists()
 
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
-    assert '<link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b76e3c8a" />' in result
+    assert '<link rel="stylesheet" type="text/css" href="_static/pygments.css?v=fa44fd50" />' in result
     assert ('<link id="pygments_dark_css" media="(prefers-color-scheme: dark)" '
             'rel="stylesheet" type="text/css" '
-            'href="_static/pygments_dark.css?v=e15ddae3" />') in result
+            'href="_static/pygments_dark.css?v=b20cc3f5" />') in result
 
 
 @pytest.mark.sphinx(testroot='theming')


### PR DESCRIPTION
Make the tests pass again.

@AA-Turner I know that you want them to be hardcoded, but should we actually compute them dynamically using our custom checksum to handle a (user) local installed version of `pygments` that may lead to different checksums ? Or should we freeze the `pygments` version? (currently it's only lowerbounded by `2.13`).

EDIT: Here it's for Pygments 2.16.1 that was released yesterday.

