### PR TITLE
🐛 FIX: Add `identifier` role for c/cpp domains

### DIFF
--- a/sphinx/domains/c/__init__.py
+++ b/sphinx/domains/c/__init__.py
@@ -658,6 +658,7 @@ class CDomain(Domain):
         'enum': CXRefRole(),
         'enumerator': CXRefRole(),
         'type': CXRefRole(),
+        'identifier': CXRefRole(),
         'expr': CExprRole(asCode=True),
         'texpr': CExprRole(asCode=False),
     }

--- a/sphinx/domains/cpp/__init__.py
+++ b/sphinx/domains/cpp/__init__.py
@@ -803,6 +803,7 @@ class CPPDomain(Domain):
         'member': CPPXRefRole(),
         'var': CPPXRefRole(),
         'type': CPPXRefRole(),
+        'identifier': CPPXRefRole(),
         'concept': CPPXRefRole(),
         'enum': CPPXRefRole(),
         'enumerator': CPPXRefRole(),


### PR DESCRIPTION
In #8682 `identifier` was added as a related role name for most object types in the c/cpp domains.

The problem is that this is not currently an existing role on these domains, and so breaks semantics, e.g. when attempting to suggest roles for intersphinx referencing (see #12152)


