### PR TITLE
linkcheck builder: update linkcheck_timeout value and documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Bugs fixed
   Set this option to ``False`` to report HTTP 401 (unauthorized) server
   responses as broken.
   Patch by James Addison.
+* #11869: Refresh the documentation for the ``linkcheck_timeout`` setting.
+  Patch by James Addison.
+* #11874: Configure a default 30-second value for ``linkcheck_timeout``.
+  Patch by James Addison.
 
 Testing
 -------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2806,7 +2806,7 @@ Options for the linkcheck builder
 .. confval:: linkcheck_timeout
 
    The duration, in seconds, that the linkcheck builder will wait for a
-   response after each hyperlink request.
+   response after each hyperlink request.  Defaults to 30 seconds.
 
    .. versionadded:: 1.1
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2805,8 +2805,8 @@ Options for the linkcheck builder
 
 .. confval:: linkcheck_timeout
 
-   A timeout value, in seconds, for the linkcheck builder.  The default is to
-   use Python's global socket timeout.
+   The duration, in seconds, that the linkcheck builder will wait for a
+   response after each hyperlink request.
 
    .. versionadded:: 1.1
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -651,7 +651,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value('linkcheck_auth', [], '')
     app.add_config_value('linkcheck_request_headers', {}, '')
     app.add_config_value('linkcheck_retries', 1, '')
-    app.add_config_value('linkcheck_timeout', None, '', (int, float))
+    app.add_config_value('linkcheck_timeout', 30, '', (int, float))
     app.add_config_value('linkcheck_workers', 5, '')
     app.add_config_value('linkcheck_anchors', True, '')
     # Anchors starting with ! are ignored since they are


### PR DESCRIPTION
### Feature or Bugfix
- Change
- Documentation

### Purpose
- Improve the usability of the `linkcheck` builder, in particular related to some discussion items from #11853.

### Detail
- Configure a non-empty default `linkcheck` timeout so that indefinite-duration linkchecking is less likely to occur by default.
- Update the `linkcheck_timeout` config setting documentation to clarify that the timeout applies on a per-hyperlink-request basis.

### Relates
- Resolves #11874.
- Resolves #11869.