### PR TITLE
[tests] Increase timeouts for linkcheck build tests.

### DIFF
--- a/tests/roots/test-linkcheck-anchors-ignore-for-url/conf.py
+++ b/tests/roots/test-linkcheck-anchors-ignore-for-url/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-anchors-ignore/conf.py
+++ b/tests/roots/test-linkcheck-anchors-ignore/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-documents_exclude/conf.py
+++ b/tests/roots/test-linkcheck-documents_exclude/conf.py
@@ -3,4 +3,4 @@ linkcheck_exclude_documents = [
     '^broken_link$',
     'br[0-9]ken_link',
 ]
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-localserver-anchor/conf.py
+++ b/tests/roots/test-linkcheck-localserver-anchor/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-localserver-https/conf.py
+++ b/tests/roots/test-linkcheck-localserver-https/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-localserver-warn-redirects/conf.py
+++ b/tests/roots/test-linkcheck-localserver-warn-redirects/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-localserver/conf.py
+++ b/tests/roots/test-linkcheck-localserver/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-raw-node/conf.py
+++ b/tests/roots/test-linkcheck-raw-node/conf.py
@@ -1,2 +1,2 @@
 exclude_patterns = ['_build']
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck-too-many-retries/conf.py
+++ b/tests/roots/test-linkcheck-too-many-retries/conf.py
@@ -1,3 +1,3 @@
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25

--- a/tests/roots/test-linkcheck/conf.py
+++ b/tests/roots/test-linkcheck/conf.py
@@ -1,4 +1,4 @@
 root_doc = 'links'
 exclude_patterns = ['_build']
 linkcheck_anchors = True
-linkcheck_timeout = 0.05
+linkcheck_timeout = 0.25


### PR DESCRIPTION
### Feature or Bugfix
- Workaround

### Purpose
- Reduce distration due to failed continuous integration pipelines.

### Detail
- Increase the timeout duration in `linkcheck`-related test roots by a factor of 5x, to a quarter-second.

### Relates
- May resolve #12159.