### PR TITLE
Upgrade Ruff configuration for v0.2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install Ruff
-      run: python -m pip install "ruff==0.1.14"
+      run: python -m pip install "ruff==0.2.0"
 
     - name: Lint with Ruff
       run: ruff . --output-format github

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 target-version = "py39"  # Pin Ruff to Python 3.9
 line-length = 95
-required-version = "0.1.14"
-show-source = true
+required-version = "0.2.0"
+output-format = "full"
 
 [lint]
 preview = true
@@ -36,8 +36,6 @@ select = [
     "ANN001",  # Missing type annotation for function argument `{name}`
     "ANN002",  # Missing type annotation for `*{name}`
     "ANN003",  # Missing type annotation for `**{name}`
-#    "ANN101",  # Missing type annotation for `{name}` in method
-    "ANN102",  # Missing type annotation for `{name}` in classmethod
     "ANN201",  # Missing return type annotation for public function `{name}`
     "ANN202",  # Missing return type annotation for private function `{name}`
 #    "ANN204",  # Missing return type annotation for special method `{name}`
@@ -101,7 +99,7 @@ select = [
     "D410",  # Missing blank line after section ("{name}")
     "D411",  # Missing blank line before section ("{name}")
 #    "D412",  # No blank lines allowed between a section header and its content ("{name}")
-    "D413",  # Missing blank line after last section ("{name}")
+#    "D413",  # Missing blank line after last section ("{name}")
     "D414",  # Section has no content ("{name}")
 #    "D415",  # First line should end with a period, question mark, or exclamation point
     "D416",  # Section name should end with a colon ("{name}")
@@ -296,7 +294,6 @@ select = [
     "RUF008",  # Do not use mutable default values for dataclass attributes
     "RUF009",  # Do not perform function call `{name}` in dataclass defaults
     "RUF010",  # Use explicit conversion flag
-    "RUF011",  # Dictionary comprehension uses static key: `{key}`
 #    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF013",  # PEP 484 prohibits implicit `Optional`
 #    "RUF015",  # Prefer `next({iterable})` over single element slice
@@ -325,7 +322,7 @@ select = [
     "S304",  # Use of insecure cipher, replace with a known secure cipher such as AES
     "S305",  # Use of insecure cipher mode, replace with a known secure cipher such as AES
     "S306",  # Use of insecure and deprecated function (`mktemp`)
-#    "S307",  # Use of possibly insecure function; consider using `ast.literal_eval`
+    "S307",  # Use of possibly insecure function; consider using `ast.literal_eval`
     "S308",  # Use of `mark_safe` may expose cross-site scripting vulnerabilities
     "S310",  # Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.
     "S311",  # Standard pseudo-random generators are not suitable for cryptographic purposes
@@ -402,7 +399,7 @@ select = [
     "TCH003",  # Move standard library import `{}` into a type-checking block
     "TCH004",  # Move import `{qualified_name}` out of type-checking block. Import is used for more than type hinting.
     "TCH005",  # Found empty type-checking block
-    "TCH006",  # Invalid string member in `X | Y`-style union type
+    "TCH010",  # Invalid string member in `X | Y`-style union type
     # flake8-todos ('TD')
 #    "TD001",  # Invalid TODO tag: `{tag}`
 #    "TD003",  # Missing issue link on the line following this TODO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
 ]
 lint = [
     "flake8>=3.5.0",
-    "ruff==0.1.14",
+    "ruff==0.2.0",
     "mypy==1.8.0",
     "sphinx-lint",
     "docutils-stubs",

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -395,7 +395,7 @@ Doctest summary
             context: dict[str, Any] = {}
             if self.config.doctest_global_setup:
                 exec(self.config.doctest_global_setup, context)  # NoQA: S102
-            should_skip = eval(condition, context)  # NoQA: PGH001
+            should_skip = eval(condition, context)  # NoQA: S307
             if self.config.doctest_global_cleanup:
                 exec(self.config.doctest_global_cleanup, context)  # NoQA: S102
             return should_skip

--- a/sphinx/ext/ifconfig.py
+++ b/sphinx/ext/ifconfig.py
@@ -58,7 +58,7 @@ def process_ifconfig_nodes(app: Sphinx, doctree: nodes.document, docname: str) -
     ns['builder'] = app.builder.name
     for node in list(doctree.findall(ifconfig)):
         try:
-            res = eval(node['expr'], ns)  # NoQA: PGH001
+            res = eval(node['expr'], ns)  # NoQA: S307
         except Exception as err:
             # handle exceptions in a clean fashion
             from traceback import format_exception_only


### PR DESCRIPTION
## Summary

Hopefully a welcome PR, but this upgrades Sphinx's Ruff configuration to reflect some of the changes we're making in v0.2.0. We use Sphinx in our ecosystem checks, and I wanted to do an example migration anyway, both for illustrative purposes and for my own testing. (This PR won't pass until we do the actual v0.2.0 release.)

Here's a summary of the relevant changes for Sphinx:

- `show-source = true` was replaced by `output-format = "full"`. (This is a deprecation, not a removal, so changing it here merely removes the deprecation warning.)
- Rules `ANN101` and `ANN102` were deprecated. (Selecting them with preview enabled is now an error; selecting them outside of preview is a warning.)
- `PGH001` was redirected to `S307` (I enabled `S307` and changed the `# NoQA` assertions, which would've continued to work, but with a deprecation warning).
- `RUF011` was redirected to `B035` (which you already have enabled, so I just removed `RUF011`, which would've warned).
- `TCH006` was redirected to `TCH010` to match the upstream plugin.
