### PR TITLE
Enable parallel reading if requested, even if there are few documents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,10 @@ Bugs fixed
   e.g., ``index.html#foo`` becomes ``#foo``.
   (note: continuation of a partial fix added in Sphinx 7.3.0)
   Patch by James Addison (with reference to prior work by Eric Norige)
+* #12796: Enable parallel reading if requested,
+  even if there are fewer than 6 documents.
+  Patch by Matthias Geier.
+
 
 Testing
 -------

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -428,7 +428,7 @@ class Builder:
         self.events.emit('env-before-read-docs', self.env, docnames)
 
         # check if we should do parallel or serial read
-        if parallel_available and len(docnames) > 1 and self.app.parallel > 1:
+        if parallel_available and self.app.parallel > 1:
             par_ok = self.app.is_parallel_allowed('read')
         else:
             par_ok = False

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -428,7 +428,7 @@ class Builder:
         self.events.emit('env-before-read-docs', self.env, docnames)
 
         # check if we should do parallel or serial read
-        if parallel_available and len(docnames) > 5 and self.app.parallel > 1:
+        if parallel_available and len(docnames) > 1 and self.app.parallel > 1:
             par_ok = self.app.is_parallel_allowed('read')
         else:
             par_ok = False


### PR DESCRIPTION
I would expect that if parallel reading is requested (and possible), that Sphinx actually does parallel reading.

However, it turns out that it doesn't do it if there are fewer than 6 documents.

The limit has been added 10 years ago by @birkenfeld in 1f23a5c369ba58c6ec5ab806e25c63dd615327dd, but I didn't find any motivation for it.

I found this quite confusing when trying to debug this issue: https://github.com/spatialaudio/nbsphinx/issues/801

In many cases this won't be noticed because reading is fast, but in my case (executing Jupyter notebooks with `nbsphinx` in Sphinx's "reading" phase) it often is not fast.

### Feature or Bugfix
- Bugfix