### PR TITLE
tests: cleanup: remove unused _setup_intl autouse fixture

### DIFF
--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -33,29 +33,6 @@ def read_po(pathname):
         return pofile.read_po(f)
 
 
-def write_mo(pathname, po):
-    with open(pathname, 'wb') as f:
-        return mofile.write_mo(f, po)
-
-
-@pytest.fixture(autouse=True)
-def _setup_intl(app_params):
-    assert isinstance(app_params.kwargs['srcdir'], Path)
-    srcdir = app_params.kwargs['srcdir']
-    for dirpath, _dirs, files in os.walk(srcdir):
-        dirpath = Path(dirpath)
-        for f in [f for f in files if f.endswith('.po')]:
-            po = str(dirpath / f)
-            mo = srcdir / 'xx' / 'LC_MESSAGES' / (
-                os.path.relpath(po[:-3], srcdir) + '.mo')
-            if not mo.parent.exists():
-                mo.parent.mkdir(parents=True, exist_ok=True)
-
-            if not mo.exists() or os.stat(mo).st_mtime < os.stat(po).st_mtime:
-                # compile .mo file only if needed
-                write_mo(mo, read_po(po))
-
-
 @pytest.fixture(autouse=True)
 def _info(app):
     yield

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -8,10 +8,9 @@ import os.path
 import re
 import shutil
 import time
-from pathlib import Path
 
 import pytest
-from babel.messages import mofile, pofile
+from babel.messages import pofile
 from babel.messages.catalog import Catalog
 from docutils import nodes
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Removes an unused test fixture.

### Detail
- This can wait until after a fix for #11941 is merged, if we'd prefer to ensure that the two are unrelated (I believe they are, but there is no harm in waiting).
- See #11953 for details.

### Relates
- Resolves #11953.
