### PR TITLE
Allow image directory to be specified (solution for #10906)

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -193,6 +193,10 @@ class StandaloneHTMLBuilder(Builder):
     imgpath: str = ''
     domain_indices: list[DOMAIN_INDEX_TYPE] = []
 
+    # Used to override the path reference inside built documents
+    imagepath = None
+    
+
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
         super().__init__(app, env)
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -195,7 +195,6 @@ class StandaloneHTMLBuilder(Builder):
 
     # Used to override the path reference inside built documents
     imagepath = None
-    
 
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
         super().__init__(app, env)
@@ -242,7 +241,6 @@ class StandaloneHTMLBuilder(Builder):
         # Always set this from the config since we want the default to
         # be None if not specified in the config
         self.imagepath = self.get_builder_config('image_path', 'html')
-
         # section numbers for headings in the currently visited document
         self.secnumbers: dict[str, tuple[int, ...]] = {}
         # currently written docname

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1418,6 +1418,8 @@ def setup(app: Sphinx) -> ExtensionMetadata:
                          ENUM('table', 'inline'))
     app.add_config_value('html_math_renderer', None, 'env')
     app.add_config_value('html4_writer', False, 'html')
+    app.add_config_value('html_image_dir', None, 'html', [str])
+    app.add_config_value('html_image_path', None, 'html', [str])
 
     # events
     app.add_event('html-collect-pages')


### PR DESCRIPTION
Subject: extends image support to allow directory and HTML path to be set

### Feature or Bugfix
- Feature

### Purpose
- Using #10906 as the initial concept, this PR allows the name of the directory where the images will be stored to be set, as well as an optional setting for the path to be used when generating the HTML.

### Detail
- Provides a configuration key of `html_image_dir` which is a relative path, e.g. `images` or `images/foo`. This will be used instead of `_images` when building the documentation.
- Provides a configuration key of `html_image_path` which is the path from the documentation root to be used instead of the default, which is a path relative to the page referencing the image. This is useful if the images get copied elsewhere as part of incorporating the documentation into a larger website.

### Relates
- #10906

