### PR TITLE
Sphinx.add_js_file(): replace `None` filename with `''` before passing to HTML builder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bugs fixed
 ----------
 
 * #13392: Fix argument type for ``jieba.load_userdict()``.
+* #13402: Ensure inline ``<script>`` tags are written exactly once.
 
 Testing
 -------

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1510,7 +1510,7 @@ class Sphinx:
         self.registry.add_js_file(filename, priority=priority, **kwargs)
         with contextlib.suppress(AttributeError):
             self.builder.add_js_file(  # type: ignore[attr-defined]
-                filename, priority=priority, **kwargs
+                filename or '', priority=priority, **kwargs
             )
 
     def add_css_file(self, filename: str, priority: int = 500, **kwargs: Any) -> None:

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1507,10 +1507,11 @@ class Sphinx:
         elif loading_method == 'defer':
             kwargs['defer'] = 'defer'
 
+        filename = filename or ''
         self.registry.add_js_file(filename, priority=priority, **kwargs)
         with contextlib.suppress(AttributeError):
             self.builder.add_js_file(  # type: ignore[attr-defined]
-                filename or '', priority=priority, **kwargs
+                filename, priority=priority, **kwargs
             )
 
     def add_css_file(self, filename: str, priority: int = 500, **kwargs: Any) -> None:


### PR DESCRIPTION
The `Sphinx.add_js_file()` method first adds the JS file to the registry, and then calls `self.builder.add_js_file()`:
https://github.com/sphinx-doc/sphinx/blob/287ee204e4a381707760351cdae54af36114ee59/sphinx/application.py#L1510-L1514

However, `StandaloneHTMLBuilder.init_js_files()` method also calls `self.add_js_file()`, but replaces `None` filename with empty string while doing so:
https://github.com/sphinx-doc/sphinx/blob/287ee204e4a381707760351cdae54af36114ee59/sphinx/builders/html/__init__.py#L306-L307

And when `add_js_file()` is called second time, the check for non-presence of asset in `self._js_files` returns `True`, because it is present there with a different filename (`None != ''`), so it ends up being appended second time:
https://github.com/sphinx-doc/sphinx/blob/287ee204e4a381707760351cdae54af36114ee59/sphinx/builders/html/__init__.py#L320-L321

To avoid including a file second time, make sure that both times when `StandaloneHTMLBuilder.add_js_file()` is called, `None` is replaced with an empty string.

This fixes issue that can be seen with [sphinx-book-theme](https://sphinx-book-theme.readthedocs.io/en/stable/):

    Uncaught SyntaxError: redeclaration of const THEBE_JS_URL

Cc @choldgraf (sphinx-thebe maintainer)