### PR TITLE
"minversion" should be a string, not a float

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,7 +284,7 @@ module = [
 disallow_any_generics = false
 
 [tool.pytest.ini_options]
-minversion = 6.0
+minversion = "6.0"
 addopts = [
     "-ra",
     "--import-mode=prepend",


### PR DESCRIPTION
Subject: fix repo-review crash

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
This fixes a crash of repo-review:
```python
Traceback (most recent call last):
  File "/lib/python311.zip/_pyodide/_base.py", line 468, in eval_code
    .run(globals, locals)
     ^^^^^^^^^^^^^^^^^^^^
  File "/lib/python311.zip/_pyodide/_base.py", line 310, in run
    coroutine = eval(self.code, globals, locals)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "", line 9, in 
  File "/lib/python3.11/site-packages/repo_review/processor.py", line 214, in process
    result = apply_fixtures({"name": name, **fixtures}, tasks[name].check)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/repo_review/fixtures.py", line 106, in apply_fixtures
    return func(**kwargs)
           ^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/sp_repo_review/checks/pyproject.py", line 92, in check
    return "minversion" in options and int(options["minversion"].split(".")[0]) >= 6
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'float' object has no attribute 'split'
```
### Details
- Documentation of pytest:
  https://docs.pytest.org/en/7.3.x/reference/customize.html#pyproject-toml

### Relates
- https://github.com/scientific-python/cookie/issues/404

