### PR TITLE
Performance improvement: Cache pre-pickled documents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,8 @@ Features added
 * #12743: Add :option:`sphinx-build --exception-on-warning`,
   to raise an exception when warnings are emitted during the build.
   Patch by Adam Turner and Jeremy Maitin-Shepard.
+* #12882: Cache entire (pickled + parsed) document objects instead of
+  raw bytes during the build phase.
 
 Bugs fixed
 ----------


### PR DESCRIPTION
Subject: Cache pre-pickled documents

### Feature or Bugfix
- Feature (I guess)

### Purpose
When resolving cross-references on doctrees ([`resolve_xref`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/transforms/post_transforms/__init__.py#L90)) every call to `env.get_doctree` performed by the subsequent resolver will trigger a `pickle.loads()`. 

When dealing with enormous documents, where an individual `.doctree` file can exceed 5MB, this operation causes the build to be extremely slow. Caching the complete pre-pickled document instead of the raw bytes skips the need for `pickle.loads()` at every call. 

Build times for 1000+ pages document sped up from ~5 hours to less than 5 minutes. 

Since this cache does not look used outside of the `__init__` file, and is only used in this specific method, changing the cache objects is not a breaking change IMO. 

* Closes #12883

