### PR TITLE
Require PyTest 6.0 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ module = [
 disallow_any_generics = false
 
 [tool.pytest.ini_options]
-minversion = 4.6
+minversion = 6.0
 addopts = [
     "--import-mode=importlib",
 #    "--pythonwarnings=error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ lint = [
     "types-requests",
 ]
 test = [
-    "pytest>=4.6",
+    "pytest>=6.0",
     "html5lib",
     "cython>=3.0",
     "setuptools>=67.0",  # for Cython compilation


### PR DESCRIPTION
Subject: Bump pytest `minversion`

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
As far as I know, _pytest_ supports configuration in `pyproject.toml` since version 6. Since _pytest_ is configured in `pyroject.toml`, it makes sense to require version 6, although an earlier version of _pytest_ would just skip the configuration in `pyproject.toml` that precisely forbids that earlier version<.

### Relates
- [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master)
- [Configuring pytest ](https://learn.scientific-python.org/development/guides/pytest/#configuring-pytest)

