### PR TITLE
C domain: Fix namespace-pop context

### DIFF
--- a/sphinx/domains/c/__init__.py
+++ b/sphinx/domains/c/__init__.py
@@ -374,7 +374,7 @@ class CNamespacePopObject(SphinxDirective):
             symbol = self.env.domaindata['c']['root_symbol']
         self.env.temp_data['c:parent_symbol'] = symbol
         self.env.temp_data['c:namespace_stack'] = stack
-        self.env.ref_context['cp:parent_key'] = symbol.get_lookup_key()
+        self.env.ref_context['c:parent_key'] = symbol.get_lookup_key()
         return []
 
 


### PR DESCRIPTION
The ref_context key is `c:parent_key`, not `cp:parent_key`.

Subject: Correct a `ref_context` key in `CNamespacePop`

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Correct a `ref_context` item named `cp:parent_key`, which the `CNamespacePop` directive was seetting when restoring the context.

### Detail
- The erroneous key here was the only instance in the entire codebase of that name being used. All others are `c:parent_key`.
- This appears to have likely been a typo, made when converting the code from the C++ domain and editing the key down from `cpp:parent_key`.
