### PR TITLE
Simplify pyupgrade lint group configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,12 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install Ruff
-      run: python -m pip install "ruff==0.2.0"
+      run: |
+          ruff_version=$(awk -F'[="]' '/\[project\.optional-dependencies\]/ {p=1} /ruff/ {if (p) print $4}' pyproject.toml)
+          python -m pip install "ruff==${ruff_version}"
 
     - name: Lint with Ruff
-      run: ruff . --output-format github
+      run: ruff check . --output-format github
 
   flake8:
     runs-on: ubuntu-latest

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,5 @@
 target-version = "py39"  # Pin Ruff to Python 3.9
 line-length = 95
-required-version = "0.2.0"
 output-format = "full"
 
 [lint]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -15,12 +15,11 @@ exclude = [
     "doc/usage/extensions/example*.py",
 ]
 ignore = [
-    # pycodestyle
     "E741",  # Ambiguous variable name: `{name}`
-    # pyflakes
     "F841",  # Local variable `{name}` is assigned to but never used
-    # pylint
     "PLC1901",  # simplify truthy/falsey string comparisons
+    "UP031",    # Use format specifiers instead of percent format
+    "UP032",    # Use f-string instead of `format` call
 ]
 external = [  # Whitelist for RUF100 unknown code warnings
     "E704",
@@ -414,46 +413,7 @@ select = [
       # Trio is not used in Sphinx
     # tryceratops ('TRY')
       # NOT YET USED
-    # pyupgrade ('UP')
-    "UP001",  # `__metaclass__ = type` is implied
-    "UP003",  # Use `{}` instead of `type(...)`
-    "UP004",  # Class `{name}` inherits from `object`
-    "UP005",  # `{alias}` is deprecated, use `{target}`
-    "UP006",  # Use `{to}` instead of `{from}` for type annotation
-    "UP007",  # Use `X | Y` for type annotations
-    "UP008",  # Use `super()` instead of `super(__class__, self)`
-    "UP009",  # UTF-8 encoding declaration is unnecessary
-    "UP010",  # Unnecessary `__future__` import `{import}` for target Python version
-    "UP011",  # Unnecessary parentheses to `functools.lru_cache`
-    "UP012",  # Unnecessary call to `encode` as UTF-8
-    "UP013",  # Convert `{name}` from `TypedDict` functional to class syntax
-    "UP014",  # Convert `{name}` from `NamedTuple` functional to class syntax
-    "UP015",  # Unnecessary open mode parameters
-    "UP017",  # Use `datetime.UTC` alias
-    "UP018",  # Unnecessary `{literal_type}` call (rewrite as a literal)
-    "UP019",  # `typing.Text` is deprecated, use `str`
-    "UP020",  # Use builtin `open`
-    "UP021",  # `universal_newlines` is deprecated, use `text`
-    "UP022",  # Sending `stdout` and `stderr` to `PIPE` is deprecated, use `capture_output`
-    "UP023",  # `cElementTree` is deprecated, use `ElementTree`
-    "UP024",  # Replace aliased errors with `OSError`
-    "UP025",  # Remove unicode literals from strings
-    "UP026",  # `mock` is deprecated, use `unittest.mock`
-    "UP027",  # Replace unpacked list comprehension with a generator expression
-    "UP028",  # Replace `yield` over `for` loop with `yield from`
-    "UP029",  # Unnecessary builtin import: `{import}`
-    "UP030",  # Use implicit references for positional format fields
-#    "UP031",  # Use format specifiers instead of percent format
-#    "UP032",  # Use f-string instead of `format` call
-    "UP033",  # Use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`
-    "UP034",  # Avoid extraneous parentheses
-    "UP035",  # Import from `{target}` instead: {names}
-    "UP036",  # Version block is outdated for minimum Python version
-    "UP037",  # Remove quotes from type annotation
-    "UP038",  # Use `X | Y` in `{}` call instead of `(X, Y)`
-    "UP039",  # Unnecessary parentheses after class definition
-    "UP040",  # Type alias `{name}` uses `TypeAlias` annotation instead of the `type` keyword
-    "UP041",  # Replace aliased errors with `TimeoutError`
+    "UP",  # pyupgrade ('UP')
     # pycodestyle ('W')
     "W191",  # Indentation contains tabs
 #    "W291",  # Trailing whitespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
 ]
 lint = [
     "flake8>=3.5.0",
-    "ruff==0.2.0",
+    "ruff==0.3.2",
     "mypy==1.8.0",
     "sphinx-lint",
     "docutils-stubs",

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -235,6 +235,7 @@ def test_format_signature(app):
 
             some docstring for __init__.
             """
+
     class G2(F2):
         pass
 
@@ -345,6 +346,7 @@ def test_get_doc(app):
     # standard function, diverse docstring styles...
     def f():
         """Docstring"""
+
     def g():
         """
         Docstring

--- a/tests/test_util/test_util_inspect.py
+++ b/tests/test_util/test_util_inspect.py
@@ -62,6 +62,7 @@ async def coroutinefunc():
 async def asyncgenerator():
     yield
 
+
 partial_func = functools.partial(func)
 partial_coroutinefunc = functools.partial(coroutinefunc)
 


### PR DESCRIPTION
simplifies config
also means future pyupgrade lints will be opt out, not opt in (but still only introduced on explicit bump of ruff version)
