### PR TITLE
Use ``<search>`` HTML tag instead of ``<div>``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ Deprecated
 Features added
 --------------
 
+* #11701: HTML Search: use of `<search>`_ tag. Browsers compatibility is
+  preserved through the ARIA ``role="search"``.
+  Patch by Bénédikt Tran.
+
+  .. _`<search>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
+
 Bugs fixed
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,7 @@ Deprecated
 Features added
 --------------
 
-* #11701: HTML Search: use of `<search>`_ tag. Browsers compatibility is
-  preserved through the ARIA ``role="search"``.
+* #11701: HTML Search: Adopt the new `<search>`_ element.
   Patch by Bénédikt Tran.
 
   .. _`<search>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -39,13 +39,13 @@
           {{ toctree(includehidden=True) }}
           {%- endblock %}
           {%- block sidebarsearch %}
-          <div role="search">
+          <search role="search">
             <h3 style="margin-top: 1.5em;">{{ _('Search') }}</h3>
             <form class="search" action="{{ pathto('search') }}" method="get">
                 <input type="text" name="q" />
                 <input type="submit" value="{{ _('Go') }}" />
             </form>
-          </div>
+          </search>
           {%- endblock %}
 {% endmacro %}
 

--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -8,14 +8,14 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if pagename != "search" and builder != "singlehtml" %}
-<div id="searchbox" style="display: none" role="search">
+<search role="search">
   <h3 id="searchlabel">{{ _('Quick search') }}</h3>
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
       <input type="submit" value="{{ _('Go') }}" />
     </form>
     </div>
-</div>
+</search>
 <script>document.getElementById('searchbox').style.display = "block"</script>
 {%- endif %}

--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -12,7 +12,7 @@
   <h3 id="searchlabel">{{ _('Quick search') }}</h3>
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
       <input type="submit" value="{{ _('Go') }}" />
     </form>
     </div>

--- a/sphinx/themes/basic/searchbox.html
+++ b/sphinx/themes/basic/searchbox.html
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if pagename != "search" and builder != "singlehtml" %}
-<search role="search">
+<search id="searchbox" style="display: none" role="search">
   <h3 id="searchlabel">{{ _('Quick search') }}</h3>
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">

--- a/sphinx/themes/basic/searchfield.html
+++ b/sphinx/themes/basic/searchfield.html
@@ -14,7 +14,7 @@
 <search id="searchbox" style="display: none" role="search">
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search" />
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search"/>
       <input type="submit" value="{{ _('Go') }}" />
     </form>
     </div>

--- a/sphinx/themes/basic/searchfield.html
+++ b/sphinx/themes/basic/searchfield.html
@@ -11,7 +11,7 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if pagename != "search" and builder != "singlehtml" %}
-<search role="search">
+<search id="searchbox" style="display: none" role="search">
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
       <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search" />

--- a/sphinx/themes/basic/searchfield.html
+++ b/sphinx/themes/basic/searchfield.html
@@ -11,13 +11,13 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if pagename != "search" and builder != "singlehtml" %}
-<div id="searchbox" style="display: none" role="search">
+<search role="search">
     <div class="searchformwrapper">
     <form class="search" action="{{ pathto('search') }}" method="get">
-      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search"/>
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search" />
       <input type="submit" value="{{ _('Go') }}" />
     </form>
     </div>
-</div>
+</search>
 <script>document.getElementById('searchbox').style.display = "block"</script>
 {%- endif %}


### PR DESCRIPTION
Fix #11701.

The use of ``role="search"`` is to ensure backward compatibility for browsers without ``<search>`` support.

cc @AA-Turner @hugovk