### PR TITLE
LaTeX: fix docs for ``'babel'`` key of ``latex_elements``

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -158,8 +158,18 @@ Keys that you may want to override include:
       ``'lualatex'`` uses same default setting as ``'xelatex'``
 
    .. versionchanged:: 1.7.6
-      For French, ``xelatex`` and ``lualatex`` default to using
-      ``babel``, not ``polyglossia``.
+      For French with ``xelatex`` (not ``lualatex``) the default is to use
+      ``babel``, not ``polyglossia``.  To let ``lualatex`` use ``babel``,
+      use this:
+
+      .. code-block:: python
+
+         latex_elements = {
+             'polyglossia': '',
+             'babel': r'\usepackage{babel}',
+         }
+
+      in file :file:`conf.py`.
 
 ``'fontpkg'``
    Font package inclusion. The default is::


### PR DESCRIPTION
Relates #12410

This fixes the documentation which was faulty since v1.7.6, but #12410 is left open until a decision is taken.

Subject: <short purpose of this pull request>

- Bugfix (docs)

