### PR TITLE
Type hint multiple accumulator variables

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -382,7 +382,7 @@ class Config:
                 logger.warning(__('unknown config value %r in override, ignoring'), name)
 
     def __repr__(self) -> str:
-        values = []
+        values: list[str] = []
         for opt_name in self._options:
             try:
                 opt_value = getattr(self, opt_name)

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -59,7 +59,7 @@ def dedent_lines(
     if any(s[:dedent].strip() for s in lines):
         logger.warning(__('non-whitespace stripped by dedent'), location=location)
 
-    new_lines = []
+    new_lines: list[str] = []
     for line in lines:
         new_line = line[dedent:]
         if line.endswith('\n') and not new_line:

--- a/sphinx/domains/c/__init__.py
+++ b/sphinx/domains/c/__init__.py
@@ -157,7 +157,7 @@ class CObject(ObjectDescription[ASTDeclaration]):
 
     def add_target_and_index(self, ast: ASTDeclaration, sig: str,
                              signode: TextElement) -> None:
-        ids = []
+        ids: list[str] = []
         for i in range(1, _max_id + 1):
             try:
                 id = ast.get_id(version=i)

--- a/sphinx/domains/c/_ast.py
+++ b/sphinx/domains/c/_ast.py
@@ -614,7 +614,7 @@ class ASTBinOpExpr(ASTBase):
         return hash((self.exprs, self.ops))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.exprs[0]))
         for i in range(1, len(self.exprs)):
             res.append(' ')
@@ -656,7 +656,7 @@ class ASTAssignmentExpr(ASTExpression):
         return hash((self.exprs, self.ops))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.exprs[0]))
         for i in range(1, len(self.exprs)):
             res.append(' ')
@@ -758,7 +758,7 @@ class ASTTrailingTypeSpecName(ASTTrailingTypeSpec):
         return self.nestedName
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.prefix:
             res.append(self.prefix)
             res.append(' ')
@@ -823,7 +823,7 @@ class ASTParameters(ASTBase):
         return self.args
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append('(')
         first = True
         for a in self.args:
@@ -1072,7 +1072,7 @@ class ASTArray(ASTBase):
         ))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        el = []
+        el: list[str] = []
         if self.static:
             el.append('static')
         if self.restrict:
@@ -1162,7 +1162,7 @@ class ASTDeclaratorNameParam(ASTDeclarator):
         return self.declId is not None
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.declId:
             res.append(transform(self.declId))
         res.extend(transform(op) for op in self.arrayOps)
@@ -1204,7 +1204,7 @@ class ASTDeclaratorNameBitField(ASTDeclarator):
         return self.declId is not None
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.declId:
             res.append(transform(self.declId))
         res.append(" : ")
@@ -1477,7 +1477,7 @@ class ASTType(ASTBase):
         return self.decl.function_params
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         declSpecs = transform(self.declSpecs)
         res.append(declSpecs)
         if self.decl.require_space_after_declSpecs() and len(declSpecs) > 0:
@@ -1526,7 +1526,7 @@ class ASTTypeWithInit(ASTBase):
         return self.type.get_id(version, objectType, symbol)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.type))
         if self.init:
             res.append(transform(self.init))
@@ -1600,7 +1600,7 @@ class ASTMacro(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.ident))
         if self.args is not None:
             res.append('(')
@@ -1722,7 +1722,7 @@ class ASTEnumerator(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.name))
         if len(self.attrs) != 0:
             res.append(' ')

--- a/sphinx/domains/c/_parser.py
+++ b/sphinx/domains/c/_parser.py
@@ -63,6 +63,7 @@ from sphinx.domains.c._ids import (
     _string_re,
 )
 from sphinx.util.cfamily import (
+    ASTAttribute,
     ASTAttributeList,
     BaseParser,
     DefinitionError,
@@ -193,7 +194,7 @@ class DefinitionParser(BaseParser):
         if self.skip_string(close):
             return [], False
 
-        exprs = []
+        exprs: list[ASTExpression] = []
         trailingComma = False
         while True:
             self.skip_ws()
@@ -330,7 +331,7 @@ class DefinitionParser(BaseParser):
                 try:
                     return self._parse_unary_expression()
                 except DefinitionError as exUnary:
-                    errs = []
+                    errs: list[tuple[DefinitionError, str]] = []
                     errs.append((exCast, "If type cast expression"))
                     errs.append((exUnary, "If unary expression"))
                     raise self._make_multi_error(errs,
@@ -357,8 +358,8 @@ class DefinitionParser(BaseParser):
             else:
                 def parser() -> ASTExpression:
                     return _parse_bin_op_expr(self, opId + 1)
-            exprs = []
-            ops = []
+            exprs: list[ASTExpression] = []
+            ops: list[str] = []
             exprs.append(parser())
             while True:
                 self.skip_ws()
@@ -400,8 +401,8 @@ class DefinitionParser(BaseParser):
         #     logical-or-expression
         #   | logical-or-expression "?" expression ":" assignment-expression
         #   | logical-or-expression assignment-operator initializer-clause
-        exprs = []
-        ops = []
+        exprs: list[ASTExpression] = []
+        ops: list[str] = []
         orExpr = self._parse_logical_or_expression()
         exprs.append(orExpr)
         # TODO: handle ternary with _parse_conditional_expression_tail
@@ -560,7 +561,7 @@ class DefinitionParser(BaseParser):
             else:
                 return None
 
-        args = []
+        args: list[ASTFunctionParameter] = []
         self.skip_ws()
         if not self.skip_string(')'):
             while 1:
@@ -750,14 +751,14 @@ class DefinitionParser(BaseParser):
         if paramMode not in ('type', 'function'):
             raise Exception(
                 "Internal error, unknown paramMode '%s'." % paramMode)
-        prevErrors = []
+        prevErrors: list[tuple[DefinitionError, str]] = []
         self.skip_ws()
         if typed and self.skip_string('*'):
             self.skip_ws()
             restrict = False
             volatile = False
             const = False
-            attrs = []
+            attrs: list[ASTAttribute] = []
             while 1:
                 if not restrict:
                     restrict = self.skip_word_and_ws('restrict')
@@ -866,7 +867,7 @@ class DefinitionParser(BaseParser):
 
         if outer == 'type':
             # We allow type objects to just be a name.
-            prevErrors = []
+            prevErrors: list[tuple[DefinitionError, str]] = []
             startPos = self.pos
             # first try without the type
             try:
@@ -930,7 +931,7 @@ class DefinitionParser(BaseParser):
             return ASTMacro(ident, None)
         if self.skip_string(')'):
             return ASTMacro(ident, [])
-        args = []
+        args: list[ASTMacroParameter] = []
         while 1:
             self.skip_ws()
             if self.skip_string('...'):
@@ -1046,7 +1047,7 @@ class DefinitionParser(BaseParser):
                 self.assert_end()
             except DefinitionError as exType:
                 header = "Error when parsing (type) expression."
-                errs = []
+                errs: list[tuple[DefinitionError, str]] = []
                 errs.append((exExpr, "If expression"))
                 errs.append((exType, "If type"))
                 raise self._make_multi_error(errs, header) from exType

--- a/sphinx/domains/cpp/__init__.py
+++ b/sphinx/domains/cpp/__init__.py
@@ -212,7 +212,7 @@ class CPPObject(ObjectDescription[ASTDeclaration]):
     def add_target_and_index(self, ast: ASTDeclaration, sig: str,
                              signode: TextElement) -> None:
         # general note: name must be lstrip(':')'ed, to remove "::"
-        ids = []
+        ids: list[str] = []
         for i in range(1, _max_id + 1):
             try:
                 id = ast.get_id(version=i)

--- a/sphinx/domains/cpp/_ast.py
+++ b/sphinx/domains/cpp/_ast.py
@@ -223,7 +223,7 @@ class ASTNestedName(ASTBase):
             else:
                 return '::'.join(n.get_id(version) for n in self.names)
 
-        res = []
+        res: list[str] = []
         if len(self.names) > 1 or len(modifiers) > 0:
             res.append('N')
         res.append(modifiers)
@@ -233,7 +233,7 @@ class ASTNestedName(ASTBase):
         return ''.join(res)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.rooted:
             res.append('')
         for i in range(len(self.names)):
@@ -571,7 +571,7 @@ class ASTFoldExpr(ASTExpression):
         if version == 3:
             return str(self)
         # https://github.com/itanium-cxx-abi/cxx-abi/pull/67
-        res = []
+        res: list[str] = []
         if self.leftExpr is None:  # (... op expr)
             res.append('fl')
         elif self.rightExpr is None:  # (expr op ...)
@@ -1087,7 +1087,7 @@ class ASTNewExpr(ASTExpression):
         return hash((self.rooted, self.isNewTypeId, self.typ, self.initList))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.rooted:
             res.append('::')
         res.append('new ')
@@ -1146,7 +1146,7 @@ class ASTDeleteExpr(ASTExpression):
         return hash((self.rooted, self.array, self.expr))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.rooted:
             res.append('::')
         res.append('delete ')
@@ -1230,7 +1230,7 @@ class ASTBinOpExpr(ASTExpression):
         return hash((self.exprs, self.ops))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.exprs[0]))
         for i in range(1, len(self.exprs)):
             res.append(' ')
@@ -1241,7 +1241,7 @@ class ASTBinOpExpr(ASTExpression):
 
     def get_id(self, version: int) -> str:
         assert version >= 2
-        res = []
+        res: list[str] = []
         for i in range(len(self.ops)):
             res.append(_id_operator_v2[self.ops[i]])
             res.append(self.exprs[i].get_id(version))
@@ -1282,7 +1282,7 @@ class ASTConditionalExpr(ASTExpression):
         return hash((self.ifExpr, self.thenExpr, self.elseExpr))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.ifExpr))
         res.append(' ? ')
         res.append(transform(self.thenExpr))
@@ -1292,7 +1292,7 @@ class ASTConditionalExpr(ASTExpression):
 
     def get_id(self, version: int) -> str:
         assert version >= 2
-        res = []
+        res: list[str] = []
         res.append(_id_operator_v2['?'])
         res.append(self.ifExpr.get_id(version))
         res.append(self.thenExpr.get_id(version))
@@ -1371,7 +1371,7 @@ class ASTAssignmentExpr(ASTExpression):
         return hash((self.leftExpr, self.op, self.rightExpr))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.leftExpr))
         res.append(' ')
         res.append(self.op)
@@ -1381,7 +1381,7 @@ class ASTAssignmentExpr(ASTExpression):
 
     def get_id(self, version: int) -> str:
         # we end up generating the ID from left to right, instead of right to left
-        res = []
+        res: list[str] = []
         res.append(_id_operator_v2[self.op])
         res.append(self.leftExpr.get_id(version))
         res.append(self.rightExpr.get_id(version))
@@ -1417,7 +1417,7 @@ class ASTCommaExpr(ASTExpression):
 
     def get_id(self, version: int) -> str:
         id_ = _id_operator_v2[',']
-        res = []
+        res: list[str] = []
         for i in range(len(self.exprs) - 1):
             res.append(id_)
             res.append(self.exprs[i].get_id(version))
@@ -1657,7 +1657,7 @@ class ASTTemplateArgs(ASTBase):
 
     def get_id(self, version: int) -> str:
         if version == 1:
-            res = []
+            res: list[str] = []
             res.append(':')
             res.append('.'.join(a.get_id(version) for a in self.args))
             res.append(':')
@@ -1731,7 +1731,7 @@ class ASTTrailingTypeSpecFundamental(ASTTrailingTypeSpec):
 
     def get_id(self, version: int) -> str:
         if version == 1:
-            res = []
+            res: list[str] = []
             for a in self.canonNames:
                 if a in _id_fundamental_v1:
                     res.append(_id_fundamental_v1[a])
@@ -1836,7 +1836,7 @@ class ASTTrailingTypeSpecName(ASTTrailingTypeSpec):
         return self.nestedName.get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.prefix:
             res.append(self.prefix)
             res.append(' ')
@@ -1977,7 +1977,7 @@ class ASTParametersQualifiers(ASTBase):
         return self.args
 
     def get_modifiers_id(self, version: int) -> str:
-        res = []
+        res: list[str] = []
         if self.volatile:
             res.append('V')
         if self.const:
@@ -2003,7 +2003,7 @@ class ASTParametersQualifiers(ASTBase):
             return ''.join(a.get_id(version) for a in self.args)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append('(')
         first = True
         for a in self.args:
@@ -2302,7 +2302,7 @@ class ASTDeclSpecs(ASTBase):
 
     def get_id(self, version: int) -> str:
         if version == 1:
-            res = []
+            res: list[str] = []
             res.append(self.trailingTypeSpec.get_id(version))
             if self.allSpecs.volatile:
                 res.append('V')
@@ -2500,7 +2500,7 @@ class ASTDeclaratorNameParamQual(ASTDeclarator):
 
     def get_type_id(self, version: int, returnTypeId: str) -> str:
         assert version >= 2
-        res = []
+        res: list[str] = []
         # TODO: can we actually have both array ops and paramQual?
         res.append(self.get_ptr_suffix_id(version))
         if self.paramQual:
@@ -2522,7 +2522,7 @@ class ASTDeclaratorNameParamQual(ASTDeclarator):
         return self.paramQual is not None
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.declId:
             res.append(transform(self.declId))
         res.extend(transform(op) for op in self.arrayOps)
@@ -2577,7 +2577,7 @@ class ASTDeclaratorNameBitField(ASTDeclarator):
         return False
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.declId:
             res.append(transform(self.declId))
         res.append(" : ")
@@ -2909,7 +2909,7 @@ class ASTDeclaratorMemPtr(ASTDeclarator):
         return True
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.className))
         res.append('::*')
         if self.volatile:
@@ -3184,7 +3184,7 @@ class ASTType(ASTBase):
     def get_id(self, version: int, objectType: str | None = None,
                symbol: Symbol | None = None) -> str:
         if version == 1:
-            res = []
+            res: list[str] = []
             if objectType:  # needs the name
                 if objectType == 'function':  # also modifiers
                     res.append(symbol.get_full_nested_name().get_id(version))
@@ -3236,7 +3236,7 @@ class ASTType(ASTBase):
         return ''.join(res)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         declSpecs = transform(self.declSpecs)
         res.append(declSpecs)
         if self.decl.require_space_after_declSpecs() and len(declSpecs) > 0:
@@ -3345,7 +3345,7 @@ class ASTTypeWithInit(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.type))
         if self.init:
             res.append(transform(self.init))
@@ -3379,7 +3379,7 @@ class ASTTypeUsing(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.name))
         if self.type:
             res.append(' = ')
@@ -3461,7 +3461,7 @@ class ASTBaseClass(ASTBase):
         return hash((self.name, self.visibility, self.virtual, self.pack))
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.visibility is not None:
             res.append(self.visibility)
             res.append(' ')
@@ -3512,7 +3512,7 @@ class ASTClass(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.attrs))
         if len(self.attrs) != 0:
             res.append(' ')
@@ -3570,7 +3570,7 @@ class ASTUnion(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.attrs))
         if len(self.attrs) != 0:
             res.append(' ')
@@ -3613,7 +3613,7 @@ class ASTEnum(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.scoped:
             res.append(self.scoped)
             res.append(' ')
@@ -3667,7 +3667,7 @@ class ASTEnumerator(ASTBase):
         return symbol.get_full_nested_name().get_id(version)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.name))
         if len(self.attrs) != 0:
             res.append(' ')
@@ -3744,7 +3744,7 @@ class ASTTemplateKeyParamPackIdDefault(ASTTemplateParam):
     def get_id(self, version: int) -> str:
         assert version >= 2
         # this is not part of the normal name mangling in C++
-        res = []
+        res: list[str] = []
         if self.parameterPack:
             res.append('Dp')
         else:
@@ -3961,7 +3961,7 @@ class ASTTemplateParams(ASTBase):
 
     def get_id(self, version: int, excludeRequires: bool = False) -> str:
         assert version >= 2
-        res = []
+        res: list[str] = []
         res.append("I")
         res.extend(param.get_id(version) for param in self.params)
         res.append("E")
@@ -3970,7 +3970,7 @@ class ASTTemplateParams(ASTBase):
         return ''.join(res)
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append("template<")
         res.append(", ".join(transform(a) for a in self.params))
         res.append("> ")
@@ -4080,7 +4080,7 @@ class ASTTemplateIntroductionParameter(ASTBase):
             return res
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.parameterPack:
             res.append('...')
         res.append(transform(self.identifier))
@@ -4125,7 +4125,7 @@ class ASTTemplateIntroduction(ASTBase):
         ])
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         res.append(transform(self.concept))
         res.append('{')
         res.append(', '.join(transform(param) for param in self.params))
@@ -4178,7 +4178,7 @@ class ASTTemplateDeclarationPrefix(ASTBase):
     def get_id_except_requires_clause_in_last(self, version: int) -> str:
         assert version >= 2
         # This is not part of the Itanium ABI mangling system.
-        res = []
+        res: list[str] = []
         lastIndex = len(self.templates) - 1
         for i, t in enumerate(self.templates):
             if isinstance(t, ASTTemplateParams):
@@ -4330,7 +4330,7 @@ class ASTDeclaration(ASTBase):
         return self._newest_id_cache
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.visibility and self.visibility != "public":
             res.append(self.visibility)
             res.append(' ')
@@ -4424,7 +4424,7 @@ class ASTNamespace(ASTBase):
         )
 
     def _stringify(self, transform: StringifyTransform) -> str:
-        res = []
+        res: list[str] = []
         if self.templatePrefix:
             res.append(transform(self.templatePrefix))
         res.append(transform(self.nestedName))

--- a/sphinx/domains/cpp/_parser.py
+++ b/sphinx/domains/cpp/_parser.py
@@ -634,7 +634,7 @@ class DefinitionParser(BaseParser):
                 try:
                     return self._parse_unary_expression()
                 except DefinitionError as exUnary:
-                    errs = []
+                    errs: list[tuple[DefinitionError, str]] = []
                     errs.append((exCast, "If type cast expression"))
                     errs.append((exUnary, "If unary expression"))
                     raise self._make_multi_error(errs,
@@ -662,8 +662,8 @@ class DefinitionParser(BaseParser):
             else:
                 def parser(inTemplate: bool) -> ASTExpression:
                     return _parse_bin_op_expr(self, opId + 1, inTemplate=inTemplate)
-            exprs = []
-            ops = []
+            exprs: list[ASTExpression] = []
+            ops: list[str] = []
             exprs.append(parser(inTemplate=inTemplate))
             while True:
                 self.skip_ws()
@@ -855,7 +855,7 @@ class DefinitionParser(BaseParser):
             return None
         if self.skip_string('>'):
             return ASTTemplateArgs([], False)
-        prevErrors = []
+        prevErrors: list[tuple[DefinitionError, str]] = []
         templateArgs: list[ASTType | ASTTemplateArgConstant] = []
         packExpansion = False
         while 1:
@@ -1102,7 +1102,7 @@ class DefinitionParser(BaseParser):
                 self.fail('Expecting "(" in parameters-and-qualifiers.')
             else:
                 return None
-        args = []
+        args: list[ASTFunctionParameter] = []
         self.skip_ws()
         if not self.skip_string(')'):
             while 1:
@@ -1332,7 +1332,7 @@ class DefinitionParser(BaseParser):
             declId = self._parse_nested_name()
         else:
             declId = None
-        arrayOps = []
+        arrayOps: list[ASTArray] = []
         while 1:
             self.skip_ws()
             if typed and self.skip_string('['):
@@ -1367,7 +1367,7 @@ class DefinitionParser(BaseParser):
         if paramMode not in ('type', 'function', 'operatorCast', 'new'):
             raise Exception(
                 "Internal error, unknown paramMode '%s'." % paramMode)
-        prevErrors = []
+        prevErrors: list[tuple[DefinitionError, str]] = []
         self.skip_ws()
         if typed and self.skip_string('*'):
             self.skip_ws()
@@ -1541,7 +1541,7 @@ class DefinitionParser(BaseParser):
             # We allow type objects to just be a name.
             # Some functions don't have normal return types: constructors,
             # destructors, cast operators
-            prevErrors = []
+            prevErrors: list[tuple[DefinitionError, str]] = []
             startPos = self.pos
             # first try without the type
             try:
@@ -1650,7 +1650,7 @@ class DefinitionParser(BaseParser):
         except DefinitionError as eType:
             if eExpr is None:
                 raise
-            errs = []
+            errs: list[tuple[DefinitionError, str]] = []
             errs.append((eExpr, "If default template argument is an expression"))
             errs.append((eType, "If default template argument is a type"))
             msg = "Error in non-type template parameter"
@@ -1676,7 +1676,7 @@ class DefinitionParser(BaseParser):
         name = self._parse_nested_name()
         self.skip_ws()
         final = self.skip_word_and_ws('final')
-        bases = []
+        bases: list[ASTBaseClass] = []
         self.skip_ws()
         if self.skip_string(':'):
             while 1:
@@ -1788,7 +1788,7 @@ class DefinitionParser(BaseParser):
             except DefinitionError as eNonType:
                 self.pos = pos
                 header = "Error when parsing template parameter."
-                errs = []
+                errs: list[tuple[DefinitionError, str]] = []
                 errs.append(
                     (eType, "If unconstrained type parameter or template type parameter"))
                 errs.append(
@@ -1819,7 +1819,7 @@ class DefinitionParser(BaseParser):
                 continue
             else:
                 header = "Error in template parameter list."
-                errs = []
+                errs: list[tuple[DefinitionError, str]] = []
                 if err:
                     errs.append((err, "If parameter"))
                 try:
@@ -1842,7 +1842,7 @@ class DefinitionParser(BaseParser):
             return None
 
         # for sure it must be a template introduction now
-        params = []
+        params: list[ASTTemplateIntroductionParameter] = []
         while 1:
             self.skip_ws()
             parameterPack = self.skip_string('...')
@@ -1878,8 +1878,8 @@ class DefinitionParser(BaseParser):
             return None
 
         def parse_and_expr(self: DefinitionParser) -> ASTExpression:
-            andExprs = []
-            ops = []
+            andExprs: list[ASTExpression] = []
+            ops: list[str] = []
             andExprs.append(self._parse_primary_expression())
             while True:
                 self.skip_ws()
@@ -1898,8 +1898,8 @@ class DefinitionParser(BaseParser):
             else:
                 return ASTBinOpExpr(andExprs, ops)
 
-        orExprs = []
-        ops = []
+        orExprs: list[ASTExpression] = []
+        ops: list[str] = []
         orExprs.append(parse_and_expr(self))
         while True:
             self.skip_ws()
@@ -2013,7 +2013,7 @@ class DefinitionParser(BaseParser):
             templatePrefix = self._parse_template_declaration_prefix(objectType)
 
         if objectType == 'type':
-            prevErrors = []
+            prevErrors: list[tuple[DefinitionError, str]] = []
             pos = self.pos
             try:
                 if not templatePrefix:
@@ -2090,7 +2090,7 @@ class DefinitionParser(BaseParser):
                 self.assert_end()
                 return res2, False
             except DefinitionError as e2:
-                errs = []
+                errs: list[tuple[DefinitionError, str]] = []
                 errs.append((e1, "If shorthand ref"))
                 errs.append((e2, "If full function ref"))
                 msg = "Error in cross-reference."
@@ -2112,7 +2112,7 @@ class DefinitionParser(BaseParser):
                 return typ
             except DefinitionError as exType:
                 header = "Error when parsing (type) expression."
-                errs = []
+                errs: list[tuple[DefinitionError, str]] = []
                 errs.append((exExpr, "If expression"))
                 errs.append((exType, "If type"))
                 raise self._make_multi_error(errs, header) from exType

--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -438,7 +438,7 @@ class JavaScriptDomain(Domain):
         if name[-2:] == '()':
             name = name[:-2]
 
-        searches = []
+        searches: list[str] = []
         if mod_name and prefix:
             searches.append(f'{mod_name}.{prefix}.{name}')
         if mod_name:

--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -164,7 +164,7 @@ def _parse_annotation(annotation: str, env: BuildEnvironment) -> list[Node]:
         if isinstance(node, ast.Call):
             # Call nodes can be used in Annotated type metadata,
             # for example Annotated[str, ArbitraryTypeValidator(str, len=10)]
-            args = []
+            args: list[Node] = []
             for arg in node.args:
                 args += unparse(arg)
                 args.append(addnodes.desc_sig_punctuation('', ','))
@@ -234,7 +234,7 @@ class _TypeParameterListParser(TokenProcessor):
         self.type_params: list[tuple[str, int, Any, Any]] = []
 
     def fetch_type_param_spec(self) -> list[Token]:
-        tokens = []
+        tokens: list[Token] = []
         while current := self.fetch_token():
             tokens.append(current)
             for ldelim, rdelim in ('(', ')'), ('{', '}'), ('[', ']'):

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -180,7 +180,7 @@ class TocTreeCollector(EnvironmentCollector):
     def assign_section_numbers(self, env: BuildEnvironment) -> list[str]:
         """Assign a section number to each heading under a numbered toctree."""
         # a list of all docnames whose section numbers changed
-        rewrite_needed = []
+        rewrite_needed: list[str] = []
 
         assigned: set[str] = set()
         old_secnumbers = env.toc_secnumbers
@@ -262,7 +262,7 @@ class TocTreeCollector(EnvironmentCollector):
         """Assign a figure number to each figure under a numbered toctree."""
         generated_docnames = frozenset(env.domains['std']._virtual_doc_names)
 
-        rewrite_needed = []
+        rewrite_needed: list[str] = []
 
         assigned: set[str] = set()
         old_fignumbers = env.toc_fignumbers

--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -302,8 +302,8 @@ def recurse_tree(
         # otherwise, the base is a directory with packages
         root_package = None
 
-    toplevels = []
-    written_files = []
+    toplevels: list[str] = []
+    written_files: list[Path] = []
     for root, subs, files in walk(rootpath, excludes, opts):
         is_pkg = is_packagedir(None, files)
         is_namespace = not is_pkg and opts.implicit_namespaces

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -658,7 +658,7 @@ class Documenter:
 
             return False
 
-        ret = []
+        ret: list[tuple[str, Any, bool]] = []
 
         # search for members in source code too
         namespace = '.'.join(self.objpath)  # will be empty for modules
@@ -1070,7 +1070,7 @@ class ModuleDocumenter(Documenter):
                 return False, list(members.values())
         else:
             memberlist = self.options.members or []
-            ret = []
+            ret: list[ObjectMember] = []
             for name in memberlist:
                 if name in members:
                     ret.append(members[name])
@@ -1177,7 +1177,7 @@ class DocstringSignatureMixin:
 
     def _find_signature(self) -> tuple[str | None, str | None] | None:
         # candidates of the object name
-        valid_names = [self.objpath[-1]]  # type: ignore[attr-defined]
+        valid_names: list[str] = [self.objpath[-1]]  # type: ignore[attr-defined]
         if isinstance(self, ClassDocumenter):
             valid_names.append('__init__')
             if hasattr(self.object, '__mro__'):
@@ -1187,7 +1187,7 @@ class DocstringSignatureMixin:
         if docstrings is None:
             return None, None
         self._new_docstrings = docstrings[:]
-        self._signatures = []
+        self._signatures: list[str] = []
         result = None
         for i, doclines in enumerate(docstrings):
             for j, line in enumerate(doclines):
@@ -1322,7 +1322,7 @@ class FunctionDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # typ
         if self.config.autodoc_typehints_format == "short":
             kwargs.setdefault('unqualified_typehints', True)
 
-        sigs = []
+        sigs: list[str] = []
         if (self.analyzer and
                 '.'.join(self.objpath) in self.analyzer.overloads and
                 self.config.autodoc_typehints != 'none'):
@@ -1623,7 +1623,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             kwargs.setdefault('unqualified_typehints', True)
 
         sig = super().format_signature()
-        sigs = []
+        sigs: list[str] = []
 
         overloads = self.get_overloaded_signatures()
         if overloads and self.config.autodoc_typehints != 'none':
@@ -1724,7 +1724,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
             if not self.options.members:
                 return False, []
             # specific members given
-            selected = []
+            selected: list[ObjectMember] = []
             for name in self.options.members:
                 if name in members:
                     selected.append(members[name])
@@ -1754,7 +1754,7 @@ class ClassDocumenter(DocstringSignatureMixin, ModuleLevelDocumenter):  # type: 
 
         classdoc_from = self.options.get('class-doc-from', self.config.autoclass_content)
 
-        docstrings = []
+        docstrings: list[str] = []
         attrdocstring = getdoc(self.object, self.get_attr)
         if attrdocstring:
             docstrings.append(attrdocstring)
@@ -2205,7 +2205,7 @@ class MethodDocumenter(DocstringSignatureMixin, ClassLevelDocumenter):  # type: 
         if self.config.autodoc_typehints_format == "short":
             kwargs.setdefault('unqualified_typehints', True)
 
-        sigs = []
+        sigs: list[str] = []
         if (self.analyzer and
                 '.'.join(self.objpath) in self.analyzer.overloads and
                 self.config.autodoc_typehints != 'none'):

--- a/sphinx/ext/autodoc/type_comment.py
+++ b/sphinx/ext/autodoc/type_comment.py
@@ -38,7 +38,7 @@ def signature_from_ast(node: ast.FunctionDef, bound_method: bool,
 
     :param bound_method: Specify *node* is a bound method or not
     """
-    params = []
+    params: list[Parameter] = []
     for arg in node.args.posonlyargs:
         param = Parameter(arg.arg, Parameter.POSITIONAL_ONLY, annotation=arg.type_comment)
         params.append(param)

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -241,7 +241,7 @@ class Autosummary(SphinxDirective):
             dirname = posixpath.dirname(self.env.docname)
 
             tree_prefix = self.options['toctree'].strip()
-            docnames = []
+            docnames: list[str] = []
             excluded = Matcher(self.config.exclude_patterns)
             filename_map = self.config.autosummary_filename_map
             for _name, _sig, _summary, real_name in items:
@@ -637,7 +637,7 @@ def import_by_name(
     """Import a Python object that has the given *name*, under one of the
     *prefixes*.  The first name that succeeds is used.
     """
-    tried = []
+    tried: list[str] = []
     errors: list[ImportExceptionGroup] = []
     for prefix in prefixes:
         if prefix is not None and name.startswith(f'{prefix}.'):

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -222,7 +222,7 @@ class ModuleScanner:
             return False
 
     def scan(self, imported_members: bool) -> list[str]:
-        members = []
+        members: list[str] = []
         try:
             analyzer = ModuleAnalyzer.for_module(self.object.__name__)
             attr_docs = analyzer.find_attr_docs()
@@ -456,7 +456,8 @@ def _get_members(
 
 def _get_module_attrs(name: str, members: Any) -> tuple[list[str], list[str]]:
     """Find module attributes with docstrings."""
-    attrs, public = [], []
+    attrs: list[str] = []
+    public: list[str] = []
     try:
         analyzer = ModuleAnalyzer.for_module(name)
         attr_docs = analyzer.find_attr_docs()

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -39,7 +39,7 @@ def write_header(f: IO[str], text: str, char: str = '-') -> None:
 
 
 def compile_regex_list(name: str, exps: str) -> list[re.Pattern[str]]:
-    lst = []
+    lst: list[re.Pattern[str]] = []
     for exp in exps:
         try:
             lst.append(re.compile(exp))
@@ -284,7 +284,7 @@ class CoverageBuilder(Builder):
             documented_objects: set[str] = set()
             undocumented_objects: set[str] = set()
 
-            funcs = []
+            funcs: list[str] = []
             classes: dict[str, list[str]] = {}
 
             for name, obj in inspect.getmembers(mod):

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -407,7 +407,7 @@ Doctest summary
 
     def test_doc(self, docname: str, doctree: Node) -> None:
         groups: dict[str, TestGroup] = {}
-        add_to_all_groups = []
+        add_to_all_groups: list[TestCode] = []
         self.setup_runner = SphinxDocTestRunner(verbose=False,
                                                 optionflags=self.opt)
         self.test_runner = SphinxDocTestRunner(verbose=False,
@@ -494,7 +494,7 @@ Doctest summary
         ns: dict = {}
 
         def run_setup_cleanup(runner: Any, testcodes: list[TestCode], what: Any) -> bool:
-            examples = []
+            examples: list[doctest.Example] = []
             for testcode in testcodes:
                 example = doctest.Example(testcode.code, '', lineno=testcode.lineno)
                 examples.append(example)

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -140,7 +140,7 @@ def load_mappings(app: Sphinx) -> None:
     intersphinx_cache: dict[InventoryURI, InventoryCacheEntry] = inventories.cache
     intersphinx_mapping: IntersphinxMapping = app.config.intersphinx_mapping
 
-    projects = []
+    projects: list[_IntersphinxProject] = []
     for name, (uri, locations) in intersphinx_mapping.values():
         try:
             project = _IntersphinxProject(name=name, target_uri=uri, locations=locations)

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -259,7 +259,7 @@ class GoogleDocstring:
         return self._parsed_lines
 
     def _consume_indented_block(self, indent: int = 1) -> list[str]:
-        lines = []
+        lines: list[str] = []
         line = self._lines.get(0)
         while (
             not self._is_section_break() and
@@ -270,7 +270,7 @@ class GoogleDocstring:
         return lines
 
     def _consume_contiguous(self) -> list[str]:
-        lines = []
+        lines: list[str] = []
         while (self._lines and
                self._lines.get(0) and
                not self._is_section_header()):
@@ -278,7 +278,7 @@ class GoogleDocstring:
         return lines
 
     def _consume_empty(self) -> list[str]:
-        lines = []
+        lines: list[str] = []
         line = self._lines.get(0)
         while self._lines and not line:
             lines.append(self._lines.next())
@@ -369,14 +369,14 @@ class GoogleDocstring:
         return section
 
     def _consume_to_end(self) -> list[str]:
-        lines = []
+        lines: list[str] = []
         while self._lines:
             lines.append(self._lines.next())
         return lines
 
     def _consume_to_next_section(self) -> list[str]:
         self._consume_empty()
-        lines = []
+        lines: list[str] = []
         while not self._is_section_break():
             lines.append(self._lines.next())
         return lines + self._consume_empty()
@@ -428,7 +428,7 @@ class GoogleDocstring:
         if lines:
             if padding is None:
                 padding = ' ' * len(prefix)
-            result_lines = []
+            result_lines: list[str] = []
             for i, line in enumerate(lines):
                 if i == 0:
                     result_lines.append((prefix + line).rstrip())
@@ -443,7 +443,7 @@ class GoogleDocstring:
     def _format_docutils_params(self, fields: list[tuple[str, str, list[str]]],
                                 field_role: str = 'param', type_role: str = 'type',
                                 ) -> list[str]:
-        lines = []
+        lines: list[str] = []
         for _name, _type, _desc in fields:
             _desc = self._strip_empty(_desc)
             if any(_desc):
@@ -651,7 +651,7 @@ class GoogleDocstring:
         return lines
 
     def _parse_attributes_section(self, section: str) -> list[str]:
-        lines = []
+        lines: list[str] = []
         for _name, _type, _desc in self._consume_fields():
             if not _type:
                 _type = self._lookup_annotation(_name)
@@ -829,8 +829,8 @@ class GoogleDocstring:
         return self._format_fields(_('Yields'), fields)
 
     def _partition_field_on_colon(self, line: str) -> tuple[str, str, str]:
-        before_colon = []
-        after_colon = []
+        before_colon: list[str] = []
+        after_colon: list[str] = []
         colon = ''
         found_colon = False
         for i, source in enumerate(_xref_or_code_regex.split(line)):

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -292,7 +292,7 @@ def collect_pages(app: Sphinx) -> Iterator[tuple[str, dict[str, Any], str]]:
             lines[min(end, max_index)] += '</div>\n'
 
         # try to find parents (for submodules)
-        parents = []
+        parents: list[dict[str, str]] = []
         parent = modname
         while '.' in parent:
             parent = parent.rsplit('.', 1)[0]

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -55,7 +55,7 @@ def get_lvar_names(node: ast.AST, self: ast.arg | None = None) -> list[str]:
         else:
             raise TypeError('The assignment %r is not instance variable' % node)
     elif node_name in ('Tuple', 'List'):
-        members = []
+        members: list[str] = []
         for elt in node.elts:  # type: ignore[attr-defined]
             with contextlib.suppress(TypeError):
                 members.extend(get_lvar_names(elt, self))
@@ -152,7 +152,7 @@ class TokenProcessor:
 
         .. note:: This also handles parenthesis well.
         """
-        tokens = []
+        tokens: list[Token] = []
         while current := self.fetch_token():
             tokens.append(current)
             if current == condition:
@@ -278,7 +278,7 @@ class VariableCommentPicker(ast.NodeVisitor):
             self.annotations[(basename, name)] = ast_unparse(annotation)
 
     def is_final(self, decorators: list[ast.expr]) -> bool:
-        final = []
+        final: list[str] = []
         if self.typing:
             final.append('%s.final' % self.typing)
         if self.typing_final:
@@ -294,7 +294,7 @@ class VariableCommentPicker(ast.NodeVisitor):
         return False
 
     def is_overload(self, decorators: list[ast.expr]) -> bool:
-        overload = []
+        overload: list[str] = []
         if self.typing:
             overload.append('%s.overload' % self.typing)
         if self.typing_overload:
@@ -379,7 +379,7 @@ class VariableCommentPicker(ast.NodeVisitor):
 
         # check comments before assignment
         if indent_re.match(current_line[:node.col_offset]):
-            comment_lines = []
+            comment_lines: list[str] = []
             for i in range(node.lineno - 1):
                 before_line = self.get_line(node.lineno - 1 - i)
                 if comment_re.match(before_line):

--- a/sphinx/search/ja.py
+++ b/sphinx/search/ja.py
@@ -417,7 +417,7 @@ class DefaultSplitter(BaseSplitter):
         if not input:
             return []
 
-        result = []
+        result: list[str] = []
         seg = ['B3', 'B2', 'B1', *input, 'E1', 'E2', 'E3']
         ctype = ['O', 'O', 'O', *map(self.ctype_, input), 'O', 'O', 'O']
         word = seg[3]

--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -189,7 +189,7 @@ def make_app(test_params: dict[str, Any]) -> Iterator[Callable[[], SphinxTestApp
     if you want to initialize 'app' in your test function. please use this
     instead of using SphinxTestApp class directory.
     """
-    apps = []
+    apps: list[SphinxTestApp] = []
     syspath = sys.path.copy()
 
     def make(*args: Any, **kwargs: Any) -> SphinxTestApp:

--- a/sphinx/theming.py
+++ b/sphinx/theming.py
@@ -531,7 +531,7 @@ def _migrate_conf_to_toml(argv: list[str]) -> int:
         toml_lines += [f'    "{s}",' for s in map(str.strip, sidebar.split(','))]
         toml_lines.append(']')
 
-    styles = []
+    styles: list[str] = []
     default = _cfg_parser.get('theme', 'pygments_style', fallback=...)
     if default is not ...:
         styles.append(f'default = "{default}"')

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -520,7 +520,7 @@ class Locale(SphinxTransform):
                 new_entries: list[tuple[str, str, str, str, str | None]] = []
                 for entry_type, value, target_id, main, _category_key in entries:
                     msg_parts = split_index_msg(entry_type, value)
-                    msgstr_parts = []
+                    msgstr_parts: list[str] = []
                     for part in msg_parts:
                         msgstr = merged.get(part, '')
                         if not msgstr:

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -96,7 +96,7 @@ def parselinenos(spec: str, total: int) -> list[int]:
     """Parse a line number spec (such as "1,2,4-6") and return a list of
     wanted line numbers.
     """
-    items = []
+    items: list[int] = []
     parts = spec.split(',')
     for part in parts:
         try:

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -318,7 +318,7 @@ class BaseParser:
         logger.debug(f"{msg}\n{self.definition}\n{indicator}")  # NoQA: G004
 
     def fail(self, msg: str) -> None:
-        errors = []
+        errors: list[tuple[DefinitionError, str]] = []
         indicator = '-' * self.pos + '^'
         exMain = DefinitionError(
             'Invalid %s declaration: %s [error at %d]\n  %s\n  %s' %
@@ -448,7 +448,7 @@ class BaseParser:
                 self.fail("Expected '(' after '__attribute__'.")
             if not self.skip_string_and_ws('('):
                 self.fail("Expected '(' after '__attribute__('.")
-            attrs = []
+            attrs: list[ASTGnuAttribute] = []
             while 1:
                 if self.match(identifier_re):
                     name = self.matched_text
@@ -482,7 +482,7 @@ class BaseParser:
         return None
 
     def _parse_attribute_list(self) -> ASTAttributeList:
-        res = []
+        res: list[ASTAttribute] = []
         while True:
             attr = self._parse_attribute()
             if attr is None:

--- a/sphinx/util/docstrings.py
+++ b/sphinx/util/docstrings.py
@@ -14,7 +14,7 @@ def separate_metadata(s: str | None) -> tuple[str | None, dict[str, str]]:
     """Separate docstring into metadata and others."""
     in_other_element = False
     metadata: dict[str, str] = {}
-    lines = []
+    lines: list[str] = []
 
     if not s:
         return s, metadata
@@ -74,7 +74,7 @@ def prepare_commentdoc(s: str) -> list[str]:
     """Extract documentation comment lines (starting with #:) and return them
     as a list of lines.  Returns an empty list if there is no documentation.
     """
-    result = []
+    result: list[str] = []
     lines = [line.strip() for line in s.expandtabs().splitlines()]
     for line in lines:
         if line.startswith('#:'):

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -234,7 +234,7 @@ def format_date(
         else:
             date = datetime.now(tz=timezone.utc).astimezone()
 
-    result = []
+    result: list[str] = []
     tokens = date_format_re.split(format)
     for token in tokens:
         if token in date_format_mappings:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -757,7 +757,7 @@ def stringify_signature(
 
     EMPTY = Parameter.empty
 
-    args = []
+    args: list[str] = []
     last_kind = None
     for param in sig.parameters.values():
         if param.kind != Parameter.POSITIONAL_ONLY and last_kind == Parameter.POSITIONAL_ONLY:

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -257,7 +257,7 @@ def pending_warnings() -> Iterator[logging.Handler]:
     memhandler.setLevel(logging.WARNING)
 
     try:
-        handlers = []
+        handlers: list[logging.Handler] = []
         for handler in logger.handlers[:]:
             if isinstance(handler, WarningStreamHandler):
                 logger.removeHandler(handler)
@@ -289,7 +289,7 @@ def suppress_logging() -> Iterator[MemoryHandler]:
     memhandler = MemoryHandler()
 
     try:
-        handlers = []
+        handlers: list[logging.Handler] = []
         for handler in logger.handlers[:]:
             logger.removeHandler(handler)
             handlers.append(handler)

--- a/sphinx/util/matching.py
+++ b/sphinx/util/matching.py
@@ -136,7 +136,7 @@ def get_matching_files(
             relative_root = ""  # suppress dirname for files on the target dir
 
         # Filter files
-        included_files = []
+        included_files: list[str] = []
         for entry in sorted(files):
             entry = path_stabilize(os.path.join(relative_root, entry))
             keep = False
@@ -154,7 +154,7 @@ def get_matching_files(
                 included_files.append(entry)
 
         # Filter directories
-        filtered_dirs = []
+        filtered_dirs: list[str] = []
         for dir_name in sorted(dirs):
             normalised = path_stabilize(os.path.join(relative_root, dir_name))
             for matcher in exclude_matchers:

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -422,7 +422,7 @@ def inline_all_toctrees(
     """
     tree = tree.deepcopy()
     for toctreenode in list(tree.findall(addnodes.toctree)):
-        newnodes = []
+        newnodes: list[Node] = []
         includefiles = map(str, toctreenode['includefiles'])
         indent += ' '
         for includefile in includefiles:

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -256,7 +256,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
             return f':py:class:`{module_prefix}{_INVALID_BUILTIN_CLASSES[cls]}`'
         elif _is_annotated_form(cls):
             args = restify(cls.__args__[0], mode)
-            meta_args = []
+            meta_args: list[str] = []
             for m in cls.__metadata__:
                 if isinstance(m, type):
                     meta_args.append(restify(m, mode))
@@ -500,7 +500,7 @@ def stringify_annotation(
             return f'{module_prefix}Literal[{args}]'
         elif _is_annotated_form(annotation):  # for py310+
             args = stringify_annotation(annotation_args[0], mode)
-            meta_args = []
+            meta_args: list[str] = []
             for m in annotation.__metadata__:
                 if isinstance(m, type):
                     meta_args.append(stringify_annotation(m, mode))

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -872,7 +872,9 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):  # type: ignore[misc]
         self._table_row_indices.append(0)
 
         atts = {}
-        classes = [cls.strip(' \t\n') for cls in self.settings.table_style.split(',')]
+        classes: list[str] = [
+            cls.strip(' \t\n') for cls in self.settings.table_style.split(',')
+        ]
         classes.insert(0, "docutils")  # compat
 
         # set align-default if align not specified to give a default style

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -316,7 +316,7 @@ class LaTeXTranslator(SphinxTranslator):
         self.first_param = 0
         self.in_desc_signature = False
 
-        sphinxpkgoptions = []
+        sphinxpkgoptions: list[str] = []
 
         # sort out some elements
         self.elements = self.builder.context.copy()
@@ -499,7 +499,7 @@ class LaTeXTranslator(SphinxTranslator):
                                (entry[2], self.idescape(entry[3])) + CR)
             ret.append(r'\end{sphinxtheindex}' + CR)
 
-        ret = []
+        ret: list[str] = []
         # latex_domain_indices can be False/True or a list of index names
         if indices_config := self.config.latex_domain_indices:
             if not isinstance(indices_config, bool):
@@ -1455,7 +1455,7 @@ class LaTeXTranslator(SphinxTranslator):
     def visit_image(self, node: Element) -> None:
         pre: list[str] = []  # in reverse order
         post: list[str] = []
-        include_graphics_options = []
+        include_graphics_options: list[str] = []
         has_hyperlink = isinstance(node.parent, nodes.reference)
         if has_hyperlink:
             is_inline = self.is_inline(node.parent)

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -84,7 +84,7 @@ TEMPLATE = """\
 
 def find_subsections(section: Element) -> list[nodes.section]:
     """Return a list of subsections for the given ``section``."""
-    result = []
+    result: list[nodes.section] = []
     for child in section:
         if isinstance(child, nodes.section):
             result.append(child)

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -200,7 +200,7 @@ class Table:
         return physical_lines
 
     def __str__(self) -> str:
-        out = []
+        out: list[str] = []
         self.rewrap()
 
         def writesep(char: str = "-", lineno: int | None = None) -> str:
@@ -275,7 +275,7 @@ class TextWrapper(textwrap.TextWrapper):
         chunks.reverse()
 
         while chunks:
-            cur_line = []
+            cur_line: list[str] = []
             cur_len = 0
 
             if lines:


### PR DESCRIPTION
This is required for strict type checking, and even without that, it prevents errors of e.g. `.append`-ing the wrong type accidentally.