### PR TITLE
Remote image download caching: always use hash-based directory names.

### DIFF
--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -68,7 +68,7 @@ class ImageDownloader(BaseImageConverter):
                 ord("?"): "/",
                 ord("&"): "/",
             })  # remappings formerly used for filepath sanitization; retained for cache reuse
-            dirname = sha1(  # Note: formerly applied only to length 32+ URIs
+            dirname = sha1(  # Note: formerly applied only to length 33+ URIs
                 hashinput.encode(),
                 usedforsecurity=False,
             ).hexdigest()

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -67,7 +67,7 @@ class ImageDownloader(BaseImageConverter):
             hashinput = node['uri'].replace('://', '/').translate({
                 ord("?"): "/",
                 ord("&"): "/",
-            })  # remappings formerly used for filepath sanitization; retained for cache keying
+            })  # remappings formerly used for filepath sanitization; retained for cache reuse
             dirname = sha1(  # Note: formerly applied only to length 32+ URIs
                 hashinput.encode(),
                 usedforsecurity=False,

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -25,10 +25,6 @@ logger = logging.getLogger(__name__)
 
 MAX_FILENAME_LEN = 32
 CRITICAL_PATH_CHAR_RE = re.compile('[:;<>|*" ]')
-# Replace reserved Windows or Unix path characters with '/'.
-_URI_TO_PATH = {
-    ord(k): '/' for k in ('"', '&', '*', '/', ':', '<', '>', '?', '\\', '|')
-}
 
 
 class BaseImageConverter(SphinxTransform):
@@ -68,7 +64,8 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            dirname = node['uri'].replace('://', '/').translate(_URI_TO_PATH)
+            dirname = node['uri'].replace('://', '/').translate({ord("?"): "/",
+                                                                 ord("&"): "/"})
             if len(dirname) > MAX_FILENAME_LEN:
                 dirname = sha1(dirname.encode(), usedforsecurity=False).hexdigest()
             ensuredir(os.path.join(self.imagedir, dirname))

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -64,16 +64,9 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            hashinput = node['uri'].replace('://', '/').translate({
-                ord("?"): "/",
-                ord("&"): "/",
-            })  # remappings formerly used for filepath sanitization; retained for cache reuse
-            dirname = sha1(  # Note: formerly applied only to length 33+ URIs
-                hashinput.encode(),
-                usedforsecurity=False,
-            ).hexdigest()
-            ensuredir(os.path.join(self.imagedir, dirname))
-            path = os.path.join(self.imagedir, dirname, basename)
+            uri_hash = sha1(node['uri'].encode(), usedforsecurity=False).hexdigest()
+            ensuredir(os.path.join(self.imagedir, uri_hash))
+            path = os.path.join(self.imagedir, uri_hash, basename)
 
             headers = {}
             if os.path.exists(path):
@@ -105,7 +98,7 @@ class ImageDownloader(BaseImageConverter):
                 if mimetype != '*' and os.path.splitext(basename)[1] == '':
                     # append a suffix if URI does not contain suffix
                     ext = get_image_extension(mimetype)
-                    newpath = os.path.join(self.imagedir, dirname, basename + ext)
+                    newpath = os.path.join(self.imagedir, uri_hash, basename + ext)
                     os.replace(path, newpath)
                     self.app.env.original_image_uri.pop(path)
                     self.app.env.original_image_uri[newpath] = node['uri']

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -64,10 +64,14 @@ class ImageDownloader(BaseImageConverter):
                 basename = sha1(filename.encode(), usedforsecurity=False).hexdigest() + ext
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
-            dirname = node['uri'].replace('://', '/').translate({ord("?"): "/",
-                                                                 ord("&"): "/"})
-            if len(dirname) > MAX_FILENAME_LEN:
-                dirname = sha1(dirname.encode(), usedforsecurity=False).hexdigest()
+            hashinput = node['uri'].replace('://', '/').translate({
+                ord("?"): "/",
+                ord("&"): "/",
+            })  # remappings formerly used for filepath sanitization; retained for cache keying
+            dirname = sha1(  # Note: formerly applied only to length 32+ URIs
+                hashinput.encode(),
+                usedforsecurity=False,
+            ).hexdigest()
             ensuredir(os.path.join(self.imagedir, dirname))
             path = os.path.join(self.imagedir, dirname, basename)
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Allow (short-length) remote image downloads from URLs that contain port number specifications to be saved to the local Sphinx remote-image download cache correctly on Windows.

### Detail
- Use permissible directory path characters on Windows, resolving #12100, but instead of by attempting to replace all reserved characters, use the `sha1`-hashing of the URL that already applied to many (all `length > 32`) image URLs already.

### Relates
- Resolves #12100.
- Supersedes #12253.