### PR TITLE
Draft: ToCTree env collector: disable read-parallelism

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,9 @@ Bugs fixed
   file URL (user-defined base URL of an intersphinx project are left untouched
   even if they end with double forward slashes).
   Patch by Bénédikt Tran.
+* #6714, #12409: Workaround parallel-unsafe ``toctree`` collection process by
+  disabling the ``parallel_read_safe`` flag for the relevant collector.
+  Patch by James Addison.
 
 Testing
 -------

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -364,6 +364,6 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
     return {
         'version': 'builtin',
-        'parallel_read_safe': True,
+        'parallel_read_safe': False,
         'parallel_write_safe': True,
     }


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Bugreports #6714 and #12409 indicate that the table-of-contents collection process is not currently implemented in a way that guarantees deterministic resolution in the presence of parallelism.

Until such time as we can implement that, disable parallel reads for the `TocTreeCollector` so that the tree is resolved serially.

### Detail
- Disable parallel reads for the `TocTreeCollector` by setting `parallel_read_safe: False` for it.

### Relates
- May resolve #6714.
- May resolve #12409. 