### PR TITLE
Tests: fixup: explicitly unset SOURCE_DATE_EPOCH during 'test_html_multi_line_copyright'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,3 +58,6 @@ Bugs fixed
 
 Testing
 -------
+
+* #13224: Correctness fixup for ``test_html_multi_line_copyright``.
+  Patch by Colin Watson, applied by James Addison.

--- a/tests/test_builders/test_build_html_copyright.py
+++ b/tests/test_builders/test_build_html_copyright.py
@@ -9,6 +9,13 @@ LT_NEW = (2009, *LT[1:], LT.tm_zone, LT.tm_gmtoff)
 LOCALTIME_2009 = type(LT)(LT_NEW)
 
 
+@pytest.fixture
+def no_source_date_year(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv('SOURCE_DATE_EPOCH', raising=False)
+        yield
+
+
 @pytest.fixture(
     params=[
         1199145600,  # 2008-01-01 00:00:00
@@ -24,7 +31,7 @@ def source_date_year(request, monkeypatch):
 
 
 @pytest.mark.sphinx('html', testroot='copyright-multiline')
-def test_html_multi_line_copyright(app):
+def test_html_multi_line_copyright(no_source_date_year, app):
     app.build(force_all=True)
 
     content = (app.outdir / 'index.html').read_text(encoding='utf-8')

--- a/tests/test_builders/test_build_html_copyright.py
+++ b/tests/test_builders/test_build_html_copyright.py
@@ -11,9 +11,11 @@ LOCALTIME_2009 = type(LT)(LT_NEW)
 
 @pytest.fixture
 def no_source_date_year(monkeypatch):
-    """Explicitly clear SOURCE_DATE_EPOCH from the environment; this
+    """
+    Explicitly clear SOURCE_DATE_EPOCH from the environment; this
     fixture can be used to ensure that copyright substitution logic
-    does not occur during selected test cases."""
+    does not occur during selected test cases.
+    """
     with monkeypatch.context() as m:
         m.delenv('SOURCE_DATE_EPOCH', raising=False)
         yield

--- a/tests/test_builders/test_build_html_copyright.py
+++ b/tests/test_builders/test_build_html_copyright.py
@@ -11,6 +11,9 @@ LOCALTIME_2009 = type(LT)(LT_NEW)
 
 @pytest.fixture
 def no_source_date_year(monkeypatch):
+    """Explicitly clear SOURCE_DATE_EPOCH from the environment; this
+    fixture can be used to ensure that copyright substitution logic
+    does not occur during selected test cases."""
     with monkeypatch.context() as m:
         m.delenv('SOURCE_DATE_EPOCH', raising=False)
         yield


### PR DESCRIPTION
## Purpose
Sphinx's copyright substitution currently allows years identified as the current year to be downgraded to previous years when `SOURCE_DATE_EPOCH` is configured, to assist [reproducibility](https://www.reproducible-builds.org) of documentation builds.

However, we have a test case `test_html_multi_line_copyright`, written in Y2024, that mentioned a future year - Y2025.

Now that that year is current, it is eligible for substitution when `SOURCE_DATE_EPOCH` is configured.  Many buildsystems, such as those used by Debian and Fedora, choose the most-recent packaging/commit timestamp to use as `SOURCE_DATE_EPOCH`'s timestamp, since those corresponds sensibly to a time-of-build.

However, for the v8.1.3 Sphinx release including the updated substitution logic, the year-of-release/commit was Y2024.  Thus, if a commit/packaging date from that year is chosen, and `SOURCE_DATE_EPOCH` is configured when the unit tests run, the `test_html_multi_line_copyright` test will fail.

The fix suggested here is to explicitly unset `SOURCE_DATE_EPOCH` within `test_html_multi_line_copyright`.

## References
- Resolves #13223
- Bug introduced by #12516 
- Relates to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091951 (cc @mitya57)

Edit: add a reference to the pull request that introduced the bug