### PR TITLE
Add an initial pyright configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,6 +83,26 @@ jobs:
     - name: Type check with mypy
       run: mypy
 
+  pyright:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3"
+    - name: Install uv
+      run: >
+        curl --no-progress-meter --location --fail
+        --proto '=https' --tlsv1.2
+        "https://astral.sh/uv/install.sh"
+        | sh
+    - name: Install dependencies
+      run: uv pip install ".[lint,test]"
+    - name: Type check with pyright
+      run: pyright
+
   docs-lint:
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,12 @@ ignore_errors = true
 
 [tool.pyright]
 typeCheckingMode = "strict"
-include = ["sphinx", "utils", "tests", "doc/conf.py"]
+include = [
+    "doc/conf.py",
+    "utils", 
+    "sphinx",
+    "tests", 
+]
 
 reportArgumentType = "none"
 reportAssignmentType = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ lint = [
     "types-requests==2.32.0.20240914",  # align with requests
     "types-urllib3==1.26.25.14",
     "tomli>=2",  # for mypy (Python<=3.10)
+    "pyright==1.1.382.post0",
     "pytest>=6.0",
 ]
 test = [
@@ -303,3 +304,57 @@ exclude_lines = [
     'if __name__ == .__main__.:',
 ]
 ignore_errors = true
+
+[tool.pyright]
+typeCheckingMode = "strict"
+include = ["sphinx", "utils", "tests", "doc/conf.py"]
+
+reportArgumentType = "none"
+reportAssignmentType = "none"
+reportAttributeAccessIssue = "none"
+reportCallIssue = "none"
+reportConstantRedefinition = "none"
+reportDeprecated = "none"
+reportGeneralTypeIssues = "none"
+reportIncompatibleMethodOverride = "none"
+reportIncompatibleVariableOverride = "none"
+reportInconsistentOverload = "none"
+reportIndexIssue = "none"
+reportInvalidTypeArguments = "none"
+reportInvalidTypeForm = "none"
+reportInvalidTypeVarUse = "none"
+reportMissingImports = "none"
+reportMissingModuleSource = "none"
+reportMissingParameterType = "none"
+reportMissingTypeArgument = "none"
+reportMissingTypeStubs = "none"
+reportOperatorIssue = "none"
+reportOptionalIterable = "none"
+reportOptionalMemberAccess = "none"
+reportOptionalOperand = "none"
+reportOptionalSubscript = "none"
+reportPossiblyUnboundVariable = "none"
+reportPrivateUsage = "none"
+reportRedeclaration = "none"
+reportReturnType = "none"
+reportSelfClsParameterName = "none"
+reportTypeCommentUsage = "none"
+reportTypedDictNotRequiredAccess = "none"
+reportUndefinedVariable = "none"
+reportUnknownArgumentType = "none"
+reportUnknownLambdaType = "none"
+reportUnknownMemberType = "none"
+reportUnknownParameterType = "none"
+reportUnknownVariableType = "none"
+reportUnnecessaryComparison = "none"
+reportUnnecessaryContains = "none"
+reportUnnecessaryIsInstance = "none"
+reportUnsupportedDunderAll = "none"
+reportUntypedBaseClass = "none"
+reportUntypedFunctionDecorator = "none"
+reportUntypedNamedTuple = "none"
+reportUnusedClass = "none"
+reportUnusedFunction = "none"
+reportUnusedImport = "none"
+reportUnusedVariable = "none"
+reportWildcardImportFromLibrary = "none"

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ commands =
     ruff check . --output-format github
     flake8 .
     mypy
+    pyright
 
 [testenv:docs]
 description =


### PR DESCRIPTION
This change adds an initial pyright configuration, as part of getting good pyright check coverage.
See discussion around
https://github.com/sphinx-doc/sphinx/pull/12854#issuecomment-2336723857.

If accepted I will:

* Create an issue to track removing the ignores
* Start creating PRs for some of the ignores
* Consider, in future, switching configuration to `pyrightconfig.json` which allows for per-file ignores, similar to what Sphinx has for `mypy`

Some advantages of having pyright in addition to mypy:

* For some error types, pyright gives clearer error messages than mypy, helping more easily resolve mypy issues.
* pyright has some useful checks which are not covered by mypy.