### PR TITLE
HTML search: adjust type signatures for custom HTML scoring

### DIFF
--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -1350,7 +1350,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value('html_secnumber_suffix', '. ', 'html')
     app.add_config_value('html_search_language', None, 'html', str)
     app.add_config_value('html_search_options', {}, 'html')
-    app.add_config_value('html_search_scorer', '', '')
+    app.add_config_value('html_search_scorer', None, '', str)
     app.add_config_value('html_scaled_image_link', True, 'html')
     app.add_config_value('html_baseurl', '', 'html')
     # removal is indefinitely on hold (ref: https://github.com/sphinx-doc/sphinx/issues/10265)

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -250,7 +250,7 @@ class IndexBuilder:
         'pickle':   pickle
     }
 
-    def __init__(self, env: BuildEnvironment, lang: str, options: dict[str, str], scoring: str) -> None:
+    def __init__(self, env: BuildEnvironment, lang: str, options: dict[str, str], scoring: str | None) -> None:
         self.env = env
         # docname -> title
         self._titles: dict[str, str | None] = env._search_index_titles


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Adjust the type hint for the `scoring` argument to the `IndexBuilder`

### Detail
- Currently we have test coverage that provides a `scoring` value of `None` -- but the type signature we have on the class doesn't accept that, strictly speaking.
- Adjust the type signature to accept that single additional value (since we already have test coverage for it).
- Also: add a `str` type to the relevant HTML builder config value.

### Relates
- Originates from discussion in #12816.

cc @danieleades 