### PR TITLE
Enable MyPy error codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ enable_error_code = [
     "redundant-self",
     "truthy-iterable",
     "ignore-without-code",
+    "redundant-expr",
     "unused-awaitable",
 ]
 disable_error_code = [

--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -232,13 +232,14 @@ class _TypeParameterListParser(TokenProcessor):
         while current := self.fetch_token():
             if current == token.NAME:
                 tp_name = current.value.strip()
+                tp_kind: Parameter.kind
                 if self.previous and self.previous.match([token.OP, '*'], [token.OP, '**']):
                     if self.previous == [token.OP, '*']:
                         tp_kind = Parameter.VAR_POSITIONAL
                     else:
-                        tp_kind = Parameter.VAR_KEYWORD  # type: ignore[assignment]
+                        tp_kind = Parameter.VAR_KEYWORD
                 else:
-                    tp_kind = Parameter.POSITIONAL_OR_KEYWORD  # type: ignore[assignment]
+                    tp_kind = Parameter.POSITIONAL_OR_KEYWORD
 
                 tp_ann: Any = Parameter.empty
                 tp_default: Any = Parameter.empty


### PR DESCRIPTION
Subject: Enable MyPy error codes

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
Enable MyPy error codes as suggested by [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master).

### Detail
* [MY104](https://learn.scientific-python.org/development/guides/style#MY104): MyPy enables ignore-without-code
  Must have `"ignore-without-code"` in `enable_error_code = [...]`. This will force all skips in your project to include the error code, which makes them more readable, and avoids skipping something unintended.
  ```ini
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
* [MY105](https://learn.scientific-python.org/development/guides/style#MY105): MyPy enables redundant-expr
  Must have `"redundant-expr"` in `enable_error_code = [...]`. This helps catch useless lines of code, like checking the same condition twice.
  ```ini
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```
* [MY106](https://learn.scientific-python.org/development/guides/style#MY106): MyPy enables truthy-bool
  Must have `"truthy-bool"` in `enable_error_code = []`. This catches mistakes in using a value as truthy if it cannot be falsey.
  ```ini
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```

### Relates
- [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master)

