### PR TITLE
Restore support for ``cut_lines()`` with no object type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Release 8.1.3 (in development)
 Bugs fixed
 ----------
 
+* #13013: Restore support for :func:`!cut_lines` with no object type.
+  Patch by Adam Turner.
 
 Release 8.1.2 (released Oct 12, 2024)
 =====================================

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -200,7 +200,7 @@ def cut_lines(
     This can (and should) be used in place of :confval:`automodule_skip_lines`.
     """
     if not what:
-        what_unique = frozenset()
+        what_unique: frozenset[str] = frozenset()
     elif isinstance(what, str):  # strongly discouraged
         what_unique = frozenset({what})
     else:

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -186,7 +186,7 @@ def merge_members_option(options: dict) -> None:
 # Some useful event listener factories for autodoc-process-docstring.
 
 def cut_lines(
-    pre: int, post: int = 0, what: str | list[str] | None = None
+    pre: int, post: int = 0, what: Sequence[str] | None = None
 ) -> _AutodocProcessDocstringListener:
     """Return a listener that removes the first *pre* and last *post*
     lines of every docstring.  If *what* is a sequence of strings,
@@ -199,7 +199,12 @@ def cut_lines(
 
     This can (and should) be used in place of :confval:`automodule_skip_lines`.
     """
-    what_unique = frozenset(what or ())
+    if not what:
+        what_unique = frozenset()
+    elif isinstance(what, str):  # strongly discouraged
+        what_unique = frozenset({what})
+    else:
+        what_unique = frozenset(what)
 
     def process(
         app: Sphinx,
@@ -209,7 +214,7 @@ def cut_lines(
         options: dict[str, bool],
         lines: list[str],
     ) -> None:
-        if what_ not in what_unique:
+        if what_unique and what_ not in what_unique:
             return
         del lines[:pre]
         if post:

--- a/tests/test_extensions/test_ext_autodoc_events.py
+++ b/tests/test_extensions/test_ext_autodoc_events.py
@@ -58,6 +58,26 @@ def test_cut_lines(app):
     ]
 
 
+def test_cut_lines_no_objtype():
+    docstring_lines = [
+        'first line',
+        '---',
+        'second line',
+        '---',
+        'third line ',
+        '',
+    ]
+    process = cut_lines(2)
+
+    process(None, 'function', 'func', None, {}, docstring_lines)  # type: ignore[arg-type]
+    assert docstring_lines == [
+        'second line',
+        '---',
+        'third line ',
+        ''
+    ]
+
+
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_between(app):
     app.connect('autodoc-process-docstring', between('---', ['function']))

--- a/tests/test_extensions/test_ext_autodoc_events.py
+++ b/tests/test_extensions/test_ext_autodoc_events.py
@@ -74,7 +74,7 @@ def test_cut_lines_no_objtype():
         'second line',
         '---',
         'third line ',
-        ''
+        '',
     ]
 
 


### PR DESCRIPTION
Closes #13013.

cc @jdknight 

A