### PR TITLE
Apply refurb/ruff rule FURB134

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -438,7 +438,7 @@ class IndexBuilder:
         _stem = self.lang.stem
 
         # memoise self.lang.stem
-        @functools.lru_cache
+        @functools.cache
         def stem(word_to_stem: str) -> str:
             return _stem(word_to_stem).lower()
 

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -438,7 +438,7 @@ class IndexBuilder:
         _stem = self.lang.stem
 
         # memoise self.lang.stem
-        @functools.lru_cache(maxsize=None)
+        @functools.lru_cache
         def stem(word_to_stem: str) -> str:
             return _stem(word_to_stem).lower()
 


### PR DESCRIPTION
[FURB134]: Replace `@functools.lru_cache(maxsize=None)` with `@functools.cache`

Subject: Apply refurb/ruff rule FURB134
### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix this issue:
```
[FURB134]: Replace `@functools.lru_cache(maxsize=None)` with `@functools.cache`
```

### Relates
- https://docs.astral.sh/ruff/rules/#refurb-furb
- https://github.com/sphinx-doc/sphinx/issues/11834

