### PR TITLE
search: score non-main index entries lower

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Bugs fixed
 * #11483: singlehtml builder: Fix MathJax lazy loading when the index does not
   contain any math equations.
   Patch by Bénédikt Tran.
+* #11578: HTML Search: Order non-main index entries later in search results.
+  Patch by Brad King.
 
 Testing
 -------

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -396,10 +396,10 @@ class IndexBuilder:
             for title, titleid in titlelist:
                 alltitles.setdefault(title, []).append((fn2index[docname], titleid))
 
-        index_entries: dict[str, list[tuple[int, str]]] = {}
+        index_entries: dict[str, list[tuple[int, str, bool]]] = {}
         for docname, entries in self._index_entries.items():
             for entry, entry_id, main_entry in entries:
-                index_entries.setdefault(entry.lower(), []).append((fn2index[docname], entry_id))
+                index_entries.setdefault(entry.lower(), []).append((fn2index[docname], entry_id, main_entry == "main"))
 
         return dict(docnames=docnames, filenames=filenames, titles=titles, terms=terms,
                     objects=objects, objtypes=objtypes, objnames=objnames,

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -308,8 +308,17 @@ const Search = {
     // search for explicit entries in index directives
     for (const [entry, foundEntries] of Object.entries(indexEntries)) {
       if (entry.includes(queryLower) && (queryLower.length >= entry.length/2)) {
-        for (const [file, id] of foundEntries) {
-          let score = Math.round(100 * queryLower.length / entry.length)
+        for (const [file, id, isMain] of foundEntries) {
+          // Give main entries a high score so they are ordered early.
+          // Give non-main entries a low score so they are ordered later.
+          // We only get here if the query length is at least half the entry
+          // length, so with a weight of 100, main entries will have a minimum
+          // score of 50.  We can choose any weight lower than 50 for non-main
+          // entries to ensure they can never be ordered before main entries.
+          // Since non-main entries are typically just arbitrary cross-references
+          // to the indexed entity, give them a very low score.
+          const maxScore = isMain ? 100 : 1;
+          const score = Math.round(maxScore * queryLower.length / entry.length);
           results.push([
             docNames[file],
             titles[file],

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -317,8 +317,8 @@ const Search = {
           // score of 50.  We can choose any weight lower than 50 for non-main
           // entries to ensure they are always ordered after main entries, but
           // since they are typically just arbitrary cross-references to the
-          // indexed entity, we choose a very low score.
-          const maxScore = isMain ? 100 : 1;
+          // indexed entity, we choose a low range of scores.
+          const maxScore = isMain ? 100 : 10;
           const score = Math.round(maxScore * queryLower.length / entry.length);
           results.push([
             docNames[file],

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -309,14 +309,15 @@ const Search = {
     for (const [entry, foundEntries] of Object.entries(indexEntries)) {
       if (entry.includes(queryLower) && (queryLower.length >= entry.length/2)) {
         for (const [file, id, isMain] of foundEntries) {
-          // Give main entries a high score so they are ordered early.
-          // Give non-main entries a low score so they are ordered later.
+          // Give main entries a high score so they are ordered early
+          // and non-main entries a low score so they are ordered later.
+          //
           // We only get here if the query length is at least half the entry
-          // length, so with a weight of 100, main entries will have a minimum
+          // length, hence, with a weight of 100, main entries have a minimum
           // score of 50.  We can choose any weight lower than 50 for non-main
-          // entries to ensure they can never be ordered before main entries.
-          // Since non-main entries are typically just arbitrary cross-references
-          // to the indexed entity, give them a very low score.
+          // entries to ensure they are always ordered after main entries, but
+          // since they are typically just arbitrary cross-references to the
+          // indexed entity, we choose a very low score.
           const maxScore = isMain ? 100 : 1;
           const score = Math.round(maxScore * queryLower.length / entry.length);
           results.push([


### PR DESCRIPTION
Since #10819, index entries are returned as search results. When the query string exactly matches an indexed term, all index entries become search results with score 100.  This places them above most other search results.

Reporting "main" index entries early in the search results makes sense, but non-main index entries are often just arbitrary cross-references to the indexed term.  Give non-main entries lower scores so they are not ordered early in search results.  This avoids obscuring the main entries and other more-important matches such as document titles.

Fixes: #11578
