### PR TITLE
Revert "Mark ``test_build_manpage`` as XFAIL following changes in Doc…

### DIFF
--- a/tests/test_builders/test_build_manpage.py
+++ b/tests/test_builders/test_build_manpage.py
@@ -7,8 +7,6 @@ from sphinx.builders.manpage import default_man_pages
 from sphinx.config import Config
 
 
-@pytest.mark.xfail(docutils.__version_info__[:2] > (0, 21),
-                   reason='Docutils has removed the reference key in master')
 @pytest.mark.sphinx('man')
 def test_all(app):
     app.build(force_all=True)
@@ -49,8 +47,6 @@ def test_man_make_section_directory(app):
     assert (app.outdir / 'man1' / 'projectnamenotset.1').exists()
 
 
-@pytest.mark.xfail(docutils.__version_info__[:2] > (0, 21),
-                   reason='Docutils has removed the reference key in master')
 @pytest.mark.sphinx('man', testroot='directive-code')
 def test_captioned_code_block(app):
     app.build(force_all=True)


### PR DESCRIPTION
…utils master"

This reverts commit 1ed4ca7e038364b3b10e3d36abb84ee034d4d94c.

We have currently 3 test failures on DocUtils HEAD (currently at [r9852](https://sourceforge.net/p/docutils/code/9852/)).

Two of them come from a XFAIL because DocUtils master version is currently at 0.22b.dev.  The tests failed at some earlier stage of DocUtils master after their 0.21.2 but now currently they do not.

The third failure is tests/test_builders/test_build_latex.py::test_one_parameter_per_line and comes from typing annotations added at Docutils [revision r9813](https://sourceforge.net/p/docutils/code/9813/).

I am not addressing this here, also because I found what appears to be a bug in PDF output, which is unrelated to that recent failure but displayed by the test.