### PR TITLE
linkcheck: use non-interpolated (and still quoted) anchor name in localized exception message.

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -473,7 +473,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                 ) as response:
                     if (self.check_anchors and response.ok and anchor
                             and not contains_anchor(response, anchor)):
-                        raise Exception(__(f'Anchor {quote(anchor)!r} not found'))
+                        raise Exception(__("Anchor '%s' not found") % quote(anchor))
 
                 # Copy data we need from the (closed) response
                 status_code = response.status_code


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Restores localization for an anchor-not-found broken-link message output by the `linkcheck` builder.

### Detail
- Partially logically reverts commit e45fb5e61b6ea3ee707a9e4ee8792f45c9246fae (but we retain the more-recently-introduced usage of `quote` on the anchor name itself).

### Relates
- Resolves #12559.