### PR TITLE
[LaTeX] For 'lualatex' with French, use `babel` LaTeX package as default, as for 'xelatex', and not `polyglossia`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,9 @@ Bugs fixed
 * #12380: LaTeX: Footnote mark sometimes indicates ``Page N`` where ``N`` is
   the current page number and the footnote does appear on that same page.
   Patch by Jean-François B.
+* #12410: LaTeX: for French and ``'lualatex'`` as :confval:`latex_engine`
+  ``polyglossia`` and not ``babel`` is used (contrarily to ``'xelatex'``).
+  Patch by Jean-François B.
 * #12416: Ensure that configuration setting aliases are always synchronised
   when one value or the other is modified.
   Patch by Bénédikt Tran.

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -158,18 +158,11 @@ Keys that you may want to override include:
       ``'lualatex'`` uses same default setting as ``'xelatex'``
 
    .. versionchanged:: 1.7.6
-      For French with ``xelatex`` (not ``lualatex``) the default is to use
-      ``babel``, not ``polyglossia``.  To let ``lualatex`` use ``babel``,
-      use this:
+      For French with ``'xelatex'`` (not ``'lualatex'``) the default is to
+      use ``babel``, not ``polyglossia``.
 
-      .. code-block:: python
-
-         latex_elements = {
-             'polyglossia': '',
-             'babel': r'\usepackage{babel}',
-         }
-
-      in file :file:`conf.py`.
+   .. versionchanged:: 7.4.0
+      For French with ``'lualatex'`` the default is to use ``babel``.
 
 ``'fontpkg'``
    Font package inclusion. The default is::

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -148,7 +148,7 @@ Keys that you may want to override include:
       build repertory before next PDF build, else left-over auxiliary
       files are likely to break the build.
 
-   Default:  ``'\\usepackage{babel}'`` (``''`` for Japanese documents)
+   Default:  ``'\\usepackage{babel}'`` (for Japanese documents)
 
    .. versionchanged:: 1.5
       For :confval:`latex_engine` set to ``'xelatex'``, the default

--- a/sphinx/builders/latex/constants.py
+++ b/sphinx/builders/latex/constants.py
@@ -183,6 +183,11 @@ ADDITIONAL_SETTINGS: dict[Any, dict[str, Any]] = {
     },
 
     # special settings for latex_engine + language_code
+    ('lualatex', 'fr'): {
+        # use babel instead of polyglossia by default
+        'polyglossia':  '',
+        'babel':        '\\usepackage{babel}',
+    },
     ('xelatex', 'fr'): {
         # use babel instead of polyglossia by default
         'polyglossia':  '',


### PR DESCRIPTION
Fix #12410

As I consider this a bugfix I did not register it as an "incompatible change" in CHANGES.  I think French Sphinx ``'lualatex'`` users either do not care or have their `conf.py` already set to use the `babel` LaTeX package.

