### PR TITLE
HTML search: Ensure that ``checkRanking`` fails when the final entry is not found

### DIFF
--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -22,6 +22,7 @@ describe('Basic html theme search', function() {
     }
 
     expect(remainingItems.length).toEqual(0);
+    expect(nextExpected).toEqual(undefined);
   }
 
   describe('terms search', function() {

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -138,7 +138,7 @@ describe('Basic html theme search', function() {
 
       expectedRanking = [
         ['relevance', 'Relevance', ''],  /* main title */
-        ['index', 'relevance.Example.relevance', '#module-relevance'],  /* py:class attribute */
+        ['index', 'relevance.Example.relevance', '#relevance.Example.relevance'],  /* py:class attribute */
       ];
 
       searchParameters = Search._parseQuery('relevance');


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix (in test suite)

### Purpose
- Correction for the `checkRanking` function provided in the HTML search JavaScript test framework.

### Detail
- Ensure that `nextExpected` does not have a value when the function is ready to exit.
- A `CI (node.js)` test suite failure is expected on commit da3b6c73aa8800d96c10026890413cf0aa49e824.
- Commit 49154f66d168d7449e1ce8af472fe1347e73c567 (pending push) will resolve the problem by correcting the anchor (as noted in the bugreport).

### Relates
- Resolves #12607.