### PR TITLE
html builder omit query component when builder name start with 'epub'

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1052,7 +1052,7 @@ class StandaloneHTMLBuilder(Builder):
                      if value is not None]
             uri = pathto(os.fspath(css.filename), resource=True)
             # the EPUB format does not allow the use of query components
-            if self.name != 'epub':
+            if not self.name.startswith('epub'):
                 if checksum := _file_checksum(outdir, css.filename):
                     uri += f'?v={checksum}'
             return f'<link {" ".join(sorted(attrs))} href="{uri}" />'
@@ -1082,7 +1082,7 @@ class StandaloneHTMLBuilder(Builder):
                 # https://github.com/sphinx-doc/sphinx/issues/11658
                 pass
             # the EPUB format does not allow the use of query components
-            elif self.name != 'epub':
+            elif not self.name.startswith('epub'):
                 if checksum := _file_checksum(outdir, js.filename):
                     uri += f'?v={checksum}'
             if attrs:


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
- Bugfix

### Purpose
PR #11766 removed query component from URLs in EPUB.  But if we want enhance epub builder for their own needs, it doesn't work. This PR aim to solve this.

### Detail
compare builder name start with 'epub'  not fixed literal. we can use our own builder name with prefix 'epub'.

### Relates
#11598
