### PR TITLE
python domain: support unary subtraction operator (ast.USub) during annotation parsing

### DIFF
--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -109,6 +109,8 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> list[Node]:
             return unparse(node.value)
         if isinstance(node, ast.Invert):
             return [addnodes.desc_sig_punctuation('', '~')]
+        if isinstance(node, ast.USub):
+            return [addnodes.desc_sig_punctuation('', '-')]
         if isinstance(node, ast.List):
             result = [addnodes.desc_sig_punctuation('', '[')]
             if node.elts:

--- a/tests/roots/test-domain-py/module.rst
+++ b/tests/roots/test-domain-py/module.rst
@@ -58,3 +58,9 @@ module
 .. py:module:: object
 
 .. py:function:: sum()
+
+.. py:data:: test
+    :type: typing.Literal[2]
+
+.. py:data:: test2
+    :type: typing.Literal[-2]

--- a/tests/test_domains/test_domain_py.py
+++ b/tests/test_domains/test_domain_py.py
@@ -133,7 +133,9 @@ def test_domain_py_xrefs(app, status, warning):
     assert_refnode(refnodes[13], False, False, 'list', 'class')
     assert_refnode(refnodes[14], False, False, 'ModTopLevel', 'class')
     assert_refnode(refnodes[15], False, False, 'index', 'doc', domain='std')
-    assert len(refnodes) == 16
+    assert_refnode(refnodes[16], False, False, 'typing.Literal', 'obj', domain='py')
+    assert_refnode(refnodes[17], False, False, 'typing.Literal', 'obj', domain='py')
+    assert len(refnodes) == 18
 
     doctree = app.env.get_doctree('module_option')
     refnodes = list(doctree.findall(pending_xref))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Allow negative literal integers expressed using the unary subtraction operator when parsing Python type annotations.

### Detail
- Unary addition is not supported since literals such as `+2` resolves to `2`.
- Unusual edge cases could remain - this does not attempt to handle `foo[1+2j]` for example -- but that seems unlikely to be a likely annotation (?).
- Strictly speaking, does not add test coverage for the `intersphinx` case mentioned in the ~~test~~ bugreport; but I believe that these changes will solve the problem.

### Relates
- Resolves #11900.