### PR TITLE
[tests] deprecate ``html5lib`` in favor of ``lxml.html``

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,7 @@ jobs:
       run: python --version
     - name: Install graphviz
       run: sudo apt-get install graphviz
-    - name: Install development libraries
-      if: matrix.python == "3.13"
+    - name: Install lxml dependencies
       run: sudo apt-get install libxml2-dev libxslt-dev
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,9 @@ jobs:
       run: python --version
     - name: Install graphviz
       run: sudo apt-get install graphviz
+    - name: Install development libraries
+      if: matrix.python == "3.13"
+      run: sudo apt-get install libxml2-dev libxslt-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ lint = [
 ]
 test = [
     "pytest>=6.0",
-    "html5lib",
+    "lxml",  # because native XML does not support all HTML specs
     "cython>=3.0",
     "setuptools>=67.0",  # for Cython compilation
     "filelock",

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -6,14 +6,14 @@ import contextlib
 import os
 import re
 import sys
-import warnings
 from io import StringIO
 from types import MappingProxyType
 from typing import TYPE_CHECKING
-from xml.etree import ElementTree
+from xml.etree.ElementTree import parse as parse_xml_etree
 
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
+from lxml.html import parse as parse_html_etree
 
 import sphinx.application
 import sphinx.locale
@@ -24,8 +24,10 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
     from typing import Any
+    from xml.etree.ElementTree import ElementTree as XmlElementTree
 
     from docutils.nodes import Node
+    from lxml.etree import _ElementTree as HtmlElementTree
 
 __all__ = 'SphinxTestApp', 'SphinxTestAppWrapperForSkipBuilding'
 
@@ -70,10 +72,14 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
                 f'The node{xpath}[{key}] is not {value!r}: {node[key]!r}'
 
 
-def etree_parse(path: str) -> Any:
-    with warnings.catch_warnings(record=False):
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        return ElementTree.parse(path)  # NoQA: S314  # using known data in tests
+def etree_parse(path: str | os.PathLike[str]) -> XmlElementTree:
+    """Parse an XML document as an Element tree."""
+    return parse_xml_etree(path)  # NoQA: S314
+
+
+def etree_html_parse(path: str | os.PathLike[str]) -> HtmlElementTree:
+    """Parse an HTML document as an Element tree."""
+    return parse_html_etree(path)
 
 
 class SphinxTestApp(sphinx.application.Sphinx):

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -11,9 +11,9 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING
 from xml.etree.ElementTree import parse as parse_xml_etree
 
+import lxml.html
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
-from lxml.html import parse as parse_html_etree
 
 import sphinx.application
 import sphinx.locale
@@ -78,8 +78,13 @@ def etree_parse(path: str | os.PathLike[str]) -> XmlElementTree:
 
 
 def etree_html_parse(path: str | os.PathLike[str]) -> HtmlElementTree:
-    """Parse an HTML document as an Element tree."""
-    return parse_html_etree(path)
+    """Parse an HTML document as an Element tree.
+
+    The source is assumed to be UTF-8 encoded.
+    """
+    # allow for very large trees
+    parser = lxml.html.HTMLParser(huge_tree=True, encoding='utf-8')
+    return lxml.html.parse(path, parser=parser)
 
 
 class SphinxTestApp(sphinx.application.Sphinx):

--- a/tests/test_builders/html_util.py
+++ b/tests/test_builders/html_util.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import TYPE_CHECKING
+
+import lxml.etree
+from lxml.etree import _Element as ElementLXML
+from lxml.etree import _ElementTree as ElementTreeLXML
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+def _get_text(node: ElementLXML) -> str:
+    if node.text is not None:
+        # the node has only one text
+        return node.text
+
+    # the node has tags and text; gather texts just under the node
+    return ''.join(n.tail or '' for n in node)
+
+
+def check_xpath(
+    etree: ElementTreeLXML,
+    fname: str | os.PathLike[str],
+    xpath: str,
+    check: str | re.Pattern[str] | Callable[[Sequence[ElementLXML]], None] | None,
+    be_found: bool = True,
+) -> None:
+    assert isinstance(etree, ElementTreeLXML)
+
+    nodes = list(etree.findall(xpath))
+    assert all(isinstance(node, ElementLXML) for node in nodes)
+
+    if check is None:
+        assert nodes == [], ('found any nodes matching xpath '
+                             f'{xpath!r} in file {os.fsdecode(fname)}')
+        return
+    else:
+        assert nodes != [], ('did not find any node matching xpath '
+                             f'{xpath!r} in file {os.fsdecode(fname)}')
+    if callable(check):
+        check(nodes)
+    elif not check:
+        # only check for node presence
+        pass
+    else:
+        rex = re.compile(check)
+        if be_found:
+            if any(rex.search(_get_text(node)) for node in nodes):
+                return
+        else:
+            if all(not rex.search(_get_text(node)) for node in nodes):
+                return
+
+        context = list(map(lxml.etree.tostring, nodes))
+        msg = (f'{check!r} not found in any node matching '
+               f'{xpath!r} in file {os.fsdecode(fname)}: {context}')
+        raise AssertionError(msg)

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -1,5 +1,7 @@
 """Test the HTML builder and check output against XPath."""
 
+from __future__ import annotations
+
 import posixpath
 import re
 
@@ -10,43 +12,9 @@ from sphinx.deprecation import RemovedInSphinx80Warning
 from sphinx.errors import ConfigError
 from sphinx.util.inventory import InventoryFile
 
+from tests.test_builders.html_util import check_xpath
+
 FIGURE_CAPTION = ".//figure/figcaption/p"
-
-
-def check_xpath(etree, fname, path, check, be_found=True):
-    nodes = list(etree.findall(path))
-    if check is None:
-        assert nodes == [], ('found any nodes matching xpath '
-                             f'{path!r} in file {fname}')
-        return
-    else:
-        assert nodes != [], ('did not find any node matching xpath '
-                             f'{path!r} in file {fname}')
-    if callable(check):
-        check(nodes)
-    elif not check:
-        # only check for node presence
-        pass
-    else:
-        def get_text(node):
-            if node.text is not None:
-                # the node has only one text
-                return node.text
-            else:
-                # the node has tags and text; gather texts just under the node
-                return ''.join(n.tail or '' for n in node)
-
-        rex = re.compile(check)
-        if be_found:
-            if any(rex.search(get_text(node)) for node in nodes):
-                return
-        else:
-            if all(not rex.search(get_text(node)) for node in nodes):
-                return
-
-        msg = (f'{check!r} not found in any node matching '
-               f'{path!r} in file {fname}: {[node.text for node in nodes]!r}')
-        raise AssertionError(msg)
 
 
 def test_html4_error(make_app, tmp_path):

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -274,13 +274,3 @@ def tail_check(check):
 def test_html5_output(app, cached_etree_parse, fname, path, check):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check)
-
-
-@pytest.mark.sphinx('html', tags=['testtag'],
-                    confoverrides={'html_context.hckey_co': 'hcval_co'})
-@pytest.mark.test_params(shared_result='test_build_html_output')
-def test_foo(app, cached_etree_parse):
-    fname, path, check = ('includes.html', ".//div[@class='inc-startend highlight-text notranslate']//pre", '^foo')
-
-    app.build()
-    check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check, False)

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -128,7 +128,7 @@ def tail_check(check):
     # ``seealso`` directive
     ('markup.html', ".//div/p[@class='admonition-title']", 'See also'),
     # a ``hlist`` directive
-    ('markup.html', ".//table[@class='hlist']/tbody/tr/td/ul/li/p", '^This$'),
+    ('markup.html', ".//table[@class='hlist']/tr/td/ul/li/p", '^This$'),
     # a ``centered`` directive
     ('markup.html', ".//p[@class='centered']/strong", 'LICENSE'),
     # a glossary

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from tests.test_builders.test_build_html import check_xpath
+from tests.test_builders.html_util import check_xpath
 
 
 def tail_check(check):
@@ -274,3 +274,13 @@ def tail_check(check):
 def test_html5_output(app, cached_etree_parse, fname, path, check):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check)
+
+
+@pytest.mark.sphinx('html', tags=['testtag'],
+                    confoverrides={'html_context.hckey_co': 'hcval_co'})
+@pytest.mark.test_params(shared_result='test_build_html_output')
+def test_foo(app, cached_etree_parse):
+    fname, path, check = ('includes.html', ".//div[@class='inc-startend highlight-text notranslate']//pre", '^foo')
+
+    app.build()
+    check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check, False)

--- a/tests/test_builders/test_build_html_numfig.py
+++ b/tests/test_builders/test_build_html_numfig.py
@@ -5,7 +5,8 @@ import re
 
 import pytest
 
-from tests.test_builders.test_build_html import FIGURE_CAPTION, check_xpath
+from tests.test_builders.html_util import check_xpath
+from tests.test_builders.test_build_html import FIGURE_CAPTION
 
 
 @pytest.mark.sphinx('html', testroot='numfig')

--- a/tests/test_builders/test_build_html_tocdepth.py
+++ b/tests/test_builders/test_build_html_tocdepth.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.test_builders.test_build_html import check_xpath
+from tests.test_builders.html_util import check_xpath
 
 
 @pytest.mark.parametrize(("fname", "path", "check", "be_found"), [

--- a/tests/test_domains/test_domain_std.py
+++ b/tests/test_domains/test_domain_std.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 from docutils import nodes
 from docutils.nodes import definition, definition_list, definition_list_item, term
-from html5lib import HTMLParser
 
 from sphinx import addnodes
 from sphinx.addnodes import (
@@ -20,7 +19,7 @@ from sphinx.addnodes import (
 )
 from sphinx.domains.std import StandardDomain
 from sphinx.testing import restructuredtext
-from sphinx.testing.util import assert_node
+from sphinx.testing.util import assert_node, etree_html_parse
 
 
 def test_process_doc_handle_figure_caption():
@@ -375,9 +374,11 @@ def test_productionlist(app, status, warning):
     assert warnings[-1] == ''
     assert "Dup2.rst:4: WARNING: duplicate token description of Dup, other instance in Dup1" in warnings[0]
 
-    with (app.outdir / 'index.html').open('rb') as f:
-        etree = HTMLParser(namespaceHTMLElements=False).parse(f)
-    ul = list(etree.iter('ul'))[1]
+    etree = etree_html_parse(app.outdir / 'index.html')
+    elements = list(etree.iter('ul'))
+    assert len(elements) >= 2
+
+    ul = elements[1]
     cases = []
     for li in list(ul):
         assert len(list(li)) == 1

--- a/tests/test_extensions/test_ext_napoleon_docstring.py
+++ b/tests/test_extensions/test_ext_napoleon_docstring.py
@@ -9,7 +9,6 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
-from html5lib import HTMLParser
 
 from sphinx.ext.intersphinx import load_mappings, normalize_intersphinx_mapping
 from sphinx.ext.napoleon import Config
@@ -21,6 +20,7 @@ from sphinx.ext.napoleon.docstring import (
     _token_type,
     _tokenize_type_spec,
 )
+from sphinx.testing.util import etree_html_parse
 
 from tests.test_extensions.ext_napoleon_pep526_data_google import PEP526GoogleClass
 from tests.test_extensions.ext_napoleon_pep526_data_numpy import PEP526NumpyClass
@@ -2684,8 +2684,7 @@ int py:class 1 int.html -
 
     app.build(force_all=True)
 
-    buffer = (app.outdir / 'index.html').read_bytes()
-    etree = HTMLParser(namespaceHTMLElements=False).parse(buffer)
+    etree = etree_html_parse(app.outdir / 'index.html')
 
     for name, typename in product(('keyword', 'kwarg', 'kwparam'), ('paramtype', 'kwtype')):
         param = f'{name}_{typename}'

--- a/tests/test_markup/test_smartquotes.py
+++ b/tests/test_markup/test_smartquotes.py
@@ -1,7 +1,8 @@
 """Test smart quotes."""
 
 import pytest
-from html5lib import HTMLParser
+
+from sphinx.testing.util import etree_html_parse
 
 
 @pytest.mark.sphinx(buildername='html', testroot='smartquotes', freshenv=True)
@@ -16,8 +17,8 @@ def test_basic(app, status, warning):
 def test_literals(app, status, warning):
     app.build()
 
-    with (app.outdir / 'literals.html').open(encoding='utf-8') as html_file:
-        etree = HTMLParser(namespaceHTMLElements=False).parse(html_file)
+    etree = etree_html_parse(app.outdir / 'literals.html')
+    assert next(etree.iter('code'), None) is not None
 
     for code_element in etree.iter('code'):
         code_text = ''.join(code_element.itertext())


### PR DESCRIPTION
Closes #12150.

Note that we still need to use ``lxml.html`` because some HTML documents are not XML-compliant. For instance, `search.html` contains `<script src="..." defer />`. While it is correct in HTML, it is not in XML to have an attribute without a value (namely `defer` raises a parser error).

There was a subtle bug in

```
('markup.html', ".//table[@class='hlist']/tr/td/ul/li/p", '^This$'),
```

where the xpath was ``.//table[@class='hlist']/tbody/tr/td/ul/li/p`` (i.e., contained a ``tbody`` additional node). Apparently ``html5lib`` ignored it and directly jumped to ``tr`` (i.e., it was meant to be "implicit") but technically speaking it's incorrect since the HTML content is `<table class="hlist"><tr><td>...`.