### PR TITLE
Integrate pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,19 +25,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3"
-    - name: Install pip
-      run: python -m pip install --upgrade pip
-
-    - name: Install known good Ruff
-      run: python -m pip install ruff==0.0.284
-    - name: Lint with known good Ruff
-      run: ruff . --format github
-
-    - name: Install latest Ruff
-      run: python -m pip install --upgrade ruff
-    - name: Lint with latest Ruff
-      continue-on-error: true
-      run: ruff . --format github
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: ruff --all-files
 
   flake8:
     runs-on: ubuntu-latest
@@ -48,12 +38,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade "flake8>=3.5.0" "flake8-simplify"
-    - name: Lint with flake8
-      run: flake8 .
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: flake8 --all-files
 
   isort:
     runs-on: ubuntu-latest
@@ -64,12 +51,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade isort
-    - name: Lint with isort
-      run: isort --check-only --diff .
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: isort --all-files
 
   mypy:
     runs-on: ubuntu-latest
@@ -80,12 +64,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade "mypy>=0.990" docutils-stubs types-requests
-    - name: Type check with mypy
-      run: mypy sphinx/
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: mypy --all-files
 
   docs-lint:
     runs-on: ubuntu-latest
@@ -96,21 +77,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade sphinx-lint
-    - name: Lint documentation with sphinx-lint
-      run: >
-        sphinx-lint
-        --enable line-too-long
-        --max-line-length 85 
-        AUTHORS.rst
-        CHANGES.rst
-        CODE_OF_CONDUCT.rst
-        CONTRIBUTING.rst
-        README.rst
-        doc/
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: sphinx-lint --all-files
 
   twine:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.284
+    hooks:
+      - id: ruff
+        args: ['--diff', '--format', 'github']
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-simplify
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - docutils-stubs
+          - types-requests
+        files: ^sphinx/
+
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v0.6.8
+    hooks:
+      - id: sphinx-lint
+        args: ['--enable', 'line-too-long', '--max-line-length', '85']
+        files: |
+          (?x)^(
+            CHANGES
+            | CONTRIBUTING.rst
+            | README.rst
+            | doc/.*
+          )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-json
+      - id: check-yaml
+      - id: debug-statements
+        exclude: '^sphinx/cmd/build.py$'
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.284
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,16 +79,6 @@ dynamic = ["version"]
 docs = [
     "sphinxcontrib-websupport",
 ]
-lint = [
-    "flake8>=3.5.0",
-    "flake8-simplify",
-    "isort",
-    "ruff",
-    "mypy>=0.990",
-    "sphinx-lint",
-    "docutils-stubs",
-    "types-requests",
-]
 test = [
     "pytest>=4.6",
     "html5lib",

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,14 @@ setenv =
 commands=
     python -X dev -X warn_default_encoding -m pytest --durations 25 {posargs}
 
+[testenv:lint]
+description =
+    Run style checks.
+deps =
+    pre-commit
+commands =
+    pre-commit run --all-files --show-diff-on-failure
+
 [testenv:docs]
 basepython = python3
 description =


### PR DESCRIPTION
### Feature or Bugfix

Refactoring

### Purpose

Integrate `pre-commit` for linting. This is an exceptionally useful tool that provides a mechanism to automate all sorts of linters, including all of those that we currently support and rely on. It can also be used as a standalone tool, as demonstrated by the GitHub Workflows used within.

This change also adds a `lint` tox environment, which is simply a wrapper around `pre-commit` (for those used to this workflow), and migrates the various linter-related GitHub Action steps to use `pre-commit`. The latter is important since without this, configurations will drift. Developers who wish to configure their environment manually or in a different manner can continue to do so, but the vast majority can benefit from automated linting and fixing.

As a future change, we may wish to integrate [pre-commit.ci](https://pre-commit.ci/) since that will automate the fixing of PRs using pre-commit (currently we just check if they would require fixes) but that's a separate issue.

> **Note**
> The `pre-commit` tool utilises the `pre-commit` client-side hook. Client-side hooks are not included in clones and must be enabled manually by the user. In addition, the `pre-commit` tool itself must be installed and enabled on the `sphinx` repo to enable the pre-commit check workflow. As such, this is entirely optional and can be ignored by contributors with different workflows or those who do not wish to use `pre-commit`.

### Detail

This is an alternative to #11602 and potentially #11375. It resolves #11205.

### Relates

- #11602
- #11375
- #11205
