### PR TITLE
Docs: Use Python 3 print() functions in examples

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -544,9 +544,9 @@ __ https://pygments.org/docs/lexers
 
           def some_function():
               interesting = False
-              print 'This line is highlighted.'
-              print 'This one is not...'
-              print '...but this one is.'
+              print('This line is highlighted.')
+              print('This one is not...')
+              print('...but this one is.')
 
       .. versionadded:: 1.1
       .. versionchanged:: 1.6.6
@@ -576,7 +576,7 @@ __ https://pygments.org/docs/lexers
            :caption: this.py
            :name: this-py
 
-           print 'Explicit is better than implicit.'
+           print('Explicit is better than implicit.')
 
       In order to cross-reference a code-block using either the
       :rst:role:`ref` or the :rst:role:`numref` role, it is necessary

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -468,8 +468,8 @@ different style:
 
    A piece of literal text, such as code.  Within the contents, you can use
    curly braces to indicate a "variable" part, as in :rst:role:`file`.  For
-   example, in ``:samp:`print 1+{variable}```, the part ``variable`` would be
-   emphasized: :samp:`print 1+{variable}`
+   example, in ``:samp:`print(1+{variable})```, the part ``variable`` would be
+   emphasized: :samp:`print(1+{variable})`
 
    If you don't need the "variable part" indication, use the standard
    :rst:role:`code` role instead.


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix?

### Purpose

Let's use Python 3 `print()` functions in the examples:

* https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-samp
* https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-option-code-block-emphasize-lines
