### PR TITLE
Use existing HAS_MULTIPROCESSING variable to avoid potential NameError

### DIFF
--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # our parallel functionality only works for the forking Process
-parallel_available = multiprocessing and os.name == 'posix'
+parallel_available = HAS_MULTIPROCESSING and os.name == 'posix'
 
 
 class SerialTasks:


### PR DESCRIPTION
In the case that HAS_MULTIPROCESSING is False, this would raise an Exception (`NameError`, I believe) as `multiprocessing` was unbound).

From https://docs.python.org/3/library/multiprocessing.html:

```
Availability: not Emscripten, not WASI.
```

### Feature or Bugfix
- Bugfix

---

I found this by running `pyright` against `sphinx/` which told me that `multiprocessing` was potentially unbound.