### PR TITLE
Make a dedicated section for cross-reference syntax in docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,7 +18,7 @@ Sphinx
    .. admonition:: 🔗 Powerful Cross-Referencing
       :class: sphinx-feature
 
-      Create :ref:`cross-references <xref-syntax>`
+      Create :ref:`cross-references <xref>`
       within your project,
       and even across :ref:`different projects <ext-intersphinx>`.
       Include references to

--- a/doc/tutorial/narrative-documentation.rst
+++ b/doc/tutorial/narrative-documentation.rst
@@ -73,7 +73,7 @@ Adding cross-references
 -----------------------
 
 One powerful feature of Sphinx is the ability to seamlessly add
-:ref:`cross-references <xref-syntax>` to specific parts of the documentation:
+:ref:`cross-references <xref>` to specific parts of the documentation:
 a document, a section, a figure, a code object, etc.  This tutorial is full of
 them!
 

--- a/doc/usage/referencing.rst
+++ b/doc/usage/referencing.rst
@@ -1,14 +1,19 @@
-.. _xref-syntax:
+.. _xref:
 
-========================
-Cross-referencing syntax
-========================
+================
+Cross-references
+================
 
 One of Sphinx's most useful features is creating automatic cross-references
 through semantic cross-referencing roles.
 A cross reference to an object description, such as ``:func:`spam```,
 will create a link to the place where ``spam()`` is documented,
 appropriate to each output format (HTML, PDF, ePUB, etc.).
+
+.. _xref-syntax:
+
+Syntax
+------
 
 Sphinx supports various cross-referencing roles to create links
 to other elements in the documentation.

--- a/doc/usage/restructuredtext/roles.rst
+++ b/doc/usage/restructuredtext/roles.rst
@@ -18,8 +18,8 @@ They are written as ``:rolename:`content```.
 See :doc:`/usage/domains/index` for roles added by domains.
 
 
-Cross-referencing syntax
-------------------------
+Cross-references
+----------------
 
 See :doc:`/usage/referencing/`.
 


### PR DESCRIPTION
... and rename the current "Cross-referencing syntax" page to "Cross-references", of which "Syntax" is one subsection.

This section naming fits better to the current content structure. It also allows to distinguish between links to the general cross-referencing topic, and specific links to the syntax.

A small step towards solving #12980.