### PR TITLE
[HTML search] correction for scoring of search terms that only appear in document indexed with id zero.

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -483,7 +483,7 @@ const Search = {
         });
         Object.keys(titleTerms).forEach((term) => {
           if (term.match(escapedWord) && titleTerms[word] === undefined)
-            arr.push({ files: titleTerms[term], score: Scorer.partialTitle });
+            arr.push({ files: titleTerms[word], score: Scorer.partialTitle });
         });
       }
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -478,12 +478,12 @@ const Search = {
       if (word.length > 2) {
         const escapedWord = _escapeRegExp(word);
         Object.keys(terms).forEach((term) => {
-          if (term.match(escapedWord) && !terms[word])
+          if (term.match(escapedWord) && terms[word] === undefined)
             arr.push({ files: terms[term], score: Scorer.partialTerm });
         });
         Object.keys(titleTerms).forEach((term) => {
-          if (term.match(escapedWord) && !titleTerms[word])
-            arr.push({ files: titleTerms[word], score: Scorer.partialTitle });
+          if (term.match(escapedWord) && titleTerms[word] === undefined)
+            arr.push({ files: titleTerms[term], score: Scorer.partialTitle });
         });
       }
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -477,14 +477,18 @@ const Search = {
       // add support for partial matches
       if (word.length > 2) {
         const escapedWord = _escapeRegExp(word);
-        Object.keys(terms).forEach((term) => {
-          if (term.match(escapedWord) && terms[word] === undefined)
-            arr.push({ files: terms[term], score: Scorer.partialTerm });
-        });
-        Object.keys(titleTerms).forEach((term) => {
-          if (term.match(escapedWord) && titleTerms[word] === undefined)
-            arr.push({ files: titleTerms[word], score: Scorer.partialTitle });
-        });
+        if (!terms.hasOwnProperty(word)) {
+          Object.keys(terms).forEach((term) => {
+            if (term.match(escapedWord))
+              arr.push({ files: terms[term], score: Scorer.partialTerm });
+          });
+        }
+        if (!titleTerms.hasOwnProperty(word)) {
+          Object.keys(titleTerms).forEach((term) => {
+            if (term.match(escapedWord))
+              arr.push({ files: titleTerms[word], score: Scorer.partialTitle });
+          });
+        }
       }
 
       // no match but word was a required one

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -27,31 +27,6 @@ describe('Basic html theme search', function() {
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
     });
 
-    it('should partially-match "sphinx" when in title index', function() {
-      index = {
-        docnames:["index"],
-        filenames:["index.rst"],
-        terms:{'useful': 0, 'utilities': 0},
-        titles:["sphinx_utils module"],
-        titleterms:{'sphinx_utils': 0}
-      }
-      Search.setIndex(index);
-      searchterms = ['sphinx'];
-      excluded = [];
-      terms = index.terms;
-      titleterms = index.titleterms;
-
-      hits = [[
-        "index",
-        "sphinx_utils module",
-        "",
-        null,
-        7,
-        "index.rst"
-      ]];
-      expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
-    });
-
   });
 
 });

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -21,7 +21,32 @@ describe('Basic html theme search', function() {
         "&lt;no title&gt;",
         "",
         null,
-        2,
+        5,
+        "index.rst"
+      ]];
+      expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
+    });
+
+    it('should partially-match "sphinx" when in title index', function() {
+      index = {
+        docnames:["index"],
+        filenames:["index.rst"],
+        terms:{'useful': 0, 'utilities': 0},
+        titles:["sphinx_utils module"],
+        titleterms:{'sphinx_utils': 0}
+      }
+      Search.setIndex(index);
+      searchterms = ['sphinx'];
+      excluded = [];
+      terms = index.terms;
+      titleterms = index.titleterms;
+
+      hits = [[
+        "index",
+        "sphinx_utils module",
+        "",
+        null,
+        7,
         "index.rst"
       ]];
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Restores expected scoring for exact-match query terms that only appear in document zero in the client-side JavaScript search index.
- Includes a performance optimization: skips partial-matching entirely when exact-matches exist.

### Detail
- Words (terms) from both document content and document titles are stored in the JavaScript search index on the client -- this results in a mapping from individual terms to a list of the document-ids of the documents where they appear.
- For terms/title-terms that appear in multiple documents, the document-ids are stored as a [(sorted) list/`Array`](https://github.com/sphinx-doc/sphinx/blob/bea8b6bf4db0992a987d3645029b990610f5212b/sphinx/search/__init__.py#L380).  In cases where the term only appears in a single document, only a [single integer value is stored](https://github.com/sphinx-doc/sphinx/blob/bea8b6bf4db0992a987d3645029b990610f5212b/sphinx/search/__init__.py#L375-L378).  (credit to [@wlach for explaining](https://github.com/sphinx-doc/sphinx/pull/11958#issuecomment-1974071072))
- The document-ids are zero-indexed (`0, 1, 2, ...`) so there is a zeroth document, and we need to be careful when evaluating that in boolean expressions because zero is falsy in JavaScript.
- :bug: A term that only appears in the document with ID zero will incorrectly be scored as a partial-match.

### Relates
- Resolves #11957.
- Resolves #12045.
- Alternative approach to #11958.

cc @wlach 