### PR TITLE
Extension registry: add sphinxprettysearchresults to blacklist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Bugs fixed
   Patch by Colin Marquardt.
 * #11598: Do not use query components in URLs for assets in EPUB rendering.
   Patch by David Runge.
+* #11925: Blacklist the ``sphinxprettysearchresults`` extension; the functionality
+  it provides was merged into Sphinx v2.0.0.
+  Patch by James Addison.
 
 Testing
 -------

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 # Values are Sphinx version that merge the extension.
 EXTENSION_BLACKLIST = {
     "sphinxjp.themecore": "1.2",
+    "sphinxprettysearchresults": "2.0.0",
 }
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Discourage use of the now-fairly-long-redundant `sphinxprettysearchresults` extension.

### Detail
- Adds `sphinxprettysearchresults` to the list of blacklisted extensions, with the corresponding Sphinx version where the functionality became available in Sphinx core (v2.0.0).

### Relates
- Resolves #11925.
- Relates to #1618, #4022.