### PR TITLE
DOC: Format role and directive cross-references in ReST format

### DIFF
--- a/sphinx/domains/rst.py
+++ b/sphinx/domains/rst.py
@@ -230,8 +230,8 @@ class ReSTDomain(Domain):
         'role':      ReSTRole,
     }
     roles = {
-        'dir':  XRefRole(),
-        'role': XRefRole(),
+        'dir':  XRefRole(title_fmt=".. {title}::"),
+        'role': XRefRole(title_fmt=":{title}:"),
     }
     initial_data: dict[str, dict[tuple[str, str], str]] = {
         'objects': {},  # fullname -> docname, objtype

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -61,6 +61,9 @@ class XRefRole(ReferenceRole):
       * `lowercase` to lowercase the target
       * `nodeclass` and `innernodeclass` select the node classes for
         the reference and the content node
+      * `title_fmt`: an optional format string using one ``{title}`` variable
+        that can be used to customize the rendered text, e.g.
+        ``title_fmt=":{title}:"`
 
     * Subclassing and overwriting `process_link()` and/or `result_nodes()`.
     """
@@ -75,6 +78,7 @@ class XRefRole(ReferenceRole):
         nodeclass: type[Element] | None = None,
         innernodeclass: type[TextElement] | None = None,
         warn_dangling: bool = False,
+        title_fmt: str | None = None,
     ) -> None:
         self.fix_parens = fix_parens
         self.lowercase = lowercase
@@ -83,6 +87,7 @@ class XRefRole(ReferenceRole):
             self.nodeclass = nodeclass
         if innernodeclass is not None:
             self.innernodeclass = innernodeclass
+        self.title_fmt = title_fmt
 
         super().__init__()
 
@@ -145,6 +150,8 @@ class XRefRole(ReferenceRole):
             self.env, refnode, self.has_explicit_title, title, target
         )
         refnode['reftarget'] = target
+        if self.title_fmt is not None:
+            title = self.title_fmt.format(title=title)
         refnode += self.innernodeclass(self.rawtext, title, classes=self.classes)
 
         return self.result_nodes(self.inliner.document, self.env, refnode, is_ref=True)


### PR DESCRIPTION
Cross-references only consisted of the target name so far:
![image](https://github.com/user-attachments/assets/10f75583-efe8-4685-852a-38f09ec39d6c)
![image](https://github.com/user-attachments/assets/f0345fd2-aee3-4d85-8f3f-5a0ac52990ce)

This PR formats the references as one would write the role / directive in ReST:

![image](https://github.com/user-attachments/assets/37e8cfef-53f5-4ee9-bcaf-df4ebe4da5b2)
![image](https://github.com/user-attachments/assets/7e4dc982-9bb8-45b7-ae19-a237f6406cf6)

While the ReST formatting is a bit more noisy, using the actual ReST format helps to make the mental connection, in particular also for less experienced sphinx users, who may not have a clear idea what a directive is, but much more likely can connect tot the `.. directive::` notation, which they have seen or written.
