### PR TITLE
Avoid zombie processes on parallel build fail

### DIFF
--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -96,7 +96,8 @@ class ParallelTasks:
         try:
             self._join_one()
         except Exception:
-            # shutdown other child processes on failure (e.g. OSError: Failed to allocate memory)
+            # shutdown other child processes on failure
+            # (e.g. OSError: Failed to allocate memory)
             self.terminate()
 
     def join(self) -> None:

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -93,7 +93,11 @@ class ParallelTasks:
         proc = context.Process(target=self._process, args=(psend, task_func, arg))
         self._procs[tid] = proc
         self._precvsWaiting[tid] = precv
-        self._join_one()
+        try:
+            self._join_one()
+        except Exception:
+            # shutdown other child processes on failure (e.g. OSError: Failed to allocate memory)
+            self.terminate()
 
     def join(self) -> None:
         try:


### PR DESCRIPTION
Subject: Terminate processes correctly when parallel build fails

### Feature or Bugfix
- Bugfix

### Purpose
On our build servers, we have had recurring (every 1-4 weeks) and hard-to-reproduce issues with sphinx builds that do not terminate. We have applied the change in this MR and have seen no reoccurrence of the error.

### Detail
Without this change, this error message used to appear in our build logs at rare times:
```
Exception occurred:
  File "/usr/lib/python3.9/multiprocessing/popen_fork.py", line 66, in _launch
    self.pid = os.fork()
OSError: [Errno 12] Cannot allocate memory
```
I assume that when one of the threads dies, it cannot be joined and the build hangs.

Sadly, I lost most of the logs for and description of the original issue. All I know is that this change fixed the issue for us to the best of our knowledge.

I apologize for the lack of documentation, but I hope this can be merged nonetheless.

### Relates
- A similar problem was reported and fixed in https://github.com/sphinx-doc/sphinx/pull/10952, but it did not cover this instance of `_join_one`.

cc @cielavenir