### PR TITLE
Fix `TypeError: Some type variables (...) are not listed in Generic[...]`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,9 @@ Bugs fixed
   file URL (user-defined base URL of an intersphinx project are left untouched
   even if they end with double forward slashes).
   Patch by Bénédikt Tran.
+* #12797: Fix
+  `TypeError: Some type variables (...) are not listed in Generic[...]`
+  when inheriting from both Generic and autodoc mocked class.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,7 +97,7 @@ Bugs fixed
   even if they end with double forward slashes).
   Patch by Bénédikt Tran.
 * #12797: Fix
-  `TypeError: Some type variables (...) are not listed in Generic[...]`
+  ``TypeError: Some type variables (...) are not listed in Generic[...]``
   when inheriting from both Generic and autodoc mocked class.
 
 Testing

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -29,7 +29,7 @@ class _MockObject:
     __name__ = ''
     __sphinx_mock__ = True
     __sphinx_decorator_args__: tuple[Any, ...] = ()
-    __sphinx_empty_attrs__: ('__typing_subst__',)
+    __sphinx_empty_attrs__ = ('__typing_subst__',)
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         if len(args) == 3 and isinstance(args[1], tuple):

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -29,6 +29,7 @@ class _MockObject:
     __name__ = ''
     __sphinx_mock__ = True
     __sphinx_decorator_args__: tuple[Any, ...] = ()
+    __sphinx_empty_attrs__: ('__typing_subst__',)
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:
         if len(args) == 3 and isinstance(args[1], tuple):
@@ -59,6 +60,8 @@ class _MockObject:
         return _make_subclass(str(key), self.__display_name__, self.__class__)()
 
     def __getattr__(self, key: str) -> _MockObject:
+        if key in self.__sphinx_empty_attrs__:
+            return self.__getattribute__(key)
         return _make_subclass(key, self.__display_name__, self.__class__)()
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Closes: #12797

### Detail
- #12797

### Relates
None
