### PR TITLE
Make the first party extensions optional, add [extensions] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,12 +55,6 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "sphinxcontrib-applehelp",
-    "sphinxcontrib-devhelp",
-    "sphinxcontrib-jsmath",
-    "sphinxcontrib-htmlhelp>=2.0.0",
-    "sphinxcontrib-serializinghtml>=1.1.9",
-    "sphinxcontrib-qthelp",
     "Jinja2>=3.0",
     "Pygments>=2.14",
     "docutils>=0.18.1,<0.21",
@@ -76,8 +70,35 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+applehelp = [
+    "sphinxcontrib-applehelp",
+]
+devhelp = [
+    "sphinxcontrib-devhelp",
+]
+jsmath = [
+    "sphinxcontrib-jsmath",
+]
+htmlhelp = [
+    "sphinxcontrib-htmlhelp>=2.0.0",
+]
+serializinghtml = [
+    "sphinxcontrib-serializinghtml>=1.1.9",
+]
+qthelp = [
+    "sphinxcontrib-qthelp",
+]
+extensions = [
+    "sphinx[applehelp]",
+    "sphinx[devhelp]",
+    "sphinx[jsmath]",
+    "sphinx[htmlhelp]",
+    "sphinx[serializinghtml]",
+    "sphinx[qthelp]",
+]
 docs = [
     "sphinxcontrib-websupport",
+    "sphinx[extensions]",
 ]
 lint = [
     "flake8>=3.5.0",

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -22,6 +22,7 @@ DEFAULT_ENABLED_MARKERS = [
         'sphinx(builder, testroot=None, freshenv=False, confoverrides=None, tags=None,'
         ' docutilsconf=None, parallel=0): arguments to initialize the sphinx test application.'
     ),
+    'sphinxcontrib(...): required sphinxcontrib.* extensions',
     'test_params(shared_result=...): test parameters.',
 ]
 
@@ -66,6 +67,11 @@ def app_params(request: Any, test_params: dict, shared_result: SharedResult,
     Parameters that are specified by 'pytest.mark.sphinx' for
     sphinx.application.Sphinx initialization
     """
+
+    # ##### process pytest.mark.sphinxcontrib
+    for info in reversed(list(request.node.iter_markers("sphinxcontrib"))):
+        for arg in info.args:
+            pytest.importorskip("sphinxcontrib." + arg)
 
     # ##### process pytest.mark.sphinx
 

--- a/tests/test_api_translator.py
+++ b/tests/test_api_translator.py
@@ -36,6 +36,7 @@ def test_singlehtml_set_translator_for_singlehtml(app, status, warning):
     assert translator_class.__name__ == 'ConfSingleHTMLTranslator'
 
 
+@pytest.mark.sphinxcontrib('serializinghtml')
 @pytest.mark.sphinx('pickle', testroot='api-set-translator')
 def test_pickle_set_translator_for_pickle(app, status, warning):
     translator_class = app.builder.get_translator_class()
@@ -43,6 +44,7 @@ def test_pickle_set_translator_for_pickle(app, status, warning):
     assert translator_class.__name__ == 'ConfPickleTranslator'
 
 
+@pytest.mark.sphinxcontrib('serializinghtml')
 @pytest.mark.sphinx('json', testroot='api-set-translator')
 def test_json_set_translator_for_json(app, status, warning):
     translator_class = app.builder.get_translator_class()

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1547,6 +1547,7 @@ def test_html_math_renderer_is_imgmath(app, status, warning):
     assert app.builder.math_renderer_name == 'imgmath'
 
 
+@pytest.mark.sphinxcontrib('serializinghtml', 'jsmath')
 @pytest.mark.sphinx('html', testroot='basic',
                     confoverrides={'extensions': ['sphinxcontrib.jsmath',
                                                   'sphinx.ext.imgmath']})
@@ -1567,6 +1568,7 @@ def test_html_math_renderer_is_duplicated2(app, status, warning):
     assert app.builder.math_renderer_name == 'imgmath'  # The another one is chosen
 
 
+@pytest.mark.sphinxcontrib('jsmath')
 @pytest.mark.sphinx('html', testroot='basic',
                     confoverrides={'extensions': ['sphinxcontrib.jsmath',
                                                   'sphinx.ext.imgmath'],
@@ -1575,6 +1577,7 @@ def test_html_math_renderer_is_chosen(app, status, warning):
     assert app.builder.math_renderer_name == 'imgmath'
 
 
+@pytest.mark.sphinxcontrib('jsmath')
 @pytest.mark.sphinx('html', testroot='basic',
                     confoverrides={'extensions': ['sphinxcontrib.jsmath',
                                                   'sphinx.ext.mathjax'],


### PR DESCRIPTION
This is my attempt to make all the sphinxcontrib requirements optional.


### Feature or Bugfix

- Feature

### Purpose

We package sphinx in Fedora Linux and we don't really have a strong reason to pull in packages like applehelp there.
I decided to see if we could get rid of them.

### Detail

<del>Note that this is a very early draft. I am yet to test this in Fedora and see if this approach is feasible.</del> It works for us.

If it is, this obviously requires some documentation changes and possible deprecations. I am however unable to drive that forward right now. I would be interested to hear from the Sphinx maintainers whether this approach makes sense or not at all.

### Relates
- https://github.com/sphinx-doc/sphinx/issues/11567

