### PR TITLE
Use structural pattern matching to handle linkcheck result statuses

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -119,9 +119,10 @@ class CheckExternalLinksBuilder(DummyBuilder):
             logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
         if result.status == _Status.IGNORED:
             if result.message:
-                logger.info(darkgray('-ignored- ') + result.uri + ': ' + result.message)
+                msg = darkgray('-ignored- ') + result.uri + ': ' + result.message
             else:
-                logger.info(darkgray('-ignored- ') + result.uri)
+                msg = darkgray('-ignored- ') + result.uri
+            logger.info(msg)
         elif result.status == _Status.LOCAL:
             logger.info(darkgray('-local-   ') + result.uri)
             self.write_entry(
@@ -135,14 +136,11 @@ class CheckExternalLinksBuilder(DummyBuilder):
             logger.info(darkgreen('ok        ') + result.uri + result.message)
         elif result.status == _Status.TIMEOUT:
             if self.app.quiet:
-                logger.warning(
-                    'timeout   ' + result.uri + result.message,
-                    location=(result.docname, result.lineno),
-                )
+                msg = 'timeout   ' + result.uri + result.message
+                logger.warning(msg, location=(result.docname, result.lineno))
             else:
-                logger.info(
-                    red('timeout   ') + result.uri + red(' - ' + result.message)
-                )
+                msg = red('timeout   ') + result.uri + red(' - ' + result.message)
+                logger.info(msg)
             self.write_entry(
                 _Status.TIMEOUT,
                 result.docname,
@@ -160,9 +158,8 @@ class CheckExternalLinksBuilder(DummyBuilder):
                     location=(result.docname, result.lineno),
                 )
             else:
-                logger.info(
-                    red('broken    ') + result.uri + red(' - ' + result.message)
-                )
+                msg = red('broken    ') + result.uri + red(' - ' + result.message)
+                logger.info(msg)
             self.write_entry(
                 _Status.BROKEN,
                 result.docname,
@@ -183,17 +180,13 @@ class CheckExternalLinksBuilder(DummyBuilder):
             except KeyError:
                 text, color = ('with unknown code', purple)
             linkstat['text'] = text
+            redirection = text + ' to ' + result.message
             if self.config.linkcheck_allowed_redirects:
-                logger.warning(
-                    'redirect  ' + result.uri + ' - ' + text + ' to ' + result.message,
-                    location=(result.docname, result.lineno),
-                )
+                msg = 'redirect  ' + result.uri + ' - ' + redirection
+                logger.warning(msg, location=(result.docname, result.lineno))
             else:
-                logger.info(
-                    color('redirect  ')
-                    + result.uri
-                    + color(' - ' + text + ' to ' + result.message)
-                )
+                msg = color('redirect  ') + result.uri + color(' - ' + redirection)
+                logger.info(msg)
             self.write_entry(
                 'redirected ' + text,
                 result.docname,

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -111,11 +111,15 @@ class CheckExternalLinksBuilder(DummyBuilder):
         }
         self.write_linkstat(linkstat)
 
-        if result.status == _Status.UNCHECKED:
-            return
         if result.lineno:
-            logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
+            if result.status == _Status.UNCHECKED:
+                pass  # unchecked links are not logged
+            else:
+                logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
+
         match result.status:
+            case _Status.RATE_LIMITED | _Status.UNCHECKED:
+                pass
             case _Status.IGNORED:
                 if result.message:
                     msg = darkgray('-ignored- ') + result.uri + ': ' + result.message
@@ -193,8 +197,8 @@ class CheckExternalLinksBuilder(DummyBuilder):
                     result.lineno,
                     result.uri + ' to ' + result.message,
                 )
-            case _:
-                msg = f'Unknown status {result.status!r}.'
+            case _Status.UNKNOWN:
+                msg = 'Unknown status.'
                 raise ValueError(msg)
 
     def write_linkstat(self, data: dict[str, str | int | _Status]) -> None:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -111,13 +111,9 @@ class CheckExternalLinksBuilder(DummyBuilder):
         }
         self.write_linkstat(linkstat)
 
-        if result.lineno:
-            if result.status == _Status.UNCHECKED:
-                pass  # unchecked links are not logged
-            else:
-                logger.info(
-                    '(%16s: line %4d) ', result.docname, result.lineno, nonl=True
-                )
+        if result.lineno and result.status != _Status.UNCHECKED:
+            # unchecked links are not logged
+            logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
 
         match result.status:
             case _Status.RATE_LIMITED | _Status.UNCHECKED:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -113,8 +113,6 @@ class CheckExternalLinksBuilder(DummyBuilder):
 
         if result.status == _Status.UNCHECKED:
             return
-        if result.status == _Status.WORKING and result.message == 'old':
-            return
         if result.lineno:
             logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
         match result.status:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -115,7 +115,9 @@ class CheckExternalLinksBuilder(DummyBuilder):
             if result.status == _Status.UNCHECKED:
                 pass  # unchecked links are not logged
             else:
-                logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
+                logger.info(
+                    '(%16s: line %4d) ', result.docname, result.lineno, nonl=True
+                )
 
         match result.status:
             case _Status.RATE_LIMITED | _Status.UNCHECKED:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -117,86 +117,87 @@ class CheckExternalLinksBuilder(DummyBuilder):
             return
         if result.lineno:
             logger.info('(%16s: line %4d) ', result.docname, result.lineno, nonl=True)
-        if result.status == _Status.IGNORED:
-            if result.message:
-                msg = darkgray('-ignored- ') + result.uri + ': ' + result.message
-            else:
-                msg = darkgray('-ignored- ') + result.uri
-            logger.info(msg)
-        elif result.status == _Status.LOCAL:
-            logger.info(darkgray('-local-   ') + result.uri)
-            self.write_entry(
-                _Status.LOCAL,
-                result.docname,
-                filename,
-                result.lineno,
-                result.uri,
-            )
-        elif result.status == _Status.WORKING:
-            logger.info(darkgreen('ok        ') + result.uri + result.message)
-        elif result.status == _Status.TIMEOUT:
-            if self.app.quiet:
-                msg = 'timeout   ' + result.uri + result.message
-                logger.warning(msg, location=(result.docname, result.lineno))
-            else:
-                msg = red('timeout   ') + result.uri + red(' - ' + result.message)
+        match result.status:
+            case _Status.IGNORED:
+                if result.message:
+                    msg = darkgray('-ignored- ') + result.uri + ': ' + result.message
+                else:
+                    msg = darkgray('-ignored- ') + result.uri
                 logger.info(msg)
-            self.write_entry(
-                _Status.TIMEOUT,
-                result.docname,
-                filename,
-                result.lineno,
-                result.uri + ': ' + result.message,
-            )
-            self.timed_out_hyperlinks += 1
-        elif result.status == _Status.BROKEN:
-            if self.app.quiet:
-                logger.warning(
-                    __('broken link: %s (%s)'),
+            case _Status.LOCAL:
+                logger.info(darkgray('-local-   ') + result.uri)
+                self.write_entry(
+                    _Status.LOCAL,
+                    result.docname,
+                    filename,
+                    result.lineno,
                     result.uri,
-                    result.message,
-                    location=(result.docname, result.lineno),
                 )
-            else:
-                msg = red('broken    ') + result.uri + red(' - ' + result.message)
-                logger.info(msg)
-            self.write_entry(
-                _Status.BROKEN,
-                result.docname,
-                filename,
-                result.lineno,
-                result.uri + ': ' + result.message,
-            )
-            self.broken_hyperlinks += 1
-        elif result.status == _Status.REDIRECTED:
-            try:
-                text, color = {
-                    301: ('permanently', purple),
-                    302: ('with Found', purple),
-                    303: ('with See Other', purple),
-                    307: ('temporarily', turquoise),
-                    308: ('permanently', purple),
-                }[result.code]
-            except KeyError:
-                text, color = ('with unknown code', purple)
-            linkstat['text'] = text
-            redirection = text + ' to ' + result.message
-            if self.config.linkcheck_allowed_redirects:
-                msg = 'redirect  ' + result.uri + ' - ' + redirection
-                logger.warning(msg, location=(result.docname, result.lineno))
-            else:
-                msg = color('redirect  ') + result.uri + color(' - ' + redirection)
-                logger.info(msg)
-            self.write_entry(
-                'redirected ' + text,
-                result.docname,
-                filename,
-                result.lineno,
-                result.uri + ' to ' + result.message,
-            )
-        else:
-            msg = f'Unknown status {result.status!r}.'
-            raise ValueError(msg)
+            case _Status.WORKING:
+                logger.info(darkgreen('ok        ') + result.uri + result.message)
+            case _Status.TIMEOUT:
+                if self.app.quiet:
+                    msg = 'timeout   ' + result.uri + result.message
+                    logger.warning(msg, location=(result.docname, result.lineno))
+                else:
+                    msg = red('timeout   ') + result.uri + red(' - ' + result.message)
+                    logger.info(msg)
+                self.write_entry(
+                    _Status.TIMEOUT,
+                    result.docname,
+                    filename,
+                    result.lineno,
+                    result.uri + ': ' + result.message,
+                )
+                self.timed_out_hyperlinks += 1
+            case _Status.BROKEN:
+                if self.app.quiet:
+                    logger.warning(
+                        __('broken link: %s (%s)'),
+                        result.uri,
+                        result.message,
+                        location=(result.docname, result.lineno),
+                    )
+                else:
+                    msg = red('broken    ') + result.uri + red(' - ' + result.message)
+                    logger.info(msg)
+                self.write_entry(
+                    _Status.BROKEN,
+                    result.docname,
+                    filename,
+                    result.lineno,
+                    result.uri + ': ' + result.message,
+                )
+                self.broken_hyperlinks += 1
+            case _Status.REDIRECTED:
+                try:
+                    text, color = {
+                        301: ('permanently', purple),
+                        302: ('with Found', purple),
+                        303: ('with See Other', purple),
+                        307: ('temporarily', turquoise),
+                        308: ('permanently', purple),
+                    }[result.code]
+                except KeyError:
+                    text, color = ('with unknown code', purple)
+                linkstat['text'] = text
+                redirection = text + ' to ' + result.message
+                if self.config.linkcheck_allowed_redirects:
+                    msg = 'redirect  ' + result.uri + ' - ' + redirection
+                    logger.warning(msg, location=(result.docname, result.lineno))
+                else:
+                    msg = color('redirect  ') + result.uri + color(' - ' + redirection)
+                    logger.info(msg)
+                self.write_entry(
+                    'redirected ' + text,
+                    result.docname,
+                    filename,
+                    result.lineno,
+                    result.uri + ' to ' + result.message,
+                )
+            case _:
+                msg = f'Unknown status {result.status!r}.'
+                raise ValueError(msg)
 
     def write_linkstat(self, data: dict[str, str | int | _Status]) -> None:
         self.json_outfile.write(json.dumps(data))


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring (and a legacy code cleanup)

### Purpose
- The repeated `[el]if...result.status == <status>` conditions in part of the `linkcheck` code expose an intended behaviour: each status code implies that the code should follow one particular code path to handle the result.  This seems like a good fit for a [`match` clause](https://peps.python.org/pep-0622/), available from Python3.11+.

### Detail
- Handle `linkcheck` status codes using a `match` statement.
- Also includes a tangential refactor of some logging code, to fit the resulting code within formatting guidelines while remaining aesthetically reasonable.
- For review purposes, it could be helpful to ignore whitespace differences introduced by this changeset (`w=1` query-string parameter, if using the GitHub web comparison interface).

### Relates
- Builds upon #13043.