### PR TITLE
Re-export various names in ``sphinx.domains.python``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 7.3.5 (in development)
 Bugs fixed
 ----------
 
+* Re-export various objects from ``sphinx.domains.python._object``
+  in ``sphinx.domains.python``.
+  Patch by Jacob Chesslo and Adam Turner.
 
 Release 7.3.4 (released Apr 17, 2024)
 =====================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Release 7.3.5 (in development)
 Bugs fixed
 ----------
 
-* Re-export various objects from ``sphinx.domains.python._object``
+* #12295: Re-export various objects from ``sphinx.domains.python._object``
   in ``sphinx.domains.python``.
   Patch by Jacob Chesslo and Adam Turner.
 

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -13,14 +13,7 @@ from docutils.parsers.rst import directives
 from sphinx import addnodes
 from sphinx.domains import Domain, Index, IndexEntry, ObjType
 from sphinx.domains.python._annotations import _parse_annotation
-from sphinx.domains.python._object import (
-    PyField,  # NoQA: F401
-    PyGroupedField,  # NoQA: F401
-    PyObject,
-    PyTypedField,  # NoQA: F401
-    PyXrefMixin,  # NoQA: F401
-    py_sig_re,  # NoQA: F401
-)
+from sphinx.domains.python._object import PyObject
 from sphinx.locale import _, __
 from sphinx.roles import XRefRole
 from sphinx.util import logging
@@ -42,6 +35,16 @@ if TYPE_CHECKING:
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
     from sphinx.util.typing import ExtensionMetadata, OptionSpec
+
+# re-export objects for backwards compatibility
+# xref https://github.com/sphinx-doc/sphinx/issues/12295
+from sphinx.domains.python._object import (  # NoQA: F401
+    PyField,
+    PyGroupedField,
+    PyTypedField,
+    PyXrefMixin,
+    py_sig_re,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -17,6 +17,7 @@ from sphinx.domains.python._object import (
     PyObject,
     PyXrefMixin,
     PyField,
+    PyTypedField,
     PyGroupedField,
     py_sig_re,
 )

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -14,12 +14,12 @@ from sphinx import addnodes
 from sphinx.domains import Domain, Index, IndexEntry, ObjType
 from sphinx.domains.python._annotations import _parse_annotation
 from sphinx.domains.python._object import (
-    PyField,
-    PyGroupedField,
+    PyField,  # NoQA: F401
+    PyGroupedField,  # NoQA: F401
     PyObject,
-    PyTypedField,
-    PyXrefMixin,
-    py_sig_re,
+    PyTypedField,  # NoQA: F401
+    PyXrefMixin,  # NoQA: F401
+    py_sig_re,  # NoQA: F401
 )
 from sphinx.locale import _, __
 from sphinx.roles import XRefRole

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -14,11 +14,11 @@ from sphinx import addnodes
 from sphinx.domains import Domain, Index, IndexEntry, ObjType
 from sphinx.domains.python._annotations import _parse_annotation
 from sphinx.domains.python._object import (
-    PyObject,
-    PyXrefMixin,
     PyField,
-    PyTypedField,
     PyGroupedField,
+    PyObject,
+    PyTypedField,
+    PyXrefMixin,
     py_sig_re,
 )
 from sphinx.locale import _, __

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -13,7 +13,13 @@ from docutils.parsers.rst import directives
 from sphinx import addnodes
 from sphinx.domains import Domain, Index, IndexEntry, ObjType
 from sphinx.domains.python._annotations import _parse_annotation
-from sphinx.domains.python._object import PyObject
+from sphinx.domains.python._object import (
+    PyObject,
+    PyXrefMixin,
+    PyField,
+    PyGroupedField,
+    py_sig_re,
+)
 from sphinx.locale import _, __
 from sphinx.roles import XRefRole
 from sphinx.util import logging


### PR DESCRIPTION
Subject: PyXrefMixin, PyField, PyGroupedField, and py_sig_re now exist again in sphinx.domains.python

### Feature or Bugfix
- Bugfix

### Purpose
- PyXrefMixin, PyField, PyGroupedField, and py_sig_re now exist again in sphinx.domains.python

### Detail
- PyXrefMixin, PyField, PyGroupedField, and py_sig_re now exist again in sphinx.domains.python

### Relates
- https://github.com/sphinx-doc/sphinx/issues/12295
- https://github.com/sphinx-doc/sphinx/commit/e9dcfebcf9f3cb5db6a47448e10e9b61c5abc416

