### PR TITLE
Use the ``misc.highlighting_failure`` warning sub-type for ``PygmentsBridge.get_lexer()``

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ Contributors
 * Antonio Valentino -- qthelp builder, docstring inheritance
 * Antti Kaihola -- doctest extension (skipif option)
 * Barry Warsaw -- setup command improvements
+* Bart Kamphorst -- warning improvements
 * Ben Egan -- Napoleon improvements & viewcode improvements
 * Benjamin Peterson -- unittests
 * Blaise Laflamme -- pyramid theme

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,8 @@ Features added
   Patch by Jakob Lykke Andersen and Adam Turner.
 * #11280: Add ability to skip a particular section using the ``no-search`` class.
   Patch by Will Lachance.
+* #13335: Use ``misc.highlighting_failure`` subtype for Pygments unknown lexers.
+  Patch by Bart Kamphorst.
 
 Bugs fixed
 ----------

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -167,7 +167,11 @@ class PygmentsBridge:
                     lexer = get_lexer_by_name(lang, **opts)
             except ClassNotFound:
                 logger.warning(
-                    __('Pygments lexer name %r is not known'), lang, location=location
+                    __('Pygments lexer name %r is not known'),
+                    lang,
+                    location=location,
+                    type='misc',
+                    subtype='higlighting_failure',
                 )
                 lexer = lexer_classes['none'](**opts)
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

add warning type to `PygmentsBridge.get_lexer`

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

Closes https://github.com/sphinx-doc/sphinx/issues/13334
