### PR TITLE
intersphinx: Don't warn about pure-duplicate ambiguous definitions when loading 'objects.inv' entries.

### DIFF
--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -126,7 +126,7 @@ class InventoryFile:
         invdata: Inventory = {}
         projname = stream.readline().rstrip()[11:]
         version = stream.readline().rstrip()[11:]
-        potential_ambiguities = {}
+        potential_ambiguities: dict[str, tuple[str, str, str]] = {}
         actual_ambiguities = set()
         line = stream.readline()
         if 'zlib' not in line:
@@ -154,7 +154,7 @@ class InventoryFile:
                 # Some types require case insensitive matches:
                 # * 'term': https://github.com/sphinx-doc/sphinx/issues/9291
                 # * 'label': https://github.com/sphinx-doc/sphinx/issues/12008
-                definition, content = f"{type}:{name}", {prio, location, dispname}
+                definition, content = f"{type}:{name}", (prio, location, dispname)
                 lowercase_definition = definition.lower()
                 if lowercase_definition in potential_ambiguities:
                     if potential_ambiguities[lowercase_definition] != content:

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -126,6 +126,7 @@ class InventoryFile:
         invdata: Inventory = {}
         projname = stream.readline().rstrip()[11:]
         version = stream.readline().rstrip()[11:]
+        # definition -> priority, location, display name
         potential_ambiguities: dict[str, tuple[str, str, str]] = {}
         actual_ambiguities = set()
         line = stream.readline()
@@ -154,7 +155,8 @@ class InventoryFile:
                 # Some types require case insensitive matches:
                 # * 'term': https://github.com/sphinx-doc/sphinx/issues/9291
                 # * 'label': https://github.com/sphinx-doc/sphinx/issues/12008
-                definition, content = f"{type}:{name}", (prio, location, dispname)
+                definition = f"{type}:{name}"
+                content = prio, location, dispname
                 lowercase_definition = definition.lower()
                 if lowercase_definition in potential_ambiguities:
                     if potential_ambiguities[lowercase_definition] != content:

--- a/tests/test_util/intersphinx_data.py
+++ b/tests/test_util/intersphinx_data.py
@@ -59,4 +59,6 @@ INVENTORY_V2_AMBIGUOUS_TERMS: Final[bytes] = b'''\
 ''' + zlib.compress(b'''\
 a term std:term -1 glossary.html#term-a-term -
 A term std:term -1 glossary.html#term-a-term -
+b term std:term -1 document.html#id5 -
+B term std:term -1 document.html#B -
 ''')

--- a/tests/test_util/test_util_inventory.py
+++ b/tests/test_util/test_util_inventory.py
@@ -53,7 +53,8 @@ def test_ambiguous_definition_warning(warning):
     f = BytesIO(INVENTORY_V2_AMBIGUOUS_TERMS)
     InventoryFile.load(f, '/util', posixpath.join)
 
-    assert 'contains multiple definitions for std:term:a' in warning.getvalue().lower()
+    assert 'contains multiple definitions for std:term:a' not in warning.getvalue().lower()
+    assert 'contains multiple definitions for std:term:b' in warning.getvalue().lower()
 
 
 def _write_appconfig(dir, language, prefix=None):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Don't emit a warning _at inventory load time_ if two ambiguously-resolved Intersphinx `objects.inv` entries resolve to exactly the same result (i.e. are duplicates that differ only by lowercase/uppercase characters).

### Detail
- ~~Use `set`-comparison of the reference fields.~~ 
- Do log a `debug` message for reference.

### Todo / open questions
- [ ] Also handle a [similar scenario in some Intersphinx entity resolution code](https://github.com/sphinx-doc/sphinx/issues/12585#issuecomment-2228518109) introduced at the same time?
  - TBD.  Moved to separate PR #12587. 

### Relates
- Warning introduced in #12329.
- Resolves #12585.

Edit: clarify the false-positive warning that is filtered by this branch.