### PR TITLE
Apply refurb/ruff rule FURB116

### DIFF
--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -524,7 +524,7 @@ class TexinfoTranslator(SphinxTranslator):
         try:
             sid = self.short_ids[id]
         except KeyError:
-            sid = hex(len(self.short_ids))[2:]
+            sid = f'{len(self.short_ids):x}'
             self.short_ids[id] = sid
         return sid
 


### PR DESCRIPTION
[FURB116]: Replace `hex(num)[2:]` with `f"{num:x}"`

Subject: Apply refurb/ruff rule FURB116

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix this issue:
```
[FURB116]: Replace `hex(num)[2:]` with `f"{num:x}"`
```

### Relates
- https://docs.astral.sh/ruff/rules/#refurb-furb
- https://github.com/sphinx-doc/sphinx/issues/11834

