### PR TITLE
[events] move `write-started` from `Builder.write` to  `Builder.build` method

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -362,6 +362,8 @@ class Builder:
         # for now, just execute them serially
         self.finish_tasks = SerialTasks()
 
+        # Allow any extensions to perform setup for writing
+        self.events.emit('write-started', self)
         # write all "normal" documents (or everything for some builders)
         self.write(docnames, list(updated_docnames), method)
 
@@ -578,9 +580,6 @@ class Builder:
         method: Literal['all', 'specific', 'update'] = 'update',
     ) -> None:
         """Write builder specific output files."""
-        # Allow any extensions to perform setup for writing
-        self.events.emit('write-started', self)
-
         if build_docnames is None or build_docnames == ['__all__']:
             # build_all
             build_docnames = self.env.found_docs


### PR DESCRIPTION
This event was recently added in https://github.com/sphinx-doc/sphinx/pull/12567,
but as pointed out in #12680 this may not fire for all builders, since `write` can be overriden.

I can't recall if there was any additional thinking as to its original placement,
but certainly with https://github.com/sphinx-doc/sphinx/pull/12436, we can "guarantee" that it will be called for all builders when called in `build`.