### PR TITLE
[tests] Make the 'test_html_copy_source' case agnostic of test evaluation order.

### DIFF
--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -119,7 +119,7 @@ def test_enumerable_node(app, cached_etree_parse, expect):
     check_xpath(cached_etree_parse(app.outdir / 'index.html'), 'index.html', *expect)
 
 
-@pytest.mark.sphinx('html', testroot='basic', confoverrides={'html_copy_source': False})
+@pytest.mark.sphinx('html', testroot='basic', srcdir='copy', confoverrides={'html_copy_source': False})
 def test_html_copy_source(app):
     app.build(force_all=True)
     assert not (app.outdir / '_sources' / 'index.rst.txt').exists()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- In an attempt to help with issues with parallelizing tests documented in #11285, I've begun running tests locally in random order to attempt to find and resolve problems.

### Detail
- Use a unique `srcdir` during the [`test_html_copy_source` test case](https://github.com/sphinx-doc/sphinx/blob/bf0bec3b4b8c019acad4a77a9e228de4e65b538b/tests/test_builders/test_build_html.py#L122-L125) so that it can succeed even if other tests cases that use the same `testroot` modify their source files before it runs.

### Relates
- Contributes towards #11285.