### PR TITLE
Fix C coverage support for `sphinx.ext.coverage`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -80,6 +80,8 @@ Bugs fixed
 * #11473: Type annotations containing :py:data:`~typing.Literal` enumeration
   values now render correctly.
   Patch by Bénédikt Tran.
+* #11591: Fix support for C coverage in ``sphinx.ext.coverage`` extension.
+  Patch by Stephen Finucane.
 
 Testing
 -------

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -77,7 +77,7 @@ _macroKeywords = [
     'thread_local',
 ]
 
-# these are ordered by preceedence
+# these are ordered by precedence
 _expression_bin_ops = [
     ['||', 'or'],
     ['&&', 'and'],

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -114,8 +114,9 @@ class CoverageBuilder(Builder):
         self.write_c_coverage()
 
     def build_c_coverage(self) -> None:
-        # Fetch all the info from the header files
-        c_objects = self.env.domaindata['c']['objects']
+        c_objects = {}
+        for obj in self.env.domains['c'].get_objects():
+            c_objects[obj[2]] = obj[1]
         for filename in self.c_sourcefiles:
             undoc: set[tuple[str, str]] = set()
             with open(filename, encoding="utf-8") as f:
@@ -124,7 +125,11 @@ class CoverageBuilder(Builder):
                         match = regex.match(line)
                         if match:
                             name = match.groups()[0]
-                            if name not in c_objects:
+                            if key not in c_objects:
+                                undoc.add((key, name))
+                                continue
+
+                            if name not in c_objects[key]:
                                 for exp in self.c_ignorexps.get(key, []):
                                     if exp.match(name):
                                         break

--- a/tests/roots/test-root/objects.txt
+++ b/tests/roots/test-root/objects.txt
@@ -133,6 +133,8 @@ C items
 
 .. c:var:: int sphinx_global
 
+.. c:function:: PyObject* Py_SphinxFoo(void)
+
 
 Javascript items
 ================

--- a/tests/roots/test-root/special/api.h
+++ b/tests/roots/test-root/special/api.h
@@ -1,1 +1,2 @@
-PyAPI_FUNC(PyObject *) Py_SphinxTest();
+PyAPI_FUNC(PyObject *) Py_SphinxTest(void);
+PyAPI_FUNC(PyObject *) Py_SphinxFoo(void);


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

We were using the `objects` attribute of the C domain to pull all C objects that we were aware of. However, this is never set to any value nor does it ever appear to have been. Instead, we should have been using and parsing the return value from `get_objects`.

As an aside, this would suggest code coverage for C APIs has never worked or at least has not worked for a *very* long time. This explains why every GitHub hit for the various configuration options comes from Sphinx (for the implementation), Python (for the sole user), or a fork of these. This might be a good time to deprecate and remove this aspect of the coverage extension. We can discuss that elsewhere.

### Detail

- #11590

### Relates

(none)
