### PR TITLE
Resolve a `mypy --strict` `comparison-overlap` error

### DIFF
--- a/sphinx/ext/apidoc.py
+++ b/sphinx/ext/apidoc.py
@@ -69,7 +69,7 @@ def module_join(*modnames: str | None) -> str:
 
 def is_packagedir(dirname: str | None = None, files: list[str] | None = None) -> bool:
     """Check given *files* contains __init__ file."""
-    if files is dirname is None:
+    if files is None and dirname is None:
         return False
 
     if files is None:


### PR DESCRIPTION
Without this, `mypy --strict sphinx/` gives:

```
sphinx/ext/apidoc.py: note: In function "is_packagedir":
sphinx/ext/apidoc.py:72:8: error: Non-overlapping identity check (left operand type: "list[str] | None", right operand type: "str | None")  [comparison-overlap]
```