### PR TITLE
Short-circuit HTTP requests in tests

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -248,7 +248,7 @@ class BuildEnvironment:
         self.dlfiles: DownloadFiles = DownloadFiles()
 
         # the original URI for images
-        self.original_image_uri: dict[str, str] = {}
+        self.original_image_uri: dict[_StrPath, str] = {}
 
         # temporary data storage while reading a document
         self.temp_data: dict[str, Any] = {}

--- a/sphinx/environment/adapters/asset.py
+++ b/sphinx/environment/adapters/asset.py
@@ -1,6 +1,7 @@
 """Assets adapter for sphinx.environment."""
 
 from sphinx.environment import BuildEnvironment
+from sphinx.util._pathlib import _StrPath
 
 
 class ImageAdapter:
@@ -9,7 +10,7 @@ class ImageAdapter:
 
     def get_original_image_uri(self, name: str) -> str:
         """Get the original image URI."""
-        while name in self.env.original_image_uri:
-            name = self.env.original_image_uri[name]
+        while _StrPath(name) in self.env.original_image_uri:
+            name = self.env.original_image_uri[_StrPath(name)]
 
         return name

--- a/sphinx/transforms/post_transforms/images.py
+++ b/sphinx/transforms/post_transforms/images.py
@@ -6,6 +6,7 @@ import os
 import re
 from hashlib import sha1
 from math import ceil
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from docutils import nodes
@@ -13,6 +14,7 @@ from docutils import nodes
 from sphinx.locale import __
 from sphinx.transforms import SphinxTransform
 from sphinx.util import logging, requests
+from sphinx.util._pathlib import _StrPath
 from sphinx.util.http_date import epoch_to_rfc1123, rfc1123_to_epoch
 from sphinx.util.images import get_image_extension, guess_mimetype, parse_data_uri
 from sphinx.util.osutil import ensuredir
@@ -65,50 +67,57 @@ class ImageDownloader(BaseImageConverter):
             basename = CRITICAL_PATH_CHAR_RE.sub("_", basename)
 
             uri_hash = sha1(node['uri'].encode(), usedforsecurity=False).hexdigest()
-            ensuredir(os.path.join(self.imagedir, uri_hash))
-            path = os.path.join(self.imagedir, uri_hash, basename)
+            path = Path(self.imagedir, uri_hash, basename)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._download_image(node, path)
 
-            headers = {}
-            if os.path.exists(path):
-                timestamp: float = ceil(os.stat(path).st_mtime)
-                headers['If-Modified-Since'] = epoch_to_rfc1123(timestamp)
-
-            config = self.app.config
-            r = requests.get(
-                node['uri'], headers=headers,
-                _user_agent=config.user_agent,
-                _tls_info=(config.tls_verify, config.tls_cacerts),
-            )
-            if r.status_code >= 400:
-                logger.warning(__('Could not fetch remote image: %s [%d]'),
-                               node['uri'], r.status_code)
-            else:
-                self.app.env.original_image_uri[path] = node['uri']
-
-                if r.status_code == 200:
-                    with open(path, 'wb') as f:
-                        f.write(r.content)
-
-                last_modified = r.headers.get('last-modified')
-                if last_modified:
-                    timestamp = rfc1123_to_epoch(last_modified)
-                    os.utime(path, (timestamp, timestamp))
-
-                mimetype = guess_mimetype(path, default='*')
-                if mimetype != '*' and os.path.splitext(basename)[1] == '':
-                    # append a suffix if URI does not contain suffix
-                    ext = get_image_extension(mimetype)
-                    newpath = os.path.join(self.imagedir, uri_hash, basename + ext)
-                    os.replace(path, newpath)
-                    self.app.env.original_image_uri.pop(path)
-                    self.app.env.original_image_uri[newpath] = node['uri']
-                    path = newpath
-                node['candidates'].pop('?')
-                node['candidates'][mimetype] = path
-                node['uri'] = path
-                self.app.env.images.add_file(self.env.docname, path)
         except Exception as exc:
-            logger.warning(__('Could not fetch remote image: %s [%s]'), node['uri'], exc)
+            msg = __('Could not fetch remote image: %s [%s]')
+            logger.warning(msg, node['uri'], exc)
+
+    def _download_image(self, node: nodes.image, path: Path) -> None:
+        headers = {}
+        if os.path.exists(path):
+            timestamp: float = ceil(os.stat(path).st_mtime)
+            headers['If-Modified-Since'] = epoch_to_rfc1123(timestamp)
+
+        config = self.app.config
+        r = requests.get(
+            node['uri'], headers=headers,
+            _user_agent=config.user_agent,
+            _tls_info=(config.tls_verify, config.tls_cacerts),
+        )
+        if r.status_code >= 400:
+            msg = __('Could not fetch remote image: %s [%d]')
+            logger.warning(msg, node['uri'], r.status_code)
+        else:
+            self.app.env.original_image_uri[path] = node['uri']
+
+            if r.status_code == 200:
+                path.write_bytes(r.content)
+            if last_modified := r.headers.get('Last-Modified'):
+                timestamp = rfc1123_to_epoch(last_modified)
+                os.utime(path, (timestamp, timestamp))
+
+            self._process_image(node, path)
+
+    def _process_image(self, node: nodes.image, path: Path) -> None:
+        self.app.env.original_image_uri[_StrPath(path)] = node['uri']
+
+        mimetype = guess_mimetype(path, default='*')
+        if mimetype != '*' and path.suffix == '':
+            # append a suffix if URI does not contain suffix
+            ext = get_image_extension(mimetype)
+            with_ext = path.with_name(path.name + ext)
+            os.replace(path, with_ext)
+            self.app.env.original_image_uri.pop(path)
+            self.app.env.original_image_uri[_StrPath(with_ext)] = node['uri']
+            path = with_ext
+        str_path = str(path)
+        node['candidates'].pop('?')
+        node['candidates'][mimetype] = str_path
+        node['uri'] = str_path
+        self.app.env.images.add_file(self.env.docname, str_path)
 
 
 class DataURIExtractor(BaseImageConverter):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,11 +44,7 @@ os.environ['SPHINX_AUTODOC_RELOAD_MODULES'] = '1'
 
 @pytest.fixture(scope='session')
 def rootdir() -> Path:
-    roots = Path(__file__).parent.resolve() / 'roots'
-    all_files = set(roots.rglob('*'))
-    yield roots
-    added_files = set(roots.rglob('*')) - all_files
-    Path('added_files.txt').write_text('\n'.join(str(f) for f in added_files))
+    return Path(__file__).parent.resolve() / 'roots'
 
 
 def pytest_report_header(config: pytest.Config) -> str:

--- a/tests/test_builders/test_build.py
+++ b/tests/test_builders/test_build.py
@@ -100,6 +100,7 @@ def test_numbered_circular_toctree(app):
     ) in warnings
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx('dummy', testroot='images')
 def test_image_glob(app):
     app.build(force_all=True)

--- a/tests/test_builders/test_build_epub.py
+++ b/tests/test_builders/test_build_epub.py
@@ -473,6 +473,7 @@ def test_xml_name_pattern_check():
     assert not _XML_NAME_PATTERN.match('1bfda21')
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx('epub', testroot='images')
 def test_copy_images(app):
     app.build()

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -266,6 +266,7 @@ def test_html_inventory(app):
     )
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx(
     'html',
     testroot='images',

--- a/tests/test_builders/test_build_html_image.py
+++ b/tests/test_builders/test_build_html_image.py
@@ -5,6 +5,7 @@ import docutils
 import pytest
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx('html', testroot='images')
 def test_html_remote_images(app):
     app.build(force_all=True)
@@ -77,6 +78,7 @@ def test_html_scaled_image_link(app):
     )
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx('html', testroot='images')
 def test_copy_images(app):
     app.build()

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -2157,6 +2157,7 @@ def test_latex_code_role(app):
     ) in content
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx('latex', testroot='images')
 def test_copy_images(app):
     app.build()

--- a/tests/test_builders/test_build_texinfo.py
+++ b/tests/test_builders/test_build_texinfo.py
@@ -131,6 +131,7 @@ def test_texinfo_samp_with_variable(app):
     assert '@code{Show @var{variable} in the middle}' in output
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx('texinfo', testroot='images')
 def test_copy_images(app):
     app.build()

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -288,6 +288,7 @@ def test_mathjax_numsep_html(app):
     assert html in content
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx(
     'html',
     testroot='ext-math',

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -1705,6 +1705,7 @@ SUBSTITUTED IMAGE [image: SUBST_EPILOG_2 TRANSLATED][image] HERE.
     )
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx(
     'dummy',
     testroot='images',
@@ -1782,6 +1783,7 @@ def test_image_glob_intl(app):
     )
 
 
+@pytest.mark.usefixtures('_http_teapot')
 @pytest.mark.sphinx(
     'dummy',
     testroot='images',


### PR DESCRIPTION
Windows takes too long to fail on invalid connections to localhost -- ``test_copy_images`` for the epub builder was taking 30 seconds alone.

A