### PR TITLE
Split `test` dependencies into `dev` and `test` dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,13 @@ lint = [
     "tomli",  # for mypy (Python<=3.10)
     "pytest>=6.0",
 ]
+dev = [
+    "pytest>=6.0",
+    "defusedxml>=0.7.1",  # for secure XML/HTML parsing
+]
 test = [
     "pytest>=6.0",
-    "defusedxml>=0.7.1", # for secure XML/HTML parsing
+    "defusedxml>=0.7.1",
     "cython>=3.0",
     "setuptools>=67.0",  # for Cython compilation
 ]


### PR DESCRIPTION
When (and if) [PEP 735](https://peps.python.org/pep-0735/) is accepted, we can probably simplify the deduplication of packages. It would at least be cleaner that way.

This does *not* resolve #12339 because we still need to change the `pyproject` and `tox.ini` of `sphinxcontrib-*` packages so that they use `sphinx[dev]` and not just `sphinx`.