### PR TITLE
Check for targets prefixed with user-content-

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bugs fixed
 * #12514: intersphinx: fix the meaning of a negative value for
   :confval:`intersphinx_cache_limit`.
   Patch by Shengyu Zhang.
+* #9016: Fix linkcheck builder reporting broken Anchor not found when testing
+  links to targets in parsed .rst and .md files.
 
 Testing
 -------


### PR DESCRIPTION
When looking for anchors, check for targets prefixed with `user-content-`.

### Feature or Bugfix
- Bugfix

### Purpose
When parsing user `.md` and `.rst` files, GitHub, GitLab and Gitea automatically create `href` fragment targets to headings. To avoid DOM clobbering they append `user-content-` to the automatically created `name` and `id` targets and use JavaScript to manually scroll to the heading when the URL contains the un-prefixed fragment. Since prefixing targets with `user-content-` is the de facto standard, to avoid `linkcheck.py` failing to find the un-prefixed anchors, we need to also check for targets prefixed with `user-content-` when parsing the HTML looking for a URL's fragment.

### Detail
Using Sphinx's own `README.rst`, we can reference the [Features](https://github.com/sphinx-doc/sphinx#features) section using https://github.com/sphinx-doc/sphinx#features.

However, when testing this reference with:
`index.rst`:
```
https://github.com/sphinx-doc/sphinx#features
```
`conf.py`: empty

Running linkcheck:
```
sphinx-build -b linkcheck . _linkcheck
```
Without this PR, it fails:
```
(           index: line    1) broken    https://github.com/sphinx-doc/sphinx#features - Anchor 'features' not found
build finished with problems.
```
With this PR, it succeeds:
```
(           index: line    1) ok        https://github.com/sphinx-doc/sphinx#features
build succeeded.
```

**Note:** this does not reintroduce regression #9435, because `linkcheck.py` currently fails with these `#Lxxx` fragments. The `#Lxxx` fragments only work with JavaScript. There are no prefixed `Lxxx` `name` and `id` targets.

### Relates
- Fixes #12688
- Fixes #9016
- #9435 

