### PR TITLE
Config: adjust a paragraph in 'latex_table_style' documentation

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -3046,9 +3046,9 @@ These options influence LaTeX output.
          Please update your project to use the
          :ref:`latex table color configuration <tablecolors>` keys instead.
 
-   To customize the styles on an individual table, either set the ``:class:``
-   option on the enclosing table directive - if there is one - or insert a
-   :ref:`rst-class <rstclass>` directive before the table otherwise
+   To customise the styles for a table,
+   use the ``:class:`` option if the table is defined using a directive,
+   or otherwise insert a :ref:`rst-class <rstclass>` directive before the table
    (cf. :ref:`table-directives`).
 
    Currently recognised classes are ``booktabs``, ``borderless``,

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -3046,8 +3046,11 @@ These options influence LaTeX output.
          Please update your project to use the
          :ref:`latex table color configuration <tablecolors>` keys instead.
 
-   Each table can override the global style via ``:class:`` option,
-   or ``.. rst-class::`` for no-directive tables (cf.  :ref:`table-directives`).
+   To customize the styles on an individual table, either set the ``:class:``
+   option when the table's contents are documented inside a table directive,
+   or, otherwise, add a preceding :ref:`rst-class <rstclass>` directive
+   (cf. :ref:`table-directives`).
+
    Currently recognised classes are ``booktabs``, ``borderless``,
    ``standard``, ``colorrows``, ``nocolorrows``.
    The latter two can be combined with any of the first three.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -3047,8 +3047,8 @@ These options influence LaTeX output.
          :ref:`latex table color configuration <tablecolors>` keys instead.
 
    To customize the styles on an individual table, either set the ``:class:``
-   option when the table's contents are documented inside a table directive,
-   or, otherwise, add a preceding :ref:`rst-class <rstclass>` directive
+   option on the enclosing table directive - if there is one - or insert a
+   :ref:`rst-class <rstclass>` directive before the table otherwise
    (cf. :ref:`table-directives`).
 
    Currently recognised classes are ``booktabs``, ``borderless``,


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose
- Nitpicky rephrasing of a `latex_table_style` documentation paragraph based on something I experienced here: https://github.com/sphinx-doc/sphinx/pull/12986#issuecomment-2400616466

### Detail
- Perhaps the result is too wordy?  (repetition of the word 'table', for example)

### Relates
- N/A