### PR TITLE
🔧 Add `flake8` to `make style-check`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,6 +22,7 @@ exclude =
     .git,
     .tox,
     .venv,
+    node_modules/*,
     tests/roots/*,
     build/*,
     doc/_build/*,

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ clean: clean
 
 .PHONY: style-check
 style-check:
+	@flake8 .
 	@ruff check .
 
 .PHONY: type-check


### PR DESCRIPTION
Realised this was missing from `make check`,
also skip `node_modules` folder (added when running JS tests)
