### PR TITLE
Add domain and objtype classes to objdesc ToC entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,8 @@ Features added
 * #12523: Added configuration option, :confval:`math_numsep`, to define the
   separator for math numbering.
   Patch by Thomas Fanning
+* #12542: Add the domain name and object type as CSS classes
+  for domain object decsriptions in the table of contents.
 
 Bugs fixed
 ----------

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -114,6 +114,10 @@ class TocTreeCollector(EnvironmentCollector):
                             note_toctree(app.env, docname, toctreenode)
                         # add object signatures within a section to the ToC
                         elif isinstance(toctreenode, addnodes.desc):
+                            desc_classes = list(filter(None, (
+                                toctreenode.get('domain', ''),
+                                toctreenode.get('objtype', ''),
+                            )))
                             for sig_node in toctreenode:
                                 if not isinstance(sig_node, addnodes.desc_signature):
                                     continue
@@ -132,7 +136,9 @@ class TocTreeCollector(EnvironmentCollector):
 
                                 reference = nodes.reference(
                                     '', '', nodes.literal('', sig_node['_toc_name']),
-                                    internal=True, refuri=docname, anchorname=anchorname)
+                                    internal=True, refuri=docname, anchorname=anchorname,
+                                    classes=desc_classes.copy(),
+                                )
                                 para = addnodes.compact_paragraph('', '', reference,
                                                                   skip_section_number=True)
                                 entry = nodes.list_item('', para)


### PR DESCRIPTION
Adds ``domain.name`` and ``self.objtype`` as CSS classes on domain object descriptions in the table of contents, to allow diffentional styling of ToC object entries.

A