### PR TITLE
Disambiguate ``:type:`` as a directive option or field-list item

### DIFF
--- a/doc/usage/domains/python.rst
+++ b/doc/usage/domains/python.rst
@@ -133,6 +133,14 @@ The following directives are provided for module and class contents:
    .. rst:directive:option:: type: type of the variable
       :type: text
 
+      This will be parsed as a Python expression for cross-referencing
+      the type annotation.
+      As such, the argument to ``:type:`` should be a valid Python expression.
+
+      .. caution:: The valid syntax for the ``:type:`` directive option
+                   differs from the syntax for the ``:type:`` `info field
+                   <info-field-lists_>`__.
+
       .. versionadded:: 2.4
 
    .. rst:directive:option:: value: initial value of the variable
@@ -267,6 +275,14 @@ The following directives are provided for module and class contents:
    .. rst:directive:option:: type: type of the attribute
       :type: text
 
+      This will be parsed as a Python expression for cross-referencing
+      the type annotation.
+      As such, the argument to ``:type:`` should be a valid Python expression.
+
+      .. caution:: The valid syntax for the ``:type:`` directive option
+                   differs from the syntax for the ``:type:`` `info field
+                   <info-field-lists_>`__.
+
       .. versionadded:: 2.4
 
    .. rst:directive:option:: value: initial value of the attribute
@@ -310,6 +326,14 @@ The following directives are provided for module and class contents:
 
    .. rst:directive:option:: type: type of the property
       :type: text
+
+      This will be parsed as a Python expression for cross-referencing
+      the type annotation.
+      As such, the argument to ``:type:`` should be a valid Python expression.
+
+      .. caution:: The valid syntax for the ``:type:`` directive option
+                   differs from the syntax for the ``:type:`` `info field
+                   <info-field-lists_>`__.
 
    .. rst::directive:option:: module
       :type: text
@@ -608,7 +632,7 @@ explained by an example::
       :param str recipient: The recipient of the message
       :param str message_body: The body of the message
       :param priority: The priority of the message, can be a number 1-5
-      :type priority: integer or None
+      :type priority: int or None
       :return: the message id
       :rtype: int
       :raises ValueError: if the message_body exceeds 160 characters
@@ -649,12 +673,16 @@ using the following syntax::
    :type point: tuple(float, float)
    :type point: tuple[float, float]
 
-Multiple types in a type field will be linked automatically if separated by the
-word "or"::
+Multiple types in a type field will be linked automatically
+if separated by either the vertical bar (``|``) or the word "or"::
 
    :type an_arg: int or None
    :vartype a_var: str or int
    :rtype: float or str
+
+   :type an_arg: int | None
+   :vartype a_var: str | int
+   :rtype: float | str
 
 .. _python-xref-roles:
 


### PR DESCRIPTION
## Purpose

It is currently very confusing. We should make it less so.

Notably, @erlend-aasland's change failed to create a cross-reference, with the following rST:

```diff
 .. attribute:: TarInfo.mtime
-   :type: int | float
+   :type: int or float
```

This is because `:type:` is interepreted as [the directive option](https://www.sphinx-doc.org/en/master/usage/domains/python.html#directive-option-py-attribute-type), which runs through `sphinx.domains.python._annotations._parse_annotation()` and employs an `ast` unparser. The correct change would have been:

```diff
 .. attribute:: TarInfo.mtime
-   :type: int | float
+
+   :type: int or float
```

The extra blank line seperates directive arguments and options from their content. In this context, `:type:` becomes a [field list entry](https://www.sphinx-doc.org/en/master/usage/domains/python.html#info-field-lists), which is then parsed with `sphinx.domains.python._object.PyXrefMixin._delimiters_re`, a regular expression that includes the ability to split on `'or'`.

---

Note that I'm not suggesting that any of this makes sense, but at least we can improve the documentation as a first step...

## References

- https://discuss.python.org/t/48196/25
- [python/cpython@`d464f3f` (#116389)](https://github.com/python/cpython/pull/116389/commits/d464f3fc049b4cefec2786536d78ced759c7989d)
- https://github.com/python/cpython/pull/116389

## Preview

https://sphinx--13242.org.readthedocs.build/en/13242/usage/domains/python.html#directive-option-py-attribute-type

https://sphinx--13242.org.readthedocs.build/en/13242/usage/domains/python.html#info-field-lists

cc @erlend-aasland @nedbat 

A
