### PR TITLE
Apply refurb/ruff rule FURB124

### DIFF
--- a/sphinx/domains/c.py
+++ b/sphinx/domains/c.py
@@ -2314,7 +2314,7 @@ class DefinitionParser(BaseParser):
                 break
             if not self.skip_string_and_ws(','):
                 self.fail(f"Error in {name}, expected ',' or '{close}'.")
-            if self.current_char == close and close == '}':
+            if self.current_char == close == '}':
                 self.pos += 1
                 trailingComma = True
                 break
@@ -2480,7 +2480,7 @@ class DefinitionParser(BaseParser):
                     else:
                         if not self.skip_string(op):
                             continue
-                    if op == '&' and self.current_char == '&':
+                    if op == self.current_char == '&':
                         # don't split the && 'token'
                         self.pos -= 1
                         # and btw. && has lower precedence, so we are done

--- a/sphinx/domains/cpp.py
+++ b/sphinx/domains/cpp.py
@@ -5438,7 +5438,7 @@ class DefinitionParser(BaseParser):
                 break
             if not self.skip_string_and_ws(','):
                 self.fail(f"Error in {name}, expected ',' or '{close}'.")
-            if self.current_char == close and close == '}':
+            if self.current_char == close == '}':
                 self.pos += 1
                 trailingComma = True
                 break
@@ -5783,7 +5783,7 @@ class DefinitionParser(BaseParser):
                     else:
                         if not self.skip_string(op):
                             continue
-                    if op == '&' and self.current_char == '&':
+                    if op == self.current_char == '&':
                         # don't split the && 'token'
                         self.pos -= 1
                         # and btw. && has lower precedence, so we are done

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -68,7 +68,7 @@ def module_join(*modnames: str | None) -> str:
 
 def is_packagedir(dirname: str | None = None, files: list[str] | None = None) -> bool:
     """Check given *files* contains __init__ file."""
-    if files is None and dirname is None:
+    if files is dirname is None:
         return False
 
     if files is None:

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -476,7 +476,7 @@ class DefinitionFinder(TokenProcessor):
 
     def add_definition(self, name: str, entry: tuple[str, int, int]) -> None:
         """Add a location of definition."""
-        if self.indents and self.indents[-1][0] == 'def' and entry[0] == 'def':
+        if self.indents and self.indents[-1][0] == entry[0] == 'def':
             # ignore definition of inner function
             pass
         else:


### PR DESCRIPTION
Subject: Apply refurb/ruff rule FURB124

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix these issues:
```
[FURB124]: Replace `x == y and z == y` with `x == y == z`
[FURB124]: Replace `x is y and z is y` with `x is y is z`
```

### Relates
- https://docs.astral.sh/ruff/rules/#refurb-furb
- https://github.com/sphinx-doc/sphinx/issues/11834

