### PR TITLE
CI: Print detailed Python version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Check Python version
-      run: python --version
+      run: python --version --version
     - name: Install graphviz
       run: sudo apt-get install graphviz
     - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
       with:
         python-version: "3"
     - name: Check Python version
-      run: python --version
+      run: python --version --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -104,7 +104,7 @@ jobs:
       with:
         python-version: "3"
     - name: Check Python version
-      run: python --version
+      run: python --version --version
     - name: Install graphviz
       run: sudo apt-get install graphviz
     - name: Install dependencies
@@ -131,7 +131,7 @@ jobs:
       with:
         python-version: "3"
     - name: Check Python version
-      run: python --version
+      run: python --version --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -154,7 +154,7 @@ jobs:
       with:
         python-version: "3"
     - name: Check Python version
-      run: python --version
+      run: python --version --version
     - name: Install graphviz
       run: sudo apt-get install graphviz
     - name: Install dependencies


### PR DESCRIPTION
### Purpose
- Print more debug info on CI

### Detail

Running `python` with a single `--version` gives info like:

```
Python 3.12.2
Python 3.13.0a5+
```

Running with a double `--version --version` gives more details:

```
Python 3.12.2 (v3.12.2:6abddd9f6a, Feb  6 2024, 17:02:06) [Clang 13.0.0 (clang-1300.0.29.30)]
Python 3.13.0a5+ (heads/main-dirty:63d6f2623e, Mar 22 2024, 15:29:42) [Clang 15.0.0 (clang-1500.3.9.4)]
```

This contains a commit hash and timestamp, which could be useful in identifying the Python version in more details.

