### PR TITLE
Make test_include_source_read_event pass when run from /tmp

### DIFF
--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -18,7 +18,7 @@ from sphinx.util import docname_join, logging, url_re
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.matching import Matcher, patfilter
 from sphinx.util.nodes import explicit_title_re
-from sphinx.util.osutil import os_path
+from sphinx.util.osutil import abspath, os_path
 
 if TYPE_CHECKING:
     from docutils.nodes import Element, Node
@@ -386,7 +386,7 @@ class Include(BaseInclude, SphinxDirective):
             text = "\n".join(include_lines[:-2])
 
             # The docname to pass into the source-read event
-            docname = self.env.path2doc(os_path(source))
+            docname = self.env.path2doc(os_path(abspath(source)))
             # Emit the "source-read" event
             arg = [text]
             self.env.app.events.emit("source-read", docname, arg)

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from os.path import abspath
 from typing import TYPE_CHECKING, Any, cast
 
 from docutils import nodes
@@ -18,7 +19,7 @@ from sphinx.util import docname_join, logging, url_re
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.matching import Matcher, patfilter
 from sphinx.util.nodes import explicit_title_re
-from sphinx.util.osutil import abspath, os_path
+from sphinx.util.osutil import os_path
 
 if TYPE_CHECKING:
     from docutils.nodes import Element, Node
@@ -386,7 +387,7 @@ class Include(BaseInclude, SphinxDirective):
             text = "\n".join(include_lines[:-2])
 
             # The docname to pass into the source-read event
-            docname = self.env.path2doc(os_path(abspath(source)))
+            docname = self.env.path2doc(abspath(os_path(source)))
             # Emit the "source-read" event
             arg = [text]
             self.env.app.events.emit("source-read", docname, arg)


### PR DESCRIPTION
Subject: Make test_include_source_read_event pass when run from /tmp

### Feature or Bugfix
- Bugfix

### Purpose
Because pytest's base tmp_path is also in /tmp, `source` here is relative path, and thus is not properly converted to doc name.

So the test fails because `sources_reported` dict has a key like `../../../pytest-of-debci/pytest-0/directive-include/baz/baz`, and `assert "baz/baz" in sources_reported` fails.

Example failures in Debian infrastructure can be seen here:
- https://salsa.debian.org/python-team/packages/sphinx/-/jobs/4579414
- https://salsa.debian.org/python-team/packages/sphinx/-/jobs/4612253

You can reproduce locally by copying Sphinx source tree to `/tmp` and running tests from there.