### PR TITLE
Apply refurb/ruff rule FURB115

### DIFF
--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -287,7 +287,7 @@ class LiteralIncludeReader:
                                         'set of "lines"'))
 
             lines = [lines[n] for n in linelist if n < len(lines)]
-            if lines == []:
+            if not lines:
                 raise ValueError(__('Line spec %r: no lines pulled from include file %r') %
                                  (linespec, self.filename))
 


### PR DESCRIPTION
Subject: Apply refurb/ruff rule FURB115

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix this issue:
```
[FURB115]: Replace `x == []` with `not x`
```

### Detail
- Fix only a single occurrence of FURB115 that makes total sense, for now.

### Relates
- https://docs.astral.sh/ruff/rules/#refurb-furb
- https://github.com/sphinx-doc/sphinx/issues/11834