### PR TITLE
Replace term 'blacklist' with 'denylist'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,7 +173,7 @@ Bugs fixed
   Patch by David Runge.
 * #11904: Support unary subtraction when parsing annotations.
   Patch by James Addison.
-* #11925: Blacklist the ``sphinxprettysearchresults`` extension; the functionality
+* #11925: Denylist the ``sphinxprettysearchresults`` extension; the functionality
   it provides was merged into Sphinx v2.0.0.
   Patch by James Addison.
 * #11917: Fix rendering of annotated inherited members for Python 3.9.

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1448,13 +1448,13 @@ class DecoratorDocumenter(FunctionDocumenter):
 # Types which have confusing metaclass signatures it would be best not to show.
 # These are listed by name, rather than storing the objects themselves, to avoid
 # needing to import the modules.
-_METACLASS_CALL_BLACKLIST = [
+_METACLASS_CALL_DENYLIST = [
     'enum.EnumMeta.__call__',
 ]
 
 
 # Types whose __new__ signature is a pass-through.
-_CLASS_NEW_BLACKLIST = [
+_CLASS_NEW_DENYLIST = [
     'typing.Generic.__new__',
 ]
 
@@ -1550,7 +1550,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         call = get_user_defined_function_or_method(type(self.object), '__call__')
 
         if call is not None:
-            if f"{call.__module__}.{call.__qualname__}" in _METACLASS_CALL_BLACKLIST:
+            if f"{call.__module__}.{call.__qualname__}" in _METACLASS_CALL_DENYLIST:
                 call = None
 
         if call is not None:
@@ -1566,7 +1566,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
         new = get_user_defined_function_or_method(self.object, '__new__')
 
         if new is not None:
-            if f"{new.__module__}.{new.__qualname__}" in _CLASS_NEW_BLACKLIST:
+            if f"{new.__module__}.{new.__qualname__}" in _CLASS_NEW_DENYLIST:
                 new = None
 
         if new is not None:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 # list of deprecated extensions. Keys are extension name.
 # Values are Sphinx version that merge the extension.
-EXTENSION_BLACKLIST = {
+EXTENSION_DENYLIST = {
     "sphinxjp.themecore": "1.2",
     "sphinxprettysearchresults": "2.0.0",
 }
@@ -440,10 +440,10 @@ class SphinxComponentRegistry:
         """Load a Sphinx extension."""
         if extname in app.extensions:  # already loaded
             return
-        if extname in EXTENSION_BLACKLIST:
+        if extname in EXTENSION_DENYLIST:
             logger.warning(__('the extension %r was already merged with Sphinx since '
                               'version %s; this extension is ignored.'),
-                           extname, EXTENSION_BLACKLIST[extname])
+                           extname, EXTENSION_DENYLIST[extname])
             return
 
         # update loading context

--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -10,7 +10,7 @@
  */
 "use strict";
 
-const BLACKLISTED_KEY_CONTROL_ELEMENTS = new Set([
+const DENYLISTED_KEY_CONTROL_ELEMENTS = new Set([
   "TEXTAREA",
   "INPUT",
   "SELECT",
@@ -112,7 +112,7 @@ const Documentation = {
 
     document.addEventListener("keydown", (event) => {
       // bail for input elements
-      if (BLACKLISTED_KEY_CONTROL_ELEMENTS.has(document.activeElement.tagName)) return;
+      if (DENYLISTED_KEY_CONTROL_ELEMENTS.has(document.activeElement.tagName)) return;
       // bail with special keys
       if (event.altKey || event.ctrlKey || event.metaKey) return;
 

--- a/sphinx/themes/basic/static/sphinx_highlight.js
+++ b/sphinx/themes/basic/static/sphinx_highlight.js
@@ -134,7 +134,7 @@ const SphinxHighlight = {
 
     document.addEventListener("keydown", (event) => {
       // bail for input elements
-      if (BLACKLISTED_KEY_CONTROL_ELEMENTS.has(document.activeElement.tagName)) return;
+      if (DENYLISTED_KEY_CONTROL_ELEMENTS.has(document.activeElement.tagName)) return;
       // bail with special keys
       if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return;
       if (DOCUMENTATION_OPTIONS.ENABLE_SEARCH_SHORTCUTS && (event.key === "Escape")) {

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -84,7 +84,7 @@ def test_extensions(app, status, warning):
     assert "extension 'shutil' has no setup() function" in warning
 
 
-def test_extension_in_blacklist(app, status, warning):
+def test_extension_in_denylist(app, status, warning):
     app.setup_extension('sphinxjp.themecore')
     msg = strip_colors(warning.getvalue())
     assert msg.startswith("WARNING: the extension 'sphinxjp.themecore' was")


### PR DESCRIPTION
Subject: Remove term blacklist from Sphinx repo

### Feature or Bugfix
- Bugfix

### Purpose
Many organizations (including my employer) have inclusive language policies. There are a few references to a commonly banned term, 'blacklist'. This PR removes those few references.

### Detail
 In some cases some organizations might limit or bar the use of Sphinx if automated checkers like Acrolinx find this term in files like doctools.js after sphinx documentation is generated.

### Relates


