### PR TITLE
misc: Mention dynamically-evaluated templates during static file copying

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Deprecated
 Features added
 --------------
 
+* #11328: Mention evaluation of templated content during production of static
+  output files.
+
 Bugs fixed
 ----------
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -887,7 +887,7 @@ class StandaloneHTMLBuilder(Builder):
 
     def copy_static_files(self) -> None:
         try:
-            with progress_message(__('copying static files')):
+            with progress_message(__('copying static files'), nonl=False):
                 ensuredir(self.outdir / '_static')
 
                 # prepare context for templates
@@ -908,7 +908,7 @@ class StandaloneHTMLBuilder(Builder):
     def copy_extra_files(self) -> None:
         """Copy html_extra_path files."""
         try:
-            with progress_message(__('copying extra files')):
+            with progress_message(__('copying extra files'), nonl=False):
                 excluded = Matcher(self.config.exclude_patterns)
                 for extra_path in self.config.html_extra_path:
                     copy_asset(

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -81,6 +81,9 @@ def copy_asset_file(source: str | os.PathLike[str], destination: str | os.PathLi
 
         destination = _template_basename(destination) or destination
         with open(destination, 'w', encoding='utf-8') as fdst:
+            msg = __('Writing evaluated template result to %s')
+            logger.info(msg, os.fsdecode(destination), type='misc',
+                        subtype='template_evaluation')
             fdst.write(rendered_template)
     else:
         copyfile(source, destination, force=force)

--- a/tests/test_util/test_util_fileutil.py
+++ b/tests/test_util/test_util_fileutil.py
@@ -106,11 +106,11 @@ def test_copy_asset(tmp_path):
     assert not (destdir / '_templates' / 'sidebar.html').exists()
 
 
-@pytest.mark.sphinx('html')
+@pytest.mark.sphinx('html', testroot='html_assets')
 def test_copy_asset_template(app):
     app.build(force_all=True)
 
-    expected_filename = app.outdir / '_static' / 'basic.css'
+    expected_filename = app.outdir / '_static' / 'API.html'
     expected_msg = f"Writing evaluated template result to {expected_filename}"
     assert expected_msg in strip_colors(app.status.getvalue())
 

--- a/tests/test_util/test_util_fileutil.py
+++ b/tests/test_util/test_util_fileutil.py
@@ -1,6 +1,5 @@
 """Tests sphinx.util.fileutil functions."""
 
-import os
 import re
 from unittest import mock
 
@@ -112,9 +111,8 @@ def test_copy_asset(tmp_path):
 def test_copy_asset_template(app):
     app.build(force_all=True)
 
-    expected_filename = rf"{app.outdir / '_static'}[{os.sep}{os.altsep}]API.html"
-    expected_msg = rf"Writing evaluated template result to {expected_filename}"
-    assert re.findall(expected_msg, strip_colors(app.status.getvalue()))
+    expected_msg = r"^Writing evaluated template result to [^\n]*\bAPI.html$"
+    assert re.findall(expected_msg, strip_colors(app.status.getvalue()), flags=re.MULTILINE)
 
 
 @pytest.mark.sphinx('html', testroot='util-copyasset_overwrite')

--- a/tests/test_util/test_util_fileutil.py
+++ b/tests/test_util/test_util_fileutil.py
@@ -108,7 +108,7 @@ def test_copy_asset(tmp_path):
 
 @pytest.mark.sphinx('html')
 def test_copy_asset_template(app):
-    app.build(freshenv=True)
+    app.build(force_all=True)
 
     expected_filename = app.outdir / '_static' / 'basic.css'
     expected_msg = f"Writing evaluated template result to {expected_filename}"

--- a/tests/test_util/test_util_fileutil.py
+++ b/tests/test_util/test_util_fileutil.py
@@ -108,7 +108,7 @@ def test_copy_asset(tmp_path):
 
 @pytest.mark.sphinx('html')
 def test_copy_asset_template(app):
-    app.build()
+    app.build(freshenv=True)
 
     expected_filename = app.outdir / '_static' / 'basic.css'
     expected_msg = f"Writing evaluated template result to {expected_filename}"

--- a/tests/test_util/test_util_fileutil.py
+++ b/tests/test_util/test_util_fileutil.py
@@ -106,6 +106,15 @@ def test_copy_asset(tmp_path):
     assert not (destdir / '_templates' / 'sidebar.html').exists()
 
 
+@pytest.mark.sphinx('html')
+def test_copy_asset_template(app):
+    app.build()
+
+    expected_filename = app.outdir / '_static' / 'basic.css'
+    expected_msg = f"Writing evaluated template result to {expected_filename}"
+    assert expected_msg in strip_colors(app.status.getvalue())
+
+
 @pytest.mark.sphinx('html', testroot='util-copyasset_overwrite')
 def test_copy_asset_overwrite(app):
     app.build()

--- a/tests/test_util/test_util_fileutil.py
+++ b/tests/test_util/test_util_fileutil.py
@@ -1,5 +1,7 @@
 """Tests sphinx.util.fileutil functions."""
 
+import os
+import re
 from unittest import mock
 
 import pytest
@@ -110,9 +112,9 @@ def test_copy_asset(tmp_path):
 def test_copy_asset_template(app):
     app.build(force_all=True)
 
-    expected_filename = app.outdir / '_static' / 'API.html'
-    expected_msg = f"Writing evaluated template result to {expected_filename}"
-    assert expected_msg in strip_colors(app.status.getvalue())
+    expected_filename = rf"{app.outdir / '_static'}[{os.sep}{os.altsep}]API.html"
+    expected_msg = rf"Writing evaluated template result to {expected_filename}"
+    assert re.findall(expected_msg, strip_colors(app.status.getvalue()))
 
 
 @pytest.mark.sphinx('html', testroot='util-copyasset_overwrite')


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Provide a clearer indication when static content in the output is evaluated from template.

### Detail
- When dynamic contents are evaluated during a build, add a corresponding `info`-level output message.

### Relates
- Resolves #11328 (although not exactly in the way originally described).