### PR TITLE
#11917 - Careful access of annotations on class objects/fix incorrect display of inherited members 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ Bugs fixed
   Patch by Colin Marquardt.
 * #11598: Do not use query components in URLs for assets in EPUB rendering.
   Patch by David Runge.
+* #11917: Fixes some corner-cases involving inherited class members on python 3.9 and earlier
+  Patch by Janet Carson.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,8 +72,8 @@ Bugs fixed
   Patch by Colin Marquardt.
 * #11598: Do not use query components in URLs for assets in EPUB rendering.
   Patch by David Runge.
-* #11917: Fixes some corner-cases involving inherited class members on python 3.9
-  and earlier. Patch by Janet Carson.
+* #11917: Fix rendering of annotated inherited members for Python 3.9.
+  Patch by Janet Carson.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,8 +72,8 @@ Bugs fixed
   Patch by Colin Marquardt.
 * #11598: Do not use query components in URLs for assets in EPUB rendering.
   Patch by David Runge.
-* #11917: Fixes some corner-cases involving inherited class members on python 3.9 and earlier
-  Patch by Janet Carson.
+* #11917: Fixes some corner-cases involving inherited class members on python 3.9
+  and earlier. Patch by Janet Carson.
 
 Testing
 -------

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -87,7 +87,7 @@ def getall(obj: Any) -> Sequence[str] | None:
 
 def getannotations(obj: Any) -> Mapping[str, Any]:
     """Get __annotations__ from given *obj* safely."""
-    if (sys.version_info >= (3, 10, 0)) or (not isinstance(obj, type)):
+    if sys.version_info >= (3, 10, 0) or not isinstance(obj, type):
         __annotations__ = safe_getattr(obj, '__annotations__', None)
     else:
         # Workaround for bugfix not available until python 3.10 as recommended by docs

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -92,7 +92,8 @@ def getannotations(obj: Any) -> Mapping[str, Any]:
     else:
         # Workaround for bugfix not available until python 3.10 as recommended by docs
         # https://docs.python.org/3.10/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
-        __annotations__ = obj.__dict__.get('__annotations__', None)
+        __dict__ = safe_getattr(obj, '__dict__', {})
+        __annotations__ = __dict__.get('__annotations__', None)
     if isinstance(__annotations__, Mapping):
         return __annotations__
     else:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -87,7 +87,12 @@ def getall(obj: Any) -> Sequence[str] | None:
 
 def getannotations(obj: Any) -> Mapping[str, Any]:
     """Get __annotations__ from given *obj* safely."""
-    __annotations__ = safe_getattr(obj, '__annotations__', None)
+    if (sys.version_info >= (3, 10, 0)) or (not isinstance(obj, type)):
+        __annotations__ = safe_getattr(obj, '__annotations__', None)
+    else:
+        # Workaround for bugfix not available until python 3.10 as recommended by docs
+        # https://docs.python.org/3.10/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
+        __annotations__ = obj.__dict__.get('__annotations__', None)
     if isinstance(__annotations__, Mapping):
         return __annotations__
     else:

--- a/tests/roots/test-ext-autodoc/target/inherited_annotations.py
+++ b/tests/roots/test-ext-autodoc/target/inherited_annotations.py
@@ -1,0 +1,16 @@
+"""
+    Test case for #11387 corner case involving inherited
+    members with type annotations on python 3.9 and earlier
+"""
+
+class HasTypeAnnotatedMember:
+    inherit_me: int
+    """Inherited"""
+
+class NoTypeAnnotation(HasTypeAnnotatedMember):
+    a = 1
+    """Local"""
+
+class NoTypeAnnotation2(HasTypeAnnotatedMember):
+    a = 1
+    """Local"""

--- a/tests/roots/test-ext-autodoc/target/inherited_annotations.py
+++ b/tests/roots/test-ext-autodoc/target/inherited_annotations.py
@@ -14,3 +14,4 @@ class NoTypeAnnotation(HasTypeAnnotatedMember):
 class NoTypeAnnotation2(HasTypeAnnotatedMember):
     a = 1
     """Local"""
+

--- a/tests/test_extensions/test_ext_autodoc_autoclass.py
+++ b/tests/test_extensions/test_ext_autodoc_autoclass.py
@@ -515,3 +515,54 @@ def test_autoattribute_TypeVar_module_level(app):
         "   alias of TypeVar('T1')",
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_inherited_instance_variable_with_annotations(app):
+    """Tests interaction between processing type annotations
+    and inherited members
+    """
+    options = {'members': None,
+               'inherited-members': None}
+    actual = do_autodoc(app, 'class', 'target.inherited_annotations.NoTypeAnnotation', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: NoTypeAnnotation()',
+        '   :module: target.inherited_annotations',
+        '',
+        '',
+        '   .. py:attribute:: NoTypeAnnotation.a',
+        '      :module: target.inherited_annotations',
+        '      :value: 1',
+        '',
+        '      Local',
+        '',
+        '',
+        '   .. py:attribute:: NoTypeAnnotation.inherit_me',
+        '      :module: target.inherited_annotations',
+        '      :type: int',
+        '',
+        '      Inherited',
+        '',
+    ]
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_no_inherited_instance_variable_with_annotations(app):
+    """Tests interaction between processing type annotations
+    and inherited members
+    """
+    options = {'members': None}
+    actual = do_autodoc(app, 'class', 'target.inherited_annotations.NoTypeAnnotation2', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: NoTypeAnnotation2()',
+        '   :module: target.inherited_annotations',
+        '',
+        '',
+        '   .. py:attribute:: NoTypeAnnotation2.a',
+        '      :module: target.inherited_annotations',
+        '      :value: 1',
+        '',
+        '      Local',
+        '',
+    ]

--- a/tests/test_extensions/test_ext_autodoc_autoclass.py
+++ b/tests/test_extensions/test_ext_autodoc_autoclass.py
@@ -561,4 +561,3 @@ def test_no_inherited_instance_variable_with_annotations(app):
         '      Local',
         '',
     ]
-

--- a/tests/test_extensions/test_ext_autodoc_autoclass.py
+++ b/tests/test_extensions/test_ext_autodoc_autoclass.py
@@ -519,9 +519,6 @@ def test_autoattribute_TypeVar_module_level(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_inherited_instance_variable_with_annotations(app):
-    """Tests interaction between processing type annotations
-    and inherited members
-    """
     options = {'members': None,
                'inherited-members': None}
     actual = do_autodoc(app, 'class', 'target.inherited_annotations.NoTypeAnnotation', options)
@@ -549,9 +546,6 @@ def test_inherited_instance_variable_with_annotations(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_no_inherited_instance_variable_with_annotations(app):
-    """Tests interaction between processing type annotations
-    and inherited members
-    """
     options = {'members': None}
     actual = do_autodoc(app, 'class', 'target.inherited_annotations.NoTypeAnnotation2', options)
     assert list(actual) == [
@@ -567,3 +561,4 @@ def test_no_inherited_instance_variable_with_annotations(app):
         '      Local',
         '',
     ]
+

--- a/tests/test_extensions/test_ext_autodoc_autoclass.py
+++ b/tests/test_extensions/test_ext_autodoc_autoclass.py
@@ -546,6 +546,7 @@ def test_inherited_instance_variable_with_annotations(app):
         '',
     ]
 
+
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_no_inherited_instance_variable_with_annotations(app):
     """Tests interaction between processing type annotations


### PR DESCRIPTION
Subject: Fixes a bug in the access of class __annotations__ dictionary in python 3.9 and earlier, causing superclass members to be mistaken for members of the class being documented

### Feature or Bugfix
- Bugfix

### Purpose
If the __annotations__ dictionary on a class object is not accessed correctly, then Sphinx autoclass can get the superclass annotations rather than the annotations of the object currently being documented. If "inherited-members" is not requested, then these superclass annotations would result in incorrect output.

This problem only happens in python 3.9 and earlier, and I implemented the suggested work-around per the docs

https://docs.python.org/3.10/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older

### Detail
Closes #11917

### Relates
#11917
