### PR TITLE
Use Windows-specific Colorama initialisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "packaging>=21.0",
     "importlib-metadata>=4.8; python_version < '3.10'",
     "tomli>=2; python_version < '3.11'",
-    "colorama>=0.4.5; sys_platform == 'win32'",
+    "colorama>=0.4.6; sys_platform == 'win32'",
 ]
 dynamic = ["version"]
 

--- a/sphinx/util/console.py
+++ b/sphinx/util/console.py
@@ -93,7 +93,7 @@ def color_terminal() -> bool:
     if 'NO_COLOR' in os.environ:
         return False
     if sys.platform == 'win32' and colorama is not None:
-        colorama.init()
+        colorama.just_fix_windows_console()
         return True
     if 'FORCE_COLOR' in os.environ:
         return True


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix

### Purpose

Colorama has a newer `just_fix_windows_console` call (v0.4.6+) which provides a better initialization for Windows consoles. This should improve a user's colored terminal experience when using other scripts/utilities that may use multiple Sphinx instances over the life-cycle of a run.

### Detail

This is most likely outside the supported use cases for Sphinx but this change is driven to help the user experience when performing testing a third-party Sphinx extension. When testing for a third-party extension, the Sphinx application is [built through a utility call](https://github.com/sphinx-contrib/confluencebuilder/blob/54b1fea17557f4eafa00688fe623babd8cd8e6d1/tests/lib/__init__.py#L622) that can be used to create multiple instances over time in unit and other testing. Noticed when in a Windows environment, if a second instance of Sphinx is created, the color becomes disabled in the console. Stumbled upon [an issue](https://github.com/tartley/colorama/issues/145) which looked to be related to this case and a [specific comment](https://github.com/tartley/colorama/issues/145#issuecomment-2099552420) suggests to use a `just_fix_windows_console` call instead. Testing between two versions of Sphinx with changing the initialization call seemed to show an improved experience.

Before:

![image](https://github.com/sphinx-doc/sphinx/assets/1834509/136d0ba5-d039-48ba-8891-2ac8e0d29949)

After:

![image](https://github.com/sphinx-doc/sphinx/assets/1834509/b80d097d-fc63-43e8-a201-43e5742be54d)

### Relates
- https://github.com/tartley/colorama?tab=readme-ov-file#usage


