### PR TITLE
autodoc: Fix test expectation for enum rendering on Python 3.12.3

### DIFF
--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -1454,7 +1454,7 @@ class _EnumFormatter:
         """Generate the brief part of the class being documented."""
         assert doc, f'enumeration class {self.target!r} should have an explicit docstring'
 
-        if sys.version_info[:2] >= (3, 13) or sys.version_info >= (3, 12, 3):
+        if sys.version_info[:2] >= (3, 13) or sys.version_info[:3] >= (3, 12, 3):
             args = ('(value, names=<not given>, *values, module=None, '
                     'qualname=None, type=None, start=1, boundary=None)')
         elif sys.version_info[:2] >= (3, 12):

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -1454,7 +1454,7 @@ class _EnumFormatter:
         """Generate the brief part of the class being documented."""
         assert doc, f'enumeration class {self.target!r} should have an explicit docstring'
 
-        if sys.version_info[:2] >= (3, 13):
+        if sys.version_info[:2] >= (3, 13) or sys.version_info >= (3, 12, 3):
             args = ('(value, names=<not given>, *values, module=None, '
                     'qualname=None, type=None, start=1, boundary=None)')
         elif sys.version_info[:2] >= (3, 12):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Resolve formatting expectations for the default `enum` sentinel value on Py3.12.3+ to fix a test that succeeeds for Py3.12.2 but fails for Py3.12.3 currently.

### Detail
- Adjust some of the Python `sys.version_info` checks in the `test_ext_autodoc` test module.

### Relates
- Re-resolves #12202 (initially Py3.13-only).