### PR TITLE
Insert missed space character between version string and Chinese text.

### DIFF
--- a/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.js
+++ b/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.js
@@ -12,7 +12,7 @@ Documentation.addTranslations({
         "Complete Table of Contents": "\u5b8c\u6574\u76ee\u5f55",
         "Contents": "\u76ee\u5f55",
         "Copyright": "\u7248\u6743\u6240\u6709",
-        "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> %(sphinx_version)s.": "\u7531 <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> %(sphinx_version)s\u521b\u5efa\u3002",
+        "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> %(sphinx_version)s.": "\u7531 <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> %(sphinx_version)s \u521b\u5efa\u3002",
         "Expand sidebar": "\u5c55\u5f00\u8fb9\u680f",
         "Full index on one page": "\u5355\u9875\u5168\u7d22\u5f15",
         "General Index": "\u603b\u7d22\u5f15",


### PR DESCRIPTION
Subject: Insert missed space character

### Feature or Bugfix
Bugfix

### Purpose
In Chinese template, insert a missed a space character

### Detail
Current output: `由 [Sphinx](https://www.sphinx-doc.org/) 8.0.2创建`.
Expect output: `由 [Sphinx](https://www.sphinx-doc.org/) 8.0.2 创建。`

### Relates
No