### PR TITLE
autosummary: Filter invalid import prefixes in ``autolink``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Bugs fixed
   ``sphinx.ext.autodoc``,
   especially when using :mod:`dataclasses` as type metadata.
   Patch by Adam Turner.
-* #12589, #12623: autosummary: Fix warnings with :rst:role:`!autolink`.
+* #12589, #12626: autosummary: Fix warnings with :rst:role:`!autolink`.
   Patch by Adam Turner.
 
 Release 7.4.6 (released Jul 18, 2024)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Bugs fixed
   ``sphinx.ext.autodoc``,
   especially when using :mod:`dataclasses` as type metadata.
   Patch by Adam Turner.
+* #12589, #12623: autosummary: Fix warnings with :rst:role:`!autolink`.
+  Patch by Adam Turner.
 
 Release 7.4.6 (released Jul 18, 2024)
 =====================================
@@ -22,7 +24,7 @@ Release 7.4.6 (released Jul 18, 2024)
 Bugs fixed
 ----------
 
-* #12859, #9743, #12609: autosummary: Do not add the package prefix when
+* #12589, #9743, #12609: autosummary: Do not add the package prefix when
   generating autosummary directives for modules within a package.
   Patch by Adam Turner.
 * #12613: Reduce log severity for ambiguity detection during inventory loading.

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -765,7 +765,14 @@ class AutoLink(SphinxRole):
         try:
             # try to import object by name
             prefixes = get_import_prefixes_from_env(self.env)
-            import_by_name(pending_xref['reftarget'], prefixes)
+            name = pending_xref['reftarget']
+            prefixes = [
+                prefix
+                for prefix in prefixes
+                if prefix is None
+                or not (name.startswith(f'{prefix}.') or name == prefix)
+            ]
+            import_by_name(name, prefixes)
         except ImportExceptionGroup:
             literal = cast(nodes.literal, pending_xref[0])
             objects[0] = nodes.emphasis(self.rawtext, literal.astext(),


### PR DESCRIPTION
Closes #12589 (again).

cc: @larsoner -- running the steps in your comment (https://github.com/sphinx-doc/sphinx/issues/12589#issuecomment-2237829847), I no longer get errors -- plese could you confirm?

A