### PR TITLE
Trim leading whitespace characters along doctest flags

### DIFF
--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 blankline_re = re.compile(r'^\s*<BLANKLINE>', re.MULTILINE)
-doctestopt_re = re.compile(r'#\s*doctest:.+$', re.MULTILINE)
+doctestopt_re = re.compile(r'\s*#\s*doctest:.+$', re.MULTILINE)
 
 
 def is_allowed_version(spec: str, version: str) -> bool:

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 blankline_re = re.compile(r'^\s*<BLANKLINE>', re.MULTILINE)
-doctestopt_re = re.compile(r'\s*#\s*doctest:.+$', re.MULTILINE)
+doctestopt_re = re.compile(r'[ \t]*#\s*doctest:.+$', re.MULTILINE)
 
 
 def is_allowed_version(spec: str, version: str) -> bool:

--- a/tests/test_transforms/test_transforms_post_transforms_code.py
+++ b/tests/test_transforms/test_transforms_post_transforms_code.py
@@ -15,6 +15,7 @@ def test_trim_doctest_flags_html(app):
     assert 'QUUX' not in result
     assert 'CORGE' not in result
     assert 'GRAULT' in result
+    assert '<span class="n">now</span><span class="p">()</span>   \n' not in result
 
 
 @pytest.mark.sphinx(

--- a/tests/test_transforms/test_transforms_post_transforms_code.py
+++ b/tests/test_transforms/test_transforms_post_transforms_code.py
@@ -16,6 +16,7 @@ def test_trim_doctest_flags_html(app):
     assert 'CORGE' not in result
     assert 'GRAULT' in result
     assert '<span class="n">now</span><span class="p">()</span>   \n' not in result
+    assert '<span class="n">now</span><span class="p">()</span>\n' in result
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
Subject: trim leading whitespaces along with doctest flags comments

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- improve rendering of doctest blocks by removing trailing spaces from the output

### Detail
- extra trailing spaces can be seen in the code blocks output in a line where doctest comment is in the [source code](https://github.com/python/cpython/blob/3024b16d51bb7f74177c5a5038cc9a56fd2b26bd/Doc/tutorial/modules.rst#L315) (note extra highlight after the `dir(sys)`
<img width="500" alt="Zrzut ekranu 2024-12-5 o 00 45 19" src="https://github.com/user-attachments/assets/3d2e070d-cfc5-48ec-a1ad-b47617a997ac">

- it indirectly is causing `sphinx-lint` failures in a translated code blocks, as the `sphinx-lint` disallows trailing spaces

### Related
- https://github.com/sphinx-contrib/sphinx-lint/issues/120