### PR TITLE
imgmath: Avoid parallel workers depth write race

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,6 +78,7 @@ Contributors
 * Josip Dzolonga -- coverage builder
 * Juan Luis Cano Rodríguez -- new tutorial (2021)
 * Julien Palard -- Colspan and rowspan in text builder
+* Julien Schueller -- imgmath module fix
 * Justus Magin -- napoleon improvements
 * Kazuya Take -- ``sphinx.testing.path`` bug fix
 * Kevin Dunn -- MathJax extension

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* Avoid parallel workers depth write race in imgmath extension.
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies = [
     "snowballstemmer>=2.2",
     "babel>=2.13",
     "alabaster>=0.7.14",
+    "filelock>=3.13",
     "imagesize>=1.3",
     "requests>=2.30.0",
     "roman-numerals>=1.0.0",

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -320,7 +320,8 @@ def clean_up_files(app: Sphinx, exc: Exception) -> None:
     else:
         # cleanup lock files when using parallel workers
         for lockfile in math_outdir.glob('*.lock'):
-            Path.unlink(lockfile)
+            with contextlib.suppress(OSError):
+                Path.unlink(lockfile)
 
 
 def get_tooltip(self: HTML5Translator, node: Element, *, config: Config) -> str:

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -18,6 +18,7 @@ from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from docutils import nodes
+from filelock import FileLock
 
 import sphinx
 from sphinx import package_dir
@@ -29,7 +30,6 @@ from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.template import LaTeXRenderer
 
 if TYPE_CHECKING:
-    from types import TracebackType
     from typing import Any
 
     from docutils.nodes import Element
@@ -60,48 +60,6 @@ class MathExtError(SphinxError):
 
 class InvokeError(SphinxError):
     """errors on invoking converters."""
-
-
-class FileLock:
-    """Locks a file from concurrent access."""
-
-    def __init__(self, path: str | os.PathLike[str]) -> None:
-        try:
-            self.fd = os.open(path, os.O_RDWR | os.O_CREAT)
-        except OSError:
-            with contextlib.suppress(OSError):
-                os.unlink(path)  # noqa: PTH108
-            raise
-
-    def __enter__(self) -> None:
-        try:
-            if os.name == 'posix':
-                os.lockf(self.fd, os.F_LOCK, 0)
-            elif os.name == 'nt':
-                import msvcrt
-
-                msvcrt.locking(self.fd, msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
-        except OSError:
-            with contextlib.suppress(OSError):
-                os.close(self.fd)
-            raise
-
-    def __exit__(
-        self,
-        typ: type[BaseException] | None,
-        val: BaseException | None,
-        tb: TracebackType | None,
-    ) -> None:
-        try:
-            if os.name == 'posix':
-                os.lockf(self.fd, os.F_ULOCK, 0)
-            elif os.name == 'nt':
-                import msvcrt
-
-                msvcrt.locking(self.fd, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
-        finally:
-            with contextlib.suppress(OSError):
-                os.close(self.fd)
 
 
 SUPPORT_FORMAT = ('png', 'svg')

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -66,15 +66,25 @@ class FileLock:
     """Locks a file from concurrent access."""
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
-        self.fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        try:
+            self.fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        except OSError:
+            with contextlib.suppress(OSError):
+                os.unlink(path)  # noqa: PTH108
+            raise
 
     def __enter__(self) -> None:
-        if os.name == 'posix':
-            os.lockf(self.fd, os.F_LOCK, 0)
-        elif os.name == 'nt':
-            import msvcrt
+        try:
+            if os.name == 'posix':
+                os.lockf(self.fd, os.F_LOCK, 0)
+            elif os.name == 'nt':
+                import msvcrt
 
-            msvcrt.locking(self.fd, msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+                msvcrt.locking(self.fd, msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+        except OSError:
+            with contextlib.suppress(OSError):
+                os.close(self.fd)
+            raise
 
     def __exit__(
         self,
@@ -82,13 +92,16 @@ class FileLock:
         val: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        if os.name == 'posix':
-            os.lockf(self.fd, os.F_ULOCK, 0)
-        elif os.name == 'nt':
-            import msvcrt
+        try:
+            if os.name == 'posix':
+                os.lockf(self.fd, os.F_ULOCK, 0)
+            elif os.name == 'nt':
+                import msvcrt
 
-            msvcrt.locking(self.fd, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
-        os.close(self.fd)
+                msvcrt.locking(self.fd, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(self.fd)
 
 
 SUPPORT_FORMAT = ('png', 'svg')

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -141,7 +141,7 @@ def test_imgmath_svg_parallel(app: SphinxTestApp) -> None:
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
     shutil.rmtree(app.outdir)
     html = base64.b64encode(b'<!-- DEPTH=0 -->\n<!-- DEPTH=0 -->\n').decode()
-    assert not re.search(html, content, re.DOTALL)
+    assert html not in content
 
 
 @pytest.mark.sphinx(

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -133,10 +133,10 @@ def test_imgmath_svg_parallel(app: SphinxTestApp) -> None:
     app.build(force_all=True)
     if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
         msg = 'LaTeX command "latex" is not available'
-        raise pytest.skip.Exception(msg)
+        pytest.skip(msg)
     if "dvisvgm command 'dvisvgm' cannot be run" in app.warning.getvalue():
         msg = 'dvisvgm command "dvisvgm" is not available'
-        raise pytest.skip.Exception(msg)
+        pytest.skip(msg)
 
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
     shutil.rmtree(app.outdir)

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import re
 import shutil
 import subprocess
@@ -112,6 +113,35 @@ def test_imgmath_svg_embed(app: SphinxTestApp) -> None:
     shutil.rmtree(app.outdir)
     html = r'<img src="data:image/svg\+xml;base64,[\w\+/=]+"'
     assert re.search(html, content, re.DOTALL)
+
+
+@pytest.mark.skipif(
+    not has_binary('dvisvgm'),
+    reason='Requires dvisvgm" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math-simple',
+    parallel=4,
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_image_format': 'svg',
+        'imgmath_embed': True,
+    },
+)
+def test_imgmath_svg_parallel(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvisvgm command 'dvisvgm' cannot be run" in app.warning.getvalue():
+        msg = 'dvisvgm command "dvisvgm" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    shutil.rmtree(app.outdir)
+    html = base64.b64encode(b'<!-- DEPTH=0 -->\n<!-- DEPTH=0 -->\n').decode()
+    assert not re.search(html, content, re.DOTALL)
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
Ensure parallel workers do not try to write the image depth multiple times to achieve reproducible builds without -j1.

Typically some of my svg files randomly ended up like this:
```
...
<!-- DEPTH=0 -->
<!-- DEPTH=0 -->
```
So images were not the same and sometimes the depth was incorrect too.

Introduces a new dependency to the filelock module though.

My project openturns has a pretty big doc with ~8k math formulas and I didnt notice any slowdown with this (-j8).

