### PR TITLE
Insert abbreviation nodes for positional- and keyword-only separators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,9 @@ Features added
   Patch by Adam Turner.
 * #13335: Use ``misc.highlighting_failure`` subtype for Pygments unknown lexers.
   Patch by Bart Kamphorst.
+* #13354: Insert abbreviation nodes (hover text) for positional- and keyword-only
+  separators in Python signatures.
+  Patch by Adam Turner.
 
 Bugs fixed
 ----------

--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -12,20 +12,18 @@ from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.addnodes import pending_xref, pending_xref_condition
+from sphinx.locale import _
 from sphinx.pycode.parser import Token, TokenProcessor
 from sphinx.util.inspect import signature_from_str
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
-    from typing import Any, Final
+    from typing import Any
 
     from docutils.nodes import Element, Node
 
     from sphinx.addnodes import desc_signature
     from sphinx.environment import BuildEnvironment
-
-ABBREVIATION_POSITIONAL_ONLY: Final = 'Positional-only parameter separator (PEP 570)'
-ABBREVIATION_KEYWORD_ONLY: Final = 'Keyword-only parameters separator (PEP 3102)'
 
 
 def parse_reftarget(
@@ -528,7 +526,7 @@ def _parse_arglist(
 def _positional_only_separator() -> addnodes.desc_parameter:
     # PEP 570: Separator for positional only parameters: /
     positional_only_abbr = nodes.abbreviation(
-        '/', '/', explanation=ABBREVIATION_POSITIONAL_ONLY
+        '/', '/', explanation=_('Positional-only parameter separator (PEP 570)')
     )
     positional_only_op = addnodes.desc_sig_operator(
         '/', '', positional_only_abbr, classes=['positional-only-separator']
@@ -539,7 +537,7 @@ def _positional_only_separator() -> addnodes.desc_parameter:
 def _keyword_only_separator() -> addnodes.desc_parameter:
     # PEP 3102: Separator for keyword only parameters: *
     keyword_only_abbr = nodes.abbreviation(
-        '*', '*', explanation=ABBREVIATION_KEYWORD_ONLY
+        '*', '*', explanation=_('Keyword-only parameters separator (PEP 3102)')
     )
     keyword_only_op = addnodes.desc_sig_operator(
         '*', '', keyword_only_abbr, classes=['keyword-only-separator']

--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -352,11 +352,14 @@ class PyObject(ObjectDescription[tuple[str, str]]):
                     multi_line_parameter_list,
                     trailing_comma,
                 )
-            except SyntaxError:
+            except SyntaxError as exc:
                 # fallback to parse arglist original parser
                 # (this may happen if the argument list is incorrectly used
                 # as a list of bases when documenting a class)
                 # it supports to represent optional arguments (ex. "func(foo [, bar])")
+                logger.debug(
+                    'syntax error in arglist (%r): %s', arglist, exc, location=signode
+                )
                 _pseudo_parse_arglist(
                     signode,
                     arglist,

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -906,8 +906,8 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):  # type: ignore[misc]
 
     def visit_abbreviation(self, node: Element) -> None:
         attrs = {}
-        if node.hasattr('explanation'):
-            attrs['title'] = node['explanation']
+        if explanation := node.get('explanation', ''):
+            attrs['title'] = explanation
         self.body.append(self.starttag(node, 'abbr', '', **attrs))
 
     def depart_abbreviation(self, node: Element) -> None:

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2082,11 +2082,12 @@ class LaTeXTranslator(SphinxTranslator):
         self.body.append('}}')
 
     def visit_abbreviation(self, node: Element) -> None:
+        explanation = node.get('explanation', '')
         abbr = node.astext()
         self.body.append(r'\sphinxstyleabbreviation{')
         # spell out the explanation once
-        if node.hasattr('explanation') and abbr not in self.handled_abbrs:
-            self.context.append('} (%s)' % self.encode(node['explanation']))
+        if explanation and abbr not in self.handled_abbrs:
+            self.context.append('} (%s)' % self.encode(explanation))
             self.handled_abbrs.add(abbr)
         else:
             self.context.append('}')

--- a/sphinx/writers/texinfo.py
+++ b/sphinx/writers/texinfo.py
@@ -1537,10 +1537,11 @@ class TexinfoTranslator(SphinxTranslator):
         pass
 
     def visit_abbreviation(self, node: Element) -> None:
+        explanation = node.get('explanation', '')
         abbr = node.astext()
         self.body.append('@abbr{')
-        if node.hasattr('explanation') and abbr not in self.handled_abbrs:
-            self.context.append(',%s}' % self.escape_arg(node['explanation']))
+        if explanation and abbr not in self.handled_abbrs:
+            self.context.append(',%s}' % self.escape_arg(explanation))
             self.handled_abbrs.add(abbr)
         else:
             self.context.append('}')

--- a/sphinx/writers/text.py
+++ b/sphinx/writers/text.py
@@ -1237,8 +1237,8 @@ class TextTranslator(SphinxTranslator):
         self.add_text('')
 
     def depart_abbreviation(self, node: Element) -> None:
-        if node.hasattr('explanation'):
-            self.add_text(' (%s)' % node['explanation'])
+        if explanation := node.get('explanation', ''):
+            self.add_text(f' ({explanation})')
 
     def visit_manpage(self, node: Element) -> None:
         return self.visit_literal_emphasis(node)

--- a/tests/test_domains/test_domain_py_pyfunction.py
+++ b/tests/test_domains/test_domain_py_pyfunction.py
@@ -259,7 +259,10 @@ def test_pyfunction_signature_full(app):
         doctree[1][0][1],
         [
             desc_parameterlist,
-            ([desc_parameter, nodes.inline, '*'], [desc_parameter, desc_sig_name, 'a']),
+            (
+                [desc_parameter, desc_sig_operator, nodes.abbreviation, '*'],
+                [desc_parameter, desc_sig_name, 'a'],
+            ),
         ],
     )
 
@@ -272,9 +275,9 @@ def test_pyfunction_signature_full(app):
             desc_parameterlist,
             (
                 [desc_parameter, desc_sig_name, 'a'],
-                [desc_parameter, desc_sig_operator, '/'],
+                [desc_parameter, desc_sig_operator, nodes.abbreviation, '/'],
                 [desc_parameter, desc_sig_name, 'b'],
-                [desc_parameter, desc_sig_operator, '*'],
+                [desc_parameter, desc_sig_operator, nodes.abbreviation, '*'],
                 [desc_parameter, desc_sig_name, 'c'],
             ),
         ],
@@ -289,8 +292,8 @@ def test_pyfunction_signature_full(app):
             desc_parameterlist,
             (
                 [desc_parameter, desc_sig_name, 'a'],
-                [desc_parameter, desc_sig_operator, '/'],
-                [desc_parameter, desc_sig_operator, '*'],
+                [desc_parameter, desc_sig_operator, nodes.abbreviation, '/'],
+                [desc_parameter, desc_sig_operator, nodes.abbreviation, '*'],
                 [desc_parameter, desc_sig_name, 'b'],
             ),
         ],
@@ -305,7 +308,7 @@ def test_pyfunction_signature_full(app):
             desc_parameterlist,
             (
                 [desc_parameter, desc_sig_name, 'a'],
-                [desc_parameter, desc_sig_operator, '/'],
+                [desc_parameter, desc_sig_operator, nodes.abbreviation, '/'],
             ),
         ],
     )


### PR DESCRIPTION
## Purpose

It has been suggested that `/` and `*` in Python function signatures can be cryptic. This inserts abbreviation nodes to create hover-text to explain the meaning of the tokens in such signatures.
