### PR TITLE
Implement the only directive through input lines manipulation

### DIFF
--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -123,7 +123,7 @@ class I18nTags(Tags):
     always returns True value even if no tags are defined.
     """
 
-    def eval_condition(self, condition: Any) -> bool:
+    def eval_condition(self, condition: str) -> bool:
         return True
 
 
@@ -140,7 +140,7 @@ class I18nBuilder(Builder):
         super().init()
         self.env.set_versioning_method(self.versioning_method,
                                        self.env.config.gettext_uuid)
-        self.tags = I18nTags()
+        self.tags = self.app.tags = I18nTags()
         self.catalogs: defaultdict[str, Catalog] = defaultdict(Catalog)
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from os.path import abspath, relpath
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -319,6 +319,23 @@ class HList(SphinxDirective):
 class Only(SphinxDirective):
     """
     Directive to only include text if the given tag(s) are enabled.
+
+    This directive functions somewhat akin to a pre-processor,
+    as tag expressions are constant throughout the build.
+    The ``only`` directive is the only one that is able to 'hoist'
+    content in the section hierarchy, as the expected usage includes
+    conditional inclusion of sections.
+
+    At present, there is no supported mechanism to parse content that
+    may contain section headings at a level equal to or greater than
+    the section containing the ``only`` directive. Implementation of
+    such a mechanism is possible, though complex. Prior to Sphinx 7.4,
+    this approach was used to implement the ``only`` directive.
+
+    The current implementation makes use of the ability to modify the
+    input lines of the document being parsed, whilst parsing it. This
+    is not encouraged. Given the nature of ``only`` as both a special
+    case and akin to a pre-processor, this is considered acceptable.
     """
 
     has_content = True
@@ -328,51 +345,55 @@ class Only(SphinxDirective):
     option_spec: ClassVar[OptionSpec] = {}
 
     def run(self) -> list[Node]:
-        node = addnodes.only()
-        node.document = self.state.document
-        self.set_source_info(node)
-        node['expr'] = self.arguments[0]
+        tags = self.env.app.builder.tags
+        expr = self.arguments[0]
 
-        # Same as util.nested_parse_with_titles but try to handle nested
-        # sections which should be raised higher up the doctree.
-        memo: Any = self.state.memo
-        surrounding_title_styles = memo.title_styles
-        surrounding_section_level = memo.section_level
-        memo.title_styles = []
-        memo.section_level = 0
         try:
-            self.state.nested_parse(self.content, self.content_offset,
-                                    node, match_titles=True)
-            title_styles = memo.title_styles
-            if (not surrounding_title_styles or
-                    not title_styles or
-                    title_styles[0] not in surrounding_title_styles or
-                    not self.state.parent):
-                # No nested sections so no special handling needed.
-                return [node]
-            # Calculate the depths of the current and nested sections.
-            current_depth = 0
-            parent = self.state.parent
-            while parent:
-                current_depth += 1
-                parent = parent.parent
-            current_depth -= 2
-            title_style = title_styles[0]
-            nested_depth = len(surrounding_title_styles)
-            if title_style in surrounding_title_styles:
-                nested_depth = surrounding_title_styles.index(title_style)
-            # Use these depths to determine where the nested sections should
-            # be placed in the doctree.
-            n_sects_to_raise = current_depth - nested_depth + 1
-            parent = cast(nodes.Element, self.state.parent)
-            for _i in range(n_sects_to_raise):
-                if parent.parent:
-                    parent = parent.parent
-            parent.append(node)
-            return []
-        finally:
-            memo.title_styles = surrounding_title_styles
-            memo.section_level = surrounding_section_level
+            keep_content = tags.eval_condition(expr)
+        except Exception as err:
+            logger.warning(
+                __('exception while evaluating only directive expression: %s'),
+                err,
+                location=self.get_location())
+            keep_content = True
+
+        # Does the directive content end with a newline?
+        trailing_newline = self.block_text[-1] == '\n'
+
+        # Calculate line counts for the entire block, the content, and the preamble.
+        total_line_count = self.block_text.count('\n') + 1
+        content_line_count = len(self.content.data) + (1 * trailing_newline)
+        preamble_line_count = total_line_count - content_line_count
+
+        # Calculate the location of the directive content in the input lines.
+        offset_end = self.state_machine.line_offset
+        offset_start = offset_end - total_line_count + 1
+
+        # Every copy of ``input_lines`` must be updated, so we propagate up
+        # through the parent hierarchy.
+        input_lines = self.state_machine.input_lines
+        while input_lines is not None:
+            if keep_content:
+                blank_lines = [''] * preamble_line_count
+                content = self.content.data + ([''] * trailing_newline)
+                # Blank out the initial lines
+                input_lines.data[offset_start:offset_start + preamble_line_count] = blank_lines
+                # Replace the remaining lines with the unindented content
+                input_lines.data[offset_start + preamble_line_count:offset_end + 1] = content
+            else:
+                blank_lines = [''] * total_line_count
+                # Blank out every line
+                input_lines.data[offset_start:offset_end + 1] = blank_lines
+
+            # Update the offsets for the parent
+            if input_lines.parent_offset is not None:
+                offset_start += input_lines.parent_offset
+                offset_end += input_lines.parent_offset
+            input_lines = input_lines.parent
+
+        # ``1 - directive_lines`` is from the offset_start calculation
+        self.state_machine.next_line(1 - total_line_count)
+        return []
 
 
 class Include(BaseInclude, SphinxDirective):

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -344,6 +344,69 @@ def nested_parse_with_titles(state: Any, content: StringList, node: Node,
         state.memo.section_level = surrounding_section_level
 
 
+def _lift_sections(
+    node: Node,
+    *,
+    state_parent: Element | None,
+    inner_title_styles: list[str | tuple[str, str]],
+    surrounding_title_styles: list[str | tuple[str, str]],
+) -> None:
+    """Try to handle nested sections which should be raised higher up the doctree.
+
+    For example:
+
+    .. code-block:: rst
+
+       1. Sections in only directives
+       ==============================
+
+       1.1. Section
+       -------------
+
+       .. only:: not nonexisting_tag
+
+          1.2. Section
+          -------------
+          Should be lifted one level.
+
+          1.3. Section
+          -------------
+          Should be here.
+
+       .. only:: not nonexisting_tag
+
+          2. Included document level heading
+          ==================================
+          Should be lifted two levels.
+    """
+    if state_parent is None:
+        return
+    extant_nested_sections = (
+        surrounding_title_styles
+        and inner_title_styles
+        and inner_title_styles[0] in surrounding_title_styles
+    )
+    if not extant_nested_sections:
+        # No nested sections so no special handling needed.
+        return
+    # Calculate the depths of the current and nested sections.
+    current_depth = 0
+    parent = state_parent
+    while not isinstance(parent.parent, nodes.document):
+        current_depth += 1
+        parent = parent.parent
+    nested_depth = surrounding_title_styles.index(inner_title_styles[0])
+    # Use these depths to determine where the nested sections should
+    # be placed in the doctree.
+    num_sections_to_raise = current_depth - nested_depth + 1
+    parent = state_parent
+    for _ in range(num_sections_to_raise):
+        if parent.parent:
+            parent = parent.parent
+    parent.append(node)
+    return
+
+
 def clean_astext(node: Element) -> str:
     """Like node.astext(), but ignore images."""
     node = node.deepcopy()

--- a/tests/roots/test-intl-only-directive/conf.py
+++ b/tests/roots/test-intl-only-directive/conf.py
@@ -1,0 +1,1 @@
+exclude_patterns = ['_build']

--- a/tests/roots/test-intl-only-directive/index.rst
+++ b/tests/roots/test-intl-only-directive/index.rst
@@ -1,0 +1,14 @@
+Only directive
+--------------
+
+.. only:: html
+
+   In HTML.
+
+.. only:: latex
+
+   In LaTeX.
+
+.. only:: html or latex
+
+   In both.

--- a/tests/roots/test-intl-only-directive/xx/LC_MESSAGES/index.po
+++ b/tests/roots/test-intl-only-directive/xx/LC_MESSAGES/index.po
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2010, Georg Brandl & Team
+# This file is distributed under the same license as the Sphinx <Tests> package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Sphinx <Tests> 0.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-04 13:06+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Only directive"
+msgstr "ONLY DIRECTIVE"
+
+msgid "In HTML."
+msgstr "IN HTML."
+
+msgid "In LaTeX."
+msgstr "IN LATEX."
+
+msgid "In both."
+msgstr "IN BOTH."

--- a/tests/test_directives/test_directive_only.py
+++ b/tests/test_directives/test_directive_only.py
@@ -8,39 +8,37 @@ from docutils import nodes
 
 @pytest.mark.sphinx('text', testroot='directive-only')
 def test_sectioning(app, status, warning):
-
-    def getsects(section):
-        if not isinstance(section, nodes.section):
-            return [getsects(n) for n in section.children]
-        title = section.next_node(nodes.title).astext().strip()
-        subsects = []
-        children = section.children[:]
-        while children:
-            node = children.pop(0)
-            if isinstance(node, nodes.section):
-                subsects.append(node)
-                continue
-            children = list(node.children) + children
-        return [title, [getsects(subsect) for subsect in subsects]]
-
-    def testsects(prefix, sects, indent=0):
-        title = sects[0]
-        parent_num = title.split()[0]
-        assert prefix == parent_num, \
-            'Section out of place: %r' % title
-        for i, subsect in enumerate(sects[1]):
-            num = subsect[0].split()[0]
-            assert re.match('[0-9]+[.0-9]*[.]', num), \
-                'Unnumbered section: %r' % subsect[0]
-            testsects(prefix + str(i + 1) + '.', subsect, indent + 4)
-
     app.build(filenames=[app.srcdir / 'only.rst'])
     doctree = app.env.get_doctree('only')
     app.env.apply_post_transforms(doctree, 'only')
 
-    parts = [getsects(n)
-             for n in [_n for _n in doctree.children if isinstance(_n, nodes.section)]]
-    for i, s in enumerate(parts):
-        testsects(str(i + 1) + '.', s, 4)
+    parts = _get_sections(doctree)
+    for i, section in enumerate(parts):
+        _test_sections(f'{i + 1}.', section, 4)
     assert len(parts) == 4, 'Expected 4 document level headings, got:\n%s' % \
         '\n'.join(p[0] for p in parts)
+
+
+def _get_sections(section: nodes.Node):
+    if not isinstance(section, nodes.section):
+        return list(map(_get_sections, section.children))
+    title = section.next_node(nodes.title).astext().strip()
+    subsections = []
+    children = section.children.copy()
+    while children:
+        node = children.pop(0)
+        if isinstance(node, nodes.section):
+            subsections.append(node)
+            continue
+        children = list(node.children) + children
+    return [title, list(map(_get_sections, subsections))]
+
+
+def _test_sections(prefix: str, sections, indent=0):
+    title = sections[0]
+    parent_num = title.split()[0]
+    assert prefix == parent_num, f'Section out of place: {title!r}'
+    for i, subsection in enumerate(sections[1]):
+        num = subsection[0].split()[0]
+        assert re.match('[0-9]+[.0-9]*[.]', num), f'Unnumbered section: {subsection[0]!r}'
+        _test_sections(f'{prefix}{i + 1}.', subsection, indent + 4)

--- a/tests/test_environment/test_environment_toctree.py
+++ b/tests/test_environment/test_environment_toctree.py
@@ -5,22 +5,23 @@ from docutils import nodes
 from docutils.nodes import bullet_list, list_item, literal, reference, title
 
 from sphinx import addnodes
-from sphinx.addnodes import compact_paragraph, only
+from sphinx.addnodes import compact_paragraph
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment.adapters.toctree import document_toc, global_toctree_for_doc
 from sphinx.testing.util import assert_node
 
 
-@pytest.mark.sphinx('xml', testroot='toctree')
-@pytest.mark.test_params(shared_result='test_environment_toctree_basic')
-def test_process_doc(app):
+@pytest.mark.sphinx('html', testroot='toctree')
+def test_process_doc_html(app):
     app.build()
     # tocs
     toctree = app.env.tocs['index']
     assert_node(toctree,
                 [bullet_list, ([list_item, (compact_paragraph,  # [0][0]
                                             [bullet_list, (addnodes.toctree,  # [0][1][0]
-                                                           only,  # [0][1][1]
+                                                           # The ``only`` content remains
+                                                           # in the HTML builder.
+                                                           list_item,  # [0][1][1]
                                                            list_item)])],  # [0][1][2]
                                [list_item, (compact_paragraph,  # [1][0]
                                             [bullet_list, (addnodes.toctree,  # [1][1][0]
@@ -38,17 +39,18 @@ def test_process_doc(app):
                 includefiles=['foo', 'bar'])
 
     # only branch
-    assert_node(toctree[0][1][1], addnodes.only, expr="html")
+    assert_node(toctree[0][1][1], list_item)
     assert_node(toctree[0][1][1],
-                [only, list_item, ([compact_paragraph, reference, "Section for HTML"],
-                                   [bullet_list, addnodes.toctree])])
-    assert_node(toctree[0][1][1][0][0][0], reference, anchorname='#section-for-html')
-    assert_node(toctree[0][1][1][0][1][0], addnodes.toctree,
+                [list_item, ([compact_paragraph, reference, "Section for HTML"],
+                             [bullet_list, (addnodes.toctree, list_item)])])
+    assert_node(toctree[0][1][1][0][0], reference, anchorname='#section-for-html')
+    assert_node(toctree[0][1][1][1][0], addnodes.toctree,
                 caption=None, glob=False, hidden=False, entries=[(None, 'baz')],
                 includefiles=['baz'], titlesonly=False, maxdepth=-1, numbered=0)
+    assert_node(toctree[0][1][1][1][1][0],
+                [compact_paragraph, reference, "subsection"])
     assert_node(toctree[0][1][2],
-                ([compact_paragraph, reference, "subsection"],
-                 [bullet_list, list_item, compact_paragraph, reference, "subsubsection"]))
+                [list_item, compact_paragraph, reference, "subsubsection"])
 
     assert_node(toctree[1][0],
                 [compact_paragraph, reference, "Test for issue #1157"])
@@ -71,6 +73,66 @@ def test_process_doc(app):
     assert app.env.files_to_rebuild['foo'] == {'index'}
     assert app.env.files_to_rebuild['bar'] == {'index'}
     assert app.env.files_to_rebuild['baz'] == {'index'}
+    assert app.env.glob_toctrees == set()
+    assert app.env.numbered_toctrees == {'index'}
+
+    # qux has no section title
+    assert len(app.env.tocs['qux']) == 0
+    assert_node(app.env.tocs['qux'], nodes.bullet_list)
+    assert app.env.toc_num_entries['qux'] == 0
+    assert 'qux' not in app.env.toctree_includes
+
+
+@pytest.mark.sphinx('xml', testroot='toctree')
+@pytest.mark.test_params(shared_result='test_environment_toctree_basic')
+def test_process_doc(app):
+    app.build()
+    # tocs
+    toctree = app.env.tocs['index']
+    assert_node(toctree,
+                [bullet_list, ([list_item, (compact_paragraph,  # [0][0]
+                                            [bullet_list, (addnodes.toctree,  # [0][1][0]
+                                                           # The ``only`` directive is removed
+                                                           # as this is an XML builder
+                                                           list_item)])],  # [0][1][1]
+                               [list_item, (compact_paragraph,  # [1][0]
+                                            [bullet_list, (addnodes.toctree,  # [1][1][0]
+                                                           addnodes.toctree)])],  # [1][1][1]
+                               list_item)])
+
+    assert_node(toctree[0][0],
+                [compact_paragraph, reference, "Welcome to Sphinx Tests’s documentation!"])
+    assert_node(toctree[0][0][0], reference, anchorname='')
+    assert_node(toctree[0][1][0], addnodes.toctree,
+                caption="Table of Contents", glob=False, hidden=False,
+                titlesonly=False, maxdepth=2, numbered=999,
+                entries=[(None, 'foo'), (None, 'bar'), (None, 'https://sphinx-doc.org/'),
+                         (None, 'self')],
+                includefiles=['foo', 'bar'])
+    assert_node(toctree[0][1][1],
+                ([compact_paragraph, reference, "subsection"],
+                 [bullet_list, list_item, compact_paragraph, reference, "subsubsection"]))
+
+    assert_node(toctree[1][0],
+                [compact_paragraph, reference, "Test for issue #1157"])
+    assert_node(toctree[1][0][0], reference, anchorname='#test-for-issue-1157')
+    assert_node(toctree[1][1][0], addnodes.toctree,
+                caption=None, entries=[], glob=False, hidden=False,
+                titlesonly=False, maxdepth=-1, numbered=0)
+    assert_node(toctree[1][1][1], addnodes.toctree,
+                caption=None, glob=False, hidden=True,
+                titlesonly=False, maxdepth=-1, numbered=0,
+                entries=[('Latest reference', 'https://sphinx-doc.org/latest/'),
+                         ('Python', 'https://python.org/')])
+
+    assert_node(toctree[2][0],
+                [compact_paragraph, reference, "Indices and tables"])
+
+    # other collections
+    assert app.env.toc_num_entries['index'] == 5
+    assert app.env.toctree_includes['index'] == ['foo', 'bar']
+    assert app.env.files_to_rebuild['foo'] == {'index'}
+    assert app.env.files_to_rebuild['bar'] == {'index'}
     assert app.env.glob_toctrees == set()
     assert app.env.numbered_toctrees == {'index'}
 
@@ -196,8 +258,7 @@ def test_document_toc_only(app):
     assert_node(toctree,
                 [bullet_list, ([list_item, (compact_paragraph,  # [0][0]
                                             [bullet_list, (addnodes.toctree,  # [0][1][0]
-                                                           list_item,  # [0][1][1]
-                                                           list_item)])],  # [0][1][2]
+                                                           list_item)])],  # [0][1][1]
                                [list_item, (compact_paragraph,  # [1][0]
                                             [bullet_list, (addnodes.toctree,
                                                            addnodes.toctree)])],
@@ -205,9 +266,6 @@ def test_document_toc_only(app):
     assert_node(toctree[0][0],
                 [compact_paragraph, reference, "Welcome to Sphinx Tests’s documentation!"])
     assert_node(toctree[0][1][1],
-                ([compact_paragraph, reference, "Section for HTML"],
-                 [bullet_list, addnodes.toctree]))
-    assert_node(toctree[0][1][2],
                 ([compact_paragraph, reference, "subsection"],
                  [bullet_list, list_item, compact_paragraph, reference, "subsubsection"]))
     assert_node(toctree[1][0],
@@ -239,7 +297,6 @@ def test_global_toctree_for_doc(app):
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
                                      bullet_list,
-                                     bullet_list,
                                      bullet_list)])
 
     assert_node(toctree[1],
@@ -263,12 +320,10 @@ def test_global_toctree_for_doc(app):
     assert_node(toctree[1][3][0][0], reference, refuri="")
 
     assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
-    assert_node(toctree[3],
                 ([list_item, compact_paragraph, reference, "Latest reference"],
                  [list_item, compact_paragraph, reference, "Python"]))
-    assert_node(toctree[3][0][0][0], reference, refuri="https://sphinx-doc.org/latest/")
-    assert_node(toctree[3][1][0][0], reference, refuri="https://python.org/")
+    assert_node(toctree[2][0][0][0], reference, refuri="https://sphinx-doc.org/latest/")
+    assert_node(toctree[2][1][0][0], reference, refuri="https://python.org/")
 
 
 @pytest.mark.sphinx('xml', testroot='toctree')
@@ -278,7 +333,6 @@ def test_global_toctree_for_doc_collapse(app):
     toctree = global_toctree_for_doc(app.env, 'index', app.builder, collapse=True)
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
-                                     bullet_list,
                                      bullet_list,
                                      bullet_list)])
 
@@ -294,12 +348,10 @@ def test_global_toctree_for_doc_collapse(app):
     assert_node(toctree[1][3][0][0], reference, refuri="")
 
     assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
-    assert_node(toctree[3],
                 ([list_item, compact_paragraph, reference, "Latest reference"],
                  [list_item, compact_paragraph, reference, "Python"]))
-    assert_node(toctree[3][0][0][0], reference, refuri="https://sphinx-doc.org/latest/")
-    assert_node(toctree[3][1][0][0], reference, refuri="https://python.org/")
+    assert_node(toctree[2][0][0][0], reference, refuri="https://sphinx-doc.org/latest/")
+    assert_node(toctree[2][1][0][0], reference, refuri="https://python.org/")
 
 
 @pytest.mark.sphinx('xml', testroot='toctree')
@@ -310,7 +362,6 @@ def test_global_toctree_for_doc_maxdepth(app):
                                      collapse=False, maxdepth=3)
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
-                                     bullet_list,
                                      bullet_list,
                                      bullet_list)])
 
@@ -340,12 +391,10 @@ def test_global_toctree_for_doc_maxdepth(app):
     assert_node(toctree[1][3][0][0], reference, refuri="")
 
     assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
-    assert_node(toctree[3],
                 ([list_item, compact_paragraph, reference, "Latest reference"],
                  [list_item, compact_paragraph, reference, "Python"]))
-    assert_node(toctree[3][0][0][0], reference, refuri="https://sphinx-doc.org/latest/")
-    assert_node(toctree[3][1][0][0], reference, refuri="https://python.org/")
+    assert_node(toctree[2][0][0][0], reference, refuri="https://sphinx-doc.org/latest/")
+    assert_node(toctree[2][1][0][0], reference, refuri="https://python.org/")
 
 
 @pytest.mark.sphinx('xml', testroot='toctree')
@@ -356,7 +405,6 @@ def test_global_toctree_for_doc_includehidden(app):
                                      collapse=False, includehidden=False)
     assert_node(toctree,
                 [compact_paragraph, ([title, "Table of Contents"],
-                                     bullet_list,
                                      bullet_list)])
 
     assert_node(toctree[1],
@@ -377,9 +425,6 @@ def test_global_toctree_for_doc_includehidden(app):
     assert_node(toctree[1][0][1][2][0][0], reference, refuri="foo#foo-2", secnumber=[1, 3])
     assert_node(toctree[1][1][0][0], reference, refuri="bar", secnumber=[2])
     assert_node(toctree[1][2][0][0], reference, refuri="https://sphinx-doc.org/")
-
-    assert_node(toctree[2],
-                [bullet_list, list_item, compact_paragraph, reference, "baz"])
 
 
 @pytest.mark.sphinx('xml', testroot='toctree-index')

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -326,8 +326,10 @@ def test_gettext_section(app):
     # --- section
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'section.po')
     actual = read_po(app.outdir / 'section.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl
@@ -478,13 +480,17 @@ def test_gettext_toctree(app):
     # --- toctree (index.rst)
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'index.po')
     actual = read_po(app.outdir / 'index.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
     # --- toctree (toctree.rst)
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'toctree.po')
     actual = read_po(app.outdir / 'toctree.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl
@@ -495,8 +501,10 @@ def test_gettext_table(app):
     # --- toctree
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'table.po')
     actual = read_po(app.outdir / 'table.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl
@@ -536,8 +544,10 @@ def test_gettext_topic(app):
     # --- topic
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'topic.po')
     actual = read_po(app.outdir / 'topic.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl
@@ -560,8 +570,10 @@ def test_gettext_definition_terms(app):
     # --- definition terms: regression test for #2198, #2205
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'definition_terms.po')
     actual = read_po(app.outdir / 'definition_terms.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl
@@ -572,8 +584,10 @@ def test_gettext_glossary_terms(app, warning):
     # --- glossary terms: regression test for #1090
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'glossary_terms.po')
     actual = read_po(app.outdir / 'glossary_terms.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
     warnings = warning.getvalue().replace(os.sep, '/')
     assert 'term not in glossary' not in warnings
 
@@ -586,8 +600,10 @@ def test_gettext_glossary_term_inconsistencies(app):
     # --- glossary term inconsistencies: regression test for #1090
     expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'glossary_terms_inconsistency.po')
     actual = read_po(app.outdir / 'glossary_terms_inconsistency.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl
@@ -606,16 +622,23 @@ def test_gettext_literalblock(app):
             pass  # skip code-blocks and literalblocks
 
 
-@sphinx_intl
-@pytest.mark.sphinx('gettext')
-@pytest.mark.test_params(shared_result='test_intl_gettext')
+@pytest.mark.sphinx(
+    'gettext',
+    testroot='intl-only-directive',
+    confoverrides={
+        'language': _CATALOG_LOCALE, 'locale_dirs': ['.'],
+        'gettext_compact': False,
+    },
+)
 def test_gettext_buildr_ignores_only_directive(app):
     app.build()
     # --- gettext builder always ignores ``only`` directive
-    expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'only.po')
-    actual = read_po(app.outdir / 'only.pot')
-    for expect_msg in [m for m in expect if m.id]:
-        assert expect_msg.id in [m.id for m in actual if m.id]
+    expect = read_po(app.srcdir / _CATALOG_LOCALE / 'LC_MESSAGES' / 'index.po')
+    actual = read_po(app.outdir / 'index.pot')
+    actual_ids = {m.id for m in actual if m.id}
+    for expect_msg in expect:
+        if expect_msg.id:
+            assert expect_msg.id in actual_ids
 
 
 @sphinx_intl


### PR DESCRIPTION
This adjusts how ``.. only::`` directives are implemented.

``only`` directives are special, as a supported use-case is conditional inclusion of a section or sections. For example:

```rest
Alpha
-----

Lorem ipsum 

.. only:: exemplar_tag

   Bravo
   -----

   dolar sit

Charlie
-------

amet.
```

However, directives have no way within Docutils to create a new section. The current implementation therefore takes the approach of a post-hoc pass to identify sections that ought be at a greater level in the document hierarchy, and raises those sections accordingly. This approach works, though is somewhat fragile.

The approach suggested in this PR does have fragility concerns, but I believe is a stronger approach to take. We treat the ``only`` directive like a pre-processor, and replace the text in the buffer with either the de-indented contents of the directive, or blank lines, depending on the status of the tag condition. This has the benefit of reducing complexity as the ``only`` post-transform is no longer needed (although not removed here), as tags are eagerly evaluated.

A 