### PR TITLE
Introducing Sphinx Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,11 @@
    :target: https://opensource.org/licenses/BSD-2-Clause
    :alt: BSD 2 Clause
 
+.. image:: https://img.shields.io/badge/Gurubase-Ask%20Sphinx%20Guru-006BFF
+   :target: https://gurubase.io/g/sphinx
+   :alt: Sphinx Guru
+
+
 **Sphinx makes it easy to create intelligent and beautiful documentation.**
 
 Sphinx uses reStructuredText as its markup language, and many of its strengths


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Sphinx Guru](https://gurubase.io/g/sphinx) to Gurubase. Sphinx Guru uses the data from this repo and data from the [docs](https://www.sphinx-doc.org/en/master/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Sphinx Guru", which highlights that Sphinx now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Sphinx Guru in Gurubase, just let me know that's totally fine.
