### PR TITLE
config: Accept string values 0 and 1 for  'translation_progress_classes' option

### DIFF
--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -213,7 +213,7 @@ class Config:
         'figure_language_filename': _Opt('{root}.{language}{ext}', 'env', frozenset((str,))),
         'gettext_allow_fuzzy_translations': _Opt(False, 'gettext', ()),
         'translation_progress_classes': _Opt(
-            False, 'env', ENUM(True, False, 'translated', 'untranslated')),
+            False, 'env', ENUM(True, False, '1', '0', 'translated', 'untranslated')),
 
         'master_doc': _Opt('index', 'env', ()),
         'root_doc': _Opt(lambda config: config.master_doc, 'env', ()),

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -652,9 +652,9 @@ class AddTranslationClasses(SphinxTransform):
         if not self.config.translation_progress_classes:
             return
 
-        if self.config.translation_progress_classes in (True, '1'):
+        if self.config.translation_progress_classes in {True, '1'}:
             add_translated = add_untranslated = True
-        elif self.config.translation_progress_classes in (False, '0'):
+        elif self.config.translation_progress_classes in {False, '0'}:
             add_translated = add_untranslated = False
         elif self.config.translation_progress_classes == 'translated':
             add_translated = True

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -665,7 +665,7 @@ class AddTranslationClasses(SphinxTransform):
         else:
             msg = (
                 'translation_progress_classes must be '
-                'True, False, 1, 0, "translated" or "untranslated"'
+                'True, False, "1", "0", "translated" or "untranslated"'
             )
             raise ConfigError(msg)
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -652,8 +652,10 @@ class AddTranslationClasses(SphinxTransform):
         if not self.config.translation_progress_classes:
             return
 
-        if self.config.translation_progress_classes is True:
+        if self.config.translation_progress_classes in (True, '1'):
             add_translated = add_untranslated = True
+        elif self.config.translation_progress_classes in (False, '0'):
+            add_translated = add_untranslated = False
         elif self.config.translation_progress_classes == 'translated':
             add_translated = True
             add_untranslated = False
@@ -663,7 +665,7 @@ class AddTranslationClasses(SphinxTransform):
         else:
             msg = (
                 'translation_progress_classes must be '
-                'True, False, "translated" or "untranslated"'
+                'True, False, 1, 0, "translated" or "untranslated"'
             )
             raise ConfigError(msg)
 

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -769,6 +769,26 @@ def test_translation_progress_classes_true(app):
     assert len(doctree[0]) == 20
 
 
+@pytest.mark.sphinx(
+    'html',
+    testroot='intl',
+    freshenv=True,
+    confoverrides={
+        'language': _CATALOG_LOCALE,
+        'locale_dirs': ['.'],
+        'gettext_compact': False,
+        'translation_progress_classes': '0',
+    },
+)
+def test_translation_progress_classes_disabled(app):
+    app.build(filenames=[app.srcdir / 'translation_progress.txt'])
+
+    doctree = app.env.get_doctree('translation_progress')
+
+    # title
+    assert 'translated' not in doctree[0][0]['classes']
+
+
 class _MockClock:
     """Object for mocking :func:`time.time_ns` (if needed).
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Allow the `translation_progress_classes` config option, that is documented as accepting boolean values, accept the string values `0` or `1` as documented for boolean options.

### Detail
- Allow the `translation_progress_classes` configuration option to be specified using the [`define`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/cmd/build.py#L259-L267) (type: `str`) command-line option.
- This isn't as trivial as it might seem; the values read are strings, not integer values -- and naively boolean casting the string `'0'` would result in a `True` value.  Also, there is an existing falsiness test -- so, technically speaking, the introduction of a comparison to `False` is redundant in this changeset.

### Relates
- Resolves #13071.
- Relates-to #11509.