### PR TITLE
[docs] Improve sidebar

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -34,12 +34,13 @@
 <div class="document">
   <div class="sphinxsidebar" role="navigation" aria-label="Main">
     {%- include "searchfield.html" %}
-    <div class="sphinxsidebar-navigation__contents">
-      <h3>{{ _('On this page') }}</h3>
-      {{ toc }}
-    </div>
+    {%- if display_toc %}
+      <div class="sphinxsidebar-navigation__contents">
+        <h3>{{ _('On this page') }}</h3>
+        {{ toc }}
+      </div>
+    {%- endif %}
     <div class="sphinxsidebar-navigation__pages">
-      <h3>{{ _('Site navigation') }}</h3>
       {{ toctree(includehidden=True, maxdepth=3, titles_only=True) }}
     </div>
   </div>

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -110,7 +110,8 @@ div.sphinxsidebar input {
 }
 
 div.sphinxsidebar h3 {
-    font-size: 1.5em;
+    font-size: 1.2em;
+    font-weight: 300;
     margin-top: 0;
     margin-bottom: 0.5em;
     padding-top: 0.5em;


### PR DESCRIPTION
- Remove "Site navigation" header
  - this is already contextually clear (especially since separators were added in #12439)
- Hide "On this page" if `display_toc is False`
- Format "On this page" header similar to top-level site-nav sections

https://sphinx--12461.org.readthedocs.build/en/12461/

-----

before:

<img width="293" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/3b72d7a4-2649-4c9c-b7cd-bc8393b00f28">
<img width="295" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/e446c1f6-2579-47bb-ae13-1d7959504f63">

-----

after:

<img width="196" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/d87616d9-2363-4fcb-bb9e-b74f39a00dcd">
<img width="215" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/521eb80c-417c-4433-989b-6f6460aa4071">

