### PR TITLE
[docs] Add Previous/Next links after content

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block header %}
+{{ svgs() }}
 <div class="pageheader">
   <div class="brand">
     <a href="{{ pathto(root_doc)|e }}">
@@ -18,7 +19,7 @@
   </div>
   <div class="icons">
     <a href="https://github.com/sphinx-doc/sphinx" title="{{ _('Source Code') }}" target="_blank">
-      {{ github_icon() }}
+      <svg><use href="#github"></use></svg>
     </a>
   </div>
 </div>
@@ -54,6 +55,7 @@
   {%- block document %}
   <div class="body" role="main">
     {% block body %}{% endblock %}
+    {{ prev_next() }}
   </div>
   {%- endblock %}
 </div>
@@ -68,17 +70,59 @@
 </div>
 {%- endblock %}
 
-{% macro github_icon() %}
+{% macro prev_next() %}
+  <div class="related-pages" role="navigation" aria-label="Related">
+    {% if prev -%}
+      <a class="prev-page" href="{{ prev.link }}">
+        <svg><use href="#svg-arrow-right"></use></svg>
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Previous") }}</span>
+          </div>
+          {% if prev.link == pathto(root_doc) %}
+          <div class="title">{{ _("Home") }}</div>
+          {% else %}
+          <div class="title">{{ prev.title }}</div>
+          {% endif %}
+        </div>
+      </a>
+    {%- else %}
+    <div></div>
+    {%- endif %}
+    {% if next -%}
+      <a class="next-page" href="{{ next.link }}">
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Next") }}</span>
+          </div>
+          <div class="title">{{ next.title }}</div>
+        </div>
+        <svg><use href="#svg-arrow-right"></use></svg>
+      </a>
+    {%- endif %}
+  </div>
+{% endmacro %}
+
+{% macro svgs() %}
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="github" viewBox="0 0 16 16">
+    <title>GitHub</title>
     <svg
-    stroke="currentColor"
-    fill="currentColor"
-    stroke-width="0"
-    viewBox="0 0 16 16"
-    class="gh-source"
-  >
-    <path
-      fill-rule="evenodd"
-      d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-    ></path>
-  </svg>
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 16 16"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+      ></path>
+    </svg>
+  <symbol id="svg-arrow-right" viewBox="0 0 24 24">
+    <title>Expand</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather-chevron-right">
+      <polyline points="9 18 15 12 9 6"></polyline>
+    </svg>
+  </symbol>
+</svg>
 {% endmacro %}

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -68,6 +68,7 @@ body {
 
 .pageheader .icons svg {
     height: 1.6em;
+    width: 1.6em;
 }
 
 div.document {
@@ -456,6 +457,51 @@ div.viewcode-block:target {
         padding-left: 0.5em;
         padding-right: 0.5em;
     }
+}
+
+/* Next/previous content footer */
+.related-pages {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 2rem;
+  font-size: smaller;
+}
+.related-pages .next-page {
+  text-align: right;
+}
+.related-pages a.prev-page,
+.related-pages a.next-page {
+    flex: 1 1 0%;
+    display: flex;
+    align-items: center;
+    border-radius: .25rem;
+    padding: .25rem;
+    text-decoration: none;
+}
+.related-pages a.prev-page {
+    justify-content: flex-start;
+    padding-left: 0;
+}
+.related-pages a.next-page {
+    justify-content: flex-end;
+    padding-right: 0;
+}
+.related-pages a:hover {
+    background-color: #f8f8f8;
+}
+.related-pages a .context {
+    font-size: small;
+    color: #5f5f5f;
+}
+.related-pages svg {
+    height: .75rem;
+    width: .75rem;
+    margin: 0 .5rem;
+    flex-shrink: 0;
+}
+.related-pages .prev-page svg {
+    transform: rotate(180deg);
 }
 
 /* ReadtheDocs docs selector */


### PR DESCRIPTION
Following [furo](https://pradyunsg.me/furo) / [lutra](https://pradyunsg.me/lutra) themes, I feel this is particularly helpful when following multi-page tutorials (as there is in the documentation)

https://sphinx--12466.org.readthedocs.build/en/12466/

<img width="822" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/2f66e919-84c4-4ea9-90df-f8d31e420303">


