### PR TITLE
autodoc: Allow TypeVars to be reimported from other modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,7 @@ Bugs fixed
 * #12975: Avoid rendering a trailing comma in C and C++ multi-line signatures.
 * #13178: autodoc: Fix resolution for ``pathlib`` types.
   Patch by Adam Turner.
+* #13276: autodoc: Allow TypeVars to be reimported from other modules
 
 Testing
 -------

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -763,6 +763,18 @@ class Documenter:
         for obj in members:
             membername = obj.__name__
             member = obj.object
+            # If the member doesn't have docs in the current module, see if it does
+            # where it is imported from
+            key = (namespace, membername)
+            if key not in attr_docs and hasattr(obj.object, '__module__'):
+                try:
+                    analyzer = ModuleAnalyzer.for_module(obj.object.__module__)
+                except PycodeError:
+                    pass
+                else:
+                    orig_docs = analyzer.find_attr_docs()
+                    if key in orig_docs:
+                        attr_docs[key] = orig_docs[key]
 
             # if isattr is True, the member is documented as an attribute
             isattr = member is INSTANCEATTR or (namespace, membername) in attr_docs

--- a/tests/roots/test-ext-autodoc/target/reimport/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/reimport/__init__.py
@@ -1,0 +1,8 @@
+from typing import TypeVar
+
+from ._private import T
+
+V = TypeVar('V')
+"""A locally defined TypeVar"""
+
+__all__ = ['T', 'V']

--- a/tests/roots/test-ext-autodoc/target/reimport/__init__.py
+++ b/tests/roots/test-ext-autodoc/target/reimport/__init__.py
@@ -1,8 +1,9 @@
 from typing import TypeVar
 
 from ._private import T
+from ._usage import add
 
 V = TypeVar('V')
 """A locally defined TypeVar"""
 
-__all__ = ['T', 'V']
+__all__ = ['T', 'V', 'add']

--- a/tests/roots/test-ext-autodoc/target/reimport/_private.py
+++ b/tests/roots/test-ext-autodoc/target/reimport/_private.py
@@ -1,0 +1,4 @@
+from typing import TypeVar
+
+T = TypeVar('T', bound=int | str)
+"""A reimported TypeVar"""

--- a/tests/roots/test-ext-autodoc/target/reimport/_usage.py
+++ b/tests/roots/test-ext-autodoc/target/reimport/_usage.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from ._private import T
+
+
+def add(x: T, y: T) -> T:
+    """Add two things together"""
+    return x + y

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -3146,6 +3146,13 @@ def test_reimport_typevar(app):
         '',
         "   alias of TypeVar('V')",
         '',
+        '',
+        '.. py:function:: add(x: ~target.reimport.T, y: ~target.reimport.T) ->'
+        ' ~target.reimport.T',
+        '   :module: target.reimport',
+        '',
+        '   Add two things together',
+        '',
     ]
 
 

--- a/tests/test_extensions/test_ext_autodoc.py
+++ b/tests/test_extensions/test_ext_autodoc.py
@@ -3120,6 +3120,36 @@ def test_canonical(app):
 
 
 @pytest.mark.sphinx('html', testroot='ext-autodoc')
+def test_reimport_typevar(app):
+    options = {
+        'members': None,
+        'imported-members': None,
+    }
+    actual = do_autodoc(app, 'module', 'target.reimport', options)
+    assert list(actual) == [
+        '',
+        '.. py:module:: target.reimport',
+        '',
+        '',
+        '.. py:class:: T',
+        '   :module: target.reimport',
+        '',
+        '   A reimported TypeVar',
+        '',
+        "   alias of TypeVar('T', bound=\\ :py:class:`int` | :py:class:`str`)",
+        '',
+        '',
+        '.. py:class:: V',
+        '   :module: target.reimport',
+        '',
+        '   A locally defined TypeVar',
+        '',
+        "   alias of TypeVar('V')",
+        '',
+    ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc')
 def test_literal_render(app):
     def bounded_typevar_rst(name, bound):
         return [


### PR DESCRIPTION


## Purpose

To allow autodoc to read the doc comments of TypeVars re-imported from other modules. This allows TypeVars from private modules to be documented there and re-exported as part of the public interface.

## References

Fixes #13276
