### PR TITLE
Remove "On this page" nav for start page

### DIFF
--- a/doc/_themes/sphinx13/layout.html
+++ b/doc/_themes/sphinx13/layout.html
@@ -42,7 +42,7 @@
 <div class="document">
   <div class="sphinxsidebar" role="navigation" aria-label="Main">
     {%- include "searchfield.html" %}
-    {%- if display_toc %}
+    {%- if display_toc and (pagename != root_doc) %}
       <div class="sphinxsidebar-navigation__contents">
         <h3>{{ _('On this page') }}</h3>
         {{ toc }}


### PR DESCRIPTION
For the start page "On this page" repeats the top-level entries of the full toctree right below. Removing "On this page" here declutters the interface.

Before / after:
![grafik](https://github.com/user-attachments/assets/86681939-21a4-4e8a-b72e-2416bc5dd281)    ![grafik](https://github.com/user-attachments/assets/064107af-891f-48bf-8411-39c0bcc53f95)
