### PR TITLE
HTML Search: Fix removal of unwanted anchor content from search results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ Bugs fixed
 * #12162: Fix a performance regression in the C domain that has
   been present since version 3.0.0.
   Patch by Donald Hunter.
-* #12320: Fix removal of anchors from search summaries.
+* #12320: Fix removal of anchors from search summaries (regression in 7.3.0).
   Patch by Will Lachance.
 
 Testing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Bugs fixed
 * #12162: Fix a performance regression in the C domain that has
   been present since version 3.0.0.
   Patch by Donald Hunter.
+* #12320: Fix removal of anchors from search summaries.
+  Patch by Will Lachance.
 
 Testing
 -------

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -178,7 +178,7 @@ const Search = {
 
   htmlToText: (htmlString, anchor) => {
     const htmlElement = new DOMParser().parseFromString(htmlString, 'text/html');
-    for (const removalQuery of [".headerlinks", "script", "style"]) {
+    for (const removalQuery of [".headerlink", "script", "style"]) {
       htmlElement.querySelectorAll(removalQuery).forEach((el) => { el.remove() });
     }
     if (anchor) {

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -100,15 +100,15 @@ describe("htmlToText", function() {
       </style>
       <!-- main content -->
       <section id="getting-started">
-        <h1>Getting Started</h1>
+        <h1>Getting Started <a class="headerlink" href="#getting-started" title="Link to this heading">¶</a></h1>
         <p>Some text</p>
       </section>
       <section id="other-section">
-        <h1>Other Section</h1>
+        <h1>Other Section <a class="headerlink" href="#other-section" title="Link to this heading">¶</a></h1>
         <p>Other text</p>
       </section>
       <section id="yet-another-section">
-        <h1>Yet Another Section</h1>
+        <h1>Yet Another Section <a class="headerlink" href="#yet-another-section" title="Link to this heading">¶</a></h1>
         <p>More text</p>
       </section>
     </div>


### PR DESCRIPTION
Subject: Fix removal of unwanted anchor content from search results

### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Purpose

This was accidentally broken in https://github.com/sphinx-doc/sphinx/commit/bf0bec3b4b8c019acad4a77a9e228de4e65b538b (https://github.com/sphinx-doc/sphinx/pull/12057), this just fixes it (and updates the existing test so it hopefully doesn't happen again).

### Detail

N/A

### Relates

Closes #12320
