### PR TITLE
Put sphinx.ext.autodoc together in markupapi.rst

### DIFF
--- a/doc/extdev/markupapi.rst
+++ b/doc/extdev/markupapi.rst
@@ -124,8 +124,8 @@ Both APIs parse the content into a given node. They are used like this::
 .. note::
 
    ``sphinx.util.docutils.switch_source_input()`` allows to change a target file
-   during nested_parse.  It is useful to mixed contents.  For example, ``sphinx.
-   ext.autodoc`` uses it to parse docstrings::
+   during nested_parse.  It is useful to mixed contents.
+   For example, ``sphinx.ext.autodoc`` uses it to parse docstrings::
 
        from sphinx.util.docutils import switch_source_input
 


### PR DESCRIPTION
Subject: Fix a typo in doc, removing a whitespace in the rendered `sphinx. ext.autodoc`

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Current text is shown as "For example, `sphinx. ext.autodoc` uses it to parse docstrings:", and this PR removes the space in `sphinx. ext.autodoc`

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

