### PR TITLE
Recommend recent Sphinx for GitHub Pages

### DIFF
--- a/doc/tutorial/deploying.rst
+++ b/doc/tutorial/deploying.rst
@@ -189,7 +189,7 @@ contents:
        steps:
        - uses: actions/checkout@v4
        - name: Build HTML
-         uses: ammaraskar/sphinx-action@master
+         uses: ammaraskar/sphinx-action@8.0.2
        - name: Upload artifacts
          uses: actions/upload-artifact@v4
          with:


### PR DESCRIPTION
sphinx-action runs Python 3.8 on its master branch, which may fail even if you force upgrading sphinx
in the requirements file.

Recommend a newer base docker image (there doesn't seem to be a rolling "latest" tag available).
