### PR TITLE
DOC: Move general project description to main page

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -642,6 +642,7 @@ then for larger screens align them two per-row. */
     flex-wrap: wrap;
     gap: 10px;
     justify-content: center;
+    margin-top: 2em;
 }
 .sphinx-feature {
     flex: 1 1 100%;

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,6 +5,11 @@ Sphinx
 .. cssclass:: sphinx-tagline
 .. epigraph:: Create intelligent and beautiful documentation with ease
 
+Sphinx is a *documentation generator*. It translates plain text source files
+into various output formats (HTML, PDF, ePUB, man pages etc.). Sphinx focuses
+on technical documentation, but can also be used to generate blogs, homepages
+and books.
+
 .. container:: sphinx-features
 
    .. admonition:: 📝 Rich Text Formatting

--- a/doc/usage/quickstart.rst
+++ b/doc/usage/quickstart.rst
@@ -2,19 +2,6 @@
 Getting Started
 ===============
 
-Sphinx is a *documentation generator* or a tool that translates a set of plain
-text source files into various output formats, automatically producing
-cross-references, indices, etc.  That is, if you have a directory containing a
-bunch of :doc:`/usage/restructuredtext/index` or :doc:`/usage/markdown`
-documents, Sphinx can generate a series of HTML files, a PDF file (via LaTeX),
-man pages and much more.
-
-Sphinx focuses on documentation, in particular handwritten documentation,
-however, Sphinx can also be used to generate blogs, homepages and even books.
-Much of Sphinx's power comes from the richness of its default plain-text markup
-format, :doc:`reStructuredText </usage/restructuredtext/index>`, along with
-its :doc:`significant extensibility capabilities </development/index>`.
-
 The goal of this document is to give you a quick taste of what Sphinx is and
 how you might use it. When you're done here, you can check out the
 :doc:`installation guide </usage/installation>` followed by the intro to the


### PR DESCRIPTION
These paragraphs are a high-level project description ("What is the project about?"). As such, they belong on the main page, not in "Getting started". I've condensed them into one paragraph to make it more compact. Most of the omitted information is contained in the nicely formatted feature list right below.
