### PR TITLE
Update linkcheck_rate_limit_timeout docs using seconds instead of minutes

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2939,7 +2939,8 @@ Options for the linkcheck builder
 
    Otherwise, ``linkcheck`` waits for a minute before to retry and keeps
    doubling the wait time between attempts until it succeeds or exceeds the
-   ``linkcheck_rate_limit_timeout``. By default, the timeout is 300 seconds.
+   ``linkcheck_rate_limit_timeout``. By default, the timeout is 300 seconds
+   and custom timeouts should be given in seconds.
 
    .. _Retry-After: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3
 

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2939,7 +2939,7 @@ Options for the linkcheck builder
 
    Otherwise, ``linkcheck`` waits for a minute before to retry and keeps
    doubling the wait time between attempts until it succeeds or exceeds the
-   ``linkcheck_rate_limit_timeout``. By default, the timeout is 5 minutes.
+   ``linkcheck_rate_limit_timeout``. By default, the timeout is 300 seconds.
 
    .. _Retry-After: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3
 


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_rate_limit_timeout
The docs here states that the default is 5 minutes. I checked the class itself doesn't have docstring about the unit. I am not sure exactly why or it's a convention.

I have run into a CI issues that timeout, after changing the configuration a few times and look into the source code. I found out the unit of the configuration is seconds instead of minutes. 

https://github.com/kedro-org/kedro/pull/3769
### Purpose
To make this clear the units of the configuration is seconds instead of minute.

I can also update change in code when appropriate but please let me know where should the change goes in.
