### PR TITLE
Make stringify_annotation recursive on builtins with args

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Deprecated
 Features added
 --------------
 
+* #11570: Use short names when using PEP585 builtin generics
 * #11526: Support ``os.PathLike`` types and ``pathlib.Path`` objects
   in many more places.
 * #5474: coverage: Print summary statistics tables.

--- a/CHANGES
+++ b/CHANGES
@@ -31,7 +31,6 @@ Deprecated
 Features added
 --------------
 
-* #11570: Use short names when using PEP585 builtin generics
 * #11526: Support ``os.PathLike`` types and ``pathlib.Path`` objects
   in many more places.
 * #5474: coverage: Print summary statistics tables.
@@ -52,6 +51,8 @@ Features added
 * #10678: Emit "source-read" events for files read via
   the :dudir:`include` directive.
   Patch by Halldor Fannar.
+* #11570: Use short names when using :pep:`585` built-in generics.
+  Patch by Riccardo Mori.
 
 Bugs fixed
 ----------

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -276,11 +276,14 @@ def stringify_annotation(
     elif str(annotation).startswith('typing.Annotated'):  # for py310+
         pass
     elif annotation_module == 'builtins' and annotation_qualname:
-        if (args := getattr(annotation, '__args__', None)):  # PEP 585 generic
-            return (
-                f'{annotation_qualname}['
-                f'{", ".join(stringify_annotation(arg, mode=mode) for arg in args)}]'
-            )
+        if (args := getattr(annotation, '__args__', None)) is not None:  # PEP 585 generic
+            if not args:
+                return repr(annotation)
+            else:
+                return (
+                    f'{annotation_qualname}['
+                    f'{", ".join(stringify_annotation(arg, mode=mode) for arg in args)}]'
+                )
         else:
             return annotation_qualname
     elif annotation is Ellipsis:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -139,9 +139,9 @@ def restify(cls: type | None, mode: str = 'fully-qualified-except-typing') -> st
             else:
                 return ' | '.join(restify(a, mode) for a in cls.__args__)
         elif cls.__module__ in ('__builtin__', 'builtins'):
-            if (args := getattr(cls, '__args__', None)) is not None:
-                if not args:  # Empty tuple, list, ...
-                    return fr':py:class:`{cls.__name__}`\ [{repr(args)}]'
+            if hasattr(cls, '__args__'):
+                if not cls.__args__:  # Empty tuple, list, ...
+                    return fr':py:class:`{cls.__name__}`\ [{repr(cls.__args__)}]'
 
                 concatenated_args = ', '.join(restify(arg, mode) for arg in cls.__args__)
                 return fr':py:class:`{cls.__name__}`\ [{concatenated_args}]'

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -277,13 +277,11 @@ def stringify_annotation(
         pass
     elif annotation_module == 'builtins' and annotation_qualname:
         if (args := getattr(annotation, '__args__', None)) is not None:  # PEP 585 generic
-            if not args:
+            if not args:  # Empty tuple, list, ...
                 return repr(annotation)
-            else:
-                return (
-                    f'{annotation_qualname}['
-                    f'{", ".join(stringify_annotation(arg, mode=mode) for arg in args)}]'
-                )
+
+            annotation_args = ", ".join(stringify_annotation(arg, mode=mode) for arg in args)
+            return f'{annotation_qualname}[{annotation_args}]'
         else:
             return annotation_qualname
     elif annotation is Ellipsis:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -141,7 +141,7 @@ def restify(cls: type | None, mode: str = 'fully-qualified-except-typing') -> st
         elif cls.__module__ in ('__builtin__', 'builtins'):
             if hasattr(cls, '__args__'):
                 if not cls.__args__:  # Empty tuple, list, ...
-                    return fr':py:class:`{cls.__name__}`\ [{repr(cls.__args__)}]'
+                    return fr':py:class:`{cls.__name__}`\ [{cls.__args__!r}]'
 
                 concatenated_args = ', '.join(restify(arg, mode) for arg in cls.__args__)
                 return fr':py:class:`{cls.__name__}`\ [{concatenated_args}]'

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -139,7 +139,10 @@ def restify(cls: type | None, mode: str = 'fully-qualified-except-typing') -> st
             else:
                 return ' | '.join(restify(a, mode) for a in cls.__args__)
         elif cls.__module__ in ('__builtin__', 'builtins'):
-            if hasattr(cls, '__args__'):
+            if (args := getattr(cls, '__args__', None)) is not None:
+                if not args:  # Empty tuple, list, ...
+                    return fr':py:class:`{cls.__name__}`\ [{repr(args)}]'
+
                 concatenated_args = ', '.join(restify(arg, mode) for arg in cls.__args__)
                 return fr':py:class:`{cls.__name__}`\ [{concatenated_args}]'
             else:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -277,7 +277,10 @@ def stringify_annotation(
         pass
     elif annotation_module == 'builtins' and annotation_qualname:
         if (args := getattr(annotation, '__args__', None)):  # PEP 585 generic
-            return f'{annotation_qualname}[{", ".join(stringify_annotation(arg) for arg in args)}]'
+            return (
+                f'{annotation_qualname}['
+                f'{", ".join(stringify_annotation(arg, mode=mode) for arg in args)}]'
+            )
         else:
             return annotation_qualname
     elif annotation is Ellipsis:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -283,8 +283,8 @@ def stringify_annotation(
             if not args:  # Empty tuple, list, ...
                 return repr(annotation)
 
-            annotation_args = ", ".join(stringify_annotation(arg, mode=mode) for arg in args)
-            return f'{annotation_qualname}[{annotation_args}]'
+            concatenated_args = ", ".join(stringify_annotation(arg, mode=mode) for arg in args)
+            return f'{annotation_qualname}[{concatenated_args}]'
         else:
             return annotation_qualname
     elif annotation is Ellipsis:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -283,7 +283,7 @@ def stringify_annotation(
             if not args:  # Empty tuple, list, ...
                 return repr(annotation)
 
-            concatenated_args = ", ".join(stringify_annotation(arg, mode=mode) for arg in args)
+            concatenated_args = ', '.join(stringify_annotation(arg, mode) for arg in args)
             return f'{annotation_qualname}[{concatenated_args}]'
         else:
             return annotation_qualname

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -276,8 +276,8 @@ def stringify_annotation(
     elif str(annotation).startswith('typing.Annotated'):  # for py310+
         pass
     elif annotation_module == 'builtins' and annotation_qualname:
-        if hasattr(annotation, '__args__'):  # PEP 585 generic
-            return repr(annotation)
+        if (args := getattr(annotation, '__args__', None)):  # PEP 585 generic
+            return f'{annotation_qualname}[{", ".join(stringify_annotation(arg) for arg in args)}]'
         else:
             return annotation_qualname
     elif annotation is Ellipsis:

--- a/tests/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc.py
@@ -2018,7 +2018,7 @@ def test_autodoc_TYPE_CHECKING(app):
         '      :type: ~_io.StringIO',
         '',
         '',
-        '.. py:function:: spam(ham: ~collections.abc.Iterable[str]) -> tuple[gettext.NullTranslations, bool]',
+        '.. py:function:: spam(ham: ~collections.abc.Iterable[str]) -> tuple[~gettext.NullTranslations, bool]',
         '   :module: target.TYPE_CHECKING',
         '',
     ]

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -187,7 +187,7 @@ def test_restify_type_ForwardRef():
 
     assert restify(list[ForwardRef("myint")]) == ":py:class:`list`\\ [:py:class:`myint`]"
 
-    assert restify(Tuple[dict[ForwardRef("myint"), str], list[List[int]]]) == ":py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`myint`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]"
+    assert restify(Tuple[dict[ForwardRef("myint"), str], list[List[int]]]) == ":py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`myint`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]"  # type: ignore
 
 
 def test_restify_type_Literal():
@@ -518,6 +518,6 @@ def test_stringify_type_ForwardRef():
     assert stringify_annotation(list[ForwardRef("myint")]) == "list[myint]"
     assert stringify_annotation(list[ForwardRef("myint")], 'smart') == "list[myint]"
 
-    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]]) == "Tuple[dict[myint, str], list[List[int]]]"
-    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]], 'fully-qualified-except-typing') == "Tuple[dict[myint, str], list[List[int]]]"
-    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]], 'smart') == "~typing.Tuple[dict[myint, str], list[~typing.List[int]]]"
+    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]]) == "Tuple[dict[myint, str], list[List[int]]]"  # type: ignore
+    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]], 'fully-qualified-except-typing') == "Tuple[dict[myint, str], list[List[int]]]"  # type: ignore
+    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]], 'smart') == "~typing.Tuple[dict[myint, str], list[~typing.List[int]]]"  # type: ignore

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -509,6 +509,7 @@ def test_stringify_mock():
         assert stringify_annotation(unknown.secret.Class, 'fully-qualified-except-typing') == 'unknown.secret.Class'
         assert stringify_annotation(unknown.secret.Class, "smart") == 'unknown.secret.Class'
 
+
 def test_stringify_type_ForwardRef():
     from typing import ForwardRef  # type: ignore
 

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -213,7 +213,7 @@ def test_restify_pep_585():
     assert restify(List[dict[str, Tuple[str, ...]]]) == (":py:class:`~typing.List`\\ "
                                                "[:py:class:`dict`\\ "
                                                "[:py:class:`str`, :py:class:`~typing.Tuple`\\ "
-                                               "[:py:class:`str`, :py:class:`int`, ...]]]")
+                                               "[:py:class:`str`, ...]]]")
     assert restify(tuple[MyList[list[int]], int]) == (":py:class:`tuple`\\ ["
                                                 ":py:class:`tests.test_util_typing.MyList`\\ "
                                                 "[:py:class:`list`\\ [:py:class:`int`]], "

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -210,7 +210,7 @@ def test_restify_pep_585():
     assert restify(tuple[()]) == ":py:class:`tuple`\\ [()]"
 
     # Mix old typing with PEP 585
-    assert restify(List[dict[str, Tuple[str, int, ...]]]) == (":py:class:`~typing.List`\\ "
+    assert restify(List[dict[str, Tuple[str, ...]]]) == (":py:class:`~typing.List`\\ "
                                                "[:py:class:`dict`\\ "
                                                "[:py:class:`str`, :py:class:`~typing.Tuple`\\ "
                                                "[:py:class:`str`, :py:class:`int`, ...]]]")

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -187,7 +187,7 @@ def test_restify_type_ForwardRef():
 
     assert restify(list[ForwardRef("MyInt")]) == ":py:class:`list`\\ [:py:class:`MyInt`]"
 
-    assert restify(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]]) == ":py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`MyInt`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]"  # type: ignore
+    assert restify(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]]) == ":py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`MyInt`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]"  # type: ignore[attr-defined]
 
 
 def test_restify_type_Literal():
@@ -490,8 +490,8 @@ def test_stringify_type_union_operator():
     assert stringify_annotation(int | str | None) == "int | str | None"  # type: ignore[attr-defined]
     assert stringify_annotation(int | str | None, "smart") == "int | str | None"  # type: ignore[attr-defined]
 
-    assert stringify_annotation(int | tuple[dict[str, int | None], list[int | str]] | None) == "int | tuple[dict[str, int | None], list[int | str]] | None"  # type: ignore
-    assert stringify_annotation(int | tuple[dict[str, int | None], list[int | str]] | None, "smart") == "int | tuple[dict[str, int | None], list[int | str]] | None"  # type: ignore
+    assert stringify_annotation(int | tuple[dict[str, int | None], list[int | str]] | None) == "int | tuple[dict[str, int | None], list[int | str]] | None"  # type: ignore[attr-defined]
+    assert stringify_annotation(int | tuple[dict[str, int | None], list[int | str]] | None, "smart") == "int | tuple[dict[str, int | None], list[int | str]] | None"  # type: ignore[attr-defined]
 
     assert stringify_annotation(int | Struct) == "int | struct.Struct"  # type: ignore[attr-defined]
     assert stringify_annotation(int | Struct, "smart") == "int | ~struct.Struct"  # type: ignore[attr-defined]
@@ -511,7 +511,7 @@ def test_stringify_mock():
 
 
 def test_stringify_type_ForwardRef():
-    from typing import ForwardRef  # type: ignore
+    from typing import ForwardRef  # type: ignore[attr-defined]
 
     assert stringify_annotation(ForwardRef("MyInt")) == "MyInt"
     assert stringify_annotation(ForwardRef("MyInt"), 'smart') == "MyInt"
@@ -519,6 +519,6 @@ def test_stringify_type_ForwardRef():
     assert stringify_annotation(list[ForwardRef("MyInt")]) == "list[MyInt]"
     assert stringify_annotation(list[ForwardRef("MyInt")], 'smart') == "list[MyInt]"
 
-    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]]) == "Tuple[dict[MyInt, str], list[List[int]]]"  # type: ignore
-    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]], 'fully-qualified-except-typing') == "Tuple[dict[MyInt, str], list[List[int]]]"  # type: ignore
-    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]], 'smart') == "~typing.Tuple[dict[MyInt, str], list[~typing.List[int]]]"  # type: ignore
+    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]]) == "Tuple[dict[MyInt, str], list[List[int]]]"  # type: ignore[attr-defined]
+    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]], 'fully-qualified-except-typing') == "Tuple[dict[MyInt, str], list[List[int]]]"  # type: ignore[attr-defined]
+    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]], 'smart') == "~typing.Tuple[dict[MyInt, str], list[~typing.List[int]]]"  # type: ignore[attr-defined]

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -183,11 +183,11 @@ def test_restify_type_hints_alias():
 
 def test_restify_type_ForwardRef():
     from typing import ForwardRef  # type: ignore[attr-defined]
-    assert restify(ForwardRef("myint")) == ":py:class:`myint`"
+    assert restify(ForwardRef("MyInt")) == ":py:class:`MyInt`"
 
-    assert restify(list[ForwardRef("myint")]) == ":py:class:`list`\\ [:py:class:`myint`]"
+    assert restify(list[ForwardRef("MyInt")]) == ":py:class:`list`\\ [:py:class:`MyInt`]"
 
-    assert restify(Tuple[dict[ForwardRef("myint"), str], list[List[int]]]) == ":py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`myint`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]"  # type: ignore
+    assert restify(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]]) == ":py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`MyInt`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]"  # type: ignore
 
 
 def test_restify_type_Literal():
@@ -211,13 +211,13 @@ def test_restify_pep_585():
 
     # Mix old typing with PEP 585
     assert restify(List[dict[str, Tuple[str, ...]]]) == (":py:class:`~typing.List`\\ "
-                                               "[:py:class:`dict`\\ "
-                                               "[:py:class:`str`, :py:class:`~typing.Tuple`\\ "
-                                               "[:py:class:`str`, ...]]]")
+                                                         "[:py:class:`dict`\\ "
+                                                         "[:py:class:`str`, :py:class:`~typing.Tuple`\\ "
+                                                         "[:py:class:`str`, ...]]]")
     assert restify(tuple[MyList[list[int]], int]) == (":py:class:`tuple`\\ ["
-                                                ":py:class:`tests.test_util_typing.MyList`\\ "
-                                                "[:py:class:`list`\\ [:py:class:`int`]], "
-                                                ":py:class:`int`]")
+                                                      ":py:class:`tests.test_util_typing.MyList`\\ "
+                                                      "[:py:class:`list`\\ [:py:class:`int`]], "
+                                                      ":py:class:`int`]")
 
 
 @pytest.mark.skipif(sys.version_info[:2] <= (3, 9), reason='python 3.10+ is required.')
@@ -513,12 +513,12 @@ def test_stringify_mock():
 def test_stringify_type_ForwardRef():
     from typing import ForwardRef  # type: ignore
 
-    assert stringify_annotation(ForwardRef("myint")) == "myint"
-    assert stringify_annotation(ForwardRef("myint"), 'smart') == "myint"
+    assert stringify_annotation(ForwardRef("MyInt")) == "MyInt"
+    assert stringify_annotation(ForwardRef("MyInt"), 'smart') == "MyInt"
 
-    assert stringify_annotation(list[ForwardRef("myint")]) == "list[myint]"
-    assert stringify_annotation(list[ForwardRef("myint")], 'smart') == "list[myint]"
+    assert stringify_annotation(list[ForwardRef("MyInt")]) == "list[MyInt]"
+    assert stringify_annotation(list[ForwardRef("MyInt")], 'smart') == "list[MyInt]"
 
-    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]]) == "Tuple[dict[myint, str], list[List[int]]]"  # type: ignore
-    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]], 'fully-qualified-except-typing') == "Tuple[dict[myint, str], list[List[int]]]"  # type: ignore
-    assert stringify_annotation(Tuple[dict[ForwardRef("myint"), str], list[List[int]]], 'smart') == "~typing.Tuple[dict[myint, str], list[~typing.List[int]]]"  # type: ignore
+    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]]) == "Tuple[dict[MyInt, str], list[List[int]]]"  # type: ignore
+    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]], 'fully-qualified-except-typing') == "Tuple[dict[MyInt, str], list[List[int]]]"  # type: ignore
+    assert stringify_annotation(Tuple[dict[ForwardRef("MyInt"), str], list[List[int]]], 'smart') == "~typing.Tuple[dict[MyInt, str], list[~typing.List[int]]]"  # type: ignore

--- a/tests/test_util_typing.py
+++ b/tests/test_util_typing.py
@@ -174,10 +174,10 @@ def test_restify_type_hints_custom_class():
 
 def test_restify_type_hints_alias():
     MyStr = str
-    MyTupleDeprecated = Tuple[str, str]
+    MyTypingTuple = Tuple[str, str]
     MyTuple = tuple[str, str]
     assert restify(MyStr) == ":py:class:`str`"
-    assert restify(MyTupleDeprecated) == ":py:class:`~typing.Tuple`\\ [:py:class:`str`, :py:class:`str`]"
+    assert restify(MyTypingTuple) == ":py:class:`~typing.Tuple`\\ [:py:class:`str`, :py:class:`str`]"
     assert restify(MyTuple) == ":py:class:`tuple`\\ [:py:class:`str`, :py:class:`str`]"
 
 


### PR DESCRIPTION
Subject: Make stringify_annotation recursive on builtins with args

### Bugfix

### Purpose

The current implementation of `stringify_annotation` in case of a builtin type with arguments is to just return the internal representation of the type (`repr(annotation)`).
With the following patch it is recursively calling itself on the arguments. This way it correctly displaying all the types.

Consider the following example:

```python
from other.external.package import SomeType

class Example:
    def foo(self) -> list[SomeType]:
        # do stuff
        return ...
```

The autodoc sphinx extension, even when `autodoc_typehints_format = "short"`, it is showing the fully qualified name

```
foo() : list [other.external.package.SomeType]
```

While instead with the following patch it is showing

```
foo() : list [SomeType]
```
