### PR TITLE
Fix coverage extension crash when module contents are not found 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Bugs fixed
   Patch by Bénédikt Tran.
 * #11697: HTML Search: add 'noindex' meta robots tag.
   Patch by James Addison.
+* #11678: Fix ``ZeroDivisionError`` in ``sphinx.ext.coverage``.
+  Patch by Lonami.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,8 +36,8 @@ Bugs fixed
   Patch by Bénédikt Tran.
 * #11697: HTML Search: add 'noindex' meta robots tag.
   Patch by James Addison.
-* #11678: Fix ``ZeroDivisionError`` in ``sphinx.ext.coverage``.
-  Patch by Lonami.
+* #11678: Fix a possible ``ZeroDivisionError`` in ``sphinx.ext.coverage``.
+  Patch by Stephen Finucane.
 
 Testing
 -------

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -291,7 +291,7 @@ class CoverageBuilder(Builder):
 
             table.append([module, '%.2f%%' % value, '%d' % len(self.py_undocumented[module])])
 
-        if len(all_objects):
+        if all_objects:
             table.append([
                 'TOTAL',
                 f'{100 * len(all_documented_objects) / len(all_objects):.2f}%',

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -290,11 +290,15 @@ class CoverageBuilder(Builder):
                 value = 100.0
 
             table.append([module, '%.2f%%' % value, '%d' % len(self.py_undocumented[module])])
-        table.append([
-            'TOTAL',
-            f'{100 * len(all_documented_objects) / len(all_objects):.2f}%',
-            f'{len(all_objects) - len(all_documented_objects)}',
-        ])
+
+        if len(all_objects):
+            table.append([
+                'TOTAL',
+                f'{100 * len(all_documented_objects) / len(all_objects):.2f}%',
+                f'{len(all_objects) - len(all_documented_objects)}',
+            ])
+        else:
+            table.append(['TOTAL', '100', '0'])
 
         for line in _write_table(table):
             op.write(f'{line}\n')


### PR DESCRIPTION
Subject: Fix #11678.

### Feature or Bugfix
- Bugfix

### Purpose
- Fix `ZeroDivisionError` in `_write_py_statistics`.
- Running with `python -m sphinx -M coverage`.

### Detail
Fixes:
```
Exception occurred:
  File "C:\Users\L\Documents\Projects\sphinx\sphinx\ext\coverage.py", line 295, in _write_py_statistics
    f'{100 * len(all_documented_objects) / len(all_objects):.2f}%',
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
ZeroDivisionError: division by zero
```

### Relates
- https://github.com/sphinx-doc/sphinx/commit/31829a9a9cf331fb3dfe867c62b3e0390da44b0c