### PR TITLE
👌 Allow access to the parser during the read phase

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* #12361: Allow the parser instance to be accessed within directives
+  with ``self.env.parser``. Patch by Chris Sewell.
+
 * #11165: Support the `officially recommended`_ ``.jinja`` suffix for template
   files.
   Patch by James Addison and Adam Turner

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -485,7 +485,7 @@ class Builder:
         filename = self.env.doc2path(docname)
         filetype = get_filetype(self.app.config.source_suffix, filename)
         publisher = self.app.registry.get_publisher(self.app, filetype)
-        self.env.temp_data['parser'] = publisher.parser
+        self.env.temp_data['_parser'] = publisher.parser
         # record_dependencies is mutable even though it is in settings,
         # explicitly re-initialise for each document
         publisher.settings.record_dependencies = DependencyList()

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -485,6 +485,7 @@ class Builder:
         filename = self.env.doc2path(docname)
         filetype = get_filetype(self.app.config.source_suffix, filename)
         publisher = self.app.registry.get_publisher(self.app, filetype)
+        self.env.temp_data['parser'] = publisher.parser
         # record_dependencies is mutable even though it is in settings,
         # explicitly re-initialise for each document
         publisher.settings.record_dependencies = DependencyList()

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
     from docutils import nodes
     from docutils.nodes import Node
+    from docutils.parsers import Parser
 
     from sphinx.application import Sphinx
     from sphinx.builders import Builder
@@ -548,6 +549,11 @@ class BuildEnvironment:
     def docname(self) -> str:
         """Returns the docname of the document currently being parsed."""
         return self.temp_data['docname']
+
+    @property
+    def parser(self) -> Parser:
+        """Returns the parser being used for to parse the current document."""
+        return self.temp_data['_parser']
 
     def new_serialno(self, category: str = '') -> int:
         """Return a serial number, e.g. for index entry targets.


### PR DESCRIPTION
This PR allows access to the `Parser` instance during parsing, using the read-only property `BuildEnvironment.parser`.

The primary use case here is for within directives (also to a lesser extent roles).

Context:

To be fair to docutils, it never actually exposes directives as an extension point to users, this is done by sphinx (mainly in `Sphinx.add_directive` and `Domain.directives`)

The "problem" with this is that

1. `Directives` are currently a pretty leaky abstraction; exposing a lot of the "internals" of the docutils rST parser, particularly when it comes to nested parsing or parsing from other sources (like docstrings).
2. The docutils rst parser itself is not the greatest when it comes to things such as nested parsing, and also source mapped logging

This has started to lead to a proliferation of "hacks" into the rst parser, to try to overcome these shortcomings.
To name a few:

- `nested_parse_with_titles` https://github.com/sphinx-doc/sphinx/blob/v7.3.0/sphinx/util/nodes.py#L327
- `parse_generated_content` https://github.com/sphinx-doc/sphinx/blob/v7.3.0/sphinx/ext/autodoc/directive.py#L84
- `switch_source_input` https://github.com/sphinx-doc/sphinx/blob/v7.3.0/sphinx/util/docutils.py#L362
- `Include.run` https://github.com/sphinx-doc/sphinx/blob/v7.3.0/sphinx/directives/other.py#L384
- `Only.run` https://github.com/sphinx-doc/sphinx/blob/v7.3.0/sphinx/directives/other.py#L330
- `sphinx.ext.collapse` https://github.com/sphinx-doc/sphinx/pull/10532/files#r1581911730

These are exceptionally difficult to reconcile with other parsers like Myst, or even alternative rST parsers

Allowing access to the parser would allow the possibility for this sort of code to be centralised and abstracted better on the parser implementation

---

Also somewhat related https://github.com/sphinx-doc/sphinx/pull/12238 by @n-peugnet 