### PR TITLE
Restore 'noindex' support for JS, Python domains

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,7 +99,9 @@ Bugs fixed
 * #12796: Enable parallel reading if requested,
   even if there are fewer than 6 documents.
   Patch by Matthias Geier.
-
+* #12844: Restore support for ``:noindex:`` for the :rst:dir:`js:module`
+  and :rst:dir:`py:module` directives.
+  Patch by Stephen Finucane.
 
 Testing
 -------

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -307,15 +307,14 @@ class JSModule(SphinxDirective):
     }
 
     def run(self) -> list[Node]:
-        mod_name = self.arguments[0].strip()
-        self.env.ref_context['js:module'] = mod_name
-
         # Copy old option names to new ones
         # xref RemovedInSphinx90Warning
         # # deprecate noindex in Sphinx 9.0
         if 'no-index' not in self.options and 'noindex' in self.options:
             self.options['no-index'] = self.options['noindex']
 
+        mod_name = self.arguments[0].strip()
+        self.env.ref_context['js:module'] = mod_name
         no_index = 'no-index' in self.options
 
         content_nodes = self.parse_content_to_nodes(allow_section_headings=True)

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -309,6 +309,13 @@ class JSModule(SphinxDirective):
     def run(self) -> list[Node]:
         mod_name = self.arguments[0].strip()
         self.env.ref_context['js:module'] = mod_name
+
+        # Copy old option names to new ones
+        # xref RemovedInSphinx90Warning
+        # # deprecate noindex in Sphinx 9.0
+        if 'no-index' not in self.options and 'noindex' in self.options:
+            self.options['no-index'] = self.options['noindex']
+
         no_index = 'no-index' in self.options
 
         content_nodes = self.parse_content_to_nodes(allow_section_headings=True)

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -451,6 +451,12 @@ class PyModule(SphinxDirective):
     def run(self) -> list[Node]:
         domain = cast(PythonDomain, self.env.get_domain('py'))
 
+        # Copy old option names to new ones
+        # xref RemovedInSphinx90Warning
+        # # deprecate noindex in Sphinx 9.0
+        if 'no-index' not in self.options and 'noindex' in self.options:
+            self.options['no-index'] = self.options['noindex']
+
         modname = self.arguments[0].strip()
         no_index = 'no-index' in self.options
         self.env.ref_context['py:module'] = modname

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -449,13 +449,13 @@ class PyModule(SphinxDirective):
     }
 
     def run(self) -> list[Node]:
-        domain = cast(PythonDomain, self.env.get_domain('py'))
-
         # Copy old option names to new ones
         # xref RemovedInSphinx90Warning
         # # deprecate noindex in Sphinx 9.0
         if 'no-index' not in self.options and 'noindex' in self.options:
             self.options['no-index'] = self.options['noindex']
+
+        domain = cast(PythonDomain, self.env.get_domain('py'))
 
         modname = self.arguments[0].strip()
         no_index = 'no-index' in self.options


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose

Fixes: e439c6f33f (Ensure that old-style object description options are respected (#12620))
Closes: #12843

### Detail
- #12843

> **Note**
> Ideally this should be backport to the 7.x branch, but it appears we don't maintain stable branches any more?

### Relates

None.
