### PR TITLE
Draft: tests: prevent HTTP server socket re-use on Windows during test suite.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   ubuntu:
+    if: false
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python }} (Docutils ${{ matrix.docutils }})
     strategy:
@@ -74,20 +75,38 @@ jobs:
 
   windows:
     runs-on: windows-2019
-    name: Windows
+    name: Windows ${{ matrix.python }} (Docutils ${{ matrix.docutils }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13-dev"
+        docutils:
+        - "0.18"
+        - "0.20"
+        include:
+        # test every supported Docutils version for the latest supported Python
+        - python: "3.12"
+          docutils: "0.19"
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:
-        python-version: "3"
+        python-version: ${{ matrix.python }}
     - name: Check Python version
       run: python --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[test]
+    - name: Install Docutils ${{ matrix.docutils }}
+      run: python -m pip install --upgrade "docutils~=${{ matrix.docutils }}.0"
     - name: Test with pytest
       run: python -m pytest -vv --durations 25
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,6 @@ jobs:
         PYTHONWARNINGS: "error"  # treat all warnings as errors
 
   windows:
-    if: false
     runs-on: windows-2019
     name: Windows ${{ matrix.python }} (Docutils ${{ matrix.docutils }})
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
         PYTHONWARNINGS: "error"  # treat all warnings as errors
 
   windows:
+    if: false
     runs-on: windows-2019
     name: Windows ${{ matrix.python }} (Docutils ${{ matrix.docutils }})
     strategy:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,6 +34,7 @@ class HttpServerThread(threading.Thread):
                 option=socket.SO_EXCLUSIVEADDRUSE,
                 value=1,
             )
+            self.server.allow_reuse_address = 0
         self.server.serve_forever(poll_interval=0.001)
 
     def terminate(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,6 +27,13 @@ class HttpServerThread(threading.Thread):
         self.server = http.server.ThreadingHTTPServer(ADDRESS, handler)
 
     def run(self):
+        # credit: https://stackoverflow.com/a/51094879
+        if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+            self.server.socket.setsockopt(
+                level=socket.SOL_SOCKET,
+                option=socket.SO_EXCLUSIVEADDRUSE,
+                value=1,
+            )
         self.server.serve_forever(poll_interval=0.001)
 
     def terminate(self):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Solve -- or further expose -- flaky test failures by trying to eliminate the possibility that two or more separate test cases could somehow be interfering with each other by listening on the same address and port during unit tests on Windows.

### Detail
- Enable the `SO_EXCLUSIVEADDRUSE` option on test HTTP server sockets when it is available (Windows).

### Relates
- https://github.com/python/cpython/issues/85307
- https://stackoverflow.com/a/51094879
- May help to resolve #12038.