### PR TITLE
✨ Add `show_warning_types` configuration variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Deprecated
 Features added
 --------------
 
+* #12131: Added :confval:`show_warning_types` configuration option.
+  Patch by Chris Sewell.
+
 * #11701: HTML Search: Adopt the new `<search>`_ element.
   Patch by Bénédikt Tran.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,6 +23,7 @@ version = sphinx.__display_version__
 release = version
 show_authors = True
 nitpicky = True
+show_warning_types = True
 
 html_theme = 'sphinx13'
 html_theme_path = ['_themes']

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -364,7 +364,7 @@ General configuration
    * ``toc.not_readable``
    * ``toc.secnum``
 
-   Then extensions can also define their own warning types. 
+   Then extensions can also define their own warning types.
 
    You can choose from these types.  You can also give only the first
    component to exclude all warnings attached to it.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -328,7 +328,8 @@ General configuration
 
 .. confval:: show_warning_types
 
-   If ``True``, the type of each warning is added as a suffix to the warning message.
+   If ``True``, the type of each warning is added as a suffix to the warning message,
+   e.g., ``WARNING: [...] [index]`` or ``WARNING: [...] [toc.circular]``.
    The default is ``False``.
 
    .. versionadded:: 7.3.0

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -331,6 +331,8 @@ General configuration
    If ``True``, the type of each warning is added as a suffix to the warning message.
    The default is ``False``.
 
+   .. versionadded:: 7.3.0
+
 .. confval:: suppress_warnings
 
    A list of warning types to suppress arbitrary warning messages.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -326,11 +326,16 @@ General configuration
 
    .. versionadded:: 0.5
 
+.. confval:: show_warning_types
+
+   If ``True``, the type of each warning is added as a suffix to the warning message.
+   The default is ``False``.
+
 .. confval:: suppress_warnings
 
    A list of warning types to suppress arbitrary warning messages.
 
-   Sphinx supports following warning types:
+   Sphinx core supports following warning types:
 
    * ``app.add_node``
    * ``app.add_directive``
@@ -359,10 +364,10 @@ General configuration
    * ``toc.not_readable``
    * ``toc.secnum``
 
+   Then extensions can also define their own warning types. 
+
    You can choose from these types.  You can also give only the first
    component to exclude all warnings attached to it.
-
-   Now, this option should be considered *experimental*.
 
    .. versionadded:: 1.4
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -227,7 +227,7 @@ class Config:
         'template_bridge': _Opt(None, 'html', frozenset((str,))),
         'keep_warnings': _Opt(False, 'env', ()),
         'suppress_warnings': _Opt([], 'env', ()),
-        'show_warning_types': _Opt(False, 'env', ()),
+        'show_warning_types': _Opt(False, 'env', frozenset((bool,))),
         'modindex_common_prefix': _Opt([], 'html', ()),
         'rst_epilog': _Opt(None, 'env', frozenset((str,))),
         'rst_prolog': _Opt(None, 'env', frozenset((str,))),

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -227,6 +227,7 @@ class Config:
         'template_bridge': _Opt(None, 'html', frozenset((str,))),
         'keep_warnings': _Opt(False, 'env', ()),
         'suppress_warnings': _Opt([], 'env', ()),
+        'show_warning_types': _Opt(False, 'env', ()),
         'modindex_common_prefix': _Opt([], 'html', ()),
         'rst_epilog': _Opt(None, 'env', frozenset((str,))),
         'rst_prolog': _Opt(None, 'env', frozenset((str,))),

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -480,7 +480,7 @@ class SphinxLogRecordTranslator(logging.Filter):
 
     * Make a instance of SphinxLogRecord
     * docname to path if location given
-    * append warning type/subtype to message if show_warning_types is True
+    * append warning type/subtype to message if :confval:`show_warning_types` is ``True``
     """
 
     LogRecordClass: type[logging.LogRecord]

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -524,7 +524,7 @@ class WarningLogRecordTranslator(SphinxLogRecordTranslator):
     LogRecordClass = SphinxWarningLogRecord
 
     def filter(self, record: SphinxWarningLogRecord) -> bool:  # type: ignore[override]
-        super().filter(record)
+        ret = super().filter(record)
 
         try:
             show_warning_types = self.app.config.show_warning_types
@@ -538,7 +538,7 @@ class WarningLogRecordTranslator(SphinxLogRecordTranslator):
                 else:
                     record.msg += f' [{log_type}]'
 
-        return True
+        return ret
 
 
 def get_node_location(node: Node) -> str | None:

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -512,8 +512,6 @@ class SphinxLogRecordTranslator(logging.Filter):
         return True
 
 
-
-
 class InfoLogRecordTranslator(SphinxLogRecordTranslator):
     """LogRecordTranslator for INFO level log records."""
 

--- a/tests/test_util/test_util_logging.py
+++ b/tests/test_util/test_util_logging.py
@@ -409,8 +409,7 @@ def test_show_warning_types(app, status, warning):
     warnings = strip_colors(warning.getvalue()).splitlines()
 
     assert warnings == [
-        'WARNING: message2', 
-        'WARNING: message3 [test]', 
+        'WARNING: message2',
+        'WARNING: message3 [test]',
         'WARNING: message4 [test.logging]',
     ]
-

--- a/tests/test_util/test_util_logging.py
+++ b/tests/test_util/test_util_logging.py
@@ -396,3 +396,16 @@ def test_get_node_location_abspath():
     location = logging.get_node_location(n)
 
     assert location == absolute_filename + ':'
+
+
+@pytest.mark.sphinx(confoverrides={'show_warning_types': True})
+def test_show_warning_types(app, status, warning):
+    logging.setup(app, status, warning)
+    logger = logging.getLogger(__name__)
+    logger.warning('message2')
+    logger.warning('message3', type='test')
+    logger.warning('message4', type='test', subtype='logging')
+
+    assert 'WARNING: message2' in warning.getvalue()
+    assert 'WARNING: message3 [test]' in warning.getvalue()
+    assert 'WARNING: message4 [test.logging]' in warning.getvalue()

--- a/tests/test_util/test_util_logging.py
+++ b/tests/test_util/test_util_logging.py
@@ -10,7 +10,7 @@ from docutils import nodes
 from sphinx.errors import SphinxWarning
 from sphinx.testing.util import strip_escseq
 from sphinx.util import logging, osutil
-from sphinx.util.console import colorize
+from sphinx.util.console import colorize, strip_colors
 from sphinx.util.logging import is_suppressed_warning, prefixed_warnings
 from sphinx.util.parallel import ParallelTasks
 
@@ -406,6 +406,11 @@ def test_show_warning_types(app, status, warning):
     logger.warning('message3', type='test')
     logger.warning('message4', type='test', subtype='logging')
 
-    assert 'WARNING: message2' in warning.getvalue()
-    assert 'WARNING: message3 [test]' in warning.getvalue()
-    assert 'WARNING: message4 [test.logging]' in warning.getvalue()
+    warnings = strip_colors(warning.getvalue()).splitlines()
+
+    assert warnings == [
+        'WARNING: message2', 
+        'WARNING: message3 [test]', 
+        'WARNING: message4 [test.logging]',
+    ]
+


### PR DESCRIPTION
This PR add the `show_warning_types` config variable which when set to `True`, prepends the type and subtype (if set) to warning messages.
For example:

```
WARNING: py:class reference target not found: TextElement [ref.class]
```

This follows the best practices of other tools, such as mypy and ruff to provide the user greater information on the warning:

1. To provide greater specificity for the origin of the warning, particularly for extensions which utilise warning types. Currently these extensions have to provide bespoke solutions for showing the warning origin (see e.g. https://myst-parser.readthedocs.io/en/latest/configuration.html#build-warnings)

2. To encourage users to deal with warnings. I strongly recommend for users to run `sphinx-build -nW --keep-going`, then fix all warnings. Practically this is not always possible and so the use of `show_warning_types` and `suppress_warnings`, provides a way for users to deal with most warnings, whilst being able to suppress "less important" ones

Note currently, the default is `False`, i.e. they will still not be shown, which is done in order to introduce any breaking changes.
But, like https://github.com/python/mypy/pull/13542, I would strongly encourage this eventualy defaulting to `True`.

closes #8845