### PR TITLE
[linkcheck] Allow integer for `linkcheck_rate_limit_timeout`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ Bugs fixed
   Patch by Bénédikt Tran.
 * #12220: Fix loading custom template translations for ``en`` locale.
   Patch by Nicolas Peugnet.
+* #12459: Add valid-type arguments to the ``linkcheck_rate_limit_timeout``
+  configuration setting.
+  Patch by James Addison.
 
 Improvements
 ------------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2950,8 +2950,8 @@ Options for the linkcheck builder
 
    Otherwise, ``linkcheck`` waits for a minute before to retry and keeps
    doubling the wait time between attempts until it succeeds or exceeds the
-   ``linkcheck_rate_limit_timeout``. By default, the timeout is 300 seconds
-   and custom timeouts should be given in seconds.
+   ``linkcheck_rate_limit_timeout``. By default, the timeout is 300 seconds.
+   Custom timeouts should be given as a number of seconds.
 
    .. _Retry-After: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -708,7 +708,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     # commonly used for dynamic pages
     app.add_config_value('linkcheck_anchors_ignore', ['^!'], '')
     app.add_config_value('linkcheck_anchors_ignore_for_url', (), '', (tuple, list))
-    app.add_config_value('linkcheck_rate_limit_timeout', 300.0, '', (int, float))
+    app.add_config_value('linkcheck_rate_limit_timeout', 300.0, '')
     app.add_config_value('linkcheck_allow_unauthorized', True, '')
     app.add_config_value('linkcheck_report_timeouts_as_broken', True, '', bool)
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -708,7 +708,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     # commonly used for dynamic pages
     app.add_config_value('linkcheck_anchors_ignore', ['^!'], '')
     app.add_config_value('linkcheck_anchors_ignore_for_url', (), '', (tuple, list))
-    app.add_config_value('linkcheck_rate_limit_timeout', 300.0, '')
+    app.add_config_value('linkcheck_rate_limit_timeout', 300.0, '', (int, float))
     app.add_config_value('linkcheck_allow_unauthorized', True, '')
     app.add_config_value('linkcheck_report_timeouts_as_broken', True, '', bool)
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1051,3 +1051,10 @@ def test_linkcheck_exclude_documents(app: Sphinx) -> None:
         'uri': 'https://www.sphinx-doc.org/this-is-another-broken-link',
         'info': 'br0ken_link matched br[0-9]ken_link from linkcheck_exclude_documents',
     } in content
+
+
+@pytest.mark.sphinx('linkcheck', testroot='linkcheck',
+                    confoverrides={'linkcheck_rate_limit_timeout': 30})
+def test_limit_rate_type_checking(app: Sphinx, warning: StringIO) -> None:
+    app.build()
+    assert warning.getvalue() == ''

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1051,10 +1051,3 @@ def test_linkcheck_exclude_documents(app: Sphinx) -> None:
         'uri': 'https://www.sphinx-doc.org/this-is-another-broken-link',
         'info': 'br0ken_link matched br[0-9]ken_link from linkcheck_exclude_documents',
     } in content
-
-
-@pytest.mark.sphinx('linkcheck', testroot='linkcheck',
-                    confoverrides={'linkcheck_rate_limit_timeout': 30})
-def test_limit_rate_type_checking(app: Sphinx, warning: StringIO) -> None:
-    app.build()
-    assert warning.getvalue() == ''


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Eliminate type-related warnings when users configure a valid integer value for the ``linkcheck_rate_limit_timeout`` config setting.

### Detail
- A both `int` and the existing default of `float` as valid value types for ``linkcheck_rate_limit_timeout``.
- Apply a grammatical documentation fixup to address a sidenote mentioned by the bugreporter. 

### Relates
- Resolves #12459.