### PR TITLE
[html] propagate `rel` attribute from `reference` nodes

### DIFF
--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -325,6 +325,8 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
             atts['title'] = node['reftitle']
         if 'target' in node:
             atts['target'] = node['target']
+        if 'rel' in node:
+            atts['rel'] = node['rel']
         self.body.append(self.starttag(node, 'a', '', **atts))
 
         if node.get('secnumber'):


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel,
this allows third-party extensions to set this attribute on the node and have it propagate to the output HTML,
for example https://github.com/executablebooks/MyST-Parser/pull/857

related to #12477
(see also https://www.freecodecamp.org/news/what-is-tabnabbing/, for why it should be used when opening links in new tabs)