### PR TITLE
Enable custom latex_elements for each latex_document

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -284,7 +284,7 @@ class LaTeXBuilder(Builder):
             docname, targetname, title, author, themename = entry[:5]
             theme = self.themes.get(themename)
             toctree_only = False
-            latex_elements: dict[str, str] = {}
+            latex_elements: dict[str, str] = self.config.latex_elements
             if len(entry) > 5:
                 toctree_only = entry[5]
             if len(entry) > 6:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -288,7 +288,8 @@ class LaTeXBuilder(Builder):
             if len(entry) > 5:
                 toctree_only = entry[5]
             if len(entry) > 6:
-                latex_elements = entry[6]
+                latex_elements = latex_elements.copy()
+                latex_elements.update(entry[6])
             destination = SphinxFileOutput(destination_path=path.join(self.outdir, targetname),
                                            encoding='utf-8', overwrite_if_changed=True)
             with progress_message(__("processing %s") % targetname):

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -124,7 +124,7 @@ class LaTeXBuilder(Builder):
         self.babel: ExtBabel
         self.context: dict[str, Any] = {}
         self.docnames: Iterable[str] = {}
-        self.document_data: list[tuple[str, str, str, str, str, bool]] = []
+        self.document_data: list[tuple[str, str, str, str, str, bool, dict[str, str]]] = []
         self.themes = ThemeFactory(self.app)
         texescape.init()
 
@@ -284,8 +284,11 @@ class LaTeXBuilder(Builder):
             docname, targetname, title, author, themename = entry[:5]
             theme = self.themes.get(themename)
             toctree_only = False
+            latex_elements: dict[str, str] = {}
             if len(entry) > 5:
                 toctree_only = entry[5]
+            if len(entry) > 6:
+                latex_elements = entry[6]
             destination = SphinxFileOutput(destination_path=path.join(self.outdir, targetname),
                                            encoding='utf-8', overwrite_if_changed=True)
             with progress_message(__("processing %s") % targetname):
@@ -303,7 +306,7 @@ class LaTeXBuilder(Builder):
                 doctree['contentsname'] = self.get_contentsname(docname)
                 doctree['tocdepth'] = tocdepth
                 self.post_process_images(doctree)
-                self.update_doc_context(title, author, theme)
+                self.update_doc_context(title, author, theme, latex_elements)
                 self.update_context()
 
             with progress_message(__("writing")):
@@ -327,13 +330,16 @@ class LaTeXBuilder(Builder):
 
         return contentsname
 
-    def update_doc_context(self, title: str, author: str, theme: Theme) -> None:
+    def update_doc_context(self, title: str, author: str, theme: Theme, 
+            latex_elements: dict[str, str]) -> None:
         self.context['title'] = title
         self.context['author'] = author
         self.context['docclass'] = theme.docclass
         self.context['papersize'] = theme.papersize
         self.context['pointsize'] = theme.pointsize
         self.context['wrapperclass'] = theme.wrapperclass
+        self.context.update(latex_elements)
+
 
     def assemble_doctree(
         self, indexfile: str, toctree_only: bool, appendices: list[str],


### PR DESCRIPTION
Hi, this isn't ready to be a proper PR yet (need to ramp up on how to add tests, docs, etc) but I wanted to float it to evaluate if it's worth looking into. I'm finding this feature very useful myself and it would accommodate #9145 as well.

### Feature or Bugfix
- Feature

### Purpose
- Allow overriding latex_elements (e.g. `preamble`) per latex document provided in latex_documents

### Detail
- Enable a per-document latex_elements override dict as an optional 7th element of latex_documents entry tuple
  - If provided, overrides any options provided in global latex_elements

The document tuple is getting a little unwieldy IMO, so I'm wondering if as a separate effort it could be refactored into a dict/dataclass (backwards compatible with the tuple format).

### Relates
- #9145
