### PR TITLE
Fix debug option in autosectionlabel documentation

### DIFF
--- a/doc/usage/extensions/autosectionlabel.rst
+++ b/doc/usage/extensions/autosectionlabel.rst
@@ -51,6 +51,6 @@ Debugging
 ---------
 
 The ``WARNING: undefined label`` indicates that your reference in
-:rst:role:`ref` is mis-spelled. Invoking :program:`sphinx-build` with ``-vv``
+:rst:role:`ref` is mis-spelled. Invoking :program:`sphinx-build` with ``-vvv``
 (see :option:`-v`) will print all section names and the labels that have been
 generated for them. This output can help finding the right reference label.


### PR DESCRIPTION
With Sphinx 7.3.7, I had to use sphinx-build with -vvv to get the generated labels for the sections.

Subject: small fix to the extension documentation

### Feature or Bugfix

- Bugfix

### Purpose

- I couldn't get the generated labels with `-vv` as previously documented but it worked with `-vvv`
- Ubuntu 22.04
  Python 3.10.12
  Sphinx 7.3.7
