### PR TITLE
HTML builder: toctree reliability during parallel builds

### DIFF
--- a/tests/test_builders/test_build_html_toctree.py
+++ b/tests/test_builders/test_build_html_toctree.py
@@ -44,7 +44,9 @@ def test_parallel_toctree(app, cached_etree_parse):
     # top-level documents should only contain depth-1 navigation links
     sidebar_xpath = "//div[@class='sphinxsidebarwrapper']"
     nested_links = f"{sidebar_xpath}//li[@class!='toctree-l1']/a"
-    check_xpath(cached_etree_parse(index), index.name, nested_links, None, be_found=False)
+    check_xpath(
+        cached_etree_parse(index), index.name, nested_links, None, be_found=False
+    )
 
     # nested documents should contain breadcrumbs for depths one and two
     crumb1 = f"{sidebar_xpath}//li[@class='toctree-l1 current']/a"

--- a/tests/test_builders/test_build_html_toctree.py
+++ b/tests/test_builders/test_build_html_toctree.py
@@ -42,7 +42,7 @@ def test_parallel_toctree(app, cached_etree_parse):
     bar1 = app.outdir / 'bar' / 'bar_1.html'
 
     # top-level documents should only contain depth-1 navigation links
-    sidebar_xpath = "//div[@class='sphinxsidebarwrapper']"
+    sidebar_xpath = ".//div[@class='sphinxsidebarwrapper']"
     nested_links = f"{sidebar_xpath}//li[@class!='toctree-l1']/a"
     check_xpath(
         cached_etree_parse(index), index.name, nested_links, None, be_found=False

--- a/tests/test_builders/test_build_html_toctree.py
+++ b/tests/test_builders/test_build_html_toctree.py
@@ -32,7 +32,7 @@ def test_relations(app):
 @pytest.mark.sphinx(
     'html',
     testroot='toctree-glob',
-    parallel=2,
+    parallel=5,
     confoverrides={'html_theme': 'alabaster'},
 )
 def test_parallel_toctree(app, cached_etree_parse):

--- a/tests/test_builders/test_build_html_toctree.py
+++ b/tests/test_builders/test_build_html_toctree.py
@@ -32,21 +32,19 @@ def test_relations(app):
 @pytest.mark.sphinx(
     'html',
     testroot='toctree-glob',
-    parallel=5,
+    parallel=2,
     confoverrides={'html_theme': 'alabaster'},
 )
 def test_parallel_toctree(app, cached_etree_parse):
     app.build(force_all=True)
 
-    index = app.outdir / 'index.html'
+    root = app.outdir / 'index.html'
     bar1 = app.outdir / 'bar' / 'bar_1.html'
 
     # top-level documents should only contain depth-1 navigation links
     sidebar_xpath = ".//div[@class='sphinxsidebarwrapper']"
     nested_links = f"{sidebar_xpath}//li[@class!='toctree-l1']/a"
-    check_xpath(
-        cached_etree_parse(index), index.name, nested_links, None, be_found=False
-    )
+    check_xpath(cached_etree_parse(root), root.name, nested_links, None, be_found=False)
 
     # nested documents should contain breadcrumbs for depths one and two
     crumb1 = f"{sidebar_xpath}//li[@class='toctree-l1 current']/a"


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- This changeset is intended to resolve a `toctree` output nondeterminism problem that I believe may be the cause of both #6714 and #12409.
- A fix is pending -- to begin with this pull request offers test coverage that should expose the problem (albeit intermittently, because _some_ parallelised builds do produce correct output).

### Detail
- Extend the test coverage on the `toctree-glob` testroot to enable a parallelised test where the `alabaster` theme is used (required so that a navigation sidebar, where the problem manifests, is included in the output)

### Relates
- May resolve #6714.
- May resolve #12409.