### PR TITLE
[tests] JavaScript: developer/test-facing tweaks to fixture generation.

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,7 +13,11 @@ from sphinx.search import IndexBuilder
 
 from tests.utils import TESTS_ROOT
 
-JAVASCRIPT_TEST_ROOTS = list((TESTS_ROOT / 'js' / 'roots').iterdir())
+JAVASCRIPT_TEST_ROOTS = list(
+    directory
+    for directory in (TESTS_ROOT / 'js' / 'roots').iterdir()
+    if (directory / 'conf.py').exists()
+)
 
 
 class DummyEnvironment:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,11 +13,11 @@ from sphinx.search import IndexBuilder
 
 from tests.utils import TESTS_ROOT
 
-JAVASCRIPT_TEST_ROOTS = list(
+JAVASCRIPT_TEST_ROOTS = [
     directory
     for directory in (TESTS_ROOT / 'js' / 'roots').iterdir()
     if (directory / 'conf.py').exists()
-)
+]
 
 
 class DummyEnvironment:

--- a/utils/generate_js_fixtures.py
+++ b/utils/generate_js_fixtures.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import shutil
 import subprocess
 from pathlib import Path
 

--- a/utils/generate_js_fixtures.py
+++ b/utils/generate_js_fixtures.py
@@ -34,5 +34,5 @@ for directory in TEST_JS_ROOTS:
 
     print(f'Copying {searchindex} to {destination} ... ', end='')
     destination.parent.mkdir(exist_ok=True)
-    destination.write_bytes(searchindex.read_bytes())
+    shutil.copy2(searchindex, destination)
     print('done')

--- a/utils/generate_js_fixtures.py
+++ b/utils/generate_js_fixtures.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 SPHINX_ROOT = Path(__file__).resolve().parent.parent
 TEST_JS_FIXTURES = SPHINX_ROOT / 'tests' / 'js' / 'fixtures'
-TEST_JS_ROOTS = SPHINX_ROOT / 'tests' / 'js' / 'roots'
+TEST_JS_ROOTS = list(
+    directory
+    for directory in (SPHINX_ROOT / 'tests' / 'js' / 'roots').iterdir()
+    if (directory / 'conf.py').exists()
+)
 
 
 def build(srcdir: Path) -> None:
@@ -20,7 +24,7 @@ def build(srcdir: Path) -> None:
     subprocess.run(cmd, check=True, capture_output=True)
 
 
-for directory in TEST_JS_ROOTS.iterdir():
+for directory in TEST_JS_ROOTS:
     searchindex = directory / '_build' / 'searchindex.js'
     destination = TEST_JS_FIXTURES / directory.name / 'searchindex.js'
 
@@ -28,7 +32,7 @@ for directory in TEST_JS_ROOTS.iterdir():
     build(directory)
     print('done')
 
-    print(f'Moving {searchindex} to {destination} ... ', end='')
+    print(f'Copying {searchindex} to {destination} ... ', end='')
     destination.parent.mkdir(exist_ok=True)
-    searchindex.replace(destination)
+    destination.write_bytes(searchindex.read_bytes())
     print('done')

--- a/utils/generate_js_fixtures.py
+++ b/utils/generate_js_fixtures.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 SPHINX_ROOT = Path(__file__).resolve().parent.parent
 TEST_JS_FIXTURES = SPHINX_ROOT / 'tests' / 'js' / 'fixtures'
-TEST_JS_ROOTS = list(
+TEST_JS_ROOTS = [
     directory
     for directory in (SPHINX_ROOT / 'tests' / 'js' / 'roots').iterdir()
     if (directory / 'conf.py').exists()
-)
+]
 
 
 def build(srcdir: Path) -> None:


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- These changes don't affect application functionality, but can make it marginally more convenient to switch between `git` branches when developing/testing changes that relate to the JavaScript test fixtures (added in #12102).

### Detail
- Instead of _moving_ each `searchindex.js` file built by the `utils/generate_js_fixtures.py` script, _copy_ it into the fixtures dir.  This means that each built project remains as a complete Sphinx `html` project build output (and can, for example, be hosted in a local webserver to test behaviour).
- Check for presence of a `conf.py` file when iterating through the local directories that are considered possible sources of JS test fixtures.  When switching branches using `git`, some previous-branch directories may not be removed, even when the files within are cleared -- and without this change, the `utils/generate_js_fixtures.py` script and `test_check_js_search_indexes` test case would try to build from those empty dirs (and fail).

### Relates
- Follow-up to #12102.

cc @wlach 

Edit: clarify that the util script builds multiple projects