### PR TITLE
Account for nodes without children in Texinfo's ignores

### DIFF
--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -691,7 +691,7 @@ class TexinfoTranslator(SphinxTranslator):
         # cases for the sake of appearance
         if isinstance(node.parent, (nodes.title, addnodes.desc_type)):
             return
-        if isinstance(node[0], nodes.image):
+        if len(node) != 0 and isinstance(node[0], nodes.image):
             return
         name = node.get('name', node.astext()).strip()
         uri = node.get('refuri', '')


### PR DESCRIPTION
Subject: Account for nodes without children in Texinfo's ignores

### Feature or Bugfix
- Bugfix

### Purpose
- This prevented compilation of the Pytorch tutorial at https://github.com/pytorch/tutorials, with the latest master.
- It requires the environment for the above repo, detailed there.

### Detail
- Incidentally, this also required the following patch to the above repo (to get it compiling):
```
diff --git a/custom_directives.py b/custom_directives.py
index 388aa262e..3b22ec2d8 100644
--- a/custom_directives.py
+++ b/custom_directives.py
@@ -88,7 +88,7 @@ class GalleryItemDirective(Directive):
             if 'intro' in self.options:
                 intro = self.options['intro'][:195] + '...'
             else:
-                _, blocks = sphinx_gallery.gen_rst.split_code_and_text_blocks(abs_fname)
+                _, blocks = sphinx_gallery.py_source_parser.split_code_and_text_blocks(abs_fname)
                 intro, _ = sphinx_gallery.gen_rst.extract_intro_and_title(abs_fname, blocks[0][1])
 
             thumbnail_rst = ''
```

### Relates
- (NA)

