### PR TITLE
DOCS: hide todo admonitions on RTD

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ linkcheck_anchors_ignore_for_url = [
 
 autodoc_member_order = 'groupwise'
 autosummary_generate = False
-todo_include_todos = "READTHEDOCS" not in os.environ
+todo_include_todos = 'READTHEDOCS' not in os.environ
 extlinks = {
     'dupage': ('https://docutils.sourceforge.io/docs/ref/rst/%s.html', '%s'),
     'duref': (

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ linkcheck_anchors_ignore_for_url = [
 
 autodoc_member_order = 'groupwise'
 autosummary_generate = False
-todo_include_todos = True
+todo_include_todos = "READTHEDOCS" not in os.environ
 extlinks = {
     'dupage': ('https://docutils.sourceforge.io/docs/ref/rst/%s.html', '%s'),
     'duref': (

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ passenv =
     TERM
     CLEAN
     BUILDER
+    READTHEDOCS
 description =
     py{39,310,311,312,313}: Run unit tests against {envname}.
 extras =


### PR DESCRIPTION
todo admonitions should not be present in the user-facing documentation


