### PR TITLE
Fix ordering inside searchindex.js not being deterministic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugs fixed
 
 * #11668: Raise a useful error when ``theme.conf`` is missing.
   Patch by Vinay Sajip.
+* #11622: Fix ordering inside searchindex.js not being deterministic.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,8 @@ Bugs fixed
 
 * #11668: Raise a useful error when ``theme.conf`` is missing.
   Patch by Vinay Sajip.
-* #11622: Fix ordering inside searchindex.js not being deterministic.
+* #11622: Ensure that the order of keys in ``searchindex.js`` is deterministic.
+  Patch by Pietro Albini.
 
 Testing
 -------

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -162,7 +162,7 @@ class _JavaScriptIndex:
     SUFFIX = ')'
 
     def dumps(self, data: Any) -> str:
-        return self.PREFIX + json.dumps(data) + self.SUFFIX
+        return self.PREFIX + json.dumps(data, sort_keys=True) + self.SUFFIX
 
     def loads(self, s: str) -> Any:
         data = s[len(self.PREFIX):-len(self.SUFFIX)]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -308,14 +308,14 @@ def test_parallel(app):
 
 @pytest.mark.sphinx(testroot='search')
 def test_search_index_is_deterministic(app):
-    LISTS_NOT_TO_SORT = [
+    lists_not_to_sort = {
         # Each element of .titles is related to the element of .docnames in the same position.
         # The ordering is deterministic because .docnames is sorted.
         '.titles',
         # Each element of .filenames is related to the element of .docnames in the same position.
         # The ordering is deterministic because .docnames is sorted.
         '.filenames',
-    ]
+    }
 
     # In the search index, titles inside .alltitles are stored as a tuple of
     # (document_idx, title_anchor). Tuples are represented as lists in JSON,
@@ -331,12 +331,13 @@ def test_search_index_is_deterministic(app):
             for key, value in item.items():
                 assert_is_sorted(value, f'{path}.{key}')
         elif isinstance(item, list):
-            if not is_title_tuple_type(item) and path not in LISTS_NOT_TO_SORT:
+            if not is_title_tuple_type(item) and path not in lists_not_to_sort:
                 assert item == sorted(item), f'{err_path} is not sorted'
             for i, child in enumerate(item):
                 assert_is_sorted(child, f'{path}[{i}]')
 
     app.builder.build_all()
     index = load_searchindex(app.outdir / 'searchindex.js')
-    print(f'index contents:\n{json.dumps(index, indent=2)}')  # Pretty print the index.
+    # Pretty print the index. Only shown by pytest on failure.
+    print(f'searchindex.js contents:\n\n{json.dumps(index, indent=2)}')
     assert_is_sorted(index, '')


### PR DESCRIPTION
This PR changes `searchindex.js`'s sorting of dictionary keys to be deterministic.

### Feature or Bugfix

- Bugfix

### Purpose

At my day job we have a need to digitally sign the HTML output of Sphinx, and for those signatures to stay valid as we rebuild the documentation (if all dependencies and source code do not change).

Unfortunately, the contents of `searchindex.js` are not deterministic, as the keys are inserted in random order. This breaks our digital signatures as soon as a rebuild is done.

### Detail

This PR changes the sorting of dumped dictionary keys to be deterministic, and adds a test verifying all dictionary keys in `searchindex.js` are sorted.

### Relates

- Fixes #11622

