### PR TITLE
Type-hints: update to pass mypy checks with types-docutils 0.21.0.20240704

### DIFF
--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -13,10 +13,10 @@ from sphinx.util.parsing import nested_parse_to_nodes
 
 if TYPE_CHECKING:
     from docutils.nodes import Node
-    from sphinx.util.typing import _RSTState as RSTState
 
     from sphinx.config import Config
     from sphinx.environment import BuildEnvironment
+    from sphinx.util.typing import _RSTState as RSTState
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -112,7 +112,7 @@ class AutodocDirective(SphinxDirective):
         reporter = self.state.document.reporter
 
         try:
-            source, lineno = reporter.get_source_and_line(
+            source, lineno = reporter.get_source_and_line(  # type: ignore[attr-defined]
                 self.lineno)
         except AttributeError:
             source, lineno = (None, None)

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -13,7 +13,7 @@ from sphinx.util.parsing import nested_parse_to_nodes
 
 if TYPE_CHECKING:
     from docutils.nodes import Node
-    from docutils.parsers.rst.states import RSTState
+    from sphinx.util.typing import _RSTState as RSTState
 
     from sphinx.config import Config
     from sphinx.environment import BuildEnvironment

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -378,7 +378,7 @@ class InheritanceDiagram(SphinxDirective):
                 aliases=self.config.inheritance_alias,
                 top_classes=node['top-classes'])
         except InheritanceException as err:
-            return [node.document.reporter.warning(err, line=self.lineno)]  # type: ignore[union-attr]
+            return [node.document.reporter.warning(err, line=self.lineno)]
 
         # Create xref nodes for each target of the graph's image map and
         # add them to the doc tree so that Sphinx can resolve the
@@ -386,7 +386,7 @@ class InheritanceDiagram(SphinxDirective):
         # removed from the doctree after we're done with them.
         for name in graph.get_all_class_names():
             refnodes, x = class_role(  # type: ignore[call-arg,misc]
-                'class', ':class:`%s`' % name, name, 0, self.state)
+                'class', ':class:`%s`' % name, name, 0, self.state.inliner)
             node.extend(refnodes)
         # Store the graph object so we can use it to generate the
         # dot file later

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -386,7 +386,7 @@ class InheritanceDiagram(SphinxDirective):
         # removed from the doctree after we're done with them.
         for name in graph.get_all_class_names():
             refnodes, x = class_role(  # type: ignore[call-arg,misc]
-                'class', ':class:`%s`' % name, name, 0, self.state.inliner)
+                'class', ':class:`%s`' % name, name, 0, self.state)  # type: ignore[arg-type]
             node.extend(refnodes)
         # Store the graph object so we can use it to generate the
         # dot file later

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -386,7 +386,7 @@ class InheritanceDiagram(SphinxDirective):
         # removed from the doctree after we're done with them.
         for name in graph.get_all_class_names():
             refnodes, x = class_role(  # type: ignore[call-arg,misc]
-                'class', ':class:`%s`' % name, name, 0, self.state)  # type: ignore[arg-type]
+                'class', ':class:`%s`' % name, name, 0, self.state.inliner)
             node.extend(refnodes)
         # Store the graph object so we can use it to generate the
         # dot file later

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -326,7 +326,7 @@ def traverse_translatable_index(
         yield node, entries
 
 
-def nested_parse_with_titles(state: RSTState[Any], content: StringList, node: Node,
+def nested_parse_with_titles(state: RSTState, content: StringList, node: Node,
                              content_offset: int = 0) -> str:
     """Version of state.nested_parse() that allows titles and does not require
     titles to have the same decoration as the calling document.

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -325,7 +325,6 @@ def traverse_translatable_index(
         yield node, entries
 
 
-
 def nested_parse_with_titles(state: RSTState[Any], content: StringList, node: Node,
                              content_offset: int = 0) -> str:
     """Version of state.nested_parse() that allows titles and does not require

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -325,10 +325,8 @@ def traverse_translatable_index(
         yield node, entries
 
 
-_RSTContext = TypeVar("_RSTContext")
 
-
-def nested_parse_with_titles(state: RSTState[_RSTContext], content: StringList, node: Node,
+def nested_parse_with_titles(state: RSTState[Any], content: StringList, node: Node,
                              content_offset: int = 0) -> str:
     """Version of state.nested_parse() that allows titles and does not require
     titles to have the same decoration as the calling document.

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -20,12 +20,13 @@ if TYPE_CHECKING:
 
     from docutils.nodes import Element
     from docutils.parsers.rst import Directive
-    from docutils.parsers.rst.states import Inliner, RSTState
+    from docutils.parsers.rst.states import Inliner
     from docutils.statemachine import StringList
 
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
     from sphinx.util.tags import Tags
+    from sphinx.util.typing import _RSTState as RSTState
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -325,7 +325,10 @@ def traverse_translatable_index(
         yield node, entries
 
 
-def nested_parse_with_titles(state: RSTState, content: StringList, node: Node,
+_RSTContext = TypeVar("_RSTContext")
+
+
+def nested_parse_with_titles(state: RSTState[_RSTContext], content: StringList, node: Node,
                              content_offset: int = 0) -> str:
     """Version of state.nested_parse() that allows titles and does not require
     titles to have the same decoration as the calling document.

--- a/sphinx/util/parsing.py
+++ b/sphinx/util/parsing.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from docutils.nodes import Element, Node
 from docutils.statemachine import StringList, string2lines
@@ -11,14 +11,11 @@ from docutils.statemachine import StringList, string2lines
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    # TODO(py312+):
-    # Attempt to improve on 'Any' generic type-arg, perhaps using the 'type' stmt
-    # Ref: https://github.com/sphinx-doc/sphinx/issues/10785#issuecomment-1897551241
-    from docutils.parsers.rst.states import RSTState
+    from sphinx.util.typing import _RSTState as RSTState
 
 
 def nested_parse_to_nodes(
-    state: RSTState[Any],
+    state: RSTState,
     text: str | StringList,
     *,
     source: str = '<generated text>',
@@ -70,7 +67,7 @@ def nested_parse_to_nodes(
 
 
 @contextlib.contextmanager
-def _fresh_title_style_context(state: RSTState[Any]) -> Iterator[None]:
+def _fresh_title_style_context(state: RSTState) -> Iterator[None]:
     # hack around title style bookkeeping
     memo = state.memo
     surrounding_title_styles: list[str | tuple[str, str]] = memo.title_styles

--- a/sphinx/util/parsing.py
+++ b/sphinx/util/parsing.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from docutils.nodes import Element, Node
 from docutils.statemachine import StringList, string2lines
@@ -14,8 +14,11 @@ if TYPE_CHECKING:
     from docutils.parsers.rst.states import RSTState
 
 
+_RSTContext = TypeVar("_RSTContext")
+
+
 def nested_parse_to_nodes(
-    state: RSTState,
+    state: RSTState[_RSTContext],
     text: str | StringList,
     *,
     source: str = '<generated text>',
@@ -67,7 +70,7 @@ def nested_parse_to_nodes(
 
 
 @contextlib.contextmanager
-def _fresh_title_style_context(state: RSTState) -> Iterator[None]:
+def _fresh_title_style_context(state: RSTState[_RSTContext]) -> Iterator[None]:
     # hack around title style bookkeeping
     memo = state.memo
     surrounding_title_styles: list[str | tuple[str, str]] = memo.title_styles

--- a/sphinx/util/parsing.py
+++ b/sphinx/util/parsing.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from docutils.nodes import Element, Node
 from docutils.statemachine import StringList, string2lines
@@ -11,14 +11,14 @@ from docutils.statemachine import StringList, string2lines
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    # TODO(py312+):
+    # Attempt to improve on 'Any' generic type-arg, perhaps using the 'type' stmt
+    # Ref: https://github.com/sphinx-doc/sphinx/issues/10785#issuecomment-1897551241
     from docutils.parsers.rst.states import RSTState
 
 
-_RSTContext = TypeVar("_RSTContext")
-
-
 def nested_parse_to_nodes(
-    state: RSTState[_RSTContext],
+    state: RSTState[Any],
     text: str | StringList,
     *,
     source: str = '<generated text>',
@@ -70,7 +70,7 @@ def nested_parse_to_nodes(
 
 
 @contextlib.contextmanager
-def _fresh_title_style_context(state: RSTState[_RSTContext]) -> Iterator[None]:
+def _fresh_title_style_context(state: RSTState[Any]) -> Iterator[None]:
     # hack around title style bookkeeping
     memo = state.memo
     surrounding_title_styles: list[str | tuple[str, str]] = memo.title_styles

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -26,10 +26,12 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from typing import Final, Literal
 
+    from docutils.parsers.rst.states import RSTState as _RSTStateGeneric
     from typing_extensions import TypeAlias, TypeIs
 
     from sphinx.application import Sphinx
 
+    _RSTState: TypeAlias = _RSTStateGeneric[Any]
     _RestifyMode: TypeAlias = Literal[
         'fully-qualified-except-typing',
         'smart',

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from sphinx.application import Sphinx
 
-    _RSTState: TypeAlias = _RSTStateGeneric[Any]
+    _RSTState: TypeAlias = _RSTStateGeneric[list[str]]
     _RestifyMode: TypeAlias = Literal[
         'fully-qualified-except-typing',
         'smart',

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst.languages import en as english  # type: ignore[attr-defined]
@@ -16,12 +15,12 @@ def make_directive(*, env: SimpleNamespace, input_lines: StringList | None = Non
     return directive
 
 
-def make_directive_and_state(*, env: SimpleNamespace, input_lines: StringList | None = None) -> tuple[RSTState[Any], SphinxDirective]:
+def make_directive_and_state(*, env: SimpleNamespace, input_lines: StringList | None = None) -> tuple[RSTState[list[str]], SphinxDirective]:
     sm = RSTStateMachine(state_classes, initial_state='Body')
     sm.reporter = object()
     if input_lines is not None:
         sm.input_lines = input_lines
-    state: RSTState[Any] = RSTState(sm)
+    state: RSTState[list[str]] = RSTState(sm)
     state.document = new_document('<tests>')
     state.document.settings.env = env
     state.document.settings.tab_width = 4

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst.languages import en as english  # type: ignore[attr-defined]
@@ -11,16 +12,16 @@ from sphinx.util.docutils import SphinxDirective, new_document
 
 
 def make_directive(*, env: SimpleNamespace, input_lines: StringList | None = None) -> SphinxDirective:
-    state, directive = make_directive_and_state(env=env, input_lines=input_lines)
+    _, directive = make_directive_and_state(env=env, input_lines=input_lines)
     return directive
 
 
-def make_directive_and_state(*, env: SimpleNamespace, input_lines: StringList | None = None) -> tuple[RSTState, SphinxDirective]:
+def make_directive_and_state(*, env: SimpleNamespace, input_lines: StringList | None = None) -> tuple[RSTState[Any], SphinxDirective]:
     sm = RSTStateMachine(state_classes, initial_state='Body')
     sm.reporter = object()
     if input_lines is not None:
         sm.input_lines = input_lines
-    state = RSTState(sm)
+    state: RSTState[Any] = RSTState(sm)
     state.document = new_document('<tests>')
     state.document.settings.env = env
     state.document.settings.tab_width = 4


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix / maintenance

### Purpose
- A recent update to [`types-docutils`](https://pypi.org/project/types-docutils/) has resulted in some `mypy` linting failures; this changeset attempts to address those.

### Detail
This was less trivial than I expected; here are some of the resolved and unresolved questions I've encountered along the way:

- [x] In the case of an attribute warning about `Reporter.get_source_and_line`, the `mypy` type warning is ignored; the relevant attribute is [added at runtime by `docutils`](https://sourceforge.net/p/docutils/code/HEAD/tree/tags/docutils-0.21.2/docutils/parsers/rst/states.py#l226).
- [x] Some generic type arguments are added to `RSTState` typehints.  These _could_ be declared in a single location and then re-used using `import`.  Is that worthwhile in this case?  I'm not sure.
  - Update: the generic type arguments have been removed in the upstream `types-docutils`, and `RSTState` moved into `sphinx.utils.typing` for convenience without any generic-binding divergence risk, so this is resolved. 
- [x] :warning: A behaviour change: `self.state.inliner` is passed to a callee that expects an `Inliner` type argument instead of the previous `self.state` value.  I'm not 100% certain whether this is correct; some more code archaeology (perhaps in `docutils` too, in case the interface has changed) may be necessary.
- [x] In the tests, there is a [`make_directive_and_state` function](https://github.com/sphinx-doc/sphinx/blob/b23ac4f16ed3d0ed214aa84189ad10fa636b6945/tests/test_util/test_util_docutils_sphinx_directive.py#L18) with the signature: `def make_directive_and_state(*, env: SimpleNamespace, input_lines: StringList | None = None) -> tuple[RSTState, SphinxDirective]:`.  Deciding on a generic type argument for the `RSTState` entry in the return-tuple-type spec seems tricky.  As an interim measure I've placed `Any` in there.
  - This is (also) resolved and much simplified by the removal of generic type arguments to `RSTState` in the upstream typestub library.

### Relates
- Resolves #12510.