### PR TITLE
DOC: Reduce horizontal padding on small screens

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -442,6 +442,8 @@ div.viewcode-block:target {
     }
     div.body {
         border-left: none;
+        padding-left: 0.5em;
+        padding-right: 0.5em;
     }
 }
 


### PR DESCRIPTION
The motivation is to maximize used horizontal space when the screen is small.

Before:
![grafik](https://github.com/sphinx-doc/sphinx/assets/2836374/5a6d51c0-211a-4f2a-903e-6d630b9e1add)


After:
![grafik](https://github.com/sphinx-doc/sphinx/assets/2836374/6881ec13-5b3a-4f2a-94bb-63e0d04c211a)
