### PR TITLE
🔧 Apply ruff rule ISC001

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,13 +116,13 @@ autodoc_member_order = 'groupwise'
 autosummary_generate = False
 todo_include_todos = True
 extlinks = {
-    'dupage': ('https://docutils.sourceforge.io/docs/ref/rst/' '%s.html', '%s'),
+    'dupage': ('https://docutils.sourceforge.io/docs/ref/rst/%s.html', '%s'),
     'duref': (
-        'https://docutils.sourceforge.io/docs/ref/rst/' 'restructuredtext.html#%s',
+        'https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#%s',
         '%s',
     ),
-    'durole': ('https://docutils.sourceforge.io/docs/ref/rst/' 'roles.html#%s', '%s'),
-    'dudir': ('https://docutils.sourceforge.io/docs/ref/rst/' 'directives.html#%s', '%s'),
+    'durole': ('https://docutils.sourceforge.io/docs/ref/rst/roles.html#%s', '%s'),
+    'dudir': ('https://docutils.sourceforge.io/docs/ref/rst/directives.html#%s', '%s'),
 }
 
 man_pages = [
@@ -137,7 +137,7 @@ man_pages = [
     (
         'man/sphinx-quickstart',
         'sphinx-quickstart',
-        'Sphinx documentation ' 'template generator',
+        'Sphinx documentation template generator',
         '',
         1,
     ),


### PR DESCRIPTION

Subject: Enforce ruff/flake8-implicit-str-concat rule ISC001

### Feature or Bugfix
- Refactoring

### Purpose

ISC001 Implicitly concatenated string literals on one line

### Relates
- https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/

