### PR TITLE
html search: use a ``Map`` to collect file-term scores

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,5 +18,9 @@ Features added
 Bugs fixed
 ----------
 
+* #13060: HTML Search: use ``Map`` instead of object literal to store
+  per-file term scores, to prevent prototype pollution.
+  Patch by James Addison
+
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,7 @@ Features added
 Bugs fixed
 ----------
 
-* #13060: HTML Search: use ``Map`` instead of object literal to store
-  per-file term scores, to prevent prototype pollution.
+* #13060: HTML Search: use ``Map`` to store per-file term scores.
   Patch by James Addison
 
 Testing

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -548,7 +548,8 @@ const Search = {
         // set score for the word in each file
         recordFiles.forEach((file) => {
           if (!scoreMap.has(file)) scoreMap.set(file, new Map());
-          scoreMap.get(file)[word] = record.score;
+          const fileScores = scoreMap.get(file);
+          fileScores.set(word, record.score);
         });
       });
 
@@ -587,7 +588,7 @@ const Search = {
         break;
 
       // select one (max) score for the file.
-      const score = Math.max(...wordList.map((w) => scoreMap.get(file)[w]));
+      const score = Math.max(...wordList.map((w) => scoreMap.get(file).get(w)));
       // add result to the result list
       results.push([
         docNames[file],

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -547,7 +547,7 @@ const Search = {
 
         // set score for the word in each file
         recordFiles.forEach((file) => {
-          if (!scoreMap.has(file)) scoreMap.set(file, {});
+          if (!scoreMap.has(file)) scoreMap.set(file, new Map());
           scoreMap.get(file)[word] = record.score;
         });
       });


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Prevent carefully-crafted search queries on the frontend from polluting the `scoreMap`, potentially allowing for undesired result scoring adjustments.

### Detail
- As recommended in the [OWASP Prototype Pollution Cheat-Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html), use a JavaScript `Map` instead of an object literal to record per-file term scoring.
- Use the `Map.set` method instead of assigning to the properties of the map object.

### Relates
- N/A

Edit: add note about using `Map.set` in preference to object-property assignment.