### PR TITLE
Update EXAMPLES.rst: Linux kernel switched theme

### DIFF
--- a/EXAMPLES.rst
+++ b/EXAMPLES.rst
@@ -28,6 +28,7 @@ Documentation using the alabaster theme
 * `Invoke <https://docs.pyinvoke.org/>`__
 * `Jinja <https://jinja.palletsprojects.com/>`__
 * `Lino <https://www.lino-framework.org/>`__ (customized)
+* `Linux kernel <https://www.kernel.org/doc/html/latest/index.html>`__ (customized)
 * `marbl <https://getmarbl.readthedocs.io/>`__
 * `MeshPy <https://documen.tician.de/meshpy/>`__
 * `Molecule <https://molecule.readthedocs.io/>`__
@@ -214,7 +215,6 @@ Documentation using sphinx_rtd_theme
 * `Learning Apache Spark with Python <https://runawayhorse001.github.io/LearningApacheSpark>`__
 * `LibCEED <https://libceed.readthedocs.io/>`__
 * `Linguistica <https://linguistica-uchicago.github.io/lxa5/>`__
-* `Linux kernel <https://www.kernel.org/doc/html/latest/index.html>`__
 * `Mailman <https://docs.list.org/>`__
 * `MathJax <https://docs.mathjax.org/>`__
 * `MDTraj <https://mdtraj.org/>`__ (customized)


### PR DESCRIPTION
Subject: Update EXAMPLES.rst to reflect theme change in Linux kernel documentation

### Feature or Bugfix
- Bugfix (documentation)

### Purpose
- Update EXAMPLES.rst to reflect theme change

### Detail
The Linux kernel documentation has switched with Linux 6.2 (2023) to the Alabaster theme [1] and customized it [2].

[1] torvalds/linux@d5389d31
[2] torvalds/linux@2056b920, torvalds/linux@c404f5d4

