### PR TITLE
Use Babel errors for the PR body in the transifex workflow

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -31,7 +31,7 @@ jobs:
       run: python utils/babel_runner.py extract
     - name: Push translations to transifex.com
       run: |
-        cd sphinx/locale 
+        cd sphinx/locale
         /tmp/tx_cli/tx push --source --use-git-timestamps --workers 10
       env:
         TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
       run: python utils/babel_runner.py extract
     - name: Pull translations from transifex.com
       run: |
-        cd sphinx/locale 
+        cd sphinx/locale
         /tmp/tx_cli/tx pull --translations --all --force --use-git-timestamps --workers 10
       env:
         TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -73,3 +73,4 @@ jobs:
         branch: bot/pull-translations
         title: "[bot]: Update message catalogues"
         labels: "internals:internationalisation"
+        body-path: babel_compile.txt


### PR DESCRIPTION
Currently, when Babel fails for a locale, the entire PR fails. Instead, just skip compiling the catalogue for that locale, and report the failures in the body of the PR to be more visible.

A