### PR TITLE
[autosummary] fix suffix detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,8 @@ Bugs fixed
   Patch by James Addison.
 * #11578: HTML Search: Order non-main index entries after other results.
   Patch by Brad King.
+* #12147: autosummary: Fix a bug that wrong suffix may be used when multiple suffixes are specified by ``source_suffix``.
+  Patch by Sutou Kouhei.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,7 +127,9 @@ Bugs fixed
   Patch by James Addison.
 * #11578: HTML Search: Order non-main index entries after other results.
   Patch by Brad King.
-* #12147: autosummary: Fix a bug that wrong suffix may be used when multiple suffixes are specified by ``source_suffix``.
+* #12147: autosummary: Fix a bug whereby the wrong file extension
+  may be used,
+  when multiple suffixes are specified in :confval:`source_suffix`.
   Patch by Sutou Kouhei.
 
 Testing

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -770,7 +770,7 @@ class AutoLink(SphinxRole):
 
 def get_rst_suffix(app: Sphinx) -> str | None:
     def get_supported_format(suffix: str) -> tuple[str, ...]:
-        parser_class = app.registry.get_source_parsers().get(suffix)
+        parser_class = app.registry.get_source_parsers().get(suffix.removeprefix('.'))
         if parser_class is None:
             return ('restructuredtext',)
         return parser_class.supported


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

`SphinxComponentRegistry.source_parsers` uses `rst`, `md` and so on (without `.`) as key but `source_suffix` in `conf.py` uses `.rst`, `md` and so on (with `.`) as key. So we need to remove preceding `.` from suffixes from `source_suffix` to detect supported format from `SphinxComponentRegistry.source_parsers`.

### Detail

See #12147 which describes what is this problem and how to reproduce this problem.

### Relates
- fix #12147

