### PR TITLE
Draft: PEP 740 attestations for PyPI: add git source commit digest (closed: not required - the commit is already included)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,6 +57,7 @@ jobs:
         id: attest
         with:
           subject-path: "dist/*"
+          subject-digest: ${{ steps.push.outputs.digest }}
           predicate-type: "https://docs.pypi.org/attestations/publish/v1"
           predicate: "null"
           show-summary: "true"


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- In the PEP740 attestation for releases, include a [`Build Signer Digest`](https://github.com/sigstore/fulcio/blob/ab24f1c956158e80fdc6adab2ab35953c9beb2f2/docs/oid-info.md?plain=1#L130-L132) reference to the commit that the release was built from (thank you @woodruffw for the pointer).

### Detail
- - Use the GitHub Actions `attest` action to provide the digest, following a [readme example](https://github.com/actions/attest/blob/81a79f22f87c77ea30976cd8f2792cccc5d696cd/README.md?plain=1#L258).

### Relates
- Follow-up to #12981.

cc @AA-Turner - I think this would be a valuable addition to release artifact attestations.  I've no specific use case for it, other than that I think it's helpful to be able to trace from source to built artifact and vice-versa.