### PR TITLE
Update CVE URL

### DIFF
--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -54,7 +54,7 @@ default_settings: dict[str, Any] = {
     'image_loading': 'link',
     'embed_stylesheet': False,
     'cloak_email_addresses': True,
-    'cve_base_url': 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-',
+    'cve_base_url': 'https://www.cve.org/CVERecord?id=CVE-',
     'cve_references': None,
     'cwe_base_url': 'https://cwe.mitre.org/data/definitions/',
     'cwe_references': None,

--- a/tests/test_markup/test_markup.py
+++ b/tests/test_markup/test_markup.py
@@ -166,14 +166,14 @@ def get_verifier(verify, verify_re):
             ':cve:`2020-10735`',
             (
                 '<p><span class="target" id="index-0"></span><a class="cve reference external" '
-                'href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735">'
+                'href="https://www.cve.org/CVERecord?id=CVE-2020-10735">'
                 '<strong>CVE 2020-10735</strong></a></p>'
             ),
             (
                 '\\sphinxAtStartPar\n'
                 '\\index{Common Vulnerabilities and Exposures@\\spxentry{Common Vulnerabilities and Exposures}'
                 '!CVE 2020\\sphinxhyphen{}10735@\\spxentry{CVE 2020\\sphinxhyphen{}10735}}'
-                '\\sphinxhref{https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735}'
+                '\\sphinxhref{https://www.cve.org/CVERecord?id=CVE-2020-10735}'
                 '{\\sphinxstylestrong{CVE 2020\\sphinxhyphen{}10735}}'
             ),
         ),
@@ -183,14 +183,14 @@ def get_verifier(verify, verify_re):
             ':cve:`2020-10735#id1`',
             (
                 '<p><span class="target" id="index-0"></span><a class="cve reference external" '
-                'href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735#id1">'
+                'href="https://www.cve.org/CVERecord?id=CVE-2020-10735#id1">'
                 '<strong>CVE 2020-10735#id1</strong></a></p>'
             ),
             (
                 '\\sphinxAtStartPar\n'
                 '\\index{Common Vulnerabilities and Exposures@\\spxentry{Common Vulnerabilities and Exposures}'
                 '!CVE 2020\\sphinxhyphen{}10735\\#id1@\\spxentry{CVE 2020\\sphinxhyphen{}10735\\#id1}}'
-                '\\sphinxhref{https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735\\#id1}'
+                '\\sphinxhref{https://www.cve.org/CVERecord?id=CVE-2020-10735\\#id1}'
                 '{\\sphinxstylestrong{CVE 2020\\sphinxhyphen{}10735\\#id1}}'
             ),
         ),


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Bugfix?

### Purpose
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-28219 says:

  > NOTICE: Transition to the all-new CVE website at [WWW.CVE.ORG](https://www.cve.org/) and [CVE Record Format JSON](https://www.cve.org/Media/News/item/blog/2022/10/06/CVE-Records-Are-Now-Displayed) are underway.

### Detail
- This PR updates the URL for the CVE role.

### Relates
- https://github.com/sphinx-doc/sphinx/pull/11781
- https://github.com/python-pillow/Pillow/pull/8186

