### PR TITLE
sphinx-autogen doc: Fix :toctree: option ref

### DIFF
--- a/doc/man/sphinx-autogen.rst
+++ b/doc/man/sphinx-autogen.rst
@@ -14,7 +14,7 @@ that, using the :py:mod:`~sphinx.ext.autodoc` extension, document items included
 in :rst:dir:`autosummary` listing(s).
 
 *sourcefile* is the path to one or more reStructuredText documents containing
-:rst:dir:`autosummary` entries with the ``:toctree::`` option set. *sourcefile*
+:rst:dir:`autosummary` entries with the ``:toctree:`` option set. *sourcefile*
 can be an :py:mod:`fnmatch`-style pattern.
 
 Options


### PR DESCRIPTION
Subject: Correct a typo in the `sphinx-autogen` documentation.

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
`:toctree::` isn't a valid option name.

