### PR TITLE
Fix call to `safe_getattr()`

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -1079,7 +1079,8 @@ class ModuleDocumenter(Documenter):
                 else:
                     logger.warning(__('missing attribute mentioned in :members: option: '
                                       'module %s, attribute %s'),
-                                   safe_getattr(self.object, '__name__', '???', name),
+                                   safe_getattr(self.object, '__name__', '???'),
+                                   name,
                                    type='autodoc')
             return False, ret
 


### PR DESCRIPTION


Subject: Fix parenthesis dropped in 6514a86f ([diff](https://github.com/sphinx-doc/sphinx/commit/6514a86f434f1febf19408a794efd6b7f11e22bd#diff-e43bdd6f8f37a12d2536e09e57c5e8999cb8de18b9c7ba49126f90576c4328acR1107)) for autodoc missing attribute logging

### Feature or Bugfix
- Bugfix

### Purpose
- Fix nuisance logging errors for missing autodoc members

### Detail
- Caused too many arguments to be passed to `safe_getattr()`, preventing it from properly checking attributes
- Lead to errors in the logging system because only one arg got passed to `logger.warning()`, for a message that requires two

### Relates
- NA

