### PR TITLE
DOC: Fix syntax typo in intersphinx.rst

### DIFF
--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -76,7 +76,7 @@ linking:
 
    The unique identifier can be used in the :rst:role:`external` role, so that
    it is clear which intersphinx set the target belongs to.  A link like
-   ``external:python+ref:`comparison manual <comparisons>``` will link to the
+   ``:external+python:ref:`comparison manual <comparisons>``` will link to the
    label "comparisons" in the doc set "python", if it exists.
 
    **Example**


### PR DESCRIPTION
Subject: Fix typo in documentation.

### Feature or Bugfix

- Bugfix

### Purpose

The syntax didn't match what was mentioned in https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#role-external

