### PR TITLE
[themes] search.html: allow the output conform to both XML and HTML5.

### DIFF
--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -15,7 +15,7 @@
     <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
-    <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
+    <script src="{{ pathto('searchindex.js', 1) }}" defer="defer"></script>
     <meta name="robots" content="noindex" />
     {{ super() }}
 {% endblock %}

--- a/tests/test_theming/test_html_theme.py
+++ b/tests/test_theming/test_html_theme.py
@@ -1,3 +1,5 @@
+from xml.etree.ElementTree import ElementTree
+
 import pytest
 
 
@@ -28,3 +30,10 @@ def test_theme_having_multiple_stylesheets(app):
 
     assert '<link rel="stylesheet" type="text/css" href="_static/mytheme.css" />' in content
     assert '<link rel="stylesheet" type="text/css" href="_static/extra.css" />' in content
+
+
+@pytest.mark.sphinx('html', testroot='theming')
+def test_html_well_formed(app):
+    app.build()
+
+    ElementTree().parse(app.outdir / 'search.html')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Allows the `search.html` file to parse as XML, something that could reduce our dependency on permissive HTML parsers such as `lxml`/`html5lib`.

### Detail
- Broadly speaking, the [WHATWG HTML Standard](https://html.spec.whatwg.org/) does not allow [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) -- like `defer` on `<script>` elements -- to contain a value.
- However, it does make exceptions, allowing for the empty-string as a value, or alternative an exact-ASCII-match for the name of the attribute itself (`defer="defer"`).

### Relates
- Encountered during review of #12157.
- Relates to discussion topic #12165.