### PR TITLE
Apply pyupgrade/ruff rule UP035

### DIFF
--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -8,12 +8,12 @@ import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
 script_dir = Path(__file__).parent
 package_dir = script_dir.parent


### PR DESCRIPTION
UP035 Import from `collections.abc` instead: `Sequence`

Subject: Apply pyupgrade/ruff rule UP035

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Fix this issue:
```
 UP035 Import from `collections.abc` instead: `Sequence`
```

### Relates
- https://docs.astral.sh/ruff/rules/#pyupgrade-up

