### PR TITLE
Remove doctree cache from pickled BuildEnvironment

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -275,7 +275,9 @@ class BuildEnvironment:
         __dict__ = self.__dict__.copy()
         # clear unpickable attributes
         __dict__.update(app=None, domains={}, events=None)
-        # clear in-memory doctree caches
+        # clear in-memory doctree caches, to reduce memory consumption and
+        # ensure that, upon restoring the state, the most recent pickled files
+        # on the disk are used instead of those from a possibly outdated state
         __dict__.update(_pickled_doctree_cache={}, _write_doc_doctree_cache={})
         return __dict__
 

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -186,6 +186,7 @@ class BuildEnvironment:
 
         self._pickled_doctree_cache: dict[str, bytes] = {}
         """In-memory cache for reading pickled doctrees from disk.
+        docname -> pickled doctree
 
         This cache is used in the ``get_doctree`` method to avoid reading the
         doctree from disk multiple times.
@@ -193,6 +194,7 @@ class BuildEnvironment:
 
         self._write_doc_doctree_cache: dict[str, nodes.document] = {}
         """In-memory cache for unpickling doctrees from disk.
+        docname -> doctree
 
         Items are added in ``Builder.write_doctree``, during the read phase,
         then used only in the ``get_and_resolve_doctree`` method.

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -184,11 +184,19 @@ class BuildEnvironment:
         # docnames to re-read unconditionally on next build
         self.reread_always: set[str] = set()
 
-        # docname -> pickled doctree
         self._pickled_doctree_cache: dict[str, bytes] = {}
+        """In-memory cache for reading pickled doctrees from disk.
 
-        # docname -> doctree
+        This cache is used in the ``get_doctree`` method to avoid reading the
+        doctree from disk multiple times.
+        """
+
         self._write_doc_doctree_cache: dict[str, nodes.document] = {}
+        """In-memory cache for unpickling doctrees from disk.
+
+        Items are added in ``Builder.write_doctree``, during the read phase,
+        then used only in the ``get_and_resolve_doctree`` method.
+        """
 
         # File metadata
         # docname -> dict of metadata items
@@ -265,10 +273,10 @@ class BuildEnvironment:
     def __getstate__(self) -> dict:
         """Obtains serializable data for pickling."""
         __dict__ = self.__dict__.copy()
-        __dict__.update(app=None, domains={}, events=None)  # clear unpickable attributes
-        # ensure that upon restoring the state, the most recent pickled files
-        # on the disk are used instead of those from a possibly outdated state
-        __dict__.update(_pickled_doctree_cache={})
+        # clear unpickable attributes
+        __dict__.update(app=None, domains={}, events=None)
+        # clear in-memory doctree caches
+        __dict__.update(_pickled_doctree_cache={}, _write_doc_doctree_cache={})
         return __dict__
 
     def __setstate__(self, state: dict) -> None:


### PR DESCRIPTION
In https://github.com/sphinx-doc/sphinx/commit/463a69664c2b7f51562eb9d15597987e6e6784cd and https://github.com/sphinx-doc/sphinx/commit/a9b0f2708b67a355c5f4969ccbbe9bd695518805,
`_write_doc_doctree_cache` and `_pickled_doctree_cache` were added to the `BuildEnvironment`.

Although the sentiment; of increasing the speed of "initial" builds, is not bad per se, these are very problematic:

- They add a potentially unbounded memory increase to the `BuildEnvironment`, particularly for large projects with ~1000s of documents
- They were initially not removed before caching the `BuildEnvironment`, increasing its size and time to read/write
- They were initially not removed during parallel builds, increasing the size/time required to transfer the `BuildEnvironment` back from child processes (via pickling)
- None of the commits or code was documented

Subsequently, two fixes have already been made:

-  #11290: `_write_doc_doctree_cache` is no longer written to during a parallel build
-  #11939: `_pickled_doctree_cache` is no longer included when pickling the `BuildEnvironment`

This PR adds a further fix; removing `_write_doc_doctree_cache` from the pickled `BuildEnvironment`, and also documenting both cache variables

You can see the impact, when comparing the pickled  `BuildEnvironment` for the repo's document build before and after using:

```python
import pickle
from pympler import asizeof
env_path = "build/sphinx/doctrees/environment.pickle"
with open(env_path, "rb") as f:
    env = pickle.load(f)
sized = asizeof.asized(env.__dict__, detail=1)
for r in sorted(sized.refs, key=lambda r: -int(r.size)):
    if r.size > 1e4:
        print(f"{round(r.size/1e6, 2):>10}Mb {r.name}")
```

before:

```
     80.04Mb [V] _write_doc_doctree_cache: {'authors': <document: <target...><sec....t...><section "html theming; htm ...>}
      6.56Mb [V] tocs: {'authors': <bullet_list: <list_item......eming': <bullet_list: <list_item...>>}
      5.85Mb [V] intersphinx_cache: {'https://docs.readthedocs.io/en/stabl....n-python-grammar-yield_stmt', '-')}})}
      1.04Mb [V] _viewcode_modules: {'sphinx.application': ('"""Sphinx app....ns/coverage'}, 'sphinx.ext.coverage')}
      0.74Mb [V] domaindata: {'c': {'root_symbol': <Symbol '::\n'>,....do_node: <title...><paragraph...>>]}}}
      0.72Mb [V] intersphinx_inventory: {'c:member': {'CO_FUTURE_DIVISION': ('....t/api/#requests.Response.text', '-')}}
      0.13Mb [V] titles: {'authors': <title: <#text: 'Sphinx au....ng': <title: <#text: 'HTML Theming'>>}
      0.09Mb [V] config: Config(project='Sphinx', author='unkno....se, coverage_show_missing_items=False)
      0.03Mb [V] project: <sphinx.project.Project object at 0x31cc06a70>
      0.03Mb [V] files_to_rebuild: {'development/overview': {'development....ns': {'usage/restructuredtext/index'}}
      0.02Mb [V] dependencies: defaultdict(<class 'set'>, {'authors':....ls.png', '_static/themes/agogo.png'}})
```

after:

```
      7.32Mb [V] domaindata: {'c': {'root_symbol': <Symbol '::\n'>,....do_node: <title...><paragraph...>>]}}}
      6.59Mb [V] tocs: {'authors': <bullet_list: <list_item......eming': <bullet_list: <list_item...>>}
      5.85Mb [V] intersphinx_cache: {'https://docs.readthedocs.io/en/stabl....n-python-grammar-yield_stmt', '-')}})}
      1.05Mb [V] _viewcode_modules: {'sphinx.application': ('"""Sphinx app....ns/coverage'}, 'sphinx.ext.coverage')}
      0.72Mb [V] intersphinx_inventory: {'c:member': {'CO_FUTURE_DIVISION': ('....t/api/#requests.Response.text', '-')}}
      0.13Mb [V] titles: {'authors': <title: <#text: 'Sphinx au....ng': <title: <#text: 'HTML Theming'>>}
      0.09Mb [V] config: Config(project='Sphinx', author='unkno....se, coverage_show_missing_items=False)
      0.03Mb [V] project: <sphinx.project.Project object at 0x31bfdf610>
      0.03Mb [V] files_to_rebuild: {'development/overview': {'development....ns': {'usage/restructuredtext/index'}}
      0.02Mb [V] dependencies: defaultdict(<class 'set'>, {'authors':....ls.png', '_static/themes/agogo.png'}})
```

---

Note, I feel these caches need to be further improved, but will do this in follow-up PRs:

- These should probably at least be FIFO with a maximum size
- I don't feel we need both, it should only be sufficient to have `_write_doc_doctree_cache`, i.e. cache the un-pickled doctrees, 
  although I'm conscious that this might introduce a problem, if anything using  `BuildEnvironment.get_doctree` is making any modifications to the doctree, which would now be persisted (but I don't think they should)