### PR TITLE
Parallel post transform

### DIFF
--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -191,6 +191,25 @@ as metadata of the extension.  Metadata keys currently recognized are:
             * The core logic of the extension is parallelly executable during
               the writing phase.
 
+* ``'parallel_post_transform_safe'``: a boolean that specifies if parallel
+  post-processing of doctrees can be used. This is only relevant in case
+  ``parallel_write_safe`` is also active. Post transformation also contains
+  the ``doctree-resolved`` event. This can greatly improve the performance
+  for extensions that do compute intensive tasks in that event.
+  Since extensions usually don't negatively influence the process, this
+  defaults to ``True``. Technically, the post transform and
+  ``doctree-resolved`` is shifted to the parallel writing worker.
+
+  .. note:: The *parallel-post-transform-safe* extension must satisfy the
+            following conditions:
+
+            * The core logic of the extension is parallelly executable during
+              the writing phase (precondition from ``parallel_write_safe``).
+            * The extension does not write data to the environment during
+              post-transform or ``doctree-resolved`` that is expected later
+              in the build to be available, e.g. for the ``build-finished``
+              event. The environment of each subprocess will be discarded
+              after finish writing.
 
 APIs used for writing extensions
 --------------------------------

--- a/sphinx/addnodes.py
+++ b/sphinx/addnodes.py
@@ -602,4 +602,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1281,7 +1281,7 @@ class Sphinx:
     def is_parallel_allowed(self, typ: str) -> bool:
         """Check whether parallel processing is allowed or not.
 
-        :param typ: A type of processing; ``'read'`` or ``'write'``.
+        :param typ: A type of processing; ``'read'``, ``'write'`` or ``'post_transform'``.
         """
         if typ == 'read':
             attrname = 'parallel_read_safe'
@@ -1297,6 +1297,13 @@ class Sphinx:
                                       "it isn't - please ask the extension author "
                                       "to check and make it explicit")
             message_not_safe = __("the %s extension is not safe for parallel writing")
+        elif typ == 'post_transform':
+            attrname = 'parallel_post_transform_safe'
+            message_not_declared = __("the %s extension does not declare if it "
+                                      "is safe for parallel post-transforming, assuming "
+                                      "it isn't - please ask the extension author "
+                                      "to check and make it explicit")
+            message_not_safe = __("the %s extension is not safe for parallel post-transforming")
         else:
             raise ValueError('parallel type %s is not supported' % typ)
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1303,7 +1303,8 @@ class Sphinx:
                                       "is safe for parallel post-transforming, assuming "
                                       "it isn't - please ask the extension author "
                                       "to check and make it explicit")
-            message_not_safe = __("the %s extension is not safe for parallel post-transforming")
+            message_not_safe = __("the %s extension is not safe for parallel "
+                                  "post-transforming")
         else:
             raise ValueError('parallel type %s is not supported' % typ)
 

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -606,7 +606,7 @@ class Builder:
                 self.write_doc(docname, doctree)
 
     def _write_parallel(self, docnames: Sequence[str], nproc: int) -> None:
-        def write_process(docs: list[tuple[str, nodes.document]]) -> None:
+        def write_process(docs: list[tuple[str, nodes.document]]) -> bytes | None:
             self.app.phase = BuildPhase.WRITING
             for docname, doctree in docs:
                 if self.parallel_post_transform_ok:
@@ -618,6 +618,7 @@ class Builder:
                     for attr in self.post_transform_merge_attr
                 }
                 return pickle.dumps(merge_attr, pickle.HIGHEST_PROTOCOL)
+            return None
 
         # warm up caches/compile templates using the first document
         firstname, docnames = docnames[0], docnames[1:]

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -133,10 +133,7 @@ class Builder:
         """
         pass
 
-    def merge_env_post_transform(
-            self,
-            new_attrs: dict[str, Any],
-        ) -> None:
+    def merge_env_post_transform(self, new_attrs: dict[str, Any]) -> None:
         """Give builders the option to merge any parallel post-transform
         information to the main builder. This can be useful for the
         build-finish phase. The function is called once for each finished

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -158,4 +158,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/dirhtml.py
+++ b/sphinx/builders/dirhtml.py
@@ -50,4 +50,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/dummy.py
+++ b/sphinx/builders/dummy.py
@@ -45,4 +45,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -298,4 +298,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -303,4 +303,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1377,6 +1377,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }
 
 

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -83,4 +83,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -548,4 +548,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -639,4 +639,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -60,11 +60,28 @@ class CheckExternalLinksBuilder(DummyBuilder):
     epilog = __('Look for any errors in the above output or in '
                 '%(outdir)s/output.txt')
 
+    post_transform_merge_attr = ['hyperlinks']
+
     def init(self) -> None:
         self.broken_hyperlinks = 0
         self.hyperlinks: dict[str, Hyperlink] = {}
         # set a timeout for non-responding servers
         socket.setdefaulttimeout(5.0)
+
+    def merge_env_post_transform(
+            self,
+            new_attrs: dict[str, Any],
+        ) -> None:
+        """Merge hyperlinks back to the main builder after parallel
+        post-transformation.
+
+        param new_attrs: the attributes from the parallel subprocess to be
+                         udpated in the main builder (self)
+        """
+        for hyperlink, value in new_attrs['hyperlinks'].items():
+            if hyperlink not in self.hyperlinks:
+                self.hyperlinks[hyperlink] = value
+
 
     def finish(self) -> None:
         checker = HyperlinkAvailabilityChecker(self.config)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -638,4 +638,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -68,10 +68,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
         # set a timeout for non-responding servers
         socket.setdefaulttimeout(5.0)
 
-    def merge_env_post_transform(
-            self,
-            new_attrs: dict[str, Any],
-        ) -> None:
+    def merge_env_post_transform(self, new_attrs: dict[str, Any]) -> None:
         """Merge hyperlinks back to the main builder after parallel
         post-transformation.
 
@@ -81,7 +78,6 @@ class CheckExternalLinksBuilder(DummyBuilder):
         for hyperlink, value in new_attrs['hyperlinks'].items():
             if hyperlink not in self.hyperlinks:
                 self.hyperlinks[hyperlink] = value
-
 
     def finish(self) -> None:
         checker = HyperlinkAvailabilityChecker(self.config)

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -124,4 +124,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -199,4 +199,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -226,4 +226,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/text.py
+++ b/sphinx/builders/text.py
@@ -91,4 +91,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/builders/xml.py
+++ b/sphinx/builders/xml.py
@@ -120,4 +120,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -558,4 +558,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -370,4 +370,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -479,4 +479,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -440,4 +440,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/directives/patches.py
+++ b/sphinx/directives/patches.py
@@ -186,4 +186,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -3903,4 +3903,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 3,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/changeset.py
+++ b/sphinx/domains/changeset.py
@@ -158,4 +158,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 1,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/citation.py
+++ b/sphinx/domains/citation.py
@@ -151,4 +151,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 1,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -8230,4 +8230,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 9,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/index.py
+++ b/sphinx/domains/index.py
@@ -123,4 +123,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 1,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -505,4 +505,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 3,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/math.py
+++ b/sphinx/domains/math.py
@@ -152,4 +152,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 2,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -1766,4 +1766,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 4,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -296,4 +296,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 2,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/domains/std.py
+++ b/sphinx/domains/std.py
@@ -1120,4 +1120,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'env_version': 2,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -613,7 +613,7 @@ class BuildEnvironment:
         return self.get_doctree(self.config.root_doc)
 
     def get_doctree_write(self, docname: str) -> nodes.document:
-        """Split from the function get_and_resolve_doctree for write phase."""
+        """Read the doctree from pickle for the write phase."""
         try:
             doctree = self._write_doc_doctree_cache.pop(docname)
             doctree.settings.env = self
@@ -630,9 +630,7 @@ class BuildEnvironment:
         prune_toctrees: bool = True,
         includehidden: bool = False,
     ) -> nodes.document:
-        """Read the doctree from the pickle, resolve cross-references and
-        toctrees and return it.
-        """
+        """Get the doctree, resolve cross-references and toctrees and return it."""
         if doctree is None:
             doctree = self.get_doctree_write(docname)
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -612,6 +612,16 @@ class BuildEnvironment:
     def master_doctree(self) -> nodes.document:
         return self.get_doctree(self.config.root_doc)
 
+    def get_doctree_write(self, docname: str) -> nodes.document:
+        """Split from the function get_and_resolve_doctree for write phase."""
+        try:
+            doctree = self._write_doc_doctree_cache.pop(docname)
+            doctree.settings.env = self
+            doctree.reporter = LoggingReporter(self.doc2path(docname))
+        except KeyError:
+            doctree = self.get_doctree(docname)
+        return doctree
+
     def get_and_resolve_doctree(
         self,
         docname: str,
@@ -624,12 +634,7 @@ class BuildEnvironment:
         toctrees and return it.
         """
         if doctree is None:
-            try:
-                doctree = self._write_doc_doctree_cache.pop(docname)
-                doctree.settings.env = self
-                doctree.reporter = LoggingReporter(self.doc2path(docname))
-            except KeyError:
-                doctree = self.get_doctree(docname)
+            doctree = self.get_doctree_write(docname)
 
         # resolve all pending cross-references
         self.apply_post_transforms(doctree, docname)

--- a/sphinx/environment/collectors/asset.py
+++ b/sphinx/environment/collectors/asset.py
@@ -144,4 +144,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/environment/collectors/dependencies.py
+++ b/sphinx/environment/collectors/dependencies.py
@@ -54,4 +54,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/environment/collectors/metadata.py
+++ b/sphinx/environment/collectors/metadata.py
@@ -67,4 +67,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/environment/collectors/title.py
+++ b/sphinx/environment/collectors/title.py
@@ -58,4 +58,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -352,4 +352,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/ext/autodoc/typehints.py
+++ b/sphinx/ext/autodoc/typehints.py
@@ -216,4 +216,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': sphinx.__display_version__,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/ext/autosectionlabel.py
+++ b/sphinx/ext/autosectionlabel.py
@@ -66,4 +66,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': sphinx.__display_version__,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/ext/duration.py
+++ b/sphinx/ext/duration.py
@@ -89,4 +89,5 @@ def setup(app: Sphinx) -> dict[str, bool | str]:
         'version': sphinx.__display_version__,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/ext/imgconverter.py
+++ b/sphinx/ext/imgconverter.py
@@ -91,4 +91,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': sphinx.__display_version__,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -695,6 +695,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': sphinx.__display_version__,
         'env_version': 1,
         'parallel_read_safe': True,
+        'parallel_post_transform_safe': True,
     }
 
 

--- a/sphinx/ext/mathjax.py
+++ b/sphinx/ext/mathjax.py
@@ -123,4 +123,8 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value('mathjax3_config', None, 'html')
     app.connect('html-page-context', install_mathjax)
 
-    return {'version': sphinx.__display_version__, 'parallel_read_safe': True}
+    return {
+        'version': sphinx.__display_version__,
+        'parallel_read_safe': True,
+        'parallel_post_transform_safe': True,
+    }

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -45,6 +45,7 @@ class Extension:
         # subprocesses which can speed up build time by a factor of 2.5 on big projects.
         self.parallel_post_transform_safe = kwargs.pop('parallel_post_transform_safe', True)
 
+
 def verify_needs_extensions(app: Sphinx, config: Config) -> None:
     """Check that extensions mentioned in :confval:`needs_extensions` satisfy the version
     requirement, and warn if an extension is not loaded.

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -34,6 +34,16 @@ class Extension:
         # the extension does not tell its status.
         self.parallel_write_safe = kwargs.pop('parallel_write_safe', True)
 
+        # The extension supports parallel post-transform or not. The default value
+        # is ``True``. Sphinx post-transforms documents in parallel even if
+        # the extension does not tell its status. This is acceptable as
+        # post transformations and doctree-resolved events commonly don't update
+        # the environment for build-finished steps. They only act on the documents
+        # currently processed. Any extension that wants to preserve the environment
+        # of the post-transform step for build-finished can actively disable this.
+        # Parallel post-transformation shifts heavy loads from the main process to
+        # subprocesses which can speed up build time by a factor of 2.5 on big projects.
+        self.parallel_post_transform_safe = kwargs.pop('parallel_post_transform_safe', True)
 
 def verify_needs_extensions(app: Sphinx, config: Config) -> None:
     """Check that extensions mentioned in :confval:`needs_extensions` satisfy the version

--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -79,4 +79,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -94,4 +94,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -514,4 +514,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -430,4 +430,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -513,4 +513,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/compact_bullet_list.py
+++ b/sphinx/transforms/compact_bullet_list.py
@@ -88,4 +88,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -621,4 +621,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -294,4 +294,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/post_transforms/code.py
+++ b/sphinx/transforms/post_transforms/code.py
@@ -136,4 +136,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -277,4 +277,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/transforms/references.py
+++ b/sphinx/transforms/references.py
@@ -44,4 +44,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/sphinx/versioning.py
+++ b/sphinx/versioning.py
@@ -175,4 +175,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'version': 'builtin',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
+        'parallel_post_transform_safe': True,
     }

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -17,7 +17,10 @@ def _setup_module(rootdir, sphinx_test_tempdir):
     srcdir = sphinx_test_tempdir / 'test-versioning'
     if not srcdir.exists():
         shutil.copytree(rootdir / 'test-versioning', srcdir)
-    app = SphinxTestApp(srcdir=srcdir)
+    # parallelisation is not supported by this test case
+    # as the global variable 'doctrees' is not preserved
+    # when subprocesses finish
+    app = SphinxTestApp(srcdir=srcdir, parallel=0)
     app.builder.env.app = app
     app.connect('doctree-resolved', on_doctree_resolved)
     app.build()


### PR DESCRIPTION
Subject: Enable parallel post transformations including ``doctree-resolved``

### Feature or Bugfix
- Feature

### Purpose
The current parallel writing approach is quite slow for compute intensive extensions in `doctree-resolved`.
The event is part of the post transformation call chain. This PR shifts that workload to the parallel subprocesses.

### Detail
For extensions like [Sphinx-Needs](https://sphinx-needs.readthedocs.io) this speeds up the build time by a factor
of 2.5 to 4 for big projects. The new implementation also leads to more processes running in parallel as the serial post transformation of chunks blocks their execution, so a bottleneck gets resolved.
**The feature is enabled by default.**
The default-enabling of the feature is necessary as Sphinx` direct dependencies
```
sphinxcontrib-applehelp
sphinxcontrib-devhelp
sphinxcontrib-jsmath
sphinxcontrib-htmlhelp>=2.0.0
sphinxcontrib-serializinghtml>=1.1.9
sphinxcontrib-qthelp
alabaster>=0.7,<0.8
```
are also extensions and don't support the new feature yet. They would block the availability.
Other extensions that cannot live with the new implementation, can disable it using a new flag in the `setup()` return value called `parallel_post_transform_safe`. I already activated the flag for all Sphinx internal extensions.

Moving post-transformation into subprocesses can lead to problems with builders or extensions that store data on the builder or the environment. For the builder a merge feature was added that allows builders to define a method to merge certain builder attributes. The implementation works like `merge_info_from` after the parallel reading phase.
Within Sphinx, only the `CheckExternalLinksBuilder` seems to be affected due to the `hyperlinks` attribute that is consumed when the build finishes. This is fixed in this PR.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/11448

