### PR TITLE
LaTeX: Lift a potential limitation of \sphinxincludegraphics

### DIFF
--- a/sphinx/texinputs/sphinxlatexgraphics.sty
+++ b/sphinx/texinputs/sphinxlatexgraphics.sty
@@ -1,7 +1,7 @@
 %% GRAPHICS
 %
 % change this info string if making any custom modification
-\ProvidesPackage{sphinxlatexgraphics}[2021/01/27 graphics]
+\ProvidesPackage{sphinxlatexgraphics}[2024/08/13 v8.1.0 graphics]
 
 % Provides support for this output mark-up from Sphinx latex writer:
 %
@@ -84,7 +84,8 @@
     \ifin@
       \setbox\spx@image@box
       \hbox{\includegraphics
-            [%#1,% contained only width and/or height and overruled anyhow
+            [#1,% contains only width and/or height which are overruled next
+                % but in future may contain page=N hence must be kept
             width=\spx@image@requiredwidth,height=\spx@image@requiredheight]%
             {#2}}%
       % \includegraphics does not set box dimensions to the exactly


### PR DESCRIPTION
Subject: lift a potential limitation of `\sphinxincludegraphics`. 

`\sphinxincludegraphics` automatically rescales images which are too large (either width or height) to fit on the page.  When it has to change required width and/or height it drops the original options as they get overruled.


### Feature or Bugfix
- Refactoring

### Purpose

But this potentially renders impossible to use `\sphinxincludegraphics` with `page=N` option of `\includegraphics` as the  `page` option gets lost if the image is too large to be included with the requireed dimensions.  This `page=N` is a valid option when including a PDF file.  There is currently no Sphinx interface for this kind of things, but may be in future.

### Detail

It is only a single line change to not comment out the original options.

I have encountered this problem in on-going work on a project using Sphinx, the [French FAQ for LaTeX](https://faq.gutenberg-asso.fr/index.html).  The Sphinx PDF documentation compiles 850+ LaTeX samples and auto-includes them. Some examples produce multi-page output and to include all pages we need `page=N` option of `\includegraphcis` to work with `\sphinxincludegraphics` even if included pages have to be rescaled.
