### PR TITLE
test_build_html: test_html_scaled_image_link: allow newlines between HTML img and anchors

### DIFF
--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1646,7 +1646,7 @@ def test_html_scaled_image_link(app):
 
     # scaled_image_link
     assert re.search('\n<a class="reference internal image-reference" href="_images/img.png">'
-                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />\n*</a>',
+                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />\n?</a>',
                      context)
 
     # no-scaled-link class disables the feature

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1646,7 +1646,7 @@ def test_html_scaled_image_link(app):
 
     # scaled_image_link
     assert re.search('\n<a class="reference internal image-reference" href="_images/img.png">'
-                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" /></a>',
+                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />\n*</a>',
                      context)
 
     # no-scaled-link class disables the feature

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -8,6 +8,7 @@ from itertools import chain, cycle
 from pathlib import Path
 from unittest.mock import ANY, call, patch
 
+import docutils
 import pytest
 from html5lib import HTMLParser
 
@@ -1646,8 +1647,10 @@ def test_html_scaled_image_link(app):
 
     # scaled_image_link
     # Docutils 0.21 adds a newline before the closing </a> tag
+    closing_space = "\n" if docutils.__version_info__[:2] >= (0, 21) else ""
     assert re.search('\n<a class="reference internal image-reference" href="_images/img.png">'
-                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />\n?</a>',
+                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />'
+                     f'{closing_space}</a>',
                      context)
 
     # no-scaled-link class disables the feature

--- a/tests/test_build_html.py
+++ b/tests/test_build_html.py
@@ -1645,6 +1645,7 @@ def test_html_scaled_image_link(app):
     assert re.search('\n<img alt="_images/img.png" src="_images/img.png" />', context)
 
     # scaled_image_link
+    # Docutils 0.21 adds a newline before the closing </a> tag
     assert re.search('\n<a class="reference internal image-reference" href="_images/img.png">'
                      '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />\n?</a>',
                      context)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Updates a unit test to accomodate modified output of `docutils` 0.21b (unreleased).

### Detail
- In the test case, allow newlines between HTML `img` and `a` (anchor) elements when searching for a match.

### Relates
- Resolves #11862.