### PR TITLE
autosummary: Update test for Python 3.14.0a5+

### DIFF
--- a/tests/test_extensions/test_ext_autosummary.py
+++ b/tests/test_extensions/test_ext_autosummary.py
@@ -447,8 +447,12 @@ def test_autosummary_generate_content_for_module_imported_members(app):
     ]
     assert context['functions'] == ['bar']
     assert context['all_functions'] == ['_quux', 'bar']
-    assert context['classes'] == ['Class', 'Foo']
-    assert context['all_classes'] == ['Class', 'Foo', '_Baz']
+    if sys.version_info >= (3, 14, 0, 'alpha', 5):
+        assert context['classes'] == ['Class', 'Foo', 'Union']
+        assert context['all_classes'] == ['Class', 'Foo', 'Union', '_Baz']
+    else:
+        assert context['classes'] == ['Class', 'Foo']
+        assert context['all_classes'] == ['Class', 'Foo', '_Baz']
     assert context['exceptions'] == ['Exc']
     assert context['all_exceptions'] == ['Exc', '_Exc']
     assert context['attributes'] == ['CONSTANT1', 'qux', 'quuz', 'non_imported_member']


### PR DESCRIPTION
## Purpose

See https://github.com/python/cpython/pull/105511, `UnionType` and `Union` have been merged.

## References

- https://github.com/python/cpython/pull/105511
