### PR TITLE
genindex: use &#x2013; instead of &ndash; for xhtml compatibility

### DIFF
--- a/sphinx/themes/basic/genindex-single.html
+++ b/sphinx/themes/basic/genindex-single.html
@@ -30,7 +30,7 @@
 {% set title = _('Index') %}
 {% block body %}
 
-<h1 id="index">{% trans key=key %}Index &ndash; {{ key }}{% endtrans %}</h1>
+<h1 id="index">{% trans key=key %}Index &#x2013; {{ key }}{% endtrans %}</h1>
 
 <table style="width: 100%" class="indextable"><tr>
   {%- for column in entries|slice(2) if column %}

--- a/sphinx/themes/basic/genindex-single.html
+++ b/sphinx/themes/basic/genindex-single.html
@@ -30,6 +30,7 @@
 {% set title = _('Index') %}
 {% block body %}
 
+{# We use ``&#x2013;`` instead of ``&ndash;`` for XHTML compatibility #}
 <h1 id="index">{% trans key=key %}Index &#x2013; {{ key }}{% endtrans %}</h1>
 
 <table style="width: 100%" class="indextable"><tr>


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

There is no &ndash; character entitiy in xhtml.
The epubcheck reports fatal error and epub readers like Books.app crashes.

### Detail

### Relates

Fix #12359

