### PR TITLE
DOCS: improve `:tocdepth:` note

### DIFF
--- a/doc/usage/restructuredtext/field-lists.rst
+++ b/doc/usage/restructuredtext/field-lists.rst
@@ -48,9 +48,9 @@ At the moment, these metadata fields are recognized:
 
    .. note::
 
-      This metadata effects to the depth of local toctree.  But it does not
-      effect to the depth of *global* toctree.  So this would not be change
-      the sidebar of some themes which uses global one.
+      This metadata affects the depth of the local toctree.  But it does not
+      affect the depth of the *global* toctree.  So this does not change
+      the sidebar of themes that use the global toctree.
 
    .. versionadded:: 0.4
 


### PR DESCRIPTION
Subject: Clean up the note about using `:tocdepth:`

### Feature or Bug fix
- Bugfix

### Purpose
- I recently referenced this part of the docs and found the language to be confusing. It also had some grammatical errors. I've updated the note to improve it.