### PR TITLE
[docs] Fix horizontal overflow in theme header

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -25,6 +25,7 @@ body {
     width: 100%;
     background-color: var(--colour-sphinx-blue);
     padding: 10px 20px;
+    box-sizing: border-box;
 }
 
 .pageheader a {


### PR DESCRIPTION
Sphinx's own theme had a really disturbing horizontal overflow which looked very unprofessional. This is now fixed.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Before
![Peek 2024-06-21 15-48](https://github.com/sphinx-doc/sphinx/assets/23519418/ea0aad9b-3929-4145-9b26-46a03f2eb48d)

### After
![Peek 2024-06-21 15-49](https://github.com/sphinx-doc/sphinx/assets/23519418/320d9eb2-3c4b-46a5-919e-aab275cf93a3)

