### PR TITLE
[docs] Remove redundant backquote

### DIFF
--- a/doc/extdev/testing.rst
+++ b/doc/extdev/testing.rst
@@ -28,5 +28,5 @@ Usage
 -----
 
 If you want to know more detailed usage,
-please refer to :file:`tests/conftest.py`` and other :file:`test_*.py` files
+please refer to :file:`tests/conftest.py` and other :file:`test_*.py` files
 under the :file:`tests/` directory.


### PR DESCRIPTION
Subject: Fix typo in Testing API document

### Feature or Bugfix
- Bugfix

### Purpose
I noticed ` in the page,
https://www.sphinx-doc.org/en/master/extdev/testing.html#usage
<img width="811" alt="image" src="https://github.com/user-attachments/assets/e8f46ea9-3d16-466a-92e1-377c59063e05">

so send this pull request to fix this typo

### Detail
- (See Purpose)

### Relates
- N/A

