### PR TITLE
inline SIM115 whitelist

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -583,9 +583,6 @@ select = [
 # whitelist ``print`` for stdout messages
 "sphinx/testing/fixtures.py" = ["T201"]
 
-# allow returning ``open()``
-"sphinx/testing/path.py" = ["SIM115"]
-
 # Ruff bug: https://github.com/astral-sh/ruff/issues/6540
 "sphinx/transforms/i18n.py" = ["PGH004"]
 

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -150,7 +150,7 @@ class path(str):
         os.utime(self, arg)
 
     def open(self, mode: str = 'r', **kwargs: Any) -> IO:
-        return open(self, mode, **kwargs)
+        return open(self, mode, **kwargs)  # noqa: SIM115
 
     def write_text(self, text: str, encoding: str = 'utf-8', **kwargs: Any) -> None:
         """


### PR DESCRIPTION
- simplifies config
- SIM115 whitelist will be naturally removed when `sphinx.testing.path` is removed
- supports my never-ending quest to remove more lines than i add ;)