### PR TITLE
Apply refurb/ruff rule FURB111

### DIFF
--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -107,7 +107,7 @@ class ASTBaseBase:
         raise NotImplementedError(repr(self))
 
     def __str__(self) -> str:
-        return self._stringify(lambda ast: str(ast))
+        return self._stringify(str)
 
     def get_display_string(self) -> str:
         return self._stringify(lambda ast: ast.get_display_string())


### PR DESCRIPTION
Subject: Apply refurb/ruff rule FURB111

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix this issue:
```
[FURB111]: Replace `lambda ast: str(ast)` with `str`
```

### Relates
- https://docs.astral.sh/ruff/rules/#refurb-furb
- https://github.com/sphinx-doc/sphinx/issues/11834

