### PR TITLE
fix: solve absolute path resolution on windows platform

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -416,8 +416,8 @@ class BuildEnvironment:
         containing document.
         """
         filename = os_path(filename)
-        if filename.startswith(('/', os.sep)):
-            rel_fn = filename[1:]
+        if os.path.isabs(filename):
+            rel_fn = filename[filename.index(os.path.sep)+1:]
         else:
             docdir = path.dirname(self.doc2path(docname or self.docname,
                                                 base=False))

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -416,8 +416,9 @@ class BuildEnvironment:
         containing document.
         """
         filename = os_path(filename)
-        if os.path.isabs(filename):
-            rel_fn = filename[filename.index(os.path.sep)+1:]
+        filename = os.path.splitdrive(filename)[1]  # strip drive
+        if filename.startswith(('/', os.sep)):
+            rel_fn = filename[1:]
         else:
             docdir = path.dirname(self.doc2path(docname or self.docname,
                                                 base=False))


### PR DESCRIPTION
Subject: solve absolute path resolution on windows platform

### Feature or Bugfix
Bugfix

### Purpose
The method relfn2path of the class BuildEnvironment in the file `sphinx/environment/__init__.py` supposedly treats absolute paths as relative to the source dir. This is not the case in Windows. Absolute paths to page requisites provided by conf.py in the source dir remain absolute paths in Windows, but become relative paths in every other OS.

### Detail
Simply change the detection of absolute path and rely more on platform agnostic functions. 

### Relates
https://github.com/sphinx-doc/sphinx/issues/10910
https://github.com/sphinx-doc/sphinx/issues/12399

