### PR TITLE
Avoid redundant target-version

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,3 @@
-target-version = "py39"  # Pin Ruff to Python 3.9
 line-length = 95
 output-format = "full"
 


### PR DESCRIPTION
Subject: Avoid redundant target-version

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
- Do not specify the minimal Python version with `target-version`. Instead, let ruff read  `requires-python` in `pyproject.toml`.