### PR TITLE
Add the ``autodoc_use_type_comments`` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,11 @@ Features added
   and rename the :rst:dir:`autosummary` directive's ``nosignatures``option
   to :rst:dir:`no-signatures``.
   Patch by Adam Turner.
+* #13269: Added the option to disable the use of type comments in
+  via the new :confval:`autodoc_use_type_comments` option,
+  which defaults to :code-py:`True` for backwards compatibility.
+  A future version of Sphinx will change the default to :code-py:`False`.
+  Patch by Adam Turner.
 
 Bugs fixed
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,8 +67,8 @@ Features added
   Patch by Adam Turner.
 * #13269: Added the option to disable the use of type comments in
   via the new :confval:`autodoc_use_type_comments` option,
-  which defaults to :code-py:`True` for backwards compatibility.
-  The default will change to :code-py:`False` in Sphinx 10.
+  which defaults to ``True`` for backwards compatibility.
+  The default will change to ``False`` in Sphinx 10.
   Patch by Adam Turner.
 
 Bugs fixed

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,7 @@ Features added
 * #13269: Added the option to disable the use of type comments in
   via the new :confval:`autodoc_use_type_comments` option,
   which defaults to :code-py:`True` for backwards compatibility.
-  A future version of Sphinx will change the default to :code-py:`False`.
+  The default will change to :code-py:`False` in Sphinx 10.
   Patch by Adam Turner.
 
 Bugs fixed

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -1246,7 +1246,7 @@ There are also config values that you can set:
       Added the option to disable the use of type comments in
       via the new :confval:`!autodoc_use_type_comments` option,
       which defaults to :code-py:`True` for backwards compatibility.
-      A future version of Sphinx will change the default to :code-py:`False`.
+      The default will change to :code-py:`False` in Sphinx 10.
 
       .. xref RemovedInSphinx10Warning
 

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -1230,6 +1230,26 @@ There are also config values that you can set:
       Added as an experimental feature.  This will be integrated into autodoc core
       in the future.
 
+.. confval:: autodoc_use_type_comments
+   :type: :code-py:`bool`
+   :default: :code-py:`True`
+
+   Attempt to read ``# type: ...`` comments from source code
+   to supplement missing type annotations, if True.
+
+   This can be disabled if your source code does not use type comments,
+   for example if it exclusively uses type annotations or
+   does not use type hints of any kind.
+
+   .. versionadded:: 8.2
+
+      Added the option to disable the use of type comments in
+      via the new :confval:`!autodoc_use_type_comments` option,
+      which defaults to :code-py:`True` for backwards compatibility.
+      A future version of Sphinx will change the default to :code-py:`False`.
+
+      .. xref RemovedInSphinx10Warning
+
 .. confval:: autodoc_warningiserror
    :type: :code-py:`bool`
    :default: :code-py:`True`

--- a/sphinx/ext/autodoc/type_comment.py
+++ b/sphinx/ext/autodoc/type_comment.py
@@ -131,6 +131,9 @@ def update_annotations_using_type_comments(
     app: Sphinx, obj: Any, bound_method: bool
 ) -> None:
     """Update annotations info of *obj* using type_comments."""
+    if not app.config.autodoc_use_type_comments:
+        return
+
     try:
         type_sig = get_type_comment(obj, bound_method)
         if type_sig:
@@ -152,6 +155,9 @@ def update_annotations_using_type_comments(
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:
+    app.add_config_value(
+        'autodoc_use_type_comments', True, 'env', types=frozenset({bool})
+    )
     app.connect(
         'autodoc-before-process-signature', update_annotations_using_type_comments
     )


### PR DESCRIPTION
## Purpose

Type comments were a [bridging tool](https://peps.python.org/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code) between Python 2.7 and 3.0. Disabling parsing type comments means less work is done and hence autodoc should be faster.

A

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- <...>
- <...>
- <...>
