### PR TITLE
Closes #11884 fix searchtools.js: docContent.textContent

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -164,7 +164,7 @@ const Search = {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
     htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
     const docContent = htmlElement.querySelector('[role="main"]');
-    if (docContent !== undefined) return docContent.textContent;
+    if (docContent) return docContent.textContent;
     console.warn(
       "Content block not found. Sphinx search tries to obtain it via '[role=main]'. Could you check your theme or template."
     );


### PR DESCRIPTION
Subject: fix bug #11884 (searchtools.js, `docContent` would be `null` instead of `undefined`)

### Feature or Bugfix
- Bugfix

### Purpose
- Check `docContent`, returned by `document.querySelector`, for "truthy" instead of `!== undefined`.
