### PR TITLE
[tests] epub: skip the epubcheck test if Java or epubcheck itself are not found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ Bugs fixed
 Testing
 -------
 
+* pytest: report the result of ``test_run_epubcheck`` as ``skipped`` instead of
+  ``success`` when Java and/or the ``epubcheck.jar`` code are not available.
+
 Release 7.2.6 (released Sep 13, 2023)
 =====================================
 

--- a/tests/test_builders/test_build_epub.py
+++ b/tests/test_builders/test_build_epub.py
@@ -378,16 +378,21 @@ def test_duplicated_toctree_entry(app, status, warning):
 def test_run_epubcheck(app):
     app.build()
 
+    if not runnable(['java', '-version']):
+        pytest.skip("Unable to run Java; skipping test")
+
     epubcheck = os.environ.get('EPUBCHECK_PATH', '/usr/share/java/epubcheck.jar')
-    if runnable(['java', '-version']) and os.path.exists(epubcheck):
-        try:
-            subprocess.run(['java', '-jar', epubcheck, app.outdir / 'SphinxTests.epub'],
-                           capture_output=True, check=True)
-        except CalledProcessError as exc:
-            print(exc.stdout.decode('utf-8'))
-            print(exc.stderr.decode('utf-8'))
-            msg = f'epubcheck exited with return code {exc.returncode}'
-            raise AssertionError(msg) from exc
+    if not os.path.exists(epubcheck):
+        pytest.skip("Could not find epubcheck; skipping test")
+
+    try:
+        subprocess.run(['java', '-jar', epubcheck, app.outdir / 'SphinxTests.epub'],
+                       capture_output=True, check=True)
+    except CalledProcessError as exc:
+        print(exc.stdout.decode('utf-8'))
+        print(exc.stderr.decode('utf-8'))
+        msg = f'epubcheck exited with return code {exc.returncode}'
+        raise AssertionError(msg) from exc
 
 
 def test_xml_name_pattern_check():


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- The `test_run_epubcheck` test has to be enabled explicitly by the environment setting the `DO_EPUBCHECK` variable.  For the test to pass without indicating any problems when the test did not exercise any behaviour or check any results seems wrong - it could result in test reports that produce a false sense of confidence.

### Detail
- Instead of reporting `success` when the `test_run_epubcheck` does nothing due to the apparent absense of either Java or `epubcheck.jar` on the host, use `pytest` to indicate a `skip` result.

### Relates
- Relates to / discovered during investigation of #12094 (but does not fix it).
