### PR TITLE
LaTeX: allow again figure inside seealso, and seealso inside table cell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+Release 7.4.5
+=============
+
+Bugs fixed
+----------
+
+* #12594: LaTeX: since 7.4.0, :rst:dir:`seealso` and other "light" admonitions
+  now break PDF builds if they contain a :dudir:`figure` directive; and also
+  if they are contained in a table cell (rendered by ``tabulary``).
+  Patch by Jean-François B.
+
 Release 7.4.4 (released Jul 15, 2024)
 =====================================
 
@@ -7,10 +18,6 @@ Bugs fixed
 * #12585, #12586: Do not warn when an intersphinx inventory contains
   case-insensitively ambiguous duplicate items.
   Patch by James Addison.
-* #12594: LaTeX: since 7.4.0, :rst:dir:`seealso` and other "light" admonitions
-  now break PDF builds if they contain a :dudir:`figure` directive; and also
-  if they are contained in a table cell (rendered by ``tabulary``).
-  Patch by Jean-François B.
 
 Release 7.4.3 (released Jul 15, 2024)
 =====================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Bugs fixed
 * #12585, #12586: Do not warn when an intersphinx inventory contains
   case-insensitively ambiguous duplicate items.
   Patch by James Addison.
+* #12594: LaTeX: since 7.4.0, :rst:dir:`seealso` and other "light" admonitions
+  now break PDF builds if they contain a :dudir:`figure` directive; and also
+  if they are contained in a table cell (rendered by ``tabulary``).
+  Patch by Jean-François B.
 
 Release 7.4.3 (released Jul 15, 2024)
 =====================================

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -215,6 +215,9 @@ def latex_visit_todo_node(self: LaTeXTranslator, node: todo_node) -> None:
         title_node = cast(nodes.title, node[0])
         title = texescape.escape(title_node.astext(), self.config.latex_engine)
         self.body.append('%s:}' % title)
+        self.no_latex_floats += 1
+        if self.table:
+            self.table.has_problematic = True
         node.pop(0)
     else:
         raise nodes.SkipNode
@@ -222,6 +225,7 @@ def latex_visit_todo_node(self: LaTeXTranslator, node: todo_node) -> None:
 
 def latex_depart_todo_node(self: LaTeXTranslator, node: todo_node) -> None:
     self.body.append('\\end{sphinxtodo}\n')
+    self.no_latex_floats -= 1
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:

--- a/sphinx/texinputs/sphinxlatextables.sty
+++ b/sphinx/texinputs/sphinxlatextables.sty
@@ -108,6 +108,7 @@
     \vbox{}% get correct baseline from above
     \LTpre\z@skip\LTpost\z@skip % set to zero longtable's own skips
     \edef\sphinxbaselineskip{\dimexpr\the\dimexpr\baselineskip\relax\relax}%
+    \spx@inframedtrue % message to sphinxheavybox
    }%
 % Compatibility with caption package
 \def\sphinxthelongtablecaptionisattop{%
@@ -121,7 +122,9 @@
 \def\sphinxatlongtableend{\@nobreakfalse % latex3/latex2e#173
     \prevdepth\z@\vskip\sphinxtablepost\relax}%
 % B. Table with tabular or tabulary
-\def\sphinxattablestart{\par\vskip\dimexpr\sphinxtablepre\relax}%
+\def\sphinxattablestart{\par\vskip\dimexpr\sphinxtablepre\relax
+                        \spx@inframedtrue % message to sphinxheavybox
+                        }%
 \let\sphinxattableend\sphinxatlongtableend
 % This is used by tabular and tabulary templates
 \newcommand*\sphinxcapstartof[1]{%

--- a/tests/roots/test-latex-figure-in-admonition/conf.py
+++ b/tests/roots/test-latex-figure-in-admonition/conf.py
@@ -1,1 +1,3 @@
+extensions = ['sphinx.ext.todo']
+todo_include_todos = True
 exclude_patterns = ['_build']

--- a/tests/roots/test-latex-figure-in-admonition/index.rst
+++ b/tests/roots/test-latex-figure-in-admonition/index.rst
@@ -3,7 +3,24 @@ Test Figure in Admonition
 
 .. caution::
 
-   This uses a figure in an admonition.
+   This uses a figure in a caution directive.
 
    .. figure:: img.png
 
+.. note::
+
+   This uses a figure in a note directive.
+
+   .. figure:: img.png
+
+.. seealso::
+
+   This uses a figure in a seealso directive.
+
+   .. figure:: img.png
+
+.. todo::
+
+   This uses a figure in a todo directive.
+
+   .. figure:: img.png

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -230,6 +230,19 @@ Tables with multirow and multicol:
 
           figure in table
 
+   * - .. warning::
+
+          warning in table
+
+   * - .. seealso::
+
+          figure in a seealso in a table
+
+          .. figure:: img.png
+
+             with a caption
+
+             and a legend
 
 Figures
 -------

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -1591,7 +1591,9 @@ def test_latex_labels(app, status, warning):
 def test_latex_figure_in_admonition(app, status, warning):
     app.build(force_all=True)
     result = (app.outdir / 'projectnamenotset.tex').read_text(encoding='utf8')
-    assert r'\begin{figure}[H]' in result
+    assert 'tabulary' not in result
+    for type in ('caution', 'note', 'seealso', 'todo'):
+        assert f'{type} directive.\n\n\\begin{{figure}}[H]' in result
 
 
 def test_default_latex_documents():

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -158,21 +158,21 @@ def test_writer(app, status, warning):
 
     assert ('\\begin{wrapfigure}{r}{0pt}\n\\centering\n'
             '\\noindent\\sphinxincludegraphics{{rimg}.png}\n'
-            '\\caption{figure with align option}\\label{\\detokenize{markup:id9}}'
+            '\\caption{figure with align option}\\label{\\detokenize{markup:id10}}'
             '\\end{wrapfigure}\n\n'
             '\\mbox{}\\par\\vskip-\\dimexpr\\baselineskip+\\parskip\\relax' in result)
 
     assert ('\\begin{wrapfigure}{r}{0.500\\linewidth}\n\\centering\n'
             '\\noindent\\sphinxincludegraphics{{rimg}.png}\n'
             '\\caption{figure with align \\& figwidth option}'
-            '\\label{\\detokenize{markup:id10}}'
+            '\\label{\\detokenize{markup:id11}}'
             '\\end{wrapfigure}\n\n'
             '\\mbox{}\\par\\vskip-\\dimexpr\\baselineskip+\\parskip\\relax' in result)
 
     assert ('\\begin{wrapfigure}{r}{3cm}\n\\centering\n'
             '\\noindent\\sphinxincludegraphics[width=3cm]{{rimg}.png}\n'
             '\\caption{figure with align \\& width option}'
-            '\\label{\\detokenize{markup:id11}}'
+            '\\label{\\detokenize{markup:id12}}'
             '\\end{wrapfigure}\n\n'
             '\\mbox{}\\par\\vskip-\\dimexpr\\baselineskip+\\parskip\\relax' in result)
 


### PR DESCRIPTION
This fixes #12594 which emerged because #12508 had modified seealso and note-like admonitions to use background color and other effects, but the ensuing LaTeX can not work in a table cell without extras.

This also fixes unreported issues unrelated to the 7.4.0 release:
- (now old style "lightbox") admonitions render badly in tabulary,
- "heavybox" admonitions (they are all now but warning et al. were already) cause PDF crash if in tabulary and rendered badly if in tabular or longtable.
- figure in a table cell is not properly separated from immediately preceding text.


