### PR TITLE
Fix viewcode extension importing modules more than once

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,6 +45,7 @@ Contributors
 * Daniel Eades -- improved static typing
 * Daniel Hahler -- testing and CI improvements
 * Daniel Pizetta -- inheritance diagram improvements
+* Dave Hoese -- viewcode extension improvements
 * Dave Kuhlman -- original LaTeX writer
 * Dimitri Papadopoulos Orfanos -- linting and spelling
 * Dmitry Shachnev -- modernisation and reproducibility

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,7 +45,7 @@ Contributors
 * Daniel Eades -- improved static typing
 * Daniel Hahler -- testing and CI improvements
 * Daniel Pizetta -- inheritance diagram improvements
-* Dave Hoese -- viewcode extension improvements
+* Dave Hoese -- ``sphinx.ext.viewcode`` bug fix
 * Dave Kuhlman -- original LaTeX writer
 * Dimitri Papadopoulos Orfanos -- linting and spelling
 * Dmitry Shachnev -- modernisation and reproducibility

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Features added
 Bugs fixed
 ----------
 
+* #13380: viewcode: Fix importing modules more than once.
+  Patch by Dave Hoese.
+
 Testing
 -------
 

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import operator
 import posixpath
@@ -62,16 +63,14 @@ def _get_full_modname(modname: str, attribute: str) -> str | None:
         num_parts = len(module_path)
         for i in range(num_parts, 0, -1):
             mod_root = '.'.join(module_path[:i])
-            module_spec = importlib.util.find_spec(mod_root)
-            if module_spec is not None:
+            try:
+                module = importlib.import_module(mod_root)
                 break
+            except ModuleNotFoundError:
+                continue
         else:
             return None
-        # Load and execute the module
-        module = importlib.util.module_from_spec(module_spec)
-        if module_spec.loader is None:
-            return None
-        module_spec.loader.exec_module(module)
+
         if i != num_parts:
             for mod in module_path[i:]:
                 module = getattr(module, mod)

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import importlib.util
 import operator
 import posixpath
 import traceback
@@ -64,10 +63,16 @@ def _get_full_modname(modname: str, attribute: str) -> str | None:
         for i in range(num_parts, 0, -1):
             mod_root = '.'.join(module_path[:i])
             try:
+                # import_module() caches the module in sys.modules
                 module = importlib.import_module(mod_root)
                 break
             except ModuleNotFoundError:
                 continue
+            except BaseException as exc:
+                # Importing modules may cause any side effects, including
+                # SystemExit, so we need to catch all errors.
+                msg = f"viewcode failed to import '{mod_root}'."
+                raise ImportError(msg) from exc
         else:
             return None
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->

## Purpose

This PR fixes the viewcode extension improperly importing modules to compute the full module name. This results in modules being imported more than once and increase memory usage and execution time. The primary issue was modules being imported/executed but not added to `sys.modules` to be reused.

This PR reverts some of the changes in #13195 to use `importlib.import_module` again to handle the complexity of importing modules and "caching" them in `sys.modules` to be reused. It does not break the feature added to #13195 of importing a module "alias" import. That is, accessing an imported module as another module's attribute (see #13195 and #13370 for details).

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Closes #13370
- Bug introduced in #13195
