### PR TITLE
Slightly simplify toctree code

### DIFF
--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -78,17 +78,19 @@ class TocTree(SphinxDirective):
         subnode['numbered'] = self.options.get('numbered', 0)
         subnode['titlesonly'] = 'titlesonly' in self.options
         self.set_source_info(subnode)
+        self.parse_content(subnode)
+
         wrappernode = nodes.compound(
             classes=['toctree-wrapper', *self.options.get('class', ())],
         )
         wrappernode.append(subnode)
         self.add_name(wrappernode)
+        return [wrappernode]
 
-        ret = self.parse_content(subnode)
-        ret.append(wrappernode)
-        return ret
-
-    def parse_content(self, toctree: addnodes.toctree) -> list[Node]:
+    def parse_content(self, toctree: addnodes.toctree) -> None:
+        """
+        Populate ``toctree['entries']`` and ``toctree['includefiles']`` from content.
+        """
         generated_docnames = frozenset(StandardDomain._virtual_doc_names)
         suffixes = self.config.source_suffix
         current_docname = self.env.docname
@@ -99,7 +101,6 @@ class TocTree(SphinxDirective):
         all_docnames.remove(current_docname)  # remove current document
         frozen_all_docnames = frozenset(all_docnames)
 
-        ret: list[Node] = []
         excluded = Matcher(self.config.exclude_patterns)
         for entry in self.content:
             if not entry:
@@ -169,8 +170,6 @@ class TocTree(SphinxDirective):
         if 'reversed' in self.options:
             toctree['entries'] = list(reversed(toctree['entries']))
             toctree['includefiles'] = list(reversed(toctree['includefiles']))
-
-        return ret
 
 
 class Author(SphinxDirective):


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
While working on #12720, I noticed that `parse_content` creates and returns an empty node list. It does not do anything with it.

This PR moves the node out of `parse_content`, so that `parse_content` only populates the toctree entries. The complete node creation logic is now united in `TocTree.run`.
