### PR TITLE
Reword override warning for `add_directive()` and `add_role()`

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1116,7 +1116,7 @@ class Sphinx:
         logger.debug('[app] adding directive: %r', (name, cls))
         if not override and docutils.is_directive_registered(name):
             logger.warning(
-                __('directive %r is already registered, it will be overridden'),
+                __('directive %r is already registered and will not be overridden'),
                 name,
                 type='app',
                 subtype='add_directive',
@@ -1142,7 +1142,7 @@ class Sphinx:
         logger.debug('[app] adding role: %r', (name, role))
         if not override and docutils.is_role_registered(name):
             logger.warning(
-                __('role %r is already registered, it will be overridden'),
+                __('role %r is already registered and will not be overridden'),
                 name,
                 type='app',
                 subtype='add_role',
@@ -1170,7 +1170,7 @@ class Sphinx:
         logger.debug('[app] adding generic role: %r', (name, nodeclass))
         if not override and docutils.is_role_registered(name):
             logger.warning(
-                __('role %r is already registered, it will be overridden'),
+                __('role %r is already registered and will not be overridden'),
                 name,
                 type='app',
                 subtype='add_generic_role',


### PR DESCRIPTION
## Purpose

Reword the ambiguous

`WARNING: while setting up extension conf.py: directive 'autolink-skip' is already registered, it will be overridden [app.add_directive]`

to

`WARNING: while setting up extension conf.py: directive 'autolink-skip' is already registered and will not be overridden [app.add_directive]`

which makes it clearer to users what actually happens when `add_directive()` (and `add_role()`) find an already registered directive/role.

## References

The docs at https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_directive say:
"**override** – If false, do not install it if another directive is already installed as the same name If true, unconditionally install the directive."

In *this* context, it is clear that "it" means the directive that is about to be added. In the original warning text, it's IMO not clear.