### PR TITLE
Escape reserved path characters in the remote images post-transform

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -64,7 +64,8 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            dirname = node['uri'].replace('://', '/').translate({ord("?"): "/",
+            dirname = node['uri'].replace('://', '/').translate({ord(":"): "/",
+                                                                 ord("?"): "/",
                                                                  ord("&"): "/"})
             if len(dirname) > MAX_FILENAME_LEN:
                 dirname = sha1(dirname.encode(), usedforsecurity=False).hexdigest()

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -64,9 +64,11 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            dirname = node['uri'].replace('://', '/').translate({ord(":"): ":" if os.name == "posix" else "/",
-                                                                 ord("?"): "/",
-                                                                 ord("&"): "/"})
+            dirname = node['uri'].replace('://', '/').translate({
+                ord(":"): ":" if os.name == "posix" else "/",
+                ord("?"): "/",
+                ord("&"): "/",
+            })
             if len(dirname) > MAX_FILENAME_LEN:
                 dirname = sha1(dirname.encode(), usedforsecurity=False).hexdigest()
             ensuredir(os.path.join(self.imagedir, dirname))

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -64,7 +64,7 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            dirname = node['uri'].replace('://', '/').translate({ord(":"): "/",
+            dirname = node['uri'].replace('://', '/').translate({ord(":"): ":" if os.name == "posix" else "/",
                                                                  ord("?"): "/",
                                                                  ord("&"): "/"})
             if len(dirname) > MAX_FILENAME_LEN:

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -30,6 +30,7 @@ _URI_TO_PATH = {
     ord(k): '/' for k in ('"', '&', '*', '/', ':', '<', '>', '?', '\\', '|')
 }
 
+
 class BaseImageConverter(SphinxTransform):
     def apply(self, **kwargs: Any) -> None:
         for node in self.document.findall(nodes.image):

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -25,7 +25,10 @@ logger = logging.getLogger(__name__)
 
 MAX_FILENAME_LEN = 32
 CRITICAL_PATH_CHAR_RE = re.compile('[:;<>|*" ]')
-
+# Replace reserved Windows or Unix path characters with '/'.
+_URI_TO_PATH = {
+    ord(k): '/' for k in ('"', '&', '*', '/', ':', '<', '>', '?', '\\', '|')
+}
 
 class BaseImageConverter(SphinxTransform):
     def apply(self, **kwargs: Any) -> None:
@@ -64,11 +67,7 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            dirname = node['uri'].replace('://', '/').translate({
-                ord(":"): ":" if os.name == "posix" else "/",
-                ord("?"): "/",
-                ord("&"): "/",
-            })
+            dirname = node['uri'].replace('://', '/').translate(_URI_TO_PATH)
             if len(dirname) > MAX_FILENAME_LEN:
                 dirname = sha1(dirname.encode(), usedforsecurity=False).hexdigest()
             ensuredir(os.path.join(self.imagedir, dirname))


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Allow remote image URLs that contain port number specifications to be saved correctly during the post-transform steps on Windows.

### Detail
- Add the colon character (`:`) to the dictionary of character-to-path mappings in the `ImageDownloader` class; it isn't considered a valid path component character on Windows, meaning that attempts to create directories that include it in the name fail.

### Relates
- Resolves #12100.