### PR TITLE
Restore autodocs cut-lines with empty what-hints

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -209,7 +209,7 @@ def cut_lines(
         options: dict[str, bool],
         lines: list[str],
     ) -> None:
-        if what_ not in what_unique:
+        if what_unique and what_ not in what_unique:
             return
         del lines[:pre]
         if post:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose

During typecheck improvements, a change accidentally removed the ability for autodoc's `cut_lines` call to run when no what-hints are provided. The `what` argument may be empty and an empty scenario should not stop the cut call from processing lines.

### Example

An example documentation set [configures `cut_lines`](https://github.com/sphinx-contrib/confluencebuilder/blob/v2.7.1/doc/conf.py#L181) which has a [rendering](https://sphinxcontrib-confluencebuilder.readthedocs.io/en/v2.7.1/advanced-extensions/#confluence-storage-format-translator-helpers) that excludes the leading line of the docstrings. However, a [render](https://sphinxcontrib-confluencebuilder.readthedocs.io/en/latest/advanced-extensions/#confluence-storage-format-translator-helpers) (at the time of writing) using Sphinx 8.1.2 show docstrings not being cut.

### Relates
- https://github.com/sphinx-doc/sphinx/pull/12933
