### PR TITLE
Use debug log level for AttributeErrors in viewcode

### DIFF
--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -64,8 +64,8 @@ def _get_full_modname(modname: str, attribute: str) -> str | None:
         return getattr(value, '__module__', None)
     except AttributeError:
         # sphinx.ext.viewcode can't follow class instance attribute
-        # then AttributeError logging output only verbose mode.
-        logger.verbose("Didn't find %s in %s", attribute, modname)
+        # then AttributeError logging output only debug mode.
+        logger.debug("Didn't find %s in %s", attribute, modname)
         return None
     except Exception as e:
         # sphinx.ext.viewcode follow python domain directives.


### PR DESCRIPTION
Subject: Log AttributeError in viewcode as debug

### Feature or Bugfix
- Bugfix

### Purpose
This message is very common and part of normal operation.
This makes it dominate verbose output without adding value. 
In my code this message is something like ~90 % of the output in
verbose mode.

### Relates
- N/A

