### PR TITLE
Provide a better error message if the master document is not included in project documents #11873

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -409,14 +409,14 @@ class Config:
             if name in self._overrides:
                 value = self._overrides[name]
                 if not isinstance(value, str):
-                    self.__setattr__(name, value)
+                    self.__dict__[name] = value
                     return value
                 try:
                     value = self.convert_overrides(name, value)
                 except ValueError as exc:
                     logger.warning("%s", exc)
                 else:
-                    self.__setattr__(name, value)
+                    self.__dict__[name] = value
                     return value
             # then check values from 'conf.py'
             if name in self._raw_config:

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -409,18 +409,19 @@ class Config:
             if name in self._overrides:
                 value = self._overrides[name]
                 if not isinstance(value, str):
-                    self.__dict__[name] = value
+                    self.__setattr__(name, value)
                     return value
                 try:
                     value = self.convert_overrides(name, value)
                 except ValueError as exc:
                     logger.warning("%s", exc)
                 else:
-                    self.__dict__[name] = value
+                    self.__setattr__(name, value)
                     return value
             # then check values from 'conf.py'
             if name in self._raw_config:
-                self.__dict__[name] = value = self._raw_config[name]
+                value = self._raw_config[name]
+                self.__setattr__(name, value)
                 return value
             # finally, fall back to the default value
             default = self._options[name].default

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -416,7 +416,7 @@ class Config:
                 except ValueError as exc:
                     logger.warning("%s", exc)
                 else:
-                    self.__dict__[name] = value
+                    self.__setattr__(name, value)
                     return value
             # then check values from 'conf.py'
             if name in self._raw_config:

--- a/tests/test_environment/test_environment.py
+++ b/tests/test_environment/test_environment.py
@@ -34,7 +34,7 @@ def test_config_status(make_app, app_params):
     assert app3.env.config_status == CONFIG_CHANGED
     app3.build()
     shutil.move(fname[:-4] + 'x.rst', fname)
-    assert "[config changed ('root_doc')] 1 added" in app3._status.getvalue()
+    assert "[config changed ('master_doc')] 1 added" in app3._status.getvalue()
 
     # incremental build (extension changed)
     app4 = make_app(*args, confoverrides={'extensions': ['sphinx.ext.autodoc']}, **kwargs)


### PR DESCRIPTION
Subject: Provide a better error message if the master document is not included in project documents [#11873]

### Feature or Bugfix
<!-- please choose -->
- Bugfix
- Refactoring

### Purpose
- Provide a better error message if the master document is not included in project documents


### Detail
Three cases if the master document (index.rst) is not found.
- Case 1: The master document is included in the exclude_patterns
- Case 2: The include_patterns is set, but the master document is not included in the include_patterns
- Case 3: The master document does not exist in the project t document.


### Relates


