### PR TITLE
Use ``headlessFirefox`` and update to Node 20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,11 +23,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      node-version: "16"
+      node-version: "20"
 
     steps:
     - uses: actions/checkout@v4
@@ -37,5 +40,4 @@ jobs:
         node-version: ${{ env.node-version }}
         cache: "npm"
     - run: npm install
-    - name: Run headless test
-      run: xvfb-run -a npm test
+    - run: npm test

--- a/tests/js/jasmine-browser.mjs
+++ b/tests/js/jasmine-browser.mjs
@@ -23,6 +23,6 @@ export default {
   hostname: "127.0.0.1",
 
   browser: {
-    name: "firefox"
+    name: "headlessFirefox"
   }
 };


### PR DESCRIPTION
I had a very old branch (https://github.com/AA-Turner/sphinx/commit/34090858fd48c7c41e9d559f4739276be09a8720 // https://github.com/AA-Turner/sphinx/commits/use-jasmine/), most of which @jayaddison covered in the recent #12754. This PR takes a few ideas from that branch, such as avoiding `xvfb-run` as we don't need it, and also updates to the latest node LTS.

A