### PR TITLE
Don't store mtime in gzip headers

### DIFF
--- a/sphinx/texinputs/Makefile.jinja
+++ b/sphinx/texinputs/Makefile.jinja
@@ -77,7 +77,8 @@ tar: all-$(FMT)
 	rm -r $(ARCHIVEPREFIX)docs-$(FMT)
 
 gz: tar
-	gzip -9 < $(ARCHIVEPREFIX)docs-$(FMT).tar > $(ARCHIVEPREFIX)docs-$(FMT).tar.gz
+	# -n to omit mtime from gzip headers
+	gzip -n -9 < $(ARCHIVEPREFIX)docs-$(FMT).tar > $(ARCHIVEPREFIX)docs-$(FMT).tar.gz
 
 bz2: tar
 	bzip2 -9 -k $(ARCHIVEPREFIX)docs-$(FMT).tar

--- a/sphinx/texinputs_win/Makefile.jinja
+++ b/sphinx/texinputs_win/Makefile.jinja
@@ -49,7 +49,8 @@ tar: all-$(FMT)
 	rm -r $(ARCHIVEPREFIX)docs-$(FMT)
 
 gz: tar
-	gzip -9 < $(ARCHIVEPREFIX)docs-$(FMT).tar > $(ARCHIVEPREFIX)docs-$(FMT).tar.gz
+	# -n to omit mtime from gzip headers
+	gzip -n -9 < $(ARCHIVEPREFIX)docs-$(FMT).tar > $(ARCHIVEPREFIX)docs-$(FMT).tar.gz
 
 bz2: tar
 	bzip2 -9 -k $(ARCHIVEPREFIX)docs-$(FMT).tar


### PR DESCRIPTION
- Feature
- Don't store mtime in gzip headers to allow for reproducible builds.

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.