### PR TITLE
github template config: fixup: use updated issue label names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something is not working correctly.
-labels: "bug"
+labels: "type:bug"
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: '<short description for the feature>'
-labels: 'type:enhancement'
+labels: 'type:proposal'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: '<short description for the feature>'
-labels: 'enhancement'
+labels: 'type:enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (GitHub issue template config)

### Purpose
- Pre-populate labels on feature requests and bugs as expected.

### Detail
- We use `type:bug` and `type:enhancement` instead of the default `bug` and `enhancement` labels for our GitHub issues.

### Relates
- N/A