### PR TITLE
Fix typos in `usage/configuration.rst`

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1179,7 +1179,7 @@ that use Sphinx's HTMLWriter class.
                          ('print.css', {'media': 'print'})]
 
    As a special attribute, *priority* can be set as an integer to load the CSS
-   file earlier or lazier step.  For more information, refer
+   file at an earlier or lazier step.  For more information, refer
    :meth:`.Sphinx.add_css_file()`.
 
    .. versionadded:: 1.8
@@ -1201,9 +1201,9 @@ that use Sphinx's HTMLWriter class.
                         'https://example.com/scripts/custom.js',
                         ('custom.js', {'async': 'async'})]
 
-   As a special attribute, *priority* can be set as an integer to load the CSS
-   file earlier or lazier step.  For more information, refer
-   :meth:`.Sphinx.add_css_file()`.
+   As a special attribute, *priority* can be set as an integer to load the
+   JavaScript file at an earlier or lazier step.  For more information, refer
+   :meth:`.Sphinx.add_js_file()`.
 
    .. versionadded:: 1.8
    .. versionchanged:: 3.5


### PR DESCRIPTION
I’m guessing this section was copied over from the previous one and these bits got forgotten when updating.

I’m also wondering whether there is a missing “at an” before “earlier or lazier step”. I can amend this PR if that’s confirmed.