### PR TITLE
Ignore broken Babel 2.17 on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "docutils>=0.20,<0.22",
     "snowballstemmer>=2.2",
     "babel>=2.13",
+    "babel!=2.17; sys_platform == 'win32'",
     "alabaster>=0.7.14",
     "imagesize>=1.3",
     "requests>=2.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dependencies = [
     "docutils>=0.20,<0.22",
     "snowballstemmer>=2.2",
     "babel>=2.13",
-    "babel!=2.17; sys_platform == 'win32'",
     "alabaster>=0.7.14",
     "imagesize>=1.3",
     "requests>=2.30.0",

--- a/tests/test_util/test_util_i18n.py
+++ b/tests/test_util/test_util_i18n.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import datetime
 import os
+import sys
 import time
 from pathlib import Path
 
+import babel
 import pytest
 from babel.messages.mofile import read_mo
 
@@ -54,6 +56,11 @@ def test_catalog_write_mo(tmp_path):
         assert read_mo(f) is not None
 
 
+# https://github.com/python-babel/babel/issues/1183
+@pytest.mark.xfail(
+    sys.platform == 'win32' and babel.__version__ == '2.17.0',
+    reason='Windows tests fail with Babel 2.17',
+)
 def test_format_date():
     date = datetime.date(2016, 2, 7)
 


### PR DESCRIPTION
## Purpose

Unfortunatley Babel 2.17 breaks our tests on Windows.

## References

- https://github.com/python-babel/babel/issues/1183