### PR TITLE
intersphinx: Reduce log severity for ambiguity detection during inventory loading.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Bugs fixed
 * #12859, #9743, #12609: autosummary: Do not add the package prefix when
   generating autosummary directives for modules within a package.
   Patch by Adam Turner.
+* #12613: Reduce log severity for ambiguity detection during inventory loading.
+  Patch by James Addison.
 
 Release 7.4.5 (released Jul 16, 2024)
 =====================================

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -172,8 +172,8 @@ class InventoryFile:
             inv_item: InventoryItem = projname, version, location, dispname
             invdata.setdefault(type, {})[name] = inv_item
         for ambiguity in actual_ambiguities:
-            logger.warning(__("inventory <%s> contains multiple definitions for %s"),
-                           uri, ambiguity, type='intersphinx',  subtype='external')
+            logger.info(__("inventory <%s> contains multiple definitions for %s"),
+                        uri, ambiguity, type='intersphinx',  subtype='external')
         return invdata
 
     @classmethod

--- a/tests/test_util/test_util_inventory.py
+++ b/tests/test_util/test_util_inventory.py
@@ -49,13 +49,22 @@ def test_read_inventory_v2_not_having_version():
         ('foo', '', '/util/foo.html#module-module1', 'Long Module desc')
 
 
-def test_ambiguous_definition_warning(status):
+def test_ambiguous_definition_warning(warning, status):
     f = BytesIO(INVENTORY_V2_AMBIGUOUS_TERMS)
     InventoryFile.load(f, '/util', posixpath.join)
 
+    def _multiple_defs_notice_for(entity: str) -> str:
+        return f'contains multiple definitions for {entity}'
+
     # was warning-level; reduced to info-level - see https://github.com/sphinx-doc/sphinx/issues/12613
-    assert 'contains multiple definitions for std:term:a' not in status.getvalue().lower()
-    assert 'contains multiple definitions for std:term:b' in status.getvalue().lower()
+    mult_defs_a, mult_defs_b = (
+        _multiple_defs_notice_for('std:term:a'),
+        _multiple_defs_notice_for('std:term:b'),
+    )
+    assert mult_defs_a not in warning.getvalue().lower()
+    assert mult_defs_a not in status.getvalue().lower()
+    assert mult_defs_b not in warning.getvalue().lower()
+    assert mult_defs_b in status.getvalue().lower()
 
 
 def _write_appconfig(dir, language, prefix=None):

--- a/tests/test_util/test_util_inventory.py
+++ b/tests/test_util/test_util_inventory.py
@@ -49,12 +49,13 @@ def test_read_inventory_v2_not_having_version():
         ('foo', '', '/util/foo.html#module-module1', 'Long Module desc')
 
 
-def test_ambiguous_definition_warning(warning):
+def test_ambiguous_definition_warning(status):
     f = BytesIO(INVENTORY_V2_AMBIGUOUS_TERMS)
     InventoryFile.load(f, '/util', posixpath.join)
 
-    assert 'contains multiple definitions for std:term:a' not in warning.getvalue().lower()
-    assert 'contains multiple definitions for std:term:b' in warning.getvalue().lower()
+    # was warning-level; reduced to info-level - see https://github.com/sphinx-doc/sphinx/issues/12613
+    assert 'contains multiple definitions for std:term:a' not in status.getvalue().lower()
+    assert 'contains multiple definitions for std:term:b' in status.getvalue().lower()
 
 
 def _write_appconfig(dir, language, prefix=None):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Some popular Python projects contain ambiguous entries in their Intersphinx `objects.inv` files -- this generally isn't a problem unless those entities are referenced, but we do warn about it when those inventories are loaded.  This changeset reduces noise levels from the log message recorded when (non-duplicate) ambiguity is detected.

### Detail
- When an ambiguous non-duplicate entry is detected during loading of an Intersphinx inventory, log an `info`-level message instead of a `warning`-level message.

### Relates
- Resolves #12613.