### PR TITLE
Python domain: Correctly match when signature simultaneously has annotations for both the function and the return type

### DIFF
--- a/sphinx/domains/python.py
+++ b/sphinx/domains/python.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 py_sig_re = re.compile(
     r'''^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
-          (?: \[\s*(.*)\s*])?    # optional: type parameters list
+          (?: \[\s*(.*?)\s*\])?  # optional: type parameters list
           (?: \(\s*(.*)\s*\)     # optional: arguments
            (?:\s* -> \s* (.*))?  #           return annotation
           )? $                   # and nothing more

--- a/tests/test_domain_py.py
+++ b/tests/test_domain_py.py
@@ -59,6 +59,12 @@ def test_function_signatures():
     rv = parse('func(a=1) -> int object')
     assert rv == '(a=1)'
 
+    rv = parse('func[Annotated[typename]](a=1) -> int')
+    assert rv == '(a=1)'
+
+    rv = parse('func[Annotated[typename]](a=1) -> Annotated[typename]')
+    assert rv == '(a=1)'
+
     rv = parse('func(a=1, [b=None])')
     assert rv == '(a=1, [b=None])'
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fixes python signature regex to successfully parse simultaneous annotations of function and return type.

### Detail
Python domain fails to match functions where both function name and return type have type annotation, e.g.
```python
hello[int](a, b, c) -> world[int]
````

The fix comes down to an overly eager `.*` in the regex that matches everything from the first `[` to the last `]` in one fell swoop.

I'm not 100% sure if the two new test cases are in the right place but if not, let me know and I'll move them.