### PR TITLE
Allow figure dash and en dash as year separator in copyright

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -651,6 +651,8 @@ def _substitute_copyright_year(copyright_line: str, replace_year: str) -> str:
     * ``YYYY-YYYY,``
     * ``YYYY-YYYY ``
 
+    The dash in year ranges may also be figure-dash (U+2012) or en-dash (U+2013).
+
     The final year in the string is replaced with ``replace_year``.
     """
     if len(copyright_line) < 4 or not copyright_line[:4].isdigit():
@@ -659,7 +661,7 @@ def _substitute_copyright_year(copyright_line: str, replace_year: str) -> str:
     if copyright_line[4:5] in {'', ' ', ','}:
         return replace_year + copyright_line[4:]
 
-    if copyright_line[4] != '-':
+    if copyright_line[4] != '-' and copyright_line[4] != '‒' and copyright_line[4] != '–':
         return copyright_line
 
     if copyright_line[5:9].isdigit() and copyright_line[9:10] in {'', ' ', ','}:

--- a/tests/test_config/test_correct_year.py
+++ b/tests/test_config/test_correct_year.py
@@ -9,6 +9,10 @@ import pytest
         # test with SOURCE_DATE_EPOCH set: copyright year should be updated
         ('1293840000', '2006-2011'),
         ('1293839999', '2006-2010'),
+        # figure dash (U+2012)
+        ('1293840000', '2006‒2011'),
+        # en dash (U+2013)
+        ('1293840000', '2006–2011'),
     ],
 
 )


### PR DESCRIPTION
These are valid characters to denote ranges.

I've came across this as an reproducibility issue [here](https://tests.reproducible-builds.org/debian/rb-pkg/trixie/amd64/uncertainties.html)