### PR TITLE
Update tox lint to more closely match GitHub actions lint workflow

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,10 +36,9 @@ extras =
 # If you update any of these commands, don't forget to update the equivalent
 # GitHub Workflow step
 commands =
-    ruff . --diff --format github
+    ruff check . --output-format github
     flake8 .
-    isort --check-only --diff .
-    mypy sphinx/
+    mypy
 
 [testenv:docs]
 description =


### PR DESCRIPTION
* The ruff command errored - the old ruff command format now does not work:

```
error: `ruff <path>` has been removed. Use `ruff check <path>` instead.
```

* tox gave an error for isort:

```
failed with isort is not allowed, use allowlist_externals to allow it
```

I believe that ruff is now used for import sorting, so I removed this
* The `mypy` command was previously `mypy sphinx/`, not covering e.g. the `tests/`.

`pyproject.toml` now includes:

```toml
[tool.mypy]
files = ["sphinx", "utils", "tests", "doc/conf.py"]
```

so I have removed the (incorrect) duplication of the covered files.