### PR TITLE
Fix CalledProcessError wrong call type in test

### DIFF
--- a/tests/test_builders/test_build_texinfo.py
+++ b/tests/test_builders/test_build_texinfo.py
@@ -34,7 +34,7 @@ def test_texinfo(app):
     except CalledProcessError as exc:
         print(exc.stdout)
         print(exc.stderr)
-        msg = f'makeinfo exited with return code {exc.retcode}'
+        msg = f'makeinfo exited with return code {exc.returncode}'
         raise AssertionError(msg) from exc
 
 


### PR DESCRIPTION
This used `exc.retcode` but CalledProcessError has `.returncode`, not `.retcode`