### PR TITLE
Fix autodoc tests for Python 3.11+

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       run: python -m pip install --upgrade ruff
     - name: Lint with latest Ruff
       continue-on-error: true
-      run: ruff . --format github
+      run: ruff . --output-format github
 
   flake8:
     runs-on: ubuntu-latest

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -1584,6 +1584,11 @@ def test_autodoc_typehints_format_fully_qualified_for_newtype_alias(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_options(app):
+    if sys.version_info >= (3, 11):
+        list_of_weak_references = "      list of weak references to the object"
+    else:
+        list_of_weak_references = "      list of weak references to the object (if defined)"
+
     # no settings
     actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
     assert '   .. py:attribute:: EnumCls.val1' not in actual
@@ -1627,7 +1632,7 @@ def test_autodoc_default_options(app):
     assert '      Iterate squares of each value.' in actual
     if not IS_PYPY:
         assert '   .. py:attribute:: CustomIter.__weakref__' in actual
-        assert '      list of weak references to the object (if defined)' in actual
+        assert list_of_weak_references in actual
 
     # :exclude-members: None - has no effect. Unlike :members:,
     # :special-members:, etc. where None == "include all", here None means
@@ -1651,13 +1656,18 @@ def test_autodoc_default_options(app):
     assert '      Iterate squares of each value.' in actual
     if not IS_PYPY:
         assert '   .. py:attribute:: CustomIter.__weakref__' in actual
-        assert '      list of weak references to the object (if defined)' in actual
+        assert list_of_weak_references in actual
     assert '   .. py:method:: CustomIter.snafucate()' in actual
     assert '      Makes this snafucated.' in actual
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_options_with_values(app):
+    if sys.version_info >= (3, 11):
+        list_of_weak_references = "      list of weak references to the object"
+    else:
+        list_of_weak_references = "      list of weak references to the object (if defined)"
+
     # with :members:
     app.config.autodoc_default_options = {'members': 'val1,val2'}
     actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
@@ -1698,7 +1708,7 @@ def test_autodoc_default_options_with_values(app):
     assert '      Iterate squares of each value.' in actual
     if not IS_PYPY:
         assert '   .. py:attribute:: CustomIter.__weakref__' not in actual
-        assert '      list of weak references to the object (if defined)' not in actual
+        assert list_of_weak_references not in actual
 
     # with :exclude-members:
     app.config.autodoc_default_options = {
@@ -1722,6 +1732,6 @@ def test_autodoc_default_options_with_values(app):
     assert '      Iterate squares of each value.' in actual
     if not IS_PYPY:
         assert '   .. py:attribute:: CustomIter.__weakref__' not in actual
-        assert '      list of weak references to the object (if defined)' not in actual
+        assert list_of_weak_references not in actual
     assert '   .. py:method:: CustomIter.snafucate()' not in actual
     assert '      Makes this snafucated.' not in actual

--- a/tests/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc_configs.py
@@ -1584,7 +1584,10 @@ def test_autodoc_typehints_format_fully_qualified_for_newtype_alias(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_options(app):
-    if sys.version_info >= (3, 11):
+    if (
+            (3, 11, 7) <= sys.version_info < (3, 12)
+            or sys.version_info >= (3, 12, 1)
+    ):
         list_of_weak_references = "      list of weak references to the object"
     else:
         list_of_weak_references = "      list of weak references to the object (if defined)"
@@ -1663,7 +1666,10 @@ def test_autodoc_default_options(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_autodoc_default_options_with_values(app):
-    if sys.version_info >= (3, 11):
+    if (
+            (3, 11, 7) <= sys.version_info < (3, 12)
+            or sys.version_info >= (3, 12, 1)
+    ):
         list_of_weak_references = "      list of weak references to the object"
     else:
         list_of_weak_references = "      list of weak references to the object (if defined)"


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Fix the CI

### Detail

Since Python 3.11.7, 3.12.0 and 3.13.0a2, "list of weak references to the object (if defined)" was changed to "list of weak references to the object".

Add a version check to decide text to assert.

Before: https://github.com/sphinx-doc/sphinx/actions/runs/7158385030?pr=11791

![image](https://github.com/sphinx-doc/sphinx/assets/1324225/b7976ad6-e29d-4fc8-869d-a0ddc7ec4532)

After: https://github.com/sphinx-doc/sphinx/actions/runs/7166386276?pr=11793

![image](https://github.com/sphinx-doc/sphinx/assets/1324225/7bbdcfb3-65a0-42f8-84a1-e3f8ac546c97)

("Docutils HEAD" fails because https://repo.or.cz/docutils.git/ is 403 -- see PR https://github.com/sphinx-doc/sphinx/pull/11794 -- and Windows fails with `test_gettext_dont_rebuild_mo`.)

---

Also in Ruff v0.1.0:

> The `--format` option has been removed from ruff check, use `--output-format` instead

So use that option for "Lint with latest Ruff" to prevent `error: unexpected argument '--format' found`.

https://github.com/astral-sh/ruff/releases/tag/v0.1.0


### Relates
- https://github.com/python/cpython/pull/112268
