### PR TITLE
HTML Search: Fix duplicate results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,8 @@ Bugs fixed
 
 * #11961: HTML Search: Fix duplicated search results.
   Patch by Will Lachance.
-* #11959: HTML Search: Fix multiple term matching when word appears in both title and document.
+* #11959: HTML Search: Fix multiple term matching when word appears in both
+  title and document.
   Patch by Will Lachance.
 * #11958: HTML Search: Fix partial matches overwriting full matches.
   Patch by William Lachance.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,9 @@ Features added
 Bugs fixed
 ----------
 
-* #11959: Fix multiple term matching when word appears in both title and document.
+* #11961: HTML Search: Fix duplicated search results.
+  Patch by Will Lachance.
+* #11959: HTML Search: Fix multiple term matching when word appears in both title and document.
   Patch by Will Lachance.
 * #11958: HTML Search: Fix partial matches overwriting full matches.
   Patch by William Lachance.

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -198,7 +198,8 @@ const Search = {
     if (Search._queued_query !== null) {
       const query = Search._queued_query;
       Search._queued_query = null;
-      Search.query(query);
+      let { results, searchTerms, highlightTerms } = Search.query(query);
+      _displayNextItem(results, results.length, searchTerms, highlightTerms);
     }
   },
 
@@ -246,8 +247,12 @@ const Search = {
     Search.startPulse();
 
     // index already loaded, the browser was quick!
-    if (Search.hasIndex()) Search.query(query);
-    else Search.deferQuery(query);
+    if (Search.hasIndex()) { 
+      let { results, searchTerms, highlightTerms } = Search.query(query);
+      _displayNextItem(results, results.length, searchTerms, highlightTerms);
+    } else {
+      Search.deferQuery(query);
+    }
   },
 
   /**
@@ -380,8 +385,7 @@ const Search = {
     //Search.lastresults = results.slice();  // a copy
     // console.info("search results:", Search.lastresults);
 
-    // print the results
-    _displayNextItem(results, results.length, searchTerms, highlightTerms);
+    return { results, searchTerms, highlightTerms };
   },
 
   /**
@@ -476,6 +480,7 @@ const Search = {
         { files: terms[word], score: Scorer.term },
         { files: titleTerms[word], score: Scorer.title },
       ];
+
       // add support for partial matches
       if (word.length > 2) {
         const escapedWord = _escapeRegExp(word);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -304,10 +304,12 @@ const Search = {
       if (title.toLowerCase().trim().includes(queryLower) && (queryLower.length >= title.length/2)) {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
+          let isDocumentTitle = titles[file] === title
+          let sectionId = id ? "#" + id : ""
           results.push([
             docNames[file],
-            titles[file] !== title ? `${titles[file]} > ${title}` : title,
-            id !== null ? "#" + id : "",
+            isDocumentTitle ? title : `${titles[file]} > ${title}`,
+            isDocumentTitle ? "" : sectionId, // don't use the section id if we matched on the exact document title (creates duplicates below)
             null,
             score,
             filenames[file],
@@ -362,14 +364,12 @@ const Search = {
 
     // remove duplicate search results
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
-    // this may remove some entries which refer to slightly different parts of the same document
-    // but this is a tradeoff to avoid showing the same document multiple times (the preview always looks the
-    // same, so this is not very useful)
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      if (!seen.has(result[0])) {
+      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      if (!seen.has(resultStr)) {
         acc.push(result);
-        seen.add(result[0]);
+        seen.add(resultStr);
       }
       return acc;
     }, []);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -314,7 +314,7 @@ const Search = {
           results.push([
             docNames[file],
             isDocumentTitle ? title : `${titles[file]} > ${title}`,
-            isDocumentTitle ? "" : anchor, // don't provide an anchor if we matched on the exact document title (creates duplicates below)
+            anchor,
             null,
             score,
             filenames[file],
@@ -371,7 +371,8 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      // de-duplicate on file, title, and description
+      let resultStr = result.slice(0, 2).concat(result[3]).map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -305,11 +305,11 @@ const Search = {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
           let isDocumentTitle = titles[file] === title
-          let sectionId = id ? "#" + id : ""
+          let anchor = id ? `#${id}` : ""
           results.push([
             docNames[file],
             isDocumentTitle ? title : `${titles[file]} > ${title}`,
-            isDocumentTitle ? "" : sectionId, // don't use the section id if we matched on the exact document title (creates duplicates below)
+            isDocumentTitle ? "" : anchor, // don't provide an anchor if we matched on the exact document title (creates duplicates below)
             null,
             score,
             filenames[file],

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -64,7 +64,7 @@ const _displayItem = (item, searchTerms, highlightTerms) => {
   const showSearchSummary = DOCUMENTATION_OPTIONS.SHOW_SEARCH_SUMMARY;
   const contentRoot = document.documentElement.dataset.content_root;
 
-  const [docName, title, anchor, descr, score, _filename] = item;
+  const [docName, title, _isDocumentTitle, anchor, descr, score] = item;
 
   let listItem = document.createElement("li");
   let requestUrl;
@@ -314,6 +314,7 @@ const Search = {
           results.push([
             docNames[file],
             isDocumentTitle ? title : `${titles[file]} > ${title}`,
+            isDocumentTitle,
             anchor,
             null,
             score,
@@ -331,6 +332,7 @@ const Search = {
           results.push([
             docNames[file],
             titles[file],
+            false,
             id ? "#" + id : "",
             null,
             score,
@@ -355,8 +357,8 @@ const Search = {
     // display function below uses pop() to retrieve items) and then
     // alphabetically
     results.sort((a, b) => {
-      const leftScore = a[4];
-      const rightScore = b[4];
+      const leftScore = a[5];
+      const rightScore = b[5];
       if (leftScore === rightScore) {
         // same score: sort alphabetically
         const leftTitle = a[1].toLowerCase();
@@ -371,8 +373,11 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      // de-duplicate on file, title, and description
-      let resultStr = result.slice(0, 2).concat(result[3]).map(v => String(v)).join(',');
+      // de-duplicate on file, title, description, and (if not the title section) anchor
+      // we omit the anchor for the title section as otherwise we'll get two entries for the
+      // entire document
+      let [docname, title, isDocumentTitle, anchor, descr, score, filename] = result;
+      let resultStr = [docname, title, isDocumentTitle ? '' : anchor, descr].map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);
@@ -446,6 +451,7 @@ const Search = {
       results.push([
         docNames[match[0]],
         fullname,
+        false,
         "#" + anchor,
         descr,
         score,
@@ -557,6 +563,7 @@ const Search = {
       results.push([
         docNames[file],
         titles[file],
+        false,
         "",
         null,
         score,

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -16,11 +16,11 @@
 if (typeof Scorer === "undefined") {
   var Scorer = {
     // Implement the following function to further tweak the score for each result
-    // The function takes a result array [docname, title, anchor, anchorIsDocumentTitle, descr, score]
+    // The function takes a result array [docname, title, anchor, anchorIsDocumentTitle, descr, score, filename]
     // and returns the new score.
     /*
     score: result => {
-      const [docname, title, anchor, anchorIsDocumentTitle, descr, score] = result
+      const [docname, title, anchor, anchorIsDocumentTitle, descr, score, filename] = result
       return score
     },
     */

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -16,11 +16,11 @@
 if (typeof Scorer === "undefined") {
   var Scorer = {
     // Implement the following function to further tweak the score for each result
-    // The function takes a result array [docname, title, anchor, descr, score, filename]
+    // The function takes a result array [docname, title, anchor, anchorIsDocumentTitle, descr, score]
     // and returns the new score.
     /*
     score: result => {
-      const [docname, title, anchor, descr, score, filename] = result
+      const [docname, title, anchor, anchorIsDocumentTitle, descr, score] = result
       return score
     },
     */
@@ -64,7 +64,7 @@ const _displayItem = (item, searchTerms, highlightTerms) => {
   const showSearchSummary = DOCUMENTATION_OPTIONS.SHOW_SEARCH_SUMMARY;
   const contentRoot = document.documentElement.dataset.content_root;
 
-  const [docName, title, _isDocumentTitle, anchor, descr, score] = item;
+  const [docName, title, anchor, _anchorIsDocumentTitle, descr, score] = item;
 
   let listItem = document.createElement("li");
   let requestUrl;
@@ -309,13 +309,13 @@ const Search = {
       if (title.toLowerCase().trim().includes(queryLower) && (queryLower.length >= title.length/2)) {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
-          let isDocumentTitle = titles[file] === title
+          let anchorIsDocumentTitle = titles[file] === title
           let anchor = id ? `#${id}` : ""
           results.push([
             docNames[file],
-            isDocumentTitle ? title : `${titles[file]} > ${title}`,
-            isDocumentTitle,
+            anchorIsDocumentTitle ? title : `${titles[file]} > ${title}`,
             anchor,
+            anchorIsDocumentTitle,
             null,
             score,
             filenames[file],
@@ -376,8 +376,10 @@ const Search = {
       // de-duplicate on file, title, description, and (if not the title section) anchor
       // we omit the anchor for the title section as otherwise we'll get two entries for the
       // entire document
-      let [docname, title, isDocumentTitle, anchor, descr, score, filename] = result;
-      let resultStr = [docname, title, isDocumentTitle ? '' : anchor, descr].map(v => String(v)).join(',');
+      let [docname, title, anchor, anchorIsDocumentTitle, descr, score, filename] = result;
+      // Consider a link to the anchor representing the document title equivalent to a link
+      // to the document without an anchor
+      let resultStr = [docname, title, anchorIsDocumentTitle ? '' : anchor, descr].map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);
@@ -451,8 +453,8 @@ const Search = {
       results.push([
         docNames[match[0]],
         fullname,
-        false,
         "#" + anchor,
+        false,
         descr,
         score,
         filenames[match[0]],
@@ -563,8 +565,8 @@ const Search = {
       results.push([
         docNames[file],
         titles[file],
-        false,
         "",
+        false,
         null,
         score,
         filenames[file],

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -362,12 +362,14 @@ const Search = {
 
     // remove duplicate search results
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
+    // this may remove some entries which refer to slightly different parts of the same document
+    // but this is a tradeoff to avoid showing the same document multiple times (the preview always looks the
+    // same, so this is not very useful)
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
-      if (!seen.has(resultStr)) {
+      if (!seen.has(result[0])) {
         acc.push(result);
-        seen.add(resultStr);
+        seen.add(result[0]);
       }
       return acc;
     }, []);

--- a/tests/js/documentation_options.js
+++ b/tests/js/documentation_options.js
@@ -1,1 +1,9 @@
 const DOCUMENTATION_OPTIONS = {};
+
+// stub Stemmer / stopWords
+function Stemmer() {
+    this.stemWord = function (word) {
+        return word;
+    }
+};
+let stopwords = [];

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -56,6 +56,31 @@ describe('Basic html theme search', function() {
 
   });
 
+  describe('query', function() {
+    it("should not duplicate on title and content", function() {
+      index = {
+        alltitles: {
+          'Main Page': [[0, 'main-page']],
+        },
+        docnames:["index"],
+        filenames:["index.rst"],
+        indexentries:{},
+        objects:{},
+        objtypes: {},
+        objnames: {},
+        terms:{main:0, page:0},
+        titles:["Main Page"],
+        titleterms:{ main:0, page:0 }
+      }
+      Search.setIndex(index);
+      let { results } = Search.query('main page');
+      // should only be one result
+      expect(results).toEqual([
+        [ 'index', 'Main Page', '', null, 100, 'index.rst' ],
+      ]);
+    });
+  })
+
 });
 
 describe("htmlToText", function() {

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -19,6 +19,7 @@ describe('Basic html theme search', function() {
       hits = [[
         "index",
         "&lt;no title&gt;",
+        false,
         "",
         null,
         5,
@@ -76,7 +77,7 @@ describe('Basic html theme search', function() {
       let { results } = Search.query('main page');
       // should only be one result
       expect(results).toEqual([
-        [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ],
+        [ 'index', 'Main Page', true, '#main-page', null, 100, 'index.rst' ],
       ]);
     });
   })

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -19,8 +19,8 @@ describe('Basic html theme search', function() {
       hits = [[
         "index",
         "&lt;no title&gt;",
-        false,
         "",
+        false,
         null,
         5,
         "index.rst"
@@ -49,6 +49,7 @@ describe('Basic html theme search', function() {
         'index',
         'Main Page',
         '',
+        false,
         null,
         15,
         'index.rst']];
@@ -77,7 +78,7 @@ describe('Basic html theme search', function() {
       let { results } = Search.query('main page');
       // should only be one result
       expect(results).toEqual([
-        [ 'index', 'Main Page', true, '#main-page', null, 100, 'index.rst' ],
+        [ 'index', 'Main Page', '#main-page', true, null, 100, 'index.rst' ],
       ]);
     });
   })

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -76,7 +76,7 @@ describe('Basic html theme search', function() {
       let { results } = Search.query('main page');
       // should only be one result
       expect(results).toEqual([
-        [ 'index', 'Main Page', '', null, 100, 'index.rst' ],
+        [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ],
       ]);
     });
   })


### PR DESCRIPTION
Subject: Fix duplicate search results

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

We currently list the same page multiple times if, for example, both the title and content search match it. Since the preview is always the same, this is not very helpful.

Fix this by not using the anchor in the search result if it's an exact match on the document title. This ensures that each search result will appear at most one time.

### Detail

An easy way to reproduce the bug is to do a title search: the first result will link to the section, the second will link to the page in general. It appears that the "remove duplicates" feature [was added some time ago](https://github.com/sphinx-doc/sphinx/commit/e3a8744235adeefdecc1160c0fadfa2322c4bf7d), perhaps before there were multiple ways in which documents were searched.

https://pradyunsg.me/furo/search/?q=quickstart&check_keywords=yes&area=default

![Screenshot from 2024-02-04 13-42-21](https://github.com/sphinx-doc/sphinx/assets/20569/699c7f2a-5efa-4376-8cee-60aa2546c5ba)

Note that it appears the main sphinx documentation uses readthedocs' custom search, so this bug wouldn't be reproducible there.

### Relates

Closes #11961

