### PR TITLE
[search] JavaScript refactor: extract subcomponents from Search.query function.

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -402,8 +402,8 @@ const Search = {
   },
 
   query: (query) => {
-    const searchTerms = Search._parseQuery(query);
-    const results = Search._performSearch(...searchTerms);
+    const searchParameters = Search._parseQuery(query);
+    const results = Search._performSearch(...searchParameters);
 
     // for debugging
     //Search.lastresults = results.slice();  // a copy

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -268,16 +268,7 @@ const Search = {
     else Search.deferQuery(query);
   },
 
-  /**
-   * execute search (requires search index to be loaded)
-   */
-  query: (query) => {
-    const filenames = Search._index.filenames;
-    const docNames = Search._index.docnames;
-    const titles = Search._index.titles;
-    const allTitles = Search._index.alltitles;
-    const indexEntries = Search._index.indexentries;
-
+  _parseQuery: (query) => {
     // stem the search terms and add them to the correct list
     const stemmer = new Stemmer();
     const searchTerms = new Set();
@@ -312,6 +303,19 @@ const Search = {
     // console.debug("SEARCH: searching for:");
     // console.info("required: ", [...searchTerms]);
     // console.info("excluded: ", [...excludedTerms]);
+
+    return [query, searchTerms, excludedTerms, highlightTerms, objectTerms];
+  },
+
+  /**
+   * execute search (requires search index to be loaded)
+   */
+  _performSearch: (query, searchTerms, excludedTerms, highlightTerms, objectTerms) => {
+    const filenames = Search._index.filenames;
+    const docNames = Search._index.docnames;
+    const titles = Search._index.titles;
+    const allTitles = Search._index.alltitles;
+    const indexEntries = Search._index.indexentries;
 
     // Collect multiple result groups to be sorted separately and then ordered.
     // Each is an array of [docname, title, anchor, descr, score, filename].
@@ -394,7 +398,12 @@ const Search = {
       return acc;
     }, []);
 
-    results = results.reverse();
+    return results.reverse();
+  },
+
+  query: (query) => {
+    const searchTerms = Search._parseQuery(query);
+    const results = Search._performSearch(...searchTerms);
 
     // for debugging
     //Search.lastresults = results.slice();  // a copy


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Refactor the `searchtools.js` code to make it more unit-testable.

### Detail
- The JavaScript `Search.query` method intertwines [display-related logic](https://github.com/sphinx-doc/sphinx/blob/600d3d3adaee530363c88ab1a000ef83e5db428e/sphinx/themes/basic/static/searchtools.js#L403-L404) with [search-related logic](https://github.com/sphinx-doc/sphinx/blob/600d3d3adaee530363c88ab1a000ef83e5db428e/sphinx/themes/basic/static/searchtools.js#L275-L397).  In particular during unit testing, we want to test the latter without needing to mock out / stub the former -- so this changeset extracts subcomponents from `query` that can be unit-tested individually.

### Relates
- Groundwork for #12099 (using more-realistic `searchindex.js` fixtures in our JavaScript testing).