### PR TITLE
Add an introduction to HTML templating

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -107,6 +107,7 @@ Contributors
 * Thomas Lamb -- linkcheck builder
 * Thomas Waldmann -- apidoc module fixes
 * Tim Hoffmann -- theme improvements
+* Victor Wheeler -- documentation improvements
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder
 * Zac Hatfield-Dodds -- doctest reporting improvements, intersphinx performance

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -9,16 +9,23 @@ Templating
 What Is Templating?
 -------------------
 
-Templating is a method of generating HTML pages by using template files that provide,
-not only the static parts of the desired HTML output, but also provide some special
-syntax describing how content will be inserted.  Since template files function
-similar to Cascading Style Sheets, generating HTML pages this way provides a flexible
-way for Sphinx extensions (such as themes) to "inherit from" and modify basic
-templates, or replace them altogether, to achieve customized HTML page layout.
-Similarly, an individual documentation project can customize the theme it is using
-through the same mechanism, using locally-provided custom HTML templates.  Templates
-can be maintained by anyone with an understanding of HTML; no knowledge of Python is
-required.
+Templating is a method of generating HTML pages by combining data and static templates.
+The template files contain the static parts of the desired HTML output
+and include special syntax describing how variable content will be inserted.
+For example, this can be used to insert the current date in the footer of each page,
+or to surround the main content of the document with a scaffold of HTML for layout
+and formatting purposes.
+Using templates to generate HTML means that the content can be changed without altering
+Sphinx's source code, meaning that the Sphinx core can provide basic HTML generation,
+independent of the final output.
+Since template files function similar to Cascading Style Sheets,
+generating HTML pages this way provides a flexible way for Sphinx themes
+to "inherit from" and modify basic templates, or replace them altogether,
+to achieve customised HTML page layout.
+Similarly, any project can customise the theme it is using by the same mechanism,
+using locally-provided HTML templates, overriding those from the theme and Sphinx.
+Templates can be maintained by anyone with an understanding of HTML;
+no knowledge of Python is required.
 
 
 Sphinx Templating

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -10,7 +10,7 @@ What Is Templating?
 -------------------
 
 Templating is a method of generating HTML pages by using template files that provide,
-not only the static parts of the desired HTML output, but also provides some special
+not only the static parts of the desired HTML output, but also provide some special
 syntax describing how content will be inserted.  Since template files function
 similar to Cascading Style Sheets, generating HTML pages this way provides a flexible
 way for Sphinx extensions (such as themes) to "inherit from" and modify basic

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -9,19 +9,21 @@ Templating
 What Is Templating?
 -------------------
 
-Templating is a method of generating HTML pages by combining data and static templates.
-The template files contain the static parts of the desired HTML output
-and include special syntax describing how variable content will be inserted.
-For example, this can be used to insert the current date in the footer of each page,
-or to surround the main content of the document with a scaffold of HTML for layout
-and formatting purposes.
-Using templates to generate HTML means that the content can be changed without altering
-Sphinx's source code, meaning that the Sphinx core can provide basic HTML generation,
-independent of the final output.
-Since template files function similar to Cascading Style Sheets,
-generating HTML pages this way provides a flexible way for Sphinx themes
-to "inherit from" and modify basic templates, or replace them altogether,
-to achieve customised HTML page layout.
+Templating is a method of generating HTML pages by combining data and static
+templates. The template files contain the static parts of the desired HTML output and
+include special syntax describing how variable content will be inserted. For example,
+this can be used to insert the current date in the footer of each page, or to
+surround the main content of the document with a scaffold of HTML for layout and
+formatting purposes.
+
+Using templates to generate HTML means that the content can be changed without
+altering Sphinx's source code, meaning that the Sphinx core can provide basic HTML
+generation, independent of the final output.
+
+Since template files function similar to Cascading Style Sheets, generating HTML
+pages this way provides a flexible way for Sphinx themes to "inherit from" and modify
+basic templates, or replace them altogether, to achieve customised HTML page layout.
+
 Similarly, any project can customise the theme it is using by the same mechanism,
 using locally-provided HTML templates, overriding those from the theme and Sphinx.
 Templates can be maintained by anyone with an understanding of HTML;

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -11,23 +11,20 @@ What Is Templating?
 
 Templating is a method of generating HTML pages by combining data and static
 templates.  The template files contain the static parts of the desired HTML output
-and include special syntax describing how variable content will be inserted. For
+and include special syntax describing how variable content will be inserted.  For
 example, this can be used to insert the current date in the footer of each page, or
 to surround the main content of the document with a scaffold of HTML for layout and
-formatting purposes.
+formatting purposes.  Doing so only requires an understanding of HTML and the
+templating syntax.  Knowledge of Python is helpful, but not required.
 
-Using templates to generate HTML means that the content can be changed without
-altering Sphinx's source code, meaning that the Sphinx core can provide basic HTML
-generation, independent of the final output.
+Templating uses an inheritance mechanism which allows child templates files (e.g.
+in a theme) to override as much (or as little) of Sphinx templates as desired.
+Likewise, content authors can use their own local templates to override as much (or
+as little) of the theme templates as desired.
 
-Since template files function similar to Cascading Style Sheets, generating HTML
-pages this way provides a flexible way for Sphinx themes to "inherit from" and modify
-basic templates, or replace them altogether, to achieve customised HTML page layout.
-
-Similarly, any project can customise the theme it is using by the same mechanism,
-using locally-provided HTML templates, overriding those from the theme and Sphinx.
-Templates can be maintained by anyone with an understanding of HTML;
-no knowledge of Python is required.
+The result is that the Sphinx core, wihtout needing to be changed, provides basic
+HTML generation, independent of the structure and appearance of the final output,
+while granting a great deal of flexibility to theme and content authors.
 
 
 Sphinx Templating

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -6,6 +6,24 @@
 Templating
 ==========
 
+What Is Templating?
+-------------------
+
+Templating is a method of generating HTML pages by using template files that provide,
+not only the static parts of the desired HTML output, but also provides some special
+syntax describing how content will be inserted.  Since template files function
+similar to Cascading Style Sheets, generating HTML pages this way provides a flexible
+way for Sphinx extensions (such as themes) to "inherit from" and modify basic
+templates, or replace them altogether, to achieve customized HTML page layout.
+Similarly, an individual documentation project can customize the theme it is using
+through the same mechanism, using locally-provided custom HTML templates.  Templates
+can be maintained by anyone with an understanding of HTML; no knowledge of Python is
+required.
+
+
+Sphinx Templating
+-----------------
+
 Sphinx uses the `Jinja <https://jinja.palletsprojects.com/>`_ templating engine
 for its HTML templates.  Jinja is a text-based engine, inspired by Django
 templates, so anyone having used Django will already be familiar with it. It

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -9,20 +9,22 @@ Templating
 What Is Templating?
 -------------------
 
-Templating is a method of generating HTML pages by combining data and static
-templates.  The template files contain the static parts of the desired HTML output
-and include special syntax describing how variable content will be inserted.  For
-example, this can be used to insert the current date in the footer of each page, or
-to surround the main content of the document with a scaffold of HTML for layout and
-formatting purposes.  Doing so only requires an understanding of HTML and the
-templating syntax.  Knowledge of Python is helpful, but not required.
+Templating is a method of generating HTML pages by combining static templates
+with variable data.
+The template files contain the static parts of the desired HTML output
+and include special syntax describing how variable content will be inserted.
+For example, this can be used to insert the current date in the footer of each page,
+or to surround the main content of the document with a scaffold of HTML for layout
+and formatting purposes.
+Doing so only requires an understanding of HTML and the templating syntax.
+Knowledge of Python can be helpful, but is not required.
 
-Templating uses an inheritance mechanism which allows child templates files (e.g.
-in a theme) to override as much (or as little) of Sphinx templates as desired.
+Templating uses an inheritance mechanism which allows child templates files
+(e.g. in a theme) to override as much (or as little) of their 'parents' as desired.
 Likewise, content authors can use their own local templates to override as much (or
 as little) of the theme templates as desired.
 
-The result is that the Sphinx core, wihtout needing to be changed, provides basic
+The result is that the Sphinx core, without needing to be changed, provides basic
 HTML generation, independent of the structure and appearance of the final output,
 while granting a great deal of flexibility to theme and content authors.
 

--- a/doc/development/html_themes/templating.rst
+++ b/doc/development/html_themes/templating.rst
@@ -10,10 +10,10 @@ What Is Templating?
 -------------------
 
 Templating is a method of generating HTML pages by combining data and static
-templates. The template files contain the static parts of the desired HTML output and
-include special syntax describing how variable content will be inserted. For example,
-this can be used to insert the current date in the footer of each page, or to
-surround the main content of the document with a scaffold of HTML for layout and
+templates.  The template files contain the static parts of the desired HTML output
+and include special syntax describing how variable content will be inserted. For
+example, this can be used to insert the current date in the footer of each page, or
+to surround the main content of the document with a scaffold of HTML for layout and
 formatting purposes.
 
 Using templates to generate HTML means that the content can be changed without


### PR DESCRIPTION
## Purpose

To more quickly orient the reader who is new to HTML templating.  (I was recently a beginner on the topic, and I found the introductory section I added to be missing, which made it more difficult to understand the subsequent content.)

## References

- https://docs.djangoproject.com/en/5.1/ref/templates/
- https://docs.djangoproject.com/en/5.1/topics/templates/