### PR TITLE
Consistently use sentence case for headings

### DIFF
--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -89,7 +89,7 @@ To see an example of use of these objects, refer to
 
 .. _build-phases:
 
-Build Phases
+Build phases
 ------------
 
 One thing that is vital in order to understand extension mechanisms is the way

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -137,8 +137,8 @@ creating and building your own documentation from scratch.
 
 .. _user-guides:
 
-User Guides
-===========
+User guide
+==========
 
 These sections cover various topics in using and extending Sphinx for various
 use-cases. They are a comprehensive guide to using Sphinx in many contexts and
@@ -147,7 +147,7 @@ starting with :ref:`get-started`.
 
 .. toctree::
    :maxdepth: 2
-   :caption: User Guides
+   :caption: User guide
 
    usage/index
    development/index

--- a/doc/man/index.rst
+++ b/doc/man/index.rst
@@ -1,4 +1,4 @@
-Command-Line tools
+Command-line tools
 ==================
 
 These are the applications provided as part of Sphinx.

--- a/doc/man/index.rst
+++ b/doc/man/index.rst
@@ -1,9 +1,9 @@
-Command-Line Tools
+Command-Line tools
 ==================
 
 These are the applications provided as part of Sphinx.
 
-Core Applications
+Core applications
 -----------------
 
 .. toctree::
@@ -12,7 +12,7 @@ Core Applications
    sphinx-quickstart
    sphinx-build
 
-Additional Applications
+Additional applications
 -----------------------
 
 .. toctree::

--- a/doc/usage/advanced/websupport/api.rst
+++ b/doc/usage/advanced/websupport/api.rst
@@ -2,7 +2,7 @@
 
 .. currentmodule:: sphinxcontrib.websupport
 
-The WebSupport Class
+The WebSupport class
 ====================
 
 .. class:: WebSupport

--- a/doc/usage/advanced/websupport/quickstart.rst
+++ b/doc/usage/advanced/websupport/quickstart.rst
@@ -3,8 +3,8 @@
 Web Support Quick Start
 =======================
 
-Building Documentation Data
-----------------------------
+Building documentation data
+---------------------------
 
 To make use of the web support package in your application you'll need to build
 the data it uses.  This data includes pickle files representing documents,
@@ -33,8 +33,8 @@ called "static" and contains static files that should be served from "/static".
    :class:`~.WebSupport` object.
 
 
-Integrating Sphinx Documents Into Your Webapp
-----------------------------------------------
+Integrating Sphinx documents into your webapp
+---------------------------------------------
 
 Now that the data is built, it's time to do something useful with it.  Start off
 by creating a :class:`~.WebSupport` object for your application::
@@ -145,7 +145,7 @@ add this data to the ``COMMENT_OPTIONS`` that are used in the template.
       @app.route('/docs/<path:docname>')
 
 
-Performing Searches
+Performing searches
 -------------------
 
 To use the search form built-in to the Sphinx sidebar, create a function to
@@ -167,7 +167,7 @@ returns a context dict in the same format that :meth:`~.WebSupport.get_document`
 does.
 
 
-Comments & Proposals
+Comments & proposals
 --------------------
 
 Now that this is done it's time to define the functions that handle the AJAX
@@ -217,7 +217,7 @@ and will handle user votes on comments::
        return "success"
 
 
-Comment Moderation
+Comment moderation
 ------------------
 
 By default, all comments added through :meth:`~.WebSupport.add_comment` are

--- a/doc/usage/advanced/websupport/quickstart.rst
+++ b/doc/usage/advanced/websupport/quickstart.rst
@@ -33,8 +33,8 @@ called "static" and contains static files that should be served from "/static".
    :class:`~.WebSupport` object.
 
 
-Integrating Sphinx documents into your webapp
----------------------------------------------
+Integrating Sphinx documents into your web-app
+----------------------------------------------
 
 Now that the data is built, it's time to do something useful with it.  Start off
 by creating a :class:`~.WebSupport` object for your application::

--- a/doc/usage/advanced/websupport/searchadapters.rst
+++ b/doc/usage/advanced/websupport/searchadapters.rst
@@ -2,7 +2,7 @@
 
 .. currentmodule:: sphinxcontrib.websupport.search
 
-Search Adapters
+Search adapters
 ===============
 
 To create a custom search adapter you will need to subclass the

--- a/doc/usage/advanced/websupport/storagebackends.rst
+++ b/doc/usage/advanced/websupport/storagebackends.rst
@@ -2,7 +2,7 @@
 
 .. currentmodule:: sphinxcontrib.websupport.storage
 
-Storage Backends
+Storage backends
 ================
 
 To create a custom storage backend you will need to subclass the

--- a/doc/usage/quickstart.rst
+++ b/doc/usage/quickstart.rst
@@ -1,5 +1,5 @@
 ===============
-Getting Started
+Getting started
 ===============
 
 Sphinx is a *documentation generator* or a tool that translates a set of plain

--- a/doc/usage/theming.rst
+++ b/doc/usage/theming.rst
@@ -2,7 +2,7 @@
 
 .. _html-themes:
 
-HTML Theming
+HTML theming
 ============
 
 Sphinx provides a number of builders for HTML and HTML-based formats.


### PR DESCRIPTION
We basically already do this most of the time, but there were some headings in title case.

For context:
- [This page](https://titleformat.com/posts/title-case-vs-sentence-case/#when-to-use-sentence-case) discusses advantages and disadvantages of sentence case and title case
- FWIW: [Python](https://devguide.python.org/documentation/style-guide/#capitalization), [Google](https://developers.google.com/style/capitalization) and [Microsoft](https://learn.microsoft.com/en-us/style-guide/capitalization) use sentence case in their docs
