### PR TITLE
[CI/CD] patch `sphinx.util.inspect_evaluate_forwardref` causing CI failures

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -718,9 +718,10 @@ def _evaluate_forwardref(
     localns: dict[str, Any] | None,
 ) -> Any:
     """Evaluate a forward reference."""
-    if sys.version_info[:2] >= (3, 13):
+    if sys.version_info >= (3, 12, 4):
         # ``type_params`` were added in 3.13 and the signature of _evaluate()
-        # is not backward-compatible, so we will just suppress NameError's.
+        # is not backward-compatible (it was backported to 3.12.4, so anything
+        # before 3.12.4 still has the old signature).
         #
         # See: https://github.com/python/cpython/pull/118104.
         return ref._evaluate(globalns, localns, {}, recursive_guard=frozenset())

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -724,7 +724,7 @@ def _evaluate_forwardref(
         # before 3.12.4 still has the old signature).
         #
         # See: https://github.com/python/cpython/pull/118104.
-        return ref._evaluate(globalns, localns, {}, recursive_guard=frozenset())
+        return ref._evaluate(globalns, localns, {}, recursive_guard=frozenset())  # type: ignore[arg-type, misc]
     return ref._evaluate(globalns, localns, frozenset())
 
 

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -718,6 +718,12 @@ def _evaluate_forwardref(
     localns: dict[str, Any] | None,
 ) -> Any:
     """Evaluate a forward reference."""
+    if sys.version_info[:2] >= (3, 13):
+        # ``type_params`` were added in 3.13 and the signature of _evaluate()
+        # is not backward-compatible, so we will just suppress NameError's.
+        #
+        # See: https://github.com/python/cpython/pull/118104.
+        return ref._evaluate(globalns, localns, {}, recursive_guard=frozenset())
     return ref._evaluate(globalns, localns, frozenset())
 
 


### PR DESCRIPTION
This fixes the currently failing tests on master.

The reason was https://github.com/python/cpython/pull/118104, which changed the signature of `_evaluate` for forward references because of type parameters. The PR was backported to 3.12.4 (in dev) but affects 3.13.