### PR TITLE
i18n: restore relative path output by babel runner

### DIFF
--- a/utils/babel_runner.py
+++ b/utils/babel_runner.py
@@ -111,7 +111,7 @@ def run_extract() -> None:
                     catalogue.add(
                         message,
                         None,
-                        [(str(filename), lineno)],
+                        [(str(relative_name), lineno)],
                         auto_comments=comments,
                         context=context,
                     )


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix/Refactoring

### Purpose
- This makes it slightly easier to compare diffs between localization resources when running the `babel_runner.py` script on different hosts.

### Detail
- Use the relative instead of absolute file path when producing the output translation catalog.

### Relates
- Relates to #12666.

cc @AA-Turner (nitpicky fixup)