### PR TITLE
Test: use FORCE_COLOR=1 to ensure the test works

### DIFF
--- a/tests/test_util/test_util_display.py
+++ b/tests/test_util/test_util_display.py
@@ -34,7 +34,8 @@ def test_status_iterator_length_0(app, status, warning):
 
 
 @pytest.mark.sphinx('dummy')
-def test_status_iterator_verbosity_0(app, status, warning):
+def test_status_iterator_verbosity_0(app, status, warning, monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", 1)
     logging.setup(app, status, warning)
 
     # test for status_iterator (verbosity=0)
@@ -50,7 +51,8 @@ def test_status_iterator_verbosity_0(app, status, warning):
 
 
 @pytest.mark.sphinx('dummy')
-def test_status_iterator_verbosity_1(app, status, warning):
+def test_status_iterator_verbosity_1(app, status, warning, monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", 1)
     logging.setup(app, status, warning)
 
     # test for status_iterator (verbosity=1)


### PR DESCRIPTION
Subject: set the environment to get predictable test output

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Without this fix, one test fails when I run the test suite locally with tox:

```
tests/test_util/test_util_display.py::test_status_iterator_verbosity_0 FAILED [100%]

=================================== FAILURES ===================================
_______________________ test_status_iterator_verbosity_0 _______________________

app = <SphinxTestApp buildername='dummy'>
status = <_io.StringIO object at 0x10785afd0>
warning = <_io.StringIO object at 0x1190e3e30>

    @pytest.mark.sphinx('dummy')
    def test_status_iterator_verbosity_0(app, status, warning):
        logging.setup(app, status, warning)

        # test for status_iterator (verbosity=0)
        status.seek(0)
        status.truncate(0)
        yields = list(status_iterator(['hello', 'sphinx', 'world'], 'testing ... ',
                                      length=3, verbosity=0))
        output = strip_escseq(status.getvalue())
>       assert 'testing ... [ 33%] hello\r' in output
E       AssertionError: assert 'testing ... [ 33%] hello\r' in 'testing ... [ 33%] hello\ntesting ... [ 67%] sphinx\ntesting ... [100%] world\n\n'

tests/test_util/test_util_display.py:46: AssertionError
--------------------------- Captured stdout teardown ---------------------------
# testroot: root
# builder: dummy
# srcdir: /private/var/folders/6j/khn0mcrj35d1k3yylpl8zl080000gn/T/pytest-of-ned/pytest-63/root
# outdir: /private/var/folders/6j/khn0mcrj35d1k3yylpl8zl080000gn/T/pytest-of-ned/pytest-63/root/_build/dummy
# status:
testing ... [ 33%] hello
testing ... [ 67%] sphinx
testing ... [100%] world
```

The problem is that `color_terminal()` returns False because stdout is not a tty.  The output then has `\n` instead of `\r` and the test assertion fails.  By setting FORCE_COLOR=1 in the test, we remove the check on stdout, and the test produces predictable expected output.
