### PR TITLE
[lint] ignore ``venv`` directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,6 +22,7 @@ exclude =
     .git,
     .tox,
     .venv,
+    venv,
     node_modules/*,
     tests/roots/*,
     build/*,

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ TAGS
 .tox/
 .tx/
 .venv/
+venv/
 .coverage
 htmlcov
 .DS_Store


### PR DESCRIPTION
I usually use a ``venv`` and not ``.venv`` virtual environment because it's faster to type `python -m venv venv` (just writing venv twice) and it's a common name as said in https://docs.python.org/3/library/venv.html. 