### PR TITLE
📚 add tip about running karma js tests on mac

### DIFF
--- a/doc/internals/contributing.rst
+++ b/doc/internals/contributing.rst
@@ -201,7 +201,7 @@ To run JavaScript tests, use ``npm``::
 
   `karma` requires a Firefox binary to use as a test browser.
 
-  For MacOS, you can specify the path to the Firefox binary using::
+  For Unix-based systems, you can specify the path to the Firefox binary using::
 
     FIREFOX_BIN="/Applications/Firefox.app/Contents/MacOS/firefox" npm test
 

--- a/doc/internals/contributing.rst
+++ b/doc/internals/contributing.rst
@@ -197,6 +197,14 @@ To run JavaScript tests, use ``npm``::
     npm install
     npm run test
 
+.. tip::
+
+  `karma` requires a Firefox binary to use as a test browser.
+
+  For MacOS, you can specify the path to the Firefox binary using::
+
+    FIREFOX_BIN="/Applications/Firefox.app/Contents/MacOS/firefox" npm test
+
 New unit tests should be included in the ``tests`` directory where
 necessary:
 


### PR DESCRIPTION
This is how I got the npm tests to run on my Mac, not sure if there is a similar tip for Linux/Windows