### PR TITLE
Added a comment for the sphinx-build -j option

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -126,8 +126,9 @@ Options
 .. option:: -j N, --jobs N
 
    Distribute the build over *N* processes in parallel, to make building on
-   multiprocessor machines more effective.  Note that not all parts and not all
-   builders of Sphinx can be parallelized.  If ``auto`` argument is given,
+   multiprocessor machines more effective. This feature only works on systems
+   supporting "fork", e.g., linux. Windows is not supported. Also not all parts
+   and not all builders of Sphinx can be parallelized.  If ``auto`` argument is given,
    Sphinx uses the number of CPUs as *N*. Defaults to 1.
 
    .. versionadded:: 1.2

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -126,9 +126,10 @@ Options
 .. option:: -j N, --jobs N
 
    Distribute the build over *N* processes in parallel, to make building on
-   multiprocessor machines more effective. This feature only works on systems
-   supporting "fork", e.g., linux. Windows is not supported. Also not all parts
-   and not all builders of Sphinx can be parallelized.  If ``auto`` argument is given,
+   multiprocessor machines more effective. 
+   This feature only works on systems supporting "fork". Windows is not supported.
+   Note that not all parts and not all builders of Sphinx can be parallelized.
+   If ``auto`` argument is given,
    Sphinx uses the number of CPUs as *N*. Defaults to 1.
 
    .. versionadded:: 1.2

--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -126,7 +126,7 @@ Options
 .. option:: -j N, --jobs N
 
    Distribute the build over *N* processes in parallel, to make building on
-   multiprocessor machines more effective. 
+   multiprocessor machines more effective.
    This feature only works on systems supporting "fork". Windows is not supported.
    Note that not all parts and not all builders of Sphinx can be parallelized.
    If ``auto`` argument is given,


### PR DESCRIPTION
Subject: Clarify that multiprocessing does not work on operating systems, which do not support "fork".

