### PR TITLE
themes: Don't duplicate "navigation" in aria-label

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {%- block relbar1 %}
-<div class="related" role="navigation" aria-label="related navigation">
+<div class="related" role="navigation" aria-label="Related">
   <h3>{{ _('Navigation') }}</h3>
   <ul>
     <li><a href="{{ pathto(root_doc)|e }}">Documentation</a> &raquo;</li>
@@ -32,7 +32,7 @@
 
 {%- block content %}
 <div class="document">
-  <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
+  <div class="sphinxsidebar" role="navigation" aria-label="Main">
     {%- include "searchfield.html" %}
     <div class="sphinxsidebar-navigation__contents">
       <h3>{{ _('On this page') }}</h3>

--- a/sphinx/themes/agogo/layout.html
+++ b/sphinx/themes/agogo/layout.html
@@ -22,7 +22,7 @@
         <div class="headertitle"><a
           href="{{ pathto(root_doc)|e }}">{{ shorttitle|e }}</a></div>
         {%- endblock %}
-        <div class="rel" role="navigation" aria-label="related navigation">
+        <div class="rel" role="navigation" aria-label="Related">
           {%- for rellink in rellinks|reverse %}
           <a href="{{ pathto(rellink[0])|e }}" title="{{ rellink[1]|striptags|e }}"
              {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>
@@ -76,7 +76,7 @@
     <div class="footer-wrapper">
       <div class="footer">
         <div class="left">
-          <div role="navigation" aria-label="related navigation">
+          <div role="navigation" aria-label="Related">
             {%- for rellink in rellinks|reverse %}
             <a href="{{ pathto(rellink[0])|e }}" title="{{ rellink[1]|striptags|e }}"
               {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -22,7 +22,7 @@
 {%- endif %}
 
 {%- macro relbar() %}
-    <div class="related" role="navigation" aria-label="related navigation">
+    <div class="related" role="navigation" aria-label="Related">
       <h3>{{ _('Navigation') }}</h3>
       <ul>
         {%- for rellink in rellinks %}
@@ -45,7 +45,7 @@
 
 {%- macro sidebar() %}
       {%- if render_sidebar %}
-      <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
+      <div class="sphinxsidebar" role="navigation" aria-label="Main">
         <div class="sphinxsidebarwrapper">
           {%- block sidebarlogo %}
           {%- if logo_url %}

--- a/sphinx/themes/haiku/layout.html
+++ b/sphinx/themes/haiku/layout.html
@@ -48,7 +48,7 @@
         {%- endif %}
         {%- endblock %}
       </div>
-      <div class="topnav" role="navigation" aria-label="top navigation">
+      <div class="topnav" role="navigation" aria-label="Top">
       {{ nav() }}
       </div>
       <div class="content" role="main">
@@ -60,7 +60,7 @@
         {%- endif %}#}
         {% block body %}{% endblock %}
       </div>
-      <div class="bottomnav" role="navigation" aria-label="bottom navigation">
+      <div class="bottomnav" role="navigation" aria-label="Bottom">
       {{ nav() }}
       </div>
 {% endblock %}

--- a/sphinx/themes/scrolls/layout.html
+++ b/sphinx/themes/scrolls/layout.html
@@ -26,7 +26,7 @@
         <h1 class="heading"><a href="{{ pathto(root_doc)|e }}"
           title="back to the documentation overview"><span>{{ title|striptags|e }}</span></a></h1>
       </div>
-      <div class="relnav" role="navigation" aria-label="related navigation">
+      <div class="relnav" role="navigation" aria-label="Related">
         {%- if prev %}
         <a href="{{ prev.link|e }}">&laquo; {{ prev.title }}</a> |
         {%- endif %}
@@ -37,7 +37,7 @@
       </div>
       <div id="contentwrapper">
         {%- if display_toc %}
-        <div id="toc" role="navigation" aria-label="table of contents navigation">
+        <div id="toc" role="navigation" aria-label="Table of contents">
           <h3>{{ _('Table of Contents') }}</h3>
           {{ toc }}
         </div>

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -222,7 +222,7 @@ def test_html_sidebar(app, status, warning):
     app.build(force_all=True)
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
     assert ('<div class="sphinxsidebar" role="navigation" '
-            'aria-label="main navigation">' in result)
+            'aria-label="Main">' in result)
     assert '<h1 class="logo"><a href="#">Python</a></h1>' in result
     assert '<h3>Navigation</h3>' in result
     assert '<h3>Related Topics</h3>' in result
@@ -237,7 +237,7 @@ def test_html_sidebar(app, status, warning):
     app.build(force_all=True)
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
     assert ('<div class="sphinxsidebar" role="navigation" '
-            'aria-label="main navigation">' in result)
+            'aria-label="Main">' in result)
     assert '<h1 class="logo"><a href="#">Python</a></h1>' not in result
     assert '<h3>Navigation</h3>' not in result
     assert '<h3>Related Topics</h3>' in result
@@ -251,7 +251,7 @@ def test_html_sidebar(app, status, warning):
     app.build(force_all=True)
     result = (app.outdir / 'index.html').read_text(encoding='utf8')
     assert ('<div class="sphinxsidebar" role="navigation" '
-            'aria-label="main navigation">' not in result)
+            'aria-label="Main">' not in result)
     assert '<h1 class="logo"><a href="#">Python</a></h1>' not in result
     assert '<h3>Navigation</h3>' not in result
     assert '<h3>Related Topics</h3>' not in result


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

The word "navigation" is not supposed to be included as part of the aria-label attribute [0]:

    aria-label

	A brief description of the purpose of the navigation, omitting
        the term "navigation", as the screen reader will read both the role and
        the contents of the label.

[0] https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role