### PR TITLE
Expose complete objtype information to autosummary templates

### DIFF
--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -23,6 +23,7 @@ import pkgutil
 import pydoc
 import re
 import sys
+from collections import defaultdict
 from os import path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -274,24 +275,28 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
         respect_module_all = not app.config.autosummary_ignore_module_all
         imported_members = imported_members or ('__all__' in dir(obj) and respect_module_all)
 
-        ns['functions'], ns['all_functions'] = \
-            _get_members(doc, app, obj, {'function'}, imported=imported_members)
-        ns['classes'], ns['all_classes'] = \
-            _get_members(doc, app, obj, {'class'}, imported=imported_members)
-        ns['exceptions'], ns['all_exceptions'] = \
-            _get_members(doc, app, obj, {'exception'}, imported=imported_members)
-        ns['attributes'], ns['all_attributes'] = \
-            _get_module_attrs(name, ns['members'])
+        members_by_obj_type = _get_members_by_objtype(doc, app, obj, imported=imported_members)
+        for objtype in app.registry.documenters.keys():
+            ns[objtype] = members_by_obj_type.get(objtype, [])
+        # TODO: Clash between objtype "module" and variable for current module name, defined below
+        attributes_public, ns['attribute'] = _get_module_attrs(name, ns['members'])
+        ns['public'] = _get_public_members(doc, app, obj, imported=imported_members) + attributes_public
+
+        # Define legacy variables for compatibility
+        ns['functions'] = [item for item in ns['function'] if item in ns['public']]
+        ns['all_functions'] = ns['function']
+        ns['classes'] = [item for item in ns['class'] if item in ns['public']]
+        ns['all_classes'] = ns['class']
+        ns['exceptions'] = [item for item in ns['exception'] if item in ns['public']]
+        ns['all_exceptions'] = ns['exception']
+        ns['attributes'] = [item for item in ns['attribute'] if item in ns['public']]
+        ns['all_attributes'] = ns['attribute']
+
         ispackage = hasattr(obj, '__path__')
         if ispackage and recursive:
             # Use members that are not modules as skip list, because it would then mean
             # that module was overwritten in the package namespace
-            skip = (
-                ns["all_functions"]
-                + ns["all_classes"]
-                + ns["all_exceptions"]
-                + ns["all_attributes"]
-            )
+            skip = [item for objtype, items in members_by_obj_type.items() if objtype != "module" for item in items]
 
             # If respect_module_all and module has a __all__ attribute, first get
             # modules that were explicitly imported. Next, find the rest with the
@@ -408,6 +413,46 @@ def _get_members(doc: type[Documenter], app: Sphinx, obj: Any, types: set[str], 
                         # considers member as public
                         public.append(name)
     return public, items
+
+
+def _get_members_by_objtype(doc: type[Documenter], app: Sphinx, obj: Any, *,
+                            imported: bool = True) -> dict[str, list[str]]:
+    items: dict[str, list[str]] = defaultdict(list)
+
+    all_members = _get_all_members(doc, app, obj)
+    for name, value in all_members.items():
+        documenter = get_documenter(app, value, obj)
+        objtype = documenter.objtype
+        # skip imported members if expected
+        if imported or getattr(value, '__module__', None) == obj.__name__:
+            skipped = _skip_member(app, value, name, documenter.objtype)
+            if skipped is True:
+                pass
+            items[objtype].append(name)
+    return dict(items)
+
+
+def _get_public_members(doc: type[Documenter], app: Sphinx, obj: Any, *,
+                        include_public: Set[str] = frozenset(),
+                        imported: bool = True) -> list[str]:
+    public = []
+
+    all_members = _get_all_members(doc, app, obj)
+    for name, value in all_members.items():
+        documenter = get_documenter(app, value, obj)
+        # skip imported members if expected
+        if imported or getattr(value, '__module__', None) == obj.__name__:
+            skipped = _skip_member(app, value, name, documenter.objtype)
+            if skipped is True:
+                pass
+            elif skipped is False:
+                # show the member forcedly
+                public.append(name)
+            else:
+                if name in include_public or not name.startswith('_'):
+                    # considers member as public
+                    public.append(name)
+    return public
 
 
 def _get_module_attrs(name: str, members: Any) -> tuple[list[str], list[str]]:

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -276,11 +276,13 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
         imported_members = imported_members or ('__all__' in dir(obj) and respect_module_all)
 
         members_by_obj_type = _get_members_by_objtype(doc, app, obj, imported=imported_members)
-        for objtype in app.registry.documenters.keys():
+        for objtype in app.registry.documenters:
             ns[objtype] = members_by_obj_type.get(objtype, [])
-        # TODO: Clash between objtype "module" and variable for current module name, defined below
+        # TODO: Clash between objtype "module" and variable for current module name,
+        #  defined below
         attributes_public, ns['attribute'] = _get_module_attrs(name, ns['members'])
-        ns['public'] = _get_public_members(doc, app, obj, imported=imported_members) + attributes_public
+        ns['public'] = (_get_public_members(doc, app, obj, imported=imported_members) +
+                        attributes_public)
 
         # Define legacy variables for compatibility
         ns['functions'] = [item for item in ns['function'] if item in ns['public']]
@@ -296,7 +298,11 @@ def generate_autosummary_content(name: str, obj: Any, parent: Any,
         if ispackage and recursive:
             # Use members that are not modules as skip list, because it would then mean
             # that module was overwritten in the package namespace
-            skip = [item for objtype, items in members_by_obj_type.items() if objtype != "module" for item in items]
+            skip = [
+                item for objtype, items in members_by_obj_type.items()
+                if objtype != "module"
+                for item in items
+            ]
 
             # If respect_module_all and module has a __all__ attribute, first get
             # modules that were explicitly imported. Next, find the rest with the

--- a/tests/roots/test-ext-autosummary-pydantic/_templates/autosummary/module.rst
+++ b/tests/roots/test-ext-autosummary-pydantic/_templates/autosummary/module.rst
@@ -1,0 +1,84 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attribute %}
+   {% if attribute %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+   {% for item in attribute %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block function %}
+   {% if function %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+   {% for item in function %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block class %}
+   {% if class %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+   {% for item in class %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block pydantic_model %}
+   {% if pydantic_model %}
+   .. rubric:: {{ _('Models') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in pydantic_model %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block pydantic_settings %}
+   {% if pydantic_settings %}
+   .. rubric:: {{ _('Settings') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in pydantic_settings %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exception %}
+   {% if exception %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+   {% for item in exception %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: {{ _('Modules') }}
+
+.. autosummary::
+   :toctree:
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/tests/roots/test-ext-autosummary-pydantic/autosummary_dummy_module_with_pydantic.py
+++ b/tests/roots/test-ext-autosummary-pydantic/autosummary_dummy_module_with_pydantic.py
@@ -1,0 +1,9 @@
+__all__ = [
+    "MyModel",
+]
+
+from pydantic import BaseModel
+
+
+class MyModel(BaseModel):
+    attr: str

--- a/tests/roots/test-ext-autosummary-pydantic/conf.py
+++ b/tests/roots/test-ext-autosummary-pydantic/conf.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+extensions = ['sphinx.ext.autosummary', "sphinxcontrib.autodoc_pydantic"]
+autosummary_generate = True
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+templates_path = ["_templates"]

--- a/tests/roots/test-ext-autosummary-pydantic/index.rst
+++ b/tests/roots/test-ext-autosummary-pydantic/index.rst
@@ -1,0 +1,8 @@
+test-ext-autosummary-pydantic
+=============================
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+
+   autosummary_dummy_module_with_pydantic

--- a/tests/test_extensions/test_ext_autosummary.py
+++ b/tests/test_extensions/test_ext_autosummary.py
@@ -249,6 +249,26 @@ def test_autosummary_generate_content_for_module(app):
 
 
 @pytest.mark.sphinx(testroot='ext-autosummary')
+def test_autosummary_generate_content_for_module_by_objtype(app):
+    import autosummary_dummy_module
+    template = Mock()
+
+    generate_autosummary_content('autosummary_dummy_module', autosummary_dummy_module, None,
+                                 template, None, False, app, False, {})
+    assert template.render.call_args[0][0] == 'module'
+
+    context = template.render.call_args[0][1]
+
+    assert context['public'] == ['Exc', 'Foo', 'bar', 'CONSTANT1', 'qux', 'quuz', 'non_imported_member']
+    assert context['class'] == ['Foo', '_Baz']
+    assert context['function'] == ['_quux', 'bar']
+    assert context['exception'] == ['Exc', '_Exc']
+    assert context['attribute'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']
+    # TODO: Clash between objtype "module" and variable "module" (current module name)
+    assert context['module'] == 'autosummary_dummy_module'
+
+
+@pytest.mark.sphinx(testroot='ext-autosummary')
 def test_autosummary_generate_content_for_module___all__(app):
     import autosummary_dummy_module
     template = Mock()

--- a/tests/test_extensions/test_ext_autosummary.py
+++ b/tests/test_extensions/test_ext_autosummary.py
@@ -1,5 +1,6 @@
 """Test the autosummary extension."""
 
+import importlib.util
 import sys
 from io import StringIO
 from pathlib import Path
@@ -266,6 +267,22 @@ def test_autosummary_generate_content_for_module_by_objtype(app):
     assert context['attribute'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']
     # TODO: Clash between objtype "module" and variable "module" (current module name)
     assert context['module'] == 'autosummary_dummy_module'
+
+
+@pytest.mark.skipif(not importlib.util.find_spec("sphinxcontrib.autodoc_pydantic"), reason="Requires pydantic, autodoc-pydantic")
+@pytest.mark.sphinx(testroot='ext-autosummary-pydantic')
+def test_autosummary_generate_content_for_module_with_pydantic(app):
+    import autosummary_dummy_module_with_pydantic
+    template = Mock()
+
+    generate_autosummary_content('autosummary_dummy_module_with_pydantic', autosummary_dummy_module_with_pydantic, None,
+                                 template, None, False, app, False, {})
+    assert template.render.call_args[0][0] == 'module'
+
+    context = template.render.call_args[0][1]
+
+    assert context['pydantic_model'] == ['MyModel']
+    assert 'MyModel' not in context['class']
 
 
 @pytest.mark.sphinx(testroot='ext-autosummary')


### PR DESCRIPTION
Subject: Create autosummary template variables dynamically based on `objtype` from documenters, enabling custom object types like `pydantic_model` to be selectable in templates (https://github.com/sphinx-doc/sphinx/issues/12021, https://github.com/mansenfranzen/autodoc_pydantic/issues/33).

### Feature or Bugfix
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring

### Purpose

The templates and template variables in autosummary expose only a hard-coded set of object types like (`classes` for object type `class`) and the templates.

As a consequence, it is not possible to add custom sections for custom object types to the template, because one can not select/distinguish the custom type from the available types. Custom object types are provided for example by [autodoc-pydantic](https://autodoc-pydantic.readthedocs.io/en/stable/users/usage.html). It works only with one level of autosummary which then uses the base template with directive `.. auto{{ objtype }}::` (with objtype = `pydantic_model`).  However, this is not possible with `:recursive:` because then the module template is used which contains no section for the custom type.

The current recommendation is to fork autosummary (https://github.com/mansenfranzen/autodoc_pydantic/issues/33#issuecomment-962894779).

### Detail


This PR aims to avoid forking and proposes different template variables. I do not request to merge this, but it is a basis for discussion.

Changes:
- Members are grouped by `objtype` and exposed as variables with exactly that object type. This makes the implementation more generic and open to new object types, but also drops repetitive code.
- Old variable names are still kept for backward-compatibility, although the naming is overlapping and can create confusion.
- The branch contains a test case for pydantic-autodoc just for illustration. I did not add pydantic to dependencies. Also there is hopefully a better way to register and test a custom object type.

Questions:
- Naming: Object types are singular, that means "classes" is now "class".
  - On one side, this is consistent with objtype.
  - On the other side, it is unintuitive since the variables are lists of many items (plural).
  - I tested that "class" does not cause an error in jinja due to reserved word.
  - "module" clashes, since that already refers to the current module, not to the list of contained members of module type.
  - Possibly we could avoid name clashes by adding a plural suffix "s" (although then it does not match exactly the objtype), or prefixing `members_{objtype}`.
- Testing: What is the simplest way to create a custom objtype only for the purpose of a test, so I can remove pydantic from the test `test_autosummary_generate_content_for_module_with_pydantic`?

### Relates
- https://github.com/sphinx-doc/sphinx/issues/12021

