### PR TITLE
HTML Search: Fix multiple term matching edge case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Features added
 Bugs fixed
 ----------
 
+* #11959: Fix multiple term matching when word appears in both title and document.
+  Patch by Will Lachance.
 * #11958: HTML Search: Fix partial matches overwriting full matches.
   Patch by William Lachance.
 * #11944: Use anchor in search preview.

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -511,11 +511,8 @@ const Search = {
 
       // create the mapping
       files.forEach((file) => {
-        if (!fileMap.has(file)) {
-          fileMap.set(file, [word]);
-        } else if (fileMap.get(file).indexOf(word) === -1) {
-          fileMap.get(file).push(word);
-        }
+        if (!fileMap.has(file)) fileMap.set(file, [word]);
+        else if (fileMap.get(file).indexOf(word) === -1) fileMap.get(file).push(word);
       });
     });
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -511,9 +511,13 @@ const Search = {
 
       // create the mapping
       files.forEach((file) => {
-        if (fileMap.has(file) && fileMap.get(file).indexOf(word) === -1)
-          fileMap.get(file).push(word);
-        else fileMap.set(file, [word]);
+        if (fileMap.has(file)) {
+          if (fileMap.get(file).indexOf(word) === -1) {
+            fileMap.get(file).push(word);
+          }
+        } else {
+          fileMap.set(file, [word]);
+        }
       });
     });
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -511,12 +511,10 @@ const Search = {
 
       // create the mapping
       files.forEach((file) => {
-        if (fileMap.has(file)) {
-          if (fileMap.get(file).indexOf(word) === -1) {
-            fileMap.get(file).push(word);
-          }
-        } else {
+        if (!fileMap.has(file)) {
           fileMap.set(file, [word]);
+        } else if (fileMap.get(file).indexOf(word) === -1) {
+          fileMap.get(file).push(word);
         }
       });
     });

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -34,15 +34,12 @@ describe('Basic html theme search', function() {
         },
         docnames:["index"],
         filenames:["index.rst"],
-        indexentries:{},
-        objects:{},
-        objtypes: {},
-        objnames: {},
         terms:{main:0, page:0},
         titles:["Main Page"],
         titleterms:{ main:0, page:0 }
       }
       Search.setIndex(index);
+
       searchterms = ['main', 'page'];
       excluded = [];
       terms = index.terms;

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -49,7 +49,7 @@ describe('Basic html theme search', function() {
         'Main Page',
         '',
         null,
-        7,
+        15,
         'index.rst']];
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
     });

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -52,7 +52,7 @@ describe('Basic html theme search', function() {
         'Main Page',
         '',
         null,
-        15,
+        7,
         'index.rst']];
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
     });

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -27,6 +27,36 @@ describe('Basic html theme search', function() {
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
     });
 
+    it('should be able to search for multiple terms', function() {
+      index = {
+        alltitles: {
+          'Main Page': [[0, 'main-page']],
+        },
+        docnames:["index"],
+        filenames:["index.rst"],
+        indexentries:{},
+        objects:{},
+        objtypes: {},
+        objnames: {},
+        terms:{main:0, page:0},
+        titles:["Main Page"],
+        titleterms:{ main:0, page:0 }
+      }
+      Search.setIndex(index);
+      searchterms = ['main', 'page'];
+      excluded = [];
+      terms = index.terms;
+      titleterms = index.titleterms;
+      hits = [[
+        'index',
+        'Main Page',
+        '',
+        null,
+        15,
+        'index.rst']];
+      expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
+    });
+
   });
 
 });


### PR DESCRIPTION
Subject: Fix multiple term matching edge case

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

Fixes multiple matches getting accidentally overwritten in certain rare cases

### Detail

In certain rare cases, term matches could get overwritten due to a logic bug in the search code. Fix this and add a test.

### Relates

Closes #11959

