### PR TITLE
Remove type overrides for tests.test_addnodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     # tests/
-    "tests.test_addnodes",
     "tests.test_application",
     "tests.test_events",
     "tests.test_highlighting",

--- a/tests/test_addnodes.py
+++ b/tests/test_addnodes.py
@@ -20,7 +20,9 @@ def sig_elements() -> Iterator[set[type[addnodes.desc_sig_element]]]:
     addnodes.SIG_ELEMENTS = original  # restore the previous value
 
 
-def test_desc_sig_element_nodes(sig_elements):
+def test_desc_sig_element_nodes(
+    sig_elements: set[type[addnodes.desc_sig_element]],
+) -> None:
     """Test the registration of ``desc_sig_element`` subclasses."""
     # expected desc_sig_* node classes (must be declared *after* reloading
     # the module since otherwise the objects are not the correct ones)


### PR DESCRIPTION
It seems like the `sig_elements` fixture isn't really needed (or it could be a `usefixtures` fixture) but that is separate from my current goals.