### PR TITLE
remove 'final' decorator from method which is overriden in subclass

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -297,6 +297,7 @@ class Builder:
                        summary=__('targets for %d source files that are out of date') %
                        len(to_build))
 
+    @final
     def build(
         self,
         docnames: Iterable[str] | None,
@@ -304,6 +305,21 @@ class Builder:
         method: Literal['all', 'specific', 'update'] = 'update',
     ) -> None:
         """Main build method, usually called by a specific ``build_*`` method.
+
+        First updates the environment, and then calls
+        :meth:`!write`.
+        """
+        self._build(docnames, summary, method)
+
+    def _build(
+        self,
+        docnames: Iterable[str] | None,
+        summary: str | None = None,
+        method: Literal['all', 'specific', 'update'] = 'update',
+    ) -> None:
+        """Internal build method.
+        
+        This should not be overriden by consumers of this library.
 
         First updates the environment, and then calls
         :meth:`!write`.

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -318,7 +318,7 @@ class Builder:
         method: Literal['all', 'specific', 'update'] = 'update',
     ) -> None:
         """Internal build method.
-        
+
         This should not be overriden by consumers of this library.
 
         First updates the environment, and then calls

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -297,7 +297,6 @@ class Builder:
                        summary=__('targets for %d source files that are out of date') %
                        len(to_build))
 
-    @final
     def build(
         self,
         docnames: Iterable[str] | None,

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -257,7 +257,7 @@ class MessageCatalogBuilder(I18nBuilder):
                 msg = f'{template}: {exc!r}'
                 raise ThemeError(msg) from exc
 
-    def build(  # type: ignore[misc]
+    def build(
         self,
         docnames: Iterable[str] | None,
         summary: str | None = None,

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -257,14 +257,14 @@ class MessageCatalogBuilder(I18nBuilder):
                 msg = f'{template}: {exc!r}'
                 raise ThemeError(msg) from exc
 
-    def build(
+    def _build(
         self,
         docnames: Iterable[str] | None,
         summary: str | None = None,
         method: Literal['all', 'specific', 'update'] = 'update',
     ) -> None:
         self._extract_from_template()
-        super().build(docnames, summary, method)
+        super()._build(docnames, summary, method)
 
     def finish(self) -> None:
         super().finish()


### PR DESCRIPTION
this method is marked as 'final', but then overridden in a subclass. Which doesn't make a lot of sense