### PR TITLE
LaTeX: avoid large voids sometimes occurring at page bottoms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ Bugs fixed
   rise to nested ``\DUrole``'s, rather than a single one with comma separated
   classes.
   Patch by Jean-François B.
+* #12831: LaTeX: avoid large voids sometimes occurring at page bottoms.
+  Patch by Jean-François B.
 * #11970, #12551: singlehtml builder: make target URIs to be same-document
   references in the sense of :rfc:`RFC 3986, §4.4 <3986#section-4.4>`,
   e.g., ``index.html#foo`` becomes ``#foo``.

--- a/sphinx/texinputs/sphinxlatexstyleheadings.sty
+++ b/sphinx/texinputs/sphinxlatexstyleheadings.sty
@@ -8,7 +8,7 @@
 % 3 lines of text following it on same page if near bottom.
 \renewcommand\bottomtitlespace{6\baselineskip}
 % the default setting of 0.2\textheight is about 11\baselineskip
-% (for 10pt letterpaper documents) and may creates large voids.
+% (for 10pt letterpaper documents) and may create large voids.
 
 \@ifpackagelater{titlesec}{2016/03/15}%
  {\@ifpackagelater{titlesec}{2016/03/21}%

--- a/sphinx/texinputs/sphinxlatexstyleheadings.sty
+++ b/sphinx/texinputs/sphinxlatexstyleheadings.sty
@@ -4,6 +4,12 @@
 \ProvidesPackage{sphinxlatexstyleheadings}[2023/02/11 headings]
 
 \RequirePackage[nobottomtitles*]{titlesec}
+% tests showed that this setting guarantees \section title has
+% 3 lines of text following it on same page if near bottom.
+\renewcommand\bottomtitlespace{6\baselineskip}
+% the default setting of 0.2\textheight is about 11\baselineskip
+% (for 10pt letterpaper documents) and may creates large voids.
+
 \@ifpackagelater{titlesec}{2016/03/15}%
  {\@ifpackagelater{titlesec}{2016/03/21}%
   {}%
@@ -46,7 +52,6 @@
             {\py@TitleColor\theparagraph}{0.5em}{\py@TitleColor}
 \titleformat{\subparagraph}{\normalsize\py@HeaderFamily}%
             {\py@TitleColor\thesubparagraph}{0.5em}{\py@TitleColor}
-
 
 % Since Sphinx 1.5, users should use HeaderFamily key to 'sphinxsetup' rather
 % than defining their own \py@HeaderFamily command (which is still possible).


### PR DESCRIPTION
Fix #12831


### Relates
- #6633

