### PR TITLE
linkcheck builder: fixup / review item: expand another GitHub shorthand issue ref

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -467,7 +467,8 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                             "'linkcheck_allow_unauthorized' config option to "
                             "``True``."
                             "\n"
-                            "See sphinx-doc/sphinx#11433 for details."
+                            "See https://github.com/sphinx-doc/sphinx/issues/11433 "
+                            "for details."
                             "\n---"
                         )
                         warnings.warn(deprecation_msg, RemovedInSphinx80Warning, stacklevel=1)


### PR DESCRIPTION
### Feature or Bugfix
- Fixup / nitpick

### Purpose
- Applies feedback from a [code review feedback item](https://github.com/sphinx-doc/sphinx/pull/11684#discussion_r1446034411) to another location where it appears in the same file.

### Detail
- Expand a GitHub shorthand issue reference into a complete web hyperlink.

### Relates
- #11684