### PR TITLE
Remove duplicate "the" from README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Features
 * **Language Support**: Python, C, C++, JavaScript, mathematics, and many other
   languages through extensions.
 
-For more information, refer to the `the documentation`_.
+For more information, refer to `the documentation`_.
 
 Installation
 ============


### PR DESCRIPTION
Subject: Remove duplicate "the" from README file
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- **the** the documentation