### PR TITLE
HTML Search: Use anchor for search preview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Features added
 Bugs fixed
 ----------
 
+* #11944: Use anchor in search preview.
+  Patch by Will Lachance.
 * #11668: Raise a useful error when ``theme.conf`` is missing.
   Patch by Vinay Sajip.
 * #11622: Ensure that the order of keys in ``searchindex.js`` is deterministic.

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -99,7 +99,7 @@ const _displayItem = (item, searchTerms, highlightTerms) => {
       .then((data) => {
         if (data)
           listItem.appendChild(
-            Search.makeSearchSummary(data, searchTerms)
+            Search.makeSearchSummary(data, searchTerms, anchor)
           );
         // highlight search terms in the summary
         if (SPHINX_HIGHLIGHT_ENABLED)  // set in sphinx_highlight.js
@@ -160,10 +160,15 @@ const Search = {
   _queued_query: null,
   _pulse_status: -1,
 
-  htmlToText: (htmlString) => {
+  htmlToText: (htmlString, anchor) => {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
     htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
-    const docContent = htmlElement.querySelector('[role="main"]');
+    let docContent = undefined;
+    if (anchor && htmlElement.querySelector(anchor)) {
+      docContent = htmlElement.querySelector(anchor);
+    } else {
+      docContent = htmlElement.querySelector('[role="main"]');
+    }
     if (docContent) return docContent.textContent;
     console.warn(
       "Content block not found. Sphinx search tries to obtain it via '[role=main]'. Could you check your theme or template."
@@ -549,8 +554,8 @@ const Search = {
    * search summary for a given text. keywords is a list
    * of stemmed words.
    */
-  makeSearchSummary: (htmlText, keywords) => {
-    const text = Search.htmlToText(htmlText);
+  makeSearchSummary: (htmlText, keywords, anchor) => {
+    const text = Search.htmlToText(htmlText, anchor);
     if (text === "") return null;
 
     const textLower = text.toLowerCase();

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -163,13 +163,19 @@ const Search = {
   htmlToText: (htmlString, anchor) => {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
     htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
-    let docContent = undefined;
-    if (anchor && htmlElement.querySelector(anchor)) {
-      docContent = htmlElement.querySelector(anchor);
-    } else {
-      docContent = htmlElement.querySelector('[role="main"]');
+    if (anchor) {
+      const anchorContent = htmlElement.querySelector(anchor);
+      if (anchorContent) return anchorContent.textContent;
+
+      console.warn(
+        `Anchor block not found. Sphinx search tries to obtain it via '${anchor}'. Check your theme or template.`
+      );
     }
+
+    // if anchor not specified or not found, fall back to main content
+    const docContent = htmlElement.querySelector('[role="main"]');
     if (docContent) return docContent.textContent;
+
     console.warn(
       "Content block not found. Sphinx search tries to obtain it via '[role=main]'. Could you check your theme or template."
     );

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -32,32 +32,34 @@ describe('Basic html theme search', function() {
 });
 
 describe("htmlToText", function() {
+
+  const testHTML = `<html>
+  <div class="body" role="main">
+    <section id="getting-started">
+      <h1>Getting Started</h1>
+      <p>Some text</p>
+    </section>
+    <section id="other-section">
+      <h1>Other Section</h1>
+      <p>Other text</p>
+    </section>
+    <section id="yet-another-section">
+      <h1>Yet Another Section</h1>
+      <p>More text</p>
+    </section>
+  </div>
+  </html>`;
+
   it("basic case", () => {
-    expect(Search.htmlToText(`
-    <html>
-    <div class="body" role="main">
-      <section id="getting-started">
-        <h1>Getting Started</h1>
-        <p>Some text</p>
-      </section>
-    </div>
-    </html>`).trim().split(/\s+/)).toEqual(['Getting', 'Started', 'Some', 'text']);
+    expect(Search.htmlToText(testHTML).trim().split(/\s+/)).toEqual([
+      'Getting', 'Started', 'Some', 'text', 
+      'Other', 'Section', 'Other', 'text', 
+      'Yet', 'Another', 'Section', 'More', 'text'
+    ]);
   });
 
   it("will start reading from the anchor", () => {
-    expect(Search.htmlToText(`
-    <html>
-    <div class="body" role="main">
-      <section id="getting-started">
-        <h1>Getting Started</h1>
-        <p>Some text</p>
-      </section>
-      <section id="other-section">
-        <h1>Other Section</h1>
-        <p>Other text</p>
-      </section>
-    </div>
-    </html>`, '#other-section').trim().split(/\s+/)).toEqual(['Other', 'Section', 'Other', 'text']);
+    expect(Search.htmlToText(testHTML, '#other-section').trim().split(/\s+/)).toEqual(['Other', 'Section', 'Other', 'text']);
   });
 });
 

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -31,6 +31,36 @@ describe('Basic html theme search', function() {
 
 });
 
+describe("htmlToText", function() {
+  it("basic case", () => {
+    expect(Search.htmlToText(`
+    <html>
+    <div class="body" role="main">
+      <section id="getting-started">
+        <h1>Getting Started</h1>
+        <p>Some text</p>
+      </section>
+    </div>
+    </html>`).trim().split(/\s+/)).toEqual(['Getting', 'Started', 'Some', 'text']);
+  });
+
+  it("will start reading from the anchor", () => {
+    expect(Search.htmlToText(`
+    <html>
+    <div class="body" role="main">
+      <section id="getting-started">
+        <h1>Getting Started</h1>
+        <p>Some text</p>
+      </section>
+      <section id="other-section">
+        <h1>Other Section</h1>
+        <p>Other text</p>
+      </section>
+    </div>
+    </html>`, '#other-section').trim().split(/\s+/)).toEqual(['Other', 'Section', 'Other', 'text']);
+  });
+});
+
 // This is regression test for https://github.com/sphinx-doc/sphinx/issues/3150
 describe('splitQuery regression tests', () => {
 


### PR DESCRIPTION
Subject: Use anchor for generating search previews

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

Attempts to use anchor for generating HTML preview, if available. This ensures that the preview is based on the anchor in the document, for cases where we matched on that title.

### Detail

You can reproduce this bug using the procedure @jayaddison mentioned in #11943

```
sphinx.git $ sphinx-build -b html doc _build 
sphinx.git $ cd _build
sphinx.git $ python -m http.server -b 127.0.0.1
```

Then search for something like "test"

Before:

![image](https://github.com/sphinx-doc/sphinx/assets/20569/c9f5fedc-e74b-49ad-b1e8-b81ce0b8849d)

After:

![image](https://github.com/sphinx-doc/sphinx/assets/20569/23322c44-e5f5-4c61-a68b-d7a12af955f6)

Note how the content in the "after" image actually reflects what you'd be jumping to!

### Relates

Closes #11943
Discovered when discussing #11942
