### PR TITLE
Correct spelling of `highlighting_failure` in warning sub-type

### DIFF
--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -171,7 +171,7 @@ class PygmentsBridge:
                     lang,
                     location=location,
                     type='misc',
-                    subtype='higlighting_failure',
+                    subtype='highlighting_failure',
                 )
                 lexer = lexer_classes['none'](**opts)
 


### PR DESCRIPTION
Fixup of a typo in https://github.com/sphinx-doc/sphinx/pull/13335...