### PR TITLE
Add tox ``lint`` target

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
+  # If you update any of these commands, don't forget to update the equivalent
+  # tox environment
   ruff:
     runs-on: ubuntu-latest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-minversion = 2.4.0
+minversion = 4.2.0
 envlist = py{39,310,311,312,313}
-isolated_build = True
 
 [testenv]
 usedevelop = True
@@ -30,7 +29,6 @@ commands=
     python -X dev -X warn_default_encoding -m pytest --durations 25 {posargs}
 
 [testenv:docs]
-basepython = python3
 description =
     Build documentation.
 extras =
@@ -40,7 +38,6 @@ commands =
     sphinx-build -M {env:BUILDER:html} ./doc ./build/sphinx -nW --keep-going {posargs}
 
 [testenv:docs-live]
-basepython = python3
 description =
     Build documentation.
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,19 @@ setenv =
 commands=
     python -X dev -X warn_default_encoding -m pytest --durations 25 {posargs}
 
+[testenv:lint]
+description =
+    Run linters.
+extras =
+    lint
+# If you update any of these commands, don't forget to update the equivalent
+# GitHub Workflow step
+commands =
+    ruff . --diff --format github
+    flake8 .
+    isort --check-only --diff .
+    mypy sphinx/
+
 [testenv:docs]
 description =
     Build documentation.
@@ -70,4 +83,5 @@ description =
 extras =
     lint
     test
-commands = mypy {posargs}
+commands =
+    mypy {posargs}


### PR DESCRIPTION
### Feature or Bugfix

Refactoring

### Purpose

Re-add a tox environment for linters. This environment uses the 'lint' extras
and runs the same commands as the GitHub Workflows. A note is added reminding
people to keep the two in-sync.

### Detail

This resolves #11599. There is an (arguably superior but more involved) alternative at #11603.

### Relates

(none)
