### PR TITLE
[tests] linkcheck: disable docutils raw parser during raw_node test.

### DIFF
--- a/tests/roots/test-linkcheck-raw-node/docutils.conf
+++ b/tests/roots/test-linkcheck-raw-node/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+raw_enabled: false


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (test network isolation).

### Purpose
- Improve test isolation of the `linkcheck` builder `test_raw_node` test case.

### Detail
- Disable `raw` node processing by the `docutils` parser when linkchecking the contents, using the relevant [`docutils` config setting](https://docutils.sourceforge.io/docs/user/config.html#raw-enabled).
- This may seem weird or wrong for a test that is named `test_raw_node` -- but we don't have to _process_ the node to inspect and linkcheck its' contents.

### Relates
- Supersedes #12143.