### PR TITLE
Unify the type preprocessing logic in Napoleon

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,6 +35,7 @@ Contributors
 * Bruce Mitchener -- Minor epub improvement
 * Buck Evan -- dummy builder
 * Charles Duffy -- original graphviz extension
+* Chris Barrick -- Napoleon type preprocessing logic
 * Chris Holdgraf -- improved documentation structure
 * Chris Lamb -- reproducibility fixes
 * Christopher Perkins -- autosummary integration

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Features added
   Patch by Nicolas Peugnet.
 * #13144: Add a ``class`` option to the :rst:dir:`autosummary` directive.
   Patch by Tim Hoffmann.
+* #13146: Napoleon: Unify the type preprocessing logic to allow
+  Google-style docstrings to use the optional and default keywords.
+  Patch by Chris Barrick.
 
 Bugs fixed
 ----------

--- a/tests/test_extensions/test_ext_napoleon_docstring.py
+++ b/tests/test_extensions/test_ext_napoleon_docstring.py
@@ -17,7 +17,7 @@ from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon.docstring import (
     GoogleDocstring,
     NumpyDocstring,
-    _convert_numpy_type_spec,
+    _convert_type_spec,
     _recombine_set_tokens,
     _token_type,
     _tokenize_type_spec,
@@ -1332,7 +1332,7 @@ Do as you please
         expected = """\
 Do as you please
 
-:Yields: :py:class:`str` -- Extended
+:Yields: :class:`str` -- Extended
 """
         assert str(actual) == expected
 
@@ -2677,7 +2677,7 @@ definition_after_normal_text : int
         )
 
         for spec, expected in zip(specs, converted, strict=True):
-            actual = _convert_numpy_type_spec(spec, translations=translations)
+            actual = _convert_type_spec(spec, translations=translations)
             assert actual == expected
 
     def test_parameter_types(self):


### PR DESCRIPTION
Subject: Unify the type preprocessing logic in Napoleon

### Feature or Bugfix
- Feature

### Purpose
Allow Google-style docstrings to use the `optional` and `default` keywords described at https://numpydoc.readthedocs.io/en/latest/format.html#parameters

### Detail
Previously, there were two separate type preprocessing functions: `_convert_type_spec` (used in Google-style docstrings) and `_convert_numpy_type_spec` (used in Numpy-style docstrings).

The Google version simply applied type-alias translations or wrapped the text in a `:py:class:` role.

The Numpy version does the same, plus adds special handling for keywords `optional` and `default` and delimiter words `or`, `of`, and `and`. This allows one to write in natural language, like `Array of int` instead of `Array[int]` or `Widget, optional` instead of `Optional[Widget]` or `Widget | None`. Numpy style is described in full at: https://numpydoc.readthedocs.io/en/latest/format.html#parameters

This commit eliminates the distinction and allows Google-style docstrings to use these preprocessing rules.


### More details

The Numpy-style preprocessing code lived between the GoogleDocstring and NumpyDocstring classes. This was kinda an awkward location when the code would become shared by both classes.

This PR is broken into two commits. The first moves the code to a more palatable location. The second migrates GoogleDocstring to use the previously-named `_convert_numpy_type_spec`.

I think it will be much easier to review the diffs individually rather than the diff for the whole PR.