### PR TITLE
variable referenced before assignment fix.

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -675,12 +675,12 @@ class Documenter:
 
         # process members and determine which to skip
         for obj in members:
-            try:
-                membername = obj.__name__
-                member = obj.object
-                # if isattr is True, the member is documented as an attribute
-                isattr = member is INSTANCEATTR or (namespace, membername) in attr_docs
+            membername = obj.__name__
+            member = obj.object
+            # if isattr is True, the member is documented as an attribute
+            isattr = member is INSTANCEATTR or (namespace, membername) in attr_docs
 
+            try:
                 doc = getdoc(member, self.get_attr, self.config.autodoc_inherit_docstrings,
                              self.object, membername)
                 if not isinstance(doc, str):


### PR DESCRIPTION
Subject: bugfix to some variables being referenced before assignment.

### Feature or Bugfix
- Bugfix

```
/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/autodocsumm/__init__.py:223: RemovedInSphinx80Warning: The tuple interface of ObjectMember is deprecated. Use (obj.__name__, obj.object) instead.
  members = [(membername, member) for (membername, member) in members

Exception occurred:
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/sphinx/ext/autodoc/__init__.py", line 779, in filter_members
    self.name, membername, member, exc, type='autodoc')
UnboundLocalError: local variable 'membername' referenced before assignment
```



