### PR TITLE
[HTML search] tests: bugfix: correction for test index fixture format

### DIFF
--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -6,7 +6,7 @@ describe('Basic html theme search', function() {
       index = {
         docnames:["index"],
         filenames:["index.rst"],
-        terms:{'c++':0},
+        terms:{'c++':[0]},
         titles:["&lt;no title&gt;"],
         titleterms:{}
       }
@@ -21,7 +21,7 @@ describe('Basic html theme search', function() {
         "&lt;no title&gt;",
         "",
         null,
-        2,
+        5,
         "index.rst"
       ]];
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Make the `tests/js/searchtools.js` test file more representative of the search index format used by the Sphinx client-side JS code.

### Detail
- Ranking of search results relies on scoring, and Sphinx exact-match queries on terms (arbitrary words) are intended to score `5`, while partial-matches score `2` per term ([ref](https://github.com/sphinx-doc/sphinx/blob/9a30ca7da1aeffe0c21b81fc7722eb1aed1512da/sphinx/themes/basic/static/searchtools.js#L44-L46)).
- Multi-word searches such as `datetime timedelta` are supported by Sphinx; internally the JavaScript on the page tokenizes these into multi-term queries (`['datetim', 'timedelta']`).
- The search index itself only contains _single-word_ terms.
- Each term in the index is mapped to a list of documents where the term is found, and these document-ids are zero-indexed (`0, 1, 2, ...`).
- :bug: The `tests/js/searchtools.js` file has an incorrect representation of the `terms` entry in the index, instead mapping a search term to a single document-id.

### Relates
- Resolves #12028.