### PR TITLE
linkcheck: Remove unused 'local' status code

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 class _Status(StrEnum):
     BROKEN = 'broken'
     IGNORED = 'ignored'
-    LOCAL = 'local'
     RATE_LIMITED = 'rate-limited'
     REDIRECTED = 'redirected'
     TIMEOUT = 'timeout'
@@ -124,15 +123,6 @@ class CheckExternalLinksBuilder(DummyBuilder):
                 else:
                     msg = result.uri
                 logger.info(darkgray('-ignored- ') + msg)
-            case _Status.LOCAL:
-                logger.info(darkgray('-local-   ') + result.uri)
-                self.write_entry(
-                    _Status.LOCAL,
-                    result.docname,
-                    filename,
-                    result.lineno,
-                    result.uri,
-                )
             case _Status.WORKING:
                 logger.info(darkgreen('ok        ') + f'{result.uri}{result.message}')
             case _Status.TIMEOUT:


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
- Refactoring

### Purpose
- Removes an unused status code from the `linkcheck` builder.

### Detail
- This status was used in the past to indicate hyperlinks that had been skipped during linkchecking because they did not appear to be of either a known-or-ignored network protocol scheme.
- The `linkcheck` builder does, in fact, now check for some local file resources (for example, the [presence or absence of existence of file paths](https://github.com/sphinx-doc/sphinx/blob/bd7d595c6b37e68acaf988e3dded04395242474b/sphinx/builders/linkcheck.py#L463-L466)).  However, these are reported using the same status code system as remote links.
- I'd like to suggest a feature request that allows us to distinguish between those `local` and `remote` resources -- but I think it probably makes sense to remove this unused code first.

### Relates
- Originates from discussion in https://github.com/sphinx-doc/sphinx/pull/13049