### PR TITLE
Add per-event overloads to ``Sphinx.connect()``

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -186,13 +186,15 @@ nitpick_ignore = {
     ('js:func', 'number'),
     ('js:func', 'string'),
     ('py:attr', 'srcline'),
+    ('py:class', '_ConfigRebuild'),  # sphinx.application.Sphinx.add_config_value
     ('py:class', '_StrPath'),  # sphinx.environment.BuildEnvironment.doc2path
     ('py:class', 'Element'),  # sphinx.domains.Domain
-    ('py:class', 'TextElement'),
     ('py:class', 'Documenter'),  # sphinx.application.Sphinx.add_autodocumenter
     ('py:class', 'IndexEntry'),  # sphinx.domains.IndexEntry
+    ('py:class', 'Lexer'),  # sphinx.application.Sphinx.add_lexer
     ('py:class', 'Node'),  # sphinx.domains.Domain
     ('py:class', 'NullTranslations'),  # gettext.NullTranslations
+    ('py:class', 'Path'),  # sphinx.application.Sphinx.connect
     ('py:class', 'RoleFunction'),  # sphinx.domains.Domain
     ('py:class', 'RSTState'),  # sphinx.utils.parsing.nested_parse_to_nodes
     ('py:class', 'Theme'),  # sphinx.application.TemplateBridge
@@ -200,6 +202,8 @@ nitpick_ignore = {
     ('py:class', 'StringList'),  # sphinx.utils.parsing.nested_parse_to_nodes
     ('py:class', 'system_message'),  # sphinx.utils.docutils.SphinxDirective
     ('py:class', 'TitleGetter'),  # sphinx.domains.Domain
+    ('py:class', 'todo_node'),  # sphinx.application.Sphinx.connect
+    ('py:class', 'Transform'),  # sphinx.application.Sphinx.add_transform
     ('py:class', 'XRefRole'),  # sphinx.domains.Domain
     ('py:class', 'docutils.nodes.Element'),
     ('py:class', 'docutils.nodes.Node'),
@@ -211,6 +215,7 @@ nitpick_ignore = {
     ('py:class', 'docutils.parsers.rst.states.Inliner'),
     ('py:class', 'docutils.transforms.Transform'),
     ('py:class', 'nodes.NodeVisitor'),
+    ('py:class', 'nodes.TextElement'),  # sphinx.application.Sphinx.connect
     ('py:class', 'nodes.document'),
     ('py:class', 'nodes.reference'),
     ('py:class', 'pygments.lexer.Lexer'),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -188,6 +188,7 @@ nitpick_ignore = {
     ('py:attr', 'srcline'),
     ('py:class', '_StrPath'),  # sphinx.environment.BuildEnvironment.doc2path
     ('py:class', 'Element'),  # sphinx.domains.Domain
+    ('py:class', 'TextElement'),
     ('py:class', 'Documenter'),  # sphinx.application.Sphinx.add_autodocumenter
     ('py:class', 'IndexEntry'),  # sphinx.domains.IndexEntry
     ('py:class', 'Node'),  # sphinx.domains.Domain

--- a/doc/extdev/event_callbacks.rst
+++ b/doc/extdev/event_callbacks.rst
@@ -107,9 +107,9 @@ Here is a more detailed list of these events.
 
    :param app: :class:`.Sphinx`
    :param env: :class:`.BuildEnvironment`
-   :param added: ``set[str]``
-   :param changed: ``set[str]``
-   :param removed: ``set[str]``
+   :param added: ``Set[str]``
+   :param changed: ``Set[str]``
+   :param removed: ``Set[str]``
    :returns: ``Sequence[str]`` of additional docnames to re-read
 
    Emitted when the environment determines which source files have changed and

--- a/doc/extdev/event_callbacks.rst
+++ b/doc/extdev/event_callbacks.rst
@@ -110,7 +110,7 @@ Here is a more detailed list of these events.
    :param added: ``set[str]``
    :param changed: ``set[str]``
    :param removed: ``set[str]``
-   :returns: ``list[str]`` of additional docnames to re-read
+   :returns: ``Sequence[str]`` of additional docnames to re-read
 
    Emitted when the environment determines which source files have changed and
    should be re-read.

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -13,9 +13,10 @@ from collections import deque
 from collections.abc import Callable, Collection, Sequence  # NoQA: TCH003
 from io import StringIO
 from os import path
+from pathlib import Path  # NoQA: TCH003
 from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
-from docutils.nodes import TextElement  # NoQA: TCH002
+from docutils.nodes import TextElement, document  # NoQA: TCH002
 from docutils.parsers.rst import Directive, roles
 from docutils.transforms import Transform  # NoQA: TCH002
 from pygments.lexer import Lexer  # NoQA: TCH002
@@ -42,11 +43,10 @@ from sphinx.util.tags import Tags
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pathlib import Path
     from typing import Final
 
     from docutils import nodes
-    from docutils.nodes import Element, Node, document
+    from docutils.nodes import Element, Node
     from docutils.parsers import Parser
 
     from sphinx.addnodes import pending_xref

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -13,7 +13,7 @@ from collections import deque
 from collections.abc import Callable, Collection, Sequence  # NoQA: TCH003
 from io import StringIO
 from os import path
-from typing import IO, TYPE_CHECKING, Any, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
 from docutils.nodes import TextElement  # NoQA: TCH002
 from docutils.parsers.rst import Directive, roles
@@ -41,12 +41,15 @@ from sphinx.util.osutil import ensuredir, relpath
 from sphinx.util.tags import Tags
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
     from typing import Final
 
     from docutils import nodes
-    from docutils.nodes import Element, Node
+    from docutils.nodes import Element, Node, document
     from docutils.parsers import Parser
 
+    from sphinx.addnodes import pending_xref
     from sphinx.builders import Builder
     from sphinx.domains import Domain, Index
     from sphinx.environment.collectors import EnvironmentCollector
@@ -455,6 +458,103 @@ class Sphinx:
         if (major, minor) > sphinx.version_info[:2]:
             req = f'{major}.{minor}'
             raise VersionRequirementError(req)
+
+    @overload
+    def connect(self, event: Literal['config-inited'],  # NoQA: E704
+                callback: Callable[[Sphinx, Config], None], priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['builder-inited'],  # NoQA: E704
+                callback: Callable[[Sphinx], None], priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-get-outdated'],  # NoQA: E704
+                callback: Callable[
+                    [Sphinx, BuildEnvironment, set[str], set[str], set[str]],
+                    list[str]],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-before-read-docs'],  # NoQA: E704
+                callback: Callable[[Sphinx, BuildEnvironment, list[str]], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-purge-doc'],  # NoQA: E704
+                callback: Callable[[Sphinx, BuildEnvironment, str], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['source-read'],  # NoQA: E704
+                callback: Callable[[Sphinx, str, list[str]], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['include-read'],  # NoQA: E704
+                callback: Callable[[Sphinx, Path, str, list[str]], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['doctree-read'],  # NoQA: E704
+                callback: Callable[[Sphinx, document], None], priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-merge-info'],  # NoQA: E704
+                callback: Callable[
+                    [Sphinx, BuildEnvironment, list[str], BuildEnvironment],
+                    None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-updated'],  # NoQA: E704
+                callback: Callable[[Sphinx, BuildEnvironment], str],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-get-updated'],  # NoQA: E704
+                callback: Callable[[Sphinx, BuildEnvironment], Iterable[str]],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['env-check-consistency'],  # NoQA: E704
+                callback: Callable[[Sphinx, BuildEnvironment], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['write-started'],  # NoQA: E704
+                callback: Callable[[Sphinx, Builder], None], priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['doctree-resolved'],  # NoQA: E704
+                callback: Callable[[Sphinx, document, str], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['missing-reference'],  # NoQA: E704
+                callback: Callable[
+                    [Sphinx, BuildEnvironment, pending_xref, TextElement],
+                    nodes.reference | None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['warn-missing-reference'],  # NoQA: E704
+                callback: Callable[[Sphinx, Domain, pending_xref], bool | None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['build-finished'],  # NoQA: E704
+                callback: Callable[[Sphinx, Exception | None], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: Literal['autodoc-before-process-signature'],  # NoQA: E704
+                callback: Callable[[Sphinx, Any, bool], None],
+                priority: int = 500) -> int: ...
+
+    @overload
+    def connect(self, event: str,
+                callback: Callable[..., Any],
+                priority: int = 500) -> int: ...
 
     # event interface
     def connect(self, event: str, callback: Callable, priority: int = 500) -> int:

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from docutils.transforms import Transform
     from pygments.lexer import Lexer
 
-    from sphinx.addnodes import pending_xref
+    from sphinx import addnodes
     from sphinx.builders import Builder
     from sphinx.domains import Domain, Index
     from sphinx.environment.collectors import EnvironmentCollector
@@ -483,6 +483,7 @@ class Sphinx:
         self,
         event: Literal['env-get-outdated'],
         callback: Callable[
+            # do we want to allow users to mutate (added, changed, removed)?
             [Sphinx, BuildEnvironment, Set[str], Set[str], Set[str]], Sequence[str]
         ],
         priority: int = 500
@@ -530,7 +531,7 @@ class Sphinx:
         self,
         event: Literal['doctree-read'],
         callback: Callable[[Sphinx, nodes.document], None],
-    priority: int = 500
+        priority: int = 500
     ) -> int:
         ...
 
@@ -595,7 +596,7 @@ class Sphinx:
         self,
         event: Literal['missing-reference'],
         callback: Callable[
-            [Sphinx, BuildEnvironment, pending_xref, nodes.TextElement],
+            [Sphinx, BuildEnvironment, addnodes.pending_xref, nodes.TextElement],
             nodes.reference | None,
         ],
         priority: int = 500
@@ -606,7 +607,7 @@ class Sphinx:
     def connect(
         self,
         event: Literal['warn-missing-reference'],
-        callback: Callable[[Sphinx, Domain, pending_xref], bool | None],
+        callback: Callable[[Sphinx, Domain, addnodes.pending_xref], bool | None],
         priority: int = 500
     ) -> int:
         ...
@@ -657,7 +658,7 @@ class Sphinx:
     def connect(
         self,
         event: Literal['object-description-transform'],
-        callback: Callable[[Sphinx, str, str, nodes.desc_content], None],
+        callback: Callable[[Sphinx, str, str, addnodes.desc_content], None],
         priority: int = 500
     ) -> int:
         ...
@@ -676,8 +677,8 @@ class Sphinx:
                 Any,
                 dict[str, bool],
                 Sequence[str],
-             ],
-            None
+            ],
+            None,
         ],
         priority: int = 500
     ) -> int:
@@ -755,7 +756,7 @@ class Sphinx:
         event: Literal['viewcode-find-source'],
         callback: Callable[
             [Sphinx, str],
-            tuple[str, dict[str, tuple[str, int, int]]],
+            tuple[str, dict[str, tuple[Literal['class', 'def', 'other'], int, int]]],
         ],
         priority: int = 500,
     ) -> int:

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -16,7 +16,6 @@ from os import path
 from pathlib import Path  # NoQA: TCH003
 from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
-import docutils.nodes
 from docutils.nodes import TextElement, document  # NoQA: TCH002
 from docutils.parsers.rst import Directive, roles
 from docutils.transforms import Transform  # NoQA: TCH002
@@ -533,7 +532,7 @@ class Sphinx:
     @overload
     def connect(self, event: Literal['missing-reference'],  # NoQA: E704
                 callback: Callable[
-                    [Sphinx, BuildEnvironment, pending_xref, docutils.nodes.TextElement],
+                    [Sphinx, BuildEnvironment, pending_xref, TextElement],
                     nodes.reference | None],
                 priority: int = 500) -> int: ...
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -552,7 +552,7 @@ class Sphinx:
                 priority: int = 500) -> int: ...
 
     @overload
-    def connect(self, event: str,
+    def connect(self, event: str,  # NoQA: E704
                 callback: Callable[..., Any],
                 priority: int = 500) -> int: ...
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -483,7 +483,6 @@ class Sphinx:
         self,
         event: Literal['env-get-outdated'],
         callback: Callable[
-            # do we want to allow users to mutate (added, changed, removed)?
             [Sphinx, BuildEnvironment, Set[str], Set[str], Set[str]], Sequence[str]
         ],
         priority: int = 500

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -16,6 +16,7 @@ from os import path
 from pathlib import Path  # NoQA: TCH003
 from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
+import docutils.nodes
 from docutils.nodes import TextElement, document  # NoQA: TCH002
 from docutils.parsers.rst import Directive, roles
 from docutils.transforms import Transform  # NoQA: TCH002
@@ -532,7 +533,7 @@ class Sphinx:
     @overload
     def connect(self, event: Literal['missing-reference'],  # NoQA: E704
                 callback: Callable[
-                    [Sphinx, BuildEnvironment, pending_xref, TextElement],
+                    [Sphinx, BuildEnvironment, pending_xref, docutils.nodes.TextElement],
                     nodes.reference | None],
                 priority: int = 500) -> int: ...
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -23,7 +23,7 @@ else:
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Collection, Iterator, Sequence, Set
+    from collections.abc import Collection, Iterator, Sequence, Set, Iterable
     from typing import TypeAlias
 
     from sphinx.application import Sphinx
@@ -739,8 +739,8 @@ def check_primary_domain(app: Sphinx, config: Config) -> None:
         config.primary_domain = None
 
 
-def check_root_doc(app: Sphinx, env: BuildEnvironment, added: set[str],
-                   changed: set[str], removed: set[str]) -> set[str]:
+def check_root_doc(app: Sphinx, env: BuildEnvironment, added: Set[str],
+                   changed: Set[str], removed: Set[str]) -> Iterable[str]:
     """Adjust root_doc to 'contents' to support an old project which does not have
     any root_doc setting.
     """

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -23,7 +23,7 @@ else:
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Collection, Iterator, Sequence, Set, Iterable
+    from collections.abc import Collection, Iterable, Iterator, Sequence, Set
     from typing import TypeAlias
 
     from sphinx.application import Sphinx


### PR DESCRIPTION
I aim to remove a `pyright` ignore comment in my source code, needed when pyright's `typeCheckingMode` is set to `"strict"`:

```python

def my_callback(app: Sphinx) -> None:
    pass

app.connect(event="builder-inited", callback=my_callback) # pyright: ignore[reportUnknownMemberType]
```

### Feature or Bugfix

- Feature
