### PR TITLE
Tell users when a template causes build invalidation

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -390,9 +390,9 @@ class StandaloneHTMLBuilder(Builder):
                 return None
 
     def get_outdated_docs(self) -> Iterator[str]:
-        old_info = path.join(self.outdir, '.buildinfo')
+        build_info_fname = path.join(self.outdir, '.buildinfo')
         try:
-            with open(old_info, encoding="utf-8") as fp:
+            with open(build_info_fname, encoding="utf-8") as fp:
                 buildinfo = BuildInfo.load(fp)
 
             if self.build_info != buildinfo:
@@ -408,7 +408,7 @@ class StandaloneHTMLBuilder(Builder):
         if self.templates:
             template_mtime = int(self.templates.newest_template_mtime() * 10**6)
             try:
-                old_mtime = _last_modified_time(old_info)
+                old_mtime = _last_modified_time(build_info_fname)
             except Exception:
                 pass
             else:

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -390,7 +390,7 @@ class StandaloneHTMLBuilder(Builder):
                 return None
 
     def get_outdated_docs(self) -> Iterator[str]:
-        build_info_fname = path.join(self.outdir, '.buildinfo')
+        build_info_fname = self.outdir / '.buildinfo'
         try:
             with open(build_info_fname, encoding="utf-8") as fp:
                 buildinfo = BuildInfo.load(fp)
@@ -417,12 +417,10 @@ class StandaloneHTMLBuilder(Builder):
                     logger.info(
                         bold("building [html]: ") +
                         __(
-                            "template %s is newer (%s) than previous build info (%s), "
-                            "all docs will be out of date"
+                            "template %s has been changed since the previous build, "
+                            "all docs will be rebuilt"
                         ),
                         self.templates.newest_template_name(),
-                        _format_rfc3339_microseconds(template_mtime),
-                        _format_rfc3339_microseconds(old_mtime),
                     )
         else:
             template_mtime = 0

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -40,6 +40,7 @@ from sphinx.search import js_index
 from sphinx.theming import HTMLThemeFactory
 from sphinx.util import isurl, logging
 from sphinx.util._timestamps import _format_rfc3339_microseconds
+from sphinx.util.console import bold
 from sphinx.util.display import progress_message, status_iterator
 from sphinx.util.docutils import new_document
 from sphinx.util.fileutil import copy_asset
@@ -405,6 +406,23 @@ class StandaloneHTMLBuilder(Builder):
 
         if self.templates:
             template_mtime = int(self.templates.newest_template_mtime() * 10**6)
+            try:
+                old_mtime = _last_modified_time(old_info)
+            except Exception:
+                pass
+            else:
+                # Let users know they have a newer template
+                if template_mtime > old_mtime:
+                    logger.info(
+                        bold("building [html]: ") +
+                        __(
+                            "template %s is newer (%s) than previous build info (%s), "
+                            "all docs will be out of date"
+                        ),
+                        self.templates.newest_template_name(),
+                        _format_rfc3339_microseconds(template_mtime),
+                        _format_rfc3339_microseconds(old_mtime),
+                    )
         else:
             template_mtime = 0
         for docname in self.env.found_docs:

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -390,8 +390,9 @@ class StandaloneHTMLBuilder(Builder):
                 return None
 
     def get_outdated_docs(self) -> Iterator[str]:
+        old_info = path.join(self.outdir, '.buildinfo')
         try:
-            with open(path.join(self.outdir, '.buildinfo'), encoding="utf-8") as fp:
+            with open(old_info, encoding="utf-8") as fp:
                 buildinfo = BuildInfo.load(fp)
 
             if self.build_info != buildinfo:

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -204,8 +204,14 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
         return self.environment.from_string(source).render(context)
 
     def newest_template_mtime(self) -> float:
+        return self._newest_template_mtime_name()[0]
+
+    def newest_template_name(self) -> str:
+        return self._newest_template_mtime_name()[1]
+
+    def _newest_template_mtime_name(self) -> tuple[float, str]:
         return max(
-            os.stat(os.path.join(root, sfile)).st_mtime_ns / 10**9
+            (os.stat(os.path.join(root, sfile)).st_mtime_ns / 10**9, sfile)
             for dirname in self.pathchain
             for root, _dirs, files in os.walk(dirname)
             for sfile in files


### PR DESCRIPTION
Subject: Adding info about what template is problematic when rebuilds happen.

### Feature or Bugfix
- Feature

### Purpose

I was generating a template on the fly which was causing everything to be out of date. So I added a logging message for that:
```
building [html]: template avatars.html is newer (2024-08-06 20:36:50.84) than previous build info (2024-08-06 20:17:22.360), all docs will be out of date
```
allowing me to easily see that the avatars.html that we generate at the start of each doc build should more carefully be updated (or perhaps not be a template file actually!).

### Relates

Broken away for simplicity from https://github.com/sphinx-doc/sphinx/pull/12741 as suggested by @AA-Turner .