### PR TITLE
[docs] Style ReadTheDocs version selector

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -423,6 +423,7 @@ div.viewcode-block:target {
 }
 
 /* ReadtheDocs docs selector */
+/* see https://docs.readthedocs.io/en/stable/flyout-menu.html */
 .rst-versions.rst-badge {
     background-color: #f7f7f7;
     border: 1px solid var(--colour-sphinx-blue);
@@ -431,13 +432,14 @@ div.viewcode-block:target {
 }
 .rst-versions .rst-current-version {
     background-color: #f7f7f7;
-    border-radius: 3px;
+    border-radius: 3px 3px 0 0;
     color: var(--colour-sphinx-blue);
 }
 .rst-versions .rst-current-version .fa {
     color: var(--colour-sphinx-blue);
 }
 .rst-versions .rst-other-versions {
+    border-top: 1px solid var(--colour-sphinx-blue);
     background-color: #f7f7f7;
     color: var(--colour-text);
 }

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -431,6 +431,7 @@ div.viewcode-block:target {
 }
 .rst-versions .rst-current-version {
     background-color: #f7f7f7;
+    border-radius: 3px;
     color: var(--colour-sphinx-blue);
 }
 .rst-versions .rst-current-version .fa {

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -437,11 +437,11 @@ div.viewcode-block:target {
 .rst-versions .rst-current-version .fa {
     color: var(--colour-sphinx-blue);
 }
-.rst-versions .rst-other-version {
+.rst-versions .rst-other-versions {
     background-color: #f7f7f7;
     color: var(--colour-text);
 }
-.rst-versions .rst-other-version a {
+.rst-versions .rst-other-versions dd a {
     color: var(--colour-sphinx-blue);
 }
 

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -422,6 +422,25 @@ div.viewcode-block:target {
     }
 }
 
+/* ReadtheDocs docs selector */
+.rst-versions {
+    background-color: #f7f7f7;
+    border: 1px solid var(--colour-sphinx-blue);
+    border-radius: 3px;
+    color: var(--colour-sphinx-blue);
+}
+.rst-versions .rst-current-version {
+    background-color: #f7f7f7;
+    color: var(--colour-sphinx-blue);
+}
+.rst-versions .rst-current-version .fa {
+    color: var(--colour-sphinx-blue);
+}
+.rst-versions .rst-current-version {
+    background-color: #f7f7f7;
+    color: var(--colour-sphinx-blue);
+}
+
 
 /* Landing page */
 .sphinx-tagline * {

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -15,7 +15,7 @@
 body {
     font-family: var(--fonts-sans-serif);
     margin: 0 auto;
-    color: var(--colour-text);
+    color: var(var(--colour-text));
 }
 
 .pageheader {
@@ -423,7 +423,7 @@ div.viewcode-block:target {
 }
 
 /* ReadtheDocs docs selector */
-.rst-versions {
+.rst-versions.rst-badge {
     background-color: #f7f7f7;
     border: 1px solid var(--colour-sphinx-blue);
     border-radius: 3px;
@@ -436,8 +436,11 @@ div.viewcode-block:target {
 .rst-versions .rst-current-version .fa {
     color: var(--colour-sphinx-blue);
 }
-.rst-versions .rst-current-version {
+.rst-versions .rst-other-version {
     background-color: #f7f7f7;
+    color: var(--colour-text);
+}
+.rst-versions .rst-other-version a {
     color: var(--colour-sphinx-blue);
 }
 


### PR DESCRIPTION
Ideally it would be placed in the bottom of left sidebar (see https://docs.readthedocs.io/en/stable/flyout-menu.html),
but that is a lot more work, so for now we just make sure its coloring is more inline with the theme,
so it does not stand-out so much