### PR TITLE
Remove ``customsidebar``

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -963,7 +963,6 @@ class StandaloneHTMLBuilder(Builder):
             return any(char in pattern for char in '*?[')
 
         matched = None
-        customsidebar = None
 
         # default sidebars settings for selected theme
         sidebars = list(self.theme.sidebar_templates)
@@ -990,7 +989,6 @@ class StandaloneHTMLBuilder(Builder):
             pass
 
         ctx['sidebars'] = sidebars
-        ctx['customsidebar'] = customsidebar
 
     # --------- these are overwritten by the serialization builder
 

--- a/sphinx/themes/basic/layout.html
+++ b/sphinx/themes/basic/layout.html
@@ -70,9 +70,6 @@
             {%- block sidebarsourcelink %}
             {%- include "sourcelink.html" %}
             {%- endblock %}
-            {%- if customsidebar %}
-            {%- include customsidebar %}
-            {%- endif %}
             {%- block sidebarsearch %}
             {%- include "searchbox.html" %}
             {%- endblock %}


### PR DESCRIPTION
This is dead code, remnants of pre-2.0 when a string value for `html_sidebars` was allowed.

A