### PR TITLE
🔧 Setup `ruff format` (initially excluding all files)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Lint with Ruff
       run: ruff check . --output-format github
 
+    - name: Format with Ruff
+      run: ruff format . --diff
+
   flake8:
     runs-on: ubuntu-latest
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -49,7 +49,6 @@ select = [
     # mccabe ('C90')
 #    "C901",  # `{name}` is too complex ({complexity} > {max_complexity})
     # flake8-commas ('COM')
-    "COM812",  # Trailing comma missing
     "COM818",  # Trailing comma on bare tuple prohibited
     "COM819",  # Trailing comma prohibited
     # flake8-copyright ('CPY')
@@ -421,4 +420,71 @@ inline-quotes = "single"
 [lint.isort]
 forced-separate = [
     "tests",
+]
+
+[format]
+quote-style = "single"
+exclude = [
+    "doc/**/*",
+    "sphinx/__init__.py",
+    "sphinx/addnodes.py",
+    "sphinx/application.py",
+    "sphinx/builders/**/*",
+    "sphinx/cmd/**/*",
+    "sphinx/config.py",
+    "sphinx/deprecation.py",
+    "sphinx/directives/**/*",
+    "sphinx/domains/**/*",
+    "sphinx/environment/**/*",
+    "sphinx/errors.py",
+    "sphinx/events.py",
+    "sphinx/ext/**/*",
+    "sphinx/extension.py",
+    "sphinx/highlighting.py",
+    "sphinx/io.py",
+    "sphinx/jinja2glue.py",
+    "sphinx/locale/__init__.py",
+    "sphinx/parsers.py",
+    "sphinx/project.py",
+    "sphinx/pycode/**/*",
+    "sphinx/pygments_styles.py",
+    "sphinx/registry.py",
+    "sphinx/roles.py",
+    "sphinx/search/**/*",
+    "sphinx/templates/**/*",
+    "sphinx/testing/**/*",
+    "sphinx/theming.py",
+    "sphinx/transforms/**/*",
+    "sphinx/util/**/*",
+    "sphinx/versioning.py",
+    "sphinx/writers/**/*",
+    "tests/certs/**/*",
+    "tests/conftest.py",
+    "tests/roots/**/*",
+    "tests/test_addnodes.py",
+    "tests/test_application.py",
+    "tests/test_builders/**/*",
+    "tests/test_config/**/*",
+    "tests/test_directives/**/*",
+    "tests/test_domains/**/*",
+    "tests/test_environment/**/*",
+    "tests/test_errors.py",
+    "tests/test_events.py",
+    "tests/test_extensions/**/*",
+    "tests/test_highlighting.py",
+    "tests/test_intl/**/*",
+    "tests/test_markup/**/*",
+    "tests/test_project.py",
+    "tests/test_pycode/**/*",
+    "tests/test_quickstart.py",
+    "tests/test_roles.py",
+    "tests/test_search.py",
+    "tests/test_theming/**/*",
+    "tests/test_toctree.py",
+    "tests/test_transforms/**/*",
+    "tests/test_util/**/*",
+    "tests/test_versioning.py",
+    "tests/test_writers/**/*",
+    "tests/utils.py",
+    "utils/**/*",
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 .PHONY: all
-all: format style-check type-check test
+all: format style-check type-check doclinter test
 
 .PHONY: clean
 clean: clean

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ style-check:
 	@ruff check .
 
 .PHONY: format-code
-style-check:
+format-code:
 	@ruff format .
 
 .PHONY: type-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 .PHONY: all
-all: format-code style-check type-check test
+all: format style-check type-check test
 
 .PHONY: clean
 clean: clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 .PHONY: all
-all: style-check type-check test
+all: format-code style-check type-check test
 
 .PHONY: clean
 clean: clean
@@ -43,6 +43,10 @@ clean: clean
 .PHONY: style-check
 style-check:
 	@ruff check .
+
+.PHONY: format-code
+style-check:
+	@ruff format .
 
 .PHONY: type-check
 type-check:

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ clean: clean
 style-check:
 	@ruff check .
 
-.PHONY: format-code
-format-code:
+.PHONY: format
+format:
 	@ruff format .
 
 .PHONY: type-check


### PR DESCRIPTION
Lets get this show oin the road!
I think there is no reason to not have a formatter and, especially as we are already adding ruff linting, `ruff format` is a no-brainer.

Lets add it like this first, with all files excluded, so we don't introduce merge conflicts for outstanding PRs etc.
Then we can gradually un-exclude files as we go.
