### PR TITLE
pin 'docutils-types'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ lint = [
     "ruff==0.5.0",
     "mypy==1.10.1",
     "sphinx-lint",
-    "types-docutils",
+    "types-docutils==0.21.0.20240704",
     "types-requests",
     "importlib_metadata",  # for mypy (Python<=3.9)
     "tomli",  # for mypy (Python<=3.10)


### PR DESCRIPTION
prevents unintended breakage of CI due to upstream changes to docutils typestubs in typeshed

the upstream typestubs are in fairly active development and regularly cause CI breakages in this repo.
By pinning the dependency, ongoing PRs are shielded from breakages introduced by these changes.

The docutils type stubs can still be updated in a controlled way using dependabot, but will need a PR which addresses any new breakages