### PR TITLE
Fix layout issues in agogo theme on smaller devices

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -86,6 +86,9 @@ Bugs fixed
   Patch by Bénédikt Tran.
 * #11591: Fix support for C coverage in ``sphinx.ext.coverage`` extension.
   Patch by Stephen Finucane.
+* #11594: HTML Theme: Enhancements to horizontal scrolling on smaller
+  devices in the ``agogo`` theme.
+  Patch by Lukas Engelter.
 
 Testing
 -------

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -19,6 +19,10 @@ body {
   line-height: 1.4em;
   color: black;
   background-color: {{ theme_bgcolor }};
+
+  /* fix for background colors breaking at horizontal
+    scrolling on smaller devices */
+  min-width: fit-content;
 }
 
 

--- a/sphinx/themes/agogo/static/agogo.css_t
+++ b/sphinx/themes/agogo/static/agogo.css_t
@@ -135,8 +135,7 @@ dt:target, .highlighted {
 /* Header */
 
 div.header {
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding: 1em;
 }
 
 div.header .headertitle {
@@ -173,8 +172,7 @@ img.logo {
 /* Content */
 div.content-wrapper {
   background-color: white;
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding: 1em;
 }
 
 div.document {


### PR DESCRIPTION
Subject: Fix layout issues in agogo theme on smaller devices

### Feature or Bugfix
- Feature

### Purpose
- This pull request aims to improve some layout issues in the agogo theme for devices with less screen space.
- I provided before and after screenshots to show the effects
- The changes can be shown on the agogo theme demo <https://sphinx-themes.org/sample-sites/default-agogo/> by generating the demos or by patching the browser css.

### Detail
- fix: background colors breaking at horizontal scrolling on smaller devices
  The body now grows to fit all the content, which makes the background colors of the theme no longer break as seen below:
  <img src="https://user-images.githubusercontent.com/3150012/260674091-2e3ca531-bd00-4177-bd04-7b93fb3b13ce.png" data-canonical-src="https://github.com/sphinx-doc/sphinx/assets/3150012/2e3ca531-bd00-4177-bd04-7b93fb3b13ce" alt="sphinx-agogo-scrolling-fix-current" width="350" /> <img src="https://user-images.githubusercontent.com/3150012/260674112-2caf5dd1-d777-4ebf-8622-3c9bccae34a9.png" data-canonical-src="https://github.com/sphinx-doc/sphinx/assets/3150012/2e3ca531-bd00-4177-bd04-7b93fb3b13ce" alt="sphinx-agogo-scrolling-fix-current" width="350" />
- feature: add whitespace around the web page frame to ease the eyes on smaller screens
  The content text is very hard to read without any margin to the browser window. Modern browsers eliminated all margins from the browser side, which results in a painful reading experience for some users. The margin to the side does not affect the presentation on bigger screens where the content has auto-growing margins left and right. To make the changes appealing, the header was grown equal parts:
  <img src="https://user-images.githubusercontent.com/3150012/260674095-f859928d-ea38-4136-9e1a-f521f57465be.png" data-canonical-src="https://github.com/sphinx-doc/sphinx/assets/3150012/f859928d-ea38-4136-9e1a-f521f57465be" alt="sphinx-agogo-scrolling-fix-current" width="350" /> <img src="https://user-images.githubusercontent.com/3150012/260674106-8f8249e3-2522-441f-8392-51047f36e902.png" data-canonical-src="https://github.com/sphinx-doc/sphinx/assets/3150012/8f8249e3-2522-441f-8392-51047f36e902" alt="sphinx-agogo-scrolling-fix-current" width="350" />






