### PR TITLE
DOCS: Add `sphinx-build --jobs` default value

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -126,7 +126,7 @@ Options
    Distribute the build over *N* processes in parallel, to make building on
    multiprocessor machines more effective.  Note that not all parts and not all
    builders of Sphinx can be parallelized.  If ``auto`` argument is given,
-   Sphinx uses the number of CPUs as *N*.
+   Sphinx uses the number of CPUs as *N*. Defaults to 1.
 
    .. versionadded:: 1.2
       This option should be considered *experimental*.


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
Currently, sphinx-build's man page doesn't mention the default value for -j | --jobs option, which according to [sphinx/cmd/build.py](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/cmd/build.py#L150-L153) is `1`. This proposal makes it clear in the documentation.

