### PR TITLE
[doc] Clearly specify latex_engine defaults

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2783,7 +2783,7 @@ These options influence LaTeX output.
 
    * :code-py:`'pdflatex'` -- PDFLaTeX (default)
    * :code-py:`'xelatex'` -- XeLaTeX
-     (default if :confval:`language` is one of :code-py:`['zh_CN', 'zh_TW', 'el']`)
+     (default if :confval:`language` is one of ``zh_CN``', ``zh_TW``, or ``el``)
    * :code-py:`'lualatex'` -- LuaLaTeX
    * :code-py:`'platex'` -- pLaTeX
    * :code-py:`'uplatex'` -- upLaTeX

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2783,7 +2783,7 @@ These options influence LaTeX output.
 
    * :code-py:`'pdflatex'` -- PDFLaTeX (default)
    * :code-py:`'xelatex'` -- XeLaTeX
-     (default if :confval:`language` is one of ``zh_CN``', ``zh_TW``, or ``el``)
+     (default if :confval:`language` is one of ``el``', ``zh_CN``, or ``zh_TW``)
    * :code-py:`'lualatex'` -- LuaLaTeX
    * :code-py:`'platex'` -- pLaTeX
    * :code-py:`'uplatex'` -- upLaTeX

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2783,7 +2783,7 @@ These options influence LaTeX output.
 
    * :code-py:`'pdflatex'` -- PDFLaTeX (default)
    * :code-py:`'xelatex'` -- XeLaTeX
-     (default if :confval:`language` is one of ``el``', ``zh_CN``, or ``zh_TW``)
+     (default if :confval:`language` is one of ``el``, ``zh_CN``, or ``zh_TW``)
    * :code-py:`'lualatex'` -- LuaLaTeX
    * :code-py:`'platex'` -- pLaTeX
    * :code-py:`'uplatex'` -- upLaTeX

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2783,6 +2783,7 @@ These options influence LaTeX output.
 
    * :code-py:`'pdflatex'` -- PDFLaTeX (default)
    * :code-py:`'xelatex'` -- XeLaTeX
+     (default if :confval:`language` is one of :code-py:`['zh_CN', 'zh_TW', 'el']`)
    * :code-py:`'lualatex'` -- LuaLaTeX
    * :code-py:`'platex'` -- pLaTeX
    * :code-py:`'uplatex'` -- upLaTeX


### PR DESCRIPTION
Subject: [doc] Clearly specify latex_engine defaults

### Feature or Bugfix
- Refactoring

### Purpose
- Clearly specify `latex_engine` defaults based on the language typically `el`, `zh_CN` and `zh_TW` in the documentation

### Detail
- Currently the documentation does not clearly specify the default `latex_engine` that is used for the above mentioned languages. The detail is only mentioned as change notes which could be overlooked. It would be better to clearly specify the defaults next to the engine values in the same way as it is already done for `ja` language.

