### PR TITLE
Apply refurb/ruff rule FURB113

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -465,7 +465,7 @@ select = [
 # allow print() in the tutorial
 "doc/development/tutorials/examples/recipe.py" = ["T201"]
 "sphinx/domains/**" = ["FURB113"]
-"tests/test_domain_cpp.py" = ["FURB113"]
+"tests/test_domains/test_domain_cpp.py" = ["FURB113"]
 
 # from .flake8
 "sphinx/*" = ["E241"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -125,7 +125,7 @@ select = [
     # refurb ('FURB')
 #    "FURB101",  # `open` and `read` should be replaced by `Path({filename}).{suggestion}`
 #    "FURB105",  # Unnecessary empty string passed to `print`
-#    "FURB113",  # Use `{suggestion}` instead of repeatedly calling `{name}.append()`
+    "FURB113",  # Use `{suggestion}` instead of repeatedly calling `{name}.append()`
     "FURB118",  # Use `operator.{operator}` instead of defining a function
     "FURB131",  # Prefer `clear` over deleting a full slice
     "FURB132",  # Use `{suggestion}` instead of check and `remove`
@@ -464,6 +464,8 @@ select = [
 "doc/development/tutorials/examples/*" = ["INP001"]
 # allow print() in the tutorial
 "doc/development/tutorials/examples/recipe.py" = ["T201"]
+"sphinx/domains/**" = ["FURB113"]
+"tests/test_domain_cpp.py" = ["FURB113"]
 
 # from .flake8
 "sphinx/*" = ["E241"]

--- a/doc/development/tutorials/examples/todo.py
+++ b/doc/development/tutorials/examples/todo.py
@@ -107,8 +107,10 @@ def process_todo_nodes(app, doctree, fromdocname):
             para += nodes.Text('.)')
 
             # Insert into the todolist
-            content.append(todo_info['todo'])
-            content.append(para)
+            content.extend((
+                todo_info['todo'],
+                para,
+            ))
 
         node.replace_self(content)
 

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -375,9 +375,11 @@ class LaTeXBuilder(Builder):
             for subdir, title in self.titles:
                 if docname.startswith(subdir):
                     newnodes.extend(
-                        nodes.Text(_(' (in ')),
-                        nodes.emphasis(title, title),
-                        nodes.Text(')'),
+                        (
+                            nodes.Text(_(' (in ')),
+                            nodes.emphasis(title, title),
+                            nodes.Text(')'),
+                        )
                     )
                     break
             else:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -374,13 +374,11 @@ class LaTeXBuilder(Builder):
             newnodes: list[Node] = [nodes.emphasis(sectname, sectname)]
             for subdir, title in self.titles:
                 if docname.startswith(subdir):
-                    newnodes.extend(
-                        (
-                            nodes.Text(_(' (in ')),
-                            nodes.emphasis(title, title),
-                            nodes.Text(')'),
-                        )
-                    )
+                    newnodes.extend((
+                        nodes.Text(_(' (in ')),
+                        nodes.emphasis(title, title),
+                        nodes.Text(')'),
+                    ))
                     break
             else:
                 pass

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -374,9 +374,11 @@ class LaTeXBuilder(Builder):
             newnodes: list[Node] = [nodes.emphasis(sectname, sectname)]
             for subdir, title in self.titles:
                 if docname.startswith(subdir):
-                    newnodes.append(nodes.Text(_(' (in ')))
-                    newnodes.append(nodes.emphasis(title, title))
-                    newnodes.append(nodes.Text(')'))
+                    newnodes.extend(
+                        nodes.Text(_(' (in ')),
+                        nodes.emphasis(title, title),
+                        nodes.Text(')'),
+                    )
                     break
             else:
                 pass

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -165,9 +165,11 @@ class TexinfoBuilder(Builder):
             newnodes: list[Node] = [nodes.emphasis(sectname, sectname)]
             for subdir, title in self.titles:
                 if docname.startswith(subdir):
-                    newnodes.append(nodes.Text(_(' (in ')))
-                    newnodes.append(nodes.emphasis(title, title))
-                    newnodes.append(nodes.Text(')'))
+                    newnodes.extend(
+                        nodes.Text(_(' (in ')),
+                        nodes.emphasis(title, title),
+                        nodes.Text(')'),
+                    )
                     break
             else:
                 pass

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -165,13 +165,11 @@ class TexinfoBuilder(Builder):
             newnodes: list[Node] = [nodes.emphasis(sectname, sectname)]
             for subdir, title in self.titles:
                 if docname.startswith(subdir):
-                    newnodes.extend(
-                        (
-                            nodes.Text(_(' (in ')),
-                            nodes.emphasis(title, title),
-                            nodes.Text(')'),
-                        )
-                    )
+                    newnodes.extend((
+                        nodes.Text(_(' (in ')),
+                        nodes.emphasis(title, title),
+                        nodes.Text(')'),
+                    ))
                     break
             else:
                 pass

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -166,9 +166,11 @@ class TexinfoBuilder(Builder):
             for subdir, title in self.titles:
                 if docname.startswith(subdir):
                     newnodes.extend(
-                        nodes.Text(_(' (in ')),
-                        nodes.emphasis(title, title),
-                        nodes.Text(')'),
+                        (
+                            nodes.Text(_(' (in ')),
+                            nodes.emphasis(title, title),
+                            nodes.Text(')'),
+                        )
                     )
                     break
             else:

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -307,7 +307,7 @@ class InheritanceGraph:
             e_attrs.update(env.config.inheritance_edge_attrs)
 
         res: list[str] = [
-            'digraph %s {\n' % name,
+            f'digraph {name} {{\n',
             self._format_graph_attrs(g_attrs),
         ]
 

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -306,9 +306,10 @@ class InheritanceGraph:
             n_attrs.update(env.config.inheritance_node_attrs)
             e_attrs.update(env.config.inheritance_edge_attrs)
 
-        res: list[str] = []
-        res.append('digraph %s {\n' % name)
-        res.append(self._format_graph_attrs(g_attrs))
+        res: list[str] = [
+            'digraph %s {\n' % name,
+            self._format_graph_attrs(g_attrs),
+        ]
 
         for name, fullname, bases, tooltip in sorted(self.class_info):
             # Write the node

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -296,8 +296,7 @@ class EmphasizedLiteral(SphinxRole):
                     stack[-1] += "{"
                 else:
                     # start emphasis
-                    stack.append('{')
-                    stack.append('')
+                    stack.extend(('{', ''))
             elif part == '}':
                 if len(stack) == 3 and stack[1] == "{" and len(stack[2]) > 0:
                     # emphasized word found

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -419,7 +419,7 @@ class DefaultSplitter(BaseSplitter):
 
         result = []
         seg = ['B3', 'B2', 'B1', *input, 'E1', 'E2', 'E3']
-        ctype = ['O', 'O', 'O', *(self.ctype_(t) for t in input), 'O', 'O', 'O']
+        ctype = ['O', 'O', 'O', *map(self.ctype_, input), 'O', 'O', 'O']
         word = seg[3]
         p1 = 'U'
         p2 = 'U'

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -420,15 +420,10 @@ class DefaultSplitter(BaseSplitter):
         result = []
         seg = ['B3', 'B2', 'B1']
         ctype = ['O', 'O', 'O']
-        for t in input:
-            seg.append(t)
-            ctype.append(self.ctype_(t))
-        seg.append('E1')
-        seg.append('E2')
-        seg.append('E3')
-        ctype.append('O')
-        ctype.append('O')
-        ctype.append('O')
+        seg.extend(input)
+        ctype.extend(self.ctype_(t) for t in input)
+        seg.extend(('E1', 'E2', 'E3'))
+        ctype.extend(('O', 'O', 'O'))
         word = seg[3]
         p1 = 'U'
         p2 = 'U'

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -418,12 +418,8 @@ class DefaultSplitter(BaseSplitter):
             return []
 
         result = []
-        seg = ['B3', 'B2', 'B1']
-        ctype = ['O', 'O', 'O']
-        seg.extend(input)
-        ctype.extend(self.ctype_(t) for t in input)
-        seg.extend(('E1', 'E2', 'E3'))
-        ctype.extend(('O', 'O', 'O'))
+        seg = ['B3', 'B2', 'B1', *input, 'E1', 'E2', 'E3']
+        ctype = ['O', 'O', 'O', *(self.ctype_(t) for t in input), 'O', 'O', 'O']
         word = seg[3]
         p1 = 'U'
         p2 = 'U'

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -265,14 +265,11 @@ class BaseParser:
         for e in errors:
             if len(e[1]) > 0:
                 indent = '  '
-                result.append(e[1])
-                result.append(':\n')
+                result.extend((e[1], ':\n'))
                 for line in str(e[0]).split('\n'):
                     if len(line) == 0:
                         continue
-                    result.append(indent)
-                    result.append(line)
-                    result.append('\n')
+                    result.extend((indent, line, '\n'))
             else:
                 result.append(str(e[0]))
         return DefinitionError(''.join(result))


### PR DESCRIPTION
Subject: Apply refurb/ruff rule FURB113

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix some of these issues:
```
[FURB113]: Use `x.extend(...)` instead of repeatedly calling `x.append()`
```
Leave out these files for now, as most occurrences are probably more readable in their current state:
* `sphinx/domains/c.py`
* `sphinx/domains/cpp.py`

### Details

* Not sure about these changes. Sure, the number of function calls is reduced. However, readability is not always improved. Unless, the function call happens in a tight loop, the optimisation might not be worth it, unless perhaps in specific cases. Thoughts?

### Relates
- https://docs.astral.sh/ruff/rules/#refurb-furb
https://github.com/sphinx-doc/sphinx/issues/11834
