### PR TITLE
ENH: Make sourcedir and outputdir parameters in sphinx-build optional

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -113,7 +113,7 @@ def jobs_argument(value: str) -> int:
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        usage='%(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]',
+        usage='%(prog)s [OPTIONS] [SOURCEDIR] [OUTPUTDIR] [FILENAMES...]',
         epilog=__('For more information, visit <https://www.sphinx-doc.org/>.'),
         description=__("""
 Generate documentation from source files.
@@ -136,12 +136,16 @@ files can be built by specifying individual filenames.
                         version=f'%(prog)s {__display_version__}')
 
     parser.add_argument('sourcedir', metavar='SOURCE_DIR',
-                        help=__('path to documentation source files'))
+                        nargs='?', default='.',
+                        help=__('path to documentation source files (default: .)'))
     parser.add_argument('outputdir', metavar='OUTPUT_DIR',
-                        help=__('path to output directory'))
+                        nargs='?', default="_build",
+                        help=__('path to output directory (default: _build)'))
     parser.add_argument('filenames', nargs='*',
                         help=__('(optional) a list of specific files to rebuild. '
-                                'Ignored if --write-all is specified'))
+                                'Ignored if --write-all is specified. To be able to pass '
+                                'this parameter, you must also pass sourcedir and '
+                                'outputdir explicitly before.'))
 
     group = parser.add_argument_group(__('general options'))
     group.add_argument('--builder', '-b', metavar='BUILDER', dest='builder',


### PR DESCRIPTION
This allows to simply run `sphinx-build` in your doc directory, instead of having to type `sphinx-build . _build`.

The default output folder name "_build" is a bit opinionated, but it's what sphinx-quickstart uses. It creates that folder and adds it to exclude_patterns in `conf.py` already. I believe, we can therefore afford to go with this default. One may later add an `output_dir` config variable to `conf.py` and use that instead of a hard-coded default.

