### PR TITLE
Tests: Add py:currentmodule unit test

### DIFF
--- a/tests/test_domains/test_domain_py_pyobject.py
+++ b/tests/test_domains/test_domain_py_pyobject.py
@@ -390,3 +390,98 @@ def test_pydecoratormethod_signature(app):
 
     assert 'deco' in domain.objects
     assert domain.objects['deco'] == ('index', 'deco', 'method', False)
+
+
+def test_pycurrentmodule(app):
+    text = (".. py:module:: Other\n"
+            "\n"
+            ".. py:module:: Module\n"
+            ".. py:class:: A\n"
+            "\n"
+            "   .. py:method:: m1\n"
+            "   .. py:method:: m2\n"
+            "\n"
+            ".. py:currentmodule:: Other\n"
+            "\n"
+            ".. py:class:: B\n"
+            "\n"
+            "   .. py:method:: m3\n"
+            "   .. py:method:: m4\n")
+    domain = app.env.get_domain('py')
+    doctree = restructuredtext.parse(app, text)
+    print(doctree)
+    assert_node(
+        doctree, (
+            addnodes.index,
+            addnodes.index,
+            addnodes.index,
+            nodes.target,
+            nodes.target,
+            [desc, (
+                [desc_signature, (
+                    [desc_annotation, ("class", desc_sig_space)],
+                    [desc_addname, "Module."],
+                    [desc_name, "A"],
+                )],
+                [desc_content, (
+                    addnodes.index,
+                    [desc, (
+                        [desc_signature, (
+                            [desc_name, "m1"],
+                            [desc_parameterlist, ()],
+                        )],
+                        [desc_content, ()],
+                    )],
+                    addnodes.index,
+                    [desc, (
+                        [desc_signature, (
+                            [desc_name, "m2"],
+                            [desc_parameterlist, ()],
+                        )],
+                        [desc_content, ()],
+                    )],
+                )],
+            )],
+            addnodes.index,
+            [desc, (
+                [desc_signature, (
+                    [desc_annotation, ("class", desc_sig_space)],
+                    [desc_addname, "Other."],
+                    [desc_name, "B"],
+                )],
+                [desc_content, (
+                    addnodes.index,
+                    [desc, (
+                        [desc_signature, (
+                            [desc_name, "m3"],
+                            [desc_parameterlist, ()],
+                        )],
+                        [desc_content, ()],
+                    )],
+                    addnodes.index,
+                    [desc, (
+                        [desc_signature, (
+                            [desc_name, "m4"],
+                            [desc_parameterlist, ()],
+                        )],
+                        [desc_content, ()],
+                    )],
+                )],
+            )],
+        ))
+    assert 'Module' in domain.objects
+    assert domain.objects['Module'] == ('index', 'module-Module', 'module', False)
+    assert 'Other' in domain.objects
+    assert domain.objects['Other'] == ('index', 'module-Other', 'module', False)
+    assert 'Module.A' in domain.objects
+    assert domain.objects['Module.A'] == ('index', 'Module.A', 'class', False)
+    assert 'Other.B' in domain.objects
+    assert domain.objects['Other.B'] == ('index', 'Other.B', 'class', False)
+    assert 'Module.A.m1' in domain.objects
+    assert domain.objects['Module.A.m1'] == ('index', 'Module.A.m1', 'method', False)
+    assert 'Module.A.m2' in domain.objects
+    assert domain.objects['Module.A.m2'] == ('index', 'Module.A.m2', 'method', False)
+    assert 'Other.B.m3' in domain.objects
+    assert domain.objects['Other.B.m3'] == ('index', 'Other.B.m3', 'method', False)
+    assert 'Other.B.m4' in domain.objects
+    assert domain.objects['Other.B.m4'] == ('index', 'Other.B.m4', 'method', False)


### PR DESCRIPTION
Subject: Add unit test for py:currentmodule directive

### Feature or Bugfix
<!-- please choose -->
- [X] Feature (? — an internal one, perhaps)
- [ ] Bugfix
- [ ] Refactoring

### Purpose
- As an exercise for myself, to understand the code, implement a unit test for the `py:currentmodule` directive, which was previously untested.

### Detail
- We've been discussing the perceived need for a ``py:currentclass`` directive over in the CPython repo, to addresss some ordering/hierarchy issues with our class & method documentation. I ended up taking a stab at implementing `py:currentclass` (not included here).
- As preparation for working on a new directive, writing tests for `py:currentmodule` was a good way to educate myself about both the Sphinx code and its test setup.
- Once I'd done so, it struck me that the test would be useful on its own.

### Relates
- python/cpython#114336

