### PR TITLE
[mypy] explicitly exclude files instead of ignoring errors by modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,78 @@ exclude = [
 
 [tool.mypy]
 files = ["sphinx", "utils", "tests"]
-exclude = ["tests/certs", "tests/js", "tests/roots"]
+exclude = [
+    "tests/certs",
+    "tests/js",
+    "tests/roots",
+    # tests/
+    "^tests/test_events\\.py$",
+    "^tests/test_quickstart\\.py$",
+    "^tests/test_search\\.py$",
+    "^tests/test_versioning\\.py$",
+    # tests/test_builders
+    "^tests/test_builders/test_build_dirhtml\\.py$",
+    "^tests/test_builders/test_build_epub\\.py$",
+    "^tests/test_builders/test_builder\\.py$",
+    "^tests/test_builders/test_build_gettext\\.py$",
+    "^tests/test_builders/test_build_html\\.py$",
+    "^tests/test_builders/test_build_latex\\.py$",
+    "^tests/test_builders/test_build_linkcheck\\.py$",
+    "^tests/test_builders/test_build_texinfo\\.py$",
+    # tests/test_config
+    "^tests/test_config/test_config\\.py$",
+    # tests/test_directives
+    "^tests/test_directives/test_directive_object_description\\.py$",
+    "^tests/test_directives/test_directive_only\\.py$",
+    "^tests/test_directives/test_directive_other\\.py$",
+    "^tests/test_directives/test_directive_patch\\.py$",
+    # tests/test_domains
+    "^tests/test_domains/test_domain_c\\.py$",
+    "^tests/test_domains/test_domain_cpp\\.py$",
+    "^tests/test_domains/test_domain_js\\.py$",
+    "^tests/test_domains/test_domain_py\\.py$",
+    "^tests/test_domains/test_domain_py_fields\\.py$",
+    "^tests/test_domains/test_domain_py_pyfunction\\.py$",
+    "^tests/test_domains/test_domain_py_pyobject\\.py$",
+    "^tests/test_domains/test_domain_rst\\.py$",
+    "^tests/test_domains/test_domain_std\\.py$",
+    # tests/test_environment
+    "^tests/test_environment/test_environment_toctree\\.py$",
+    # tests/test_extensions
+    "^tests/test_extensions/test_ext_apidoc\\.py$",
+    "^tests/test_extensions/test_ext_autodoc\\.py$",
+    "^tests/test_extensions/test_ext_autodoc_autofunction\\.py$",
+    "^tests/test_extensions/test_ext_autodoc_events\\.py$",
+    "^tests/test_extensions/test_ext_autodoc_mock\\.py$",
+    "^tests/test_extensions/test_ext_autosummary\\.py$",
+    "^tests/test_extensions/test_ext_doctest\\.py$",
+    "^tests/test_extensions/test_ext_inheritance_diagram\\.py$",
+    "^tests/test_extensions/test_ext_intersphinx\\.py$",
+    "^tests/test_extensions/test_ext_napoleon\\.py$",
+    "^tests/test_extensions/test_ext_napoleon_docstring\\.py$",
+    # tests/test_intl
+    "^tests/test_intl/test_intl\\.py$",
+    # tests/test_markup
+    "^tests/test_markup/test_markup\\.py$",
+    # tests/test_pycode
+    "^tests/test_pycode/test_pycode\\.py$",
+    "^tests/test_pycode/test_pycode_ast\\.py$",
+    # tests/test_theming
+    # tests/test_transforms
+    "^tests/test_transforms/test_transforms_move_module_targets\\.py$",
+    "^tests/test_transforms/test_transforms_post_transforms\\.py$",
+    # tests/test_util
+    "^tests/test_util/test_util_fileutil\\.py$",
+    "^tests/test_util/test_util_i18n\\.py$",
+    "^tests/test_util/test_util_inspect\\.py$",
+    "^tests/test_util/test_util_logging\\.py$",
+    "^tests/test_util/test_util_nodes\\.py$",
+    "^tests/test_util/test_util_rst\\.py$",
+    "^tests/test_util/test_util_template\\.py$",
+    "^tests/test_util/test_util_typing\\.py$",
+    "^tests/test_util/typing_test_data\\.py$",
+    # tests/test_writers
+]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 python_version = "3.9"
@@ -213,78 +284,6 @@ module = [
     "sphinx.util.template",
 ]
 disallow_any_generics = false
-
-[[tool.mypy.overrides]]
-module = [
-    # tests/
-    "tests.test_events",
-    "tests.test_quickstart",
-    "tests.test_search",
-    "tests.test_versioning",
-    # tests/test_builders
-    "tests.test_builders.test_build_dirhtml",
-    "tests.test_builders.test_build_epub",
-    "tests.test_builders.test_builder",
-    "tests.test_builders.test_build_gettext",
-    "tests.test_builders.test_build_html",
-    "tests.test_builders.test_build_latex",
-    "tests.test_builders.test_build_linkcheck",
-    "tests.test_builders.test_build_texinfo",
-    # tests/test_config
-    "tests.test_config.test_config",
-    # tests/test_directives
-    "tests.test_directives.test_directive_object_description",
-    "tests.test_directives.test_directive_only",
-    "tests.test_directives.test_directive_other",
-    "tests.test_directives.test_directive_patch",
-    # tests/test_domains
-    "tests.test_domains.test_domain_c",
-    "tests.test_domains.test_domain_cpp",
-    "tests.test_domains.test_domain_js",
-    "tests.test_domains.test_domain_py",
-    "tests.test_domains.test_domain_py_fields",
-    "tests.test_domains.test_domain_py_pyfunction",
-    "tests.test_domains.test_domain_py_pyobject",
-    "tests.test_domains.test_domain_rst",
-    "tests.test_domains.test_domain_std",
-    # tests/test_environment
-    "tests.test_environment.test_environment_toctree",
-    # tests/test_extensions
-    "tests.test_extensions.test_ext_apidoc",
-    "tests.test_extensions.test_ext_autodoc",
-    "tests.test_extensions.test_ext_autodoc_autofunction",
-    "tests.test_extensions.test_ext_autodoc_events",
-    "tests.test_extensions.test_ext_autodoc_mock",
-    "tests.test_extensions.test_ext_autosummary",
-    "tests.test_extensions.test_ext_doctest",
-    "tests.test_extensions.test_ext_inheritance_diagram",
-    "tests.test_extensions.test_ext_intersphinx",
-    "tests.test_extensions.test_ext_napoleon",
-    "tests.test_extensions.test_ext_napoleon_docstring",
-    # tests/test_intl
-    "tests.test_intl.test_intl",
-    # tests/test_markup
-    "tests.test_markup.test_markup",
-    # tests/test_pycode
-    "tests.test_pycode.test_pycode",
-    "tests.test_pycode.test_pycode_ast",
-    # tests/test_theming
-    # tests/test_transforms
-    "tests.test_transforms.test_transforms_move_module_targets",
-    "tests.test_transforms.test_transforms_post_transforms",
-    # tests/test_util
-    "tests.test_util.test_util_fileutil",
-    "tests.test_util.test_util_i18n",
-    "tests.test_util.test_util_inspect",
-    "tests.test_util.test_util_logging",
-    "tests.test_util.test_util_nodes",
-    "tests.test_util.test_util_rst",
-    "tests.test_util.test_util_template",
-    "tests.test_util.test_util_typing",
-    "tests.test_util.typing_test_data",
-    # tests/test_writers
-]
-ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = 6.0


### PR DESCRIPTION
After merging #12173, I suggest we change the ``[[tool.mypy.overrides]]`` into a *true* exclusion list. 

The rationale is that, with `ignore-errors`, if you mypy the file without removing the module from the overrides list, you will not do anything. However, if you mypy the file and that file is excluded by default, mypy runs normally.