### PR TITLE
Intersphinx: resolve type-check failures in inventory loading module

### DIFF
--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -19,8 +19,8 @@ from sphinx.util import requests
 from sphinx.util.inventory import InventoryFile
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from io import IOBase
+    from pathlib import Path
 
     from urllib3 import HTTPResponse
 

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -20,7 +20,9 @@ from sphinx.util.inventory import InventoryFile
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import IO
+    from io import IOBase
+
+    from urllib3 import HTTPResponse
 
     from sphinx.application import Sphinx
     from sphinx.config import Config
@@ -277,6 +279,7 @@ def _fetch_inventory(
         # case: inv URI points to remote resource; strip any existing auth
         target_uri = _strip_basic_auth(target_uri)
     try:
+        f: IOBase
         if '://' in inv_location:
             f = _read_from_url(inv_location, config=config)
         else:
@@ -357,7 +360,7 @@ def _strip_basic_auth(url: str) -> str:
     return urlunsplit(frags)
 
 
-def _read_from_url(url: str, *, config: Config) -> IO:
+def _read_from_url(url: str, *, config: Config) -> HTTPResponse:
     """Reads data from *url* with an HTTP *GET*.
 
     This function supports fetching from resources which use basic HTTP auth as
@@ -380,5 +383,5 @@ def _read_from_url(url: str, *, config: Config) -> IO:
     r.raw.url = r.url
     # decode content-body based on the header.
     # ref: https://github.com/psf/requests/issues/2155
-    r.raw.read = functools.partial(r.raw.read, decode_content=True)
+    r.raw.read = functools.partial(r.raw.read, decode_content=True)  # type: ignore[method-assign, misc]
     return r.raw

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import re
 import zlib
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from sphinx.locale import __
 from sphinx.util import logging
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from io import RawIOBase
 
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
@@ -26,7 +27,7 @@ class InventoryFileReader:
     This reader supports mixture of texts and compressed texts.
     """
 
-    def __init__(self, stream: IO[bytes]) -> None:
+    def __init__(self, stream: RawIOBase) -> None:
         self.stream = stream
         self.buffer = b''
         self.eof = False

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import re
 import zlib
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING
 
 from sphinx.locale import __
 from sphinx.util import logging


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Resolve some linter and continuous integration errors that have begun occurring.

### Detail
- Adjust the type hints for Intersphinx inventory loading to accomodate updated `types-requests` stubs.
- Intends to make these adjustments without affecting any runtime behaviour.
- Also attempts to communicate where `bytes` specifically (as opposed to generic IO output) are used -- however this is incomplete.

### Relates
- Resolves #12864.