### PR TITLE
Reflect changes to Enum signature in Python 3.13

### DIFF
--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -1410,7 +1410,10 @@ def test_enum_class(app):
     options = {"members": None}
     actual = do_autodoc(app, 'class', 'target.enums.EnumCls', options)
 
-    if sys.version_info[:2] >= (3, 12):
+    if sys.version_info[:2] >= (3, 13):
+        args = ('(value, names=<not given>, *values, module=None, '
+                'qualname=None, type=None, start=1, boundary=None)')
+    elif sys.version_info[:2] >= (3, 12):
         args = ('(value, names=None, *values, module=None, '
                 'qualname=None, type=None, start=1, boundary=None)')
     elif sys.version_info[:2] >= (3, 11):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fixup to match the formatting of the default `names` argument to the `Enum` class in Python3.13 (dev, currently).

### Relates
- Resolves #12053.
