### PR TITLE
[tests] utils: refactor type-hint signatures.

### DIFF
--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -28,7 +28,7 @@ from sphinx.deprecation import RemovedInSphinx80Warning
 from sphinx.testing.util import strip_escseq
 from sphinx.util import requests
 
-from tests.utils import CERT_FILE, http_server, https_server
+from tests.utils import CERT_FILE, http_server
 
 ts_re = re.compile(r".*\[(?P<ts>.*)\].*")
 
@@ -633,7 +633,7 @@ def test_invalid_ssl(get_request, app):
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
 def test_connect_to_selfsigned_fails(app):
-    with https_server(OKHandler):
+    with http_server(OKHandler, tls_enabled=True):
         app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:
@@ -648,7 +648,7 @@ def test_connect_to_selfsigned_fails(app):
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
 def test_connect_to_selfsigned_with_tls_verify_false(app):
     app.config.tls_verify = False
-    with https_server(OKHandler):
+    with http_server(OKHandler, tls_enabled=True):
         app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:
@@ -666,7 +666,7 @@ def test_connect_to_selfsigned_with_tls_verify_false(app):
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
 def test_connect_to_selfsigned_with_tls_cacerts(app):
     app.config.tls_cacerts = CERT_FILE
-    with https_server(OKHandler):
+    with http_server(OKHandler, tls_enabled=True):
         app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:
@@ -684,7 +684,7 @@ def test_connect_to_selfsigned_with_tls_cacerts(app):
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
 def test_connect_to_selfsigned_with_requests_env_var(monkeypatch, app):
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", CERT_FILE)
-    with https_server(OKHandler):
+    with http_server(OKHandler, tls_enabled=True):
         app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:
@@ -702,7 +702,7 @@ def test_connect_to_selfsigned_with_requests_env_var(monkeypatch, app):
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck-localserver-https', freshenv=True)
 def test_connect_to_selfsigned_nonexistent_cert_file(app):
     app.config.tls_cacerts = "does/not/exist"
-    with https_server(OKHandler):
+    with http_server(OKHandler, tls_enabled=True):
         app.build()
 
     with open(app.outdir / 'output.json', encoding='utf-8') as fp:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+__all__ = ["http_server"]
+
+
 from contextlib import contextmanager
 from http.server import ThreadingHTTPServer
 from pathlib import Path
@@ -58,6 +61,3 @@ def http_server(handler: type[BaseRequestHandler], *, tls_enabled: bool = False)
             yield server
         finally:
             server.terminate()
-
-
-__all__ = ["http_server"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["http_server"]
+__all__ = ("http_server",)
 
 from contextlib import contextmanager
 from http.server import ThreadingHTTPServer

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 __all__ = ["http_server"]
 
-
 from contextlib import contextmanager
 from http.server import ThreadingHTTPServer
 from pathlib import Path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,7 +49,7 @@ class HttpsServerThread(HttpServerThread):
 
 
 @contextmanager
-def http_server(handler: type[BaseRequestHandler], tls_enabled: bool = False) -> Iterator[HttpServerThread]:
+def http_server(handler: type[BaseRequestHandler], *, tls_enabled: bool = False) -> Iterator[HttpServerThread]:
     server_cls = HttpsServerThread if tls_enabled else HttpServerThread
     with filelock.FileLock(LOCK_PATH):
         server = server_cls(handler, daemon=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -68,5 +68,9 @@ def create_server(
     return server
 
 
-http_server = create_server(HttpServerThread)
-https_server = create_server(HttpsServerThread)
+def http_server(handler: type[BaseRequestHandler], tls_enabled: bool = False) -> AbstractContextManager[_T_co]:
+    server_cls = HttpsServerThread if tls_enabled else HttpServerThread
+    return create_server(server_cls)(handler)
+
+
+__all__ = ["http_server"]


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Addresses some discussion from https://github.com/sphinx-doc/sphinx/pull/12109#discussion_r1527196512

### Detail
- Consolidate to provision of a single `http_server` utility method, with `tls_enabled` as a boolean flag.
- Rework a few type hints, attempting to make them easier to understand.

### Relates
- Borrows some ideas from #12143.