### PR TITLE
Add missing backtick to close literal role in configuration.rst

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -259,7 +259,7 @@ General configuration
 
    A URL to cross-reference :rst:role:`manpage` roles.
    If this is defined to ``https://manpages.debian.org/{path}``,
-   the :literal:`:manpage:`man(1)` role will link to
+   the :literal:`:manpage:`man(1)`` role will link to
    <https://manpages.debian.org/man(1)>.
    The patterns available are:
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
```:literal:`:manpage:`man(1)` ``` results in ```:manpage:`man(1) ```, see published docs ([link here](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-manpages_url)):

![image](https://github.com/sphinx-doc/sphinx/assets/1571783/cb873781-52ed-4b21-ab53-02ab8f695443)

Adding an extra backtick solves this without causing any warning in sphinx-build or sphinx-lint.

![image](https://github.com/sphinx-doc/sphinx/assets/1571783/bc95a8a6-786b-46ab-b0cd-fa0dc1db2169)


### Detail
N/A

### Relates
N/A

