### PR TITLE
linkcheck: Use correct function to convert from UTC time to UNIX epoch

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,8 @@ Bugs fixed
 
 * #11618: Fix a regression in the MoveModuleTargets transform,
   introduced in #10478 (#9662).
-* #11649: Use :py:func:`calendar.timegm` to convert from UTC time to UNIX epoch.
+* #11649: linkcheck: Fix conversions from UTC to UNIX time
+  for timezones west of London.
 
 Release 7.2.3 (released Aug 23, 2023)
 =====================================

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Bugs fixed
 
 * #11618: Fix a regression in the MoveModuleTargets transform,
   introduced in #10478 (#9662).
+* #11649: Use :py:func:`calendar.timegm` to convert from UTC time to UNIX epoch.
 
 Release 7.2.3 (released Aug 23, 2023)
 =====================================
@@ -24,7 +25,7 @@ Bugs fixed
   when ``autodoc_preserve_defaults`` is ``True``.
 * Restore support string methods on path objects.
   This is deprecated and will be removed in Sphinx 8.
-  Use :py:func`os.fspath` to convert :py:class:`~pathlib.Path` objects to strings,
+  Use :py:func:`os.fspath` to convert :py:class:`~pathlib.Path` objects to strings,
   or :py:class:`~pathlib.Path`'s methods to work with path objects.
 
 Release 7.2.2 (released Aug 17, 2023)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import calendar
 import contextlib
 import json
 import re
@@ -491,7 +492,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                     parsed = parsedate_tz(retry_after)
                     assert parsed is not None
                     # the 10th element is the GMT offset in seconds
-                    next_check = time.mktime(parsed[:9]) - (parsed[9] or 0)
+                    next_check = float(calendar.timegm(parsed[:9])) - (parsed[9] or 0)
                 except (AssertionError, TypeError, ValueError):
                     # TypeError: Invalid date format.
                     # ValueError: Invalid date, e.g. Oct 52th.

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import calendar
 import contextlib
 import json
 import re
 import socket
 import time
-from email.utils import parsedate_tz
 from html.parser import HTMLParser
 from os import path
 from queue import PriorityQueue, Queue
@@ -30,6 +28,7 @@ from sphinx.util.console import (  # type: ignore[attr-defined]
     red,
     turquoise,
 )
+from sphinx.util.http_date import rfc1123_to_epoch
 from sphinx.util.nodes import get_node_line
 
 if TYPE_CHECKING:
@@ -489,11 +488,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
             except ValueError:
                 try:
                     # An HTTP-date: time of next attempt.
-                    parsed = parsedate_tz(retry_after)
-                    assert parsed is not None
-                    # the 10th element is the GMT offset in seconds
-                    next_check = float(calendar.timegm(parsed[:9])) - (parsed[9] or 0)
-                except (AssertionError, TypeError, ValueError):
+                    next_check = rfc1123_to_epoch(retry_after)
+                except (ValueError, TypeError):
                     # TypeError: Invalid date format.
                     # ValueError: Invalid date, e.g. Oct 52th.
                     pass

--- a/sphinx/util/http_date.py
+++ b/sphinx/util/http_date.py
@@ -4,7 +4,12 @@ Reference: https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
 """
 
 import time
-from email.utils import formatdate, parsedate
+import warnings
+from email.utils import formatdate, parsedate_tz
+
+from sphinx.deprecation import RemovedInSphinx90Warning
+
+_GMT_OFFSET = float(time.localtime().tm_gmtoff)
 
 
 def epoch_to_rfc1123(epoch: float) -> str:
@@ -14,7 +19,21 @@ def epoch_to_rfc1123(epoch: float) -> str:
 
 def rfc1123_to_epoch(rfc1123: str) -> float:
     """Return epoch offset from HTTP-date string."""
-    t = parsedate(rfc1123)
-    if t:
-        return time.mktime(t)
-    raise ValueError
+    t = parsedate_tz(rfc1123)
+    if t is None:
+        raise ValueError
+    if not rfc1123.endswith(" GMT"):
+        warnings.warn(
+            "HTTP-date string does not meet RFC 7231 requirements "
+            f"(must end with 'GMT'): {rfc1123!r}",
+            RemovedInSphinx90Warning, stacklevel=3,
+        )
+    epoch_secs = time.mktime(time.struct_time(t[:9])) + _GMT_OFFSET
+    if (gmt_offset := t[9]) != 0:
+        warnings.warn(
+            "HTTP-date string does not meet RFC 7231 requirements "
+            f"(must be GMT time): {rfc1123!r}",
+            RemovedInSphinx90Warning, stacklevel=3,
+        )
+        return epoch_secs - (gmt_offset or 0)
+    return epoch_secs

--- a/sphinx/util/http_date.py
+++ b/sphinx/util/http_date.py
@@ -5,16 +5,16 @@ Reference: https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
 
 import time
 import warnings
-from email.utils import parsedate_tz
-from wsgiref.handlers import format_date_time
+from email.utils import formatdate, parsedate_tz
 
 from sphinx.deprecation import RemovedInSphinx90Warning
 
 _GMT_OFFSET = float(time.localtime().tm_gmtoff)
 
 
-epoch_to_rfc1123 = format_date_time
-"""Return HTTP-date string from epoch offset."""
+def epoch_to_rfc1123(epoch: float) -> str:
+    """Return HTTP-date string from epoch offset."""
+    return formatdate(epoch, usegmt=True)
 
 
 def rfc1123_to_epoch(rfc1123: str) -> float:

--- a/sphinx/util/http_date.py
+++ b/sphinx/util/http_date.py
@@ -5,16 +5,16 @@ Reference: https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
 
 import time
 import warnings
-from email.utils import formatdate, parsedate_tz
+from email.utils import parsedate_tz
+from wsgiref.handlers import format_date_time
 
 from sphinx.deprecation import RemovedInSphinx90Warning
 
 _GMT_OFFSET = float(time.localtime().tm_gmtoff)
 
 
-def epoch_to_rfc1123(epoch: float) -> str:
-    """Return HTTP-date string from epoch offset."""
-    return formatdate(epoch, usegmt=True)
+epoch_to_rfc1123 = format_date_time
+"""Return HTTP-date string from epoch offset."""
 
 
 def rfc1123_to_epoch(rfc1123: str) -> float:

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import http.server
 import json
-import os
 import re
+import sys
 import textwrap
 import time
 import wsgiref.handlers
@@ -17,6 +17,7 @@ from unittest import mock
 import pytest
 from urllib3.poolmanager import PoolManager
 
+import sphinx.util.http_date
 from sphinx.builders.linkcheck import (
     CheckRequest,
     Hyperlink,
@@ -773,22 +774,22 @@ def test_too_many_requests_retry_after_int_delay(app, capsys, status):
     )
 
 
-@pytest.mark.parametrize('tz', ['GMT', 'GMT+3', 'GMT-3'])
+@pytest.mark.parametrize('tz', [None, 'GMT', 'GMT+3', 'GMT-3'])
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver', freshenv=True)
-def test_too_many_requests_retry_after_HTTP_date(app, capsys, tz):
-    old_tz = os.environ.get('TZ')
-    os.environ['TZ'] = tz
-    if hasattr(time, 'tzset'):
-        time.tzset()
-    try:
-        retry_after = wsgiref.handlers.format_date_time(time.time())
+def test_too_many_requests_retry_after_HTTP_date(tz, app, monkeypatch, capsys):
+    retry_after = wsgiref.handlers.format_date_time(time.time())
+
+    with monkeypatch.context() as m:
+        if tz is not None:
+            m.setenv('TZ', tz)
+            if sys.platform != "win32":
+                time.tzset()
+            m.setattr(sphinx.util.http_date, '_GMT_OFFSET',
+                      float(time.localtime().tm_gmtoff))
+
         with http_server(make_retry_after_handler([(429, retry_after), (200, None)])):
             app.build()
-    finally:
-        if old_tz is None:
-            del os.environ['TZ']
-        else:
-            os.environ['TZ'] = old_tz
+
     content = (app.outdir / 'output.json').read_text(encoding='utf8')
     assert json.loads(content) == {
         "filename": "index.rst",


### PR DESCRIPTION
Subject: linkcheck: Use correct function to convert from UTC time to UNIX epoch

### Feature or Bugfix
- Bugfix

### Purpose
After subtracting the offset, we get time in UTC. But `time.mktime()` expects a time struct in local time, not in UTC. Quoting the [Python documentation](https://docs.python.org/3/library/time.html):

> Use the following functions to convert between time representations:
>
> From | To | Use
> -- | -- | --
> seconds since the epoch | struct_time in UTC | gmtime()
> seconds since the epoch | struct_time in local time | localtime()
> struct_time in UTC | seconds since the epoch | calendar.timegm()
> struct_time in local time | seconds since the epoch | mktime()

So in our case, the correct function to use is `calendar.timegm()`.

This fixes hanging tests when the local timezone is to the west of UTC. One could test this using:

    TZ=America/New_York python3 -m pytest -k test_too_many_requests_retry_after_HTTP_date

After applying this change, the test passes with timezones from both western and eastern hemispheres.