### PR TITLE
Remove unnecessary `:func:` & `:meth:` parentheses from reST content

### DIFF
--- a/doc/changes/3.5.rst
+++ b/doc/changes/3.5.rst
@@ -108,7 +108,7 @@ Features added
   functions in source code and keep them not evaluated for readability.
 * #8619: html: kbd role generates customizable HTML tags for compound keys
 * #8634: html: Allow to change the order of JS/CSS via ``priority`` parameter
-  for :meth:`.Sphinx.add_js_file()` and :meth:`.Sphinx.add_css_file()`
+  for :meth:`.Sphinx.add_js_file` and :meth:`.Sphinx.add_css_file`
 * #6241: html: Allow to add JS/CSS files to the specific page when an extension
   calls ``app.add_js_file()`` or ``app.add_css_file()`` on
   :event:`html-page-context` event

--- a/doc/changes/4.4.rst
+++ b/doc/changes/4.4.rst
@@ -27,7 +27,7 @@ Features added
   by an extlink, suggesting a replacement.
 * #9961: html: Support nested <kbd> HTML elements in other HTML builders
 * #10013: html: Allow to change the loading method of JS via ``loading_method``
-  parameter for :meth:`.Sphinx.add_js_file()`
+  parameter for :meth:`.Sphinx.add_js_file`
 * #9551: html search: "Hide Search Matches" link removes "highlight" parameter
   from URL
 * #9815: html theme: Wrap sidebar components in div to allow customizing their

--- a/doc/development/html_themes/index.rst
+++ b/doc/development/html_themes/index.rst
@@ -145,7 +145,7 @@ Python :mod:`configparser` module) and has the following structure:
 * The **pygments_dark_style** setting gives the name of a Pygments style to use
   for highlighting when the CSS media query ``(prefers-color-scheme: dark)``
   evaluates to true. It is injected into the page using
-  :meth:`~sphinx.application.Sphinx.add_css_file()`.
+  :meth:`~sphinx.application.Sphinx.add_css_file`.
 
 * The **sidebars** setting gives the comma separated list of sidebar templates
   for constructing sidebars.  This can be overridden by the user in the

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -1447,12 +1447,12 @@ The following is a list of deprecated interfaces.
    * - :meth:`!add_stylesheet`
      - 1.8
      - 6.0
-     - :meth:`~sphinx.application.Sphinx.add_css_file()`
+     - :meth:`~sphinx.application.Sphinx.add_css_file`
 
-   * - :meth:`!add_javascript()`
+   * - :meth:`!add_javascript`
      - 1.8
      - 4.0
-     - :meth:`~sphinx.application.Sphinx.add_js_file()`
+     - :meth:`~sphinx.application.Sphinx.add_js_file`
 
    * - :confval:`autodoc_default_flags`
      - 1.8
@@ -1519,7 +1519,7 @@ The following is a list of deprecated interfaces.
    * - ``sphinx.ext.mathbase.setup_math()``
      - 1.8
      - 3.0
-     - :meth:`~sphinx.application.Sphinx.add_html_math_renderer()`
+     - :meth:`~sphinx.application.Sphinx.add_html_math_renderer`
 
    * - ``sphinx.ext.mathbase.is_in_section_title()``
      - 1.8
@@ -1700,7 +1700,7 @@ The following is a list of deprecated interfaces.
    * - ``Sphinx.override_domain()``
      - 1.8
      - 3.0
-     - :meth:`~sphinx.application.Sphinx.add_domain()`
+     - :meth:`~sphinx.application.Sphinx.add_domain`
 
    * - ``Sphinx.import_object()``
      - 1.8
@@ -1708,10 +1708,10 @@ The following is a list of deprecated interfaces.
      - ``sphinx.util.import_object()``
 
    * - ``suffix`` argument of
-       :meth:`~sphinx.application.Sphinx.add_source_parser()`
+       :meth:`~sphinx.application.Sphinx.add_source_parser`
      - 1.8
      - 3.0
-     - :meth:`~sphinx.application.Sphinx.add_source_suffix()`
+     - :meth:`~sphinx.application.Sphinx.add_source_suffix`
 
 
    * - ``BuildEnvironment.load()``
@@ -1792,7 +1792,7 @@ The following is a list of deprecated interfaces.
    * - :confval:`!source_parsers`
      - 1.8
      - 3.0
-     - :meth:`~sphinx.application.Sphinx.add_source_parser()`
+     - :meth:`~sphinx.application.Sphinx.add_source_parser`
 
    * - ``sphinx.util.docutils.directive_helper()``
      - 1.8
@@ -1857,17 +1857,17 @@ The following is a list of deprecated interfaces.
    * - ``sphinx.ext.autodoc.add_documenter()``
      - 1.7
      - 2.0
-     - :meth:`~sphinx.application.Sphinx.add_autodocumenter()`
+     - :meth:`~sphinx.application.Sphinx.add_autodocumenter`
 
    * - ``sphinx.ext.autodoc.AutoDirective._register``
      - 1.7
      - 2.0
-     - :meth:`~sphinx.application.Sphinx.add_autodocumenter()`
+     - :meth:`~sphinx.application.Sphinx.add_autodocumenter`
 
    * - ``AutoDirective._special_attrgetters``
      - 1.7
      - 2.0
-     - :meth:`~sphinx.application.Sphinx.add_autodoc_attrgetter()`
+     - :meth:`~sphinx.application.Sphinx.add_autodoc_attrgetter`
 
    * - ``Sphinx.warn()``, ``Sphinx.info()``
      - 1.6

--- a/doc/extdev/deprecated.rst
+++ b/doc/extdev/deprecated.rst
@@ -1812,17 +1812,17 @@ The following is a list of deprecated interfaces.
    * - ``sphinx.locale.l_()``
      - 1.8
      - 3.0
-     - :func:`sphinx.locale._()`
+     - :func:`sphinx.locale._`
 
    * - ``sphinx.locale.lazy_gettext()``
      - 1.8
      - 3.0
-     - :func:`sphinx.locale._()`
+     - :func:`sphinx.locale._`
 
    * - ``sphinx.locale.mygettext()``
      - 1.8
      - 3.0
-     - :func:`sphinx.locale._()`
+     - :func:`sphinx.locale._`
 
    * - ``sphinx.util.copy_static_entry()``
      - 1.5

--- a/doc/extdev/parserapi.rst
+++ b/doc/extdev/parserapi.rst
@@ -12,7 +12,7 @@ __ https://docutils.sourceforge.io/docs/dev/hacking.html#parsing-the-document
 
 In Sphinx, the parser modules works as same as docutils.  The parsers are
 registered to Sphinx by extensions using Application APIs;
-:meth:`.Sphinx.add_source_suffix()` and :meth:`.Sphinx.add_source_parser()`.
+:meth:`.Sphinx.add_source_suffix` and :meth:`.Sphinx.add_source_parser`.
 
 The *source suffix* is a mapping from file suffix to file type.  For example,
 ``.rst`` file is mapped to ``'restructuredtext'`` type.  Sphinx uses the

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1612,7 +1612,7 @@ and also make use of these options.
 
    The special attribute *priority* can be set as an integer
    to load the CSS file at an earlier or later step.
-   For more information, refer to :meth:`.Sphinx.add_css_file()`.
+   For more information, refer to :meth:`.Sphinx.add_css_file`.
 
    .. versionadded:: 1.8
    .. versionchanged:: 3.5
@@ -1641,7 +1641,7 @@ and also make use of these options.
 
    As a special attribute, *priority* can be set as an integer
    to load the JavaScript file at an earlier or later step.
-   For more information, refer to :meth:`.Sphinx.add_js_file()`.
+   For more information, refer to :meth:`.Sphinx.add_js_file`.
 
    .. versionadded:: 1.8
    .. versionchanged:: 3.5

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -840,7 +840,7 @@ __ https://pygments.org/docs/lexers
 
       Strip indentation characters from the code block.  When number given,
       leading N characters are removed.  When no argument given, leading spaces
-      are removed via :func:`textwrap.dedent()`.  For example::
+      are removed via :func:`textwrap.dedent`.  For example::
 
          .. code-block:: ruby
             :linenos:


### PR DESCRIPTION
Subject: Remove unnecessary `:func:` parentheses

### Feature or Bugfix

- Bugfix (doc)

### Purpose
- We're introducing a new rule to the sphinx-lint ([issue](https://github.com/sphinx-contrib/sphinx-lint/issues/114) & [PR](https://github.com/sphinx-contrib/sphinx-lint/pull/115)) and, since sphinx-lint utilizes Sphinx doc content in the CI, we'd like to also fix the issue.

### Detail

- fix unnecessary `:func:` parentheses under `doc`.

### Relates

resolve #12847

