### PR TITLE
Add PyPI role

### DIFF
--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -251,6 +251,17 @@ The following roles generate external links:
 
    For example: :pep:`8`
 
+.. rst:role:: pypi
+
+   A reference to a PyPI project.  This generates appropriate index entries.
+   In the HTML output, the project name is used as a hyperlink to its PyPI
+   webpage.  You can link to a specific section by saying
+   ``:pypi:`project#anchor```.
+
+   For example: :pypi:`Sphinx`
+
+   .. versionadded:: 7.3
+
 .. rst:role:: rfc
 
    A reference to an Internet Request for Comments.  This generates appropriate

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -45,6 +45,8 @@ default_settings: dict[str, Any] = {
     'cloak_email_addresses': True,
     'pep_base_url': 'https://peps.python.org/',
     'pep_references': None,
+    'pypi_base_url': 'https://pypi.org/project/',
+    'pypi_references': None,
     'rfc_base_url': 'https://datatracker.ietf.org/doc/html/',
     'rfc_references': None,
     'input_encoding': 'utf-8-sig',

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -175,6 +175,30 @@ def get_verifier(verify, verify_re):
          '{\\sphinxstylestrong{PEP 8\\#id1}}'),
     ),
     (
+        # pypi role
+        'verify',
+        ':pypi:`norwegianblue`',
+        ('<p><span class="target" id="index-0"></span><a class="pypi reference external" '
+         'href="https://pypi.org/project/norwegianblue/">'
+         '<strong>norwegianblue</strong></a></p>'),
+        ('\\sphinxAtStartPar\n'
+         '\\index{PyPI@\\spxentry{PyPI}!PyPI norwegianblue@\\spxentry{PyPI norwegianblue}}'
+         '\\sphinxhref{https://pypi.org/project/norwegianblue/}'
+         '{\\sphinxstylestrong{norwegianblue}}'),
+    ),
+    (
+        # pypi role with anchor
+        'verify',
+        ':pypi:`norwegianblue#history`',
+        ('<p><span class="target" id="index-0"></span><a class="pypi reference external" '
+         'href="https://pypi.org/project/norwegianblue/#history">'
+         '<strong>norwegianblue#history</strong></a></p>'),
+        ('\\sphinxAtStartPar\n'
+         '\\index{PyPI@\\spxentry{PyPI}!PyPI norwegianblue\\#history@\\spxentry{PyPI norwegianblue\\#history}}'
+         '\\sphinxhref{https://pypi.org/project/norwegianblue/\\#history}'
+         '{\\sphinxstylestrong{norwegianblue\\#history}}'),
+    ),
+    (
         # rfc role
         'verify',
         ':rfc:`2324`',


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Add a `pypi` role to turn ``` :pypi:`Sphinx#history` ``` into https://pypi.org/project/Sphinx/
- It's a [quite common](https://github.com/search?q=extlinks+https%3A%2F%2Fpypi.org%2Fproject%2F%25s+path%3A**%2Fconf.py&type=code) `extlinks` entry, so would be useful upstream in Sphinx

### Detail
- Add `pypi` role, similar to existing `pep` and `rfc` roles

### Relates
- https://github.com/sphinx-doc/sphinx/pull/11781
