### PR TITLE
intersphinx: Resolve implicit self-references

### DIFF
--- a/sphinx/ext/intersphinx/_resolve.py
+++ b/sphinx/ext/intersphinx/_resolve.py
@@ -308,6 +308,8 @@ def resolve_reference_detect_inventory(
     to form ``inv_name:new_target``. If ``inv_name`` is a named inventory, then resolution
     is tried in that inventory with the new target.
     """
+    resolve_self = env.config.intersphinx_resolve_self
+
     # ordinary direct lookup, use data as is
     res = resolve_reference_any_inventory(env, True, node, contnode)
     if res is not None:
@@ -318,6 +320,14 @@ def resolve_reference_detect_inventory(
     if ':' not in target:
         return None
     inv_name, _, new_target = target.partition(':')
+
+    # check if the target is self-referential
+    self_referential = bool(resolve_self) and resolve_self == inv_name
+    if self_referential:
+        node['reftarget'] = new_target
+        node['intersphinx_self_referential'] = True
+        return None
+
     if not inventory_exists(env, inv_name):
         return None
     node['reftarget'] = new_target

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -137,6 +137,20 @@ class ReferencesResolver(SphinxPostTransform):
         if new_node is not None:
             return new_node
 
+        # Is this a self-referential intersphinx reference?
+        if 'intersphinx_self_referential' in node:
+            del node.attributes['intersphinx_self_referential']
+            new_node = self._resolve_pending_xref_in_domain(
+                domain=domain,
+                node=node,
+                contnode=contnode,
+                ref_doc=ref_doc,
+                typ=typ,
+                target=node['reftarget'],
+            )
+            if new_node is not None:
+                return new_node
+
         # Still not found? Emit a warning if we are in nitpicky mode
         # or if the node wishes to be warned about.
         self.warn_missing_reference(ref_doc, typ, target, node, domain)

--- a/sphinx/transforms/post_transforms/__init__.py
+++ b/sphinx/transforms/post_transforms/__init__.py
@@ -140,14 +140,17 @@ class ReferencesResolver(SphinxPostTransform):
         # Is this a self-referential intersphinx reference?
         if 'intersphinx_self_referential' in node:
             del node.attributes['intersphinx_self_referential']
-            new_node = self._resolve_pending_xref_in_domain(
-                domain=domain,
-                node=node,
-                contnode=contnode,
-                ref_doc=ref_doc,
-                typ=typ,
-                target=node['reftarget'],
-            )
+            try:
+                new_node = self._resolve_pending_xref_in_domain(
+                    domain=domain,
+                    node=node,
+                    contnode=contnode,
+                    ref_doc=ref_doc,
+                    typ=typ,
+                    target=node['reftarget'],
+                )
+            except NoUri:
+                return None
             if new_node is not None:
                 return new_node
 

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -70,6 +70,7 @@ def set_config(app, mapping):
     app.config.intersphinx_mapping = mapping.copy()
     app.config.intersphinx_cache_limit = 0
     app.config.intersphinx_disabled_reftypes = []
+    app.config.intersphinx_resolve_self = ''
     app.config.intersphinx_timeout = None
 
 


### PR DESCRIPTION
## Purpose

When we added `intersphinx_resolve_self` in #13291, it only applied to the `` :external:<...>:`...` `` role. This extends the functionality to implicit intersphinx references of the form `` :ref:`astropy:blah` ``.

I'm not hugely happy with adding intersphinx-specific code into `ReferencesResolver`, but the surface area is very limited and clearly demarked.

A

## References

- #13291
- #9169
