### PR TITLE
Fix `sphinx.testing.path.path.write_bytes` bytes type

### DIFF
--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -178,7 +178,7 @@ class path(str):
         with open(self, mode='rb') as f:
             return f.read()
 
-    def write_bytes(self, bytes: str, append: bool = False) -> None:
+    def write_bytes(self, bytes: bytes, append: bool = False) -> None:
         """
         Writes the given `bytes` to the file.
 


### PR DESCRIPTION
This function requires `bytes` but was typed as `str`.

Running `pyright sphinx/` highlighted this error.

```
  /Users/adam/Documents/forks/sphinx/sphinx/testing/path.py:193:21 - error: Argument of type "str" cannot be assigned to parameter "buffer" of type "ReadableBuffer" in function "write"
    "str" is incompatible with protocol "Buffer"
      "__buffer__" is not present (reportArgumentType)
```

### Feature or Bugfix
- Bugfix