### PR TITLE
Fixup: path resolution during 'sphinx.cmd.make_mode' cleanup

### DIFF
--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -86,7 +86,7 @@ class Make:
             print("Error: '%s' directory contains source directory!" % self.build_dir)
             return 1
         print("Removing everything under '%s'..." % self.build_dir)
-        for item in build_dir.iterdir():
+        for item in self.build_dir.iterdir():
             rmtree(item)
         return 0
 

--- a/sphinx/cmd/make_mode.py
+++ b/sphinx/cmd/make_mode.py
@@ -86,8 +86,8 @@ class Make:
             print("Error: '%s' directory contains source directory!" % self.build_dir)
             return 1
         print("Removing everything under '%s'..." % self.build_dir)
-        for item in self.build_dir.iterdir():
-            rmtree(self.build_dir_join(item))
+        for item in build_dir.iterdir():
+            rmtree(item)
         return 0
 
     def build_help(self) -> None:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Fixup for `make clean`.

### Detail
- Remove redundant and incorrect double-resolution of build dir content paths.
- ~~Also, ensure that the resolved build dir is used to begin the cleanup search.~~

### Relates
- Resolves #13157.