### PR TITLE
Remove ``markupsafe._speedups`` patch in free-threaded tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,9 +135,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[test]
-    # markupsafe._speedups has not declared that it can run safely without the GIL
-    - name: Remove markupsafe._speedups
-      run: rm -rf "$(python -c 'from markupsafe._speedups import __file__ as f; print(f)')"
     - name: Test with pytest
       run: python -m pytest -vv --durations 25
       env:
@@ -171,9 +168,6 @@ jobs:
         python -m pip install --upgrade pip
         sed -i 's/flit_core>=3.7/flit_core @ git+https:\/\/github.com\/pypa\/flit.git#subdirectory=flit_core/' pyproject.toml
         python -m pip install .[test]
-    # markupsafe._speedups has not declared that it can run safely without the GIL
-    - name: Remove markupsafe._speedups
-      run: rm -rf "$(python -c 'from markupsafe._speedups import __file__ as f; print(f)')"
     - name: Test with pytest
       run: python -m pytest -vv --durations 25
       env:


### PR DESCRIPTION
## Purpose

Markupsafe 3 now supports operating without the GIL.

## References

- https://github.com/pallets/markupsafe/pull/461
