### PR TITLE
👌 Improve signature and type annotations for `SphinxLoggerAdapter.warning`

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -166,7 +166,7 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
         and used in :confval:`suppress_warnings` to suppress specific warnings.
 
         It is also recommended to specify a ``location`` whenever possible
-        to help users correcting the warning.
+        to help users in correcting the warning.
 
         :param msg: The message, which may contain placeholders for ``args``.
         :param args: The arguments to substitute into ``msg``.

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -173,7 +173,8 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
                 or the docutils node object.
             :param nonl: whether to append a new line terminator to the message
             :param color: a color code for the message
-            :param once: show message with the same ``msg`` and ``args`` only once
+            :param once: Do not log this warning,
+                if a previous warning already has same ``msg``, ``args`` and ``once=True``.
             """
 
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -163,19 +163,30 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
         ) -> None:
             """Log a sphinx warning.
 
-            :param msg: the message, which may contain placeholders for ``args``
-            :param args: the arguments to substitute into ``msg``
-            :param type: the type of the warning
-            :param subtype: the subtype of the warning
-            :param location: the source location of the warning's origin,
+            :param msg: The message, which may contain placeholders for ``args``.
+            :param args: The arguments to substitute into ``msg``.
+            :param type: The type of the warning.
+            :param subtype: The subtype of the warning.
+            :param location: The source location of the warning's origin,
                 which can be a string (the ``docname`` or ``docname:lineno``),
                 a tuple of ``(docname, lineno)``,
                 or the docutils node object.
-            :param nonl: whether to append a new line terminator to the message
-            :param color: a color code for the message
+            :param nonl: Whether to append a new line terminator to the message.
+            :param color: A color code for the message.
             :param once: Do not log this warning,
                 if a previous warning already has same ``msg``, ``args`` and ``once=True``.
             """
+            return super().warning(
+                msg,
+                *args,
+                type=type,
+                subtype=subtype,
+                location=location,
+                nonl=nonl,
+                color=color,
+                once=once,
+                **kwargs,
+            )
 
 
 class WarningStreamHandler(logging.StreamHandler):

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -161,8 +161,8 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
     ) -> None:
         """Log a sphinx warning.
 
-        It is recommended to include a ``type`` and ``subtype`` for warnings,
-        which can be displayed to the user using :confval:`show_warning_types`
+        It is recommended to include a ``type`` and ``subtype`` for warnings as
+        these can be displayed to the user using :confval:`show_warning_types`
         and used in :confval:`suppress_warnings` to suppress specific warnings.
 
         It is also recommended to specify a ``location`` whenever possible

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -147,46 +147,44 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
     def handle(self, record: logging.LogRecord) -> None:
         self.logger.handle(record)
 
-    if TYPE_CHECKING:
+    def warning(  # type: ignore[override]
+        self,
+        msg: object,
+        *args: object,
+        type: None | str = None,
+        subtype: None | str = None,
+        location: None | str | tuple[str | None, int | None] | Node = None,
+        nonl: bool = True,
+        color: str | None = None,
+        once: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Log a sphinx warning.
 
-        def warning(  # type: ignore[override]
-            self,
-            msg: object,
-            *args: object,
-            type: None | str = None,
-            subtype: None | str = None,
-            location: None | str | tuple[str | None, int | None] | Node = None,
-            nonl: bool = True,
-            color: str | None = None,
-            once: bool = False,
-            **kwargs: Any,
-        ) -> None:
-            """Log a sphinx warning.
-
-            :param msg: The message, which may contain placeholders for ``args``.
-            :param args: The arguments to substitute into ``msg``.
-            :param type: The type of the warning.
-            :param subtype: The subtype of the warning.
-            :param location: The source location of the warning's origin,
-                which can be a string (the ``docname`` or ``docname:lineno``),
-                a tuple of ``(docname, lineno)``,
-                or the docutils node object.
-            :param nonl: Whether to append a new line terminator to the message.
-            :param color: A color code for the message.
-            :param once: Do not log this warning,
-                if a previous warning already has same ``msg``, ``args`` and ``once=True``.
-            """
-            return super().warning(
-                msg,
-                *args,
-                type=type,
-                subtype=subtype,
-                location=location,
-                nonl=nonl,
-                color=color,
-                once=once,
-                **kwargs,
-            )
+        :param msg: The message, which may contain placeholders for ``args``.
+        :param args: The arguments to substitute into ``msg``.
+        :param type: The type of the warning.
+        :param subtype: The subtype of the warning.
+        :param location: The source location of the warning's origin,
+            which can be a string (the ``docname`` or ``docname:lineno``),
+            a tuple of ``(docname, lineno)``,
+            or the docutils node object.
+        :param nonl: Whether to append a new line terminator to the message.
+        :param color: A color code for the message.
+        :param once: Do not log this warning,
+            if a previous warning already has same ``msg``, ``args`` and ``once=True``.
+        """
+        return super().warning(
+            msg,
+            *args,
+            type=type,
+            subtype=subtype,
+            location=location,
+            nonl=nonl,
+            color=color,
+            once=once,
+            **kwargs,
+        )
 
 
 class WarningStreamHandler(logging.StreamHandler):

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -161,6 +161,13 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
     ) -> None:
         """Log a sphinx warning.
 
+        It is recommended to always include a ``type`` and ``subtype`` for warnings.
+        These can be displayed to the user, using :confval:`show_warning_types`,
+        and allow for suppression of specific warning, using :confval:`suppress_warnings`.
+
+        It is also recommended to include a ``location``, where possible,
+        to aide users in correcting the warning.
+
         :param msg: The message, which may contain placeholders for ``args``.
         :param args: The arguments to substitute into ``msg``.
         :param type: The type of the warning.

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -161,12 +161,12 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
     ) -> None:
         """Log a sphinx warning.
 
-        It is recommended to always include a ``type`` and ``subtype`` for warnings.
-        These can be displayed to the user, using :confval:`show_warning_types`,
-        and allow for suppression of specific warning, using :confval:`suppress_warnings`.
+        It is recommended to include a ``type`` and ``subtype`` for warnings,
+        which can be displayed to the user using :confval:`show_warning_types`
+        and used in :confval:`suppress_warnings` to suppress specific warnings.
 
-        It is also recommended to include a ``location``, where possible,
-        to aide users in correcting the warning.
+        It is also recommended to specify a ``location`` whenever possible
+        to help users correcting the warning.
 
         :param msg: The message, which may contain placeholders for ``args``.
         :param args: The arguments to substitute into ``msg``.

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -147,6 +147,35 @@ class SphinxLoggerAdapter(logging.LoggerAdapter):
     def handle(self, record: logging.LogRecord) -> None:
         self.logger.handle(record)
 
+    if TYPE_CHECKING:
+
+        def warning(  # type: ignore[override]
+            self,
+            msg: object,
+            *args: object,
+            type: None | str = None,
+            subtype: None | str = None,
+            location: None | str | tuple[str | None, int | None] | Node = None,
+            nonl: bool = True,
+            color: str | None = None,
+            once: bool = False,
+            **kwargs: Any,
+        ) -> None:
+            """Log a sphinx warning.
+
+            :param msg: the message, which may contain placeholders for ``args``
+            :param args: the arguments to substitute into ``msg``
+            :param type: the type of the warning
+            :param subtype: the subtype of the warning
+            :param location: the source location of the warning's origin,
+                which can be a string (the ``docname`` or ``docname:lineno``),
+                a tuple of ``(docname, lineno)``,
+                or the docutils node object.
+            :param nonl: whether to append a new line terminator to the message
+            :param color: a color code for the message
+            :param once: show message with the same ``msg`` and ``args`` only once
+            """
+
 
 class WarningStreamHandler(logging.StreamHandler):
     """StreamHandler for warnings."""


### PR DESCRIPTION
this is something that has always annoyed me when writing extensions: you get no editor help / type checking when writing logger warnings.

Now you get a lovely detailed docstring / type annotations 👌 

![image](https://github.com/sphinx-doc/sphinx/assets/2997570/7cf2c691-4f10-4d1a-b42c-3317e23df9a3)
