### PR TITLE
Update Ruff 0.5.0 to 0.5.1 and apply relevant fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ docs = [
 ]
 lint = [
     "flake8>=3.5.0",
-    "ruff==0.5.0",
+    "ruff==0.5.1",
     "mypy==1.10.1",
     "sphinx-lint",
     "types-docutils==0.21.0.20240708",

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -68,7 +68,7 @@ class SharedResult:
         }
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_params(
     request: Any,
     test_params: dict,
@@ -117,7 +117,7 @@ def app_params(
 _app_params = namedtuple('_app_params', 'args,kwargs')
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_params(request: Any) -> dict:
     """
     Test parameters that are specified by 'pytest.mark.test_params'
@@ -141,7 +141,7 @@ def test_params(request: Any) -> dict:
     return result
 
 
-@pytest.fixture()
+@pytest.fixture
 def app(
     test_params: dict,
     app_params: tuple[dict, dict],
@@ -166,7 +166,7 @@ def app(
         shared_result.store(test_params['shared_result'], app_)
 
 
-@pytest.fixture()
+@pytest.fixture
 def status(app: SphinxTestApp) -> StringIO:
     """
     Back-compatibility for testing with previous @with_app decorator
@@ -174,7 +174,7 @@ def status(app: SphinxTestApp) -> StringIO:
     return app.status
 
 
-@pytest.fixture()
+@pytest.fixture
 def warning(app: SphinxTestApp) -> StringIO:
     """
     Back-compatibility for testing with previous @with_app decorator
@@ -182,7 +182,7 @@ def warning(app: SphinxTestApp) -> StringIO:
     return app.warning
 
 
-@pytest.fixture()
+@pytest.fixture
 def make_app(test_params: dict, monkeypatch: Any) -> Iterator[Callable]:
     """
     Provides make_app function to initialize SphinxTestApp instance.
@@ -208,7 +208,7 @@ def make_app(test_params: dict, monkeypatch: Any) -> Iterator[Callable]:
         app_.cleanup()
 
 
-@pytest.fixture()
+@pytest.fixture
 def shared_result() -> SharedResult:
     return SharedResult()
 
@@ -218,7 +218,7 @@ def _shared_result_cache() -> None:
     SharedResult.cache.clear()
 
 
-@pytest.fixture()
+@pytest.fixture
 def if_graphviz_found(app: SphinxTestApp) -> None:  # NoQA: PT004
     """
     The test will be skipped when using 'if_graphviz_found' fixture and graphviz
@@ -242,7 +242,7 @@ def sphinx_test_tempdir(tmp_path_factory: Any) -> Path:
     return tmp_path_factory.getbasetemp()
 
 
-@pytest.fixture()
+@pytest.fixture
 def rollback_sysmodules() -> Iterator[None]:  # NoQA: PT004
     """
     Rollback sys.modules to its value before testing to unload modules

--- a/tests/test_addnodes.py
+++ b/tests/test_addnodes.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-@pytest.fixture()
+@pytest.fixture
 def sig_elements() -> Iterator[set[type[addnodes.desc_sig_element]]]:
     """Fixture returning the current ``addnodes.SIG_ELEMENTS`` set."""
     original = addnodes.SIG_ELEMENTS.copy()  # safe copy of the current nodes

--- a/tests/test_builders/test_build.py
+++ b/tests/test_builders/test_build.py
@@ -21,7 +21,7 @@ def request_session_head(url, **kwargs):
     return response
 
 
-@pytest.fixture()
+@pytest.fixture
 def nonascii_srcdir(request, rootdir, sphinx_test_tempdir):
     # Build in a non-ASCII source dir
     test_name = '\u65e5\u672c\u8a9e'

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -403,7 +403,7 @@ def test_errors_if_setup_is_not_callable(tmp_path, make_app):
     assert 'callable' in str(excinfo.value)
 
 
-@pytest.fixture()
+@pytest.fixture
 def make_app_with_empty_project(make_app, tmp_path):
     (tmp_path / 'conf.py').write_text('', encoding='utf8')
 

--- a/tests/test_directives/test_directive_code.py
+++ b/tests/test_directives/test_directive_code.py
@@ -104,7 +104,7 @@ def test_LiteralIncludeReader_lines_and_lineno_match1(literal_inc_path):
     assert reader.lineno_start == 3
 
 
-@pytest.mark.sphinx()  # init locale for errors
+@pytest.mark.sphinx  # init locale for errors
 def test_LiteralIncludeReader_lines_and_lineno_match2(literal_inc_path, app, status, warning):
     options = {'lines': '0,3,5', 'lineno-match': True}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)
@@ -112,7 +112,7 @@ def test_LiteralIncludeReader_lines_and_lineno_match2(literal_inc_path, app, sta
         reader.read()
 
 
-@pytest.mark.sphinx()  # init locale for errors
+@pytest.mark.sphinx  # init locale for errors
 def test_LiteralIncludeReader_lines_and_lineno_match3(literal_inc_path, app, status, warning):
     options = {'lines': '100-', 'lineno-match': True}
     reader = LiteralIncludeReader(literal_inc_path, options, DUMMY_CONFIG)

--- a/tests/test_extensions/test_ext_apidoc.py
+++ b/tests/test_extensions/test_ext_apidoc.py
@@ -10,7 +10,7 @@ import sphinx.ext.apidoc
 from sphinx.ext.apidoc import main as apidoc_main
 
 
-@pytest.fixture()
+@pytest.fixture
 def apidoc(rootdir, tmp_path, apidoc_params):
     _, kwargs = apidoc_params
     coderoot = rootdir / kwargs.get('coderoot', 'test-root')
@@ -21,7 +21,7 @@ def apidoc(rootdir, tmp_path, apidoc_params):
     return namedtuple('apidoc', 'coderoot,outdir')(coderoot, outdir)
 
 
-@pytest.fixture()
+@pytest.fixture
 def apidoc_params(request):
     pargs = {}
     kwargs = {}

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -1479,7 +1479,7 @@ class _EnumFormatter:
         return self.entry(name, doc, role='attribute', indent=indent, **rst_options)
 
 
-@pytest.fixture()
+@pytest.fixture
 def autodoc_enum_options() -> dict[str, object]:
     """Default autodoc options to use when testing enum's documentation."""
     return {"members": None, "undoc-members": None}

--- a/tests/test_extensions/test_ext_imgconverter.py
+++ b/tests/test_extensions/test_ext_imgconverter.py
@@ -5,7 +5,7 @@ import subprocess
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def _if_converter_found(app):
     image_converter = getattr(app.config, 'image_converter', '')
     try:

--- a/tests/test_intl/test_catalogs.py
+++ b/tests/test_intl/test_catalogs.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def _setup_test(app_params):
     assert isinstance(app_params.kwargs['srcdir'], Path)
     srcdir = app_params.kwargs['srcdir']

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -737,7 +737,7 @@ class _MockUnixClock(_MockClock):
         time.sleep(ds)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_time_and_i18n(
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[pytest.MonkeyPatch, _MockClock]:

--- a/tests/test_markup/test_markup.py
+++ b/tests/test_markup/test_markup.py
@@ -21,7 +21,7 @@ from sphinx.writers.html import HTML5Translator, HTMLWriter
 from sphinx.writers.latex import LaTeXTranslator, LaTeXWriter
 
 
-@pytest.fixture()
+@pytest.fixture
 def settings(app):
     texescape.init()  # otherwise done by the latex builder
     with warnings.catch_warnings():
@@ -42,7 +42,7 @@ def settings(app):
     domain_context.disable()
 
 
-@pytest.fixture()
+@pytest.fixture
 def new_document(settings):
     def create():
         document = utils.new_document('test data', settings)
@@ -52,14 +52,14 @@ def new_document(settings):
     return create
 
 
-@pytest.fixture()
+@pytest.fixture
 def inliner(new_document):
     document = new_document()
     document.reporter.get_source_and_line = lambda line=1: ('dummy.rst', line)
     return SimpleNamespace(document=document, reporter=document.reporter)
 
 
-@pytest.fixture()
+@pytest.fixture
 def parse(new_document):
     def parse_(rst):
         document = new_document()
@@ -90,7 +90,7 @@ class ForgivingLaTeXTranslator(LaTeXTranslator, ForgivingTranslator):
     pass
 
 
-@pytest.fixture()
+@pytest.fixture
 def verify_re_html(app, parse):
     def verify(rst, html_expected):
         document = parse(rst)
@@ -102,7 +102,7 @@ def verify_re_html(app, parse):
     return verify
 
 
-@pytest.fixture()
+@pytest.fixture
 def verify_re_latex(app, parse):
     def verify(rst, latex_expected):
         document = parse(rst)
@@ -117,7 +117,7 @@ def verify_re_latex(app, parse):
     return verify
 
 
-@pytest.fixture()
+@pytest.fixture
 def verify_re(verify_re_html, verify_re_latex):
     def verify_re_(rst, html_expected, latex_expected):
         if html_expected:
@@ -127,7 +127,7 @@ def verify_re(verify_re_html, verify_re_latex):
     return verify_re_
 
 
-@pytest.fixture()
+@pytest.fixture
 def verify(verify_re_html, verify_re_latex):
     def verify_(rst, html_expected, latex_expected):
         if html_expected:
@@ -137,7 +137,7 @@ def verify(verify_re_html, verify_re_latex):
     return verify_
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_verifier(verify, verify_re):
     v = {
         'verify': verify,

--- a/tests/test_transforms/test_transforms_post_transforms.py
+++ b/tests/test_transforms/test_transforms_post_transforms.py
@@ -89,7 +89,7 @@ class TestSigElementFallbackTransform:
         """Fixture returning an ordered view on the original value of :data:`!sphinx.addnodes.SIG_ELEMENTS`."""
         return self._builtin_sig_elements
 
-    @pytest.fixture()
+    @pytest.fixture
     def document(
         self, app: SphinxTestApp, builtin_sig_elements: tuple[type[addnodes.desc_sig_element], ...],
     ) -> nodes.document:
@@ -103,13 +103,13 @@ class TestSigElementFallbackTransform:
         doc += addnodes.desc_inline('py')
         return doc
 
-    @pytest.fixture()
+    @pytest.fixture
     def with_desc_sig_elements(self, value: Any) -> bool:
         """Dynamic fixture acting as the identity on booleans."""
         assert isinstance(value, bool)
         return value
 
-    @pytest.fixture()
+    @pytest.fixture
     def add_visitor_method_for(self, value: Any) -> list[str]:
         """Dynamic fixture acting as the identity on a list of strings."""
         assert isinstance(value, list)


### PR DESCRIPTION
Identical to #12517 by dependabot, but also apply all the requested lints, to use `@pytest.fixture` instead of `@pytest.fixtures()`


