### PR TITLE
Clarify the proper 'make-mode' usage in the docs

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -39,8 +39,11 @@ Options
    Extensions can add their own builders.
 
    .. important::
-      Sphinx only recognizes the ``-M`` option if it is used first. The source
-      and output directories must also be passed before any options.
+      Sphinx only recognizes the ``-M`` option if it is used first, along with
+      the source and output directories, before any other options are passed.
+      For example::
+
+          sphinx-build -M html ./source ./build -W --keep-going
 
    The *make-mode* provides the same build functionality as
    a default :ref:`Makefile or Make.bat <makefile_options>`,

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -39,7 +39,8 @@ Options
    Extensions can add their own builders.
 
    .. important::
-      Sphinx only recognizes the ``-M`` option if it is used first.
+      Sphinx only recognizes the ``-M`` option if it is used first. The source
+      and output directories must also be passed before any options.
 
    The *make-mode* provides the same build functionality as
    a default :ref:`Makefile or Make.bat <makefile_options>`,


### PR DESCRIPTION
Subject: Clarify the proper 'make-mode' usage in the docs.

### Feature or Bugfix
- Bugfix documentation

### Purpose
- The fact that source and output directories need to come first isn't mentioned, which can lead to usage issues.

### Relates
- Fixes the issue mentioned here: https://github.com/sphinx-doc/sphinx/issues/10968#issuecomment-1894998203

