### PR TITLE
Unconditionally copy static assets in ``Builder``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Bugs fixed
   Patch by Ben Egan and Adam Turner.
 * #13188: autodoc: fix detection of class methods implemented in C.
   Patch by Bénédikt Tran.
+* #1810: Always copy static files when building, regardless of whether
+  any documents have changed since the previous build.
+  Patch by Adam Turner.
 
 Testing
 -------


### PR DESCRIPTION
## Purpose

Remove an early exit check for when ``docnames`` is empty. Previously, static assets (for example from HTML themes) would only be copied when at least one document had been modified when building in incremental mode.

I believe this resolves the problems @pradyunsg explained in https://github.com/sphinx-doc/sphinx/issues/1810#issuecomment-1676004196.

A

## References

- Closes #1810
- #2090
- https://github.com/sphinx-doc/sphinx-autobuild/issues/34

