### PR TITLE
Document sphinx.domains.IndexEntry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ Features added
 * #12743: Add :option:`sphinx-build --exception-on-warning`,
   to raise an exception when warnings are emitted during the build.
   Patch by Adam Turner and Jeremy Maitin-Shepard.
+* #12820: Document :py:class:`sphinx.domains.IndexEntry` in
+  :doc:`/extdev/domainapi`.
+  Patch by Shengyu Zhang.
 
 Bugs fixed
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,9 +43,6 @@ Features added
 * #12743: Add :option:`sphinx-build --exception-on-warning`,
   to raise an exception when warnings are emitted during the build.
   Patch by Adam Turner and Jeremy Maitin-Shepard.
-* #12820: Document :py:class:`sphinx.domains.IndexEntry` in
-  :doc:`/extdev/domainapi`.
-  Patch by Shengyu Zhang.
 
 Bugs fixed
 ----------

--- a/doc/extdev/domainapi.rst
+++ b/doc/extdev/domainapi.rst
@@ -13,6 +13,10 @@ Domain API
 .. autoclass:: Index
    :members:
 
+.. autoclass:: IndexEntry
+   :members:
+   :member-order: bysource
+
 .. module:: sphinx.directives
 
 .. autoclass:: ObjectDescription

--- a/sphinx/domains/_index.py
+++ b/sphinx/domains/_index.py
@@ -14,12 +14,35 @@ if TYPE_CHECKING:
 
 
 class IndexEntry(NamedTuple):
+    """
+    An entry of index.
+
+    .. note::
+
+       Qualifier and description are not rendered for some output formats such
+       as LaTeX.
+    """
+
+    #: The name of the index entry to be displayed.
     name: str
+    #: The sub-entry related type. One of:
+    #:
+    #: ``0``
+    #:   A normal entry.
+    #: ``1``
+    #:   An entry with sub-entries.
+    #: ``2``
+    #:   A sub-entry.
     subtype: int
+    #: *docname* where the entry is located.
     docname: str
+    #: Anchor for the entry within `docname`
     anchor: str
+    #: Extra info for the entry.
     extra: str
+    #: Qualifier for the description.
     qualifier: str
+    #: Description for the entry.
     descr: str
 
 
@@ -75,39 +98,7 @@ class Index(ABC):
         ``content``:
           A sequence of ``(letter, entries)`` tuples, where ``letter`` is the
           "heading" for the given ``entries``, usually the starting letter, and
-          ``entries`` is a sequence of single entries. Each entry is a sequence
-          ``[name, subtype, docname, anchor, extra, qualifier, descr]``. The
-          items in this sequence have the following meaning:
-
-          ``name``
-            The name of the index entry to be displayed.
-
-          ``subtype``
-            The sub-entry related type. One of:
-
-            ``0``
-              A normal entry.
-            ``1``
-              An entry with sub-entries.
-            ``2``
-              A sub-entry.
-
-          ``docname``
-            *docname* where the entry is located.
-
-          ``anchor``
-            Anchor for the entry within ``docname``
-
-          ``extra``
-            Extra info for the entry.
-
-          ``qualifier``
-            Qualifier for the description.
-
-          ``descr``
-            Description for the entry.
-
-        Qualifier and description are not rendered for some output formats such
-        as LaTeX.
+          ``entries`` is a sequence of single entries. Each entry is a
+          :py:class:`IndexEntry`.
         """
         raise NotImplementedError

--- a/sphinx/domains/_index.py
+++ b/sphinx/domains/_index.py
@@ -15,16 +15,17 @@ if TYPE_CHECKING:
 
 class IndexEntry(NamedTuple):
     """
-    An entry of index.
+    An index entry.
 
     .. note::
 
-       Qualifier and description are not rendered for some output formats such
-       as LaTeX.
+       The *qualifier* and *description* are not rendered for some output formats,
+       such as LaTeX.
     """
 
     #: The name of the index entry to be displayed.
     name: str
+
     #: The sub-entry related type. One of:
     #:
     #: ``0``
@@ -34,14 +35,19 @@ class IndexEntry(NamedTuple):
     #: ``2``
     #:   A sub-entry.
     subtype: int
+
     #: *docname* where the entry is located.
     docname: str
+
     #: Anchor for the entry within `docname`
     anchor: str
+
     #: Extra info for the entry.
     extra: str
+
     #: Qualifier for the description.
     qualifier: str
+
     #: Description for the entry.
     descr: str
 
@@ -98,7 +104,7 @@ class Index(ABC):
         ``content``:
           A sequence of ``(letter, entries)`` tuples, where ``letter`` is the
           "heading" for the given ``entries``, usually the starting letter, and
-          ``entries`` is a sequence of single entries. Each entry is a
-          :py:class:`IndexEntry`.
+          ``entries`` is a sequence of single entries.
+          Each entry is an :py:class:`IndexEntry`.
         """
         raise NotImplementedError


### PR DESCRIPTION
Subject: Document sphinx.domains.IndexEntry

### Feature or Bugfix
 
- Refactoring

### Purpose

Recently I am reading the source of domain. I found that the description of `IndexEntry` is written in `Index.generate`'s docstirng, rather than the docstring of itself. 

I think this may be because the docstring were not updated in time when IndexEntry became a normal class  definition since 68327ba2e617807eb3c59e9964cebd0c5f2642f9.