### PR TITLE
DOC: Add env_version to "todo" tutorial

### DIFF
--- a/doc/development/tutorials/examples/todo.py
+++ b/doc/development/tutorials/examples/todo.py
@@ -132,6 +132,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
     return {
         'version': '0.1',
+        'env_version': 1,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

According to https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata:

>  If not given, Sphinx considers the extension does not stores any data to environment.

Since the `todo` extension does store data to the environment, it should also define `env_version`.

### Relates
- #12237

