### PR TITLE
Properly strip time zones which are west of UTC

### DIFF
--- a/tests/test_util/test_util_i18n.py
+++ b/tests/test_util/test_util_i18n.py
@@ -108,7 +108,7 @@ def test_format_date_timezone():
     assert fd_gmt == '2016-08-07 05:11:17'
     assert fd_gmt == iso_gmt
 
-    iso_local = dt.astimezone().isoformat(' ').split('+')[0]
+    iso_local = dt.astimezone().isoformat(' ')[:19]  # strip the timezone
     fd_local = i18n.format_date(fmt, date=dt, language='en', local_time=True)
     assert fd_local == iso_local
     assert fd_local != fd_gmt


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Properly strip time zones which are west of UTC. Such timezones won’t have `+` character, they will have `-` instead.

This fixes test failure which was [seen in Debian](https://salsa.debian.org/python-team/packages/sphinx/-/jobs/6580201):

```
        iso_local = dt.astimezone().isoformat(' ').split('+')[0]
        fd_local = i18n.format_date(fmt, date=dt, language='en', local_time=True)
>       assert fd_local == iso_local
E       AssertionError: assert '2016-08-06 17:11:17' == '2016-08-06 17:11:17-12:00'
E         
E         - 2016-08-06 17:11:17-12:00
E         ?                    ------
E         + 2016-08-06 17:11:17
tests/test_util/test_util_i18n.py:111: AssertionError
```