### PR TITLE
[changelog] Fixup / improvement: add confval role to entry for 'linkcheck_allow_unauthorized'.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,7 +89,7 @@ Bugs fixed
 * #11715: Apply ``tls_verify`` and ``tls_cacerts`` config to
   ``ImageDownloader``.
   Patch by Nick Touran.
-* #11433: Added the ``linkcheck_allow_unauthorized`` configuration option.
+* #11433: Added the :confval:`linkcheck_allow_unauthorized` configuration option.
   Set this option to ``False`` to report HTTP 401 (unauthorized) server
   responses as broken.
   Patch by James Addison.


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Add better context about what the `linkcheck_allow_unauthorized` reference relates to in the changelog.

### Detail
- Add the `confval` role to the `linkcheck_allow_unauthorized` reference in the changelog.

### Relates
- Follow-up to #11684.