### PR TITLE
`sphinx.testing.fixtures` still also works when type of `rootdir` is `sphinx.testing.path`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,6 +74,7 @@ Contributors
 * Juan Luis Cano Rodríguez -- new tutorial (2021)
 * Julien Palard -- Colspan and rowspan in text builder
 * Justus Magin -- napoleon improvements
+* Kazuya Take (attakei) -- testings components used by other extensions
 * Kevin Dunn -- MathJax extension
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils
 * Kurt McKee -- documentation updates

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,7 +74,7 @@ Contributors
 * Juan Luis Cano Rodríguez -- new tutorial (2021)
 * Julien Palard -- Colspan and rowspan in text builder
 * Justus Magin -- napoleon improvements
-* Kazuya Take (attakei) -- testings components used by other extensions
+* Kazuya Take -- ``sphinx.testing.path`` bug fix
 * Kevin Dunn -- MathJax extension
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils
 * Kurt McKee -- documentation updates

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ Features added
 Bugs fixed
 ----------
 
+* #13377: ``sphinx.testing.fixtures`` still also works
+  when type of ``rootdir`` is ``sphinx.testing.path``.
+  Patch by Kazuya Takei.
+
 Testing
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,8 @@ Features added
 Bugs fixed
 ----------
 
-* #13377: ``sphinx.testing.fixtures`` still also works
-  when type of ``rootdir`` is ``sphinx.testing.path``.
+* #13377: Restore support for using ``sphinx.testing.path`` paths with
+  ``sphinx.testing.fixtures``.
   Patch by Kazuya Takei.
 
 Testing

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -64,13 +64,19 @@ class path(str):  # NoQA: FURB189
         """Returns ``True`` if the path is a file."""
         return os.path.isfile(self)
 
+    is_file = isfile
+
     def islink(self) -> bool:
         """Returns ``True`` if the path is a symbolic link."""
         return os.path.islink(self)
 
+    is_symlink = islink
+
     def ismount(self) -> bool:
         """Returns ``True`` if the path is a mount point."""
         return os.path.ismount(self)
+
+    is_mount = ismount
 
     def rmtree(
         self,

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -58,6 +58,8 @@ class path(str):  # NoQA: FURB189
         """Returns ``True`` if the path is a directory."""
         return os.path.isdir(self)
 
+    is_dir = isdir
+
     def isfile(self) -> bool:
         """Returns ``True`` if the path is a file."""
         return os.path.isfile(self)


### PR DESCRIPTION
## Purpose

This is patch commit until release ver 9.x will remove `sphinx.testing.path`.

This PR will not have side-effect for currently tests (any test in this repo uses pathlib.Path). 

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

* This is to close #13377 
