### PR TITLE
HTML search: Fix exact matching on titles with extra whitespace

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -288,9 +288,9 @@ const Search = {
     let results = [];
     _removeChildren(document.getElementById("search-progress"));
 
-    const queryLower = query.toLowerCase();
+    const queryLower = query.toLowerCase().trim();
     for (const [title, foundTitles] of Object.entries(allTitles)) {
-      if (title.toLowerCase().includes(queryLower) && (queryLower.length >= title.length/2)) {
+      if (title.toLowerCase().trim().includes(queryLower) && (queryLower.length >= title.length/2)) {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
           results.push([


### PR DESCRIPTION
Subject: Fix exact matching on title when there are leading/trailing spaces

### Feature or Bugfix

- Bugfix

### Purpose

When there is a search term with whitespace (e.g. ` Superman`), the override to boost entries that match on the title (e.g. `Superman`) doesn't work properly. This PR fixes that.

### Detail

N/A

### Relates

No ticket filed for this issue, just noticed it.

