### PR TITLE
Improve `external` role warnings (and revert object fallback)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,8 +27,9 @@ Features added
   to annotate the return type of their ``setup`` function.
   Patch by Chris Sewell.
 
-* #12133: Allow ``external`` roles to reference object types
-  (rather than role names). Patch by Chris Sewell.
+* #12193: Improve ``external`` warnings for unknown roles.
+  In particular, suggest related role names if an object type is mistakenly used.
+  Patch by Chris Sewell.
 
 * #12131: Added :confval:`show_warning_types` configuration option.
   Patch by Chris Sewell.

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -558,7 +558,7 @@ class IntersphinxRole(SphinxRole):
 
         if domain_name is not None:
             # the user specified a domain, so we only check that
-            if (domain := self.env.get_domain(domain_name)) is None:
+            if (domain := self.env.domains.get(domain_name)) is None:
                 logger.warning(
                     __('domain for external cross-reference not found: %s'),
                     domain_name,
@@ -599,7 +599,7 @@ class IntersphinxRole(SphinxRole):
             if default_domain := self.env.temp_data.get('default_domain'):
                 domains.append(default_domain)
             if (
-                std_domain := self.env.get_domain('std')
+                std_domain := self.env.domains.get('std')
             ) is not None and std_domain not in domains:
                 domains.append(std_domain)
 

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -590,7 +590,7 @@ class IntersphinxRole(SphinxRole):
                     break
 
             if role_func is None or domain_name is None:
-                domains_str = self._concat_strings((d.name for d in domains))
+                domains_str = self._concat_strings(d.name for d in domains)
                 msg = 'role for external cross-reference not found in domains %s: %r'
                 possible_roles: set[str] = set()
                 for d in domains:

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -615,7 +615,7 @@ class IntersphinxRole(SphinxRole):
                 possible_roles: set[str] = set()
                 for d in domains:
                     if o := d.object_types.get(role_name):
-                        possible_roles.update(o.roles)
+                        possible_roles.update([f'{d.name}:{r}' for r in o.roles])
                 if possible_roles:
                     msg += ' (perhaps you meant one of: %s)'
                     logger.warning(

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -543,7 +543,7 @@ class IntersphinxRole(SphinxRole):
 
         if role_name is None:
             self._emit_warning(
-                __('external cross-reference suffix not valid: %s'), name_suffix
+                __('invalid external cross-reference suffix: %s'), name_suffix
             )
             return [], []
 
@@ -566,7 +566,7 @@ class IntersphinxRole(SphinxRole):
                         __(f'{msg} (perhaps you meant one of: %s)'),
                         domain_name,
                         role_name,
-                        ','.join(sorted(object_types.roles)),
+                        ', '.join(sorted(object_types.roles)),
                     )
                 else:
                     self._emit_warning(__(msg), domain_name, role_name)
@@ -590,26 +590,26 @@ class IntersphinxRole(SphinxRole):
                     break
 
             if role_func is None or domain_name is None:
-                domains_str = ','.join(d.name for d in domains)
+                domains_str = ', '.join(d.name for d in domains)
                 msg = 'role for external cross-reference not found in domains %s: %s'
                 possible_roles: set[str] = set()
                 for d in domains:
                     if o := d.object_types.get(role_name):
-                        possible_roles.update(f"{d.name}:{r}" for r in o.roles)
+                        possible_roles.update(f'{d.name}:{r}' for r in o.roles)
                 if possible_roles:
-                    msg += ' (perhaps you meant one of: %s)'
+                    msg = f'{msg} (perhaps you meant one of: %s)'
                     self._emit_warning(
                         __(msg),
                         domains_str,
                         role_name,
-                        ','.join(sorted(possible_roles)),
+                        ', '.join(sorted(possible_roles)),
                     )
                 else:
                     self._emit_warning(__(msg), domains_str, role_name)
                 return [], []
 
         result, messages = role_func(
-            f"{domain_name}:{role_name}",
+            f'{domain_name}:{role_name}',
             self.rawtext,
             self.text,
             self.lineno,
@@ -662,7 +662,7 @@ class IntersphinxRole(SphinxRole):
         else:
             return None, None
 
-    def _emit_warning(self, msg: str, *args: str) -> None:
+    def _emit_warning(self, msg: str, /, *args: Any) -> None:
         logger.warning(
             msg,
             *args,

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -610,12 +610,12 @@ class IntersphinxRole(SphinxRole):
                     break
 
             if role_func is None or domain_name is None:
-                domains_str = ','.join([d.name for d in domains])
+                domains_str = ','.join(d.name for d in domains)
                 msg = 'role for external cross-reference not found in domains %s: %s'
                 possible_roles: set[str] = set()
                 for d in domains:
                     if o := d.object_types.get(role_name):
-                        possible_roles.update([f'{d.name}:{r}' for r in o.roles])
+                        possible_roles.update(f'{d.name}:{r}' for r in o.roles)
                 if possible_roles:
                     msg += ' (perhaps you meant one of: %s)'
                     logger.warning(

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -535,7 +535,7 @@ class IntersphinxRole(SphinxRole):
         inventory, name_suffix = self.get_inventory_and_name_suffix(self.orig_name)
         if inventory and not inventory_exists(self.env, inventory):
             self._emit_warning(
-                __('inventory for external cross-reference not found: %s'), inventory
+                __('inventory for external cross-reference not found: %r'), inventory
             )
             return [], []
 
@@ -543,7 +543,7 @@ class IntersphinxRole(SphinxRole):
 
         if role_name is None:
             self._emit_warning(
-                __('invalid external cross-reference suffix: %s'), name_suffix
+                __('invalid external cross-reference suffix: %r'), name_suffix
             )
             return [], []
 
@@ -554,11 +554,11 @@ class IntersphinxRole(SphinxRole):
             # the user specified a domain, so we only check that
             if (domain := self.env.domains.get(domain_name)) is None:
                 self._emit_warning(
-                    __('domain for external cross-reference not found: %s'), domain_name
+                    __('domain for external cross-reference not found: %r'), domain_name
                 )
                 return [], []
             if (role_func := domain.roles.get(role_name)) is None:
-                msg = 'role for external cross-reference not found in domain %s: %s'
+                msg = 'role for external cross-reference not found in domain %r: %r'
                 if (
                     object_types := domain.object_types.get(role_name)
                 ) is not None and object_types.roles:
@@ -566,7 +566,7 @@ class IntersphinxRole(SphinxRole):
                         __(f'{msg} (perhaps you meant one of: %s)'),
                         domain_name,
                         role_name,
-                        ', '.join(sorted(object_types.roles)),
+                        self._concat_strings(object_types.roles),
                     )
                 else:
                     self._emit_warning(__(msg), domain_name, role_name)
@@ -590,8 +590,8 @@ class IntersphinxRole(SphinxRole):
                     break
 
             if role_func is None or domain_name is None:
-                domains_str = ', '.join(d.name for d in domains)
-                msg = 'role for external cross-reference not found in domains %s: %s'
+                domains_str = self._concat_strings((d.name for d in domains))
+                msg = 'role for external cross-reference not found in domains %s: %r'
                 possible_roles: set[str] = set()
                 for d in domains:
                     if o := d.object_types.get(role_name):
@@ -602,7 +602,7 @@ class IntersphinxRole(SphinxRole):
                         __(msg),
                         domains_str,
                         role_name,
-                        ', '.join(sorted(possible_roles)),
+                        self._concat_strings(possible_roles),
                     )
                 else:
                     self._emit_warning(__(msg), domains_str, role_name)
@@ -670,6 +670,9 @@ class IntersphinxRole(SphinxRole):
             subtype='external',
             location=(self.env.docname, self.lineno),
         )
+
+    def _concat_strings(self, strings: Iterable[str]) -> str:
+        return ', '.join(f'{s!r}' for s in sorted(strings))
 
     # deprecated methods
 

--- a/sphinx/ext/intersphinx.py
+++ b/sphinx/ext/intersphinx.py
@@ -548,7 +548,7 @@ class IntersphinxRole(SphinxRole):
             return [], []
 
         # attempt to find a matching role function
-        role_func: None | RoleFunction
+        role_func: RoleFunction | None
 
         if domain_name is not None:
             # the user specified a domain, so we only check that

--- a/tests/roots/test-ext-intersphinx-role/index.rst
+++ b/tests/roots/test-ext-intersphinx-role/index.rst
@@ -35,10 +35,14 @@
 
 
 - a function with explicit inventory:
-  :external+inv:c:func:`CFunc` or :external+inv:c:function:`CFunc`
+  :external+inv:c:func:`CFunc`
 - a class with explicit non-existing inventory, which also has upper-case in name:
   :external+invNope:cpp:class:`foo::Bar`
 
+- An object type being mistakenly used instead of a role name:
+
+  - :external+inv:c:function:`CFunc`
+  - :external+inv:function:`CFunc`
 
 - explicit title:
   :external:cpp:type:`FoonsTitle <foons>`

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -554,14 +554,12 @@ def test_intersphinx_role(app, warning):
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
     warnings = strip_colors(warning.getvalue()).splitlines()
     index_path = app.srcdir / 'index.rst'
-    for w in warnings:
-        print(w)
     assert warnings == [
         f'{index_path}:21: WARNING: role for external cross-reference not found in domain py: nope',
         f'{index_path}:28: WARNING: role for external cross-reference not found in domains cpp,std: nope',
         f'{index_path}:39: WARNING: inventory for external cross-reference not found: invNope',
         f'{index_path}:44: WARNING: role for external cross-reference not found in domain c: function (perhaps you meant one of: func,identifier,type)',
-        f'{index_path}:45: WARNING: role for external cross-reference not found in domains cpp,std: function (perhaps you meant one of: func,identifier,type)',
+        f'{index_path}:45: WARNING: role for external cross-reference not found in domains cpp,std: function (perhaps you meant one of: cpp:func,cpp:identifier,cpp:type)',
         f'{index_path}:9: WARNING: external py:mod reference target not found: module3',
         f'{index_path}:14: WARNING: external py:mod reference target not found: module10',
         f'{index_path}:19: WARNING: external py:meth reference target not found: inv:Foo.bar',

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -555,11 +555,11 @@ def test_intersphinx_role(app, warning):
     warnings = strip_colors(warning.getvalue()).splitlines()
     index_path = app.srcdir / 'index.rst'
     assert warnings == [
-        f'{index_path}:21: WARNING: role for external cross-reference not found in domain py: nope',
-        f'{index_path}:28: WARNING: role for external cross-reference not found in domains cpp, std: nope',
-        f'{index_path}:39: WARNING: inventory for external cross-reference not found: invNope',
-        f'{index_path}:44: WARNING: role for external cross-reference not found in domain c: function (perhaps you meant one of: func, identifier, type)',
-        f'{index_path}:45: WARNING: role for external cross-reference not found in domains cpp, std: function (perhaps you meant one of: cpp:func, cpp:identifier, cpp:type)',
+        f"{index_path}:21: WARNING: role for external cross-reference not found in domain 'py': 'nope'",
+        f"{index_path}:28: WARNING: role for external cross-reference not found in domains 'cpp', 'std': 'nope'",
+        f"{index_path}:39: WARNING: inventory for external cross-reference not found: 'invNope'",
+        f"{index_path}:44: WARNING: role for external cross-reference not found in domain 'c': 'function' (perhaps you meant one of: 'func', 'identifier', 'type')",
+        f"{index_path}:45: WARNING: role for external cross-reference not found in domains 'cpp', 'std': 'function' (perhaps you meant one of: 'cpp:func', 'cpp:identifier', 'cpp:type')",
         f'{index_path}:9: WARNING: external py:mod reference target not found: module3',
         f'{index_path}:14: WARNING: external py:mod reference target not found: module10',
         f'{index_path}:19: WARNING: external py:meth reference target not found: inv:Foo.bar',

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -556,10 +556,10 @@ def test_intersphinx_role(app, warning):
     index_path = app.srcdir / 'index.rst'
     assert warnings == [
         f'{index_path}:21: WARNING: role for external cross-reference not found in domain py: nope',
-        f'{index_path}:28: WARNING: role for external cross-reference not found in domains cpp,std: nope',
+        f'{index_path}:28: WARNING: role for external cross-reference not found in domains cpp, std: nope',
         f'{index_path}:39: WARNING: inventory for external cross-reference not found: invNope',
-        f'{index_path}:44: WARNING: role for external cross-reference not found in domain c: function (perhaps you meant one of: func,identifier,type)',
-        f'{index_path}:45: WARNING: role for external cross-reference not found in domains cpp,std: function (perhaps you meant one of: cpp:func,cpp:identifier,cpp:type)',
+        f'{index_path}:44: WARNING: role for external cross-reference not found in domain c: function (perhaps you meant one of: func, identifier, type)',
+        f'{index_path}:45: WARNING: role for external cross-reference not found in domains cpp, std: function (perhaps you meant one of: cpp:func, cpp:identifier, cpp:type)',
         f'{index_path}:9: WARNING: external py:mod reference target not found: module3',
         f'{index_path}:14: WARNING: external py:mod reference target not found: module10',
         f'{index_path}:19: WARNING: external py:meth reference target not found: inv:Foo.bar',

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -554,10 +554,14 @@ def test_intersphinx_role(app, warning):
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
     warnings = strip_colors(warning.getvalue()).splitlines()
     index_path = app.srcdir / 'index.rst'
+    for w in warnings:
+        print(w)
     assert warnings == [
-        f'{index_path}:21: WARNING: role for external cross-reference not found: py:nope',
-        f'{index_path}:28: WARNING: role for external cross-reference not found: nope',
+        f'{index_path}:21: WARNING: role for external cross-reference not found in domain py: nope',
+        f'{index_path}:28: WARNING: role for external cross-reference not found in domains cpp,std: nope',
         f'{index_path}:39: WARNING: inventory for external cross-reference not found: invNope',
+        f'{index_path}:44: WARNING: role for external cross-reference not found in domain c: function (perhaps you meant one of: func,identifier,type)',
+        f'{index_path}:45: WARNING: role for external cross-reference not found in domains cpp,std: function (perhaps you meant one of: func,identifier,type)',
         f'{index_path}:9: WARNING: external py:mod reference target not found: module3',
         f'{index_path}:14: WARNING: external py:mod reference target not found: module10',
         f'{index_path}:19: WARNING: external py:meth reference target not found: inv:Foo.bar',


### PR DESCRIPTION
Ok @jakobandersen @picnixz, this is compromise for discussion in https://github.com/orgs/sphinx-doc/discussions/12152 😄 

The key issue this seeks to address, is that existing tools / documentation often lead users to mistakenly use object types and not role names, a classic example being `function` not `func`

Previously, the warning message for using e.g. `` external:function`target` `` (with `py` as the default domain), would be:

```
WARNING: role for external cross-reference not found: function
```

This gives no information to the user on how to fix the issue, even though there is actually quite an easy fix

In #12133, I handled this by falling back to looking for the object type, then obtaining a role from that.
There has been some push back on this fallback 😬 

So, in this PR, I revert that, but instead, create much more specific / helpful warning messages, e.g.

```
WARNING: role for external cross-reference not found in domains 'py', 'std': 'function' (perhaps you meant one of: 'py:func', 'py:obj')
```

This goes through the same original logic but, if the role is not found, it will look if the role name is actually an available object type on the domain(s), and then suggest its related roles.

---

~~Note, in doing this, I've removed some methods of `IntersphinxRole` because they are just not useful any more.~~ (added back and deprecated)
