### PR TITLE
linkcheck: add a distinct 'timeout' reporting status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@ Bugs fixed
   Set this option to ``False`` to report HTTP 401 (unauthorized) server
   responses as broken.
   Patch by James Addison.
+* #11868: linkcheck: added a distinct ``timeout`` reporting status code.
+  Patch by James Addison.
 
 Testing
 -------


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Provides a distinction between broken links (fairly high confidence that the URI/resource does not currently exist) and timeouts (no response was received for the URI within the alloted time).

### Detail
- Adds an additional case-handler for `Timeout` exceptions from the `requests` library when checking hyperlinks.
- Maintains a non-zero exit code when timeouts are encountered - the rationale here is that there was an unexpected problem that could require investigation (in other words: not all links were filtered/ignored/found-successfully).

### Relates
- Resolves #11868.
