### PR TITLE
Restore support for list-style ``source_suffix`` with third-party parsers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 7.4.3 (in development)
 Bugs fixed
 ----------
 
+* #12582: Restore support for list-styled :confval:`source_suffix` values
+  with extensions that register parsers.
+  Patch by Adam Turner.
 
 Release 7.4.2 (released Jul 15, 2024)
 =====================================

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -582,13 +582,17 @@ def convert_source_suffix(app: Sphinx, config: Config) -> None:
         # The default filetype is determined on later step.
         # By default, it is considered as restructuredtext.
         config.source_suffix = {source_suffix: 'restructuredtext'}
+        logger.info(__("Converting `source_suffix = %r` to `source_suffix = %r`."),
+                    source_suffix, config.source_suffix)
     elif isinstance(source_suffix, (list, tuple)):
         # if list, considers as all of them are default filetype
         config.source_suffix = dict.fromkeys(source_suffix, 'restructuredtext')
+        logger.info(__("Converting `source_suffix = %r` to `source_suffix = %r`."),
+                    source_suffix, config.source_suffix)
     elif not isinstance(source_suffix, dict):
-        logger.warning(__("The config value `source_suffix' expects "
-                          "a string, list of strings, or dictionary. "
-                          "But `%r' is given." % source_suffix))
+        msg = __("The config value `source_suffix' expects a dictionary,"
+                 "a string, or a list of strings. Got `%r' instead (type %s).")
+        raise ConfigError(msg % (source_suffix, type(source_suffix)))
 
 
 def convert_highlight_options(app: Sphinx, config: Config) -> None:

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -504,9 +504,13 @@ def merge_source_suffix(app: Sphinx, config: Config) -> None:
     for suffix, filetype in app.registry.source_suffix.items():
         if suffix not in app.config.source_suffix:  # NoQA: SIM114
             app.config.source_suffix[suffix] = filetype
-        elif app.config.source_suffix[suffix] is None:
-            # filetype is not specified (default filetype).
+        elif app.config.source_suffix[suffix] == 'restructuredtext':
+            # The filetype is not specified (default filetype).
             # So it overrides default filetype by extensions setting.
+            app.config.source_suffix[suffix] = filetype
+        elif app.config.source_suffix[suffix] is None:
+            msg = __('`None` is not a valid filetype for %r.') % suffix
+            logger.warning(msg)
             app.config.source_suffix[suffix] = filetype
 
     # copy config.source_suffix to registry


### PR DESCRIPTION
Fixes #12582

I have also added information/warning messages when ``source_suffix`` is mutated within Sphinx.

A