### PR TITLE
MyPy warn unreachable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ strict_optional = true
 warn_redundant_casts = true
 warn_unused_configs = true
 warn_unused_ignores = true
+warn_unreachable = true
 disallow_any_generics = true
 extra_checks = true
 enable_error_code = [


### PR DESCRIPTION
Subject: MyPy warn unreachable

### Feature or Bugfix
- Feature

### Purpose
- Give it a go, check whether this results in some true positives and not too many false positives.

### Detail

As suggested by [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master):

* [MY103](https://learn.scientific-python.org/development/guides/style#MY103): MyPy warn unreachable
  Must have `warn_unreachable = true` to pass this check. There are occasionally false positives (often due to platform or Python version static checks), so it's okay to ignore this check. But try it first - it can catch real bugs too.
  ```ini
  [tool.mypy]
  warn_unreachable = true
  ```

### Relates
* [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master)

