### PR TITLE
Use default locale_dirs value

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -173,7 +173,6 @@ intersphinx_mapping = {
 }
 
 # Sphinx document translation with sphinx gettext feature uses these settings:
-locale_dirs = ['locale/']
 gettext_compact = False
 
 nitpick_ignore = {


### PR DESCRIPTION

### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Purpose
Remove the locale_dirs entry from documentation's conf.py to use the default value 'locales', which would avoid the need for setting -Dlocale_dirs 



### Detail
https://github.com/sphinx-doc/sphinx-doc-translations/pull/58 is just holding this to land.

### Relates

