### PR TITLE
docs: fixup: pyglet now uses the sphinx-rtd-theme

### DIFF
--- a/EXAMPLES.rst
+++ b/EXAMPLES.rst
@@ -132,7 +132,6 @@ Documentation using the nature theme
 * `libLAS <https://liblas.org/>`__ (customized)
 * `Lmod <https://lmod.readthedocs.io/>`__
 * `MapServer <https://mapserver.org/>`__ (customized)
-* `pyglet <https://pyglet.readthedocs.io/>`__ (customized)
 * `PyWavelets <https://pywavelets.readthedocs.io/>`__
 * `Setuptools <https://setuptools.readthedocs.io/>`__
 * `Spring Python <https://docs.spring.io/spring-python/1.2.x/sphinx/html/>`__
@@ -253,6 +252,7 @@ Documentation using sphinx_rtd_theme
 * `PROS <https://pros.cs.purdue.edu/v5/>`__ (customized)
 * `Pweave <https://mpastell.com/pweave/>`__
 * `pyca/cryptograhpy <https://cryptography.io/>`__
+* `pyglet <https://pyglet.readthedocs.io/>`__
 * `PyNaCl <https://pynacl.readthedocs.io/>`__
 * `pyOpenSSL <https://www.pyopenssl.org/>`__
 * `PyPy <https://doc.pypy.org/>`__


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Update the `EXAMPLES.md` theme information for [`pyglet`](https://github.com/pyglet/pyglet/).

### Detail
- N/A

### Relates
- Resolves #11945.