### PR TITLE
Enable custom latex_elements for each latex_document

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -284,7 +284,7 @@ class LaTeXBuilder(Builder):
             docname, targetname, title, author, themename = entry[:5]
             theme = self.themes.get(themename)
             toctree_only = False
-            latex_elements: dict[str, str] = {}
+            latex_elements: dict[str, str] = self.config.latex_elements
             if len(entry) > 5:
                 toctree_only = entry[5]
             if len(entry) > 6:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -288,7 +288,8 @@ class LaTeXBuilder(Builder):
             if len(entry) > 5:
                 toctree_only = entry[5]
             if len(entry) > 6:
-                latex_elements = entry[6]
+                latex_elements = latex_elements.copy()
+                latex_elements.update(entry[6])
             destination = SphinxFileOutput(destination_path=path.join(self.outdir, targetname),
                                            encoding='utf-8', overwrite_if_changed=True)
             with progress_message(__("processing %s") % targetname):

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -124,7 +124,7 @@ class LaTeXBuilder(Builder):
         self.babel: ExtBabel
         self.context: dict[str, Any] = {}
         self.docnames: Iterable[str] = {}
-        self.document_data: list[tuple[str, str, str, str, str, bool]] = []
+        self.document_data: list[tuple[str, str, str, str, str, bool, dict[str, str]]] = []
         self.themes = ThemeFactory(self.app)
         texescape.init()
 
@@ -284,8 +284,11 @@ class LaTeXBuilder(Builder):
             docname, targetname, title, author, themename = entry[:5]
             theme = self.themes.get(themename)
             toctree_only = False
+            latex_elements: dict[str, str] = {}
             if len(entry) > 5:
                 toctree_only = entry[5]
+            if len(entry) > 6:
+                latex_elements = entry[6]
             destination = SphinxFileOutput(destination_path=path.join(self.outdir, targetname),
                                            encoding='utf-8', overwrite_if_changed=True)
             with progress_message(__("processing %s") % targetname):
@@ -303,7 +306,7 @@ class LaTeXBuilder(Builder):
                 doctree['contentsname'] = self.get_contentsname(docname)
                 doctree['tocdepth'] = tocdepth
                 self.post_process_images(doctree)
-                self.update_doc_context(title, author, theme)
+                self.update_doc_context(title, author, theme, latex_elements)
                 self.update_context()
 
             with progress_message(__("writing")):
@@ -327,13 +330,16 @@ class LaTeXBuilder(Builder):
 
         return contentsname
 
-    def update_doc_context(self, title: str, author: str, theme: Theme) -> None:
+    def update_doc_context(self, title: str, author: str, theme: Theme, 
+            latex_elements: dict[str, str]) -> None:
         self.context['title'] = title
         self.context['author'] = author
         self.context['docclass'] = theme.docclass
         self.context['papersize'] = theme.papersize
         self.context['pointsize'] = theme.pointsize
         self.context['wrapperclass'] = theme.wrapperclass
+        self.context.update(latex_elements)
+
 
     def assemble_doctree(
         self, indexfile: str, toctree_only: bool, appendices: list[str],

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -180,6 +180,7 @@ class LaTeXBuilder(Builder):
         self.context['booktabs'] = 'booktabs' in self.config.latex_table_style
         self.context['borderless'] = 'borderless' in self.config.latex_table_style
         self.context['colorrows'] = 'colorrows' in self.config.latex_table_style
+        self.context['tabularray'] = 'tabularray' in self.config.latex_table_style
 
         if self.config.today:
             self.context['date'] = self.config.today

--- a/sphinx/templates/latex/latex.tex_t
+++ b/sphinx/templates/latex/latex.tex_t
@@ -35,6 +35,9 @@
 <% if colorrows -%>
 \PassOptionsToPackage{colorrows}{sphinx}
 <% endif -%>
+<% if tabularray -%>
+\PassOptionsToPackage{tabularray}{sphinx}
+<% endif -%>
 <%= passoptionstopackages %>
 \PassOptionsToPackage{warn}{textcomp}
 <%= inputenc %>

--- a/sphinx/templates/latex/tabularray.tex_t
+++ b/sphinx/templates/latex/tabularray.tex_t
@@ -1,0 +1,53 @@
+\begin{savenotes}\sphinxattablestart
+\sphinxthistablewithglobalstyle
+<% if 'booktabs' in table.styles -%>
+\sphinxthistablewithbooktabsstyle
+<% endif -%>
+<% if 'borderless' in table.styles -%>
+\sphinxthistablewithborderlessstyle
+<% endif -%>
+<% if 'standard' in table.styles -%>
+\sphinxthistablewithstandardstyle
+<% endif -%>
+<% if 'vlines' in table.styles -%>
+\sphinxthistablewithvlinesstyle
+<% endif -%>
+<% if 'novlines' in table.styles -%>
+\sphinxthistablewithnovlinesstyle
+<% endif -%>
+<% if 'colorrows' in table.styles -%>
+\sphinxthistablewithcolorrowsstyle
+<% endif -%>
+<% if 'nocolorrows' in table.styles -%>
+\sphinxthistablewithnocolorrowsstyle
+<% endif -%>
+<% if table.align -%>
+  <%- if table.align in ('center', 'default') -%>
+  \centering
+  <%- elif table.align == 'left' -%>
+  \raggedright
+  <%- else -%>
+  \raggedleft
+  <%- endif %>
+<%- else -%>
+  \centering
+<%- endif %>
+<% if table.caption -%>
+\sphinxcapstartof{table}
+\sphinxthecaptionisattop
+\sphinxcaption{<%= ''.join(table.caption) %>}<%= labels %>
+\sphinxaftertopcaption
+<% elif labels -%>
+\phantomsection<%= labels %>\nobreak
+<% endif -%>
+\begin{tblr}<%= table.get_colspec() -%>
+\sphinxtoprule
+<%= ''.join(table.header) -%>
+<%- if table.header -%>
+\sphinxmidrule
+<% endif -%>
+<%=- ''.join(table.body) -%>
+\sphinxbottomrule
+\end{tblr}
+\sphinxtableafterendhook\par
+\sphinxattableend\end{savenotes}

--- a/sphinx/texinputs/sphinx.sty
+++ b/sphinx/texinputs/sphinx.sty
@@ -140,6 +140,8 @@ will be set to white}%
 }
 % Coloured table rows
 \DeclareBoolOption[false]{colorrows}
+% Optional usage of tabularray package for tables
+\DeclareBoolOption[false]{tabularray}
 % Sphinx legacy text layout: 1in margins on all four sides
 \ifx\@jsc@uplatextrue\@undefined
 \DeclareStringOption[1in]{hmargin}

--- a/sphinx/texinputs/sphinxlatextables.sty
+++ b/sphinx/texinputs/sphinxlatextables.sty
@@ -50,6 +50,7 @@
 % - varwidth
 % - colortbl
 % - booktabs if 'booktabs' in latex_table_style
+% - tabularray if 'tabularray' in latex_table_style
 %
 % Extends tabulary and longtable via patches and custom macros to support
 % merged cells possibly containing code-blocks in complex tables
@@ -757,6 +758,18 @@
   % this final one does NO \vskip-\arrayrulewidth... that's the whole point
 }
 %%%% end of \cline workarounds
+
+% If using tabularray, it needs to be required before \rownum is defined below
+\ifspx@opt@tabularray
+    \RequirePackage{tabularray}
+    \def\sphinxthistablewithglobalstyle{\sphinxthistablewithstandardstyle}
+
+    % TODO: expand command or define based on settings
+    \NewTableCommand\sphinxtoprule{\hline}
+    \NewTableCommand\sphinxmidrule{\hline}
+    \NewTableCommand\sphinxbottomrule{\hline}
+    \NewTableCommand\sphinxhline{\hline}
+\fi
 
 %
 % - passing option "table" to xcolor also loads colortbl but we needed to


### PR DESCRIPTION
Hi, this isn't ready to be a proper PR yet (need to ramp up on how to add tests, docs, etc) but I wanted to float it to evaluate if it's worth looking into. I'm finding this feature very useful myself and it would accommodate #9145 as well.

### Feature or Bugfix
- Feature

### Purpose
- Allow overriding latex_elements (e.g. `preamble`) per latex document provided in latex_documents

### Detail
- Enable a per-document latex_elements override dict as an optional 7th element of latex_documents entry tuple
  - If provided, overrides any options provided in global latex_elements

The document tuple is getting a little unwieldy IMO, so I'm wondering if as a separate effort it could be refactored into a dict/dataclass (backwards compatible with the tuple format).

### Relates
- #9145
