### PR TITLE
Fix typo 'unpickable' -> 'unpickleable'

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -661,7 +661,7 @@ class Builder:
         _cache: bool = True,
     ) -> None:
         """Write the doctree to a file, to be used as a cache by re-builds."""
-        # make it picklable
+        # make it pickleable
         doctree.reporter = None  # type: ignore[assignment]
         doctree.transformer = None  # type: ignore[assignment]
 

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -544,7 +544,7 @@ class Config:
             for key, value in self.__dict__.items()
             if not key.startswith('_') and is_serializable(value)
         }
-        # create a picklable copy of ``self._options``
+        # create a pickleable copy of ``self._options``
         __dict__['_options'] = _options = {}
         for name, opt in self._options.items():
             if not isinstance(opt, _Opt) and isinstance(opt, tuple) and len(opt) <= 3:
@@ -558,7 +558,7 @@ class Config:
                     # and thus always invalidate the cache and perform a rebuild.
                     logger.warning(
                         __(
-                            'cannot cache unpickable configuration value: %r '
+                            'cannot cache unpickleable configuration value: %r '
                             '(because it contains a function, class, or module object)'
                         ),
                         name,

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -234,7 +234,7 @@ class BuildEnvironment:
     def __getstate__(self) -> dict[str, Any]:
         """Obtains serializable data for pickling."""
         __dict__ = self.__dict__.copy()
-        # clear unpickable attributes
+        # clear unpickleable attributes
         __dict__.update(app=None, domains=None, events=None)
         # clear in-memory doctree caches, to reduce memory consumption and
         # ensure that, upon restoring the state, the most recent pickled files

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -128,6 +128,6 @@ def setup(app):
     app = make_app(srcdir=tmp_path)
     app.build()
     assert strip_escape_sequences(app.warning.getvalue()).strip() == (
-        "WARNING: cannot cache unpickable configuration value: 'my_config' "
+        "WARNING: cannot cache unpickleable configuration value: 'my_config' "
         '(because it contains a function, class, or module object) [config.cache]'
     )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -49,7 +49,7 @@ def test_add_uids():
     assert len(original_uids) == 3
 
 
-def test_picklablility():
+def test_pickleablility():
     # we have to modify the doctree so we can pickle it
     copy = original.copy()
     copy.reporter = None


### PR DESCRIPTION
Normalize other occurrences of '~picklable' to '~pickleable'.

There is no clear winner in the Python docs regarding usage of '~picklable' vs '~pickleable', so I picked the more greppable version.
