### PR TITLE
Trivial: Install: fix error "can be install" -> "can be installed"

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -168,7 +168,7 @@ __ https://www.macports.org/ports.php?by=library&substr=py313-sphinx
 Windows
 ~~~~~~~
 
-Sphinx can be install using `Chocolatey`__.
+Sphinx can be installed using `Chocolatey`__.
 
 __ https://chocolatey.org/
 


### PR DESCRIPTION
## Purpose

Fixes a minor grammar error in the installation instructions.
