### PR TITLE
Use repr when Enum has custom __repr__ impl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Features added
   Patch by Bénédikt Tran.
 
   .. _`<search>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
+* #11803: autodoc: Render enum values using ``repr()`` when they have custom
+  ``__repr__`` implementation.
+  Patch by Shengyu Zhang.
 
 Bugs fixed
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,9 +21,8 @@ Features added
   Patch by Bénédikt Tran.
 
   .. _`<search>`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
-* #11803: autodoc: Render enum values using ``repr()`` when they have custom
-  ``__repr__`` implementation.
-  Patch by Shengyu Zhang.
+* #11803: autodoc: Use an overriden ``__repr__()`` function in an enum,
+  if defined. Patch by Shengyu Zhang.
 
 Bugs fixed
 ----------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -387,7 +387,7 @@ def object_description(obj: Any, *, _seen: frozenset = frozenset()) -> str:
         return 'frozenset({%s})' % ', '.join(object_description(x, _seen=seen)
                                              for x in sorted_values)
     elif isinstance(obj, enum.Enum):
-        if obj.__repr__.__func__ is not enum.Enum.__repr__:
+        if obj.__repr__.__func__ is not enum.Enum.__repr__:  # type: ignore[attr-defined]
             return repr(obj)
         return f'{obj.__class__.__name__}.{obj.name}'
     elif isinstance(obj, tuple):

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -387,6 +387,8 @@ def object_description(obj: Any, *, _seen: frozenset = frozenset()) -> str:
         return 'frozenset({%s})' % ', '.join(object_description(x, _seen=seen)
                                              for x in sorted_values)
     elif isinstance(obj, enum.Enum):
+        if obj.__repr__.__func__ is not enum.Enum.__repr__:
+            return repr(obj)
         return f'{obj.__class__.__name__}.{obj.name}'
     elif isinstance(obj, tuple):
         if id(obj) in seen:

--- a/tests/test_util_inspect.py
+++ b/tests/test_util_inspect.py
@@ -667,6 +667,17 @@ def test_object_description_enum():
     assert inspect.object_description(MyEnum.FOO) == "MyEnum.FOO"
 
 
+def test_object_description_enum_custom_repr():
+    class MyEnum(enum.Enum):
+        FOO = 1
+        BAR = 2
+
+        def __repr__(self):
+            return self.name
+
+    assert inspect.object_description(MyEnum.FOO) == "FOO"
+
+
 def test_getslots():
     class Foo:
         pass


### PR DESCRIPTION
Subject:  Use repr when Enum has custom __repr__ imp

### Feature or Bugfix

- Feature

### Purpose

Allow users to control representation of Enum inside objdesc by repr.

### Detail

- Close #11803

### Relates
