### PR TITLE
#11873 Provide a better error message if the master document is not included in project documents

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -419,10 +419,12 @@ class Builder:
         else:
             self._read_serial(docnames)
 
-        # check if the root_doc exists
-        if self.config.root_doc not in self.env.all_docs: 
-            if  "**" not in self.config.include_patterns:
-                raise SphinxError('customized include_patterns is set, but root file %s not in the include_patterns' %
+        if self.config.root_doc not in self.env.all_docs:
+            if "**" in self.config.exclude_patterns or "**.rst" in self.config.exclude_patterns:
+                raise SphinxError('customized exclude_patterns is set and root file %s is in the exclude_patterns' %
+                        self.env.doc2path(self.config.root_doc))
+            elif "**" not in self.config.include_patterns: # if not set include_patterns, "**" will in it
+                raise SphinxError('customized include_patterns is set, but root file %s is not in the include_patterns' %
                         self.env.doc2path(self.config.root_doc))
             else: 
                 raise SphinxError('root file %s not found' %

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -419,10 +419,15 @@ class Builder:
         else:
             self._read_serial(docnames)
 
-        if self.config.root_doc not in self.env.all_docs:
-            raise SphinxError('root file %s not found' %
-                              self.env.doc2path(self.config.root_doc))
-
+        # check if the root_doc exists
+        if self.config.root_doc not in self.env.all_docs: 
+            if  "**" not in self.config.include_patterns:
+                raise SphinxError('customized include_patterns is set, but root file %s not in the include_patterns' %
+                        self.env.doc2path(self.config.root_doc))
+            else: 
+                raise SphinxError('root file %s not found' %
+                                self.env.doc2path(self.config.root_doc))
+        
         for retval in self.events.emit('env-updated', self.env):
             if retval is not None:
                 docnames.extend(retval)


### PR DESCRIPTION
Provide a better error message if the master document is not included in project documents #11873 

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
- Provide a better error message if the master document is not included in project documents

### Detail
Three cases if the master document (index.rst) is not found.
- Case 1: The master document is included in the exclude_patterns
- Case 2: The include_patterns is set, but the master document is not included in the include_patterns
- Case 3: The master document does not exist in the project t document.

### Relates
- <URL or Ticket>

