### PR TITLE
sphinx.ext.extlinks: Add `extlink-{name}` CSS class to links

### DIFF
--- a/doc/internals/contributing.rst
+++ b/doc/internals/contributing.rst
@@ -156,7 +156,7 @@ Please follow these guidelines when writing code for Sphinx:
 
 Style and type checks can be run as follows::
 
-    ruff .
+    ruff check .
     mypy sphinx/
 
 Unit tests

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -19,7 +19,6 @@ Both, the url string and the caption string must escape ``%`` as ``%%``.
 
 from __future__ import annotations
 
-import html
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -109,7 +108,7 @@ def make_link_role(name: str, base_url: str, caption: str) -> RoleFunction:
             else:
                 title = caption % part
         pnode = nodes.reference(title, title, internal=False, refuri=full_url)
-        pnode["classes"].append(f"extlink-{html.escape(name)}")
+        pnode["classes"].append(f"extlink-{name}")
         return [pnode], []
     return role
 

--- a/sphinx/ext/extlinks.py
+++ b/sphinx/ext/extlinks.py
@@ -19,6 +19,7 @@ Both, the url string and the caption string must escape ``%`` as ``%%``.
 
 from __future__ import annotations
 
+import html
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -91,9 +92,9 @@ class ExternalLinksChecker(SphinxPostTransform):
 
 def make_link_role(name: str, base_url: str, caption: str) -> RoleFunction:
     # Check whether we have base_url and caption strings have an '%s' for
-    # expansion.  If not, fall back the the old behaviour and use the string as
+    # expansion.  If not, fall back to the old behaviour and use the string as
     # a prefix.
-    # Remark: It is an implementation detail that we use Pythons %-formatting.
+    # Remark: It is an implementation detail that we use Python's %-formatting.
     # So far we only expose ``%s`` and require quoting of ``%`` using ``%%``.
     def role(typ: str, rawtext: str, text: str, lineno: int,
              inliner: Inliner, options: dict[str, Any] | None = None,
@@ -108,6 +109,7 @@ def make_link_role(name: str, base_url: str, caption: str) -> RoleFunction:
             else:
                 title = caption % part
         pnode = nodes.reference(title, title, internal=False, refuri=full_url)
+        pnode["classes"].append(f"extlink-{html.escape(name)}")
         return [pnode], []
     return role
 

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -255,6 +255,8 @@ def tail_check(check):
     ('extensions.html', ".//a[@href='https://python.org/dev/']", "https://python.org/dev/"),
     ('extensions.html', ".//a[@href='https://bugs.python.org/issue1000']", "issue 1000"),
     ('extensions.html', ".//a[@href='https://bugs.python.org/issue1042']", "explicit caption"),
+    ('extensions.html', ".//a[@class='extlink-pyurl reference external']", "https://python.org/dev/"),
+    ('extensions.html', ".//a[@class='extlink-issue reference external']", "issue 1000"),
 
     # index entries
     ('genindex.html', ".//a/strong", "Main"),


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Allow theme authors and docs builders flexibility to apply whatever custom formatting to an extlink without the need for custom extensions.

### Relates
- Fixes https://github.com/sphinx-doc/sphinx/issues/11745.

