### PR TITLE
Fix count of default substitutions

### DIFF
--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -273,7 +273,7 @@ the standard reST markup for that purpose.
 Substitutions
 -------------
 
-The documentation system provides three substitutions that are defined by
+The documentation system provides some substitutions that are defined by
 default. They are set in the build configuration file.
 
 .. describe:: |release|


### PR DESCRIPTION
Subject: With the addition of |translation progress| substitution, sphinx has now more than three default substitutions. Fixing the issue.

### Feature or Bugfix
- Bugfix

