### PR TITLE
Fix incorrect reference to ``--config-dir`` in the documentation

### DIFF
--- a/doc/man/sphinx-build.rst
+++ b/doc/man/sphinx-build.rst
@@ -141,7 +141,7 @@ Options
    .. versionchanged:: 6.2
       Add ``--jobs`` long option.
 
-.. option:: -c path, --config-dir path
+.. option:: -c path, --conf-dir path
 
    Don't look for the :file:`conf.py` in the source directory, but use the given
    configuration directory instead.  Note that various other files and paths
@@ -152,7 +152,7 @@ Options
    .. versionadded:: 0.3
 
    .. versionchanged:: 7.3
-      Add ``--config-dir`` long option.
+      Add ``--conf-dir`` long option.
 
 .. option:: -C, --isolated
 


### PR DESCRIPTION
Subject: Fix incorrect argument `config-dir` in sphinx-build

### Feature or Bugfix
<!-- please choose -->
- Bugfix (Documentation content fix)

### Purpose
- Update `--config-dir` to the current argument `--conf-dir`. `--conf-dir` argument is recognized in Sphinx 8.1.3 but `--config-dir` is not recognized

### Detail
- None

### Relates
- None

