### PR TITLE
Convert '0' and '1' to bool for config overrides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,8 @@ Bugs fixed
   Patch by Adam Turner.
 * #13136: autodoc: Correctly handle multiple inheritance.
   Patch by Pavel Holica
+* #13273, #13318: Properly convert command-line overrides for Boolean types.
+  Patch by Adam Turner.
 
 Testing
 -------

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
     from docutils.nodes import Element
 
     from sphinx.application import Sphinx
-    from sphinx.config import Config
     from sphinx.util.i18n import CatalogInfo
     from sphinx.util.typing import ExtensionMetadata
 
@@ -327,15 +326,6 @@ class MessageCatalogBuilder(I18nBuilder):
                     pofile.write(content)
 
 
-def _gettext_compact_validator(app: Sphinx, config: Config) -> None:
-    gettext_compact = config.gettext_compact
-    # Convert 0/1 from the command line to ``bool`` types
-    if gettext_compact == '0':
-        config.gettext_compact = False
-    elif gettext_compact == '1':
-        config.gettext_compact = True
-
-
 def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_builder(MessageCatalogBuilder)
 
@@ -352,7 +342,6 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         'gettext_last_translator', 'FULL NAME <EMAIL@ADDRESS>', 'gettext'
     )
     app.add_config_value('gettext_language_team', 'LANGUAGE <LL@li.org>', 'gettext')
-    app.connect('config-inited', _gettext_compact_validator, priority=800)
 
     return {
         'version': 'builtin',

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -11,7 +11,6 @@ from unittest import mock
 import pytest
 
 import sphinx
-from sphinx.builders.gettext import _gettext_compact_validator
 from sphinx.config import (
     ENUM,
     Config,
@@ -741,7 +740,6 @@ def test_conf_py_nitpick_ignore_list(tmp_path):
 def test_gettext_compact_command_line_true():
     config = Config({}, {'gettext_compact': '1'})
     config.add('gettext_compact', True, '', {bool, str})
-    _gettext_compact_validator(..., config)
 
     # regression test for #8549 (-D gettext_compact=1)
     assert config.gettext_compact is True
@@ -750,7 +748,6 @@ def test_gettext_compact_command_line_true():
 def test_gettext_compact_command_line_false():
     config = Config({}, {'gettext_compact': '0'})
     config.add('gettext_compact', True, '', {bool, str})
-    _gettext_compact_validator(..., config)
 
     # regression test for #8549 (-D gettext_compact=0)
     assert config.gettext_compact is False
@@ -759,10 +756,33 @@ def test_gettext_compact_command_line_false():
 def test_gettext_compact_command_line_str():
     config = Config({}, {'gettext_compact': 'spam'})
     config.add('gettext_compact', True, '', {bool, str})
-    _gettext_compact_validator(..., config)
 
     # regression test for #8549 (-D gettext_compact=spam)
     assert config.gettext_compact == 'spam'
+
+
+def test_translation_progress_classes_command_line():
+    config = Config({}, {'translation_progress_classes': '1'})
+
+    # regression test for --define translation_progress_classes=1
+    # https://github.com/sphinx-doc/sphinx/issues/13071
+    assert config.translation_progress_classes is True
+
+
+def test_translation_progress_classes_command_line_false():
+    config = Config({}, {'translation_progress_classes': '0'})
+
+    # regression test for --define translation_progress_classes=0
+    # https://github.com/sphinx-doc/sphinx/issues/13071
+    assert config.translation_progress_classes is False
+
+
+def test_translation_progress_classes_command_line_str():
+    config = Config({}, {'translation_progress_classes': 'translated'})
+
+    # regression test for --define translation_progress_classes=translated
+    # https://github.com/sphinx-doc/sphinx/issues/13071
+    assert config.translation_progress_classes == 'translated'
 
 
 def test_root_doc_and_master_doc_are_synchronized():

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -794,6 +794,15 @@ def test_autosummary_generate_command_line_false():
     assert config.autosummary_generate is False
 
 
+def test_boolean_command_line_invalid():
+    config = Config({}, {'rabit_of_caerbannog': ''})
+    config.add('rabit_of_caerbannog', True, '', {bool})
+    with pytest.raises(
+        ConfigError, match="'rabit_of_caerbannog' must be '0' or '1', got ''"
+    ):
+        _ = config.rabit_of_caerbannog
+
+
 def test_root_doc_and_master_doc_are_synchronized():
     c = Config()
     assert c.master_doc == 'index'

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -785,6 +785,15 @@ def test_translation_progress_classes_command_line_str():
     assert config.translation_progress_classes == 'translated'
 
 
+def test_autosummary_generate_command_line_false():
+    config = Config({}, {'autosummary_generate': '0'})
+    config.add('autosummary_generate', True, '', {bool, list})
+
+    # regression test for --define autosummary_generate=0
+    # https://github.com/sphinx-doc/sphinx/issues/13273
+    assert config.autosummary_generate is False
+
+
 def test_root_doc_and_master_doc_are_synchronized():
     c = Config()
     assert c.master_doc == 'index'


### PR DESCRIPTION
## Purpose

Fix conversion of `'0'` and `'1'` on the command line (`--define/-D`) to Booleans for config options using enums and multiple permitted types. Resolves #13273.


## References

* #13273 
* https://github.com/sphinx-doc/sphinx/pull/13074#discussion_r1818940746 (most relevant prior discussion)
* #8556 
* #6908
* #13071 
* #13074

A