### PR TITLE
More precise types in preserve_defaults.py

### DIFF
--- a/sphinx/ext/autodoc/preserve_defaults.py
+++ b/sphinx/ext/autodoc/preserve_defaults.py
@@ -109,7 +109,7 @@ def _get_arguments_inner(x: Any, /) -> ast.arguments | None:
     return None
 
 
-def get_default_value(lines: list[str], position: ast.AST) -> str | None:
+def get_default_value(lines: list[str], position: ast.expr) -> str | None:
     try:
         if position.lineno == position.end_lineno:
             line = lines[position.lineno - 1]


### PR DESCRIPTION
Followup from python/typeshed#11880. Not all AST nodes have a lineno; in this file only parameter defaults are passed to this function, which are always ast.expr.

Subject: Prepare for future typing errors from a mypy upgrade

### Feature or Bugfix
- Refactoring
