### PR TITLE
Use (new) ruff config section `lint`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -372,7 +372,7 @@ select = [
     "YTT",
 ]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "doc/conf.py" = ["INP001"]
 "doc/development/tutorials/examples/*" = ["INP001"]
 # allow print() in the tutorial
@@ -410,5 +410,5 @@ select = [
 # whitelist ``print`` for stdout messages
 "utils/*" = ["T201"]
 
-[flake8-quotes]
+[lint.flake8-quotes]
 inline-quotes = "single"


### PR DESCRIPTION
Subject: Use (new) ruff config section `lint`

### Feature or Bugfix
- Refactoring

### Purpose
- Adapt to ruff 0.1.9

### Detail
As suggested by [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master):
* RF202: Use (new) lint config section
  `flake8-quotes` should be set as `lint.flake8-quotes` instead
  `per-file-ignores` should be set as `lint.per-file-ignores` instead

### Relates
* [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=sphinx-doc%2Fsphinx&branch=master)
