### PR TITLE
linkcheck: update implementation to make use of py311 features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Deprecated
 
 Features added
 --------------
+* #13036: linkcheck: modifications including use of Py3.11 structural pattern
+  matching and ``StrEnum`` status codes.
+  Patch by James Addison.
 
 Bugs fixed
 ----------

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -116,9 +116,9 @@ class CheckExternalLinksBuilder(DummyBuilder):
         match result.status:
             case LinkStatus.IGNORED:
                 msg = (
-                    darkgray('-ignored- ') + result.uri + f': {result.message}'
-                    if result.message
-                    else ''
+                    darkgray('-ignored- ')
+                    + result.uri
+                    + (f': {result.message}' if result.message else '')
                 )
                 logger.info(msg)
             case LinkStatus.WORKING:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -115,11 +115,10 @@ class CheckExternalLinksBuilder(DummyBuilder):
 
         match result.status:
             case LinkStatus.IGNORED:
-                msg = (
-                    darkgray('-ignored- ')
-                    + result.uri
-                    + (f': {result.message}' if result.message else '')
-                )
+                if result.message:
+                    msg = darkgray('-ignored- ') + result.uri + ': ' + result.message
+                else:
+                    msg = darkgray('-ignored- ') + result.uri
                 logger.info(msg)
             case LinkStatus.WORKING:
                 msg = darkgreen('ok        ') + result.uri + result.message

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -152,16 +152,13 @@ class CheckExternalLinksBuilder(DummyBuilder):
                                  result.uri + ': ' + result.message)
                 self.broken_hyperlinks += 1
             case LinkStatus.REDIRECTED:
-                try:
-                    text, color = {
-                        301: ('permanently', purple),
-                        302: ('with Found', purple),
-                        303: ('with See Other', purple),
-                        307: ('temporarily', turquoise),
-                        308: ('permanently', purple),
-                    }[result.code]
-                except KeyError:
-                    text, color = ('with unknown code', purple)
+                text, color = ('with unknown code', purple)
+                match result.code:
+                    case 301: text, color = ('permanently', purple)
+                    case 302: text, color = ('with Found', purple)
+                    case 303: text, color = ('with See Other', purple)
+                    case 307: text, color = ('temporarily', turquoise)
+                    case 308: text, color = ('permanently', purple)
                 linkstat['text'] = text
                 if self.config.linkcheck_allowed_redirects:
                     logger.warning('redirect  ' + result.uri + ' - ' + text + ' to ' +

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -159,7 +159,6 @@ class CheckExternalLinksBuilder(DummyBuilder):
                     case 303: text, color = ('with See Other', purple)
                     case 307: text, color = ('temporarily', turquoise)
                     case 308: text, color = ('permanently', purple)
-                linkstat['text'] = text
                 if self.config.linkcheck_allowed_redirects:
                     logger.warning('redirect  ' + result.uri + ' - ' + text + ' to ' +
                                    result.message, location=(result.docname, result.lineno))

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -55,7 +55,6 @@ DEFAULT_DELAY = 60.0
 class LinkStatus(StrEnum):
     BROKEN = 'broken'
     IGNORED = 'ignored'
-    LOCAL = 'local'  # unused (?)
     TIMEOUT = 'timeout'
     RATE_LIMITED = 'rate-limited'
     REDIRECTED = 'redirected'
@@ -123,10 +122,6 @@ class CheckExternalLinksBuilder(DummyBuilder):
                     logger.info(darkgray('-ignored- ') + result.uri + ': ' + result.message)
                 else:
                     logger.info(darkgray('-ignored- ') + result.uri)
-            case LinkStatus.LOCAL:
-                logger.info(darkgray('-local-   ') + result.uri)
-                self.write_entry(result.status, result.docname, filename, result.lineno,
-                                 result.uri)
             case LinkStatus.WORKING:
                 logger.info(darkgreen('ok        ') + result.uri + result.message)
             case LinkStatus.TIMEOUT:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -107,9 +107,8 @@ class CheckExternalLinksBuilder(DummyBuilder):
         }
         self.write_linkstat(linkstat)
 
-        match result.status:
-            case LinkStatus.UNCHECKED:
-                return
+        if result.status == LinkStatus.UNCHECKED:
+            return
 
         if result.lineno:
             logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -143,13 +143,16 @@ class CheckExternalLinksBuilder(DummyBuilder):
                                  result.uri + ': ' + result.message)
                 self.broken_hyperlinks += 1
             case LinkStatus.REDIRECTED:
-                text, color = ('with unknown code', purple)
-                match result.code:
-                    case 301: text, color = ('permanently', purple)
-                    case 302: text, color = ('with Found', purple)
-                    case 303: text, color = ('with See Other', purple)
-                    case 307: text, color = ('temporarily', turquoise)
-                    case 308: text, color = ('permanently', purple)
+                try:
+                    text, color = {
+                        301: ('permanently', purple),
+                        302: ('with Found', purple),
+                        303: ('with See Other', purple),
+                        307: ('temporarily', turquoise),
+                        308: ('permanently', purple),
+                    }[result.code]
+                except KeyError:
+                    text, color = ('with unknown code', purple)
                 if self.config.linkcheck_allowed_redirects:
                     msg = f'redirect  {result.uri} - {text} to {result.message}'
                     location = (result.docname, result.lineno)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -116,31 +116,29 @@ class CheckExternalLinksBuilder(DummyBuilder):
 
         match result.status:
             case LinkStatus.IGNORED:
-                if result.message:
-                    logger.info(darkgray('-ignored- ') + result.uri + ': ' + result.message)
-                else:
-                    logger.info(darkgray('-ignored- ') + result.uri)
+                msg = darkgray('-ignored- ') + result.uri + f': {result.message}' if result.message else ''
+                logger.info(msg)
             case LinkStatus.WORKING:
-                logger.info(darkgreen('ok        ') + result.uri + result.message)
+                msg = darkgreen('ok        ') + result.uri + result.message
+                logger.info(msg)
             case LinkStatus.TIMEOUT:
                 if self.app.quiet:
-                    logger.warning(
-                        'timeout   ' + result.uri + result.message,
-                        location=(result.docname, result.lineno),
-                    )
+                    msg = 'timeout   ' + result.uri + result.message
+                    logger.warning(msg, location=(result.docname, result.lineno))
                 else:
-                    logger.info(
-                        red('timeout   ') + result.uri + red(' - ' + result.message)
-                    )
+                    msg = red('timeout   ') + result.uri + red(' - ' + result.message)
+                    logger.info(msg)
                 self.write_entry(result.status, result.docname, filename, result.lineno,
                                  result.uri + ': ' + result.message)
                 self.timed_out_hyperlinks += 1
             case LinkStatus.BROKEN:
                 if self.app.quiet or self.app.warningiserror:
-                    logger.warning(__('broken link: %s (%s)'), result.uri, result.message,
-                                   location=(result.docname, result.lineno))
+                    msg = __('broken link: %s (%s)')
+                    location = (result.docname, result.lineno)
+                    logger.warning(msg, result.uri, result.message, location=location)
                 else:
-                    logger.info(red('broken    ') + result.uri + red(' - ' + result.message))
+                    msg = red('broken    ') + result.uri + red(f' - {result.message}')
+                    logger.info(msg)
                 self.write_entry(result.status, result.docname, filename, result.lineno,
                                  result.uri + ': ' + result.message)
                 self.broken_hyperlinks += 1
@@ -153,11 +151,12 @@ class CheckExternalLinksBuilder(DummyBuilder):
                     case 307: text, color = ('temporarily', turquoise)
                     case 308: text, color = ('permanently', purple)
                 if self.config.linkcheck_allowed_redirects:
-                    logger.warning('redirect  ' + result.uri + ' - ' + text + ' to ' +
-                                   result.message, location=(result.docname, result.lineno))
+                    msg = f'redirect  {result.uri} - {text} to {result.message}'
+                    location = (result.docname, result.lineno)
+                    logger.warning(msg, location=location)
                 else:
-                    logger.info(color('redirect  ') + result.uri +
-                                color(' - ' + text + ' to ' + result.message))
+                    msg = color('redirect  ') + result.uri + color(f' - {text} to {result.message}')
+                    logger.info(msg)
                 self.write_entry(result.status, result.docname, filename,
                                  result.lineno, result.uri + ' to ' + result.message,
                                  context=' ' + text)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -110,8 +110,6 @@ class CheckExternalLinksBuilder(DummyBuilder):
         match result.status:
             case LinkStatus.UNCHECKED:
                 return
-            case LinkStatus.WORKING if result.message == 'old':
-                return
 
         if result.lineno:
             logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -116,7 +116,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
 
         match result.status:
             case LinkStatus.IGNORED:
-                msg = darkgray('-ignored- ') + result.uri + f': {result.message}' if result.message else ''
+                msg = darkgray('-ignored- ') + result.uri + f': {result.message}' if result.message else ''  # NoQA: E501
                 logger.info(msg)
             case LinkStatus.WORKING:
                 msg = darkgreen('ok        ') + result.uri + result.message
@@ -158,7 +158,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
                     location = (result.docname, result.lineno)
                     logger.warning(msg, location=location)
                 else:
-                    msg = color('redirect  ') + result.uri + color(f' - {text} to {result.message}')
+                    msg = color('redirect  ') + result.uri + color(f' - {text} to {result.message}')  # NoQA: E501
                     logger.info(msg)
                 self.write_entry(result.status, result.docname, filename,
                                  result.lineno, result.uri + ' to ' + result.message,

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -135,7 +135,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
                 self.write_entry(
                     result.status,
                     result.docname,
-                    filename,
+                    str(filename),
                     result.lineno,
                     result.uri + ': ' + result.message,
                 )
@@ -151,7 +151,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
                 self.write_entry(
                     result.status,
                     result.docname,
-                    filename,
+                    str(filename),
                     result.lineno,
                     result.uri + ': ' + result.message,
                 )
@@ -181,7 +181,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
                 self.write_entry(
                     result.status,
                     result.docname,
-                    filename,
+                    str(filename),
                     result.lineno,
                     result.uri + ' to ' + result.message,
                     context=' ' + text,
@@ -390,9 +390,9 @@ class HyperlinkAvailabilityCheckWorker(Thread):
         self.rate_limit_timeout = config.linkcheck_rate_limit_timeout
         self._allow_unauthorized = config.linkcheck_allow_unauthorized
         if config.linkcheck_report_timeouts_as_broken:
-            self._timeout_status = 'broken'
+            self._timeout_status = LinkStatus.BROKEN
         else:
-            self._timeout_status = 'timeout'
+            self._timeout_status = LinkStatus.TIMEOUT
 
         self.user_agent = config.user_agent
         self.tls_verify = config.tls_verify
@@ -535,10 +535,14 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                         try:
                             found = contains_anchor(response, anchor)
                         except UnicodeDecodeError:
-                            return 'ignored', 'unable to decode response content', 0
+                            return (
+                                LinkStatus.IGNORED,
+                                'unable to decode response content',
+                                0,
+                            )
                         if not found:
                             return (
-                                'broken',
+                                LinkStatus.BROKEN,
                                 __("Anchor '%s' not found") % quote(anchor),
                                 0,
                             )


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring (mostly; does introduce small behaviour changes)

### Purpose
- Use `StrEnum` values to provide type-checkable linkcheck status codes.

### Detail
- Utilises Python 3.11, for [`StrEnum`](https://docs.python.org/3.11/whatsnew/3.11.html#enum) and [Structural Pattern Matching](https://peps.python.org/pep-0622/) support (ref #13000).
- Removes apparently unused status codes (`local`, `old`).

### Relates
- Reinstantiates #11865.