### PR TITLE
intersphinx: fix inventory forward slashes url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,10 @@ Bugs fixed
   e.g., ``index.html#foo`` becomes ``#foo``.
   (note: continuation of a partial fix added in Sphinx 7.3.0)
   Patch by James Addison (with reference to prior work by Eric Norige)
+* #12782: intersphinx: fix double forward slashes when generating the inventory
+  file URL (user-defined base URL of an intersphinx project are left untouched
+  even if they end with double forward slashes).
+  Patch by Bénédikt Tran.
 
 Testing
 -------

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -211,7 +211,10 @@ def _fetch_inventory_group(
 
     for location in project.locations:
         # location is either None or a non-empty string
-        inv = f'{project.target_uri}/{INVENTORY_FILENAME}' if location is None else location
+        if location is None:
+            inv = posixpath.join(project.target_uri, INVENTORY_FILENAME)
+        else:
+            inv = location
 
         # decide whether the inventory must be read: always read local
         # files; remote ones only if the cache time is expired

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -768,3 +768,60 @@ def test_intersphinx_cache_limit(app):
             config=app.config,
             srcdir=app.srcdir,
         )
+
+
+@pytest.mark.sphinx('dummy')
+def test_intersphinx_fetch_inventory_group_url(app):
+    intersphinx_setup(app)
+
+    class InventoryHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200, 'OK')
+            self.end_headers()
+            self.wfile.write(INVENTORY_V2)
+
+        def log_message(*args, **kwargs):
+            # Silenced.
+            pass
+
+    with http_server(InventoryHandler) as server:
+        url1 = f'http://localhost:{server.server_port}'
+        url2 = f'http://localhost:{server.server_port}/'
+
+        app.config.intersphinx_mapping = {
+            '1': (url1, None),
+            '2': (url2, None),
+        }
+        validate_intersphinx_mapping(app, app.config)
+
+        now = int(time.time())
+        kwds = dict(cache={}, now=now, config=app.config, srcdir=app.srcdir)
+        # We need an exception with its 'args' attribute set (see error
+        # handling in sphinx.ext.intersphinx._load._fetch_inventory_group).
+        side_effect = ValueError('')
+
+        project1 = _IntersphinxProject(name='1', target_uri=url1, locations=(url1, None))
+        with mock.patch('sphinx.ext.intersphinx._load._fetch_inventory',
+                        side_effect=side_effect) as mockfn:
+            assert not _fetch_inventory_group(project=project1, **kwds)
+        mockfn.assert_any_call(
+            target_uri=url1, inv_location=url1,
+            config=app.config, srcdir=app.srcdir,
+        )
+        mockfn.assert_any_call(
+            target_uri=url1, inv_location=url1 + '/' + INVENTORY_FILENAME,
+            config=app.config, srcdir=app.srcdir,
+        )
+
+        project2 = _IntersphinxProject(name='2', target_uri=url2, locations=(url2, None))
+        with mock.patch('sphinx.ext.intersphinx._load._fetch_inventory',
+                        side_effect=side_effect) as mockfn:
+            assert not _fetch_inventory_group(project=project2, **kwds)
+        mockfn.assert_any_call(
+            target_uri=url2, inv_location=url2,
+            config=app.config, srcdir=app.srcdir,
+        )
+        mockfn.assert_any_call(
+            target_uri=url2, inv_location=url2 + INVENTORY_FILENAME,
+            config=app.config, srcdir=app.srcdir,
+        )

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -795,7 +795,7 @@ def test_intersphinx_fetch_inventory_group_url(app):
         validate_intersphinx_mapping(app, app.config)
 
         now = int(time.time())
-        kwds = dict(cache={}, now=now, config=app.config, srcdir=app.srcdir)
+        kwds = {'cache': {}, 'now': now, 'config': app.config, 'srcdir': app.srcdir}
         # We need an exception with its 'args' attribute set (see error
         # handling in sphinx.ext.intersphinx._load._fetch_inventory_group).
         side_effect = ValueError('')

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -800,28 +800,42 @@ def test_intersphinx_fetch_inventory_group_url(app):
         # handling in sphinx.ext.intersphinx._load._fetch_inventory_group).
         side_effect = ValueError('')
 
-        project1 = _IntersphinxProject(name='1', target_uri=url1, locations=(url1, None))
-        with mock.patch('sphinx.ext.intersphinx._load._fetch_inventory',
-                        side_effect=side_effect) as mockfn:
+        project1 = _IntersphinxProject(
+            name='1', target_uri=url1, locations=(url1, None)
+        )
+        with mock.patch(
+            'sphinx.ext.intersphinx._load._fetch_inventory', side_effect=side_effect
+        ) as mockfn:
             assert not _fetch_inventory_group(project=project1, **kwds)
         mockfn.assert_any_call(
-            target_uri=url1, inv_location=url1,
-            config=app.config, srcdir=app.srcdir,
+            target_uri=url1,
+            inv_location=url1,
+            config=app.config,
+            srcdir=app.srcdir,
         )
         mockfn.assert_any_call(
-            target_uri=url1, inv_location=url1 + '/' + INVENTORY_FILENAME,
-            config=app.config, srcdir=app.srcdir,
+            target_uri=url1,
+            inv_location=url1 + '/' + INVENTORY_FILENAME,
+            config=app.config,
+            srcdir=app.srcdir,
         )
 
-        project2 = _IntersphinxProject(name='2', target_uri=url2, locations=(url2, None))
-        with mock.patch('sphinx.ext.intersphinx._load._fetch_inventory',
-                        side_effect=side_effect) as mockfn:
+        project2 = _IntersphinxProject(
+            name='2', target_uri=url2, locations=(url2, None)
+        )
+        with mock.patch(
+            'sphinx.ext.intersphinx._load._fetch_inventory', side_effect=side_effect
+        ) as mockfn:
             assert not _fetch_inventory_group(project=project2, **kwds)
         mockfn.assert_any_call(
-            target_uri=url2, inv_location=url2,
-            config=app.config, srcdir=app.srcdir,
+            target_uri=url2,
+            inv_location=url2,
+            config=app.config,
+            srcdir=app.srcdir,
         )
         mockfn.assert_any_call(
-            target_uri=url2, inv_location=url2 + INVENTORY_FILENAME,
-            config=app.config, srcdir=app.srcdir,
+            target_uri=url2,
+            inv_location=url2 + INVENTORY_FILENAME,
+            config=app.config,
+            srcdir=app.srcdir,
         )


### PR DESCRIPTION
This reverts something I incorrectly did when refactoring Intersphinx. By the way, I'm not sure if we should actually normalize the `project.target_uri` value by removing all forward slashes in advance or if we should instead use `urllib` since we are dealing with some remote content.

Fixes #12782.