### PR TITLE
Remove unnecessary parentheses from doc

### DIFF
--- a/sphinx/domains/_index.py
+++ b/sphinx/domains/_index.py
@@ -65,7 +65,7 @@ class Index(ABC):
     * `shortname` is a short name for the index, for use in the relation bar in
       HTML output.  Can be empty to disable entries in the relation bar.
 
-    and providing a :meth:`generate()` method.  Then, add the index class to
+    and providing a :meth:`generate` method.  Then, add the index class to
     your domain's `indices` list.  Extensions can add indices to existing
     domains using :meth:`~sphinx.application.Sphinx.add_index_to_domain()`.
 

--- a/sphinx/domains/_index.py
+++ b/sphinx/domains/_index.py
@@ -67,7 +67,7 @@ class Index(ABC):
 
     and providing a :meth:`generate` method.  Then, add the index class to
     your domain's `indices` list.  Extensions can add indices to existing
-    domains using :meth:`~sphinx.application.Sphinx.add_index_to_domain()`.
+    domains using :meth:`~sphinx.application.Sphinx.add_index_to_domain`.
 
     .. versionchanged:: 3.0
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
Parentheses after the method name under `:meth:` role is reported as unnecessary by sphinx-lint as of version 1.0.0. This PR removes the parentheses to avoid such reports.

It might not be caught when running the sphinx-lint in the docs because the changed file is a Python file, not a reStructuredText, but it does get caught in translation files. See [this lint output in CI](https://github.com/sphinx-doc/sphinx-doc-translations/actions/runs/12475169007/job/34818221215) and [the corresponding translation file](https://github.com/sphinx-doc/sphinx-doc-translations/blob/bbf1c9614f34dbe500d2a2dce955534a3ff0fdbb/locales/ja/LC_MESSAGES/extdev/domainapi.po#L418) at sphinx-doc-translations.

### Detail

### Relates

