### PR TITLE
Don't consider "e.g." or "n.b." to end sentences when making autosummary summaries

### DIFF
--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -99,7 +99,7 @@ logger = logging.getLogger(__name__)
 periods_re = re.compile(r'\.(?:\s+)')
 literal_re = re.compile(r'::\s*$')
 
-WELL_KNOWN_ABBREVIATIONS = ('et al.', ' i.e.',)
+WELL_KNOWN_ABBREVIATIONS = ('et al.', 'i.e.', 'e.g.', 'n.b.')
 
 
 # -- autosummary_toc node ------------------------------------------------------

--- a/tests/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary.py
@@ -94,7 +94,13 @@ def test_extract_summary(capsys):
     assert extract_summary(doc, document) == ' '.join(doc)
 
     # abbreviations
-    doc = ['Blabla, i.e. bla.']
+    doc = ['Blabla, (i.e. bla) bla.']
+    assert extract_summary(doc, document) == ' '.join(doc)
+
+    doc = ['Blabla, (e.g. bla) bla.']
+    assert extract_summary(doc, document) == ' '.join(doc)
+
+    doc = ['Blabla, (n.b. bla) bla.']
     assert extract_summary(doc, document) == ' '.join(doc)
 
     doc = ['Blabla, et al. bla.']


### PR DESCRIPTION
The `autosummary` module tries to make summaries from the first sentence of an object's docstring.  It finds the first sentence by looking for the first period, with a few hard-coded extract the first sentence of already has a 
