### PR TITLE
Fix: autodoc: can't detect overloads for functions defined in other file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,8 @@ Bugs fixed
 * #12038: Resolve ``linkcheck`` unit test timeouts on Windows by adding a readiness
   check to the test HTTP(S) server setup code.
   Patch by James Addison.
+* #11410: Fix autodoc can't detect overloads for functions defined in other file.
+  Patch by Amy Pircher.
 
 Testing
 -------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -925,6 +925,11 @@ class Documenter:
             try:
                 analyzer = ModuleAnalyzer.for_module(guess_modname)
                 self.directive.record_dependencies.add(analyzer.srcname)
+                if self.analyzer:
+                    analyzer.find_attr_docs()
+                    for name, signatures in analyzer.overloads.items():
+                        if name not in self.analyzer.overloads:
+                            self.analyzer.overloads[name] = signatures
             except PycodeError:
                 pass
 

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -926,6 +926,8 @@ class Documenter:
                 analyzer = ModuleAnalyzer.for_module(guess_modname)
                 self.directive.record_dependencies.add(analyzer.srcname)
                 if self.analyzer:
+                    # Add overloads defined in other module to this module so they are
+                    # properly documented
                     analyzer.find_attr_docs()
                     for name, signatures in analyzer.overloads.items():
                         if name not in self.analyzer.overloads:

--- a/tests/roots/test-ext-autodoc/target/overload2.py
+++ b/tests/roots/test-ext-autodoc/target/overload2.py
@@ -1,5 +1,8 @@
 from target.overload import Bar
+from target.overload import sum
 
 
 class Baz(Bar):
     pass
+
+__all__ = ['sum', 'Baz']

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -2240,6 +2240,14 @@ def test_overload2(app):
         '              Baz(x: str, y: str)',
         '   :module: target.overload2',
         '',
+        '',
+        '.. py:function:: sum(x: int, y: int = 0) -> int',
+        '                 sum(x: float, y: float = 0.0) -> float',
+        '                 sum(x: str, y: str = None) -> str',
+        '   :module: target.overload2',
+        '',
+        '   docstring',
+        '',
     ]
 
 


### PR DESCRIPTION
Subject: fix autodoc not detecting overloads defined in other module, but exported in *this* module.

### Feature or Bugfix
- Bugfix

### Purpose
- Document overloads for a function defined in a private module but exposed publicly. 

### Detail
This PR fix is based on the solution used in #8283. Currently, the Documenter class gets overloads defined in the same file, and records the real/source module as a dependency, and then nothing else.

The fix provided here adds overloads defined in the "real" module to the public module.

I'm not entirely sure if this is the "right" way to go about this, but it's the simplest solution without a refactor.

### Relates
- Fixes #11410

 