### PR TITLE
[CI/CD] linting: share job steps up-to-and-including pip and lint dependency installation.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,8 @@ jobs:
       run: python -m pip install --upgrade pip
     - name: Install linting dependencies
       run: python -m pip install ".[lint]"
+    - name: Install test dependencies to support type-checks
+      run: python -m pip install ".[test]"
     - name: Type check with mypy
       run: mypy
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,10 +28,8 @@ jobs:
     - name: Install pip
       run: python -m pip install --upgrade pip
 
-    - name: Install Ruff
-      run: |
-          ruff_version=$(awk -F'[="]' '/\[project\.optional-dependencies\]/ {p=1} /ruff/ {if (p) print $4}' pyproject.toml)
-          python -m pip install "ruff==${ruff_version}"
+    - name: Install linting dependencies
+      run: python -m pip install ".[lint]"
 
     - name: Lint with Ruff
       run: ruff check . --output-format github
@@ -48,10 +46,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade "flake8>=3.5.0"
+    - name: Install pip
+      run: python -m pip install --upgrade pip
+    - name: Install linting dependencies
+      run: python -m pip install ".[lint]"
     - name: Lint with flake8
       run: flake8 .
 
@@ -64,10 +62,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ".[lint,test]"
+    - name: Install pip
+      run: python -m pip install --upgrade pip
+    - name: Install linting dependencies
+      run: python -m pip install ".[lint]"
     - name: Type check with mypy
       run: mypy
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- By using identical job steps during the creation phases of linting-related jobs, it _may_ be possible (I don't know whether it's implemented in practice) allow GitHub to re-use container images when running the relevant workflows.  It's also a little more consistent.

### Detail
- Installation of precise versions of `ruff` should occur as long as that is what is [configured in `pyproject.toml`](https://github.com/sphinx-doc/sphinx/blob/66fa790b3a41b97ccbdd61e072cb2098886a7a74/pyproject.toml#L85).
- For linting jobs, perform a `pip` upgrade install, followed by a `.[lint]` dependency set install.
- For `mypy`, where we _also_ want to having typing information for some of the test dependencies, subsequently install those too (`.` should be detected as already-installed, I think?).

### Relates
- #12065