### PR TITLE
LaTeX: remove a duplicate info-level log message during build

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -20,7 +20,7 @@ from sphinx.environment.adapters.asset import ImageAdapter
 from sphinx.errors import NoUri, SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging, texescape
-from sphinx.util.console import bold, darkgreen
+from sphinx.util.console import darkgreen
 from sphinx.util.display import progress_message, status_iterator
 from sphinx.util.docutils import SphinxFileOutput, new_document
 from sphinx.util.fileutil import copy_asset_file

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -407,7 +407,6 @@ class LaTeXBuilder(Builder):
             'xindy_lang_option': xindy_lang_option,
             'xindy_cyrillic':    xindy_cyrillic,
         }
-        logger.info(bold(__('copying TeX support files...')))
         staticdirname = path.join(package_dir, 'texinputs')
         for filename in os.listdir(staticdirname):
             if not filename.startswith('.'):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Resolves a small duplicate output message reported at https://github.com/sphinx-doc/sphinx/issues/12656#issuecomment-2246146779

### Detail
- Checked that this combination of bold-logging / decorator duplication doesn't exist elsewhere in the codebase.
- Confirmed that `@progress_message` outputs bold-formatted text (consistent with other progress updates, and confirming that it's OK to keep the decorator compared to the inline logging). 

**Before**
```
$ sphinx-build -b latex doc _build
 ...
pickling environment... done
checking consistency... done
copying TeX support files... copying TeX support files...
done
processing sphinx.tex...
```

**After**
```
$ sphinx-build -b latex doc _build
 ...
pickling environment... done
checking consistency... done
copying TeX support files... done
processing sphinx.tex...
```

### Relates
- Noticed during otherwise-unrelated #12656

cc @jfbu 