### PR TITLE
Use Latexmk in a more efficient way for `'xelatex'` as `latex_engine`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Deprecated
 Features added
 --------------
 
+* #12636: LaTeX: possibly faster builds with ``'xelatex'`` from modernized
+  invocation of :program:`Latexmk` (backward compatible).
+
 Bugs fixed
 ----------
 

--- a/doc/usage/builders/index.rst
+++ b/doc/usage/builders/index.rst
@@ -280,10 +280,6 @@ The most common builders are:
 
       reduces console output to a minimum.
 
-      Also, if ``latexmk`` is at version 4.52b or higher (January 2017)
-      ``LATEXMKOPTS="-xelatex"`` speeds up PDF builds via XeLateX in case
-      of numerous graphics inclusions.
-
       To pass options directly to the ``(pdf|xe|lua)latex`` binary, use
       variable ``LATEXOPTS``, for example:
 

--- a/sphinx/texinputs/Makefile.jinja
+++ b/sphinx/texinputs/Makefile.jinja
@@ -4,6 +4,8 @@ ALLDOCS = $(basename $(wildcard *.tex))
 ALLPDF = $(addsuffix .pdf,$(ALLDOCS))
 {% if latex_engine == 'xelatex' -%}
 ALLDVI =
+# but we do not know a way to let Latexmk produce the .xdv files
+# as final targets, only as left-overs from a .pdf build
 ALLXDV = $(addsuffix .xdv,$(ALLDOCS))
 {% else -%}
 ALLDVI = $(addsuffix .dvi,$(ALLDOCS))
@@ -16,10 +18,6 @@ ARCHIVEPREFIX =
 # Additional LaTeX options (passed via variables in latexmkrc/latexmkjarc file)
 export LATEXOPTS ?=
 # Additional latexmk options
-{% if latex_engine == 'xelatex' -%}
-# with latexmk version 4.52b or higher set LATEXMKOPTS to -xelatex either here
-# or on command line for faster builds.
-{% endif -%}
 LATEXMKOPTS ?=
 {% if xindy_use -%}
 export XINDYOPTS = {{ xindy_lang_option }} -M sphinx.xdy
@@ -40,9 +38,22 @@ FMT = pdf
 # latexmkrc is read then overridden by latexmkjarc
 LATEX = latexmk -r latexmkjarc -dvi
 PDFLATEX = latexmk -r latexmkjarc -pdfdvi -dvi- -ps-
-{% else -%}
+{% endif -%}
+{% if latex_engine == 'pdflatex' -%}
 LATEX = latexmk -dvi
 PDFLATEX = latexmk -pdf -dvi- -ps-
+{% endif -%}
+{% if latex_engine == 'xelatex' -%}
+# No LATEX as it is used for .dvi targets which xelatex can't produce.
+# The -pdf is not needed with current (2024) Latexmk but may have been
+# in the distant past.  It doesn't hurt.
+PDFLATEX = latexmk -pdf -xelatex
+{% endif -%}
+{% if latex_engine == 'lualatex' -%}
+LATEX = latexmk -dvilua
+# The -pdf is not needed with current (2024) Latexmk but may have been
+# in the distant past.  It doesn't hurt.
+PDFLATEX = latexmk -pdf -lualatex
 {% endif %}
 
 {% if latex_engine != 'xelatex' -%}


### PR DESCRIPTION
Subject: improve (slightly) efficiency of xelatex builds

- Refactoring

We have said for a long time [in our docs](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder):

> Also, if latexmk is at version 4.52b or higher (January 2017) LATEXMKOPTS="-xelatex" speeds up PDF builds via XeLateX in case of numerous graphics inclusions.

After some complex chase (as I could not find a Change log with release dates at [Latexmk home](https://www.cantab.net/users/johncollins/latexmk/) going far back enough), it appears that from [this Changes files without dates](https://distrib-coffee.ipsl.jussieu.fr/pub/mirrors/ctan/support/latexmk/CHANGES) and [CTAN announcements](https://ctan.org/ctan-ann/pkg/latexmk) that both `-xelatex` and `-lualatex` options have been available since at least 2013, but that there was [important changes at 4.52 of January 2017](https://ctan.org/ctan-ann/id/mailman.2110.1484849174.17497.ctan-ann@ctan.org) to which the above tip was actually referring.

Starting from this date the `-xelatex` option triggered faster builds by Latexmk because it produces the PDF only once at very end of the multiple LaTeX passes.  In the intermediate passes it produces `.xdv` files which is a bit faster process than producing PDF file.

What my PR does is to modernize our Makefile to use that `-xelatex` option (and `-lualatex`).  Currently I can only test it on TeXLive 2019 LaTeX distribution not on earlier ones (and of course on current TL2024). I thus *think* that the change will not impact Sphinx users, even with very obsolete LaTeX installations.  Due to this I have added it to 8.x milestone but hesitate about asking for inclusion in 8.0.0 (ping @AA-Turner). I will be able to test on antequated systems only in a few weeks, and depending on my schedule during transfers perhaps not until September.

Only the Makefile is changed, the `latexmkrc` Perl configuration appeared to require no change.

One should not expect miracles  though in terms of performance improvement.

Commits will be added to update docs after opening the PR.

### Relates
- https://github.com/python/docsbuild-scripts/issues/169
- #4159

