### PR TITLE
[lint] whitelist all test files except configuration and utils in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ test = [
     "pytest>=6.0",
     "html5lib",
     "cython>=3.0",
-    "setuptools>=67.0", # for Cython compilation
+    "setuptools>=67.0",  # for Cython compilation
     "filelock",
 ]
 
@@ -117,8 +117,8 @@ include = [
     "CHANGES.rst",
     # Documentation
     "doc/",
-    "CODE_OF_CONDUCT.rst", # used as an include in the Documentation
-    "EXAMPLES.rst", # used as an include in the Documentation
+    "CODE_OF_CONDUCT.rst",  # used as an include in the Documentation
+    "EXAMPLES.rst",  # used as an include in the Documentation
     # Tests
     "tests/",
     "tox.ini",
@@ -132,84 +132,7 @@ exclude = [
 
 [tool.mypy]
 files = ["sphinx", "utils", "tests"]
-exclude = [
-    "tests/certs", "tests/js", "tests/roots",
-    #    "^tests/__init__\\.py$",
-    #    "^tests/test_\\w+/__init__\\.py$",
-    #    # tests/test_builders
-    #    "^tests/test_builders/test_build\\.py$",
-    #    "^tests/test_builders/test_build_(changes|dirhtml|epub|gettext)\\.py$",
-    #    "^tests/test_builders/test_build_html\\.py$",
-    #    "^tests/test_builders/test_build_html_5_output\\.py$",
-    #    """(?x)(^tests/test_builders/test_build_html_(
-    #        assets|code|download|highlight|image|maths|numfig|tocdepth
-    #    )\\.py)$""",
-    #    """(?x)(^tests/test_builders/test_build_(
-    #        latex|linkcheck|manpage|texinfo|text|warnings
-    #    )\\.py)$""",
-    #    "^tests/test_builders/test_builder\\.py$",
-    #    # tests/test_config
-    #    "^tests/test_config/test_(config|correct_year)\\.py$",
-    #    # tests/test_directives
-    #    """(?x)(^tests/test_directives/test_directive_(
-    #        code|object_description|only|option|other|patch
-    #    )\\.py)$""",
-    #    "^tests/test_directives/test_directives_no_typesetting\\.py$",
-    #    # tests/test_domains
-    #    "^tests/test_domains/test_domain_(c|cpp|js)\\.py$",
-    #    "^tests/test_domains/test_domain_py\\.py$",
-    #    "^tests/test_domains/test_domain_py_(canonical|fields|pyfunction|pyobject)\\.py$",
-    #    "^tests/test_domains/test_domain_(rst|std)\\.py$",
-    #    # tests/test_environment
-    #    "^tests/test_environment/test_environment\\.py$",
-    #    """(?x)(^tests/test_environment/test_environment_(
-    #        indexentries|record_dependencies|toctree
-    #    )\\.py)$""",
-    #    # tests/test_extensions
-    #    "^tests/test_extensions/ext_napoleon_pep526_data_(google|numpy)\\.py$",
-    #    "^tests/test_extensions/test_ext_(apidoc|autodoc)\\.py$",
-    #    """(?x)(^tests/test_extensions/test_ext_autodoc_(
-    #        auto(attribute|class|data|function|module|property)|
-    #        configs|events|mock|preserve_defaults|private_members
-    #    )\\.py)$""",
-    #    """(?x)(^tests/test_extensions/test_ext_(
-    #        autosectionlabel|autosummary|coverage|doctest|duration|
-    #        extlinks|githubpages|graphviz|ifconfig|imgconverter|
-    #        imgmockconverter|inheritance_diagram|intersphinx|math|
-    #        napoleon|napoleon_docstring|todo|viewcode
-    #    )\\.py)$""",
-    #    "^tests/test_extensions/test_extension\\.py$",
-    #    # tests/test_intl
-    #    "^tests/test_intl/test_(catalogs|intl|locale)\\.py$",
-    #    # tests/test_markup
-    #    "^tests/test_markup/test_(markup|metadata|parser|smartquotes)\\.py$",
-    #    # tests/test_pycode
-    #    "^tests/test_pycode/test_pycode\\.py$",
-    #    "^tests/test_pycode/test_pycode_(ast|parser)\\.py$$",
-    #    # tests/test_theming
-    #    "^tests/test_theming/test_(html_theme|templating|theming)\\.py$",
-    #    # tests/test_transforms
-    #    "^tests/test_transforms/test_transforms_move_module_targets\\.py$",
-    #    "^tests/test_transforms/test_transforms_post_transforms\\.py$",
-    #    "^tests/test_transforms/test_transforms_post_transforms_code\\.py$",
-    #    "^tests/test_transforms/test_transforms_reorder_nodes\\.py$",
-    #    # tests/test_util
-    #    "^tests/test_util/test_util\\.py$",
-    #    """(?x)(^tests/test_util/test_util_(
-    #        display|docstrings|docutils|fileutil|i18n|images|inspect|
-    #        inventory|logging|matching|nodes|rst|template|typing
-    #    )\\.py)$""",
-    #    "^tests/test_util/typing_test_data\\.py$",
-    #    # tests/test_writers
-    #    "^tests/test_writers/test_api_translator\\.py$",
-    #    "^tests/test_writers/test_docutilsconf\\.py$",
-    #    "^tests/test_writers/test_writer_latex\\.py$",
-    #    # tests/
-    #    """(?x)(^tests/test_(
-    #        addnodes|application|errors|events|highlighting|project|
-    #        quickstart|roles|search|toctree|versioning
-    #    )\\.py)$""",
-]
+exclude = ["tests/certs", "tests/js", "tests/roots"]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 python_version = "3.9"
@@ -294,8 +217,8 @@ disallow_any_generics = false
 module = [
     "tests.__init__",
     "tests.*.__init__",
-#    "tests.conftest",
-#     tests/
+    #    "tests.conftest",
+    #     tests/
     "tests.test_addnodes",
     "tests.test_application",
     "tests.test_errors",
@@ -307,9 +230,9 @@ module = [
     "tests.test_search",
     "tests.test_toctree",
     "tests.test_versioning",
-#    "tests.utils",
+    #    "tests.utils",
     # tests/test_builders
-#    "tests.test_builders.conftest",
+    #    "tests.test_builders.conftest",
     "tests.test_builders.test_build",
     "tests.test_builders.test_build_changes",
     "tests.test_builders.test_build_dirhtml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ module = [
     # tests/
 #    "tests.conftest",
     "tests.test_addnodes",
-#    "tests.test_application",
+    "tests.test_application",
     "tests.test_errors",
     "tests.test_events",
     "tests.test_highlighting",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,22 +136,9 @@ exclude = [
     "tests/certs",
     "tests/js",
     "tests/roots",
-    # whitelisted modules
-    "tests/test_builders/",
-    "tests/test_config/",
-    "tests/test_directives/",
-    "tests/test_domains/",
-    "tests/test_environment/",
-    "tests/test_extension/",
-    "tests/test_intl/",
-    "tests/test_markup/",
-    "tests/test_pycode/",
-    "tests/test_testing/",  # currently missing, but will exist later
-    "tests/test_theming/",
-    "tests/test_transforms/",
-    "tests/test_util/",
-    "tests/test_writers/",
-    "tests/test_.*\\.py",
+    "tests/test_\\w+.py",
+    "tests/test_\\w+/test_\\w+\\.py",
+    "tests/test_util/typing_test_data\\.py",
 ]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ test = [
     "pytest>=6.0",
     "html5lib",
     "cython>=3.0",
-    "setuptools>=67.0",  # for Cython compilation
+    "setuptools>=67.0", # for Cython compilation
     "filelock",
 ]
 
@@ -117,8 +117,8 @@ include = [
     "CHANGES.rst",
     # Documentation
     "doc/",
-    "CODE_OF_CONDUCT.rst",  # used as an include in the Documentation
-    "EXAMPLES.rst",  # used as an include in the Documentation
+    "CODE_OF_CONDUCT.rst", # used as an include in the Documentation
+    "EXAMPLES.rst", # used as an include in the Documentation
     # Tests
     "tests/",
     "tox.ini",
@@ -134,81 +134,81 @@ exclude = [
 files = ["sphinx", "utils", "tests"]
 exclude = [
     "tests/certs", "tests/js", "tests/roots",
-    "^tests/__init__\\.py$",
-    "^tests/test_\\w+/__init__\\.py$",
-    # tests/test_builders
-    "^tests/test_builders/test_build\\.py$",
-    "^tests/test_builders/test_build_(changes|dirhtml|epub|gettext)\\.py$",
-    "^tests/test_builders/test_build_html\\.py$",
-    "^tests/test_builders/test_build_html_5_output\\.py$",
-    """(?x)(^tests/test_builders/test_build_html_(
-        assets|code|download|highlight|image|maths|numfig|tocdepth
-    )\\.py)$""",
-    """(?x)(^tests/test_builders/test_build_(
-        latex|linkcheck|manpage|texinfo|text|warnings
-    )\\.py)$""",
-    "^tests/test_builders/test_builder\\.py$",
-    # tests/test_config
-    "^tests/test_config/test_(config|correct_year)\\.py$",
-    # tests/test_directives
-    """(?x)(^tests/test_directives/test_directive_(
-        code|object_description|only|option|other|patch
-    )\\.py)$""",
-    "^tests/test_directives/test_directives_no_typesetting\\.py$",
-    # tests/test_domains
-    "^tests/test_domains/test_domain_(c|cpp|js)\\.py$",
-    "^tests/test_domains/test_domain_py\\.py$",
-    "^tests/test_domains/test_domain_py_(canonical|fields|pyfunction|pyobject)\\.py$",
-    "^tests/test_domains/test_domain_(rst|std)\\.py$",
-    # tests/test_environment
-    "^tests/test_environment/test_environment\\.py$",
-    """(?x)(^tests/test_environment/test_environment_(
-        indexentries|record_dependencies|toctree
-    )\\.py)$""",
-    # tests/test_extensions
-    "^tests/test_extensions/ext_napoleon_pep526_data_(google|numpy)\\.py$",
-    "^tests/test_extensions/test_ext_(apidoc|autodoc)\\.py$",
-    """(?x)(^tests/test_extensions/test_ext_autodoc_(
-        auto(attribute|class|data|function|module|property)|
-        configs|events|mock|preserve_defaults|private_members
-    )\\.py)$""",
-    """(?x)(^tests/test_extensions/test_ext_(
-        autosectionlabel|autosummary|coverage|doctest|duration|
-        extlinks|githubpages|graphviz|ifconfig|imgconverter|
-        imgmockconverter|inheritance_diagram|intersphinx|math|
-        napoleon|napoleon_docstring|todo|viewcode
-    )\\.py)$""",
-    "^tests/test_extensions/test_extension\\.py$",
-    # tests/test_intl
-    "^tests/test_intl/test_(catalogs|intl|locale)\\.py$",
-    # tests/test_markup
-    "^tests/test_markup/test_(markup|metadata|parser|smartquotes)\\.py$",
-    # tests/test_pycode
-    "^tests/test_pycode/test_pycode\\.py$",
-    "^tests/test_pycode/test_pycode_(ast|parser)\\.py$$",
-    # tests/test_theming
-    "^tests/test_theming/test_(html_theme|templating|theming)\\.py$",
-    # tests/test_transforms
-    "^tests/test_transforms/test_transforms_move_module_targets\\.py$",
-    "^tests/test_transforms/test_transforms_post_transforms\\.py$",
-    "^tests/test_transforms/test_transforms_post_transforms_code\\.py$",
-    "^tests/test_transforms/test_transforms_reorder_nodes\\.py$",
-    # tests/test_util
-    "^tests/test_util/test_util\\.py$",
-    """(?x)(^tests/test_util/test_util_(
-        display|docstrings|docutils|fileutil|i18n|images|inspect|
-        inventory|logging|matching|nodes|rst|template|typing
-    )\\.py)$""",
-    "^tests/test_util/typing_test_data\\.py$",
-    # tests/test_writers
-    "^tests/test_writers/test_api_translator\\.py$",
-    "^tests/test_writers/test_docutilsconf\\.py$",
-    "^tests/test_writers/test_writer_latex\\.py$",
-    # tests/
-    """(?x)(^tests/test_(
-        addnodes|application|errors|events|highlighting|project|
-        quickstart|roles|search|toctree|versioning
-    )\\.py)$""",
+    #    "^tests/__init__\\.py$",
+    #    "^tests/test_\\w+/__init__\\.py$",
+    #    # tests/test_builders
+    #    "^tests/test_builders/test_build\\.py$",
+    #    "^tests/test_builders/test_build_(changes|dirhtml|epub|gettext)\\.py$",
+    #    "^tests/test_builders/test_build_html\\.py$",
+    #    "^tests/test_builders/test_build_html_5_output\\.py$",
+    #    """(?x)(^tests/test_builders/test_build_html_(
+    #        assets|code|download|highlight|image|maths|numfig|tocdepth
+    #    )\\.py)$""",
+    #    """(?x)(^tests/test_builders/test_build_(
+    #        latex|linkcheck|manpage|texinfo|text|warnings
+    #    )\\.py)$""",
+    #    "^tests/test_builders/test_builder\\.py$",
+    #    # tests/test_config
+    #    "^tests/test_config/test_(config|correct_year)\\.py$",
+    #    # tests/test_directives
+    #    """(?x)(^tests/test_directives/test_directive_(
+    #        code|object_description|only|option|other|patch
+    #    )\\.py)$""",
+    #    "^tests/test_directives/test_directives_no_typesetting\\.py$",
+    #    # tests/test_domains
+    #    "^tests/test_domains/test_domain_(c|cpp|js)\\.py$",
+    #    "^tests/test_domains/test_domain_py\\.py$",
+    #    "^tests/test_domains/test_domain_py_(canonical|fields|pyfunction|pyobject)\\.py$",
+    #    "^tests/test_domains/test_domain_(rst|std)\\.py$",
+    #    # tests/test_environment
+    #    "^tests/test_environment/test_environment\\.py$",
+    #    """(?x)(^tests/test_environment/test_environment_(
+    #        indexentries|record_dependencies|toctree
+    #    )\\.py)$""",
+    #    # tests/test_extensions
+    #    "^tests/test_extensions/ext_napoleon_pep526_data_(google|numpy)\\.py$",
+    #    "^tests/test_extensions/test_ext_(apidoc|autodoc)\\.py$",
+    #    """(?x)(^tests/test_extensions/test_ext_autodoc_(
+    #        auto(attribute|class|data|function|module|property)|
+    #        configs|events|mock|preserve_defaults|private_members
+    #    )\\.py)$""",
+    #    """(?x)(^tests/test_extensions/test_ext_(
+    #        autosectionlabel|autosummary|coverage|doctest|duration|
+    #        extlinks|githubpages|graphviz|ifconfig|imgconverter|
+    #        imgmockconverter|inheritance_diagram|intersphinx|math|
+    #        napoleon|napoleon_docstring|todo|viewcode
+    #    )\\.py)$""",
+    #    "^tests/test_extensions/test_extension\\.py$",
+    #    # tests/test_intl
+    #    "^tests/test_intl/test_(catalogs|intl|locale)\\.py$",
+    #    # tests/test_markup
+    #    "^tests/test_markup/test_(markup|metadata|parser|smartquotes)\\.py$",
+    #    # tests/test_pycode
+    #    "^tests/test_pycode/test_pycode\\.py$",
+    #    "^tests/test_pycode/test_pycode_(ast|parser)\\.py$$",
+    #    # tests/test_theming
+    #    "^tests/test_theming/test_(html_theme|templating|theming)\\.py$",
+    #    # tests/test_transforms
+    #    "^tests/test_transforms/test_transforms_move_module_targets\\.py$",
+    #    "^tests/test_transforms/test_transforms_post_transforms\\.py$",
+    #    "^tests/test_transforms/test_transforms_post_transforms_code\\.py$",
+    #    "^tests/test_transforms/test_transforms_reorder_nodes\\.py$",
+    #    # tests/test_util
+    #    "^tests/test_util/test_util\\.py$",
+    #    """(?x)(^tests/test_util/test_util_(
+    #        display|docstrings|docutils|fileutil|i18n|images|inspect|
+    #        inventory|logging|matching|nodes|rst|template|typing
+    #    )\\.py)$""",
+    #    "^tests/test_util/typing_test_data\\.py$",
+    #    # tests/test_writers
+    #    "^tests/test_writers/test_api_translator\\.py$",
+    #    "^tests/test_writers/test_docutilsconf\\.py$",
+    #    "^tests/test_writers/test_writer_latex\\.py$",
+    #    # tests/
+    #    """(?x)(^tests/test_(
+    #        addnodes|application|errors|events|highlighting|project|
+    #        quickstart|roles|search|toctree|versioning
+    #    )\\.py)$""",
 ]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -290,12 +290,162 @@ module = [
 ]
 disallow_any_generics = false
 
+[[tool.mypy.overrides]]
+module = [
+    "tests.__init__",
+    "tests.*.__init__",
+#    "tests.conftest",
+#     tests/
+    "tests.test_addnodes",
+    "tests.test_application",
+    "tests.test_errors",
+    "tests.test_events",
+    "tests.test_highlighting",
+    "tests.test_project",
+    "tests.test_quickstart",
+    "tests.test_roles",
+    "tests.test_search",
+    "tests.test_toctree",
+    "tests.test_versioning",
+#    "tests.utils",
+    # tests/test_builders
+#    "tests.test_builders.conftest",
+    "tests.test_builders.test_build",
+    "tests.test_builders.test_build_changes",
+    "tests.test_builders.test_build_dirhtml",
+    "tests.test_builders.test_build_epub",
+    "tests.test_builders.test_builder",
+    "tests.test_builders.test_build_gettext",
+    "tests.test_builders.test_build_html",
+    "tests.test_builders.test_build_html_5_output",
+    "tests.test_builders.test_build_html_assets",
+    "tests.test_builders.test_build_html_code",
+    "tests.test_builders.test_build_html_download",
+    "tests.test_builders.test_build_html_highlight",
+    "tests.test_builders.test_build_html_image",
+    "tests.test_builders.test_build_html_maths",
+    "tests.test_builders.test_build_html_numfig",
+    "tests.test_builders.test_build_html_tocdepth",
+    "tests.test_builders.test_build_latex",
+    "tests.test_builders.test_build_linkcheck",
+    "tests.test_builders.test_build_manpage",
+    "tests.test_builders.test_build_texinfo",
+    "tests.test_builders.test_build_text",
+    "tests.test_builders.test_build_warnings",
+    # tests/test_config
+    "tests.test_config.test_config",
+    "tests.test_config.test_correct_year",
+    # tests/test_directives
+    "tests.test_directives.test_directive_code",
+    "tests.test_directives.test_directive_object_description",
+    "tests.test_directives.test_directive_only",
+    "tests.test_directives.test_directive_option",
+    "tests.test_directives.test_directive_other",
+    "tests.test_directives.test_directive_patch",
+    "tests.test_directives.test_directives_no_typesetting",
+    # tests/test_domains
+    "tests.test_domains.test_domain_c",
+    "tests.test_domains.test_domain_cpp",
+    "tests.test_domains.test_domain_js",
+    "tests.test_domains.test_domain_py",
+    "tests.test_domains.test_domain_py_canonical",
+    "tests.test_domains.test_domain_py_fields",
+    "tests.test_domains.test_domain_py_pyfunction",
+    "tests.test_domains.test_domain_py_pyobject",
+    "tests.test_domains.test_domain_rst",
+    "tests.test_domains.test_domain_std",
+    # tests/test_environment
+    "tests.test_environment.test_environment",
+    "tests.test_environment.test_environment_indexentries",
+    "tests.test_environment.test_environment_record_dependencies",
+    "tests.test_environment.test_environment_toctree",
+    # tests/test_extensions
+    "tests.test_extensions.ext_napoleon_pep526_data_google",
+    "tests.test_extensions.ext_napoleon_pep526_data_numpy",
+    "tests.test_extensions.test_ext_apidoc",
+    "tests.test_extensions.test_ext_autodoc",
+    "tests.test_extensions.test_ext_autodoc_autoattribute",
+    "tests.test_extensions.test_ext_autodoc_autoclass",
+    "tests.test_extensions.test_ext_autodoc_autodata",
+    "tests.test_extensions.test_ext_autodoc_autofunction",
+    "tests.test_extensions.test_ext_autodoc_automodule",
+    "tests.test_extensions.test_ext_autodoc_autoproperty",
+    "tests.test_extensions.test_ext_autodoc_configs",
+    "tests.test_extensions.test_ext_autodoc_events",
+    "tests.test_extensions.test_ext_autodoc_mock",
+    "tests.test_extensions.test_ext_autodoc_preserve_defaults",
+    "tests.test_extensions.test_ext_autodoc_private_members",
+    "tests.test_extensions.test_ext_autosectionlabel",
+    "tests.test_extensions.test_ext_autosummary",
+    "tests.test_extensions.test_ext_coverage",
+    "tests.test_extensions.test_ext_doctest",
+    "tests.test_extensions.test_ext_duration",
+    "tests.test_extensions.test_extension",
+    "tests.test_extensions.test_ext_extlinks",
+    "tests.test_extensions.test_ext_githubpages",
+    "tests.test_extensions.test_ext_graphviz",
+    "tests.test_extensions.test_ext_ifconfig",
+    "tests.test_extensions.test_ext_imgconverter",
+    "tests.test_extensions.test_ext_imgmockconverter",
+    "tests.test_extensions.test_ext_inheritance_diagram",
+    "tests.test_extensions.test_ext_intersphinx",
+    "tests.test_extensions.test_ext_math",
+    "tests.test_extensions.test_ext_napoleon",
+    "tests.test_extensions.test_ext_napoleon_docstring",
+    "tests.test_extensions.test_ext_todo",
+    "tests.test_extensions.test_ext_viewcode",
+    # tests/test_intl
+    "tests.test_intl.test_catalogs",
+    "tests.test_intl.test_intl",
+    "tests.test_intl.test_locale",
+    # tests/test_markup
+    "tests.test_markup.test_markup",
+    "tests.test_markup.test_metadata",
+    "tests.test_markup.test_parser",
+    "tests.test_markup.test_smartquotes",
+    # tests/test_pycode
+    "tests.test_pycode.test_pycode",
+    "tests.test_pycode.test_pycode_ast",
+    "tests.test_pycode.test_pycode_parser",
+    # tests/test_theming
+    "tests.test_theming.test_html_theme",
+    "tests.test_theming.test_templating",
+    "tests.test_theming.test_theming",
+    # tests/test_transforms
+    "tests.test_transforms.test_transforms_move_module_targets",
+    "tests.test_transforms.test_transforms_post_transforms",
+    "tests.test_transforms.test_transforms_post_transforms_code",
+    "tests.test_transforms.test_transforms_reorder_nodes",
+    # tests/test_util
+    "tests.test_util.test_util",
+    "tests.test_util.test_util_display",
+    "tests.test_util.test_util_docstrings",
+    "tests.test_util.test_util_docutils",
+    "tests.test_util.test_util_fileutil",
+    "tests.test_util.test_util_i18n",
+    "tests.test_util.test_util_images",
+    "tests.test_util.test_util_inspect",
+    "tests.test_util.test_util_inventory",
+    "tests.test_util.test_util_logging",
+    "tests.test_util.test_util_matching",
+    "tests.test_util.test_util_nodes",
+    "tests.test_util.test_util_rst",
+    "tests.test_util.test_util_template",
+    "tests.test_util.test_util_typing",
+    "tests.test_util.typing_test_data",
+    # tests/test_writers
+    "tests.test_writers.test_api_translator",
+    "tests.test_writers.test_docutilsconf",
+    "tests.test_writers.test_writer_latex",
+]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 minversion = 6.0
 addopts = [
     "-ra",
     "--import-mode=prepend",
-#    "--pythonwarnings=error",
+    #    "--pythonwarnings=error",
     "--strict-config",
     "--strict-markers",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,7 @@ minversion = 6.0
 addopts = [
     "-ra",
     "--import-mode=prepend",
-    #    "--pythonwarnings=error",
+#    "--pythonwarnings=error",
     "--strict-config",
     "--strict-markers",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,8 +215,6 @@ disallow_any_generics = false
 
 [[tool.mypy.overrides]]
 module = [
-    "tests.__init__",
-    "tests.*.__init__",
 #    "tests.conftest",
     # tests/
     "tests.test_addnodes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ test = [
     "pytest>=6.0",
     "html5lib",
     "cython>=3.0",
-    "setuptools>=67.0",  # for Cython compilation
+    "setuptools>=67.0", # for Cython compilation
     "filelock",
 ]
 
@@ -117,8 +117,8 @@ include = [
     "CHANGES.rst",
     # Documentation
     "doc/",
-    "CODE_OF_CONDUCT.rst",  # used as an include in the Documentation
-    "EXAMPLES.rst",  # used as an include in the Documentation
+    "CODE_OF_CONDUCT.rst", # used as an include in the Documentation
+    "EXAMPLES.rst", # used as an include in the Documentation
     # Tests
     "tests/",
     "tox.ini",
@@ -133,12 +133,82 @@ exclude = [
 [tool.mypy]
 files = ["sphinx", "utils", "tests"]
 exclude = [
-    "tests/certs",
-    "tests/js",
-    "tests/roots",
-    "tests/test_\\w+.py",
-    "tests/test_\\w+/test_\\w+\\.py",
-    "tests/test_util/typing_test_data\\.py",
+    "tests/certs", "tests/js", "tests/roots",
+    "^tests/__init__\\.py$",
+    "^tests/test_\\w+/__init__\\.py$",
+    # tests/test_builders
+    "^tests/test_builders/test_build\\.py$",
+    "^tests/test_builders/test_build_(changes|dirhtml|epub|gettext)\\.py$",
+    "^tests/test_builders/test_build_html\\.py$",
+    "^tests/test_builders/test_build_html_5_output\\.py$",
+    """(?x)(^tests/test_builders/test_build_html_(
+        assets|code|download|highlight|image|maths|numfig|tocdepth
+    )\\.py)$""",
+    """(?x)(^tests/test_builders/test_build_(
+        latex|linkcheck|manpage|texinfo|text|warnings
+    )\\.py)$""",
+    "^tests/test_builders/test_builder\\.py$",
+    # tests/test_config
+    "^tests/test_config/test_(config|correct_year)\\.py$",
+    # tests/test_directives
+    """(?x)(^tests/test_directives/test_directive_(
+        code|object_description|only|option|other|patch
+    )\\.py)$""",
+    "^tests/test_directives/test_directives_no_typesetting\\.py$",
+    # tests/test_domains
+    "^tests/test_domains/test_domain_(c|cpp|js)\\.py$",
+    "^tests/test_domains/test_domain_py\\.py$",
+    "^tests/test_domains/test_domain_py_(canonical|fields|pyfunction|pyobject)\\.py$",
+    "^tests/test_domains/test_domain_(rst|std)\\.py$",
+    # tests/test_environment
+    "^tests/test_environment/test_environment\\.py$",
+    """(?x)(^tests/test_environment/test_environment_(
+        indexentries|record_dependencies|toctree
+    )\\.py)$""",
+    # tests/test_extensions
+    "^tests/test_extensions/ext_napoleon_pep526_data_(google|numpy)\\.py$",
+    "^tests/test_extensions/test_ext_(apidoc|autodoc)\\.py$",
+    """(?x)(^tests/test_extensions/test_ext_autodoc_(
+        auto(attribute|class|data|function|module|property)|
+        configs|events|mock|preserve_defaults|private_members
+    )\\.py)$""",
+    """(?x)(^tests/test_extensions/test_ext_(
+        autosectionlabel|autosummary|coverage|doctest|duration|
+        extlinks|githubpages|graphviz|ifconfig|imgconverter|
+        imgmockconverter|inheritance_diagram|intersphinx|math|
+        napoleon|napoleon_docstring|todo|viewcode
+    )\\.py)$""",
+    "^tests/test_extensions/test_extension\\.py$",
+    # tests/test_intl
+    "^tests/test_intl/test_(catalogs|intl|locale)\\.py$",
+    # tests/test_markup
+    "^tests/test_markup/test_(markup|metadata|parser|smartquotes)\\.py$",
+    # tests/test_pycode
+    "^tests/test_pycode/test_pycode\\.py$",
+    "^tests/test_pycode/test_pycode_(ast|parser)\\.py$$",
+    # tests/test_theming
+    "^tests/test_theming/test_(html_theme|templating|theming)\\.py$",
+    # tests/test_transforms
+    "^tests/test_transforms/test_transforms_move_module_targets\\.py$",
+    "^tests/test_transforms/test_transforms_post_transforms\\.py$",
+    "^tests/test_transforms/test_transforms_post_transforms_code\\.py$",
+    "^tests/test_transforms/test_transforms_reorder_nodes\\.py$",
+    # tests/test_util
+    "^tests/test_util/test_util\\.py$",
+    """(?x)(^tests/test_util/test_util_(
+        display|docstrings|docutils|fileutil|i18n|images|inspect|
+        inventory|logging|matching|nodes|rst|template|typing
+    )\\.py)$""",
+    "^tests/test_util/typing_test_data\\.py$",
+    # tests/test_writers
+    "^tests/test_writers/test_api_translator\\.py$",
+    "^tests/test_writers/test_docutilsconf\\.py$",
+    "^tests/test_writers/test_writer_latex\\.py$",
+    # tests/
+    """(?x)(^tests/test_(
+        addnodes|application|errors|events|highlighting|project|
+        quickstart|roles|search|toctree|versioning
+    )\\.py)$""",
 ]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -220,16 +290,12 @@ module = [
 ]
 disallow_any_generics = false
 
-[[tool.mypy.overrides]]
-module = ['tests.*', 'tests.*.*']
-disable_error_code = ['var-annotated']
-
 [tool.pytest.ini_options]
 minversion = 6.0
 addopts = [
     "-ra",
     "--import-mode=prepend",
-#    "--pythonwarnings=error",
+    #    "--pythonwarnings=error",
     "--strict-config",
     "--strict-markers",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ test = [
     "pytest>=6.0",
     "html5lib",
     "cython>=3.0",
-    "setuptools>=67.0", # for Cython compilation
+    "setuptools>=67.0",  # for Cython compilation
     "filelock",
 ]
 
@@ -117,8 +117,8 @@ include = [
     "CHANGES.rst",
     # Documentation
     "doc/",
-    "CODE_OF_CONDUCT.rst", # used as an include in the Documentation
-    "EXAMPLES.rst", # used as an include in the Documentation
+    "CODE_OF_CONDUCT.rst",  # used as an include in the Documentation
+    "EXAMPLES.rst",  # used as an include in the Documentation
     # Tests
     "tests/",
     "tox.ini",
@@ -295,7 +295,7 @@ minversion = 6.0
 addopts = [
     "-ra",
     "--import-mode=prepend",
-    #    "--pythonwarnings=error",
+#    "--pythonwarnings=error",
     "--strict-config",
     "--strict-markers",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ module = [
     # tests/
 #    "tests.conftest",
     "tests.test_addnodes",
-    "tests.test_application",
+#    "tests.test_application",
     "tests.test_errors",
     "tests.test_events",
     "tests.test_highlighting",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,8 @@ disallow_any_generics = false
 module = [
     "tests.__init__",
     "tests.*.__init__",
-    #    "tests.conftest",
-    #     tests/
+#    "tests.conftest",
+    # tests/
     "tests.test_addnodes",
     "tests.test_application",
     "tests.test_errors",
@@ -230,9 +230,9 @@ module = [
     "tests.test_search",
     "tests.test_toctree",
     "tests.test_versioning",
-    #    "tests.utils",
+#    "tests.utils",
     # tests/test_builders
-    #    "tests.test_builders.conftest",
+#    "tests.test_builders.conftest",
     "tests.test_builders.test_build",
     "tests.test_builders.test_build_changes",
     "tests.test_builders.test_build_dirhtml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,8 +215,8 @@ disallow_any_generics = false
 
 [[tool.mypy.overrides]]
 module = [
-#    "tests.conftest",
     # tests/
+#    "tests.conftest",
     "tests.test_addnodes",
     "tests.test_application",
     "tests.test_errors",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,28 @@ exclude = [
 ]
 
 [tool.mypy]
-files = ["sphinx", "utils"]
+files = ["sphinx", "utils", "tests"]
+exclude = [
+    "tests/certs",
+    "tests/js",
+    "tests/roots",
+    # whitelisted modules
+    "tests/test_builders/",
+    "tests/test_config/",
+    "tests/test_directives/",
+    "tests/test_domains/",
+    "tests/test_environment/",
+    "tests/test_extension/",
+    "tests/test_intl/",
+    "tests/test_markup/",
+    "tests/test_pycode/",
+    "tests/test_testing/",  # currently missing, but will exist later
+    "tests/test_theming/",
+    "tests/test_transforms/",
+    "tests/test_util/",
+    "tests/test_writers/",
+    "tests/test_.*\\.py",
+]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 python_version = "3.9"
@@ -211,6 +232,10 @@ module = [
     "sphinx.util.template",
 ]
 disallow_any_generics = false
+
+[[tool.mypy.overrides]]
+module = ['tests.*', 'tests.*.*']
+disable_error_code = ['var-annotated']
 
 [tool.pytest.ini_options]
 minversion = 6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import docutils
 import pytest
@@ -10,8 +13,13 @@ import sphinx.locale
 import sphinx.pycode
 from sphinx.testing.util import _clean_up_global_state
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-def _init_console(locale_dir=sphinx.locale._LOCALE_DIR, catalog='sphinx'):
+
+def _init_console(
+    locale_dir: str | None = sphinx.locale._LOCALE_DIR, catalog: str = 'sphinx',
+) -> tuple[sphinx.locale.NullTranslations, bool]:
     """Monkeypatch ``init_console`` to skip its action.
 
     Some tests rely on warning messages in English. We don't want
@@ -23,7 +31,7 @@ def _init_console(locale_dir=sphinx.locale._LOCALE_DIR, catalog='sphinx'):
 
 sphinx.locale.init_console = _init_console
 
-pytest_plugins = 'sphinx.testing.fixtures'
+pytest_plugins = ['sphinx.testing.fixtures']
 
 # Exclude 'roots' dirs for pytest test collector
 collect_ignore = ['roots']
@@ -32,11 +40,11 @@ os.environ['SPHINX_AUTODOC_RELOAD_MODULES'] = '1'
 
 
 @pytest.fixture(scope='session')
-def rootdir():
+def rootdir() -> Path:
     return Path(__file__).parent.resolve() / 'roots'
 
 
-def pytest_report_header(config):
+def pytest_report_header(config: pytest.Config) -> str:
     header = f"libraries: Sphinx-{sphinx.__display_version__}, docutils-{docutils.__version__}"
     if hasattr(config, '_tmp_path_factory'):
         header += f"\nbase tmp_path: {config._tmp_path_factory.getbasetemp()}"
@@ -44,7 +52,7 @@ def pytest_report_header(config):
 
 
 @pytest.fixture(autouse=True)
-def _cleanup_docutils():
+def _cleanup_docutils() -> Generator[None, None, None]:
     saved_path = sys.path
     yield  # run the test
     sys.path[:] = saved_path

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,9 +1,11 @@
 """Test the Sphinx class."""
+from __future__ import annotations
 
 import shutil
 import sys
 from io import StringIO
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
@@ -14,8 +16,15 @@ from sphinx.errors import ExtensionError
 from sphinx.testing.util import SphinxTestApp, strip_escseq
 from sphinx.util import logging
 
+if TYPE_CHECKING:
+    import os
 
-def test_instantiation(tmp_path_factory, rootdir: str, monkeypatch):
+
+def test_instantiation(
+    tmp_path_factory: pytest.TempPathFactory,
+    rootdir: str | os.PathLike[str] | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # Given
     src_dir = tmp_path_factory.getbasetemp() / 'root'
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,11 +1,9 @@
 """Test the Sphinx class."""
-from __future__ import annotations
 
 import shutil
 import sys
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
@@ -16,15 +14,8 @@ from sphinx.errors import ExtensionError
 from sphinx.testing.util import SphinxTestApp, strip_escseq
 from sphinx.util import logging
 
-if TYPE_CHECKING:
-    import os
 
-
-def test_instantiation(
-    tmp_path_factory: pytest.TempPathFactory,
-    rootdir: str | os.PathLike[str] | None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_instantiation(tmp_path_factory, rootdir: str, monkeypatch):
     # Given
     src_dir = tmp_path_factory.getbasetemp() / 'root'
 

--- a/tests/test_builders/conftest.py
+++ b/tests/test_builders/conftest.py
@@ -6,12 +6,14 @@ import pytest
 from html5lib import HTMLParser
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
     from pathlib import Path
+    from xml.etree.ElementTree import Element
 
-etree_cache = {}
+etree_cache: dict[Path, Element] = {}
 
 
-def _parse(fname: Path) -> HTMLParser:
+def _parse(fname: Path) -> Element:
     if fname in etree_cache:
         return etree_cache[fname]
     with fname.open('rb') as fp:
@@ -21,6 +23,6 @@ def _parse(fname: Path) -> HTMLParser:
 
 
 @pytest.fixture(scope='package')
-def cached_etree_parse():
+def cached_etree_parse() -> Generator[Callable[[Path], Element], None, None]:
     yield _parse
     etree_cache.clear()


### PR DESCRIPTION
First step towards #12097.

This whitelists all test files and their related local testroots, except ``conftest.py`` and util-like files.
