### PR TITLE
Fix apidoc extension not setting default header/package name

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,7 +45,7 @@ Contributors
 * Daniel Eades -- improved static typing
 * Daniel Hahler -- testing and CI improvements
 * Daniel Pizetta -- inheritance diagram improvements
-* Dave Hoese -- ``sphinx.ext.viewcode`` bug fix
+* Dave Hoese -- ``sphinx.ext.viewcode`` and ``sphinx.ext.apidoc`` bug fixes
 * Dave Kuhlman -- original LaTeX writer
 * Dimitri Papadopoulos Orfanos -- linting and spelling
 * Dmitry Shachnev -- modernisation and reproducibility

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,5 +16,8 @@ Features added
 Bugs fixed
 ----------
 
+* #13391: apidoc: Fix TOC file not having a title.
+  Patch by Dave Hoese.
+
 Testing
 -------

--- a/sphinx/ext/apidoc/_extension.py
+++ b/sphinx/ext/apidoc/_extension.py
@@ -220,6 +220,7 @@ def _parse_module_options(
         automodule_options=automodule_options,
         max_depth=max_depth,
         quiet=True,
+        header=module_path.name,
         follow_links=bool_options['follow_links'],
         separate_modules=bool_options['separate_modules'],
         include_private=bool_options['include_private'],

--- a/sphinx/ext/apidoc/_extension.py
+++ b/sphinx/ext/apidoc/_extension.py
@@ -217,16 +217,16 @@ def _parse_module_options(
         dest_dir=dest_path,
         module_path=module_path,
         exclude_pattern=exclude_patterns,
-        automodule_options=automodule_options,
         max_depth=max_depth,
         quiet=True,
-        header=module_path.name,
         follow_links=bool_options['follow_links'],
         separate_modules=bool_options['separate_modules'],
         include_private=bool_options['include_private'],
         no_headings=bool_options['no_headings'],
         module_first=bool_options['module_first'],
         implicit_namespaces=bool_options['implicit_namespaces'],
+        automodule_options=automodule_options,
+        header=module_path.name,
     )
 
 

--- a/tests/test_extensions/test_ext_apidoc.py
+++ b/tests/test_extensions/test_ext_apidoc.py
@@ -783,17 +783,13 @@ def test_sphinx_extension(app: SphinxTestApp) -> None:
     assert app.warning.getvalue() == ''
 
     toc_file = app.srcdir / 'generated' / 'modules.rst'
-    assert set((app.srcdir / 'generated').iterdir()) == {
-        toc_file,
-        app.srcdir / 'generated' / 'my_package.rst',
-    }
+    pkg_file = app.srcdir / 'generated' / 'my_package.rst'
+    assert set((app.srcdir / 'generated').iterdir()) == {toc_file, pkg_file}
     modules_content = toc_file.read_text(encoding='utf8')
     assert modules_content == (
         'src\n===\n\n.. toctree::\n   :maxdepth: 3\n\n   my_package\n'
     )
-    assert 'show-inheritance' not in (
-        app.srcdir / 'generated' / 'my_package.rst'
-    ).read_text(encoding='utf8')
+    assert 'show-inheritance' not in pkg_file.read_text(encoding='utf8')
     assert (app.outdir / 'generated' / 'my_package.html').is_file()
 
     # test a re-build

--- a/tests/test_extensions/test_ext_apidoc.py
+++ b/tests/test_extensions/test_ext_apidoc.py
@@ -782,19 +782,14 @@ def test_sphinx_extension(app: SphinxTestApp) -> None:
     app.build()
     assert app.warning.getvalue() == ''
 
+    toc_file = app.srcdir / 'generated' / 'modules.rst'
     assert set((app.srcdir / 'generated').iterdir()) == {
-        app.srcdir / 'generated' / 'modules.rst',
+        toc_file,
         app.srcdir / 'generated' / 'my_package.rst',
     }
-    modules_content = (app.srcdir / 'generated' / 'modules.rst').read_text(encoding='utf8')
+    modules_content = toc_file.read_text(encoding='utf8')
     assert modules_content == (
-        'src\n'
-        '===\n'
-        '\n'
-        '.. toctree::\n'
-        '   :maxdepth: 3\n'
-        '\n'
-        '   my_package\n'
+        'src\n===\n\n.. toctree::\n   :maxdepth: 3\n\n   my_package\n'
     )
     assert 'show-inheritance' not in (
         app.srcdir / 'generated' / 'my_package.rst'

--- a/tests/test_extensions/test_ext_apidoc.py
+++ b/tests/test_extensions/test_ext_apidoc.py
@@ -786,6 +786,16 @@ def test_sphinx_extension(app: SphinxTestApp) -> None:
         app.srcdir / 'generated' / 'modules.rst',
         app.srcdir / 'generated' / 'my_package.rst',
     }
+    modules_content = (app.srcdir / 'generated' / 'modules.rst').read_text(encoding='utf8')
+    assert modules_content == (
+        'src\n'
+        '===\n'
+        '\n'
+        '.. toctree::\n'
+        '   :maxdepth: 3\n'
+        '\n'
+        '   my_package\n'
+    )
     assert 'show-inheritance' not in (
         app.srcdir / 'generated' / 'my_package.rst'
     ).read_text(encoding='utf8')


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

See #13389. The CLI version of apidoc adds a default for the `--project` flag which is `header` in the code's options, see:

https://github.com/sphinx-doc/sphinx/blob/e7ca2d8eaf047ddb7b860cc16e67c7faf75317ee/sphinx/ext/apidoc/_cli.py#L294-L295

This default is not set in the apidoc extension which results in the TOC file (`modules.rst`) not having a title. Additionally the header/project flag is documented as being used only for `--full` invocations of the apidoc CLI, but this is not true because of this TOC file's use of it.

TODO:

- [x] Update changelog
- [x] Update authors file
- [ ] Update apidoc CLI documentation regarding header usage? (see below)

I don't plan on updating documentation about the apidoc extension or adding an option for "--project" or anything about the header as I'm not sure it is needed? I think the idea of the flag is as documented in the CLI tool which is to name the project, but in the case of the extension the project already exists and has a name. Maybe I should change the apidoc CLI documentation :shrug: 


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Closes #13389 

