### PR TITLE
Fix the type annotation for ``sphinx.testing.fixtures.rootdir``

### DIFF
--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from collections import namedtuple
 from io import StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from collections import namedtuple
 from io import StringIO
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -42,7 +43,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 @pytest.fixture(scope='session')
-def rootdir() -> str | None:
+def rootdir() -> Path | None:
     return None
 
 
@@ -74,7 +75,7 @@ def app_params(
     test_params: dict[str, Any],
     shared_result: SharedResult,
     sphinx_test_tempdir: str,
-    rootdir: str,
+    rootdir: Path,
 ) -> _app_params:
     """
     Parameters that are specified by 'pytest.mark.sphinx' for


### PR DESCRIPTION
Subject: Tweak `rootdir` fixture's type hint

### Feature or Bugfix
<!-- please choose -->
<!-- - Feature -->
<!-- - Bugfix -->
- Refactoring

### Purpose

https://www.sphinx-doc.org/en/master/extdev/testing.html#usage
>If you want to know more detailed usage, please refer to tests/conftest.py` and other test_*.py files under the tests/ directory.

In `tests/conftest.py`, I noticed that `rootdir` returns `pathlib.Path` instead of `str`.

https://github.com/sphinx-doc/sphinx/blob/043750e406d8fe03953f5b565b36e05aef6866ec/tests/conftest.py#L43-L45

`rootdir` in `sphinx/testing/fixture.py` is type-hinted as returning `str`

https://github.com/sphinx-doc/sphinx/blob/043750e406d8fe03953f5b565b36e05aef6866ec/sphinx/testing/fixtures.py#L44-L46

but `rootdir` is treated as `pathlib.Path` in `app_params` fixture.

https://github.com/sphinx-doc/sphinx/blob/043750e406d8fe03953f5b565b36e05aef6866ec/sphinx/testing/fixtures.py#L110-L112

* `pathlib.Path` / `str`: works!
* `str` / `str`: not work

### Detail
(See Purpose. That's all)

### Relates
- N/A
