### PR TITLE
Update roles.rst doc to clarify double backslash for escaping curly braces in samp text

### DIFF
--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -240,7 +240,7 @@ different style:
    :rst:role:`code` role instead.
 
    .. versionchanged:: 1.8
-      Allowed to escape curly braces with backslash
+      Allowed to escape curly braces with double backslash
 
 There is also an :rst:role:`index` role to generate index entries.
 

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -240,7 +240,10 @@ different style:
    :rst:role:`code` role instead.
 
    .. versionchanged:: 1.8
-      Allowed to escape curly braces with double backslash
+      Allowed to escape curly braces with double backslash.  For example, in
+      ``:samp:`print(F"ans:\\{1+{variable}*2\\}")```, the part ``variable``
+      would be emphasized and the escaped curly braces would be displayed:
+      :samp:`print(F"ans:\\{1+{variable}*2\\}")`
 
 There is also an :rst:role:`index` role to generate index entries.
 

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -241,7 +241,7 @@ different style:
 
    .. versionchanged:: 1.8
       Allowed to escape curly braces with double backslash.  For example, in
-      ``:samp:`print(F"ans:\\{1+{variable}*2\\}")```, the part ``variable``
+      ``:samp:`print(f"answer=\\{1+{variable}*2\\}")```, the part ``variable``
       would be emphasized and the escaped curly braces would be displayed:
       :samp:`print(F"ans:\\{1+{variable}*2\\}")`
 

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -243,7 +243,7 @@ different style:
       Allowed to escape curly braces with double backslash.  For example, in
       ``:samp:`print(f"answer=\\{1+{variable}*2\\}")```, the part ``variable``
       would be emphasized and the escaped curly braces would be displayed:
-      :samp:`print(F"ans:\\{1+{variable}*2\\}")`
+      :samp:`print(f"answer=\\{1+{variable}*2\\}")`
 
 There is also an :rst:role:`index` role to generate index entries.
 


### PR DESCRIPTION
Update roles.rst doc to clarify double backslash for escaping curly braces in samp text

Subject: Update documentation with clarification on how to escape curly braces in samp text

### Feature or Bugfix
- Bugfix documentation

### Purpose
- Update documentation to fix ambiguity/inaccuracy that others have encountered (see #10777)

### Detail
- Documentation concerns how to escape curly braces in samp role text (implemented in #789)

### Relates
- #789
- #10777 
