### PR TITLE
[refactor] test utils: simplify signatures and remove from ruff exclusion list.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -471,5 +471,4 @@ exclude = [
     "tests/test_util/**/*",
     "tests/test_versioning.py",
     "tests/test_writers/**/*",
-    "tests/utils.py",
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ import filelock
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from socketserver import BaseRequestHandler
-    from typing import Any, Final
+    from typing import Final
 
 # Generated with:
 # $ openssl req -new -x509 -days 3650 -nodes -out cert.pem \
@@ -27,8 +27,8 @@ LOCK_PATH: Final[str] = str(TESTS_ROOT / 'test-server.lock')
 
 
 class HttpServerThread(Thread):
-    def __init__(self, handler: type[BaseRequestHandler], /, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, handler: type[BaseRequestHandler]) -> None:
+        super().__init__(daemon=True)
         self.server = ThreadingHTTPServer(("localhost", 7777), handler)
 
     def run(self) -> None:
@@ -41,10 +41,8 @@ class HttpServerThread(Thread):
 
 
 class HttpsServerThread(HttpServerThread):
-    def __init__(
-        self, handler: type[BaseRequestHandler], /, *args: Any, **kwargs: Any,
-    ) -> None:
-        super().__init__(handler, *args, **kwargs)
+    def __init__(self, handler: type[BaseRequestHandler]) -> None:
+        super().__init__(handler)
         sslcontext = SSLContext(PROTOCOL_TLS_SERVER)
         sslcontext.load_cert_chain(CERT_FILE)
         self.server.socket = sslcontext.wrap_socket(self.server.socket, server_side=True)
@@ -54,7 +52,7 @@ class HttpsServerThread(HttpServerThread):
 def http_server(handler: type[BaseRequestHandler], *, tls_enabled: bool = False) -> Iterator[HttpServerThread]:
     server_cls = HttpsServerThread if tls_enabled else HttpServerThread
     with filelock.FileLock(LOCK_PATH):
-        server = server_cls(handler, daemon=True)
+        server = server_cls(handler)
         server.start()
         try:
             yield server

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ("http_server",)
+__all__ = ('http_server',)
 
 from contextlib import contextmanager
 from http.server import ThreadingHTTPServer
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # $ openssl req -new -x509 -days 3650 -nodes -out cert.pem \
 #     -keyout cert.pem -addext "subjectAltName = DNS:localhost"
 TESTS_ROOT: Final[Path] = Path(__file__).parent
-CERT_FILE: Final[str] = str(TESTS_ROOT / "certs" / "cert.pem")
+CERT_FILE: Final[str] = str(TESTS_ROOT / 'certs' / 'cert.pem')
 
 # File lock for tests
 LOCK_PATH: Final[str] = str(TESTS_ROOT / 'test-server.lock')
@@ -29,7 +29,7 @@ LOCK_PATH: Final[str] = str(TESTS_ROOT / 'test-server.lock')
 class HttpServerThread(Thread):
     def __init__(self, handler: type[BaseRequestHandler]) -> None:
         super().__init__(daemon=True)
-        self.server = ThreadingHTTPServer(("localhost", 7777), handler)
+        self.server = ThreadingHTTPServer(('localhost', 7777), handler)
 
     def run(self) -> None:
         self.server.serve_forever(poll_interval=0.001)
@@ -49,7 +49,9 @@ class HttpsServerThread(HttpServerThread):
 
 
 @contextmanager
-def http_server(handler: type[BaseRequestHandler], *, tls_enabled: bool = False) -> Iterator[HttpServerThread]:
+def http_server(
+    handler: type[BaseRequestHandler], *, tls_enabled: bool = False
+) -> Iterator[HttpServerThread]:
     server_cls = HttpsServerThread if tls_enabled else HttpServerThread
     with filelock.FileLock(LOCK_PATH):
         server = server_cls(handler)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Expand `ruff` formatting through the codebase.

### Detail
- Apply some small method-signature cleanups in `tests/utils.py`.
- Remove `tests/utils.py` from the `ruff` exclusion list.

### Relates
- Follow-up to #12146 to remove `tests/utils.py` from the `ruff` exclusion list.