### PR TITLE
Make `nested_parse_with_titles` accept `ViewList`

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from docutils.nodes import Element
     from docutils.parsers.rst import Directive
     from docutils.parsers.rst.states import Inliner, RSTState
-    from docutils.statemachine import StringList
+    from docutils.statemachine import ViewList
 
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
@@ -325,7 +325,7 @@ def traverse_translatable_index(
         yield node, entries
 
 
-def nested_parse_with_titles(state: RSTState, content: StringList, node: Node,
+def nested_parse_with_titles(state: RSTState, content: ViewList[str], node: Node,
                              content_offset: int = 0) -> str:
     """Version of state.nested_parse() that allows titles and does not require
     titles to have the same decoration as the calling document.


### PR DESCRIPTION
This type seems to be too strict.

Many places on the internet suggest passing a `ViewList` to `nested_parse_with_titles(content=)`. However, #5723 introduced a `StringList` in the type annotations for a mysterious reason.

* https://stackoverflow.com/a/44084890/595220
* https://groups.google.com/g/sphinx-dev/c/l4fHrIJfwq4/m/6Z8Z9jWKBwAJ

Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Purpose
- I want my MyPy checks to pass

### Detail
* https://stackoverflow.com/a/44084890/595220
* https://groups.google.com/g/sphinx-dev/c/l4fHrIJfwq4/m/6Z8Z9jWKBwAJ

### Relates
- #5723

