### PR TITLE
[tests] update the ``pytest.mark.sphinx`` signature description

### DIFF
--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -21,8 +21,9 @@ if TYPE_CHECKING:
 DEFAULT_ENABLED_MARKERS = [
     (
         'sphinx('
-        'buildername="html", /, *, '
-        'testroot="root", confoverrides=None, freshenv=False, '
+        'buildername="html", *, '
+        'testroot="root", srcdir=None, '
+        'confoverrides=None, freshenv=False, '
         'warningiserror=False, tags=None, verbosity=0, parallel=0, '
         'keep_going=False, builddir=None, docutils_conf=None'
         '): arguments to initialize the sphinx test application.'

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     from typing import Any
 
 DEFAULT_ENABLED_MARKERS = [
+    # The marker signature differs from the constructor signature
+    # since the way it is processed assumes keyword arguments for
+    # the 'testroot' and 'srcdir'.
     (
         'sphinx('
         'buildername="html", *, '


### PR DESCRIPTION
The description of the marker is only for visual purposes. In addition, until now, the way that the marker was processed assumed that *srcdir* and *testroot* are keyword arguments. In addition, the marker signature description was never updated even though more parameters were supported and used publicly.