### PR TITLE
[tests] correctly intercept or suppress warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,8 @@ empty_parameter_set_mark = "xfail"
 filterwarnings = [
     "all",
     "ignore::DeprecationWarning:docutils.io",
+    "ignore:Distutils was imported before Setuptools:UserWarning:_distutils_hack",
+    "ignore:Setuptools is replacing distutils:UserWarning:_distutils_hack",
     "ignore::DeprecationWarning:pyximport.pyximport",
     "ignore::ImportWarning:importlib._bootstrap",
 ]

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -6,6 +6,7 @@ import re
 import pytest
 
 from sphinx.builders.html import validate_html_extra_path, validate_html_static_path
+from sphinx.deprecation import RemovedInSphinx80Warning
 from sphinx.errors import ConfigError
 from sphinx.util.inventory import InventoryFile
 
@@ -341,7 +342,8 @@ def test_validate_html_extra_path(app):
         app.outdir,                 # outdir
         app.outdir / '_static',     # inside outdir
     ]
-    validate_html_extra_path(app, app.config)
+    with pytest.warns(RemovedInSphinx80Warning, match='Use "pathlib.Path" or "os.fspath" instead'):
+        validate_html_extra_path(app, app.config)
     assert app.config.html_extra_path == ['_static']
 
 
@@ -354,7 +356,8 @@ def test_validate_html_static_path(app):
         app.outdir,                 # outdir
         app.outdir / '_static',     # inside outdir
     ]
-    validate_html_static_path(app, app.config)
+    with pytest.warns(RemovedInSphinx80Warning, match='Use "pathlib.Path" or "os.fspath" instead'):
+        validate_html_static_path(app, app.config)
     assert app.config.html_static_path == ['_static']
 
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -24,6 +24,7 @@ from sphinx.builders.linkcheck import (
     HyperlinkAvailabilityCheckWorker,
     RateLimit,
 )
+from sphinx.deprecation import RemovedInSphinx80Warning
 from sphinx.testing.util import strip_escseq
 from sphinx.util import requests
 
@@ -413,7 +414,10 @@ def test_unauthorized_broken(app):
     'linkcheck', testroot='linkcheck-localserver', freshenv=True,
     confoverrides={'linkcheck_auth': [(r'^$', ('user1', 'password'))]})
 def test_auth_header_no_match(app):
-    with http_server(custom_handler(valid_credentials=("user1", "password"))):
+    with (
+        http_server(custom_handler(valid_credentials=("user1", "password"))),
+        pytest.warns(RemovedInSphinx80Warning, match='linkcheck builder encountered an HTTP 401'),
+    ):
         app.build()
 
     with open(app.outdir / "output.json", encoding="utf-8") as fp:


### PR DESCRIPTION
Some tests issue warnings that we do not catch. Those are now expected accordingly (or suppressed in some cases). 

This also helps in detecting places where some components could affect tests. 