### PR TITLE
Verify that an asset file to be copied exists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,9 @@ Bugs fixed
   may be used,
   when multiple suffixes are specified in :confval:`source_suffix`.
   Patch by Sutou Kouhei.
+* #10786: improve the error message when a file to be copied (e.g., an asset)
+  is removed during Sphinx execution.
+  Patch by Bénédikt Tran.
 
 Testing
 -------

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -97,7 +97,8 @@ def copyfile(source: str | os.PathLike[str], dest: str | os.PathLike[str]) -> No
     .. note:: :func:`copyfile` is a no-op if *source* and *dest* are identical.
     """
     if not path.exists(source):
-        raise FileNotFoundError(source)
+        msg = f'{os.fsdecode(source)} does not exist'
+        raise FileNotFoundError(msg)
 
     if not path.exists(dest) or not filecmp.cmp(source, dest):
         shutil.copyfile(source, dest)

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -11,13 +11,14 @@ import sys
 import unicodedata
 from io import StringIO
 from os import path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from sphinx.deprecation import _deprecation_warning
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from types import TracebackType
+    from typing import Any
 
 # SEP separates path elements in the canonical file names
 #
@@ -89,8 +90,15 @@ def copytimes(source: str | os.PathLike[str], dest: str | os.PathLike[str]) -> N
 def copyfile(source: str | os.PathLike[str], dest: str | os.PathLike[str]) -> None:
     """Copy a file and its modification times, if possible.
 
-    Note: ``copyfile`` skips copying if the file has not been changed
+    :param source: An existing source to copy.
+    :param dest: The destination path.
+    :raise FileNotFoundError: The *source* does not exist.
+
+    .. note:: :func:`copyfile` is a no-op if *source* and *dest* are identical.
     """
+    if not path.exists(source):
+        raise FileNotFoundError(source)
+
     if not path.exists(dest) or not filecmp.cmp(source, dest):
         shutil.copyfile(source, dest)
         with contextlib.suppress(OSError):

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -1,11 +1,8 @@
 """Test the HTML builder and check output against XPath."""
 
-from __future__ import annotations
-
 import os
 import posixpath
 import re
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,10 +11,6 @@ from sphinx.deprecation import RemovedInSphinx80Warning
 from sphinx.errors import ConfigError
 from sphinx.util.console import strip_colors
 from sphinx.util.inventory import InventoryFile
-
-if TYPE_CHECKING:
-
-    from sphinx.application import Sphinx
 
 FIGURE_CAPTION = ".//figure/figcaption/p"
 
@@ -403,7 +396,7 @@ def test_html_remove_sources_before_write_gh_issue_10786(app, warning):
     # see:  https://github.com/sphinx-doc/sphinx/issues/10786
     target = app.srcdir / 'img.png'
 
-    def handler(app: Sphinx) -> list[object]:
+    def handler(app):
         assert target.exists()
         target.unlink()
         return []

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -1,14 +1,23 @@
 """Test the HTML builder and check output against XPath."""
 
+from __future__ import annotations
+
+import os
 import posixpath
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
 from sphinx.builders.html import validate_html_extra_path, validate_html_static_path
 from sphinx.deprecation import RemovedInSphinx80Warning
 from sphinx.errors import ConfigError
+from sphinx.util.console import strip_colors
 from sphinx.util.inventory import InventoryFile
+
+if TYPE_CHECKING:
+
+    from sphinx.application import Sphinx
 
 FIGURE_CAPTION = ".//figure/figcaption/p"
 
@@ -387,3 +396,25 @@ def test_html_signaturereturn_icon(app):
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
 
     assert ('<span class="sig-return-icon">&#x2192;</span>' in content)
+
+
+@pytest.mark.sphinx('html', testroot='root', srcdir=os.urandom(4).hex())
+def test_html_remove_sources_before_write_gh_issue_10786(app, warning):
+    # see:  https://github.com/sphinx-doc/sphinx/issues/10786
+    target = app.srcdir / 'img.png'
+
+    def handler(app: Sphinx) -> list[object]:
+        assert target.exists()
+        target.unlink()
+        return []
+
+    app.connect('html-collect-pages', handler)
+    assert target.exists()
+    app.build()
+    assert not target.exists()
+
+    ws = strip_colors(warning.getvalue()).splitlines()
+    assert len(ws) >= 1
+
+    file = os.fsdecode(target)
+    assert f'WARNING: cannot copy image file {file!r}: {file!s} does not exist' == ws[-1]


### PR DESCRIPTION
Closes #10786.

While this might come at a small cost for verifying whether the path exists or not, this is needed to get a better message because `shutil.copyfile` suppresses `FileNotFoundError` if the source does not exist.