### PR TITLE
sphinx.ext.coverage: Remove errant print

### DIFF
--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -168,7 +168,6 @@ class CoverageBuilder(Builder):
         skip_undoc = self.config.coverage_skip_undoc_in_source
 
         for mod_name in modules:
-            print(mod_name)
             ignore = False
             for exp in self.mod_ignorexps:
                 if exp.match(mod_name):


### PR DESCRIPTION
### Feature or Bugfix

Bugfix

### Purpose

Remove an errant print. I suspect this was left over when the coverage report was introduced recently. This is noisy and we already have the capability to log missing modules to stdout as-is.

### Detail

(none)

### Relates

(none)
