### PR TITLE
Fix "As used by: Python Foundation" in docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -92,7 +92,7 @@ Sphinx
          :align: center
          :target: https://docs.python.org
 
-         Python Foundation
+         Python
 
       .. figure:: _static/linux-logo.png
          :alt: Linux Logo


### PR DESCRIPTION
"Python Foundation" is not a thing. There's the Python Software Foundation, but that's a bit long, and I believe technically not even correct. The PSF supports the Python community but is not operatively involved in CPython. I believe just "Python" is the correct and also most intuitive description.

