### PR TITLE
[tests] use deduced ``srcdir`` instead of manual constructed

### DIFF
--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -1635,13 +1635,13 @@ def test_gettext_disallow_fuzzy_translations(app):
 
 
 @pytest.mark.sphinx('html', testroot='basic', confoverrides={'language': 'de'})
-def test_customize_system_message(make_app, app_params, sphinx_test_tempdir):
+def test_customize_system_message(make_app, app_params):
     try:
         # clear translators cache
         locale.translators.clear()
 
         # prepare message catalog (.po)
-        locale_dir = sphinx_test_tempdir / 'basic' / 'locales' / 'de' / 'LC_MESSAGES'
+        locale_dir = app_params.kwargs['srcdir'] / 'locales' / 'de' / 'LC_MESSAGES'
         locale_dir.mkdir(parents=True, exist_ok=True)
         with (locale_dir / 'sphinx.po').open('wb') as f:
             catalog = Catalog()


### PR DESCRIPTION
This is an independent fix so that we always use the application's *srcdir* instead of re-constructing it manually. It is compatible with whatever plan we use to follow for fixing test side-effects.