### PR TITLE
Normalize `name` for 'std:label' when loading inventory

### DIFF
--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -138,6 +138,11 @@ class InventoryFile:
                 continue
             if location.endswith('$'):
                 location = location[:-1] + name
+            if type == 'std:label':
+                # Normalize names for `:std:label` to match
+                # `XRefRole(lowercase=True)` for `ref` and `numref` roles.
+                # See https://github.com/sphinx-doc/sphinx/issues/12008
+                name = name.lower()
             location = join(uri, location)
             inv_item: InventoryItem = projname, version, location, dispname
             invdata.setdefault(type, {})[name] = inv_item

--- a/tests/test_util/test_util_inventory.py
+++ b/tests/test_util/test_util_inventory.py
@@ -41,6 +41,7 @@ foo.bar js:class 1 index.html#foo.bar -
 foo.bar.baz js:method 1 index.html#foo.bar.baz -
 foo.bar.qux js:data 1 index.html#foo.bar.qux -
 a term including:colon std:term -1 glossary.html#term-a-term-including-colon -
+The-Julia-Domain std:label -1 write_inventory/#$ The Julia Domain
 ''')
 
 inventory_v2_not_having_version = b'''\
@@ -78,6 +79,7 @@ def test_read_inventory_v2():
         '/util/glossary.html#term-a-term'
     assert invdata['std:term']['a term including:colon'][2] == \
         '/util/glossary.html#term-a-term-including-colon'
+    assert 'the-julia-domain' in invdata['std:label']
 
 
 def test_read_inventory_v2_not_having_version():


### PR DESCRIPTION
Lowercase the `name` for any inventory item of type `std:label` to match the lowercaseing of `ref` and `numeref` references in the `std` domain.

Closes #12008 