### PR TITLE
Change the language type given to `CatalogRepository` in tests

### DIFF
--- a/tests/test_util/test_util_i18n.py
+++ b/tests/test_util/test_util_i18n.py
@@ -179,13 +179,13 @@ def test_CatalogRepository(tmp_path):
     assert sorted(c.domain for c in repo.catalogs) == []
 
     # no languages
-    repo = i18n.CatalogRepository(tmp_path, ['loc1', 'loc2'], None, 'utf-8')
+    repo = i18n.CatalogRepository(tmp_path, ['loc1', 'loc2'], '', 'utf-8')
     assert sorted(c.domain for c in repo.catalogs) == []
 
     # unknown locale_dirs
-    repo = i18n.CatalogRepository(tmp_path, ['loc3'], None, 'utf-8')
+    repo = i18n.CatalogRepository(tmp_path, ['loc3'], '', 'utf-8')
     assert sorted(c.domain for c in repo.catalogs) == []
 
     # no locale_dirs
-    repo = i18n.CatalogRepository(tmp_path, [], None, 'utf-8')
+    repo = i18n.CatalogRepository(tmp_path, [], '', 'utf-8')
     assert sorted(c.domain for c in repo.catalogs) == []


### PR DESCRIPTION
Some tests gave `None` as the language.
The `CatalogRepository` signature says that `language` should be a `str`:

```python
class CatalogRepository:
    """A repository for message catalogs."""

    def __init__(self, basedir: str | os.PathLike[str], locale_dirs: list[str],
                 language: str, encoding: str) -> None:
```

I also looked at whether the `language` type should be changed to `str | None`. I believe that it should not - outside of tests, the only callers (within Sphinx) of `CatalogRepository.__init__` pass in `self.config.language`, where `config` is a `sphinx.config.Config`.

Looking at that, I see:

```python

...

config_values: dict[str, _Opt] = {
    ...
    'language': _Opt('en', 'env', frozenset((str,))),
}
```

This shows that the valid types at the config level do not include `types.NoneType`.