### PR TITLE
Print template path chain in TemplateNotFound exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ Bugs fixed
   Patch by James Addison.
 * #11874: Configure a default 30-second value for ``linkcheck_timeout``.
   Patch by James Addison.
+* #11886: Print Jinja2 template path chain in ``TemplateNotFound`` exception.
+  Patch by Colin Marquardt.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,7 @@ Bugs fixed
   Patch by James Addison.
 * #11874: Configure a default 30-second value for ``linkcheck_timeout``.
   Patch by James Addison.
-* #11886: Print Jinja2 template path chain in ``TemplateNotFound`` exception.
+* #11886: Print the Jinja2 template path chain in ``TemplateNotFound`` exceptions.
   Patch by Colin Marquardt.
 
 Testing

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -218,5 +218,5 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
                 return loader.get_source(environment, template)
             except TemplateNotFound:
                 pass
-        exc_message = f"{template!r} not found in {self.environment.loader.pathchain}"
-        raise TemplateNotFound(exc_message)
+        msg = f"{template!r} not found in {self.environment.loader.pathchain}"
+        raise TemplateNotFound(msg)

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -218,4 +218,5 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
                 return loader.get_source(environment, template)
             except TemplateNotFound:
                 pass
-        raise TemplateNotFound(template)
+        exc_message = f"{template!r} not found in {self.environment.loader.pathchain}"
+        raise TemplateNotFound(exc_message)


### PR DESCRIPTION
Subject: Print template path chain in `TemplateNotFound` exception

### Feature or Bugfix
- Feature

### Purpose
- Make it easier for theme authors etc. to debug jinja2's `TemplateNotFound` exceptions by printing the considered paths

### Detail
- n/a

### Relates
- n/a

