### PR TITLE
improve type safety when using NodeMatcher

### DIFF
--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -47,7 +47,7 @@ class KeyboardTransform(SphinxPostTransform):
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])
         # this list must be pre-created as during iteration new nodes
         # are added which match the condition in the NodeMatcher.
-        for node in list(self.document.findall(matcher)):  # type: nodes.literal
+        for node in list(matcher.findall_in(self.document)):
             parts = self.pattern.split(node[-1].astext())
             if len(parts) == 1 or self.is_multiwords_key(parts):
                 continue

--- a/sphinx/builders/html/transforms.py
+++ b/sphinx/builders/html/transforms.py
@@ -47,7 +47,7 @@ class KeyboardTransform(SphinxPostTransform):
         matcher = NodeMatcher(nodes.literal, classes=["kbd"])
         # this list must be pre-created as during iteration new nodes
         # are added which match the condition in the NodeMatcher.
-        for node in list(matcher.findall_in(self.document)):
+        for node in list(matcher.findall(self.document)):
             parts = self.pattern.split(node[-1].astext())
             if len(parts) == 1 or self.is_multiwords_key(parts):
                 continue

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -37,7 +37,7 @@ class FootnoteDocnameUpdater(SphinxTransform):
 
     def apply(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(*self.TARGET_NODES)
-        for node in self.document.findall(matcher):  # type: Element
+        for node in matcher.findall_in(self.document):
             node['docname'] = self.env.docname
 
 
@@ -538,7 +538,7 @@ class CitationReferenceTransform(SphinxPostTransform):
     def run(self, **kwargs: Any) -> None:
         domain = cast(CitationDomain, self.env.get_domain('citation'))
         matcher = NodeMatcher(addnodes.pending_xref, refdomain='citation', reftype='ref')
-        for node in self.document.findall(matcher):  # type: addnodes.pending_xref
+        for node in matcher.findall_in(self.document):
             docname, labelid, _ = domain.citations.get(node['reftarget'], ('', '', 0))
             if docname:
                 citation_ref = nodes.citation_reference('', '', *node.children,
@@ -574,7 +574,7 @@ class LiteralBlockTransform(SphinxPostTransform):
 
     def run(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.container, literal_block=True)
-        for node in self.document.findall(matcher):  # type: nodes.container
+        for node in matcher.findall_in(self.document):
             newnode = captioned_literal_block('', *node.children, **node.attributes)
             node.replace_self(newnode)
 

--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -37,7 +37,7 @@ class FootnoteDocnameUpdater(SphinxTransform):
 
     def apply(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(*self.TARGET_NODES)
-        for node in matcher.findall_in(self.document):
+        for node in matcher.findall(self.document):
             node['docname'] = self.env.docname
 
 
@@ -538,7 +538,7 @@ class CitationReferenceTransform(SphinxPostTransform):
     def run(self, **kwargs: Any) -> None:
         domain = cast(CitationDomain, self.env.get_domain('citation'))
         matcher = NodeMatcher(addnodes.pending_xref, refdomain='citation', reftype='ref')
-        for node in matcher.findall_in(self.document):
+        for node in matcher.findall(self.document):
             docname, labelid, _ = domain.citations.get(node['reftarget'], ('', '', 0))
             if docname:
                 citation_ref = nodes.citation_reference('', '', *node.children,
@@ -574,7 +574,7 @@ class LiteralBlockTransform(SphinxPostTransform):
 
     def run(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.container, literal_block=True)
-        for node in matcher.findall_in(self.document):
+        for node in matcher.findall(self.document):
             newnode = captioned_literal_block('', *node.children, **node.attributes)
             node.replace_self(newnode)
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -182,7 +182,7 @@ class _NodeUpdater:
 
                 # replace target's refname to new target name
                 matcher = NodeMatcher(nodes.target, refname=old_name)
-                for old_target in matcher.findall_in(self.document):
+                for old_target in matcher.findall(self.document):
                     old_target['refname'] = new_name
 
                 processed = True
@@ -198,8 +198,8 @@ class _NodeUpdater:
                 lst.append(new)
 
         is_autofootnote_ref = NodeMatcher(nodes.footnote_reference, auto=Any)
-        old_foot_refs = list(is_autofootnote_ref.findall_in(self.node))
-        new_foot_refs = list(is_autofootnote_ref.findall_in(self.patch))
+        old_foot_refs = list(is_autofootnote_ref.findall(self.node))
+        new_foot_refs = list(is_autofootnote_ref.findall(self.patch))
         self.compare_references(old_foot_refs, new_foot_refs,
                                 __('inconsistent footnote references in translated message.' +
                                    ' original: {0}, translated: {1}'))
@@ -238,8 +238,8 @@ class _NodeUpdater:
         # * use translated refname for section refname.
         # * inline reference "`Python <...>`_" has no 'refname'.
         is_refnamed_ref = NodeMatcher(nodes.reference, refname=Any)
-        old_refs = list(is_refnamed_ref.findall_in(self.node))
-        new_refs = list(is_refnamed_ref.findall_in(self.patch))
+        old_refs = list(is_refnamed_ref.findall(self.node))
+        new_refs = list(is_refnamed_ref.findall(self.patch))
         self.compare_references(old_refs, new_refs,
                                 __('inconsistent references in translated message.' +
                                    ' original: {0}, translated: {1}'))
@@ -262,8 +262,8 @@ class _NodeUpdater:
     def update_refnamed_footnote_references(self) -> None:
         # refnamed footnote should use original 'ids'.
         is_refnamed_footnote_ref = NodeMatcher(nodes.footnote_reference, refname=Any)
-        old_foot_refs = list(is_refnamed_footnote_ref.findall_in(self.node))
-        new_foot_refs = list(is_refnamed_footnote_ref.findall_in(self.patch))
+        old_foot_refs = list(is_refnamed_footnote_ref.findall(self.node))
+        new_foot_refs = list(is_refnamed_footnote_ref.findall(self.patch))
         refname_ids_map: dict[str, list[str]] = {}
         self.compare_references(old_foot_refs, new_foot_refs,
                                 __('inconsistent footnote references in translated message.' +
@@ -278,8 +278,8 @@ class _NodeUpdater:
     def update_citation_references(self) -> None:
         # citation should use original 'ids'.
         is_citation_ref = NodeMatcher(nodes.citation_reference, refname=Any)
-        old_cite_refs = list(is_citation_ref.findall_in(self.node))
-        new_cite_refs = list(is_citation_ref.findall_in(self.patch))
+        old_cite_refs = list(is_citation_ref.findall(self.node))
+        new_cite_refs = list(is_citation_ref.findall(self.patch))
         self.compare_references(old_cite_refs, new_cite_refs,
                                 __('inconsistent citation references in translated message.' +
                                    ' original: {0}, translated: {1}'))
@@ -545,7 +545,7 @@ class TranslationProgressTotaliser(SphinxTransform):
             return
 
         total = translated = 0
-        for node in NodeMatcher(nodes.Element, translated=Any).findall_in(self.document):
+        for node in NodeMatcher(nodes.Element, translated=Any).findall(self.document):
             total += 1
             if node['translated']:
                 translated += 1
@@ -584,7 +584,7 @@ class AddTranslationClasses(SphinxTransform):
                    'True, False, "translated" or "untranslated"')
             raise ConfigError(msg)
 
-        for node in NodeMatcher(nodes.Element, translated=Any).findall_in(self.document):
+        for node in NodeMatcher(nodes.Element, translated=Any).findall(self.document):
             if node['translated']:
                 if add_translated:
                     node.setdefault('classes', []).append('translated')
@@ -606,7 +606,7 @@ class RemoveTranslatableInline(SphinxTransform):
             return
 
         matcher = NodeMatcher(nodes.inline, translatable=Any)
-        for inline in matcher.findall_in(self.document):
+        for inline in matcher.findall(self.document):
             inline.parent.remove(inline)
             inline.parent += inline.children
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -182,7 +182,7 @@ class _NodeUpdater:
 
                 # replace target's refname to new target name
                 matcher = NodeMatcher(nodes.target, refname=old_name)
-                for old_target in self.document.findall(matcher):  # type: nodes.target
+                for old_target in matcher.findall_in(self.document):
                     old_target['refname'] = new_name
 
                 processed = True
@@ -198,10 +198,8 @@ class _NodeUpdater:
                 lst.append(new)
 
         is_autofootnote_ref = NodeMatcher(nodes.footnote_reference, auto=Any)
-        old_foot_refs: list[nodes.footnote_reference] = [
-            *self.node.findall(is_autofootnote_ref)]
-        new_foot_refs: list[nodes.footnote_reference] = [
-            *self.patch.findall(is_autofootnote_ref)]
+        old_foot_refs = list(is_autofootnote_ref.findall_in(self.node))
+        new_foot_refs = list(is_autofootnote_ref.findall_in(self.patch))
         self.compare_references(old_foot_refs, new_foot_refs,
                                 __('inconsistent footnote references in translated message.' +
                                    ' original: {0}, translated: {1}'))
@@ -240,8 +238,8 @@ class _NodeUpdater:
         # * use translated refname for section refname.
         # * inline reference "`Python <...>`_" has no 'refname'.
         is_refnamed_ref = NodeMatcher(nodes.reference, refname=Any)
-        old_refs: list[nodes.reference] = [*self.node.findall(is_refnamed_ref)]
-        new_refs: list[nodes.reference] = [*self.patch.findall(is_refnamed_ref)]
+        old_refs = list(is_refnamed_ref.findall_in(self.node))
+        new_refs = list(is_refnamed_ref.findall_in(self.patch))
         self.compare_references(old_refs, new_refs,
                                 __('inconsistent references in translated message.' +
                                    ' original: {0}, translated: {1}'))
@@ -264,10 +262,8 @@ class _NodeUpdater:
     def update_refnamed_footnote_references(self) -> None:
         # refnamed footnote should use original 'ids'.
         is_refnamed_footnote_ref = NodeMatcher(nodes.footnote_reference, refname=Any)
-        old_foot_refs: list[nodes.footnote_reference] = [*self.node.findall(
-            is_refnamed_footnote_ref)]
-        new_foot_refs: list[nodes.footnote_reference] = [*self.patch.findall(
-            is_refnamed_footnote_ref)]
+        old_foot_refs = list(is_refnamed_footnote_ref.findall_in(self.node))
+        new_foot_refs = list(is_refnamed_footnote_ref.findall_in(self.patch))
         refname_ids_map: dict[str, list[str]] = {}
         self.compare_references(old_foot_refs, new_foot_refs,
                                 __('inconsistent footnote references in translated message.' +
@@ -282,8 +278,8 @@ class _NodeUpdater:
     def update_citation_references(self) -> None:
         # citation should use original 'ids'.
         is_citation_ref = NodeMatcher(nodes.citation_reference, refname=Any)
-        old_cite_refs: list[nodes.citation_reference] = [*self.node.findall(is_citation_ref)]
-        new_cite_refs: list[nodes.citation_reference] = [*self.patch.findall(is_citation_ref)]
+        old_cite_refs = list(is_citation_ref.findall_in(self.node))
+        new_cite_refs = list(is_citation_ref.findall_in(self.patch))
         self.compare_references(old_cite_refs, new_cite_refs,
                                 __('inconsistent citation references in translated message.' +
                                    ' original: {0}, translated: {1}'))
@@ -549,7 +545,7 @@ class TranslationProgressTotaliser(SphinxTransform):
             return
 
         total = translated = 0
-        for node in self.document.findall(NodeMatcher(translated=Any)):  # type: nodes.Element
+        for node in NodeMatcher(nodes.Element, translated=Any).findall_in(self.document):
             total += 1
             if node['translated']:
                 translated += 1
@@ -588,7 +584,7 @@ class AddTranslationClasses(SphinxTransform):
                    'True, False, "translated" or "untranslated"')
             raise ConfigError(msg)
 
-        for node in self.document.findall(NodeMatcher(translated=Any)):  # type: nodes.Element
+        for node in NodeMatcher(nodes.Element, translated=Any).findall_in(self.document):
             if node['translated']:
                 if add_translated:
                     node.setdefault('classes', []).append('translated')
@@ -610,7 +606,7 @@ class RemoveTranslatableInline(SphinxTransform):
             return
 
         matcher = NodeMatcher(nodes.inline, translatable=Any)
-        for inline in list(self.document.findall(matcher)):  # type: nodes.inline
+        for inline in matcher.findall_in(self.document):
             inline.parent.remove(inline)
             inline.parent += inline.children
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -62,7 +62,7 @@ class NodeMatcher(Generic[N]):
         self.classes = node_classes
         self.attrs = attrs
 
-    def _match(self, node: Node) -> bool:
+    def match(self, node: Node) -> bool:
         try:
             if self.classes and not isinstance(node, self.classes):
                 return False
@@ -85,7 +85,7 @@ class NodeMatcher(Generic[N]):
             return False
 
     def __call__(self, node: Node) -> bool:
-        return self._match(node)
+        return self.match(node)
 
     def findall_in(self, node: Node) -> Iterator[N]:
         """An alternative to `Node.find_all` with improved type safety.

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -34,10 +34,10 @@ explicit_title_re = re.compile(r'^(.+?)\s*(?<!\x00)<([^<]*?)>$', re.DOTALL)
 caption_ref_re = explicit_title_re  # b/w compat alias
 
 
-T = TypeVar("T", bound=Node)
+N = TypeVar("N", bound=Node)
 
 
-class NodeMatcher(Generic[T]):
+class NodeMatcher(Generic[N]):
     """A helper class for Node.findall().
 
     It checks that the given node is an instance of the specified node-classes and
@@ -58,7 +58,7 @@ class NodeMatcher(Generic[T]):
         # => [<reference ...>, <reference ...>, ...]
     """
 
-    def __init__(self, *node_classes: type[T], **attrs: Any) -> None:
+    def __init__(self, *node_classes: type[N], **attrs: Any) -> None:
         self.classes = node_classes
         self.attrs = attrs
 
@@ -87,7 +87,7 @@ class NodeMatcher(Generic[T]):
     def __call__(self, node: Node) -> bool:
         return self._match(node)
 
-    def findall_in(self, node: Node) -> Iterator[T]:
+    def findall_in(self, node: Node) -> Iterator[N]:
         """An alternative to `Node.find_all` with improved type safety.
 
         While the `NodeMatcher` object can be used as an argument to `Node.find_all`, doing so

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -47,14 +47,14 @@ class NodeMatcher(Generic[N]):
     and ``reftype`` attributes::
 
         matcher = NodeMatcher(nodes.reference, refdomain='std', reftype='citation')
-        matcher.findall_in(doctree)
+        matcher.findall(doctree)
         # => [<reference ...>, <reference ...>, ...]
 
     A special value ``typing.Any`` matches any kind of node-attributes.  For example,
     following example searches ``reference`` node having ``refdomain`` attributes::
 
         matcher = NodeMatcher(nodes.reference, refdomain=Any)
-        matcher.findall_in(doctree)
+        matcher.findall(doctree)
         # => [<reference ...>, <reference ...>, ...]
     """
 
@@ -87,10 +87,10 @@ class NodeMatcher(Generic[N]):
     def __call__(self, node: Node) -> bool:
         return self.match(node)
 
-    def findall_in(self, node: Node) -> Iterator[N]:
-        """An alternative to `Node.find_all` with improved type safety.
+    def findall(self, node: Node) -> Iterator[N]:
+        """An alternative to `Node.findall` with improved type safety.
 
-        While the `NodeMatcher` object can be used as an argument to `Node.find_all`, doing so
+        While the `NodeMatcher` object can be used as an argument to `Node.findall`, doing so
         confounds type checkers' ability to determine the return type of the iterator.
         """
         return node.findall(self)
@@ -318,7 +318,7 @@ def traverse_translatable_index(
 ) -> Iterable[tuple[Element, list[tuple[str, str, str, str, str | None]]]]:
     """Traverse translatable index node from a document tree."""
     matcher = NodeMatcher(addnodes.index, inline=False)
-    for node in matcher.findall_in(doctree):
+    for node in matcher.findall(doctree):
         if 'raw_entries' in node:
             entries = node['raw_entries']
         else:

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -5,18 +5,19 @@ from __future__ import annotations
 import contextlib
 import re
 import unicodedata
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 
 from docutils import nodes
+from docutils.nodes import Node
 
 from sphinx import addnodes
 from sphinx.locale import __
 from sphinx.util import logging
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
-    from docutils.nodes import Element, Node
+    from docutils.nodes import Element
     from docutils.parsers.rst import Directive
     from docutils.parsers.rst.states import Inliner
     from docutils.statemachine import StringList
@@ -33,7 +34,10 @@ explicit_title_re = re.compile(r'^(.+?)\s*(?<!\x00)<([^<]*?)>$', re.DOTALL)
 caption_ref_re = explicit_title_re  # b/w compat alias
 
 
-class NodeMatcher:
+T = TypeVar("T", bound=Node)
+
+
+class NodeMatcher(Generic[T]):
     """A helper class for Node.findall().
 
     It checks that the given node is an instance of the specified node-classes and
@@ -43,24 +47,22 @@ class NodeMatcher:
     and ``reftype`` attributes::
 
         matcher = NodeMatcher(nodes.reference, refdomain='std', reftype='citation')
-        doctree.findall(matcher)
+        matcher.findall_in(doctree)
         # => [<reference ...>, <reference ...>, ...]
 
     A special value ``typing.Any`` matches any kind of node-attributes.  For example,
     following example searches ``reference`` node having ``refdomain`` attributes::
 
-        from __future__ import annotations
-    from typing import TYPE_CHECKING, Any
         matcher = NodeMatcher(nodes.reference, refdomain=Any)
-        doctree.findall(matcher)
+        matcher.findall_in(doctree)
         # => [<reference ...>, <reference ...>, ...]
     """
 
-    def __init__(self, *node_classes: type[Node], **attrs: Any) -> None:
+    def __init__(self, *node_classes: type[T], **attrs: Any) -> None:
         self.classes = node_classes
         self.attrs = attrs
 
-    def match(self, node: Node) -> bool:
+    def _match(self, node: Node) -> bool:
         try:
             if self.classes and not isinstance(node, self.classes):
                 return False
@@ -83,7 +85,15 @@ class NodeMatcher:
             return False
 
     def __call__(self, node: Node) -> bool:
-        return self.match(node)
+        return self._match(node)
+
+    def findall_in(self, node: Node) -> Iterator[T]:
+        """An alternative to `Node.find_all` with improved type safety.
+
+        While the `NodeMatcher` object can be used as an argument to `Node.find_all`, doing so
+        confounds type checkers' ability to determine the return type of the iterator.
+        """
+        return node.findall(self)
 
 
 def get_full_module_name(node: Node) -> str:
@@ -308,7 +318,7 @@ def traverse_translatable_index(
 ) -> Iterable[tuple[Element, list[tuple[str, str, str, str, str | None]]]]:
     """Traverse translatable index node from a document tree."""
     matcher = NodeMatcher(addnodes.index, inline=False)
-    for node in doctree.findall(matcher):  # type: addnodes.index
+    for node in matcher.findall_in(doctree):
         if 'raw_entries' in node:
             entries = node['raw_entries']
         else:

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -55,7 +55,7 @@ class NestedInlineTransform:
 
     def apply(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, nodes.emphasis, nodes.strong)
-        for node in list(self.document.findall(matcher)):  # type: nodes.TextElement
+        for node in list(matcher.findall_in(self.document)):
             if any(matcher(subnode) for subnode in node):
                 pos = node.parent.index(node)
                 for subnode in reversed(list(node)):

--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -55,7 +55,7 @@ class NestedInlineTransform:
 
     def apply(self, **kwargs: Any) -> None:
         matcher = NodeMatcher(nodes.literal, nodes.emphasis, nodes.strong)
-        for node in list(matcher.findall_in(self.document)):
+        for node in list(matcher.findall(self.document)):
             if any(matcher(subnode) for subnode in node):
                 pos = node.parent.index(node)
                 for subnode in reversed(list(node)):


### PR DESCRIPTION
Improve type safety by refactoring the `NodeMatcher`.

Mypy is unable to infer the return type of the `Node.find_all` method when `NodeMatcher` is used. By moving the helper method into the `NodeMatcher` class and adding some generics it's possible for type checkers to correctly infer the return type of the iterator.

I've noticed that a matcher rarely gets reused, so an alternative approach would be to get rid of the helper class entirely and turn it into a plain function.