### PR TITLE
Add 'noindex' directive for web crawlers to basic theme search results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Bugs fixed
 * #11483: singlehtml builder: Fix MathJax lazy loading when the index does not
   contain any math equations.
   Patch by Bénédikt Tran.
+* #11697: html basic theme: add 'noindex' meta robots tag.
+  Patch by James Addison.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ Bugs fixed
 * #11483: singlehtml builder: Fix MathJax lazy loading when the index does not
   contain any math equations.
   Patch by Bénédikt Tran.
-* #11697: html basic theme: add 'noindex' meta robots tag.
+* #11697: HTML Search: add 'noindex' meta robots tag.
   Patch by James Addison.
 
 Testing

--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -16,6 +16,7 @@
 {%- endblock %}
 {% block extrahead %}
   <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
+  <meta name="robots" content="noindex" />
   {{ super() }}
 {% endblock %}
 {% block body %}

--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -15,9 +15,9 @@
     <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
-  <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
-  <meta name="robots" content="noindex" />
-  {{ super() }}
+    <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
+    <meta name="robots" content="noindex" />
+    {{ super() }}
 {% endblock %}
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -399,6 +399,9 @@ def test_html4_error(make_app, tmp_path):
         (".//h1", "Generated section"),
         (".//a[@href='_sources/otherext.foo.txt']", ''),
     ],
+    'search.html': [
+        (".//meta[@name='robots'][@content='noindex']", ''),
+    ],
 }))
 @pytest.mark.sphinx('html', tags=['testtag'],
                     confoverrides={'html_context.hckey_co': 'hcval_co'})


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Web crawlers should generally prefer to crawl the contents of the documentation and build their own index of those; the `search.html` page implements client-side search, so there's no value to web crawlers in indexing it, and we should communicate to them that they avoid doing that.

### Detail
- Add an HTML `meta` element `robots` with `noindex` configured.
- See also:
  - https://en.wikipedia.org/wiki/Noindex
  - https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag
  - https://moz.com/learn/seo/robots-meta-directives

### Relates
- Resolves #11697.

Edit: update the description to match my understanding that all search results in `search.html` are from client-side searches.