### PR TITLE
Add class option to toctree directive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Deprecated
 
 Features added
 --------------
+
 * #11165: Support the `officially recommended`_ ``.jinja`` suffix for template
   files.
   Patch by James Addison and Adam Turner

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Deprecated
 
 Features added
 --------------
-
+* #12524: Add ``class`` option to ``toctree`` directive.
+  Patch by Tim Hoffmann.
 * #11165: Support the `officially recommended`_ ``.jinja`` suffix for template
   files.
   Patch by James Addison and Adam Turner

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,7 @@ Features added
 
 * #12258: Support ``typing_extensions.Unpack``
   Patch by Bénédikt Tran and Adam Turner.
-* #12524: Add ``class`` option to ``toctree`` directive.
+* #12524: Add a ``class`` option to the :rst:dir:`toctree` directive.
   Patch by Tim Hoffmann.
 
 Bugs fixed

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,6 @@ Deprecated
 
 Features added
 --------------
-* #12524: Add ``class`` option to ``toctree`` directive.
-  Patch by Tim Hoffmann.
 * #11165: Support the `officially recommended`_ ``.jinja`` suffix for template
   files.
   Patch by James Addison and Adam Turner
@@ -57,6 +55,8 @@ Features added
 
 * #12258: Support ``typing_extensions.Unpack``
   Patch by Bénédikt Tran and Adam Turner.
+* #12524: Add ``class`` option to ``toctree`` directive.
+  Patch by Tim Hoffmann.
 
 Bugs fixed
 ----------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,6 +125,7 @@ extlinks = {
     ),
     'durole': ('https://docutils.sourceforge.io/docs/ref/rst/roles.html#%s', '%s'),
     'dudir': ('https://docutils.sourceforge.io/docs/ref/rst/directives.html#%s', '%s'),
+    'dudoctree': ('https://docutils.sourceforge.io/docs/ref/doctree.html#%s', '%s'),
 }
 
 man_pages = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,6 @@ extlinks = {
     ),
     'durole': ('https://docutils.sourceforge.io/docs/ref/rst/roles.html#%s', '%s'),
     'dudir': ('https://docutils.sourceforge.io/docs/ref/rst/directives.html#%s', '%s'),
-    'dudoctree': ('https://docutils.sourceforge.io/docs/ref/doctree.html#%s', '%s'),
 }
 
 man_pages = [

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -380,6 +380,12 @@ Docutils supports the following directives:
        When the default domain contains a ``class`` directive, this directive
        will be shadowed.  Therefore, Sphinx re-exports it as ``rst-class``.
 
+    .. tip::
+
+       If you want to add a class to a directive, you may consider the
+       ``class`` :dudir:`option <common-options>` instead, which is supported
+       by most directives and allows for a more compact notation.
+
 * HTML specifics:
 
   - :dudir:`meta`

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -382,9 +382,9 @@ Docutils supports the following directives:
 
     .. tip::
 
-       If you want to add a class to a directive, you may consider the
-       ``class`` :dudir:`option <common-options>` instead, which is supported
-       by most directives and allows for a more compact notation.
+       If you want to add a class to a directive,
+       you may consider the ``:class:`` :dudir:`option <common-options>` instead,
+       which is supported by most directives and allows for a more compact notation.
 
 * HTML specifics:
 

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -124,11 +124,13 @@ tables of contents.  The ``toctree`` directive is the central element.
 
          foo
 
-   As with :dudir:`most directives <common-options>`, you can use the ``class``
-   option to assign :dudoctree:`class attributes <classes>`::
+   As with :dudir:`most directives <common-options>`,
+   you can use the ``class`` option to assign `class attributes`_::
 
       .. toctree::
          :class: custom-toc
+
+   .. _class attributes: https://docutils.sourceforge.io/docs/ref/doctree.html#classes
 
    If you want only the titles of documents in the tree to show up, not other
    headings of the same level, you can use the ``titlesonly`` option::

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -124,6 +124,12 @@ tables of contents.  The ``toctree`` directive is the central element.
 
          foo
 
+   As with :dudir:`most directives <common-options>`, you can use the ``class``
+   option to assign :dudoctree:`class attributes <classes>`::
+
+      .. toctree::
+         :class: custom-toc
+
    If you want only the titles of documents in the tree to show up, not other
    headings of the same level, you can use the ``titlesonly`` option::
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -53,6 +53,7 @@ class TocTree(SphinxDirective):
     option_spec = {
         'maxdepth': int,
         'name': directives.unchanged,
+        'class': directives.class_option,
         'caption': directives.unchanged_required,
         'glob': directives.flag,
         'hidden': directives.flag,
@@ -78,7 +79,8 @@ class TocTree(SphinxDirective):
         subnode['numbered'] = self.options.get('numbered', 0)
         subnode['titlesonly'] = 'titlesonly' in self.options
         self.set_source_info(subnode)
-        wrappernode = nodes.compound(classes=['toctree-wrapper'])
+        wrappernode = nodes.compound(
+            classes=['toctree-wrapper', *self.options.get('class', [])])
         wrappernode.append(subnode)
         self.add_name(wrappernode)
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -80,7 +80,8 @@ class TocTree(SphinxDirective):
         subnode['titlesonly'] = 'titlesonly' in self.options
         self.set_source_info(subnode)
         wrappernode = nodes.compound(
-            classes=['toctree-wrapper', *self.options.get('class', [])])
+            classes=['toctree-wrapper', *self.options.get('class', ())],
+        )
         wrappernode.append(subnode)
         self.add_name(wrappernode)
 

--- a/tests/test_directives/test_directive_other.py
+++ b/tests/test_directives/test_directive_other.py
@@ -138,10 +138,10 @@ def test_reversed_toctree(app):
 
 @pytest.mark.sphinx(testroot='toctree-glob')
 def test_toctree_class(app):
-    text = (".. toctree::\n"
-            "   :class: custom-toc\n"
-            "\n"
-            "   foo\n")
+    text = ('.. toctree::\n'
+            '   :class: custom-toc\n'
+            '\n'
+            '   foo\n')
     app.env.find_files(app.config, app.builder)
     doctree = restructuredtext.parse(app, text, 'index')
     assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])

--- a/tests/test_directives/test_directive_other.py
+++ b/tests/test_directives/test_directive_other.py
@@ -137,6 +137,18 @@ def test_reversed_toctree(app):
 
 
 @pytest.mark.sphinx(testroot='toctree-glob')
+def test_toctree_class(app):
+    text = (".. toctree::\n"
+            "   :class: custom-toc\n"
+            "\n"
+            "   foo\n")
+    app.env.find_files(app.config, app.builder)
+    doctree = restructuredtext.parse(app, text, 'index')
+    assert_node(doctree, [nodes.document, nodes.compound, addnodes.toctree])
+    assert doctree[0].attributes['classes'] == ['toctree-wrapper', 'custom-toc']
+
+
+@pytest.mark.sphinx(testroot='toctree-glob')
 def test_toctree_twice(app):
     text = (".. toctree::\n"
             "\n"


### PR DESCRIPTION
This is a common option for directives (https://docutils.sourceforge.io/docs/ref/rst/directives.html#common-options).

Implementation: The class is added to there `toctree-wrapper` element, so that
```
.. toctree::
   :class: some-class
```
is equivalent to
```
.. rst-class:: some-class
.. toctree::
```
