### PR TITLE
Separate cases in ``stringify`` and ``restify`` with greater precision

### DIFF
--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -262,7 +262,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 # Don't print the arguments; they're all system defined type variables.
                 return text
 
-            # Callable (either collections.abc or typing)
+            # Callable has special formatting
             if cls_module_is_typing and cls.__name__ == 'Callable':
                 args = ', '.join(restify(a, mode) for a in __args__[:-1])
                 returns = restify(__args__[-1], mode)

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -282,7 +282,9 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
             args = ', '.join(restify(a, mode) for a in __args__)
             return fr'{text}\ [{args}]'
         elif isinstance(cls, typing._SpecialForm):
-            return f':py:obj:`~{cls.__module__}.{cls.__name__}`'  # type: ignore[attr-defined]
+            if sys.version_info[:2] >= (3, 10):
+                return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
+            return f':py:obj:`~{cls.__module__}.{cls._name}`'  # type: ignore[attr-defined]
         elif sys.version_info[:2] >= (3, 11) and cls is typing.Any:
             # handle bpo-46998
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -263,8 +263,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 return text
 
             # Callable (either collections.abc or typing)
-            if (cls.__module__ in {'collections.abc', 'typing'}
-                    and cls.__name__ == 'Callable'):
+            if cls_module_is_typing and cls.__name__ == 'Callable':
                 args = ', '.join(restify(a, mode) for a in __args__[:-1])
                 returns = restify(__args__[-1], mode)
                 return fr'{text}\ [[{args}], {returns}]'

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -212,22 +212,22 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
     #
     # With an if-else block, mypy infers 'mode' to be a 'str'
     # instead of a literal string (and we don't want to cast).
-    modprefix = '~' if mode == 'smart' or getattr(cls, '__module__', None) == 'typing' else ''
+    module_prefix = '~' if mode == 'smart' or getattr(cls, '__module__', None) == 'typing' else ''
 
     try:
         if ismockmodule(cls):
-            return f':py:class:`{modprefix}{cls.__name__}`'
+            return f':py:class:`{module_prefix}{cls.__name__}`'
         elif ismock(cls):
-            return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
+            return f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
         elif is_invalid_builtin_class(cls):
             # The above predicate never raises TypeError but should not be
             # evaluated before determining whether *cls* is a mocked object
             # or not; instead of two try-except blocks, we keep it here.
-            return f':py:class:`{modprefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
+            return f':py:class:`{module_prefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
         elif inspect.isNewType(cls):
             if sys.version_info[:2] >= (3, 10):
                 # newtypes have correct module info since Python 3.10+
-                return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
+                return f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
             return f':py:class:`{cls.__name__}`'
         elif UnionType and isinstance(cls, UnionType):
             # Union types (PEP 585) retain their definition order when they
@@ -252,7 +252,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 # Required/NotRequired
                 text = restify(cls.__origin__, mode)
             elif cls.__name__:
-                text = f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
+                text = f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
             else:
                 text = restify(cls.__origin__, mode)
 
@@ -284,12 +284,12 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
             # handle bpo-46998
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
         elif hasattr(cls, '__qualname__'):
-            return f':py:class:`{modprefix}{cls.__module__}.{cls.__qualname__}`'
+            return f':py:class:`{module_prefix}{cls.__module__}.{cls.__qualname__}`'
         elif isinstance(cls, ForwardRef):
             return f':py:class:`{cls.__forward_arg__}`'
         else:
             # not a class (ex. TypeVar)
-            return f':py:obj:`{modprefix}{cls.__module__}.{cls.__name__}`'
+            return f':py:obj:`{module_prefix}{cls.__module__}.{cls.__name__}`'
     except (AttributeError, TypeError):
         return inspect.object_description(cls)
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -250,7 +250,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 # ClassVar; Concatenate; Final; Literal; Unpack; TypeGuard
                 # Required/NotRequired
                 text = restify(cls.__origin__, mode)
-            elif cls.__name__:
+            elif hasattr(cls, '_name'):
                 text = f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
             else:
                 text = restify(cls.__origin__, mode)

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -275,7 +275,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 # generic representation of the parameters
                 params = ', '.join(restify(a, mode) for a in __args__)
 
-            return rf'{text}\ [{params}]'
+            return fr'{text}\ [{params}]'
         elif isinstance(cls, typing._SpecialForm):
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'  # type: ignore[attr-defined]
         elif sys.version_info[:2] >= (3, 11) and cls is typing.Any:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -229,22 +229,22 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
     #
     # With an if-else block, mypy infers 'mode' to be a 'str'
     # instead of a literal string (and we don't want to cast).
-    module_prefix = '~' if mode == 'smart' or getattr(cls, '__module__', None) == 'typing' else ''
+    modprefix = '~' if mode == 'smart' or getattr(cls, '__module__', None) == 'typing' else ''
 
     try:
         if ismockmodule(cls):
-            return f':py:class:`{module_prefix}{cls.__name__}`'
+            return f':py:class:`{modprefix}{cls.__name__}`'
         elif ismock(cls):
-            return f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
+            return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
         elif is_invalid_builtin_class(cls):
             # The above predicate never raises TypeError but should not be
             # evaluated before determining whether *cls* is a mocked object
             # or not; instead of two try-except blocks, we keep it here.
-            return f':py:class:`{module_prefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
+            return f':py:class:`{modprefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
         elif inspect.isNewType(cls):
             if sys.version_info[:2] >= (3, 10):
                 # newtypes have correct module info since Python 3.10+
-                return f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
+                return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
             return f':py:class:`{cls.__name__}`'
         elif UnionType and isinstance(cls, UnionType):
             # Union types (PEP 585) retain their definition order when they
@@ -268,7 +268,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 text = restify(cls.__origin__, mode)
             elif getattr(cls, '_name', None):
                 cls_name = cls._name
-                text = f':py:class:`{module_prefix}{cls.__module__}.{cls_name}`'
+                text = f':py:class:`{modprefix}{cls.__module__}.{cls_name}`'
             else:
                 text = restify(cls.__origin__, mode)
 
@@ -288,7 +288,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                     rtype = restify(__args__[-1], mode)
                     params = f'[{vargs}], {rtype}'
                 elif _get_typing_internal_name(cls.__origin__) == 'Literal':
-                    params = ', '.join(_format_literal_arg_restify(a, mode)
+                    params = ', '.join(_format_literal_arg_restify(a, mode=mode)
                                        for a in cls.__args__)
 
             if params is None:
@@ -302,12 +302,12 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
             # handle bpo-46998
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
         elif hasattr(cls, '__qualname__'):
-            return f':py:class:`{module_prefix}{cls.__module__}.{cls.__qualname__}`'
+            return f':py:class:`{modprefix}{cls.__module__}.{cls.__qualname__}`'
         elif isinstance(cls, ForwardRef):
             return f':py:class:`{cls.__forward_arg__}`'
         else:
             # not a class (ex. TypeVar)
-            return f':py:obj:`{module_prefix}{cls.__module__}.{cls.__name__}`'
+            return f':py:obj:`{modprefix}{cls.__module__}.{cls.__name__}`'
     except (AttributeError, TypeError):
         return inspect.object_description(cls)
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -226,25 +226,25 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
     # If the mode is 'smart', we always use '~'.
     # If the mode is 'fully-qualified-except-typing',
     # we use '~' only for the objects in the ``typing`` module.
-    if mode == 'smart' or getattr(cls, '__module__', None) == 'typing':
-        modprefix = '~'
-    else:
-        modprefix = ''
+    #
+    # With an if-else block, mypy infers 'mode' to be a 'str'
+    # instead of a literal string (and we don't want to cast).
+    module_prefix = '~' if mode == 'smart' or getattr(cls, '__module__', None) == 'typing' else ''
 
     try:
         if ismockmodule(cls):
-            return f':py:class:`{modprefix}{cls.__name__}`'
+            return f':py:class:`{module_prefix}{cls.__name__}`'
         elif ismock(cls):
-            return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
+            return f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
         elif is_invalid_builtin_class(cls):
             # The above predicate never raises TypeError but should not be
             # evaluated before determining whether *cls* is a mocked object
             # or not; instead of two try-except blocks, we keep it here.
-            return f':py:class:`{modprefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
+            return f':py:class:`{module_prefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
         elif inspect.isNewType(cls):
             if sys.version_info[:2] >= (3, 10):
                 # newtypes have correct module info since Python 3.10+
-                return f':py:class:`{modprefix}{cls.__module__}.{cls.__name__}`'
+                return f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
             return f':py:class:`{cls.__name__}`'
         elif UnionType and isinstance(cls, UnionType):
             # Union types (PEP 585) retain their definition order when they
@@ -268,7 +268,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 text = restify(cls.__origin__, mode)
             elif getattr(cls, '_name', None):
                 cls_name = cls._name
-                text = f':py:class:`{modprefix}{cls.__module__}.{cls_name}`'
+                text = f':py:class:`{module_prefix}{cls.__module__}.{cls_name}`'
             else:
                 text = restify(cls.__origin__, mode)
 
@@ -302,12 +302,12 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
             # handle bpo-46998
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
         elif hasattr(cls, '__qualname__'):
-            return f':py:class:`{modprefix}{cls.__module__}.{cls.__qualname__}`'
+            return f':py:class:`{module_prefix}{cls.__module__}.{cls.__qualname__}`'
         elif isinstance(cls, ForwardRef):
             return f':py:class:`{cls.__forward_arg__}`'
         else:
             # not a class (ex. TypeVar)
-            return f':py:obj:`{modprefix}{cls.__module__}.{cls.__name__}`'
+            return f':py:obj:`{module_prefix}{cls.__module__}.{cls.__name__}`'
     except (AttributeError, TypeError):
         return inspect.object_description(cls)
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -269,13 +269,13 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                 return fr'{text}\ [[{args}], {returns}]'
 
             if cls_module_is_typing and cls.__origin__.__name__ == 'Literal':
-                params = ', '.join(_format_literal_arg_restify(a, mode=mode)
-                                   for a in cls.__args__)
-            else:
-                # generic representation of the parameters
-                params = ', '.join(restify(a, mode) for a in __args__)
+                args = ', '.join(_format_literal_arg_restify(a, mode=mode)
+                                 for a in cls.__args__)
+                return fr'{text}\ [{args}]'
 
-            return fr'{text}\ [{params}]'
+            # generic representation of the parameters
+            args = ', '.join(restify(a, mode) for a in __args__)
+            return fr'{text}\ [{args}]'
         elif isinstance(cls, typing._SpecialForm):
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'  # type: ignore[attr-defined]
         elif sys.version_info[:2] >= (3, 11) and cls is typing.Any:

--- a/tests/test_util/test_util_typing.py
+++ b/tests/test_util/test_util_typing.py
@@ -1,8 +1,6 @@
 """Tests util.typing functions."""
 
 import sys
-import typing as t
-from collections import abc
 from contextvars import Context, ContextVar, Token
 from enum import Enum
 from numbers import Integral
@@ -31,7 +29,10 @@ from types import (
 )
 from typing import (
     Any,
+    Callable,
     Dict,
+    Generator,
+    Iterator,
     List,
     NewType,
     Optional,
@@ -172,29 +173,20 @@ def test_restify_type_hints_containers():
     assert restify(MyList[Tuple[int, int]]) == (":py:class:`tests.test_util.test_util_typing.MyList`\\ "
                                                 "[:py:class:`~typing.Tuple`\\ "
                                                 "[:py:class:`int`, :py:class:`int`]]")
-    assert restify(t.Generator[None, None, None]) == (":py:class:`~typing.Generator`\\ "
-                                                      "[:py:obj:`None`, :py:obj:`None`, "
-                                                      ":py:obj:`None`]")
-    assert restify(abc.Generator[None, None, None]) == (":py:class:`collections.abc.Generator`\\ "
-                                                        "[:py:obj:`None`, :py:obj:`None`, "
-                                                        ":py:obj:`None`]")
-    assert restify(t.Iterator[None]) == (":py:class:`~typing.Iterator`\\ "
-                                         "[:py:obj:`None`]")
-    assert restify(abc.Iterator[None]) == (":py:class:`collections.abc.Iterator`\\ "
-                                           "[:py:obj:`None`]")
+    assert restify(Generator[None, None, None]) == (":py:class:`~typing.Generator`\\ "
+                                                    "[:py:obj:`None`, :py:obj:`None`, "
+                                                    ":py:obj:`None`]")
+    assert restify(Iterator[None]) == (":py:class:`~typing.Iterator`\\ "
+                                       "[:py:obj:`None`]")
 
 
 def test_restify_type_hints_Callable():
-    assert restify(t.Callable) == ":py:class:`~typing.Callable`"
-    assert restify(t.Callable[[str], int]) == (":py:class:`~typing.Callable`\\ "
-                                               "[[:py:class:`str`], :py:class:`int`]")
-    assert restify(t.Callable[..., int]) == (":py:class:`~typing.Callable`\\ "
-                                             "[[...], :py:class:`int`]")
-    assert restify(abc.Callable) == ":py:class:`collections.abc.Callable`"
-    assert restify(abc.Callable[[str], int]) == (":py:class:`collections.abc.Callable`\\ "
-                                                 "[[:py:class:`str`], :py:class:`int`]")
-    assert restify(abc.Callable[..., int]) == (":py:class:`collections.abc.Callable`\\ "
-                                               "[[...], :py:class:`int`]")
+    assert restify(Callable) == ":py:class:`~typing.Callable`"
+
+    assert restify(Callable[[str], int]) == (":py:class:`~typing.Callable`\\ "
+                                             "[[:py:class:`str`], :py:class:`int`]")
+    assert restify(Callable[..., int]) == (":py:class:`~typing.Callable`\\ "
+                                           "[[...], :py:class:`int`]")
 
 
 def test_restify_type_hints_Union():
@@ -417,21 +409,13 @@ def test_stringify_type_hints_containers():
     assert stringify_annotation(MyList[Tuple[int, int]], "fully-qualified") == "tests.test_util.test_util_typing.MyList[typing.Tuple[int, int]]"
     assert stringify_annotation(MyList[Tuple[int, int]], "smart") == "~tests.test_util.test_util_typing.MyList[~typing.Tuple[int, int]]"
 
-    assert stringify_annotation(t.Generator[None, None, None], 'fully-qualified-except-typing') == "Generator[None, None, None]"
-    assert stringify_annotation(t.Generator[None, None, None], "fully-qualified") == "typing.Generator[None, None, None]"
-    assert stringify_annotation(t.Generator[None, None, None], "smart") == "~typing.Generator[None, None, None]"
+    assert stringify_annotation(Generator[None, None, None], 'fully-qualified-except-typing') == "Generator[None, None, None]"
+    assert stringify_annotation(Generator[None, None, None], "fully-qualified") == "typing.Generator[None, None, None]"
+    assert stringify_annotation(Generator[None, None, None], "smart") == "~typing.Generator[None, None, None]"
 
-    assert stringify_annotation(abc.Generator[None, None, None], 'fully-qualified-except-typing') == "collections.abc.Generator[None, None, None]"
-    assert stringify_annotation(abc.Generator[None, None, None], "fully-qualified") == "collections.abc.Generator[None, None, None]"
-    assert stringify_annotation(abc.Generator[None, None, None], "smart") == "~collections.abc.Generator[None, None, None]"
-
-    assert stringify_annotation(t.Iterator[None], 'fully-qualified-except-typing') == "Iterator[None]"
-    assert stringify_annotation(t.Iterator[None], "fully-qualified") == "typing.Iterator[None]"
-    assert stringify_annotation(t.Iterator[None], "smart") == "~typing.Iterator[None]"
-
-    assert stringify_annotation(abc.Iterator[None], 'fully-qualified-except-typing') == "collections.abc.Iterator[None]"
-    assert stringify_annotation(abc.Iterator[None], "fully-qualified") == "collections.abc.Iterator[None]"
-    assert stringify_annotation(abc.Iterator[None], "smart") == "~collections.abc.Iterator[None]"
+    assert stringify_annotation(Iterator[None], 'fully-qualified-except-typing') == "Iterator[None]"
+    assert stringify_annotation(Iterator[None], "fully-qualified") == "typing.Iterator[None]"
+    assert stringify_annotation(Iterator[None], "smart") == "~typing.Iterator[None]"
 
 
 def test_stringify_type_hints_pep_585():
@@ -505,29 +489,17 @@ def test_stringify_type_hints_string():
 
 
 def test_stringify_type_hints_Callable():
-    assert stringify_annotation(t.Callable, 'fully-qualified-except-typing') == "Callable"
-    assert stringify_annotation(t.Callable, "fully-qualified") == "typing.Callable"
-    assert stringify_annotation(t.Callable, "smart") == "~typing.Callable"
+    assert stringify_annotation(Callable, 'fully-qualified-except-typing') == "Callable"
+    assert stringify_annotation(Callable, "fully-qualified") == "typing.Callable"
+    assert stringify_annotation(Callable, "smart") == "~typing.Callable"
 
-    assert stringify_annotation(t.Callable[[str], int], 'fully-qualified-except-typing') == "Callable[[str], int]"
-    assert stringify_annotation(t.Callable[[str], int], "fully-qualified") == "typing.Callable[[str], int]"
-    assert stringify_annotation(t.Callable[[str], int], "smart") == "~typing.Callable[[str], int]"
+    assert stringify_annotation(Callable[[str], int], 'fully-qualified-except-typing') == "Callable[[str], int]"
+    assert stringify_annotation(Callable[[str], int], "fully-qualified") == "typing.Callable[[str], int]"
+    assert stringify_annotation(Callable[[str], int], "smart") == "~typing.Callable[[str], int]"
 
-    assert stringify_annotation(t.Callable[..., int], 'fully-qualified-except-typing') == "Callable[[...], int]"
-    assert stringify_annotation(t.Callable[..., int], "fully-qualified") == "typing.Callable[[...], int]"
-    assert stringify_annotation(t.Callable[..., int], "smart") == "~typing.Callable[[...], int]"
-
-    assert stringify_annotation(abc.Callable, 'fully-qualified-except-typing') == "collections.abc.Callable"
-    assert stringify_annotation(abc.Callable, "fully-qualified") == "collections.abc.Callable"
-    assert stringify_annotation(abc.Callable, "smart") == "~collections.abc.Callable"
-
-    assert stringify_annotation(abc.Callable[[str], int], 'fully-qualified-except-typing') == "collections.abc.Callable[[str], int]"
-    assert stringify_annotation(abc.Callable[[str], int], "fully-qualified") == "collections.abc.Callable[[str], int]"
-    assert stringify_annotation(abc.Callable[[str], int], "smart") == "~collections.abc.Callable[[str], int]"
-
-    assert stringify_annotation(abc.Callable[..., int], 'fully-qualified-except-typing') == "collections.abc.Callable[[...], int]"
-    assert stringify_annotation(abc.Callable[..., int], "fully-qualified") == "collections.abc.Callable[[...], int]"
-    assert stringify_annotation(abc.Callable[..., int], "smart") == "~collections.abc.Callable[[...], int]"
+    assert stringify_annotation(Callable[..., int], 'fully-qualified-except-typing') == "Callable[[...], int]"
+    assert stringify_annotation(Callable[..., int], "fully-qualified") == "typing.Callable[[...], int]"
+    assert stringify_annotation(Callable[..., int], "smart") == "~typing.Callable[[...], int]"
 
 
 def test_stringify_type_hints_Union():

--- a/tests/test_util/test_util_typing.py
+++ b/tests/test_util/test_util_typing.py
@@ -1,6 +1,8 @@
 """Tests util.typing functions."""
 
 import sys
+import typing as t
+from collections import abc
 from contextvars import Context, ContextVar, Token
 from enum import Enum
 from numbers import Integral
@@ -29,10 +31,7 @@ from types import (
 )
 from typing import (
     Any,
-    Callable,
     Dict,
-    Generator,
-    Iterator,
     List,
     NewType,
     Optional,
@@ -173,20 +172,29 @@ def test_restify_type_hints_containers():
     assert restify(MyList[Tuple[int, int]]) == (":py:class:`tests.test_util.test_util_typing.MyList`\\ "
                                                 "[:py:class:`~typing.Tuple`\\ "
                                                 "[:py:class:`int`, :py:class:`int`]]")
-    assert restify(Generator[None, None, None]) == (":py:class:`~typing.Generator`\\ "
-                                                    "[:py:obj:`None`, :py:obj:`None`, "
-                                                    ":py:obj:`None`]")
-    assert restify(Iterator[None]) == (":py:class:`~typing.Iterator`\\ "
-                                       "[:py:obj:`None`]")
+    assert restify(t.Generator[None, None, None]) == (":py:class:`~typing.Generator`\\ "
+                                                      "[:py:obj:`None`, :py:obj:`None`, "
+                                                      ":py:obj:`None`]")
+    assert restify(abc.Generator[None, None, None]) == (":py:class:`collections.abc.Generator`\\ "
+                                                        "[:py:obj:`None`, :py:obj:`None`, "
+                                                        ":py:obj:`None`]")
+    assert restify(t.Iterator[None]) == (":py:class:`~typing.Iterator`\\ "
+                                         "[:py:obj:`None`]")
+    assert restify(abc.Iterator[None]) == (":py:class:`collections.abc.Iterator`\\ "
+                                           "[:py:obj:`None`]")
 
 
 def test_restify_type_hints_Callable():
-    assert restify(Callable) == ":py:class:`~typing.Callable`"
-
-    assert restify(Callable[[str], int]) == (":py:class:`~typing.Callable`\\ "
-                                             "[[:py:class:`str`], :py:class:`int`]")
-    assert restify(Callable[..., int]) == (":py:class:`~typing.Callable`\\ "
-                                           "[[...], :py:class:`int`]")
+    assert restify(t.Callable) == ":py:class:`~typing.Callable`"
+    assert restify(t.Callable[[str], int]) == (":py:class:`~typing.Callable`\\ "
+                                               "[[:py:class:`str`], :py:class:`int`]")
+    assert restify(t.Callable[..., int]) == (":py:class:`~typing.Callable`\\ "
+                                             "[[...], :py:class:`int`]")
+    assert restify(abc.Callable) == ":py:class:`collections.abc.Callable`"
+    assert restify(abc.Callable[[str], int]) == (":py:class:`collections.abc.Callable`\\ "
+                                                 "[[:py:class:`str`], :py:class:`int`]")
+    assert restify(abc.Callable[..., int]) == (":py:class:`collections.abc.Callable`\\ "
+                                               "[[...], :py:class:`int`]")
 
 
 def test_restify_type_hints_Union():
@@ -409,13 +417,21 @@ def test_stringify_type_hints_containers():
     assert stringify_annotation(MyList[Tuple[int, int]], "fully-qualified") == "tests.test_util.test_util_typing.MyList[typing.Tuple[int, int]]"
     assert stringify_annotation(MyList[Tuple[int, int]], "smart") == "~tests.test_util.test_util_typing.MyList[~typing.Tuple[int, int]]"
 
-    assert stringify_annotation(Generator[None, None, None], 'fully-qualified-except-typing') == "Generator[None, None, None]"
-    assert stringify_annotation(Generator[None, None, None], "fully-qualified") == "typing.Generator[None, None, None]"
-    assert stringify_annotation(Generator[None, None, None], "smart") == "~typing.Generator[None, None, None]"
+    assert stringify_annotation(t.Generator[None, None, None], 'fully-qualified-except-typing') == "Generator[None, None, None]"
+    assert stringify_annotation(t.Generator[None, None, None], "fully-qualified") == "typing.Generator[None, None, None]"
+    assert stringify_annotation(t.Generator[None, None, None], "smart") == "~typing.Generator[None, None, None]"
 
-    assert stringify_annotation(Iterator[None], 'fully-qualified-except-typing') == "Iterator[None]"
-    assert stringify_annotation(Iterator[None], "fully-qualified") == "typing.Iterator[None]"
-    assert stringify_annotation(Iterator[None], "smart") == "~typing.Iterator[None]"
+    assert stringify_annotation(abc.Generator[None, None, None], 'fully-qualified-except-typing') == "collections.abc.Generator[None, None, None]"
+    assert stringify_annotation(abc.Generator[None, None, None], "fully-qualified") == "collections.abc.Generator[None, None, None]"
+    assert stringify_annotation(abc.Generator[None, None, None], "smart") == "~collections.abc.Generator[None, None, None]"
+
+    assert stringify_annotation(t.Iterator[None], 'fully-qualified-except-typing') == "Iterator[None]"
+    assert stringify_annotation(t.Iterator[None], "fully-qualified") == "typing.Iterator[None]"
+    assert stringify_annotation(t.Iterator[None], "smart") == "~typing.Iterator[None]"
+
+    assert stringify_annotation(abc.Iterator[None], 'fully-qualified-except-typing') == "collections.abc.Iterator[None]"
+    assert stringify_annotation(abc.Iterator[None], "fully-qualified") == "collections.abc.Iterator[None]"
+    assert stringify_annotation(abc.Iterator[None], "smart") == "~collections.abc.Iterator[None]"
 
 
 def test_stringify_type_hints_pep_585():
@@ -489,17 +505,29 @@ def test_stringify_type_hints_string():
 
 
 def test_stringify_type_hints_Callable():
-    assert stringify_annotation(Callable, 'fully-qualified-except-typing') == "Callable"
-    assert stringify_annotation(Callable, "fully-qualified") == "typing.Callable"
-    assert stringify_annotation(Callable, "smart") == "~typing.Callable"
+    assert stringify_annotation(t.Callable, 'fully-qualified-except-typing') == "Callable"
+    assert stringify_annotation(t.Callable, "fully-qualified") == "typing.Callable"
+    assert stringify_annotation(t.Callable, "smart") == "~typing.Callable"
 
-    assert stringify_annotation(Callable[[str], int], 'fully-qualified-except-typing') == "Callable[[str], int]"
-    assert stringify_annotation(Callable[[str], int], "fully-qualified") == "typing.Callable[[str], int]"
-    assert stringify_annotation(Callable[[str], int], "smart") == "~typing.Callable[[str], int]"
+    assert stringify_annotation(t.Callable[[str], int], 'fully-qualified-except-typing') == "Callable[[str], int]"
+    assert stringify_annotation(t.Callable[[str], int], "fully-qualified") == "typing.Callable[[str], int]"
+    assert stringify_annotation(t.Callable[[str], int], "smart") == "~typing.Callable[[str], int]"
 
-    assert stringify_annotation(Callable[..., int], 'fully-qualified-except-typing') == "Callable[[...], int]"
-    assert stringify_annotation(Callable[..., int], "fully-qualified") == "typing.Callable[[...], int]"
-    assert stringify_annotation(Callable[..., int], "smart") == "~typing.Callable[[...], int]"
+    assert stringify_annotation(t.Callable[..., int], 'fully-qualified-except-typing') == "Callable[[...], int]"
+    assert stringify_annotation(t.Callable[..., int], "fully-qualified") == "typing.Callable[[...], int]"
+    assert stringify_annotation(t.Callable[..., int], "smart") == "~typing.Callable[[...], int]"
+
+    assert stringify_annotation(abc.Callable, 'fully-qualified-except-typing') == "collections.abc.Callable"
+    assert stringify_annotation(abc.Callable, "fully-qualified") == "collections.abc.Callable"
+    assert stringify_annotation(abc.Callable, "smart") == "~collections.abc.Callable"
+
+    assert stringify_annotation(abc.Callable[[str], int], 'fully-qualified-except-typing') == "collections.abc.Callable[[str], int]"
+    assert stringify_annotation(abc.Callable[[str], int], "fully-qualified") == "collections.abc.Callable[[str], int]"
+    assert stringify_annotation(abc.Callable[[str], int], "smart") == "~collections.abc.Callable[[str], int]"
+
+    assert stringify_annotation(abc.Callable[..., int], 'fully-qualified-except-typing') == "collections.abc.Callable[[...], int]"
+    assert stringify_annotation(abc.Callable[..., int], "fully-qualified") == "collections.abc.Callable[[...], int]"
+    assert stringify_annotation(abc.Callable[..., int], "smart") == "~collections.abc.Callable[[...], int]"
 
 
 def test_stringify_type_hints_Union():


### PR DESCRIPTION
This is the last part of the refactorization of those functions where I moved some code around and refactor some inner cases (with details).