### PR TITLE
CI: Replace broken repo.or.cz with github.com

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .[test]
     - name: Install Docutils' HEAD
-      run: python -m pip install git+https://github.com/docutils/docutils\#subdirectory=docutils
+      run: python -m pip install svn+https://svn.code.sf.net/p/docutils/code/trunk/docutils
     - name: Test with pytest
       run: python -m pytest -vv
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .[test]
     - name: Install Docutils' HEAD
-      run: python -m pip install git+https://repo.or.cz/docutils.git\#subdirectory=docutils
+      run: python -m pip install git+https://github.com/docutils/docutils\#subdirectory=docutils
     - name: Test with pytest
       run: python -m pytest -vv
       env:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Fix the "Docutils HEAD" job on the CI

### Detail

The CI clones docutils from https://repo.or.cz/docutils.git but https://repo.or.cz is down. 

Replace it with the mirror at https://github.com/docutils/docutils.

### Relates
- https://github.com/sphinx-doc/sphinx/pull/11793 for more CI fixes.

