### PR TITLE
Codify linkcheck status codes into a ``Literal``

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -201,12 +201,7 @@ class CheckExternalLinksBuilder(DummyBuilder):
         self.json_outfile.write('\n')
 
     def write_entry(
-        self,
-        what: _Status | str,
-        docname: str,
-        filename: _StrPath,
-        line: int,
-        uri: str,
+        self, what: _Status | str, docname: str, filename: _StrPath, line: int, uri: str
     ) -> None:
         self.txt_outfile.write(f'{filename}:{line}: [{what}] {uri}\n')
 

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -193,7 +193,8 @@ class CheckExternalLinksBuilder(DummyBuilder):
                 result.uri + ' to ' + result.message,
             )
         else:
-            raise ValueError('Unknown status %s.' % result.status)
+            msg = f'Unknown status {result.status!r}.'
+            raise ValueError(msg)
 
     def write_linkstat(self, data: dict[str, str | int]) -> None:
         self.json_outfile.write(json.dumps(data))
@@ -464,12 +465,13 @@ class HyperlinkAvailabilityCheckWorker(Thread):
             return 'broken', '', 0
 
         # need to actually check the URI
+        status, info, code = '', '', 0
         for _ in range(self.retries):
             status, info, code = self._check_uri(uri, hyperlink)
             if status != 'broken':
                 return status, info, code
 
-        return '', '', 0
+        return status, info, code
 
     def _retrieval_methods(
         self,


### PR DESCRIPTION
Alternative to #13039. This changes nothing in the runtime other than narrowing the current `str` to a `Literal`. Note that `Literal['']` is needed in a couple of places because of this.

cc @jayaddison 

A