### PR TITLE
Pin pypi-attestations to an exact version in `utils/convert_attestati…

### DIFF
--- a/utils/convert_attestations.py
+++ b/utils/convert_attestations.py
@@ -7,7 +7,7 @@ See https://github.com/trailofbits/pypi-attestations.
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "pypi-attestations~=0.0.12",
+#     "pypi-attestations==0.0.12",
 #     "sigstore-protobuf-specs==0.3.2",
 #     "betterproto==2.0.0b6",
 # ]


### PR DESCRIPTION
…ons.py`

The old version pin allowed for installations of versions which are incompatible with the script. In particular, it allowed for the latest version, `0.0.21` to be installed.

At
https://github.com/trailofbits/pypi-attestations/blob/41584d93b27a96861c643623cae4dde8336525e1/src/pypi_attestations/_impl.py#L227-L233 we can see that `Attestation.verify` takes two positional arguments.

In line 53 of `utils/convert_attestations` we pass in three positional arguments.

I found this error while removing `ignore_missing_imports` overrides from `mypy` type checking.