### PR TITLE
Let LaTeX build always overwrite destination when copying assets

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -411,26 +411,32 @@ class LaTeXBuilder(Builder):
         staticdirname = path.join(package_dir, 'texinputs')
         for filename in os.listdir(staticdirname):
             if not filename.startswith('.'):
-                copy_asset_file(path.join(staticdirname, filename),
-                                self.outdir,
-                                context=context,
-                                force=True
-                                )
+                copy_asset_file(
+                    path.join(staticdirname, filename),
+                    self.outdir,
+                    context=context,
+                    force=True,
+                )
 
         # use pre-1.6.x Makefile for make latexpdf on Windows
         if os.name == 'nt':
             staticdirname = path.join(package_dir, 'texinputs_win')
-            copy_asset_file(path.join(staticdirname, 'Makefile.jinja'),
-                            self.outdir, context=context)
+            copy_asset_file(
+                path.join(staticdirname, 'Makefile.jinja'),
+                self.outdir,
+                context=context,
+                force=True,
+            )
 
     @progress_message(__('copying additional files'))
     def copy_latex_additional_files(self) -> None:
         for filename in self.config.latex_additional_files:
             logger.info(' ' + filename, nonl=True)
-            copy_asset_file(path.join(self.confdir, filename),
-                            self.outdir,
-                            force=True
-                            )
+            copy_asset_file(
+                self.confdir / filename,
+                self.outdir,
+                force=True,
+            )
 
     def copy_image_files(self) -> None:
         if self.images:
@@ -440,20 +446,22 @@ class LaTeXBuilder(Builder):
                                        stringify_func=stringify_func):
                 dest = self.images[src]
                 try:
-                    copy_asset_file(path.join(self.srcdir, src),
-                                    path.join(self.outdir, dest),
-                                    force=True
-                                    )
+                    copy_asset_file(
+                        self.srcdir / src,
+                        self.outdir / dest,
+                        force=True,
+                    )
                 except Exception as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
         if self.config.latex_logo:
             if not path.isfile(path.join(self.confdir, self.config.latex_logo)):
                 raise SphinxError(__('logo file %r does not exist') % self.config.latex_logo)
-            copy_asset_file(path.join(self.confdir, self.config.latex_logo),
-                            self.outdir,
-                            force=True
-                            )
+            copy_asset_file(
+                self.confdir / self.config.latex_logo,
+                self.outdir,
+                force=True,
+            )
 
     def write_message_catalog(self) -> None:
         formats = self.config.numfig_format
@@ -468,7 +476,13 @@ class LaTeXBuilder(Builder):
             context['addtocaptions'] = r'\addto\captions%s' % self.babel.get_language()
 
         filename = path.join(package_dir, 'templates', 'latex', 'sphinxmessages.sty.jinja')
-        copy_asset_file(filename, self.outdir, context=context, renderer=LaTeXRenderer())
+        copy_asset_file(
+            filename,
+            self.outdir,
+            context=context,
+            renderer=LaTeXRenderer(),
+            force=True,
+        )
 
 
 def validate_config_values(app: Sphinx, config: Config) -> None:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -412,7 +412,10 @@ class LaTeXBuilder(Builder):
         for filename in os.listdir(staticdirname):
             if not filename.startswith('.'):
                 copy_asset_file(path.join(staticdirname, filename),
-                                self.outdir, context=context)
+                                self.outdir,
+                                context=context,
+                                force=True
+                                )
 
         # use pre-1.6.x Makefile for make latexpdf on Windows
         if os.name == 'nt':
@@ -424,7 +427,10 @@ class LaTeXBuilder(Builder):
     def copy_latex_additional_files(self) -> None:
         for filename in self.config.latex_additional_files:
             logger.info(' ' + filename, nonl=True)
-            copy_asset_file(path.join(self.confdir, filename), self.outdir)
+            copy_asset_file(path.join(self.confdir, filename),
+                            self.outdir,
+                            force=True
+                            )
 
     def copy_image_files(self) -> None:
         if self.images:
@@ -435,14 +441,19 @@ class LaTeXBuilder(Builder):
                 dest = self.images[src]
                 try:
                     copy_asset_file(path.join(self.srcdir, src),
-                                    path.join(self.outdir, dest))
+                                    path.join(self.outdir, dest),
+                                    force=True
+                                    )
                 except Exception as err:
                     logger.warning(__('cannot copy image file %r: %s'),
                                    path.join(self.srcdir, src), err)
         if self.config.latex_logo:
             if not path.isfile(path.join(self.confdir, self.config.latex_logo)):
                 raise SphinxError(__('logo file %r does not exist') % self.config.latex_logo)
-            copy_asset_file(path.join(self.confdir, self.config.latex_logo), self.outdir)
+            copy_asset_file(path.join(self.confdir, self.config.latex_logo),
+                            self.outdir,
+                            force=True
+                            )
 
     def write_message_catalog(self) -> None:
         formats = self.config.numfig_format


### PR DESCRIPTION
Fix #12656 

Template files need no `force=True`, but `Makefile.jinja` and `latexmkrc.jinja` are among other non-template files in `sphinx/texinputs` and are handled in the same loop, so `force=True` for them too.