### PR TITLE
DOC: Highlight literals a bit more

### DIFF
--- a/doc/_themes/sphinx13/static/sphinx13.css
+++ b/doc/_themes/sphinx13/static/sphinx13.css
@@ -321,6 +321,13 @@ cite, code, tt {
     letter-spacing: -0.02em;
 }
 
+div.body code.literal {
+    background-color: #f3f4f5;
+    border: 1px solid #d1d5da;
+    border-radius: 0.25rem;
+    padding: .1rem .2rem;
+}
+
 table.deprecated code.literal {
     word-break: break-all;
 }


### PR DESCRIPTION
The only style difference for literals is currently a monospace font. This blends very much into surrounding text and makes it hard to read the literals.

All other major themes (https://sphinx-themes.org/) use a background for literals. It's a good idea to do the same in sphinx13. I've taken the CSS from pydata-sphinx-theme, but I don't care too much about the actual parameters as long as it stays visible but decent. Note that I've limitied the background to `div.body` so that the background is not applied in the sidebar. The sidebar entries are often single words phrases and don't need a background. Actually, the backgound there would be too cluttery.



Previous:
![image](https://github.com/user-attachments/assets/b16d3807-5c85-4370-86d5-de775d380712)

With this PR:
![image](https://github.com/user-attachments/assets/4ff28655-802b-47cd-8387-0ada28edff66)
