### PR TITLE
Defer computation of configuration values

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -210,10 +210,6 @@ class Sphinx:
             self.confdir = _StrPath(confdir).resolve()
             self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
 
-        # initialize some limited config variables before initialize i18n and loading
-        # extensions
-        self.config.pre_init_values()
-
         # set up translation infrastructure
         self._init_i18n()
 
@@ -252,8 +248,8 @@ class Sphinx:
                            "This is needed for conf.py to behave as a Sphinx extension."),
                     )
 
-        # now that we know all config values, collect them from conf.py
-        self.config.init_values()
+        # Report any warnings for overrides.
+        self.config._report_override_warnings()
         self.events.emit('config-inited', self.config)
 
         # create the project

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -74,7 +74,6 @@ class DummyApplication:
         self.config.add('autosummary_context', {}, 'env', ())
         self.config.add('autosummary_filename_map', {}, 'env', ())
         self.config.add('autosummary_ignore_module_all', True, 'env', bool)
-        self.config.init_values()
 
     def emit_firstresult(self, *args: Any) -> None:
         pass

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -19,6 +19,7 @@ else:
 import contextlib
 
 from sphinx import package_dir
+from sphinx.config import check_confval_types as _config_post_init
 from sphinx.errors import ThemeError
 from sphinx.locale import __
 from sphinx.util import logging
@@ -188,7 +189,7 @@ class HTMLThemeFactory:
             pass
         else:
             self.app.registry.load_extension(self.app, entry_point.module)
-            self.app.config.post_init_values()
+            _config_post_init(None, self.app.config)
 
     def find_themes(self, theme_path: str) -> dict[str, str]:
         """Search themes from specified directory."""

--- a/tests/test_build_latex.py
+++ b/tests/test_build_latex.py
@@ -1594,7 +1594,6 @@ def test_default_latex_documents():
     config = Config({'root_doc': 'index',
                      'project': 'STASI™ Documentation',
                      'author': "Wolfgang Schäuble & G'Beckstein."})
-    config.init_values()
     config.add('latex_engine', None, True, None)
     config.add('latex_theme', 'manual', True, None)
     expected = [('index', 'stasi.tex', 'STASI™ Documentation',

--- a/tests/test_build_manpage.py
+++ b/tests/test_build_manpage.py
@@ -92,7 +92,6 @@ def test_default_man_pages():
     config = Config({'project': 'STASI™ Documentation',
                      'author': "Wolfgang Schäuble & G'Beckstein",
                      'release': '1.0'})
-    config.init_values()
     expected = [('index', 'stasi', 'STASI™ Documentation 1.0',
                  ["Wolfgang Schäuble & G'Beckstein"], 1)]
     assert default_man_pages(config) == expected

--- a/tests/test_build_texinfo.py
+++ b/tests/test_build_texinfo.py
@@ -84,7 +84,6 @@ def test_texinfo_citation(app, status, warning):
 def test_default_texinfo_documents():
     config = Config({'project': 'STASI™ Documentation',
                      'author': "Wolfgang Schäuble & G'Beckstein"})
-    config.init_values()
     expected = [('index', 'stasi', 'STASI™ Documentation',
                  "Wolfgang Schäuble & G'Beckstein", 'stasi',
                  'One line description of project', 'Miscellaneous')]


### PR DESCRIPTION
This change means that the ``Config`` class behaves more like one might expect, with the ``Config.init_values()`` and ``Config.pre_init_values()`` methods rendered redundant.
