### PR TITLE
Add locale check script + CI job, that runs gettext check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,10 +76,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3"
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,6 +71,18 @@ jobs:
     - name: Type check with mypy
       run: mypy
 
+  locale-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3"
+    - name: Check locale files with gettext
+      run: make locale-check
+
   docs-lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3"
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gettext
     - name: Check locale files with gettext
       run: make locale-check
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON ?= python3
 all: format style-check type-check doclinter test
 
 .PHONY: check
-check: style-check type-check doclinter
+check: style-check type-check locale-check doclinter
 
 .PHONY: clean
 clean: clean
@@ -55,6 +55,10 @@ format:
 .PHONY: type-check
 type-check:
 	@mypy
+
+.PHONY: locale-check
+locale-check:
+	@$(MAKE) -C sphinx/locale check
 
 .PHONY: doclinter
 doclinter:

--- a/sphinx/locale/Makefile
+++ b/sphinx/locale/Makefile
@@ -3,7 +3,7 @@ IGNORED = ta
 POFILES = $(wildcard */LC_MESSAGES/sphinx.po)
 CHECK   = $(POFILES:.po=.check)
 
-.PHONY: all
+.PHONY: check
 check: $(filter-out $(IGNORED:=/LC_MESSAGES/sphinx.check),$(CHECK))
 
 .PHONY: $(CHECK)

--- a/sphinx/locale/Makefile
+++ b/sphinx/locale/Makefile
@@ -1,0 +1,11 @@
+IGNORED = ta
+LOCALES = $(filter-out $(IGNORED),$(patsubst %/LC_MESSAGES,%,$(wildcard */LC_MESSAGES)))
+POFILES = $(LOCALES:%=%/LC_MESSAGES/sphinx.po)
+CHECK   = $(POFILES:.po=.check)
+
+.PHONY: all
+check: $(CHECK)
+
+.PHONY: $(CHECK)
+$(CHECK): %.check: %.po
+	msgfmt --check -o /dev/null $<

--- a/sphinx/locale/Makefile
+++ b/sphinx/locale/Makefile
@@ -1,10 +1,10 @@
+# Ignore locales that are known failures. See utils/babel_runner.py
 IGNORED = ta
-LOCALES = $(filter-out $(IGNORED),$(patsubst %/LC_MESSAGES,%,$(wildcard */LC_MESSAGES)))
-POFILES = $(LOCALES:%=%/LC_MESSAGES/sphinx.po)
+POFILES = $(wildcard */LC_MESSAGES/sphinx.po)
 CHECK   = $(POFILES:.po=.check)
 
 .PHONY: all
-check: $(CHECK)
+check: $(filter-out $(IGNORED:=/LC_MESSAGES/sphinx.check),$(CHECK))
 
 .PHONY: $(CHECK)
 $(CHECK): %.check: %.po


### PR DESCRIPTION
Subject: Add script + CI job to check locale files with gettext

### Feature or Bugfix
<!-- please choose -->
- Test

### Purpose
- To avoid having to manually check submitted translations, it can be usefull to quickly check that the translation files are correct using gettext.

### Relates
- https://github.com/sphinx-doc/sphinx/pull/12392

P.S. The docs build will be fixed by https://github.com/sphinx-doc/sphinx/pull/12395