### PR TITLE
builders: fix handling of string-based outdir  in _file_checksum

### DIFF
--- a/sphinx/builders/html/_assets.py
+++ b/sphinx/builders/html/_assets.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 from sphinx.deprecation import RemovedInSphinx90Warning
 from sphinx.errors import ThemeError
 
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 
 class _CascadingStyleSheet:
@@ -124,7 +123,7 @@ class _JavaScript:
         return os.fspath(self.filename)[key]
 
 
-def _file_checksum(outdir: Path, filename: str | os.PathLike[str]) -> str:
+def _file_checksum(outdir: str | Path, filename: str | os.PathLike[str]) -> str:
     filename = os.fspath(filename)
     # Don't generate checksums for HTTP URIs
     if '://' in filename:
@@ -138,7 +137,7 @@ def _file_checksum(outdir: Path, filename: str | os.PathLike[str]) -> str:
         raise ThemeError(msg)
     try:
         # Remove all carriage returns to avoid checksum differences
-        content = outdir.joinpath(filename).read_bytes().translate(None, b'\r')
+        content = Path(outdir).joinpath(filename).read_bytes().translate(None, b'\r')
     except FileNotFoundError:
         return ''
     if not content:

--- a/sphinx/builders/html/_assets.py
+++ b/sphinx/builders/html/_assets.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import os
 import warnings
 import zlib
-from typing import TYPE_CHECKING, Any, NoReturn
+from pathlib import Path
+from typing import Any, NoReturn
 
 from sphinx.deprecation import RemovedInSphinx90Warning
 from sphinx.errors import ThemeError
-
-from pathlib import Path
 
 
 class _CascadingStyleSheet:


### PR DESCRIPTION
Subject:  fix handling of string-based outdir in _file_checksum

### Feature or Bugfix
- Bugfix

### Purpose
- ensure robust path handling in _file_checksum

### Detail
Use sphinx in combination with jupyter-book and encountered this error: "AttributeError: 'str' object has no attribute 'joinpath'"
Sphinx.application.outdir is set to str by juypter-book (https://github.com/executablebooks/jupyter-book/blob/9e4804de11a2edf44ff9b56c5b02728acc3aa37b/jupyter_book/sphinx.py#L131C17-L131C23)
