### PR TITLE
Remove ruff version detection

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,16 +26,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - name: Get Ruff version from pyproject.toml
-      run: |
-        RUFF_VERSION=$(awk -F'[="]' '/\[project\.optional-dependencies\]/ {p=1} /ruff/ {if (p) print $4}' pyproject.toml)
-        echo "RUFF_VERSION=$RUFF_VERSION" >> $GITHUB_ENV
 
-    - name: Install Ruff ${{ env.RUFF_VERSION }}
+    - name: Install Ruff
       uses: astral-sh/ruff-action@v3
       with:
         args: --version
-        version: ${{ env.RUFF_VERSION }}
 
     - name: Lint with Ruff
       run: ruff check --output-format=github


### PR DESCRIPTION
## Purpose

ruff-action v3.1 correctly detects Ruff from tables within ``[project.optional-dependencies]``.

## References

- https://github.com/astral-sh/ruff-action/issues/9#issuecomment-2568418279
- https://github.com/sphinx-doc/sphinx/pull/13198#issuecomment-2568419580
- https://github.com/astral-sh/ruff-action/pull/66
- https://github.com/astral-sh/ruff-action/issues/40
- #12065 (originally introduced the `awk` line)
