### PR TITLE
👌 Add warning log for config values that cannot be cached

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -470,9 +470,7 @@ class Config:
                     # will always mark the config value as changed,
                     # and thus always invalidate the cache and perform a rebuild.
                     logger.warning(
-                        __(
-                            'The value of config %r is not picklable and so cannot be cached.'
-                        ),
+                        __('cannot cache unpickable configuration value: %r'),
                         name,
                         type='config',
                         subtype='cache',

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -465,6 +465,19 @@ class Config:
         for name, opt in self._options.items():
             real_value = getattr(self, name)
             if not is_serializable(real_value):
+                if opt.rebuild:
+                    # if the value is not cached, then any build that utilises this cache
+                    # will always mark the config value as changed,
+                    # and thus always invalidate the cache and perform a rebuild.
+                    logger.warning(
+                        __(
+                            'The value of config %r is not picklable and so cannot be cached.'
+                        ),
+                        name,
+                        type='config',
+                        subtype='cache',
+                        once=True,
+                    )
                 # omit unserializable value
                 real_value = None
             # valid_types is also omitted

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -72,17 +72,17 @@ def test_texinfo_warnings(app, warning):
     _check_warnings(warnings_exp, warning.getvalue())
 
 
-# def test_uncacheable_config_warning(make_app, tmp_path):
-#     """Test than an unpickleable config value raises a warning."""
-#     tmp_path.joinpath('conf.py').write_text("""
-# my_config = lambda: None
-# show_warning_types = True
-# def setup(app):
-#     app.add_config_value('my_config', None, 'env')
-#     """, encoding='utf-8')
-#     tmp_path.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
-#     app = make_app(srcdir=tmp_path)
-#     app.build()
-#     assert strip_colors(app.warning.getvalue()).strip() == (
-#         "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
-#     )
+def test_uncacheable_config_warning(make_app, tmp_path):
+    """Test than an unpickleable config value raises a warning."""
+    tmp_path.joinpath('conf.py').write_text("""
+my_config = lambda: None
+show_warning_types = True
+def setup(app):
+    app.add_config_value('my_config', None, 'env')
+    """, encoding='utf-8')
+    tmp_path.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
+    app = make_app(srcdir=tmp_path)
+    app.build()
+    assert strip_colors(app.warning.getvalue()).strip() == (
+        "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
+    )

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -72,17 +72,17 @@ def test_texinfo_warnings(app, warning):
     _check_warnings(warnings_exp, warning.getvalue())
 
 
-def test_uncacheable_config_warning(make_app, tmp_path):
-    """Test than an unpickleable config value raises a warning."""
-    tmp_path.joinpath('conf.py').write_text("""
-my_config = lambda: None
-show_warning_types = True
-def setup(app):
-    app.add_config_value('my_config', None, 'env')
-    """, encoding='utf-8')
-    tmp_path.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
-    app = make_app(srcdir=tmp_path)
-    app.build()
-    assert strip_colors(app.warning.getvalue()).strip() == (
-        "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
-    )
+# def test_uncacheable_config_warning(make_app, tmp_path):
+#     """Test than an unpickleable config value raises a warning."""
+#     tmp_path.joinpath('conf.py').write_text("""
+# my_config = lambda: None
+# show_warning_types = True
+# def setup(app):
+#     app.add_config_value('my_config', None, 'env')
+#     """, encoding='utf-8')
+#     tmp_path.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
+#     app = make_app(srcdir=tmp_path)
+#     app.build()
+#     assert strip_colors(app.warning.getvalue()).strip() == (
+#         "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
+#     )

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -70,3 +70,19 @@ def test_texinfo_warnings(app, warning):
     app.build(force_all=True)
     warnings_exp = TEXINFO_WARNINGS.format(root=re.escape(app.srcdir.as_posix()))
     _check_warnings(warnings_exp, warning.getvalue())
+
+
+def test_uncacheable_config_warning(make_app, tmp_path):
+    """Test than an unpickleable config value raises a warning."""
+    tmp_path.joinpath('conf.py').write_text("""
+my_config = lambda: None
+show_warning_types = True
+def setup(app):
+    app.add_config_value('my_config', None, 'env')
+    """, encoding='utf-8')
+    tmp_path.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
+    app = make_app(srcdir=tmp_path)
+    app.build()
+    assert strip_colors(app.warning.getvalue()).strip() == (
+        "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
+    )

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -22,7 +22,6 @@ from sphinx.config import (
 )
 from sphinx.deprecation import RemovedInSphinx90Warning
 from sphinx.errors import ConfigError, ExtensionError, VersionRequirementError
-from sphinx.util.console import strip_colors
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -291,24 +290,6 @@ def test_config_pickle_circular_reference_in_dict():
     #       recursive guard since x['b'] == x
     assert counters[type(x['a'])] == 1
     assert counters[type(x['b'])] == 2
-
-
-def test_uncacheable_config_warning(make_app, tmp_path):
-    """Test than an unpickleable config value raises a warning."""
-    srcdir = tmp_path / 'srcdir123'
-    srcdir.mkdir()
-    srcdir.joinpath('conf.py').write_text("""
-my_config = lambda: None
-show_warning_types = True
-def setup(app):
-    app.add_config_value('my_config', None, 'env')
-    """, encoding='utf-8')
-    srcdir.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
-    app = make_app(srcdir=srcdir)
-    app.build()
-    assert strip_colors(app.warning.getvalue()).strip() == (
-        "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
-    )
 
 
 def test_extension_values():

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -307,7 +307,7 @@ def setup(app):
     app = make_app(srcdir=srcdir)
     app.build()
     assert strip_colors(app.warning.getvalue()).strip() == (
-        "WARNING: The value of config 'my_config' is not picklable and so cannot be cached. [config.cache]"
+        "WARNING: cannot cache unpickable configuration value: 'my_config' [config.cache]"
     )
 
 

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -22,6 +22,7 @@ from sphinx.config import (
 )
 from sphinx.deprecation import RemovedInSphinx90Warning
 from sphinx.errors import ConfigError, ExtensionError, VersionRequirementError
+from sphinx.util.console import strip_colors
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -290,6 +291,24 @@ def test_config_pickle_circular_reference_in_dict():
     #       recursive guard since x['b'] == x
     assert counters[type(x['a'])] == 1
     assert counters[type(x['b'])] == 2
+
+
+def test_uncacheable_config_warning(make_app, tmp_path):
+    """Test than an unpickleable config value raises a warning."""
+    srcdir = tmp_path / 'srcdir123'
+    srcdir.mkdir()
+    srcdir.joinpath('conf.py').write_text("""
+my_config = lambda: None
+show_warning_types = True
+def setup(app):
+    app.add_config_value('my_config', None, 'env')
+    """, encoding='utf-8')
+    srcdir.joinpath('index.rst').write_text('Test\n====\n', encoding='utf-8')
+    app = make_app(srcdir=srcdir)
+    app.build()
+    assert strip_colors(app.warning.getvalue()).strip() == (
+        "WARNING: The value of config 'my_config' is not picklable and so cannot be cached. [config.cache]"
+    )
 
 
 def test_extension_values():


### PR DESCRIPTION
As a user and/or extension developer, it can be a source of confusion when, on performing a `sphinx-build` on a cached project, an unchanged configuration variable is always marked as changed (which then triggers a full rebuild).

This is often due to the variable being an unpicklable value, like a function, which is silently omitted from the cache (i.e. the `environment.pickle`).

This PR introduces a specific warning for when a configuration variable is omitted from the cache, allowing users to understand the root of the problem.