### PR TITLE
update mypy CI job to use local config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,9 +62,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade "mypy==1.8.0" docutils-stubs types-requests
+        python -m pip install ".[lint,test]"
     - name: Type check with mypy
-      run: mypy sphinx/
+      run: mypy
 
   docs-lint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ exclude = [
 ]
 
 [tool.mypy]
+files = "sphinx"
 check_untyped_defs = true
 disallow_incomplete_defs = true
 follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ exclude = [
 ]
 
 [tool.mypy]
-files = "sphinx"
+files = ["sphinx"]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 follow_imports = "skip"


### PR DESCRIPTION
the mypy CI job currently installs its dependencies independently of the `pyproject.toml` file. This PR updates this so that the same dependencies are used for both local dev and in CI

see https://github.com/sphinx-doc/sphinx/pull/12012#issuecomment-1963645656