### PR TITLE
Fix argument type for ``jieba.load_userdict()``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Features added
 Bugs fixed
 ----------
 
-* #13392: HTML Search: make sure jieba.load_userdict got a string param.
+* #13392: Fix argument type for ``jieba.load_userdict()``.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Features added
 Bugs fixed
 ----------
 
-* #13392: HTML Search: make sure the parameter that passed to jieba.load_userdict() is string_types
+* #13392: HTML Search: make sure jieba.load_userdict got a string param.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,5 +16,7 @@ Features added
 Bugs fixed
 ----------
 
+* #13392: HTML Search: make sure the parameter that passed to jieba.load_userdict() is string_types
+
 Testing
 -------

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -232,7 +232,7 @@ class SearchChinese(SearchLanguage):
 
     def init(self, options: dict[str, str]) -> None:
         if JIEBA:
-            dict_path = options.get('dict', JIEBA_DEFAULT_DICT)
+            dict_path = options.get('dict', JIEBA_DEFAULT_DICT.as_posix())
             if dict_path and Path(dict_path).is_file():
                 jieba.load_userdict(dict_path)
 

--- a/sphinx/search/zh.py
+++ b/sphinx/search/zh.py
@@ -232,9 +232,9 @@ class SearchChinese(SearchLanguage):
 
     def init(self, options: dict[str, str]) -> None:
         if JIEBA:
-            dict_path = options.get('dict', JIEBA_DEFAULT_DICT.as_posix())
+            dict_path = options.get('dict', JIEBA_DEFAULT_DICT)
             if dict_path and Path(dict_path).is_file():
-                jieba.load_userdict(dict_path)
+                jieba.load_userdict(str(dict_path))
 
         self.stemmer = snowballstemmer.stemmer('english')
 


### PR DESCRIPTION
make sure jieba.load_userdict() have a string parameter

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

fix #13392: jieba 'PosixPath' object is not iterable

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

[jieba.load_userdict](https://github.com/fxsjy/jieba/blob/67fa2e36e72f69d9134b8a1037b83fbb070b9775/jieba/__init__.py#L380) only accept file-like object or string path (not Path object) .

 `JIEBA_DEFAULT_DICT` is a PosixPath object, when key `dict` not in `options`, the code
`options.get('dict', JIEBA_DEFAULT_DICT)` will return a PoixPath object, which 
will cause errors in [jieba.load_userdict](https://github.com/fxsjy/jieba/blob/67fa2e36e72f69d9134b8a1037b83fbb070b9775/jieba/__init__.py#L380).


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- [issues 13392](https://github.com/sphinx-doc/sphinx/issues/13392)

