### PR TITLE
HTML Search: filter script and style elements from search result summary text.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,9 @@ Bugs fixed
   Patch by Bénédikt Tran.
 * #11894: Do not add checksums to css files if building using the htmlhelp builder.
   Patch by mkay.
+* #12052: Remove ``<script>`` and ``<style>`` tags from the content of search result
+  summary snippets.
+  Patch by James Addison.
 
 Testing
 -------

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -162,9 +162,9 @@ const Search = {
 
   htmlToText: (htmlString, anchor) => {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
-    htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
-    htmlElement.querySelectorAll("script").forEach((el) => { el.remove() });
-    htmlElement.querySelectorAll("style").forEach((el) => { el.remove() });
+    for (const removalQuery of [".headerlinks", "script", "style"]) {
+      htmlElement.querySelectorAll(removalQuery).forEach((el) => { el.remove() });
+    }
     if (anchor) {
       const anchorContent = htmlElement.querySelector(anchor);
       if (anchorContent) return anchorContent.textContent;

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -163,6 +163,7 @@ const Search = {
   htmlToText: (htmlString, anchor) => {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
     htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
+    htmlElement.querySelectorAll("script").forEach((el) => { el.remove() });
     if (anchor) {
       const anchorContent = htmlElement.querySelector(anchor);
       if (anchorContent) return anchorContent.textContent;

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -164,6 +164,7 @@ const Search = {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
     htmlElement.querySelectorAll(".headerlink").forEach((el) => { el.remove() });
     htmlElement.querySelectorAll("script").forEach((el) => { el.remove() });
+    htmlElement.querySelectorAll("style").forEach((el) => { el.remove() });
     if (anchor) {
       const anchorContent = htmlElement.querySelector(anchor);
       if (anchorContent) return anchorContent.textContent;

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -62,6 +62,10 @@ describe("htmlToText", function() {
 
   const testHTML = `<html>
   <div class="body" role="main">
+    <script src="directory/filename.js"></script>
+    <script>
+      console.log('dynamic');
+    </script>
     <section id="getting-started">
       <h1>Getting Started</h1>
       <p>Some text</p>

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -67,6 +67,12 @@ describe("htmlToText", function() {
       <script>
         console.log('dynamic');
       </script>
+      <style>
+        div.body p.centered {
+          text-align: center;
+          margin-top: 25px;
+        }
+      </style>
       <!-- main content -->
       <section id="getting-started">
         <h1>Getting Started</h1>

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -66,6 +66,7 @@ describe("htmlToText", function() {
     <script>
       console.log('dynamic');
     </script>
+    <!-- main content -->
     <section id="getting-started">
       <h1>Getting Started</h1>
       <p>Some text</p>

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -62,8 +62,8 @@ describe("htmlToText", function() {
 
   const testHTML = `<html>
   <body>
+    <script src="directory/filename.js"></script>
     <div class="body" role="main">
-      <script src="directory/filename.js"></script>
       <script>
         console.log('dynamic');
       </script>

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -61,25 +61,27 @@ describe('Basic html theme search', function() {
 describe("htmlToText", function() {
 
   const testHTML = `<html>
-  <div class="body" role="main">
-    <script src="directory/filename.js"></script>
-    <script>
-      console.log('dynamic');
-    </script>
-    <!-- main content -->
-    <section id="getting-started">
-      <h1>Getting Started</h1>
-      <p>Some text</p>
-    </section>
-    <section id="other-section">
-      <h1>Other Section</h1>
-      <p>Other text</p>
-    </section>
-    <section id="yet-another-section">
-      <h1>Yet Another Section</h1>
-      <p>More text</p>
-    </section>
-  </div>
+  <body>
+    <div class="body" role="main">
+      <script src="directory/filename.js"></script>
+      <script>
+        console.log('dynamic');
+      </script>
+      <!-- main content -->
+      <section id="getting-started">
+        <h1>Getting Started</h1>
+        <p>Some text</p>
+      </section>
+      <section id="other-section">
+        <h1>Other Section</h1>
+        <p>Other text</p>
+      </section>
+      <section id="yet-another-section">
+        <h1>Yet Another Section</h1>
+        <p>More text</p>
+      </section>
+    </div>
+  </body>
   </html>`;
 
   it("basic case", () => {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Filters-out the text content of `<script>` and `<style>` elements from the summary snippets displayed during search within Sphinx.

### Detail
- Also adds test coverage to demonstrate that HTML comments are not included in search result summaries.

### Relates
- Resolves #12052.