### PR TITLE
[tests] add missing ``@pytest.mark.sphinx`` markers

### DIFF
--- a/tests/test_extensions/test_ext_autodoc_autoclass.py
+++ b/tests/test_extensions/test_ext_autodoc_autoclass.py
@@ -169,6 +169,7 @@ def test_undocumented_uninitialized_attributes(app):
     ]
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_decorators(app):
     actual = do_autodoc(app, 'class', 'target.decorator.Baz')
     assert list(actual) == [
@@ -373,6 +374,7 @@ def test_class_doc_from_both(app):
     ]
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_class_alias(app):
     def autodoc_process_docstring(*args):
         """A handler always raises an error.
@@ -391,6 +393,7 @@ def test_class_alias(app):
     ]
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_class_alias_having_doccomment(app):
     actual = do_autodoc(app, 'class', 'target.classes.OtherAlias')
     assert list(actual) == [
@@ -403,6 +406,7 @@ def test_class_alias_having_doccomment(app):
     ]
 
 
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_class_alias_for_imported_object_having_doccomment(app):
     actual = do_autodoc(app, 'class', 'target.classes.IntAlias')
     assert list(actual) == [


### PR DESCRIPTION
Those tests fail if executed standalone.