### PR TITLE
PyCode "Unparse": Added support for slice objects in subscriptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Features added
 * #11892: Improved performance when resolving cross references in cpp domain.
   Patch by Rouslan Korneychuk.
 
+* #11981: pycode "UnparseVisitor": Added support for slice objects in subscriptions
+
 Bugs fixed
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,8 @@ Features added
 * #11892: Improved performance when resolving cross references in cpp domain.
   Patch by Rouslan Korneychuk.
 
-* #11981: pycode "UnparseVisitor": Added support for slice objects in subscriptions
+* #11981: Improve rendering of signatures using ``slice`` syntax,
+  e.g., ``def foo(arg: np.float64[:,:]) -> None: ...``.
 
 Bugs fixed
 ----------

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -156,6 +156,20 @@ class _UnparseVisitor(ast.NodeVisitor):
     def visit_Set(self, node: ast.Set) -> str:
         return "{" + ", ".join(self.visit(e) for e in node.elts) + "}"
 
+    def visit_Slice(self, node: ast.Slice) -> str:
+        if not node.lower and not node.upper and not node.step:
+            # Empty slice with default values -> [:]
+            return ":"
+
+        start = self.visit(node.lower) if node.lower else ""
+        stop = self.visit(node.upper) if node.upper else ""
+        if not node.step:
+            # Default step size -> [start:stop]
+            return f"{start}:{stop}"
+
+        step = self.visit(node.step) if node.step else ""
+        return f"{start}:{stop}:{step}"
+
     def visit_Subscript(self, node: ast.Subscript) -> str:
         def is_simple_tuple(value: ast.expr) -> bool:
             return (
@@ -188,16 +202,4 @@ class _UnparseVisitor(ast.NodeVisitor):
     def generic_visit(self, node: ast.AST) -> NoReturn:
         raise NotImplementedError('Unable to parse %s object' % type(node).__name__)
 
-    def visit_Slice(self, node: ast.Slice) -> str:
-        if not node.lower and not node.upper and not node.step:
-            # Empty slice with default values -> [:]
-            return ":"
 
-        start = self.visit(node.lower) if node.lower else ""
-        stop = self.visit(node.upper) if node.upper else ""
-        if not node.step:
-            # Default step size -> [start:stop]
-            return f"{start}:{stop}"
-
-        step = self.visit(node.step) if node.step else ""
-        return f"{start}:{stop}:{step}"

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -201,5 +201,3 @@ class _UnparseVisitor(ast.NodeVisitor):
 
     def generic_visit(self, node: ast.AST) -> NoReturn:
         raise NotImplementedError('Unable to parse %s object' % type(node).__name__)
-
-

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -187,3 +187,9 @@ class _UnparseVisitor(ast.NodeVisitor):
 
     def generic_visit(self, node: ast.AST) -> NoReturn:
         raise NotImplementedError('Unable to parse %s object' % type(node).__name__)
+
+    def visit_Slice(self, node: ast.Slice) -> str:
+        start = self.visit(node.lower) if node.lower else ""
+        stop = self.visit(node.upper) if node.upper else ""
+        step = self.visit(node.step) if node.step else ""
+        return f"{start}:{stop}:{step}"

--- a/sphinx/pycode/ast.py
+++ b/sphinx/pycode/ast.py
@@ -189,7 +189,15 @@ class _UnparseVisitor(ast.NodeVisitor):
         raise NotImplementedError('Unable to parse %s object' % type(node).__name__)
 
     def visit_Slice(self, node: ast.Slice) -> str:
+        if not node.lower and not node.upper and not node.step:
+            # Empty slice with default values -> [:]
+            return ":"
+
         start = self.visit(node.lower) if node.lower else ""
         stop = self.visit(node.upper) if node.upper else ""
+        if not node.step:
+            # Default step size -> [start:stop]
+            return f"{start}:{stop}"
+
         step = self.visit(node.step) if node.step else ""
         return f"{start}:{stop}:{step}"

--- a/tests/roots/test-ext-autodoc/target/functions.py
+++ b/tests/roots/test-ext-autodoc/target/functions.py
@@ -17,3 +17,6 @@ partial_coroutinefunc = partial(coroutinefunc)
 
 builtin_func = print
 partial_builtin_func = partial(print)
+
+def slice_arg_func(arg: 'float64[:, :]'):
+    pass

--- a/tests/test_extensions/test_ext_autodoc_autofunction.py
+++ b/tests/test_extensions/test_ext_autodoc_autofunction.py
@@ -199,3 +199,13 @@ def test_async_generator(app):
         '   :async:',
         '',
     ]
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_slice_function_arg(app):
+    actual = do_autodoc(app, 'function', 'target.functions.slice_arg_func')
+    assert list(actual) == [
+        '',
+        '.. py:function:: slice_arg_func(arg: float_t[:, :])',
+        '   :module: target.functions',
+        '',
+    ]

--- a/tests/test_extensions/test_ext_autodoc_autofunction.py
+++ b/tests/test_extensions/test_ext_autodoc_autofunction.py
@@ -200,12 +200,13 @@ def test_async_generator(app):
         '',
     ]
 
+
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_slice_function_arg(app):
     actual = do_autodoc(app, 'function', 'target.functions.slice_arg_func')
     assert list(actual) == [
         '',
-        '.. py:function:: slice_arg_func(arg: float_t[:, :])',
+        '.. py:function:: slice_arg_func(arg: float64[:, :])',
         '   :module: target.functions',
         '',
     ]

--- a/tests/test_pycode/test_pycode_ast.py
+++ b/tests/test_pycode/test_pycode_ast.py
@@ -51,7 +51,8 @@ from sphinx.pycode.ast import unparse as ast_unparse
      "lambda x=0, /, y=1, *args, z, **kwargs: ..."),  # posonlyargs
     ("0x1234", "0x1234"),                       # Constant
     ("1_000_000", "1_000_000"),                 # Constant
-    ("Tuple[:,:]", "Tuple[::, ::]"),            # Index, Subscript, Slice
+    ("Tuple[:,:]", "Tuple[:, :]"),              # Index, Subscript, 2x Slice
+    ("Tuple[1:2]", "Tuple[1:2]"),               # Index, Subscript, Slice(no-step)
     ("Tuple[1:2:3]", "Tuple[1:2:3]"),           # Index, Subscript, Slice
 ])
 def test_unparse(source, expected):

--- a/tests/test_pycode/test_pycode_ast.py
+++ b/tests/test_pycode/test_pycode_ast.py
@@ -57,7 +57,7 @@ from sphinx.pycode.ast import unparse as ast_unparse
     ("x[:, np.newaxis, :, :]",
      "x[:, np.newaxis, :, :]"),                 # Index, Subscript, numpy extended syntax
     ("y[:, 1:3][np.array([0, 2, 4]), :]",
-     "y[:, 1:3][np.array([0, 2, 4]), :]")       # Index, 2x Subscript, numpy extended syntax
+     "y[:, 1:3][np.array([0, 2, 4]), :]"),       # Index, 2x Subscript, numpy extended syntax
 ])
 def test_unparse(source, expected):
     module = ast.parse(source)

--- a/tests/test_pycode/test_pycode_ast.py
+++ b/tests/test_pycode/test_pycode_ast.py
@@ -51,6 +51,8 @@ from sphinx.pycode.ast import unparse as ast_unparse
      "lambda x=0, /, y=1, *args, z, **kwargs: ..."),  # posonlyargs
     ("0x1234", "0x1234"),                       # Constant
     ("1_000_000", "1_000_000"),                 # Constant
+    ("Tuple[:,:]", "Tuple[::, ::]"),            # Index, Subscript, Slice
+    ("Tuple[1:2:3]", "Tuple[1:2:3]"),           # Index, Subscript, Slice
 ])
 def test_unparse(source, expected):
     module = ast.parse(source)

--- a/tests/test_pycode/test_pycode_ast.py
+++ b/tests/test_pycode/test_pycode_ast.py
@@ -54,6 +54,10 @@ from sphinx.pycode.ast import unparse as ast_unparse
     ("Tuple[:,:]", "Tuple[:, :]"),              # Index, Subscript, 2x Slice
     ("Tuple[1:2]", "Tuple[1:2]"),               # Index, Subscript, Slice(no-step)
     ("Tuple[1:2:3]", "Tuple[1:2:3]"),           # Index, Subscript, Slice
+    ("x[:, np.newaxis, :, :]",
+     "x[:, np.newaxis, :, :]"),                 # Index, Subscript, numpy extended syntax
+    ("y[:, 1:3][np.array([0, 2, 4]), :]",
+     "y[:, 1:3][np.array([0, 2, 4]), :]")       # Index, 2x Subscript, numpy extended syntax
 ])
 def test_unparse(source, expected):
     module = ast.parse(source)


### PR DESCRIPTION
Subject: Fix documentation issue when slice objects are used in subscriptions

### Feature or Bugfix
- Feature

### Purpose
- Added function to handle parsed slice objects

### Detail
- For instance, consider the following class definition:
  ```python
  class Foo: ...

  class Bar(BaseType):
      #: doc comment
      field1: int
      field2: Foo[1:2:3]
      """doc comment"""
  ```
  Internally, sphinx will raise an exception while parsing this file:
  ```
  ...
  File "venv-3.12/lib/python3.12/site-packages/sphinx/pycode/ast.py", line 170, in visit_Subscript
    return f"{self.visit(node.value)}[{self.visit(node.slice)}]"
                                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "venv-3.12/lib/python3.12/site-packages/sphinx/pycode/ast.py", line 188, in generic_visit
    raise NotImplementedError('Unable to parse %s object' % type(node).__name__)
  NotImplementedError: Unable to parse Slice object
  ```
- *The implemented function does not alter existing code*

### Relates

- #10817 
