### PR TITLE
Remove unnecessary parentheses in meth role

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -81,7 +81,7 @@ class Builder:
     # doctree versioning method
     versioning_method = 'none'
     versioning_compare = False
-    #: Whether it is safe to make parallel :meth:`~.Builder.write_doc()` calls.
+    #: Whether it is safe to make parallel :meth:`~.Builder.write_doc` calls.
     allow_parallel: bool = False
     # support translation
     use_message_catalog = True


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Solves this sphinx-lint warning spotted in a translation file

```
extdev/builderapi.po:82: Unnecessary parentheses in ':meth:`~.Builder.write_doc()`' (unnecessary-parentheses)
```

### Details

See:
- [doc/extdev/builderapi.rst](https://github.com/sphinx-doc/sphinx/blob/master/doc/extdev/builderapi.rst?plain=1#L48) extracts write_doc()'s documentation from sphinx/builders/__init__.py
- [Tested translation (.po) file](https://github.com/sphinx-doc/sphinx-doc-translations/blob/93e86097ce09bcd21fb842852067ffbd3e8c2966/locales/pt_BR/LC_MESSAGES/extdev/builderapi.po#L82-L86) with ```:meth:`~.Builder.write_doc()` ``` in the extracted message.
- [sphinx-lint output](https://github.com/sphinx-doc/sphinx-doc-translations/actions/runs/11889763508/job/33127000582)