### PR TITLE
[toctree] Adding warning type/subtype `toc.no_title`

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -366,6 +366,7 @@ General configuration
    * ``toc.excluded``
    * ``toc.not_readable``
    * ``toc.secnum``
+   * ``toc.no_title``
 
    Extensions can also define their own warning types.
    Those defined by the first-party ``sphinx.ext`` extensions are:

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -316,7 +316,7 @@ def _toctree_entry(
             # empty toc means: no titles will show up in the toctree
             logger.warning(__('toctree contains reference to document %r that '
                               "doesn't have a title: no link will be generated"),
-                           ref, location=toctreenode)
+                           ref, location=toctreenode, type='toc', subtype='no_title')
     except KeyError:
         # this is raised if the included file does not exist
         ref_path = env.doc2path(ref, False)


### PR DESCRIPTION
Subject: Add warning type and subtype to warning generated in toctree

### Feature or Bugfix
- Feature

### Purpose

Firstly, I believe typing warnings is a good practice.

Then, non-typed warnings are impossible to suppress without disabling all other warnings.   

I do not think that suppressing warnings is a good practice, but sometimes it may be useful. For my use-case, Sphinx provides a very limited toolset when it comes to targeted publishing. In particular, adjusting ToC is a great challenge. I do not want to display whole toctree to a user with limited access, with only a title and possibly an admonition on classified documents.

In previous versions, there was no such warning, and doing something like 

```rst
.. only:: my_classification
  
  Test
  ====

  ...classified content goes here
```
...and then referencing the document in a ToC was viable. Yes, there was a blank page created somewhere in the output dir, but ToC was "clean". This holds with newer versions, just now the build is full of warnings. Moreover, warnings on ToC level are multiplied in the build which makes it very easy to overlook other problems.

In the pull request, I added warning type and subtype, so that i can suppress this warning, without affecting state-of-art functionality.

### Detail
- added warning type and subtype
- added the type and subtype also to docs


