### PR TITLE
LaTeX: use current parskip package for better spacing around titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Dependencies
 
 * #12756: Add lower-bounds to the ``sphinxcontrib-*`` dependencies.
   Patch by Adam Turner.
+* #12833: Update the LaTeX ``parskip`` package from 2001 to 2018.
+  Patch by Jean-François B.
 
 Incompatible changes
 --------------------

--- a/sphinx/texinputs/sphinxlatexstylepage.sty
+++ b/sphinx/texinputs/sphinxlatexstylepage.sty
@@ -4,13 +4,7 @@
 \ProvidesPackage{sphinxlatexstylepage}[2021/01/27 page styling]
 
 % Separate paragraphs by space by default.
-\IfFileExists{parskip-2001-04-09.sty}% since September 2018 TeXLive update
-% new parskip.sty, but let it rollback to old one.
-% hopefully TeX installation not broken and LaTeX kernel not too old
-   {\RequirePackage{parskip}[=v1]}
-% standard one from 1989. Admittedly \section of article/book gives possibly
-% anomalous spacing, but we can't require September 2018 release for some time.
-   {\RequirePackage{parskip}}
+\RequirePackage{parskip}
 
 % Style parameters and macros used by most documents here
 \raggedbottom


### PR DESCRIPTION
For years now we have been using LaTeX parskip v1 version.  But this old package adds extra spacing around section titles which is definitely not good.

This was done at #5964 because (as reported in #5960) the parskip package changed suddenly its behavior in 2018 and as a result people could see their projects on RTD give different results from compiling at their locale due to one location using the new and nother location using the old `parskip` (definitely the  new parskip should have been released as parskip2, i.e. not keep the same name).

2018 is now 6 years ago.

I think it is time to use the currently maintained `parskip` version not the earlier version from 2001 (and even earlier).

This will change all PDFs to have less exaggerated vertical spacings around section headings.
The current spacing is definitely anomalous.

In order to not re-create the #5960 problem that people may get different looking PDFs if compiling on a current system and simultaneously on an old one not up-to-date, we could also ship a `sphinxparskip.sty` which would be a clone of current `parskip.sty` with removal of dependency on LaTeX kernel features requiring its 2018-04-01 release (only a few lines to remove at top of the `parskip.sty` file).

+1 for that option which is the safest one (although it will override any upstream change to `parskip.sty`) and makes sure #5960 does not resuscitate.  I will wait for advices.


EDIT: attention that parskip v2 requires `etoolbox` package. It is part in Ubuntu of [texlive-latex-recommended](https://packages.ubuntu.com/focal/texlive-latex-recommended) which we document as required and on Fedora part of [texlive](https://packages.fedoraproject.org/pkgs/texlive/texlive-etoolbox/)  package people probably already require.
