### PR TITLE
Move mypy test module exclusions to per-module ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,58 +146,7 @@ files = [
 ]
 exclude = [
     "tests/roots",
-    # tests/
-    "^tests/test_quickstart\\.py$",
-    "^tests/test_search\\.py$",
-    # tests/test_builders
-    "^tests/test_builders/test_build_epub\\.py$",
-    "^tests/test_builders/test_build_gettext\\.py$",
-    "^tests/test_builders/test_build_latex\\.py$",
-    "^tests/test_builders/test_build_texinfo\\.py$",
-    # tests/test_config
-    "^tests/test_config/test_config\\.py$",
-    # tests/test_directives
-    "^tests/test_directives/test_directive_only\\.py$",
-    "^tests/test_directives/test_directive_other\\.py$",
-    "^tests/test_directives/test_directive_patch\\.py$",
-    # tests/test_domains
-    "^tests/test_domains/test_domain_c\\.py$",
-    "^tests/test_domains/test_domain_cpp\\.py$",
-    "^tests/test_domains/test_domain_js\\.py$",
-    "^tests/test_domains/test_domain_py\\.py$",
-    "^tests/test_domains/test_domain_py_fields\\.py$",
-    "^tests/test_domains/test_domain_py_pyfunction\\.py$",
-    "^tests/test_domains/test_domain_py_pyobject\\.py$",
-    "^tests/test_domains/test_domain_rst\\.py$",
-    "^tests/test_domains/test_domain_std\\.py$",
-    # tests/test_environment
-    "^tests/test_environment/test_environment_toctree\\.py$",
-    # tests/test_extensions
-    "^tests/test_extensions/test_ext_apidoc\\.py$",
-    "^tests/test_extensions/test_ext_autodoc\\.py$",
-    "^tests/test_extensions/test_ext_autodoc_events\\.py$",
-    "^tests/test_extensions/test_ext_autodoc_mock\\.py$",
-    "^tests/test_extensions/test_ext_autosummary\\.py$",
-    "^tests/test_extensions/test_ext_doctest\\.py$",
-    "^tests/test_extensions/test_ext_inheritance_diagram\\.py$",
-    "^tests/test_extensions/test_ext_intersphinx\\.py$",
-    "^tests/test_extensions/test_ext_napoleon_docstring\\.py$",
-    # tests/test_intl
-    "^tests/test_intl/test_intl\\.py$",
-    # tests/test_pycode
-    "^tests/test_pycode/test_pycode\\.py$",
-    "^tests/test_pycode/test_pycode_ast\\.py$",
-    # tests/test_transforms
-    "^tests/test_transforms/test_transforms_post_transforms\\.py$",
     # tests/test_util
-    "^tests/test_util/test_util_fileutil\\.py$",
-    "^tests/test_util/test_util_i18n\\.py$",
-    "^tests/test_util/test_util_inspect\\.py$",
-    "^tests/test_util/test_util_logging\\.py$",
-    "^tests/test_util/test_util_nodes\\.py$",
-    "^tests/test_util/test_util_rst\\.py$",
-    "^tests/test_util/test_util_template\\.py$",
-    "^tests/test_util/test_util_typing\\.py$",
     "^tests/test_util/typing_test_data\\.py$",
 ]
 python_version = "3.11"
@@ -231,6 +180,7 @@ strict_optional = false
 module = [
     "imagesize",
     "pypi_attestations",
+    "pyximport",
     "sigstore.models",
     "sigstore.verify",
     "sigstore.verify.policy",
@@ -249,7 +199,9 @@ module = [
     "tests.test_events",
     "tests.test_highlighting",
     "tests.test_project",
+    "tests.test_quickstart",
     "tests.test_roles",
+    "tests.test_search",
     "tests.test_versioning",
     # tests/test__cli
     "tests.test__cli.test__cli_util_errors",
@@ -257,6 +209,8 @@ module = [
     "tests.test_builders.test_build",
     "tests.test_builders.test_build_changes",
     "tests.test_builders.test_build_dirhtml",
+    "tests.test_builders.test_build_epub",
+    "tests.test_builders.test_build_gettext",
     "tests.test_builders.test_build_html",
     "tests.test_builders.test_build_html_5_output",
     "tests.test_builders.test_build_html_assets",
@@ -269,25 +223,43 @@ module = [
     "tests.test_builders.test_build_html_numfig",
     "tests.test_builders.test_build_html_tocdepth",
     "tests.test_builders.test_build_html_toctree",
+    "tests.test_builders.test_build_latex",
     "tests.test_builders.test_build_linkcheck",
     "tests.test_builders.test_build_manpage",
+    "tests.test_builders.test_build_texinfo",
     "tests.test_builders.test_build_text",
     "tests.test_builders.test_build_warnings",
     "tests.test_builders.test_incremental_reading",
     # tests/test_config
+    "tests.test_config.test_config",
     "tests.test_config.test_copyright",
     # tests/test_directives
     "tests.test_directives.test_directive_code",
     "tests.test_directives.test_directive_object_description",
+    "tests.test_directives.test_directive_only",
     "tests.test_directives.test_directive_option",
+    "tests.test_directives.test_directive_other",
+    "tests.test_directives.test_directive_patch",
     "tests.test_directives.test_directives_no_typesetting",
     # tests/test_domains
+    "tests.test_domains.test_domain_c",
+    "tests.test_domains.test_domain_cpp",
+    "tests.test_domains.test_domain_js",
+    "tests.test_domains.test_domain_py",
     "tests.test_domains.test_domain_py_canonical",
+    "tests.test_domains.test_domain_py_fields",
+    "tests.test_domains.test_domain_py_pyfunction",
+    "tests.test_domains.test_domain_py_pyobject",
+    "tests.test_domains.test_domain_rst",
+    "tests.test_domains.test_domain_std",
     # tests/test_environment
     "tests.test_environment.test_environment",
     "tests.test_environment.test_environment_indexentries",
     "tests.test_environment.test_environment_record_dependencies",
+    "tests.test_environment.test_environment_toctree",
     # tests/test_extensions
+    "tests.test_extensions.test_ext_apidoc",
+    "tests.test_extensions.test_ext_autodoc",
     "tests.test_extensions.test_ext_autodoc_autoattribute",
     "tests.test_extensions.test_ext_autodoc_autoclass",
     "tests.test_extensions.test_ext_autodoc_autodata",
@@ -295,11 +267,15 @@ module = [
     "tests.test_extensions.test_ext_autodoc_automodule",
     "tests.test_extensions.test_ext_autodoc_autoproperty",
     "tests.test_extensions.test_ext_autodoc_configs",
+    "tests.test_extensions.test_ext_autodoc_events",
+    "tests.test_extensions.test_ext_autodoc_mock",
     "tests.test_extensions.test_ext_autodoc_preserve_defaults",
     "tests.test_extensions.test_ext_autodoc_private_members",
     "tests.test_extensions.test_ext_autosectionlabel",
+    "tests.test_extensions.test_ext_autosummary",
     "tests.test_extensions.test_ext_autosummary_imports",
     "tests.test_extensions.test_ext_coverage",
+    "tests.test_extensions.test_ext_doctest",
     "tests.test_extensions.test_ext_duration",
     "tests.test_extensions.test_ext_extlinks",
     "tests.test_extensions.test_ext_githubpages",
@@ -307,14 +283,18 @@ module = [
     "tests.test_extensions.test_ext_ifconfig",
     "tests.test_extensions.test_ext_imgconverter",
     "tests.test_extensions.test_ext_imgmockconverter",
+    "tests.test_extensions.test_ext_inheritance_diagram",
+    "tests.test_extensions.test_ext_intersphinx",
     "tests.test_extensions.test_ext_intersphinx_cache",
     "tests.test_extensions.test_ext_math",
     "tests.test_extensions.test_ext_napoleon",
+    "tests.test_extensions.test_ext_napoleon_docstring",
     "tests.test_extensions.test_ext_todo",
     "tests.test_extensions.test_ext_viewcode",
     "tests.test_extensions.test_extension",
     # tests/test_intl
     "tests.test_intl.test_catalogs",
+    "tests.test_intl.test_intl",
     "tests.test_intl.test_locale",
     # tests/test_markup
     "tests.test_markup.test_markup",
@@ -322,6 +302,8 @@ module = [
     "tests.test_markup.test_parser",
     "tests.test_markup.test_smartquotes",
     # tests/test_pycode
+    "tests.test_pycode.test_pycode",
+    "tests.test_pycode.test_pycode_ast",
     "tests.test_pycode.test_pycode_parser",
     # tests/test_theming
     "tests.test_theming.test_html_theme",
@@ -329,6 +311,7 @@ module = [
     "tests.test_theming.test_theming",
     # tests/test_transforms
     "tests.test_transforms.test_transforms_move_module_targets",
+    "tests.test_transforms.test_transforms_post_transforms",
     "tests.test_transforms.test_transforms_post_transforms_code",
     "tests.test_transforms.test_transforms_post_transforms_images",
     "tests.test_transforms.test_transforms_reorder_nodes",
@@ -338,18 +321,33 @@ module = [
     "tests.test_util.test_util_docstrings",
     "tests.test_util.test_util_docutils",
     "tests.test_util.test_util_docutils_sphinx_directive",
+    "tests.test_util.test_util_fileutil",
+    "tests.test_util.test_util_i18n",
     "tests.test_util.test_util_images",
     "tests.test_util.test_util_importer",
+    "tests.test_util.test_util_inspect",
     "tests.test_util.test_util_inventory",
     "tests.test_util.test_util_lines",
+    "tests.test_util.test_util_logging",
     "tests.test_util.test_util_matching",
+    "tests.test_util.test_util_nodes",
+    "tests.test_util.test_util_rst",
+    "tests.test_util.test_util_template",
+    "tests.test_util.test_util_typing",
     "tests.test_util.test_util_uri",
     # tests/test_writers
     "tests.test_writers.test_api_translator",
     "tests.test_writers.test_docutilsconf",
     "tests.test_writers.test_writer_latex",
 ]
+check_untyped_defs = false
+disable_error_code = [
+    "annotation-unchecked",
+]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
 disallow_untyped_defs = false
+warn_unused_ignores = false
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,9 +197,7 @@ module = [
     "tests.test_events",
     "tests.test_highlighting",
     "tests.test_project",
-    "tests.test_quickstart",
     "tests.test_roles",
-    "tests.test_search",
     "tests.test_versioning",
     # tests/test__cli
     "tests.test__cli.test__cli_util_errors",
@@ -207,8 +205,6 @@ module = [
     "tests.test_builders.test_build",
     "tests.test_builders.test_build_changes",
     "tests.test_builders.test_build_dirhtml",
-    "tests.test_builders.test_build_epub",
-    "tests.test_builders.test_build_gettext",
     "tests.test_builders.test_build_html",
     "tests.test_builders.test_build_html_5_output",
     "tests.test_builders.test_build_html_assets",
@@ -221,43 +217,25 @@ module = [
     "tests.test_builders.test_build_html_numfig",
     "tests.test_builders.test_build_html_tocdepth",
     "tests.test_builders.test_build_html_toctree",
-    "tests.test_builders.test_build_latex",
     "tests.test_builders.test_build_linkcheck",
     "tests.test_builders.test_build_manpage",
-    "tests.test_builders.test_build_texinfo",
     "tests.test_builders.test_build_text",
     "tests.test_builders.test_build_warnings",
     "tests.test_builders.test_incremental_reading",
     # tests/test_config
-    "tests.test_config.test_config",
     "tests.test_config.test_copyright",
     # tests/test_directives
     "tests.test_directives.test_directive_code",
     "tests.test_directives.test_directive_object_description",
-    "tests.test_directives.test_directive_only",
     "tests.test_directives.test_directive_option",
-    "tests.test_directives.test_directive_other",
-    "tests.test_directives.test_directive_patch",
     "tests.test_directives.test_directives_no_typesetting",
     # tests/test_domains
-    "tests.test_domains.test_domain_c",
-    "tests.test_domains.test_domain_cpp",
-    "tests.test_domains.test_domain_js",
-    "tests.test_domains.test_domain_py",
     "tests.test_domains.test_domain_py_canonical",
-    "tests.test_domains.test_domain_py_fields",
-    "tests.test_domains.test_domain_py_pyfunction",
-    "tests.test_domains.test_domain_py_pyobject",
-    "tests.test_domains.test_domain_rst",
-    "tests.test_domains.test_domain_std",
     # tests/test_environment
     "tests.test_environment.test_environment",
     "tests.test_environment.test_environment_indexentries",
     "tests.test_environment.test_environment_record_dependencies",
-    "tests.test_environment.test_environment_toctree",
     # tests/test_extensions
-    "tests.test_extensions.test_ext_apidoc",
-    "tests.test_extensions.test_ext_autodoc",
     "tests.test_extensions.test_ext_autodoc_autoattribute",
     "tests.test_extensions.test_ext_autodoc_autoclass",
     "tests.test_extensions.test_ext_autodoc_autodata",
@@ -265,15 +243,11 @@ module = [
     "tests.test_extensions.test_ext_autodoc_automodule",
     "tests.test_extensions.test_ext_autodoc_autoproperty",
     "tests.test_extensions.test_ext_autodoc_configs",
-    "tests.test_extensions.test_ext_autodoc_events",
-    "tests.test_extensions.test_ext_autodoc_mock",
     "tests.test_extensions.test_ext_autodoc_preserve_defaults",
     "tests.test_extensions.test_ext_autodoc_private_members",
     "tests.test_extensions.test_ext_autosectionlabel",
-    "tests.test_extensions.test_ext_autosummary",
     "tests.test_extensions.test_ext_autosummary_imports",
     "tests.test_extensions.test_ext_coverage",
-    "tests.test_extensions.test_ext_doctest",
     "tests.test_extensions.test_ext_duration",
     "tests.test_extensions.test_ext_extlinks",
     "tests.test_extensions.test_ext_githubpages",
@@ -281,18 +255,14 @@ module = [
     "tests.test_extensions.test_ext_ifconfig",
     "tests.test_extensions.test_ext_imgconverter",
     "tests.test_extensions.test_ext_imgmockconverter",
-    "tests.test_extensions.test_ext_inheritance_diagram",
-    "tests.test_extensions.test_ext_intersphinx",
     "tests.test_extensions.test_ext_intersphinx_cache",
     "tests.test_extensions.test_ext_math",
     "tests.test_extensions.test_ext_napoleon",
-    "tests.test_extensions.test_ext_napoleon_docstring",
     "tests.test_extensions.test_ext_todo",
     "tests.test_extensions.test_ext_viewcode",
     "tests.test_extensions.test_extension",
     # tests/test_intl
     "tests.test_intl.test_catalogs",
-    "tests.test_intl.test_intl",
     "tests.test_intl.test_locale",
     # tests/test_markup
     "tests.test_markup.test_markup",
@@ -300,8 +270,6 @@ module = [
     "tests.test_markup.test_parser",
     "tests.test_markup.test_smartquotes",
     # tests/test_pycode
-    "tests.test_pycode.test_pycode",
-    "tests.test_pycode.test_pycode_ast",
     "tests.test_pycode.test_pycode_parser",
     # tests/test_theming
     "tests.test_theming.test_html_theme",
@@ -309,7 +277,6 @@ module = [
     "tests.test_theming.test_theming",
     # tests/test_transforms
     "tests.test_transforms.test_transforms_move_module_targets",
-    "tests.test_transforms.test_transforms_post_transforms",
     "tests.test_transforms.test_transforms_post_transforms_code",
     "tests.test_transforms.test_transforms_post_transforms_images",
     "tests.test_transforms.test_transforms_reorder_nodes",
@@ -319,24 +286,73 @@ module = [
     "tests.test_util.test_util_docstrings",
     "tests.test_util.test_util_docutils",
     "tests.test_util.test_util_docutils_sphinx_directive",
-    "tests.test_util.test_util_fileutil",
-    "tests.test_util.test_util_i18n",
     "tests.test_util.test_util_images",
     "tests.test_util.test_util_importer",
-    "tests.test_util.test_util_inspect",
     "tests.test_util.test_util_inventory",
     "tests.test_util.test_util_lines",
-    "tests.test_util.test_util_logging",
     "tests.test_util.test_util_matching",
-    "tests.test_util.test_util_nodes",
-    "tests.test_util.test_util_rst",
-    "tests.test_util.test_util_template",
-    "tests.test_util.test_util_typing",
     "tests.test_util.test_util_uri",
     # tests/test_writers
     "tests.test_writers.test_api_translator",
     "tests.test_writers.test_docutilsconf",
     "tests.test_writers.test_writer_latex",
+]
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    # tests/
+    "tests.test_quickstart",
+    "tests.test_search",
+    # tests/test_builders
+    "tests.test_builders.test_build_epub",
+    "tests.test_builders.test_build_gettext",
+    "tests.test_builders.test_build_latex",
+    "tests.test_builders.test_build_texinfo",
+    # tests/test_config
+    "tests.test_config.test_config",
+    # tests/test_directives
+    "tests.test_directives.test_directive_only",
+    "tests.test_directives.test_directive_other",
+    "tests.test_directives.test_directive_patch",
+    # tests/test_domains
+    "tests.test_domains.test_domain_c",
+    "tests.test_domains.test_domain_cpp",
+    "tests.test_domains.test_domain_js",
+    "tests.test_domains.test_domain_py",
+    "tests.test_domains.test_domain_py_fields",
+    "tests.test_domains.test_domain_py_pyfunction",
+    "tests.test_domains.test_domain_py_pyobject",
+    "tests.test_domains.test_domain_rst",
+    "tests.test_domains.test_domain_std",
+    # tests/test_environment
+    "tests.test_environment.test_environment_toctree",
+    # tests/test_extensions
+    "tests.test_extensions.test_ext_apidoc",
+    "tests.test_extensions.test_ext_autodoc",
+    "tests.test_extensions.test_ext_autodoc_events",
+    "tests.test_extensions.test_ext_autodoc_mock",
+    "tests.test_extensions.test_ext_autosummary",
+    "tests.test_extensions.test_ext_doctest",
+    "tests.test_extensions.test_ext_inheritance_diagram",
+    "tests.test_extensions.test_ext_intersphinx",
+    "tests.test_extensions.test_ext_napoleon_docstring",
+    # tests/test_intl
+    "tests.test_intl.test_intl",
+    # tests/test_pycode
+    "tests.test_pycode.test_pycode",
+    "tests.test_pycode.test_pycode_ast",
+    # tests/test_transforms
+    "tests.test_transforms.test_transforms_post_transforms",
+    # tests/test_util
+    "tests.test_util.test_util_fileutil",
+    "tests.test_util.test_util_i18n",
+    "tests.test_util.test_util_inspect",
+    "tests.test_util.test_util_logging",
+    "tests.test_util.test_util_nodes",
+    "tests.test_util.test_util_rst",
+    "tests.test_util.test_util_template",
+    "tests.test_util.test_util_typing",
 ]
 check_untyped_defs = false
 disable_error_code = [
@@ -345,7 +361,6 @@ disable_error_code = [
 disallow_incomplete_defs = false
 disallow_untyped_calls = false
 disallow_untyped_defs = false
-warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
 module = ["tests.test_util.typing_test_data"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,8 +146,6 @@ files = [
 ]
 exclude = [
     "tests/roots",
-    # tests/test_util
-    "^tests/test_util/typing_test_data\\.py$",
 ]
 python_version = "3.11"
 strict = true
@@ -348,6 +346,11 @@ disallow_incomplete_defs = false
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+
+module = ["tests.test_util.typing_test_data"]
+ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,7 +348,6 @@ disallow_untyped_defs = false
 warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
-
 module = ["tests.test_util.typing_test_data"]
 ignore_errors = true
 

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -216,7 +216,7 @@ def test_config_pickle_circular_reference_in_list():
         assert v.__class__ is u.__class__
         for u_i, v_i in zip(u, v, strict=True):
             counter[type(u)] += 1
-            check(u_i, v_i, counter=counter, guard=guard | {id(u), id(v)})
+            check(u_i, v_i, counter=counter, guard=guard | {id(u), id(v)})  # type: ignore[arg-type]
 
         return counter
 
@@ -280,7 +280,7 @@ def test_config_pickle_circular_reference_in_dict():
         assert v.__class__ is u.__class__
         for u_i, v_i in zip(u, v, strict=True):
             counter[type(u)] += 1
-            check(u[u_i], v[v_i], counter=counter, guard=guard | {id(u), id(v)})
+            check(u[u_i], v[v_i], counter=counter, guard=guard | {id(u), id(v)})  # type: ignore[arg-type]
         return counter
 
     counters = check(actual.x, x, counter=Counter())

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -320,7 +320,7 @@ def test_autodoc_process_signature_typehints(app):
 
     app.connect('autodoc-process-signature', process_signature)
 
-    def func(x: int, y: int) -> int:
+    def func(x: int, y: int) -> int:  # type: ignore[empty-body]
         pass
 
     directive = make_directive_bridge(app.env)

--- a/tests/test_extensions/test_ext_autodoc_events.py
+++ b/tests/test_extensions/test_ext_autodoc_events.py
@@ -71,7 +71,7 @@ def test_cut_lines_no_objtype():
     ]
     process = cut_lines(2)
 
-    process(None, 'function', 'func', None, {}, docstring_lines)  # type: ignore[arg-type]
+    process(None, 'function', 'func', None, {}, docstring_lines)
     assert docstring_lines == [
         'second line',
         '---',

--- a/tests/test_extensions/test_ext_autosummary.py
+++ b/tests/test_extensions/test_ext_autosummary.py
@@ -240,7 +240,7 @@ def test_escaping(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autosummary')
 def test_autosummary_generate_content_for_module(app):
-    import autosummary_dummy_module
+    import autosummary_dummy_module  # type: ignore[import-not-found]
 
     template = Mock()
 
@@ -457,7 +457,7 @@ def test_autosummary_generate_content_for_module_imported_members(app):
 
 @pytest.mark.sphinx('html', testroot='ext-autosummary')
 def test_autosummary_generate_content_for_module_imported_members_inherited_module(app):
-    import autosummary_dummy_inherited_module
+    import autosummary_dummy_inherited_module  # type: ignore[import-not-found]
 
     template = Mock()
 

--- a/tests/test_extensions/test_ext_doctest.py
+++ b/tests/test_extensions/test_ext_doctest.py
@@ -75,7 +75,7 @@ def cleanup_call():
     cleanup_called += 1
 
 
-recorded_calls = Counter()
+recorded_calls: Counter[tuple[str, str, int]] = Counter()
 
 
 @pytest.mark.sphinx('doctest', testroot='ext-doctest-skipif')

--- a/tests/test_extensions/test_ext_inheritance_diagram.py
+++ b/tests/test_extensions/test_ext_inheritance_diagram.py
@@ -327,7 +327,7 @@ def test_import_classes(rootdir):
     saved_path = sys.path.copy()
     sys.path.insert(0, str(rootdir / 'test-ext-inheritance_diagram'))
     try:
-        from example.sphinx import DummyClass
+        from example.sphinx import DummyClass  # type: ignore[import-not-found]
 
         # got exception for unknown class or module
         with pytest.raises(InheritanceException):

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -38,7 +38,7 @@ from tests.test_util.intersphinx_data import (
 from tests.utils import http_server
 
 
-class FakeList(list):  # NoQA: FURB189
+class FakeList(list[str]):
     def __iter__(self) -> NoReturn:
         raise NotImplementedError
 

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -23,6 +23,7 @@ from sphinx.testing.util import assert_node, etree_parse
 from sphinx.util.nodes import NodeMatcher
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from io import StringIO
     from pathlib import Path
 
@@ -825,7 +826,7 @@ class _MockUnixClock(_MockClock):
 
 
 @pytest.fixture
-def mock_time_and_i18n() -> tuple[pytest.MonkeyPatch, _MockClock]:
+def mock_time_and_i18n() -> Iterator[tuple[pytest.MonkeyPatch, _MockClock]]:
     from sphinx.util.i18n import CatalogInfo
 
     # save the 'original' definition
@@ -838,6 +839,7 @@ def mock_time_and_i18n() -> tuple[pytest.MonkeyPatch, _MockClock]:
 
     # see: https://github.com/pytest-dev/pytest/issues/363
     with pytest.MonkeyPatch.context() as mock:
+        clock: _MockClock
         if os.name == 'posix':
             clock = _MockUnixClock()
         else:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,7 +16,7 @@ from sphinx.search import IndexBuilder
 from tests.utils import TESTS_ROOT
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from pathlib import Path
     from typing import Any
 
@@ -53,12 +53,14 @@ class DummyEnvironment:
 
 
 class DummyDomain:
-    def __init__(self, name: str, data: dict) -> None:
+    def __init__(
+        self, name: str, data: Iterable[tuple[str, str, str, str, str, int]]
+    ) -> None:
         self.name = name
         self.data = data
         self.object_types: dict[str, ObjType] = {}
 
-    def get_objects(self) -> list[tuple[str, str, str, str, str, int]]:
+    def get_objects(self) -> Iterable[tuple[str, str, str, str, str, int]]:
         return self.data
 
 

--- a/tests/test_transforms/test_transforms_post_transforms.py
+++ b/tests/test_transforms/test_transforms_post_transforms.py
@@ -173,7 +173,7 @@ class TestSigElementFallbackTransform:
         visitor_methods = {f'visit_{tp.__name__}' for tp in desc_sig_elements_list}
         visitor_methods.update(f'visit_{name}' for name in add_visitor_method_for)
         class_dict = dict.fromkeys(visitor_methods, BaseCustomTranslatorClass.mark_node)
-        return type('CustomTranslatorClass', (BaseCustomTranslatorClass,), class_dict)  # type: ignore[return-value]
+        return type('CustomTranslatorClass', (BaseCustomTranslatorClass,), class_dict)
 
     @pytest.mark.parametrize(
         'add_visitor_method_for',
@@ -266,7 +266,7 @@ class TestSigElementFallbackTransform:
                 strict=True,
             ):
                 assert_node(node, node_type)
-                assert not node.hasattr('_sig_node_type')
+                assert not hasattr(node, '_sig_node_type')
                 assert mess == f'mark: {node_type.__name__!r}'
         else:
             # desc_sig_* nodes are converted into inline nodes

--- a/tests/test_util/test_util_inspect.py
+++ b/tests/test_util/test_util_inspect.py
@@ -890,7 +890,7 @@ def test_isattributedescriptor():
     try:
         # _testcapi module cannot be importable in some distro
         # refs: https://github.com/sphinx-doc/sphinx/issues/9868
-        import _testcapi
+        import _testcapi  # type: ignore[import-not-found]
 
         # instancemethod (C-API)
         testinstancemethod = _testcapi.instancemethod(str.__repr__)

--- a/tests/test_util/test_util_typing.py
+++ b/tests/test_util/test_util_typing.py
@@ -75,7 +75,7 @@ from typing import (
 )
 from weakref import WeakSet
 
-from sphinx.ext.autodoc import mock
+from sphinx.ext.autodoc.mock import mock
 from sphinx.util.typing import _INVALID_BUILTIN_CLASSES, restify, stringify_annotation
 
 
@@ -472,7 +472,7 @@ def test_restify_type_ForwardRef():
         restify(list[ForwardRef('MyInt')]) == ':py:class:`list`\\ [:py:class:`MyInt`]'
     )
 
-    ann_rst = restify(Tuple[dict[ForwardRef('MyInt'), str], list[List[int]]])  # type: ignore[attr-defined]
+    ann_rst = restify(Tuple[dict[ForwardRef('MyInt'), str], list[List[int]]])
     assert ann_rst == (
         ':py:class:`~typing.Tuple`\\ [:py:class:`dict`\\ [:py:class:`MyInt`, :py:class:`str`], :py:class:`list`\\ [:py:class:`~typing.List`\\ [:py:class:`int`]]]'
     )
@@ -493,14 +493,14 @@ def test_restify_type_Literal():
 
 
 def test_restify_pep_585():
-    assert restify(list[str]) == ':py:class:`list`\\ [:py:class:`str`]'  # type: ignore[attr-defined]
-    ann_rst = restify(dict[str, str])  # type: ignore[attr-defined]
+    assert restify(list[str]) == ':py:class:`list`\\ [:py:class:`str`]'
+    ann_rst = restify(dict[str, str])
     assert ann_rst == ':py:class:`dict`\\ [:py:class:`str`, :py:class:`str`]'
     assert restify(tuple[str, ...]) == ':py:class:`tuple`\\ [:py:class:`str`, ...]'
     assert restify(tuple[str, str, str]) == (
         ':py:class:`tuple`\\ [:py:class:`str`, :py:class:`str`, :py:class:`str`]'
     )
-    ann_rst = restify(dict[str, tuple[int, ...]])  # type: ignore[attr-defined]
+    ann_rst = restify(dict[str, tuple[int, ...]])
     assert ann_rst == (
         ':py:class:`dict`\\ '
         '[:py:class:`str`, :py:class:`tuple`\\ '
@@ -548,10 +548,10 @@ def test_restify_Unpack():
 
 
 def test_restify_type_union_operator():
-    assert restify(int | None) == ':py:class:`int` | :py:obj:`None`'  # type: ignore[attr-defined]
-    assert restify(None | int) == ':py:obj:`None` | :py:class:`int`'  # type: ignore[attr-defined]
-    assert restify(int | str) == ':py:class:`int` | :py:class:`str`'  # type: ignore[attr-defined]
-    ann_rst = restify(int | str | None)  # type: ignore[attr-defined]
+    assert restify(int | None) == ':py:class:`int` | :py:obj:`None`'
+    assert restify(None | int) == ':py:obj:`None` | :py:class:`int`'
+    assert restify(int | str) == ':py:class:`int` | :py:class:`str`'
+    ann_rst = restify(int | str | None)
     assert ann_rst == ':py:class:`int` | :py:class:`str` | :py:obj:`None`'
 
 
@@ -564,7 +564,7 @@ def test_restify_broken_type_hints():
 
 def test_restify_mock():
     with mock(['unknown']):
-        import unknown
+        import unknown  # type: ignore[import-not-found]
 
         assert restify(unknown) == ':py:class:`unknown`'
         assert restify(unknown.secret.Class) == ':py:class:`unknown.secret.Class`'
@@ -982,8 +982,8 @@ def test_stringify_type_hints_alias():
     assert stringify_annotation(MyStr, 'fully-qualified-except-typing') == 'str'
     assert stringify_annotation(MyStr, 'smart') == 'str'
 
-    assert stringify_annotation(MyTuple) == 'Tuple[str, str]'  # type: ignore[attr-defined]
-    assert stringify_annotation(MyTuple, 'smart') == '~typing.Tuple[str, str]'  # type: ignore[attr-defined]
+    assert stringify_annotation(MyTuple) == 'Tuple[str, str]'
+    assert stringify_annotation(MyTuple, 'smart') == '~typing.Tuple[str, str]'
 
 
 def test_stringify_type_Literal():
@@ -1005,26 +1005,26 @@ def test_stringify_type_Literal():
 
 
 def test_stringify_type_union_operator():
-    assert stringify_annotation(int | None) == 'int | None'  # type: ignore[attr-defined]
-    assert stringify_annotation(int | None, 'smart') == 'int | None'  # type: ignore[attr-defined]
+    assert stringify_annotation(int | None) == 'int | None'
+    assert stringify_annotation(int | None, 'smart') == 'int | None'
 
-    assert stringify_annotation(int | str) == 'int | str'  # type: ignore[attr-defined]
-    assert stringify_annotation(int | str, 'smart') == 'int | str'  # type: ignore[attr-defined]
+    assert stringify_annotation(int | str) == 'int | str'
+    assert stringify_annotation(int | str, 'smart') == 'int | str'
 
-    assert stringify_annotation(int | str | None) == 'int | str | None'  # type: ignore[attr-defined]
-    assert stringify_annotation(int | str | None, 'smart') == 'int | str | None'  # type: ignore[attr-defined]
+    assert stringify_annotation(int | str | None) == 'int | str | None'
+    assert stringify_annotation(int | str | None, 'smart') == 'int | str | None'
 
     ann_str = stringify_annotation(
         int | tuple[dict[str, int | None], list[int | str]] | None
     )
-    assert ann_str == 'int | tuple[dict[str, int | None], list[int | str]] | None'  # type: ignore[attr-defined]
+    assert ann_str == 'int | tuple[dict[str, int | None], list[int | str]] | None'
     ann_str = stringify_annotation(
         int | tuple[dict[str, int | None], list[int | str]] | None, 'smart'
     )
-    assert ann_str == 'int | tuple[dict[str, int | None], list[int | str]] | None'  # type: ignore[attr-defined]
+    assert ann_str == 'int | tuple[dict[str, int | None], list[int | str]] | None'
 
-    assert stringify_annotation(int | Struct) == 'int | struct.Struct'  # type: ignore[attr-defined]
-    assert stringify_annotation(int | Struct, 'smart') == 'int | ~struct.Struct'  # type: ignore[attr-defined]
+    assert stringify_annotation(int | Struct) == 'int | struct.Struct'
+    assert stringify_annotation(int | Struct, 'smart') == 'int | ~struct.Struct'
 
 
 def test_stringify_broken_type_hints():
@@ -1058,16 +1058,16 @@ def test_stringify_type_ForwardRef():
     ann_str = stringify_annotation(
         Tuple[dict[ForwardRef('MyInt'), str], list[List[int]]]
     )
-    assert ann_str == 'Tuple[dict[MyInt, str], list[List[int]]]'  # type: ignore[attr-defined]
+    assert ann_str == 'Tuple[dict[MyInt, str], list[List[int]]]'
     ann_str = stringify_annotation(
         Tuple[dict[ForwardRef('MyInt'), str], list[List[int]]],
         'fully-qualified-except-typing',
     )
-    assert ann_str == 'Tuple[dict[MyInt, str], list[List[int]]]'  # type: ignore[attr-defined]
+    assert ann_str == 'Tuple[dict[MyInt, str], list[List[int]]]'
     ann_str = stringify_annotation(
         Tuple[dict[ForwardRef('MyInt'), str], list[List[int]]], 'smart'
     )
-    assert ann_str == '~typing.Tuple[dict[MyInt, str], list[~typing.List[int]]]'  # type: ignore[attr-defined]
+    assert ann_str == '~typing.Tuple[dict[MyInt, str], list[~typing.List[int]]]'
 
 
 def test_stringify_type_hints_paramspec():


### PR DESCRIPTION
## Purpose

I think this is the right thing to do -- we switch from blanket exclusions of the test modules to finer-grained per-module ignores. This won't catch mutch at the moment as most functions are still untyped, but it has found e.g. ``node.getattr(...)`` -> ``getattr(node, ...)``. I'd welcome feedback though, as mypy config for the tests has changed a few times. I also don't know if we should attemt a similar thing for Pyright yet.

cc @danieleades who originally introduced suggested type-checking for `tests/` in #12097.

A

## References

- #12097
- #12109
- #12199
