### PR TITLE
[cleanup] deprecate ``sphinx.testing.util.strip_escseq`` in favor of ``sphinx.util.console.strip_colors``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Deprecated
   the public properties :attr:`!sphinx.testing.util.SphinxTestApp.status`
   and :attr:`!sphinx.testing.util.SphinxTestApp.warning` instead.
   Patch by Bénédikt Tran.
+* :func:`sphinx.testing.util.strip_escseq` is deprecated in favor of
+  :func:`sphinx.util.console.strip_colors`.
+  Patch by Bénédikt Tran.
 
 Features added
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,8 @@ Deprecated
   the public properties :attr:`!sphinx.testing.util.SphinxTestApp.status`
   and :attr:`!sphinx.testing.util.SphinxTestApp.warning` instead.
   Patch by Bénédikt Tran.
-* :func:`sphinx.testing.util.strip_escseq` is deprecated in favor of
-  :func:`sphinx.util.console.strip_colors`.
+* tests: :func:`!sphinx.testing.util.strip_escseq` is deprecated in favor of
+  :func:`!sphinx.util.console.strip_colors`.
   Patch by Bénédikt Tran.
 
 Features added

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -22,6 +22,11 @@ The following is a list of deprecated interfaces.
      - Removed
      - Alternatives
 
+   * - ``sphinx.testing.util.strip_escseq``
+     - 7.3
+     - 9.0
+     - ``sphinx.util.console.strip_colors``
+
    * - Old-style Makefiles in ``sphinx-quickstart``
        and the :option:`!-M`, :option:`!-m`, :option:`!--no-use-make-mode`,
        and :option:`!--use-make-mode` options

--- a/sphinx/deprecation.py
+++ b/sphinx/deprecation.py
@@ -22,6 +22,7 @@ def _deprecation_warning(
     canonical_name: str,
     *,
     remove: tuple[int, int],
+    strict: bool = False,
 ) -> None:
     """Helper function for module-level deprecations using __getattr__
 
@@ -45,6 +46,9 @@ def _deprecation_warning(
            deprecated_object, canonical_name, remove = _DEPRECATED_OBJECTS[name]
            _deprecation_warning(__name__, name, canonical_name, remove=remove)
            return deprecated_object
+
+    When *strict* is true, an exception is raised instead so that it is easy
+    to know where such object is being in tests where warnings are intercepted.
     """
     if remove == (8, 0):
         warning_class: type[Warning] = RemovedInSphinx80Warning
@@ -62,6 +66,8 @@ def _deprecation_warning(
     else:
         message = f'{qualified_name!r} is deprecated.'
 
-    warnings.warn(
-        message + ' Check CHANGES for Sphinx API modifications.', warning_class, stacklevel=3
-    )
+    if strict:
+        raise AttributeError(message)
+
+    message = f'{message} Check CHANGES for Sphinx API modifications.'
+    warnings.warn(message, warning_class, stacklevel=3)

--- a/sphinx/deprecation.py
+++ b/sphinx/deprecation.py
@@ -22,7 +22,6 @@ def _deprecation_warning(
     canonical_name: str,
     *,
     remove: tuple[int, int],
-    strict: bool = False,
 ) -> None:
     """Helper function for module-level deprecations using __getattr__
 
@@ -46,9 +45,6 @@ def _deprecation_warning(
            deprecated_object, canonical_name, remove = _DEPRECATED_OBJECTS[name]
            _deprecation_warning(__name__, name, canonical_name, remove=remove)
            return deprecated_object
-
-    When *strict* is true, an exception is raised instead so that it is easy
-    to know where such object is being in tests where warnings are intercepted.
     """
     if remove == (8, 0):
         warning_class: type[Warning] = RemovedInSphinx80Warning
@@ -66,8 +62,6 @@ def _deprecation_warning(
     else:
         message = f'{qualified_name!r} is deprecated.'
 
-    if strict:
-        raise AttributeError(message)
-
-    message = f'{message} Check CHANGES for Sphinx API modifications.'
-    warnings.warn(message, warning_class, stacklevel=3)
+    warnings.warn(
+        message + ' Check CHANGES for Sphinx API modifications.', warning_class, stacklevel=3
+    )

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -244,7 +244,7 @@ def _clean_up_global_state() -> None:
 
 # deprecated name -> (object to return, canonical path or empty string)
 _DEPRECATED_OBJECTS = {
-    'strip_escseq': (strip_colors, 'sphinx.util.console.strip_colors'),
+    'strip_escseq': (strip_colors, 'sphinx.util.console.strip_colors', (9, 0)),
 }
 
 
@@ -255,6 +255,6 @@ def __getattr__(name: str) -> Any:
 
     from sphinx.deprecation import _deprecation_warning
 
-    deprecated_object, canonical_name, remove, strict = _DEPRECATED_OBJECTS[name]
+    deprecated_object, canonical_name, remove = _DEPRECATED_OBJECTS[name]
     _deprecation_warning(__name__, name, canonical_name, remove=remove)
     return deprecated_object

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -25,7 +25,7 @@ from sphinx.util.docutils import additional_nodes
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
-    from typing import Any
+    from typing import Any, Final
 
     from docutils.nodes import Node
 
@@ -242,7 +242,7 @@ def _clean_up_global_state() -> None:
     sphinx.pycode.ModuleAnalyzer.cache.clear()
 
 
-_DEPRECATED_OBJECTS: dict[str, tuple[object, str, tuple[int, int]]] = {
+_DEPRECATED_OBJECTS: Final[dict[str, tuple[object, str, tuple[int, int]]]] = {
     'strip_escseq': (strip_colors, 'sphinx.util.console.strip_colors', (9, 0)),
 }
 

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -242,7 +242,7 @@ def _clean_up_global_state() -> None:
     sphinx.pycode.ModuleAnalyzer.cache.clear()
 
 
-_DEPRECATED_OBJECTS: Mapping[str, tuple[object, str, tuple[int, int]]] = {
+_DEPRECATED_OBJECTS: dict[str, tuple[object, str, tuple[int, int]]] = {
     'strip_escseq': (strip_colors, 'sphinx.util.console.strip_colors', (9, 0)),
 }
 

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -242,8 +242,7 @@ def _clean_up_global_state() -> None:
     sphinx.pycode.ModuleAnalyzer.cache.clear()
 
 
-# deprecated name -> (object to return, canonical path or empty string)
-_DEPRECATED_OBJECTS = {
+_DEPRECATED_OBJECTS: Mapping[str, tuple[object, str, tuple[int, int]]] = {
     'strip_escseq': (strip_colors, 'sphinx.util.console.strip_colors', (9, 0)),
 }
 

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -6,6 +6,10 @@ import os
 import re
 import shutil
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Final
 
 try:
     # check if colorama is installed to support color on Windows
@@ -23,6 +27,8 @@ _ansi_re: re.Pattern[str] = re.compile(
       \dK                # ANSI Erase in Line
     )""",
     re.VERBOSE | re.ASCII)
+_ansi_color_re: Final[re.Pattern[str]] = re.compile('\x1b.*?m')
+
 codes: dict[str, str] = {}
 
 
@@ -93,7 +99,7 @@ def colorize(name: str, text: str, input_mode: bool = False) -> str:
 
 
 def strip_colors(s: str) -> str:
-    return re.compile('\x1b.*?m').sub('', s)
+    return _ansi_color_re.sub('', s)
 
 
 def _strip_escape_sequences(s: str) -> str:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -13,8 +13,9 @@ from docutils import nodes
 
 import sphinx.application
 from sphinx.errors import ExtensionError
-from sphinx.testing.util import SphinxTestApp, strip_escseq
+from sphinx.testing.util import SphinxTestApp
 from sphinx.util import logging
+from sphinx.util.console import strip_colors
 
 if TYPE_CHECKING:
     import os
@@ -79,13 +80,13 @@ def test_emit_with_nonascii_name_node(app, status, warning):
 
 def test_extensions(app, status, warning):
     app.setup_extension('shutil')
-    warning = strip_escseq(warning.getvalue())
+    warning = strip_colors(warning.getvalue())
     assert "extension 'shutil' has no setup() function" in warning
 
 
 def test_extension_in_blacklist(app, status, warning):
     app.setup_extension('sphinxjp.themecore')
-    msg = strip_escseq(warning.getvalue())
+    msg = strip_colors(warning.getvalue())
     assert msg.startswith("WARNING: the extension 'sphinxjp.themecore' was")
 
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -25,8 +25,8 @@ from sphinx.builders.linkcheck import (
     RateLimit,
 )
 from sphinx.deprecation import RemovedInSphinx80Warning
-from sphinx.testing.util import strip_escseq
 from sphinx.util import requests
+from sphinx.util.console import strip_colors
 
 from tests.utils import CERT_FILE, http_server
 
@@ -588,7 +588,7 @@ def test_linkcheck_allowed_redirects(app, warning):
     }
 
     assert ("index.rst:3: WARNING: redirect  http://localhost:7777/path2 - with Found to "
-            "http://localhost:7777/?redirected=1\n" in strip_escseq(warning.getvalue()))
+            "http://localhost:7777/?redirected=1\n" in strip_colors(warning.getvalue()))
     assert len(warning.getvalue().splitlines()) == 1
 
 
@@ -785,7 +785,7 @@ def test_too_many_requests_retry_after_int_delay(app, capsys, status):
         "info": "",
     }
     rate_limit_log = "-rate limited-   http://localhost:7777/ | sleeping...\n"
-    assert rate_limit_log in strip_escseq(status.getvalue())
+    assert rate_limit_log in strip_colors(status.getvalue())
     _stdout, stderr = capsys.readouterr()
     assert stderr == textwrap.dedent(
         """\

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from sphinx.testing.util import strip_escseq
+from sphinx.util.console import strip_colors
 
 ENV_WARNINGS = """\
 {root}/autodoc_fodder.py:docstring of autodoc_fodder.MarkupError:\\d+: \
@@ -42,7 +42,7 @@ TEXINFO_WARNINGS = ENV_WARNINGS + """\
 
 
 def _check_warnings(expected_warnings: str, warning: str) -> None:
-    warnings = strip_escseq(re.sub(re.escape(os.sep) + '{1,2}', '/', warning))
+    warnings = strip_colors(re.sub(re.escape(os.sep) + '{1,2}', '/', warning))
     assert re.match(f'{expected_warnings}$', warnings), (
         "Warnings don't match:\n"
         + f'--- Expected (regex):\n{expected_warnings}\n'

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -15,7 +15,8 @@ from babel.messages.catalog import Catalog
 from docutils import nodes
 
 from sphinx import locale
-from sphinx.testing.util import assert_node, etree_parse, strip_escseq
+from sphinx.testing.util import assert_node, etree_parse
+from sphinx.util import strip_colors
 from sphinx.util.nodes import NodeMatcher
 
 _CATALOG_LOCALE = 'xx'
@@ -1593,7 +1594,7 @@ def test_image_glob_intl_using_figure_language_filename(app):
 
 
 def getwarning(warnings):
-    return strip_escseq(warnings.getvalue().replace(os.sep, '/'))
+    return strip_colors(warnings.getvalue().replace(os.sep, '/'))
 
 
 @pytest.mark.sphinx('html', testroot='basic',

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -16,7 +16,7 @@ from docutils import nodes
 
 from sphinx import locale
 from sphinx.testing.util import assert_node, etree_parse
-from sphinx.util import strip_colors
+from sphinx.util.console import strip_colors
 from sphinx.util.nodes import NodeMatcher
 
 _CATALOG_LOCALE = 'xx'

--- a/tests/test_util/test_util_display.py
+++ b/tests/test_util/test_util_display.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from sphinx.testing.util import strip_escseq
 from sphinx.util import logging
+from sphinx.util.console import strip_colors
 from sphinx.util.display import (
     SkipProgressMessage,
     display_chunk,
@@ -28,7 +28,7 @@ def test_status_iterator_length_0(app, status, warning):
     status.seek(0)
     status.truncate(0)
     yields = list(status_iterator(['hello', 'sphinx', 'world'], 'testing ... '))
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing ... hello sphinx world \n' in output
     assert yields == ['hello', 'sphinx', 'world']
 
@@ -43,7 +43,7 @@ def test_status_iterator_verbosity_0(app, status, warning, monkeypatch):
     status.truncate(0)
     yields = list(status_iterator(['hello', 'sphinx', 'world'], 'testing ... ',
                                   length=3, verbosity=0))
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing ... [ 33%] hello\r' in output
     assert 'testing ... [ 67%] sphinx\r' in output
     assert 'testing ... [100%] world\r\n' in output
@@ -60,7 +60,7 @@ def test_status_iterator_verbosity_1(app, status, warning, monkeypatch):
     status.truncate(0)
     yields = list(status_iterator(['hello', 'sphinx', 'world'], 'testing ... ',
                                   length=3, verbosity=1))
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing ... [ 33%] hello\n' in output
     assert 'testing ... [ 67%] sphinx\n' in output
     assert 'testing ... [100%] world\n\n' in output
@@ -75,14 +75,14 @@ def test_progress_message(app, status, warning):
     with progress_message('testing'):
         logger.info('blah ', nonl=True)
 
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing... blah done\n' in output
 
     # skipping case
     with progress_message('testing'):
         raise SkipProgressMessage('Reason: %s', 'error')  # NoQA: EM101
 
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing... skipped\nReason: error\n' in output
 
     # error case
@@ -92,7 +92,7 @@ def test_progress_message(app, status, warning):
     except Exception:
         pass
 
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing... failed\n' in output
 
     # decorator
@@ -101,5 +101,5 @@ def test_progress_message(app, status, warning):
         logger.info('in func ', nonl=True)
 
     func()
-    output = strip_escseq(status.getvalue())
+    output = strip_colors(status.getvalue())
     assert 'testing... in func done\n' in output

--- a/tests/test_util/test_util_logging.py
+++ b/tests/test_util/test_util_logging.py
@@ -8,7 +8,6 @@ import pytest
 from docutils import nodes
 
 from sphinx.errors import SphinxWarning
-from sphinx.testing.util import strip_escseq
 from sphinx.util import logging, osutil
 from sphinx.util.console import colorize, strip_colors
 from sphinx.util.logging import is_suppressed_warning, prefixed_warnings
@@ -110,7 +109,7 @@ def test_once_warning_log(app, status, warning):
     logger.warning('message: %d', 1, once=True)
     logger.warning('message: %d', 2, once=True)
 
-    assert 'WARNING: message: 1\nWARNING: message: 2\n' in strip_escseq(warning.getvalue())
+    assert 'WARNING: message: 1\nWARNING: message: 2\n' in strip_colors(warning.getvalue())
 
 
 def test_is_suppressed_warning():
@@ -278,7 +277,7 @@ def test_pending_warnings(app, status, warning):
         assert 'WARNING: message3' not in warning.getvalue()
 
     # actually logged as ordered
-    assert 'WARNING: message2\nWARNING: message3' in strip_escseq(warning.getvalue())
+    assert 'WARNING: message2\nWARNING: message3' in strip_colors(warning.getvalue())
 
 
 def test_colored_logs(app, status, warning):


### PR DESCRIPTION
The ``sphinx.testing.util.strip_escseq`` did not exactly do what its name meant, namely it only stripped ANSI color codes but not all possible ANSI codes. If in the future we must strip ANSI control sequences in general, we should make the current `sphinx.util.console._strip_escape_sequences` function public, but for now it is not planned.

I took the liberty of having `Final` objects at module level to avoid modifying them by accident (even though they are private).