### PR TITLE
Prettier console output from latex, texinfo, singlehtml and man page builders while inlining toctrees

### DIFF
--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -344,7 +344,7 @@ class LaTeXBuilder(Builder):
         self, indexfile: str, toctree_only: bool, appendices: list[str],
     ) -> nodes.document:
         self.docnames = {indexfile, *appendices}
-        logger.info(darkgreen(indexfile) + " ", nonl=True)
+        logger.info(darkgreen(indexfile))
         tree = self.env.get_doctree(indexfile)
         tree['docname'] = indexfile
         if toctree_only:

--- a/sphinx/builders/latex/__init__.py
+++ b/sphinx/builders/latex/__init__.py
@@ -293,7 +293,7 @@ class LaTeXBuilder(Builder):
                 toctree_only = entry[5]
             destination = SphinxFileOutput(destination_path=path.join(self.outdir, targetname),
                                            encoding='utf-8', overwrite_if_changed=True)
-            with progress_message(__("processing %s") % targetname):
+            with progress_message(__("processing %s") % targetname, nonl=False):
                 doctree = self.env.get_doctree(docname)
                 toctree = next(doctree.findall(addnodes.toctree), None)
                 if toctree and toctree.get('maxdepth') > 0:

--- a/sphinx/builders/manpage.py
+++ b/sphinx/builders/manpage.py
@@ -86,7 +86,7 @@ class ManualPageBuilder(Builder):
             else:
                 targetname = f'{name}.{section}'
 
-            logger.info(darkgreen(targetname) + ' { ', nonl=True)
+            logger.info(darkgreen(targetname) + ' { ')
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
                 encoding='utf-8')

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -80,8 +80,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
     def assemble_doctree(self) -> nodes.document:
         master = self.config.root_doc
         tree = self.env.get_doctree(master)
-        #  print() is abhorred but works...
-        logger.info('')  # ...probably not the best
+        logger.info(darkgreen(master))
         tree = inline_all_toctrees(self, set(), master, tree, darkgreen, [master])
         tree['docname'] = master
         self.env.resolve_references(tree, master, self)
@@ -159,7 +158,7 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
         with progress_message(__('preparing documents')):
             self.prepare_writing(docnames)  # type: ignore[arg-type]
 
-        with progress_message(__('assembling single document')):
+        with progress_message(__('assembling single document'), nonl=False):
             doctree = self.assemble_doctree()
             self.env.toc_secnumbers = self.assemble_toc_secnumbers()
             self.env.toc_fignumbers = self.assemble_toc_fignumbers()

--- a/sphinx/builders/singlehtml.py
+++ b/sphinx/builders/singlehtml.py
@@ -80,6 +80,8 @@ class SingleFileHTMLBuilder(StandaloneHTMLBuilder):
     def assemble_doctree(self) -> nodes.document:
         master = self.config.root_doc
         tree = self.env.get_doctree(master)
+        #  print() is abhorred but works...
+        logger.info('')  # ...probably not the best
         tree = inline_all_toctrees(self, set(), master, tree, darkgreen, [master])
         tree['docname'] = master
         self.env.resolve_references(tree, master, self)

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -104,7 +104,7 @@ class TexinfoBuilder(Builder):
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
                 encoding='utf-8')
-            with progress_message(__("processing %s") % targetname):
+            with progress_message(__("processing %s") % targetname, nonl=False):
                 appendices = self.config.texinfo_appendices or []
                 doctree = self.assemble_doctree(docname, toctree_only, appendices=appendices)
 

--- a/sphinx/builders/texinfo.py
+++ b/sphinx/builders/texinfo.py
@@ -135,7 +135,7 @@ class TexinfoBuilder(Builder):
         self, indexfile: str, toctree_only: bool, appendices: list[str],
     ) -> nodes.document:
         self.docnames = {indexfile, *appendices}
-        logger.info(darkgreen(indexfile) + " ", nonl=True)
+        logger.info(darkgreen(indexfile))
         tree = self.env.get_doctree(indexfile)
         tree['docname'] = indexfile
         if toctree_only:

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -27,10 +27,6 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
     from sphinx.util.tags import Tags
 
-# Ruff does not like me and wanted this line absolutely moved out of
-# its way so here we are.  This is an import if we were to use status_iterator,
-# but we are not
-# from sphinx.util.display import status_iterator
 logger = logging.getLogger(__name__)
 
 
@@ -427,19 +423,10 @@ def inline_all_toctrees(
     tree = tree.deepcopy()
     for toctreenode in list(tree.findall(addnodes.toctree)):
         newnodes = []
-        includefiles = [str(x) for x in toctreenode['includefiles']
-                        if x not in traversed]
-        if len(includefiles) > 0:
-            indent += ' '
-            # This is some attempt with status_iterator, how to handle colorfunc?
-            # Dropped because it seems to add overhead for gaining not much and
-            # perhaps breaking something.  But the refactoring above with
-            # includefiles was done in order to be able to use this:
-            # for includefile in status_iterator(includefiles,
-            #                                    indent + __('traversing... '),
-            #                                    "darkgreen",
-            #                                    len(includefiles)):
-            for includefile in includefiles:
+        includefiles = map(str, toctreenode['includefiles'])
+        indent += ' '
+        for includefile in includefiles:
+            if includefile not in traversed:
                 try:
                     traversed.append(includefile)
                     logger.info(indent + colorfunc(includefile))


### PR DESCRIPTION
Subject: Improve console output during builds while building up the doctree with single document output builders (latex, texinfo, singlehtml).

### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail

I tried out a variant with `status_iterator()` which is the reason for some refactoring of the for loop in nodes.py which could be dropped.

Before: (colors lost here)

```
processing sphinx.tex... index usage/installation usage/quickstart tutorial/index tutorial/getting-started tutorial/first-steps tutorial/more-sphinx-customization tutorial/narrative-documentation tutorial/describing-code tutorial/automatic-doc-generation tutorial/deploying tutorial/end usage/index usage/restructuredtext/index usage/restructuredtext/basics usage/restructuredtext/roles usage/restructuredtext/directives usage/restructuredtext/field-lists usage/restructuredtext/domains usage/markdown usage/referencing usage/configuration usage/builders/index usage/domains/index usage/domains/standard usage/domains/c usage/domains/cpp usage/domains/javascript usage/domains/mathematics usage/domains/python usage/domains/restructuredtext usage/extensions/index usage/extensions/autodoc usage/extensions/autosectionlabel usage/extensions/autosummary usage/extensions/coverage usage/extensions/doctest usage/extensions/duration usage/extensions/extlinks usage/extensions/githubpages usage/extensions/graphviz usage/extensions/ifconfig usage/extensions/imgconverter usage/extensions/inheritance usage/extensions/intersphinx usage/extensions/linkcode usage/extensions/math usage/extensions/napoleon usage/extensions/todo usage/extensions/viewcode usage/theming usage/advanced/intl usage/advanced/websupport/index usage/advanced/websupport/quickstart usage/advanced/websupport/api usage/advanced/websupport/searchadapters usage/advanced/websupport/storagebackends development/index development/tutorials/index development/tutorials/extending_syntax development/tutorials/extending_build development/tutorials/adding_domain development/tutorials/autodoc_ext development/howtos/index development/howtos/setup_extension development/howtos/builders development/html_themes/index development/html_themes/templating extdev/index extdev/appapi extdev/event_callbacks extdev/projectapi extdev/envapi extdev/builderapi extdev/collectorapi extdev/markupapi extdev/domainapi extdev/parserapi extdev/nodes extdev/logging extdev/i18n extdev/utils extdev/testing extdev/deprecated latex support internals/index internals/contributing internals/release-process internals/organization internals/code-of-conduct faq authors man/index man/sphinx-quickstart man/sphinx-build man/sphinx-apidoc man/sphinx-autogen glossary changes examples 
resolving references...
done
```

After:

```
processing sphinx.tex... index
 usage/installation
 usage/quickstart
 tutorial/index
  tutorial/getting-started
  tutorial/first-steps
  tutorial/more-sphinx-customization
  tutorial/narrative-documentation
  tutorial/describing-code
  tutorial/automatic-doc-generation
  tutorial/deploying
  tutorial/end
  usage/index
   usage/restructuredtext/index
    usage/restructuredtext/basics
    usage/restructuredtext/roles
    usage/restructuredtext/directives
    usage/restructuredtext/field-lists
     usage/restructuredtext/domains
   usage/markdown
   usage/referencing
   usage/configuration
   usage/builders/index
   usage/domains/index
    usage/domains/standard
    usage/domains/c
    usage/domains/cpp
    usage/domains/javascript
    usage/domains/mathematics
    usage/domains/python
    usage/domains/restructuredtext
   usage/extensions/index
    usage/extensions/autodoc
    usage/extensions/autosectionlabel
    usage/extensions/autosummary
    usage/extensions/coverage
    usage/extensions/doctest
    usage/extensions/duration
    usage/extensions/extlinks
    usage/extensions/githubpages
    usage/extensions/graphviz
    usage/extensions/ifconfig
    usage/extensions/imgconverter
    usage/extensions/inheritance
    usage/extensions/intersphinx
    usage/extensions/linkcode
    usage/extensions/math
    usage/extensions/napoleon
    usage/extensions/todo
    usage/extensions/viewcode
   usage/theming
   usage/advanced/intl
   usage/advanced/websupport/index
    usage/advanced/websupport/quickstart
    usage/advanced/websupport/api
    usage/advanced/websupport/searchadapters
    usage/advanced/websupport/storagebackends
  development/index
   development/tutorials/index
    development/tutorials/extending_syntax
    development/tutorials/extending_build
    development/tutorials/adding_domain
    development/tutorials/autodoc_ext
   development/howtos/index
    development/howtos/setup_extension
    development/howtos/builders
   development/html_themes/index
    development/html_themes/templating
  extdev/index
   extdev/appapi
   extdev/event_callbacks
   extdev/projectapi
   extdev/envapi
   extdev/builderapi
   extdev/collectorapi
   extdev/markupapi
   extdev/domainapi
   extdev/parserapi
   extdev/nodes
   extdev/logging
   extdev/i18n
   extdev/utils
   extdev/testing
   extdev/deprecated
  latex
   support
   internals/index
    internals/contributing
    internals/release-process
    internals/organization
    internals/code-of-conduct
   faq
   authors
    man/index
     man/sphinx-quickstart
     man/sphinx-build
      man/sphinx-apidoc
      man/sphinx-autogen
    glossary
    changes
    examples

resolving references...
```

(similarly with `make texinfo` and `make singlehtml`)

I would actually prefer the `index` of `latex` and `texinfo` to skip to next line, which I can achieve via a `logger.info('')` as I do in singlehtml.py but that may not be professional way.

<hr>

edit, also the `man` builder console output is now "one-line-per-file"

with this PR:

```
writing... sphinx-all.1 { 
 usage/installation
 usage/quickstart
 tutorial/index
  tutorial/getting-started
  tutorial/first-steps
  tutorial/more-sphinx-customization
  tutorial/narrative-documentation
  tutorial/describing-code
  tutorial/automatic-doc-generation
  tutorial/deploying
  tutorial/end
  usage/index
   usage/restructuredtext/index
    usage/restructuredtext/basics
    usage/restructuredtext/roles
    usage/restructuredtext/directives
    usage/restructuredtext/field-lists
     usage/restructuredtext/domains
   usage/markdown
   usage/referencing
   usage/configuration
   usage/builders/index
   usage/domains/index
    usage/domains/standard
    usage/domains/c
    usage/domains/cpp
    usage/domains/javascript
    usage/domains/mathematics
    usage/domains/python
    usage/domains/restructuredtext
   usage/extensions/index
    usage/extensions/autodoc
    usage/extensions/autosectionlabel
    usage/extensions/autosummary
    usage/extensions/coverage
    usage/extensions/doctest
    usage/extensions/duration
    usage/extensions/extlinks
    usage/extensions/githubpages
    usage/extensions/graphviz
    usage/extensions/ifconfig
    usage/extensions/imgconverter
    usage/extensions/inheritance
    usage/extensions/intersphinx
    usage/extensions/linkcode
    usage/extensions/math
    usage/extensions/napoleon
    usage/extensions/todo
    usage/extensions/viewcode
   usage/theming
   usage/advanced/intl
   usage/advanced/websupport/index
    usage/advanced/websupport/quickstart
    usage/advanced/websupport/api
    usage/advanced/websupport/searchadapters
    usage/advanced/websupport/storagebackends
  development/index
   development/tutorials/index
    development/tutorials/extending_syntax
    development/tutorials/extending_build
    development/tutorials/adding_domain
    development/tutorials/autodoc_ext
   development/howtos/index
    development/howtos/setup_extension
    development/howtos/builders
   development/html_themes/index
    development/html_themes/templating
  extdev/index
   extdev/appapi
   extdev/event_callbacks
   extdev/projectapi
   extdev/envapi
   extdev/builderapi
   extdev/collectorapi
   extdev/markupapi
   extdev/domainapi
   extdev/parserapi
   extdev/nodes
   extdev/logging
   extdev/i18n
   extdev/utils
   extdev/testing
   extdev/deprecated
  latex
   support
   internals/index
    internals/contributing
    internals/release-process
    internals/organization
    internals/code-of-conduct
   faq
   authors
    man/index
     man/sphinx-quickstart
     man/sphinx-build
      man/sphinx-apidoc
      man/sphinx-autogen
    glossary
    changes
    examples
} sphinx-build.1 { 
} sphinx-quickstart.1 { 
} sphinx-apidoc.1 { 
} sphinx-autogen.1 { 
} done
build succeeded.
```

maybe room for improvement here
<hr>
request for comments...
