### PR TITLE
Fix typo in `:final:` option for methods

### DIFF
--- a/doc/usage/restructuredtext/domains.rst
+++ b/doc/usage/restructuredtext/domains.rst
@@ -527,7 +527,7 @@ The following directives are provided for module and class contents:
    .. rst:directive:option:: final
       :type: no value
 
-      Indicate the class is a final method.
+      Indicate the method is a final method.
 
       .. versionadded:: 3.1
 


### PR DESCRIPTION
It used to be like this:
<img width="843" alt="Снимок экрана 2023-09-02 в 12 03 53" src="https://github.com/sphinx-doc/sphinx/assets/4660275/3a76e774-5535-448f-812a-043c60404989">


### Feature or Bugfix
- Typo fix

