### PR TITLE
[search] typo fixup: 'if' instead of 'is'.

### DIFF
--- a/sphinx/themes/basic/static/language_data.js_t
+++ b/sphinx/themes/basic/static/language_data.js_t
@@ -13,7 +13,7 @@
 var stopwords = {{ search_language_stop_words }};
 
 {% if search_language_stemming_code %}
-/* Non-minified version is copied as a separate JS file, is available */
+/* Non-minified version is copied as a separate JS file, if available */
 {{ search_language_stemming_code|safe }}
 {% endif -%}
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (typo)

### Purpose
- Fixup for a typo in the `language_data.js_t` file.

### Detail
- Spotted by @picnixz during review of #12102.

### Relates
- N/A

