### PR TITLE
LaTeX: fix mark-up when \DUrole is used with multiple classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,14 +62,15 @@ Bugs fixed
   get passed to :program:`latexmk`.  Let :option:`-Q <sphinx-build -Q>`
   (silent) apply as well to the PDF build phase.
   Patch by Jean-François B.
+* #12744: LaTeX: Classes injected by a custom interpreted text role now give
+  rise to nested ``\DUrole``'s, rather than a single one with comma separated
+  classes.
+  Patch by Jean-François B.
 * #11970, #12551: singlehtml builder: make target URIs to be same-document
   references in the sense of :rfc:`RFC 3986, §4.4 <3986#section-4.4>`,
   e.g., ``index.html#foo`` becomes ``#foo``.
   (note: continuation of a partial fix added in Sphinx 7.3.0)
   Patch by James Addison (with reference to prior work by Eric Norige)
-* #12744: Classes injected by a custom interpreted text role now give rise to
-  nested ``\DUrole``'s, rather than a single one with comma separated classes.
-  Patch by Jean-François B.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Bugs fixed
   e.g., ``index.html#foo`` becomes ``#foo``.
   (note: continuation of a partial fix added in Sphinx 7.3.0)
   Patch by James Addison (with reference to prior work by Eric Norige)
+* #12744: Classes injected by a custom interpreted text role now give rise to
+  nested ``\DUrole``'s, rather than a single one with comma separated classes.
+  Patch by Jean-François B.
 
 Testing
 -------

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -1870,11 +1870,11 @@ Miscellany
   in Docutils <classarguments_>`_.  Object signatures also use ``\DUrole`` for
   some components, with one or two-letters class names as in HTML output.
 
-  .. versionchanged:: 8.1.0 When multiple classes are injected via a a custom
-     role, the LaTeX output uses nested ``\DUrole``'s as in the `Docutils
-     documentation <classarguments_>`_.  Formerly it used a single ``\DUrole``
-     with comma separated classes, making the LaTeX customization more
-     arduous.
+  .. versionchanged:: 8.1.0
+     When multiple classes are injected via a a custom role, the LaTeX output
+     uses nested ``\DUrole``'s as in the `Docutils documentation
+     <classarguments_>`_.  Formerly it used a single ``\DUrole`` with comma
+     separated classes, making the LaTeX customization more arduous.
 
 .. _classarguments: https://docutils.sourceforge.io/docs/user/latex.html#custom-interpreted-text-roles
 

--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -1865,6 +1865,19 @@ Miscellany
      Formerly, use of *fncychap* with other styles than ``Bjarne`` was
      dysfunctional.
 
+- The :dudir:`role` directive allows to mark inline text with class arguments.
+  This is handled in LaTeX output via the ``\DUrole`` dispatcher command `as
+  in Docutils <classarguments_>`_.  Object signatures also use ``\DUrole`` for
+  some components, with one or two-letters class names as in HTML output.
+
+  .. versionchanged:: 8.1.0 When multiple classes are injected via a a custom
+     role, the LaTeX output uses nested ``\DUrole``'s as in the `Docutils
+     documentation <classarguments_>`_.  Formerly it used a single ``\DUrole``
+     with comma separated classes, making the LaTeX customization more
+     arduous.
+
+.. _classarguments: https://docutils.sourceforge.io/docs/user/latex.html#custom-interpreted-text-roles
+
 .. _latexcontainer:
 
 - Docutils :dudir:`container` directives are supported in LaTeX output: to

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2173,8 +2173,8 @@ class LaTeXTranslator(SphinxTranslator):
             self.body.append(r'\sphinxaccelerator{')
             self.context.append('}')
         elif classes and not self.in_title:
-            self.body.append(r'\DUrole{%s}{' % ','.join(classes))
-            self.context.append('}')
+            self.body.append(r'\DUrole{' + r'}{\DUrole{'.join(classes) + '}{')
+            self.context.append('}' * len(classes))
         else:
             self.context.append('')
 

--- a/tests/roots/test-latex-table/expects/longtable_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/longtable_having_widths.tex
@@ -70,4 +70,4 @@ cell3\sphinxhyphen{}2
 \end{savenotes}
 
 \sphinxAtStartPar
-See {\hyperref[\detokenize{longtable:mylongtable}]{\sphinxcrossref{mylongtable}}}, same as {\hyperref[\detokenize{longtable:namedlongtable}]{\sphinxcrossref{\DUrole{std,std-ref}{this one}}}}.
+See {\hyperref[\detokenize{longtable:mylongtable}]{\sphinxcrossref{mylongtable}}}, same as {\hyperref[\detokenize{longtable:namedlongtable}]{\sphinxcrossref{\DUrole{std}{\DUrole{std-ref}{this one}}}}}.

--- a/tests/roots/test-latex-table/expects/table_having_widths.tex
+++ b/tests/roots/test-latex-table/expects/table_having_widths.tex
@@ -43,4 +43,4 @@ cell3\sphinxhyphen{}2
 \sphinxattableend\end{savenotes}
 
 \sphinxAtStartPar
-See {\hyperref[\detokenize{tabular:mytabular}]{\sphinxcrossref{\DUrole{std,std-ref}{this}}}}, same as {\hyperref[\detokenize{tabular:namedtabular}]{\sphinxcrossref{namedtabular}}}.
+See {\hyperref[\detokenize{tabular:mytabular}]{\sphinxcrossref{\DUrole{std}{\DUrole{std-ref}{this}}}}}, same as {\hyperref[\detokenize{tabular:namedtabular}]{\sphinxcrossref{namedtabular}}}.

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -981,11 +981,13 @@ def test_reference_in_caption_and_codeblock_in_footnote(app):
     ) in result
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
     assert (
-        '\\sphinxcaption{The table title with a reference to {[}AuthorYear{]}}'
-    ) in result
+        '\\sphinxcaption{The table title with a reference'
+        ' to {[}AuthorYear{]}}' in result
+    )
     assert (
         '\\subsubsection*{The rubric title with a reference to {[}AuthorYear{]}}'
-    ) in result
+        in result
+    )
     assert (
         '\\chapter{The section with a reference to \\sphinxfootnotemark[6]}\n'
         '\\label{\\detokenize{index:the-section-with-a-reference-to}}'
@@ -1016,14 +1018,15 @@ def test_reference_in_caption_and_codeblock_in_footnote(app):
     assert (
         'This is a reference to the code\\sphinxhyphen{}block in the footnote:\n'
         '{\\hyperref[\\detokenize{index:codeblockinfootnote}]'
-        '{\\sphinxcrossref{\\DUrole{std,std-ref}{I am in a footnote}}}}'
+        '{\\sphinxcrossref{\\DUrole{std}{\\DUrole{std-ref}'
+        '{I am in a footnote}}}}}'
     ) in result
     assert (
         '&\n\\sphinxAtStartPar\nThis is one more footnote with some code in it %\n'
         '\\begin{footnote}[12]\\sphinxAtStartFootnote\n'
         'Third footnote in longtable\n'
     ) in result
-    assert '\\end{sphinxVerbatim}\n%\n\\end{footnote}.\n' in result
+    assert ('\\end{sphinxVerbatim}\n%\n\\end{footnote}.\n') in result
     assert '\\begin{sphinxVerbatim}[commandchars=\\\\\\{\\}]' in result
 
 

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -981,13 +981,11 @@ def test_reference_in_caption_and_codeblock_in_footnote(app):
     ) in result
     assert '\\chapter{The section with a reference to {[}AuthorYear{]}}' in result
     assert (
-        '\\sphinxcaption{The table title with a reference'
-        ' to {[}AuthorYear{]}}' in result
-    )
+        '\\sphinxcaption{The table title with a reference to {[}AuthorYear{]}}'
+    ) in result
     assert (
         '\\subsubsection*{The rubric title with a reference to {[}AuthorYear{]}}'
-        in result
-    )
+    ) in result
     assert (
         '\\chapter{The section with a reference to \\sphinxfootnotemark[6]}\n'
         '\\label{\\detokenize{index:the-section-with-a-reference-to}}'

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -1024,7 +1024,7 @@ def test_reference_in_caption_and_codeblock_in_footnote(app):
         '\\begin{footnote}[12]\\sphinxAtStartFootnote\n'
         'Third footnote in longtable\n'
     ) in result
-    assert ('\\end{sphinxVerbatim}\n%\n\\end{footnote}.\n') in result
+    assert '\\end{sphinxVerbatim}\n%\n\\end{footnote}.\n' in result
     assert '\\begin{sphinxVerbatim}[commandchars=\\\\\\{\\}]' in result
 
 

--- a/tests/test_directives/test_directive_code.py
+++ b/tests/test_directives/test_directive_code.py
@@ -333,7 +333,7 @@ def test_code_block_namedlink_latex(app):
     )
     link1 = (
         '\\hyperref[\\detokenize{caption:name-test-rb}]'
-        '{\\sphinxcrossref{\\DUrole{std,std-ref}{Ruby}}'
+        '{\\sphinxcrossref{\\DUrole{std}{\\DUrole{std-ref}{Ruby}}}}'
     )
     label2 = (
         '\\def\\sphinxLiteralBlockLabel'
@@ -341,7 +341,7 @@ def test_code_block_namedlink_latex(app):
     )
     link2 = (
         '\\hyperref[\\detokenize{namedblocks:some-ruby-code}]'
-        '{\\sphinxcrossref{\\DUrole{std,std-ref}{the ruby code}}}'
+        '{\\sphinxcrossref{\\DUrole{std}{\\DUrole{std-ref}{the ruby code}}}}'
     )
     assert label1 in latex
     assert link1 in latex
@@ -472,7 +472,7 @@ def test_literalinclude_namedlink_latex(app):
     )
     link1 = (
         '\\hyperref[\\detokenize{caption:name-test-py}]'
-        '{\\sphinxcrossref{\\DUrole{std,std-ref}{Python}}'
+        '{\\sphinxcrossref{\\DUrole{std}{\\DUrole{std-ref}{Python}}}}'
     )
     label2 = (
         '\\def\\sphinxLiteralBlockLabel'
@@ -480,7 +480,7 @@ def test_literalinclude_namedlink_latex(app):
     )
     link2 = (
         '\\hyperref[\\detokenize{namedblocks:some-python-code}]'
-        '{\\sphinxcrossref{\\DUrole{std,std-ref}{the python code}}}'
+        '{\\sphinxcrossref{\\DUrole{std}{\\DUrole{std-ref}{the python code}}}}'
     )
     assert label1 in latex
     assert link1 in latex


### PR DESCRIPTION
Fix #12744


### Relates
- #3207.  It could have been opportunity then to use nested mark-up in output.  I did not check probably using comma separated classes was there since origin.  It may have evolved in Docutils after Sphinx had inherited it.

This may be in all rigor breaking but I doubt very much people have customized LaTeX via `\DUrole` for simultaneous classes (the PR changes nothing when there is only one class) and anyhow it was never documented as possible so far.

EDIT: *when I say "breaking" I only mean by that that if someone for example has defined via `\@namedef` a LaTeX command `\DUrolestd,std-ref` (where both comma and hyphen are part of the name) then this styling command will not be executed anymore as now only `\DUrolestd` and `\DUrolestd-ref` will be (if and only if they exist). The PDF build will not be broken in any way.  And anyhow I would be very surprised someone has actually done that!*.

I rebased on tip of master now that master passes tests.