### PR TITLE
Fall back to 'en' if `format_date` is called with a falsy value

### DIFF
--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -228,6 +228,14 @@ def babel_format_date(
     if not hasattr(date, 'tzinfo'):
         formatter = babel.dates.format_date
 
+    if not locale:
+        # Babel would not accept a falsy locale
+        # (or would try to fall back to the LC_TIME
+        # locale, which would be not what was requested),
+        # so we can just short-cut to English, as we
+        # would for the `"fallback to English"` case.
+        locale = 'en'
+
     try:
         return formatter(date, format, locale=locale)
     except (ValueError, babel.core.UnknownLocaleError):

--- a/tests/test_util/test_util_i18n.py
+++ b/tests/test_util/test_util_i18n.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import datetime
 import os
-import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import babel
 import pytest
 from babel.messages.mofile import read_mo
 
@@ -60,11 +58,6 @@ def test_catalog_write_mo(tmp_path):
         assert read_mo(f) is not None
 
 
-# https://github.com/python-babel/babel/issues/1183
-@pytest.mark.xfail(
-    sys.platform == 'win32' and babel.__version__ == '2.17.0',
-    reason='Windows tests fail with Babel 2.17',
-)
 def test_format_date():
     date = datetime.date(2016, 2, 7)
 


### PR DESCRIPTION
## Purpose

If somehow a falsy value is passed in as the language value for `sphinx.util.i18n.format_date`,  fall back directly to `"en"`, as that is what the end result from Babel raising an exception would be anyway.

## References


- https://github.com/python-babel/babel/issues/1183 
- Follows up on #13290
