### PR TITLE
Fix #10322: autodoc: Fail on enums containing special characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,7 @@ Bugs fixed
 * #11925: Blacklist the ``sphinxprettysearchresults`` extension; the functionality
   it provides was merged into Sphinx v2.0.0.
   Patch by James Addison.
+* #10322: autodoc: Fail on enums containing special characters
 
 Testing
 -------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -696,6 +696,11 @@ class Documenter:
                     RemovedInSphinx80Warning, stacklevel=2,
                 )
 
+            # filter a member having invalid name
+            match = py_ext_sig_re.match(membername)
+            if not match:
+                break
+
             # if isattr is True, the member is documented as an attribute
             isattr = member is INSTANCEATTR or (namespace, membername) in attr_docs
 

--- a/tests/roots/test-ext-autodoc/target/enums.py
+++ b/tests/roots/test-ext-autodoc/target/enums.py
@@ -21,3 +21,6 @@ class EnumCls(enum.Enum):
     def say_goodbye(cls):
         """a classmethod says good-bye to you."""
         pass
+
+
+ColorSpace = enum.Enum("ColorSpace", "RGB RGBA CMYK CMYK;I")

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -1463,6 +1463,33 @@ def test_enum_class(app):
     ]
 
     # checks for an attribute of EnumClass
+    options = {"members": None, "undoc-members": None}
+    actual = do_autodoc(app, 'class', 'target.enums.ColorSpace', options)
+    assert list(actual) == [
+        '',
+        '.. py:class:: ColorSpace' + args,
+        '   :module: target.enums',
+        '',
+        '   An enumeration.',
+        '',
+        '',
+        '   .. py:attribute:: ColorSpace.CMYK',
+        '      :module: target.enums',
+        '      :value: 3',
+        '',
+        '',
+        '   .. py:attribute:: ColorSpace.RGB',
+        '      :module: target.enums',
+        '      :value: 1',
+        '',
+        '',
+        '   .. py:attribute:: ColorSpace.RGBA',
+        '      :module: target.enums',
+        '      :value: 2',
+        '',
+    ]
+
+    # checks for an attribute of EnumClass
     actual = do_autodoc(app, 'attribute', 'target.enums.EnumCls.val1')
     assert list(actual) == [
         '',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- refs: #10322 
- Filter members having invalid characters in python (like `CMYK;I`).
