### PR TITLE
[docs] Improve contents title style

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -361,6 +361,10 @@ aside.topic {
     background-color: #f8f8f8;
 }
 
+p.topic-title {
+    margin-top: 0;
+}
+
 table {
     border-collapse: collapse;
     margin: 0 -0.5em 0 -0.5em;


### PR DESCRIPTION
Currently, there is an overly large gap at the top, due to both the containing div having padding and the title having a top margin. Here we remove the top-margin.

---

before:

<img width="765" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/ae37e439-8532-48be-94d8-8f6cf0a042cd">

after:

<img width="763" alt="image" src="https://github.com/sphinx-doc/sphinx/assets/2997570/6732a02b-b0fa-4411-8e3a-fa6e4da2359b">

