### PR TITLE
DEPS: Lazy import `defusedxml` only when necessary

### DIFF
--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -11,7 +11,6 @@ from io import StringIO
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
-from defusedxml.ElementTree import parse as xml_parse
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
 
@@ -73,6 +72,8 @@ def assert_node(node: Node, cls: Any = None, xpath: str = "", **kwargs: Any) -> 
 # keep this to restrict the API usage and to have a correct return type
 def etree_parse(path: str | os.PathLike[str]) -> ElementTree:
     """Parse a file into a (safe) XML element tree."""
+    from defusedxml.ElementTree import parse as xml_parse
+
     return xml_parse(path)
 
 


### PR DESCRIPTION
Subject: Move `defusedxml` import into the function using it

### Feature or Bugfix
- Refactoring

### Purpose
Import `defusedxml` inside the `etree_parse()` function rather than in global scope of `sphinx.testing.util`.  This makes it possible for reverse dependencies (such as `breathe`) to use this module without adding an unnecessary transitive dependency on `defusedxml` when it's not actually used.

### Detail

### Relates
- #12339.