### PR TITLE
HTML: Assign glossary terms with grouping keys to single-character groupings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,10 @@ Bugs fixed
   file URL (user-defined base URL of an intersphinx project are left untouched
   even if they end with double forward slashes).
   Patch by Bénédikt Tran.
+* #12707: HTML: Fix a bug where the grouping keys (categories) used in
+  glossaries would be used instead of the expected single-character groupings
+  displayed for all other index entries.
+  Patch by James Addison.
 
 Testing
 -------

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -219,7 +219,7 @@ def _group_by_func(entry: tuple[str, _IndexEntry]) -> str:
     key, (targets, sub_items, category_key) = entry
 
     if category_key is not None:
-        return category_key
+        key = category_key
 
     # now calculate the key
     if key.startswith('\N{RIGHT-TO-LEFT MARK}'):

--- a/sphinx/environment/adapters/indexentries.py
+++ b/sphinx/environment/adapters/indexentries.py
@@ -82,6 +82,9 @@ class IndexEntries:
                         except ValueError:
                             entry, = _split_into(1, 'single', value)
                             sub_entry = ''
+                        if category_key and not entry.startswith(category_key):
+                            # TODO: can sub_entry be non-empty here?  under what conditions?
+                            entry, sub_entry = category_key, entry
                         _add_entry(entry, sub_entry, main,
                                    dic=new, link=uri, key=category_key)
                     elif entry_type == 'pair':

--- a/tests/roots/test-glossary/index.rst
+++ b/tests/roots/test-glossary/index.rst
@@ -10,9 +10,9 @@ test-glossary
    *fermion*
       Particle with half-integer spin.
 
-   tauon
-   myon
-   electron
+   tauon : fermions
+   myon : fermions
+   electron : fermions
       Examples for fermions.
 
    über

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -360,9 +360,9 @@ This tests :CLASS:`role names in uppercase`.
    *fermion*
       Particle with half-integer spin.
 
-   tauon
-   myon
-   electron
+   tauon : fermions
+   myon : fermions
+   electron : fermions
       Examples for fermions.
 
    über

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -24,7 +24,7 @@ def _symbolic_hyperlink_check(nodes: Sequence[Element]) -> None:
     _ = locale.get_translation('sphinx')
     for idx, node in enumerate(nodes):
         assert node.tag == 'a', 'Attempted to check hyperlink on a non-anchor element'
-        hyperlink_label = "".join(node.itertext())
+        hyperlink_label = ''.join(node.itertext())
         if idx == 0 and hyperlink_label == _('Symbols'):
             continue  # allow the first label to be a named group of symbols
         assert len(hyperlink_label) == 1
@@ -495,7 +495,7 @@ def tail_check(check: str) -> Callable[[Iterable[Element]], Literal[True]]:
         ('genindex.html', './/a/strong', 'Other'),
         ('genindex.html', './/a', 'entry'),
         ('genindex.html', './/li/a', 'double'),
-        ('genindex.html', './/div[@class="genindex-jumpbox"]/a', _symbolic_hyperlink_check),
+        ('genindex.html', './/div[@class~="jumpbox"]/a', _symbolic_hyperlink_check),
         ('otherext.html', './/h1', 'Generated section'),
         ('otherext.html', ".//a[@href='_sources/otherext.foo.txt']", ''),
         ('search.html', ".//meta[@name='robots'][@content='noindex']", ''),

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -8,12 +8,26 @@ from typing import TYPE_CHECKING
 import pytest
 from docutils import nodes
 
+from sphinx import locale
+
 from tests.test_builders.xpath_util import check_xpath
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
     from typing import Literal
     from xml.etree.ElementTree import Element
+
+
+def _symbolic_hyperlink_check(nodes: Sequence[Element]) -> None:
+    """Confirm that a series of nodes are HTML hyperlinks represented by individual symbols"""
+    assert nodes, 'Expected at least one node to check'
+    _ = locale.get_translation('sphinx')
+    for idx, node in enumerate(nodes):
+        assert node.tag == 'a', 'Attempted to check hyperlink on a non-anchor element'
+        hyperlink_label = "".join(node.itertext())
+        if idx == 0 and hyperlink_label == _('Symbols'):
+            continue  # allow the first label to be a named group of symbols
+        assert len(hyperlink_label) == 1
 
 
 def tail_check(check: str) -> Callable[[Iterable[Element]], Literal[True]]:
@@ -481,6 +495,7 @@ def tail_check(check: str) -> Callable[[Iterable[Element]], Literal[True]]:
         ('genindex.html', './/a/strong', 'Other'),
         ('genindex.html', './/a', 'entry'),
         ('genindex.html', './/li/a', 'double'),
+        ('genindex.html', './/div[@class="genindex-jumpbox"]/a', _symbolic_hyperlink_check),
         ('otherext.html', './/h1', 'Generated section'),
         ('otherext.html', ".//a[@href='_sources/otherext.foo.txt']", ''),
         ('search.html', ".//meta[@name='robots'][@content='noindex']", ''),

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from xml.etree.ElementTree import Element
 
 
-def _symbolic_hyperlink_check(nodes: Sequence[Element]) -> None:
+def _symbolic_link_check(nodes: Sequence[Element]) -> None:
     """Confirm that a series of nodes are HTML hyperlinks represented by individual symbols"""
     assert nodes, 'Expected at least one node to check'
     _ = locale.get_translation('sphinx')
@@ -495,7 +495,7 @@ def tail_check(check: str) -> Callable[[Iterable[Element]], Literal[True]]:
         ('genindex.html', './/a/strong', 'Other'),
         ('genindex.html', './/a', 'entry'),
         ('genindex.html', './/li/a', 'double'),
-        ('genindex.html', './/div[@class~="jumpbox"]/a', _symbolic_hyperlink_check),
+        ('genindex.html', './/div[@class="genindex-jumpbox"]/a', _symbolic_link_check),
         ('otherext.html', './/h1', 'Generated section'),
         ('otherext.html', ".//a[@href='_sources/otherext.foo.txt']", ''),
         ('search.html', ".//meta[@name='robots'][@content='noindex']", ''),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Group `glossary` items by a single-character symbol instead of grouping key (when present).

### Detail
- Instead of short-circuit returning the (optional) `category_key` -- the entire grouping key name -- and using that as a heading to place glossary terms under, instead derive a single-character symbol _from_ `category_key`.
- This [borrows existing logic used in the `_key_func_1` function](https://github.com/sphinx-doc/sphinx/blob/04381789db7466d56d9eb29d23d979fc16604acc/sphinx/environment/adapters/indexentries.py#L189-L192).

### Concerns
- I'm uncertain whether this grouping logic is valid for locales other than Latin-based scripts.  In particular, there are some use cases for Katakana in the test suite that seem to indicate that glossary grouping keys are used for curated organization of index entries.

### Relates
- Resolves #12707.

### Screenshots

**Before (en)**
![image](https://github.com/user-attachments/assets/f467133c-eeda-4b0e-8ad1-883a605cdcad)

**After (en)**
![image](https://github.com/user-attachments/assets/6ee3c148-28d4-46d4-9386-4b4013043230)

Edit: fixup: I'd uploaded an incorrect after-fix sample image, containing a made-up `fooon` fermion in the glossary.  That is now corrected.