### PR TITLE
Allow suppressing a warning of non-matching glob pattern in TOC

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -96,6 +96,7 @@ Contributors
 * \A. Rafey Khan -- improved intersphinx typing
 * Roland Meister -- epub builder
 * Sebastian Wiesner -- image handling, distutils support
+* Slawek Figiel -- additional warning suppression
 * Stefan Seefeld -- toctree improvements
 * Stefan van der Walt -- autosummary extension
 * \T. Powers -- HTML output improvements
@@ -106,7 +107,6 @@ Contributors
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder
 * Zac Hatfield-Dodds -- doctest reporting improvements, intersphinx performance
-* Slawek Figiel -- additional warning suppression
 
 Former maintainers
 ==================

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,6 +106,7 @@ Contributors
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder
 * Zac Hatfield-Dodds -- doctest reporting improvements, intersphinx performance
+* Slawek Figiel -- additional warning suppression
 
 Former maintainers
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,8 +46,9 @@ Features added
   Patch by Adam Turner.
 * #13065: Enable colour by default in when running on CI.
   Patch by Adam Turner.
-* Add the subtype ``toc.empty_glob`` to allow suppressing the warning of
-  a non-matching glob pattern in TOC.
+* Allow supressing warnings from the :rst:dir`toctree` directive when a glob pattern
+  doesn't match any documents, via the new ``toc.glob_not_matching`` warning sub-type.
+  Patch by Slawek Figiel.
 
 Bugs fixed
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ Features added
   Patch by Adam Turner.
 * #13065: Enable colour by default in when running on CI.
   Patch by Adam Turner.
+* Add a subtype ``toc.glob_not_matching`` to a warning of a non-matching glob
+  pattern in TOC.
 
 Bugs fixed
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,8 +46,8 @@ Features added
   Patch by Adam Turner.
 * #13065: Enable colour by default in when running on CI.
   Patch by Adam Turner.
-* Add a subtype ``toc.glob_not_matching`` to a warning of a non-matching glob
-  pattern in TOC.
+* Add the subtype ``toc.empty_glob`` to allow suppressing the warning of
+  a non-matching glob pattern in TOC.
 
 Bugs fixed
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,8 +46,9 @@ Features added
   Patch by Adam Turner.
 * #13065: Enable colour by default in when running on CI.
   Patch by Adam Turner.
-* Allow supressing warnings from the :rst:dir`toctree` directive when a glob pattern
-  doesn't match any documents, via the new ``toc.glob_not_matching`` warning sub-type.
+* Allow supressing warnings from the :rst:dir:`toctree` directive when a glob
+  pattern doesn't match any documents, via the new ``toc.glob_not_matching``
+  warning sub-type.
   Patch by Slawek Figiel.
 
 Bugs fixed

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1448,10 +1448,8 @@ Options for warning control
       Added ``misc.copy_overwrite``.
 
    .. versionadded:: 8.2
-      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``.
-
-   .. versionadded:: 8.2
-      Added ``toc.glob_not_matching``.
+      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``, and 
+      ``toc.glob_not_matching``.
 
 Builder options
 ===============

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1448,7 +1448,7 @@ Options for warning control
       Added ``misc.copy_overwrite``.
 
    .. versionadded:: 8.2
-      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``, and 
+      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``, and
       ``toc.glob_not_matching``.
 
 Builder options

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1397,7 +1397,7 @@ Options for warning control
    * ``toc.no_title``
    * ``toc.not_readable``
    * ``toc.secnum``
-   * ``toc.glob_not_matching``
+   * ``toc.empty_glob``
 
    Extensions can also define their own warning types.
    Those defined by the first-party ``sphinx.ext`` extensions are:
@@ -1448,8 +1448,10 @@ Options for warning control
       Added ``misc.copy_overwrite``.
 
    .. versionadded:: 8.2
-      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``, and
-      ``toc.glob_not_matching``.
+      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``
+
+   .. versionadded:: 8.2
+      Added ``toc.empty_glob``.
 
 Builder options
 ===============

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1393,11 +1393,11 @@ Options for warning control
    * ``misc.copy_overwrite``
    * ``misc.highlighting_failure``
    * ``toc.circular``
+   * ``toc.empty_glob``
    * ``toc.excluded``
    * ``toc.no_title``
    * ``toc.not_readable``
    * ``toc.secnum``
-   * ``toc.empty_glob``
 
    Extensions can also define their own warning types.
    Those defined by the first-party ``sphinx.ext`` extensions are:
@@ -1448,7 +1448,7 @@ Options for warning control
       Added ``misc.copy_overwrite``.
 
    .. versionadded:: 8.2
-      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``
+      Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``.
 
    .. versionadded:: 8.2
       Added ``toc.empty_glob``.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1397,7 +1397,7 @@ Options for warning control
    * ``toc.no_title``
    * ``toc.not_readable``
    * ``toc.secnum``
-   * ``toc.glob_not_matching
+   * ``toc.glob_not_matching``
 
    Extensions can also define their own warning types.
    Those defined by the first-party ``sphinx.ext`` extensions are:

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1397,6 +1397,7 @@ Options for warning control
    * ``toc.no_title``
    * ``toc.not_readable``
    * ``toc.secnum``
+   * ``toc.glob_not_matching
 
    Extensions can also define their own warning types.
    Those defined by the first-party ``sphinx.ext`` extensions are:
@@ -1449,6 +1450,8 @@ Options for warning control
    .. versionadded:: 8.2
       Added ``duplicate_declaration.c`` and ``duplicate_declaration.cpp``.
 
+   .. versionadded:: 8.2
+      Added ``toc.glob_not_matching``.
 
 Builder options
 ===============

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -120,7 +120,7 @@ class TocTree(SphinxDirective):
                         __("toctree glob pattern %r didn't match any documents"),
                         entry,
                         location=toctree,
-                        subtype='glob_not_matching',
+                        subtype='empty_glob',
                     )
 
                 for docname in doc_names:

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -120,6 +120,7 @@ class TocTree(SphinxDirective):
                         __("toctree glob pattern %r didn't match any documents"),
                         entry,
                         location=toctree,
+                        subtype='glob_not_matching',
                     )
 
                 for docname in doc_names:


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Some documentation files are created dynamically in my project. They are included in TOC by the glob pattern. The number of included files varies and may be zero.

I have enabled the `--fail-on-warning` that I found very helpful in improving the quality of my documentation. However, it interrupts the documentation build when the glob pattern matches no entries in any TOC, which is not an error in my project.

Unfortunately, the related warning has no subtype specified, and it cannot be suppressed using the `suppress_warnings` list.

## References

No references. I haven't created an issue. 
