### PR TITLE
sphinx13 theme: Include the project name in home link

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -14,8 +14,8 @@
   <div class="brand">
     <a href="{{ pathto(root_doc)|e }}">
       <img src="{{ pathto('_static/sphinx-logo.svg', resource=True) }}" alt="logo" />
+      <span>Sphinx</span>
     </a>
-    <h1>Sphinx</h1>
   </div>
   <div class="icons">
     <a href="https://github.com/sphinx-doc/sphinx" title="{{ _('Source Code') }}" target="_blank">

--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -62,17 +62,14 @@ body {
     text-decoration: none;
 }
 
-.pageheader .brand a {
-    width: 2em;
-}
-
 .pageheader .brand img {
+    width: 2em;
     filter: invert(1) drop-shadow(1px 1px 2px black);
 }
 
-.pageheader .brand h1 {
+.pageheader .brand span {
     color: white;
-    margin: 0;
+    margin-left: 0.4em;
     font-weight: 400;
     font-size: 2em;
     line-height: 1;


### PR DESCRIPTION
So far, only the sphinx logo was contained in the home link. This PR includes also the project name "Sphinx" in the link.
