### PR TITLE
Ensure `changeset.descname` is a string when not None

### DIFF
--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -61,10 +61,7 @@ class ChangesBuilder(Builder):
             return
         logger.info(bold(__('writing summary file...')))
         for changeset in changesets:
-            if isinstance(changeset.descname, tuple):
-                descname = changeset.descname[0]
-            else:
-                descname = changeset.descname
+            descname = changeset.descname
             ttext = self.typemap[changeset.type]
             context = changeset.content.replace('\n', ' ')
             if descname and changeset.docname.startswith('c-api'):

--- a/sphinx/directives/__init__.py
+++ b/sphinx/directives/__init__.py
@@ -282,7 +282,11 @@ class ObjectDescription(SphinxDirective, Generic[ObjDescT]):
 
         if self.names:
             # needed for association of version{added,changed} directives
-            self.env.temp_data['object'] = self.names[0]
+            object_name: ObjDescT = self.names[0]
+            if isinstance(object_name, tuple):
+                self.env.temp_data['object'] = str(object_name[0])
+            else:
+                self.env.temp_data['object'] = str(object_name)
         self.before_content()
         content_children = self.parse_content_to_nodes(allow_section_headings=True)
         content_node = addnodes.desc_content('', *content_children)


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Purpose

`ChangeSet` defines the type of `descname` as `str | None`. Currently, it is actually `ObjDescT | None`, which can be `str | tuple[str, str] | ASTDeclaration | None`. We only use `descname` in `ChangesBuilder.write_documents()` where we coerce it to a string, so this PR converts to a string earlier to ensure type safety.

A