### PR TITLE
Add type hint for a use of Pytest's tmp_path_factory

### DIFF
--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -239,7 +239,7 @@ def if_graphviz_found(app: SphinxTestApp) -> None:  # NoQA: PT004
 
 
 @pytest.fixture(scope='session')
-def sphinx_test_tempdir(tmp_path_factory: Any) -> Path:
+def sphinx_test_tempdir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Temporary directory."""
     return tmp_path_factory.getbasetemp()
 


### PR DESCRIPTION
This makes the `sphinx_test_tempdir` more type safe.

I found this using `mypy --strict sphinx/`:

```
sphinx/testing/fixtures.py: note: In function "sphinx_test_tempdir":
sphinx/testing/fixtures.py:244:5: error: Returning Any from function declared to return "Path"  [no-any-return]
```


### Feature or Bugfix

- Refactoring