### PR TITLE
Use root_doc variable instead of hardcoded 'index' in themes template

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -3,14 +3,14 @@
 
 {% block extrahead %}
 {{ super() }}
-{%- if not embedded and pagename == 'index' %}
+{%- if not embedded and pagename == root_doc %}
 <style>.related { display: none; }</style>
 {%- endif %}
 {% endblock %}
 
 {% block header %}
 <div class="pageheader">
-  <a href="{{ pathto('index') }}">
+  <a href="{{ pathto(root_doc)|e }}">
     <img src="{{ pathto('_static/sphinx-logo.svg', resource=True) }}" alt="logo" />
   </a>
   <h1>Sphinx</h1>
@@ -21,7 +21,7 @@
 <div class="related" role="navigation" aria-label="related navigation">
   <h3>{{ _('Navigation') }}</h3>
   <ul>
-    <li><a href="{{ pathto('index') }}">Documentation</a> &raquo;</li>
+    <li><a href="{{ pathto(root_doc)|e }}">Documentation</a> &raquo;</li>
     {%- for parent in parents %}
       <li class="nav-item nav-item-{{ loop.index }}"><a href="{{ parent.link|e }}" {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>{{ reldelim1 }}</li>
     {%- endfor %}

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -35,14 +35,14 @@
       <div class="header" role="banner">
         {%- block haikuheader %}
         {%- if theme_full_logo != "false" %}
-        <a href="{{ pathto('index') }}">
+        <a href="{{ pathto(root_doc)|e }}">
           <img class="logo" src="{{ logo_url|e }}" alt="Logo"/>
         </a>
         {%- else %}
         {%- if logo -%}
           <img class="rightlogo" src="{{ logo_url|e }}" alt="Logo"/>
         {%- endif -%}
-        <h1 class="heading"><a href="{{ pathto('index') }}">
+        <h1 class="heading"><a href="{{ pathto(root_doc)|e }}">
           <span>{{ shorttitle|e }}</span></a></h1>
         <h2 class="heading"><span>{{ title|striptags|e }}</span></h2>
         {%- endif %}

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -23,7 +23,7 @@
 {% block content %}
     <div id="content">
       <div class="header">
-        <h1 class="heading"><a href="{{ pathto('index') }}"
+        <h1 class="heading"><a href="{{ pathto(root_doc)|e }}"
           title="back to the documentation overview"><span>{{ title|striptags|e }}</span></a></h1>
       </div>
       <div class="relnav" role="navigation" aria-label="related navigation">


### PR DESCRIPTION
Subject: Use root_doc variable instead of hardcoded 'index' in themes template

### Feature or Bugfix

- Bugfix

### Purpose

- Fix incorrect link in generated HTML when `root_doc` is no default value

### Detail

- Use `root_doc` variable instead of hardcoded 'index' in themes template

### Relates

- https://github.com/sphinx-doc/sphinx/issues/11663

