### PR TITLE
HTML writer: update filtering logic for meta tags merged from docutils

### DIFF
--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -43,10 +43,9 @@ class HTMLWriter(Writer):
             setattr(self, attr, getattr(visitor, attr, None))
         self.clean_meta = ''.join([
             meta_tag for meta_tag in self.visitor.meta
-            if not any (skip_tag in meta_tag for skip_tag in (
-                    'charset="utf-8"',
-                    'name="generator"',
-                    'name="viewport"',
-                )
-            )
+            if not any(skip_tag in meta_tag for skip_tag in (
+                'charset="utf-8"',
+                'name="generator"',
+                'name="viewport"',
+            ))
         ])

--- a/sphinx/writers/html.py
+++ b/sphinx/writers/html.py
@@ -41,4 +41,12 @@ class HTMLWriter(Writer):
                      'footer', 'html_prolog', 'html_head', 'html_title',
                      'html_subtitle', 'html_body'):
             setattr(self, attr, getattr(visitor, attr, None))
-        self.clean_meta = ''.join(self.visitor.meta[2:])
+        self.clean_meta = ''.join([
+            meta_tag for meta_tag in self.visitor.meta
+            if not any (skip_tag in meta_tag for skip_tag in (
+                    'charset="utf-8"',
+                    'name="generator"',
+                    'name="viewport"',
+                )
+            )
+        ])

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -363,6 +363,9 @@ def test_html4_error(make_app, tmp_path):
          '-p'),
     ],
     'index.html': [
+        (".//meta[@charset='utf-8']", '', True, 1),
+        (".//meta[@name='viewport']", '', True, 2),  # TODO: de-duplicate across basic+alabaster themes
+        (".//meta[@name='generator']", None),
         (".//meta[@name='hc'][@content='hcval']", ''),
         (".//meta[@name='hc_co'][@content='hcval_co']", ''),
         (".//li[@class='toctree-l1']/a", 'Testing various markup'),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Reduces duplication of `viewport` HTML `meta` tags on Sphinx documentation pages.

### Detail
- Updates the existing filtering logic to be less list-index-position-dependent.

### Relates
- Resolves #11699.
