### PR TITLE
[HTML search] enable discovery of named caption ids

### DIFF
--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -504,7 +504,8 @@ class IndexBuilder:
             elif isinstance(node, nodes.title):
                 title = node.astext()
                 ids = node.parent['ids']
-                word_store.titles.append((title, ids[0] if ids else None))
+                if ids:
+                    word_store.titles.append((title, ids[0] if ids else None))
                 word_store.title_words.extend(split(title))
             for child in node.children:
                 _visit_nodes(child)

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -503,10 +503,8 @@ class IndexBuilder:
                 word_store.words.extend(split(node.astext()))
             elif isinstance(node, nodes.title):
                 title = node.astext()
-                ids = node.parent['ids']
-                if not ids:  # for example, a caption directive without a name ref
-                    return
-                word_store.titles.append((title, ids[0]))
+                ids = node.parent['ids'] or node.parent.parent['ids']
+                word_store.titles.append((title, ids[0] if ids else None))
                 word_store.title_words.extend(split(title))
             for child in node.children:
                 _visit_nodes(child)

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -504,6 +504,8 @@ class IndexBuilder:
             elif isinstance(node, nodes.title):
                 title = node.astext()
                 ids = node.parent['ids'] or node.parent.parent['ids']
+                if not ids:
+                    return
                 word_store.titles.append((title, ids[0] if ids else None))
                 word_store.title_words.extend(split(title))
             for child in node.children:

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -504,8 +504,9 @@ class IndexBuilder:
             elif isinstance(node, nodes.title):
                 title = node.astext()
                 ids = node.parent['ids']
-                if ids:
-                    word_store.titles.append((title, ids[0] if ids else None))
+                if not ids:  # for example, a caption directive without a name ref
+                    return
+                word_store.titles.append((title, ids[0]))
                 word_store.title_words.extend(split(title))
             for child in node.children:
                 _visit_nodes(child)

--- a/tests/roots/test-search/index.rst
+++ b/tests/roots/test-search/index.rst
@@ -18,6 +18,8 @@ textinheading
 International
 
 .. toctree::
+   :caption: table-of-contents
+   :name: index-toc
 
    tocitem
 

--- a/tests/roots/test-search/index.rst
+++ b/tests/roots/test-search/index.rst
@@ -23,6 +23,11 @@ International
 
    tocitem
 
+.. toctree::
+   :caption: nosearch-table-of-contents
+
+   nosearch
+
 .. raw:: html
 
    <span class="raw">rawword"</span>

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -300,6 +300,7 @@ def test_nosearch(app):
     # the index-toc name is declared for the table-of-contents caption in 'index.rst'
     assert "table-of-contents" in index['alltitles']
     assert [0, "index-toc"] in index['alltitles']["table-of-contents"]
+    assert "nosearch-table-of-contents" not in index['alltitles']
 
 
 @pytest.mark.sphinx(testroot='search', parallel=3, freshenv=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -297,6 +297,9 @@ def test_nosearch(app):
     # bat is indexed from 'index.rst' and 'tocitem.rst' (document IDs 0, 2), and
     # not from 'nosearch.rst' (document ID 1)
     assert index['terms']['bat'] == [0, 2]
+    # the index-toc name is declared for the table-of-contents caption in 'index.rst'
+    assert "table-of-contents" in index['alltitles']
+    assert [0, "index-toc"] in index['alltitles']["table-of-contents"]
 
 
 @pytest.mark.sphinx(testroot='search', parallel=3, freshenv=True)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- It seems that under some circumstances, items in the `alltitles` key of the JavaScript search index contain near-duplicates, where some items have an `id` (corresponding to an HTML anchor) and some do not.
- Given that all titles should (I think?) be hyperlinkable references, this changeset prevents title entries without IDs from being included in the search index.

### Detail
- ~~Skip `title` index entries when no IDs are present on the `title` node.~~
- ~~TBD: Work out why an equivalent entry _with_ an ID exists in the doctree.~~
- Allow the ID references for `caption` title nodes to be discovered from the parent of the `compact_paragraph` node that they are contained with.

### Relates
- May resolve #11965.

cc @wlach 