### PR TITLE
Allow relative-to-root toctree dirs in autosummary

### DIFF
--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -81,15 +81,16 @@ The :mod:`sphinx.ext.autosummary` extension does this in two parts:
      directory. If no argument is given, output is placed in the same directory
      as the file that contains the directive.  The directory is interpreted as
      relative to the directory of the source file, unless it begins with the
-     path separator ``/``, in which case it is relative to the documentation
-     root.  All paths should use the separator ``/`` regardless of the
-     operating system used for the build.
+     ``/``, in which case it is relative to the documentation source directory.
+     All paths should use the separator ``/`` regardless of the operating system
+     used for the build.
 
      You can also use ``caption`` option to give a caption to the toctree.
 
      .. versionadded:: 7.3
 
-        allowed setting a directory relative to the documentation root.
+        Directories may now be set relative to the documentation source
+        directory.
 
      .. versionadded:: 3.1
 

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -81,12 +81,13 @@ The :mod:`sphinx.ext.autosummary` extension does this in two parts:
      directory. If no argument is given, output is placed in the same directory
      as the file that contains the directive.  The directory is interpreted as
      relative to the directory of the source file, unless it begins with the
-     system path separator (``/`` for Unix-likes), in which case it is relative
-     to the documentation root.
+     path separator ``/``, in which case it is relative to the documentation
+     root.  All paths should use the separator ``/`` regardless of the
+     operating system used for the build.
 
      You can also use ``caption`` option to give a caption to the toctree.
 
-     .. versionchanged:: 7.3
+     .. versionadded:: 7.3
 
         allowed setting a directory relative to the documentation root.
 

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -74,12 +74,21 @@ The :mod:`sphinx.ext.autosummary` extension does this in two parts:
 
      The ``toctree`` option also signals to the :program:`sphinx-autogen` script
      that stub pages should be generated for the entries listed in this
-     directive.  The option accepts a directory name as an argument;
+     directive.
+
+     The option accepts a directory name as an argument;
      :program:`sphinx-autogen` will by default place its output in this
      directory. If no argument is given, output is placed in the same directory
-     as the file that contains the directive.
+     as the file that contains the directive.  The directory is interpreted as
+     relative to the directory of the source file, unless it begins with the
+     system path separator (``/`` for Unix-likes), in which case it is relative
+     to the documentation root.
 
      You can also use ``caption`` option to give a caption to the toctree.
+
+     .. versionchanged:: 7.3
+
+        allowed setting a directory relative to the documentation root.
 
      .. versionadded:: 3.1
 

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -235,7 +235,7 @@ class Autosummary(SphinxDirective):
 
         if 'toctree' in self.options:
             tree_prefix = self.options['toctree'].strip()
-            if posixpath.isabs(tree_prefix):
+            if tree_prefix.startswith("/"):
                 tree_prefix = posixpath.relpath(tree_prefix, "/")
                 dirname = ""
             else:

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -75,7 +75,7 @@ from sphinx.locale import __
 from sphinx.project import Project
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.registry import SphinxComponentRegistry
-from sphinx.util import logging, rst
+from sphinx.util import SEP, logging, rst
 from sphinx.util.docutils import (
     NullReporter,
     SphinxDirective,
@@ -235,8 +235,8 @@ class Autosummary(SphinxDirective):
 
         if 'toctree' in self.options:
             tree_prefix = self.options['toctree'].strip()
-            if tree_prefix.startswith("/"):
-                tree_prefix = posixpath.relpath(tree_prefix, "/")
+            if tree_prefix.startswith(SEP):
+                tree_prefix = posixpath.relpath(tree_prefix, SEP)
                 dirname = ""
             else:
                 dirname = posixpath.dirname(self.env.docname)

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -234,9 +234,12 @@ class Autosummary(SphinxDirective):
         nodes = self.get_table(items)
 
         if 'toctree' in self.options:
-            dirname = posixpath.dirname(self.env.docname)
-
             tree_prefix = self.options['toctree'].strip()
+            if posixpath.isabs(tree_prefix):
+                tree_prefix = posixpath.relpath(tree_prefix, "/")
+                dirname = ""
+            else:
+                dirname = posixpath.dirname(self.env.docname)
             docnames = []
             excluded = Matcher(self.config.exclude_patterns)
             filename_map = self.config.autosummary_filename_map

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -640,7 +640,7 @@ def find_autosummary_in_lines(lines: list[str],
             m = toctree_arg_re.match(line)
             if m:
                 toctree = m.group(1)
-                if base_path is not None and posixpath.isabs(toctree):
+                if base_path is not None and toctree.startswith("/"):
                     toctree = os.path.join(base_path, posixpath.relpath(toctree, "/"))
                 elif filename:
                     toctree = os.path.join(os.path.dirname(filename),

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -44,7 +44,7 @@ from sphinx.ext.autosummary import (
 from sphinx.locale import __
 from sphinx.pycode import ModuleAnalyzer, PycodeError
 from sphinx.registry import SphinxComponentRegistry
-from sphinx.util import logging, rst
+from sphinx.util import SEP, logging, rst
 from sphinx.util.inspect import getall, safe_getattr
 from sphinx.util.osutil import ensuredir
 from sphinx.util.template import SphinxTemplateLoader
@@ -640,8 +640,8 @@ def find_autosummary_in_lines(lines: list[str],
             m = toctree_arg_re.match(line)
             if m:
                 toctree = m.group(1)
-                if base_path is not None and toctree.startswith("/"):
-                    toctree = os.path.join(base_path, posixpath.relpath(toctree, "/"))
+                if base_path is not None and toctree.startswith(SEP):
+                    toctree = os.path.join(base_path, posixpath.relpath(toctree, SEP))
                 elif filename:
                     toctree = os.path.join(os.path.dirname(filename),
                                            toctree)

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -20,6 +20,7 @@ import inspect
 import locale
 import os
 import pkgutil
+import posixpath
 import pydoc
 import re
 import sys
@@ -479,7 +480,7 @@ def generate_autosummary_docs(sources: list[str],
     template = AutosummaryRenderer(app)
 
     # read
-    items = find_autosummary_in_files(sources)
+    items = find_autosummary_in_files(sources, base_path=base_path)
 
     # keep track of new files
     new_files = []
@@ -552,7 +553,9 @@ def generate_autosummary_docs(sources: list[str],
 
 # -- Finding documented entries in files ---------------------------------------
 
-def find_autosummary_in_files(filenames: list[str]) -> list[AutosummaryEntry]:
+def find_autosummary_in_files(filenames: list[str],
+                              base_path: str | os.PathLike[str] | None = None,
+                              ) -> list[AutosummaryEntry]:
     """Find out what items are documented in source/*.rst.
 
     See `find_autosummary_in_lines`.
@@ -561,13 +564,16 @@ def find_autosummary_in_files(filenames: list[str]) -> list[AutosummaryEntry]:
     for filename in filenames:
         with open(filename, encoding='utf-8', errors='ignore') as f:
             lines = f.read().splitlines()
-            documented.extend(find_autosummary_in_lines(lines, filename=filename))
+            documented.extend(find_autosummary_in_lines(lines,
+                                                        filename=filename,
+                                                        base_path=base_path))
     return documented
 
 
-def find_autosummary_in_docstring(
-    name: str, filename: str | None = None,
-) -> list[AutosummaryEntry]:
+def find_autosummary_in_docstring(name: str,
+                                  filename: str | None = None,
+                                  base_path: str | os.PathLike[str] | None = None,
+                                  ) -> list[AutosummaryEntry]:
     """Find out what items are documented in the given object's docstring.
 
     See `find_autosummary_in_lines`.
@@ -575,7 +581,10 @@ def find_autosummary_in_docstring(
     try:
         real_name, obj, parent, modname = import_by_name(name)
         lines = pydoc.getdoc(obj).splitlines()
-        return find_autosummary_in_lines(lines, module=name, filename=filename)
+        return find_autosummary_in_lines(lines,
+                                         module=name,
+                                         filename=filename,
+                                         base_path=base_path)
     except AttributeError:
         pass
     except ImportExceptionGroup as exc:
@@ -587,18 +596,20 @@ def find_autosummary_in_docstring(
     return []
 
 
-def find_autosummary_in_lines(
-    lines: list[str], module: str | None = None, filename: str | None = None,
-) -> list[AutosummaryEntry]:
+def find_autosummary_in_lines(lines: list[str],
+                              module: str | None = None,
+                              filename: str | None = None,
+                              base_path: str | os.PathLike[str] | None = None,
+                              ) -> list[AutosummaryEntry]:
     """Find out what items appear in autosummary:: directives in the
     given lines.
 
     Returns a list of (name, toctree, template) where *name* is a name
     of an object and *toctree* the :toctree: path of the corresponding
-    autosummary directive (relative to the root of the file name), and
-    *template* the value of the :template: option. *toctree* and
-    *template* ``None`` if the directive does not have the
-    corresponding options set.
+    autosummary directive (relative to the root of the file name unless it
+    begins with the path separator, in which case relative to `base_path`), and
+    *template* the value of the :template: option. *toctree* and *template*
+    ``None`` if the directive does not have the corresponding options set.
     """
     autosummary_re = re.compile(r'^(\s*)\.\.\s+autosummary::\s*')
     automodule_re = re.compile(
@@ -629,7 +640,9 @@ def find_autosummary_in_lines(
             m = toctree_arg_re.match(line)
             if m:
                 toctree = m.group(1)
-                if filename:
+                if base_path is not None and posixpath.isabs(toctree):
+                    toctree = os.path.join(base_path, posixpath.relpath(toctree, "/"))
+                elif filename:
                     toctree = os.path.join(os.path.dirname(filename),
                                            toctree)
                 continue
@@ -672,7 +685,7 @@ def find_autosummary_in_lines(
             current_module = m.group(1).strip()
             # recurse into the automodule docstring
             documented.extend(find_autosummary_in_docstring(
-                current_module, filename=filename))
+                current_module, filename=filename, base_path=base_path))
             continue
 
         m = module_re.match(line)

--- a/tests/roots/test-ext-autosummary-toctree-absolute/conf.py
+++ b/tests/roots/test-ext-autosummary-toctree-absolute/conf.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autosummary']
+autosummary_generate = True

--- a/tests/roots/test-ext-autosummary-toctree-absolute/doc_module2/index.rst
+++ b/tests/roots/test-ext-autosummary-toctree-absolute/doc_module2/index.rst
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+.. rubric:: Inner package
+
+.. autosummary::
+   :toctree: /generated
+
+   module2.MyClass

--- a/tests/roots/test-ext-autosummary-toctree-absolute/index.rst
+++ b/tests/roots/test-ext-autosummary-toctree-absolute/index.rst
@@ -1,0 +1,12 @@
+API Reference
+=============
+
+.. rubric:: Packages
+
+.. toctree::
+   doc_module2/index.rst
+
+.. autosummary::
+   :toctree: /generated
+
+   module1.MyClass

--- a/tests/roots/test-ext-autosummary-toctree-absolute/module1.py
+++ b/tests/roots/test-ext-autosummary-toctree-absolute/module1.py
@@ -1,0 +1,2 @@
+class MyClass:
+    """Hello, world."""

--- a/tests/roots/test-ext-autosummary-toctree-absolute/module2.py
+++ b/tests/roots/test-ext-autosummary-toctree-absolute/module2.py
@@ -1,0 +1,2 @@
+class MyClass:
+    """Hello, world."""

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -665,6 +665,16 @@ def test_autosummary_template(app):
     assert 'EMPTY' in content
 
 
+@pytest.mark.sphinx(testroot='ext-autosummary-toctree-absolute')
+def test_autosummary_absolute_toctree(app):
+    app.build()
+
+    # The autosummary directive for `module2` is not in the documentation
+    # root, but specifies the same toctree directory by absolute path.
+    assert (app.srcdir / 'generated' / 'module1.MyClass.rst').exists()
+    assert (app.srcdir / 'generated' / 'module2.MyClass.rst').exists()
+
+
 @pytest.mark.sphinx('dummy', testroot='ext-autosummary',
                     confoverrides={'autosummary_generate': []})
 def test_empty_autosummary_generate(app, status, warning):


### PR DESCRIPTION
Subject: Allow relative-to-root toctree dirs in autosummary

### Feature or Bugfix
- Feature

### Purpose

At the moment, Autosummary's `toctree` directory is always relative to the current file. This means that the generated files always move with the file that contains an toctree-creating `autosummary` directive. In our case, we'd like to universally put the generated files into one separate folder at the documentation root, regardless of where they were generated from. This is particularly a problem when dealing with recursive autosummary generations, and at the moment is effectively limiting us to our manual documentation all having a flat folder structure.

### Detail

This treats a leading `/` in the directory of a `toctree` option in an `autosummary` block as requesting a directory relative to the source documentation root, rather than relative to the current directory.  Previously, prefixing a path with `/` would typically cause build failures on Unix-likes because

```python
posixpath.join("/prefix/path", "/other") == "/other"
```

and Sphinx (hopefully!) didn't have permission to create directories in the filesystem root.  This means that the change should not conflict with any existing practical working documentation builds.

Autosummary currently uses `posixpath` for most operations even on Windows, so the root indicator is only permitted as `/`, not `os.sep`.


### Relates
- Fix #11637
