### PR TITLE
State that exclude_patterns has priority

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -224,6 +224,7 @@ General configuration
    are matched against the source file names relative to the source directory,
    using slashes as directory separators on all platforms. The default is ``**``,
    meaning that all files are recursively included from the source directory.
+   :confval:`exclude_patterns` has priority over :confval:`include_patterns`.
 
    Example patterns:
 


### PR DESCRIPTION
Subject: state that include_patterns has priority over exclude_patterns

This is a 1-line doc tweak. I had to look this point up in the source to figure it out.