### PR TITLE
searchindex.js: ensure that document titles are sorted before serializing index

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -392,7 +392,7 @@ class IndexBuilder:
         objnames = self._objnames
 
         alltitles: dict[str, list[tuple[int, str]]] = {}
-        for docname, titlelist in self._all_titles.items():
+        for docname, titlelist in sorted(self._all_titles.items()):
             for title, titleid in titlelist:
                 alltitles.setdefault(title, []).append((fn2index[docname], titleid))
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -157,8 +157,8 @@ def test_IndexBuilder():
     index = IndexBuilder(env, 'en', {}, None)
     index.feed('docname1_1', 'filename1_1', 'title1_1', doc)
     index.feed('docname1_2', 'filename1_2', 'title1_2', doc)
-    index.feed('docname2_1', 'filename2_1', 'title2_1', doc)
     index.feed('docname2_2', 'filename2_2', 'title2_2', doc)
+    index.feed('docname2_1', 'filename2_1', 'title2_1', doc)
     assert index._titles == {'docname1_1': 'title1_1', 'docname1_2': 'title1_2',
                              'docname2_1': 'title2_1', 'docname2_2': 'title2_2'}
     assert index._filenames == {'docname1_1': 'filename1_1', 'docname1_2': 'filename1_2',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The intent here is to emit a determinisic `searchindex.js` search index; some software packages include Sphinx-constructed documentation in their build artifacts.  To verify whether those software packages [build reproducibly](https://www.reproducible-builds.org), reducing sources of non-deterministic build results is important.

### Detail
- Sort the `IndexBuilder._all_titles` attribute before writing a search index to the filesystem.

### Relates
- Follows-on-from / companion-to #11622.
- Resolves #11887.