### PR TITLE
Un-remove deprecated "style" field from html_context

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -548,6 +548,7 @@ class StandaloneHTMLBuilder(Builder):
             'sphinx_version_tuple': sphinx_version,
             'docutils_version_info': docutils.__version_info__[:5],
             'styles': styles,
+            'style': styles[-1],  # only for backwards compatibility
             'rellinks': rellinks,
             'builder': self.name,
             'parents': [],


### PR DESCRIPTION
### Purpose

The `style` field was removed in #11381, obsoleted by `styles`.

However, this broke many old themes.

To be concrete, on https://sphinx-themes.org/ there are currently 10 themes that are broken by this.

### Relates
- #11931

