### PR TITLE
intersphinx: Simplify `_fetch_inventory()`

### DIFF
--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import io
 import os.path
 import posixpath
 import time
@@ -305,9 +304,8 @@ def _fetch_inventory(
     else:
         raw_data = _fetch_inventory_file(inv_location=inv_location, srcdir=srcdir)
 
-    stream = io.BytesIO(raw_data)
     try:
-        invdata = InventoryFile.load(stream, target_uri, posixpath.join)
+        invdata = InventoryFile.loads(raw_data, uri=target_uri)
     except ValueError as exc:
         msg = f'unknown or unsupported inventory version: {exc!r}'
         raise ValueError(msg) from exc

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import io
 import os.path
 import posixpath
 import time
@@ -297,50 +298,50 @@ def _fetch_inventory(
     # and *inv_location* (actual location of the inventory file)
     # can be local or remote URIs
     if '://' in target_uri:
-        # case: inv URI points to remote resource; strip any existing auth
+        # inv URI points to remote resource; strip any existing auth
         target_uri = _strip_basic_auth(target_uri)
-    try:
-        if '://' in inv_location:
-            f: _ReadableStream[bytes] = _read_from_url(inv_location, config=config)
-        else:
-            f = open(os.path.join(srcdir, inv_location), 'rb')  # NoQA: SIM115
-    except Exception as err:
-        err.args = (
-            'intersphinx inventory %r not fetchable due to %s: %s',
-            inv_location,
-            err.__class__,
-            str(err),
-        )
-        raise
-    try:
-        if hasattr(f, 'url'):
-            new_inv_location = f.url
-            if inv_location != new_inv_location:
-                msg = __('intersphinx inventory has moved: %s -> %s')
-                LOGGER.info(msg, inv_location, new_inv_location)
+    if '://' in inv_location:
+        try:
+            raw_data, new_inv_location = _read_from_url(inv_location, config=config)
+        except Exception as err:
+            err.args = (
+                'intersphinx inventory %r not fetchable due to %s: %s',
+                inv_location,
+                err.__class__,
+                str(err),
+            )
+            raise
 
-                if target_uri in {
-                    inv_location,
-                    os.path.dirname(inv_location),
-                    os.path.dirname(inv_location) + '/',
-                }:
-                    target_uri = os.path.dirname(new_inv_location)
-        with f:
-            try:
-                invdata = InventoryFile.load(f, target_uri, posixpath.join)
-            except ValueError as exc:
-                msg = f'unknown or unsupported inventory version: {exc!r}'
-                raise ValueError(msg) from exc
-    except Exception as err:
-        err.args = (
-            'intersphinx inventory %r not readable due to %s: %s',
-            inv_location,
-            err.__class__.__name__,
-            str(err),
-        )
-        raise
+        if inv_location != new_inv_location:
+            msg = __('intersphinx inventory has moved: %s -> %s')
+            LOGGER.info(msg, inv_location, new_inv_location)
+
+            if target_uri in {
+                inv_location,
+                os.path.dirname(inv_location),
+                os.path.dirname(inv_location) + '/',
+            }:
+                target_uri = os.path.dirname(new_inv_location)
     else:
-        return invdata
+        try:
+            with open(srcdir / inv_location, 'rb') as f:
+                raw_data = f.read()
+        except Exception as err:
+            err.args = (
+                'intersphinx inventory %r not readable due to %s: %s',
+                inv_location,
+                err.__class__.__name__,
+                str(err),
+            )
+            raise
+
+    stream = io.BytesIO(raw_data)
+    try:
+        invdata = InventoryFile.load(stream, target_uri, posixpath.join)
+    except ValueError as exc:
+        msg = f'unknown or unsupported inventory version: {exc!r}'
+        raise ValueError(msg) from exc
+    return invdata
 
 
 def _get_safe_url(url: str) -> str:
@@ -389,35 +390,28 @@ def _strip_basic_auth(url: str) -> str:
     return urlunsplit(frags)
 
 
-def _read_from_url(url: str, *, config: Config) -> HTTPResponse:
+def _read_from_url(url: str, *, config: Config) -> tuple[bytes, str]:
     """Reads data from *url* with an HTTP *GET*.
 
     This function supports fetching from resources which use basic HTTP auth as
     laid out by RFC1738 § 3.1. See § 5 for grammar definitions for URLs.
 
-    .. seealso:
-
-       https://www.ietf.org/rfc/rfc1738.txt
+    .. seealso:: https://www.ietf.org/rfc/rfc1738.txt
 
     :param url: URL of an HTTP resource
-    :type url: ``str``
-
-    :return: data read from resource described by *url*
-    :rtype: ``file``-like object
+    :returns: A pair of data read from the resource described by *url*
+              and the final URL after any redirects.
     """
-    r = requests.get(
+    with requests.get(
         url,
         stream=True,
         timeout=config.intersphinx_timeout,
         _user_agent=config.user_agent,
         _tls_info=(config.tls_verify, config.tls_cacerts),
-    )
-    r.raise_for_status()
-
-    # For inv_location / new_inv_location
-    r.raw.url = r.url  # type: ignore[union-attr]
-
-    # Decode content-body based on the header.
-    # xref: https://github.com/psf/requests/issues/2155
-    r.raw.decode_content = True
-    return r.raw
+    ) as r:
+        r.raise_for_status()
+        # Decode content-body based on the header.
+        # xref: https://github.com/psf/requests/issues/2155
+        response_content = r.content
+        new_inv_location = r.url
+    return response_content, new_inv_location

--- a/sphinx/util/_inventory_file_reader.py
+++ b/sphinx/util/_inventory_file_reader.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import zlib
+from typing import TYPE_CHECKING
+
+from sphinx.util import logging
+
+BUFSIZE = 16 * 1024
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Protocol
+
+    # Readable file stream for inventory loading
+    class _SupportsRead(Protocol):
+        def read(self, size: int = ...) -> bytes: ...
+
+
+__all__ = ('InventoryFileReader',)
+
+
+class InventoryFileReader:
+    """A file reader for an inventory file.
+
+    This reader supports mixture of texts and compressed texts.
+    """
+
+    def __init__(self, stream: _SupportsRead) -> None:
+        self.stream = stream
+        self.buffer = b''
+        self.eof = False
+
+    def read_buffer(self) -> None:
+        chunk = self.stream.read(BUFSIZE)
+        if chunk == b'':
+            self.eof = True
+        self.buffer += chunk
+
+    def readline(self) -> str:
+        pos = self.buffer.find(b'\n')
+        if pos != -1:
+            line = self.buffer[:pos].decode()
+            self.buffer = self.buffer[pos + 1 :]
+        elif self.eof:
+            line = self.buffer.decode()
+            self.buffer = b''
+        else:
+            self.read_buffer()
+            line = self.readline()
+
+        return line
+
+    def readlines(self) -> Iterator[str]:
+        while not self.eof:
+            line = self.readline()
+            if line:
+                yield line
+
+    def read_compressed_chunks(self) -> Iterator[bytes]:
+        decompressor = zlib.decompressobj()
+        while not self.eof:
+            self.read_buffer()
+            yield decompressor.decompress(self.buffer)
+            self.buffer = b''
+        yield decompressor.flush()
+
+    def read_compressed_lines(self) -> Iterator[str]:
+        buf = b''
+        for chunk in self.read_compressed_chunks():
+            buf += chunk
+            pos = buf.find(b'\n')
+            while pos != -1:
+                yield buf[:pos].decode()
+                buf = buf[pos + 1 :]
+                pos = buf.find(b'\n')

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import posixpath
 import re
 import zlib
@@ -16,11 +15,16 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterator, Sequence
+    from typing import Protocol
 
     from sphinx.builders import Builder
     from sphinx.environment import BuildEnvironment
-    from sphinx.util.typing import Inventory, InventoryItem, _ReadableStream
+    from sphinx.util.typing import Inventory, InventoryItem
+
+    # Readable file stream for inventory loading
+    class _SupportsRead(Protocol):
+        def read(self, size: int = ...) -> bytes: ...
 
     _JoinFunc = Callable[[str, str], str]
 
@@ -31,7 +35,7 @@ class InventoryFileReader:
     This reader supports mixture of texts and compressed texts.
     """
 
-    def __init__(self, stream: _ReadableStream[bytes]) -> None:
+    def __init__(self, stream: _SupportsRead) -> None:
         self.stream = stream
         self.buffer = b''
         self.eof = False
@@ -104,9 +108,7 @@ class InventoryFile:
         raise ValueError(msg)
 
     @classmethod
-    def load(
-        cls, stream: _ReadableStream[bytes], uri: str, joinfunc: _JoinFunc
-    ) -> Inventory:
+    def load(cls, stream: _SupportsRead, uri: str, joinfunc: _JoinFunc) -> Inventory:
         return cls.loads(stream.read(), uri=uri)
 
     @classmethod

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import posixpath
 import re
 import zlib
 from typing import TYPE_CHECKING
@@ -78,6 +80,10 @@ class InventoryFileReader:
 
 
 class InventoryFile:
+    @classmethod
+    def loads(cls, content: bytes, *, uri: str) -> Inventory:
+        return cls.load(io.BytesIO(content), uri, posixpath.join)
+
     @classmethod
     def load(
         cls: type[InventoryFile],

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -119,26 +119,6 @@ OptionSpec: TypeAlias = dict[str, Callable[[str], Any]]
 # title getter functions for enumerable nodes (see sphinx.domains.std)
 TitleGetter: TypeAlias = Callable[[nodes.Node], str]
 
-# Readable file stream for inventory loading
-if TYPE_CHECKING:
-    from types import TracebackType
-    from typing import Self
-
-    _T_co = TypeVar('_T_co', str, bytes, covariant=True)
-
-    class _ReadableStream(Protocol[_T_co]):  # NoQA: PYI046 (false positive)
-        def read(self, size: int = ...) -> _T_co: ...
-
-        def __enter__(self) -> Self: ...
-
-        def __exit__(
-            self,
-            exc_type: type[BaseException] | None,
-            exc_val: BaseException | None,
-            exc_tb: TracebackType | None,
-        ) -> None: ...
-
-
 # inventory data on memory
 InventoryItem: TypeAlias = tuple[
     str,  # project name


### PR DESCRIPTION
## Purpose

The streams-based interfaces in intersphinx and `sphinx.util.inventory` are clever, but also complex and prevent using methods of compression that don't support incrememntal decoding. This PR only affects `_fetch_inventory()`, refactoring to read all inventory content from disk or an HTTP request at once.

## References

- #12204

A