### PR TITLE
config: copyright correction logic: handle year-to-year ranges without trailing authorship info

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -610,7 +610,7 @@ def _substitute_copyright_year(copyright_line: str, replace_year: str) -> str:
     if copyright_line[4] != '-':
         return copyright_line
 
-    if copyright_line[5:9].isdigit() and copyright_line[9] in ' ,':
+    if copyright_line[5:9].isdigit() and copyright_line[9:10] in {'', ' ', ','}:
         return copyright_line[:5] + replace_year + copyright_line[9:]
 
     return copyright_line

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -562,21 +562,22 @@ def test_multi_line_copyright(source_date_year, app, monkeypatch):
         ) in content
 
 
-@pytest.mark.parametrize('copyright_line', [
-    # '1970',
-    '1970-1990',  # https://github.com/sphinx-doc/sphinx/issues/11913
-    '1970-1990 Alice',
+@pytest.mark.parametrize(('conf_copyright', 'expected_copyright'), [
+    ('1970', '{current_year}'),
+    # https://github.com/sphinx-doc/sphinx/issues/11913
+    ('1970-1990', '1970-{current_year}'),
+    ('1970-1990 Alice', '1970-{current_year} Alice'),
 ])
-def test_correct_copyright_year(copyright_line, source_date_year):
-    config = Config({}, {'copyright': copyright_line})
+def test_correct_copyright_year(conf_copyright, expected_copyright, source_date_year):
+    config = Config({}, {'copyright': conf_copyright})
     correct_copyright_year(_app=None, config=config)
-    corrected_copyright_line = config['copyright']
+    actual_copyright = config['copyright']
 
-    assert '1970' in corrected_copyright_line
     if source_date_year is None:
-        assert corrected_copyright_line == copyright_line
+        expected_copyright = conf_copyright
     else:
-        assert str(source_date_year) in corrected_copyright_line
+        expected_copyright = expected_copyright.format(current_year=source_date_year)
+    assert actual_copyright == expected_copyright
 
 
 def test_gettext_compact_command_line_true():

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -8,7 +8,13 @@ import pytest
 
 import sphinx
 from sphinx.builders.gettext import _gettext_compact_validator
-from sphinx.config import ENUM, Config, _Opt, check_confval_types
+from sphinx.config import (
+    ENUM,
+    Config,
+    _Opt,
+    check_confval_types,
+    correct_copyright_year,
+)
 from sphinx.deprecation import RemovedInSphinx90Warning
 from sphinx.errors import ConfigError, ExtensionError, VersionRequirementError
 
@@ -554,6 +560,17 @@ def test_multi_line_copyright(source_date_year, app, monkeypatch):
             f'    \n'
             f'      &#169; Copyright 2022-{source_date_year}, Eve.'
         ) in content
+
+
+@pytest.mark.parametrize('copyright_line', [
+    '1970',
+    '1970-1990',  # https://github.com/sphinx-doc/sphinx/issues/11913
+    '1970-1990 Alice',
+])
+def test_correct_copyright_year(copyright_line, source_date_year):
+    config = Config({}, {'copyright': copyright_line})
+    correct_copyright_year(_app=None, config=config)
+    assert str(source_date_year or 1970) in config['copyright']
 
 
 def test_gettext_compact_command_line_true():

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -563,14 +563,20 @@ def test_multi_line_copyright(source_date_year, app, monkeypatch):
 
 
 @pytest.mark.parametrize('copyright_line', [
-    '1970',
+    # '1970',
     '1970-1990',  # https://github.com/sphinx-doc/sphinx/issues/11913
     '1970-1990 Alice',
 ])
 def test_correct_copyright_year(copyright_line, source_date_year):
     config = Config({}, {'copyright': copyright_line})
     correct_copyright_year(_app=None, config=config)
-    assert str(source_date_year or 1970) in config['copyright']
+    corrected_copyright_line = config['copyright']
+
+    assert '1970' in corrected_copyright_line
+    if source_date_year is None:
+        assert corrected_copyright_line == copyright_line
+    else:
+        assert str(source_date_year) in corrected_copyright_line
 
 
 def test_gettext_compact_command_line_true():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Allow concise, year-to-year copyright declarations such as `1970-1971` (with no trailing author name / info).

### Detail
- Use a string slice when performing a conditional check on trailing content, allowing an empty string to be returned instead of an array access error exception being raised.

### Relates
- Resolves #11913.