### PR TITLE
LaTeX: fix #12380

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Bugs fixed
   Patch by Matthias Geier.
 * #12224: Properly detect WebP files.
   Patch by Benjamin Cabé.
+* #12380: LaTeX: Footnote mark sometimes indicates ``Page N`` where ``N`` is
+  the current page number and the footnote does appear on that same page.
+  Patch by Jean-François B.
 
 Testing
 -------

--- a/sphinx/texinputs/sphinxpackagefootnote.sty
+++ b/sphinx/texinputs/sphinxpackagefootnote.sty
@@ -1,6 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{sphinxpackagefootnote}%
- [2022/08/15 v5.3.0 Sphinx custom footnotehyper package (Sphinx team)]
+ [2024/05/17 v7.3.x Sphinx custom footnotehyper package (Sphinx team)]
 %%
 %% Package: sphinxpackagefootnote
 %% Version: based on footnotehyper.sty 2021/02/04 v1.1d
@@ -409,9 +409,10 @@
     {\gdef\@thefnmark{?}% on first LaTeX run
      \refstepcounter{sphinxfootnotemark}\label{footnotemark.\thesphinxfootnotemark}%
     }%
-    {\sphinx@xdef@thefnmark{#1}% also defines \spx@footrefHref
-     \def\@makefnmark{% will be used by \H@@footnotemark
+    {\def\@makefnmark{% will be used by \H@@footnotemark
        \refstepcounter{sphinxfootnotemark}\label{footnotemark.\thesphinxfootnotemark}%
+       \sphinx@xdef@thefnmark{#1}% also defines \spx@footrefHref
+                                 % must be executed after \refstepcounter
        \hyper@linkstart{link}{\spx@footrefHref}%
        \spx@saved@makefnmark
        \hyper@linkend


### PR DESCRIPTION
Subject: Fix #12380 (LaTeX footnotes)

The problem was there ever since #10191 added the footnote feature to
indicate the page number where footnote ends up printed, if not on same
page.

It is complicated to add a test for this change because the patch only
modifies how a certain custom LaTeX macro behaves so one has to check
PDF output which is bothersome.  But it got tested with a number of
sources already used for #10191 (one such test showed already the #12380
problem, but got overlooked at that time).

MEMO: the feature works only when Sphinx uses `\sphinxfootnotemark`
mark-up in LaTeX output; sometimes it may use rather a `footnote`
environment, then the mechanism is not activated.  This may happen for
example inside a cell of a long table, it can be that `Page N` will not
be added, because the `\sphinxfootnotemark` which does that is not
activated, although the footnote, which gets printed after the long
table ends, is on a different page.


### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Relates
- #10191

