### PR TITLE
[themes]: Include project name in `logo_alt` by default

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -552,7 +552,7 @@ class StandaloneHTMLBuilder(Builder):
             'builder': self.name,
             'parents': [],
             'logo_url': logo,
-            'logo_alt': 'Logo',
+            'logo_alt': _('Logo of %s') % self.config.project,
             'favicon_url': favicon,
             'html5_doctype': True,
         }

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -552,6 +552,7 @@ class StandaloneHTMLBuilder(Builder):
             'builder': self.name,
             'parents': [],
             'logo_url': logo,
+            'logo_alt': 'Logo',
             'favicon_url': favicon,
             'html5_doctype': True,
         }

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -15,7 +15,7 @@
       <div class="header">
         {%- if logo_url %}
           <p class="logo"><a href="{{ pathto(root_doc)|e }}">
-            <img class="logo" src="{{ logo_url|e }}" alt="Logo"/>
+            <img class="logo" src="{{ logo_url|e }}" alt="{{ logo_alt|e }}"/>
           </a></p>
         {%- endif %}
         {%- block headertitle %}

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -50,7 +50,7 @@
           {%- block sidebarlogo %}
           {%- if logo_url %}
             <p class="logo"><a href="{{ pathto(root_doc)|e }}">
-              <img class="logo" src="{{ logo_url|e }}" alt="Logo"/>
+              <img class="logo" src="{{ logo_url|e }}" alt="{{ logo_alt|e }}"/>
             </a></p>
           {%- endif %}
           {%- endblock %}

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -36,11 +36,11 @@
         {%- block haikuheader %}
         {%- if theme_full_logo != "false" %}
         <a href="{{ pathto(root_doc)|e }}">
-          <img class="logo" src="{{ logo_url|e }}" alt="Logo"/>
+          <img class="logo" src="{{ logo_url|e }}" alt="{{ logo_alt|e }}"/>
         </a>
         {%- else %}
         {%- if logo -%}
-          <img class="rightlogo" src="{{ logo_url|e }}" alt="Logo"/>
+          <img class="rightlogo" src="{{ logo_url|e }}" alt="{{ logo_alt|e }}"/>
         {%- endif -%}
         <h1 class="heading"><a href="{{ pathto(root_doc)|e }}">
           <span>{{ shorttitle|e }}</span></a></h1>

--- a/sphinx/themes/pyramid/layout.html
+++ b/sphinx/themes/pyramid/layout.html
@@ -13,7 +13,7 @@
 <div class="header" role="banner">
   <div class="logo">
     <a href="{{ pathto(root_doc)|e }}">
-      <img class="logo" src="{{ logo_url|e }}" alt="Logo"/>
+      <img class="logo" src="{{ logo_url|e }}" alt="{{ logo_alt|e }}"/>
     </a>
   </div>
 </div>

--- a/tests/test_builders/test_build_html_image.py
+++ b/tests/test_builders/test_build_html_image.py
@@ -29,7 +29,7 @@ def test_html_remote_logo(app, status, warning):
     app.build(force_all=True)
 
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
-    assert ('<img class="logo" src="https://www.python.org/static/img/python-logo.png" alt="Logo"/>' in result)
+    assert ('<img class="logo" src="https://www.python.org/static/img/python-logo.png" alt="Logo of Python"/>' in result)
     assert ('<link rel="icon" href="https://www.python.org/static/favicon.ico"/>' in result)
     assert not (app.outdir / 'python-logo.png').exists()
 
@@ -39,7 +39,7 @@ def test_html_local_logo(app, status, warning):
     app.build(force_all=True)
 
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
-    assert ('<img class="logo" src="_static/img.png" alt="Logo"/>' in result)
+    assert ('<img class="logo" src="_static/img.png" alt="Logo of Python"/>' in result)
     assert (app.outdir / '_static/img.png').exists()
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose

The "alt" attribute of an `<img>` is required to convey all information.
Make it clear which logo is shown.
Also make it possible for users to override the logo_alt with a custom value.
