### PR TITLE
Improve tox docs config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ passenv =
     DO_EPUBCHECK
     EPUBCHECK_PATH
     TERM
+    CLEAN
+    BUILDER
 description =
     py{39,310,311,312,313}: Run unit tests against {envname}.
 extras =
@@ -33,7 +35,8 @@ description =
 extras =
     docs
 commands =
-    sphinx-build -M html ./doc ./build/sphinx -W --keep-going
+    python -c "import shutil; shutil.rmtree('./build/sphinx', ignore_errors=True) if '{env:CLEAN:}' else None"
+    sphinx-build -M {env:BUILDER:html} ./doc ./build/sphinx -nW --keep-going {posargs}
 
 [testenv:docs-live]
 basepython = python3


### PR DESCRIPTION
For example, allow for `CLEAN=true BUILDER=man tox -e docs -- -j4`, 
to use the `man` builder on a clean build, with 4 processes
