### PR TITLE
docs: add reference to templating from theme development.

### DIFF
--- a/doc/development/templating.rst
+++ b/doc/development/templating.rst
@@ -30,6 +30,7 @@ No.  You have several other options:
   produces pickle files with the page contents, and postprocess them using a
   custom tool, or use them in your Web application.
 
+.. _templating-primer:
 
 Jinja/Sphinx Templating Primer
 ------------------------------

--- a/doc/development/theming.rst
+++ b/doc/development/theming.rst
@@ -141,7 +141,7 @@ searches for templates:
 When extending a template in the base theme with the same name, use the theme
 name as an explicit directory: ``{% extends "basic/layout.html" %}``.  From a
 user ``templates_path`` template, you can still use the "exclamation mark"
-syntax as described in the templating document.
+syntax as :ref:`described in the templating document <templating-primer>`.
 
 
 .. _theming-static-templates:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Clearly link the mentioned "exclamation mark" syntax from the theme guide to the explanation of it in the templating primer.

### Detail
- (strictly speaking it is kinda hinted by reference to the previous paragraph that it's the place to look; I think we could make it more direct though)

### Relates
- Discovered during investigation of #12049.