### PR TITLE
Give a more plausible example for a combination of tags

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -1042,7 +1042,7 @@ Including content based on tags
 
    Undefined tags are false, defined tags (via the ``-t`` command-line option or
    within :file:`conf.py`, see :ref:`here <conf-tags>`) are true.  Boolean
-   expressions, also using parentheses (like ``html and (latex or draft)``) are
+   expressions, also using parentheses (like ``(latex or html) and draft``) are
    supported.
 
    The *format* and the *name* of the current builder (``html``, ``latex`` or


### PR DESCRIPTION
Minor emendation. The tags "latex" and "html" are seldom true at the same time.