### PR TITLE
Tests: uncover a quirk in our linkcheck tests

### DIFF
--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -715,6 +715,7 @@ def make_redirect_handler(*, support_head: bool) -> type[BaseHTTPRequestHandler]
 )
 def test_follows_redirects_on_HEAD(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=True)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')
@@ -738,6 +739,7 @@ def test_follows_redirects_on_HEAD(app, capsys):
 )
 def test_follows_redirects_on_GET(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=False)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')


### PR DESCRIPTION
## Purpose
This change only affects our test suite; it exposes a quirk in behaviour as a result of an [event-based](https://github.com/sphinx-doc/sphinx/blob/a6d7ae16739bf92a032a7c4df0297db7cf120ec9/sphinx/builders/linkcheck.py#L816) call to the [`compile_linkcheck_allowed_redirects` method](https://github.com/sphinx-doc/sphinx/blob/a6d7ae16739bf92a032a7c4df0297db7cf120ec9/sphinx/builders/linkcheck.py#L751-L772) (a fairly self-descriptive method).

This is a limitation of our `linkcheck` testsuite; some test cases may unwittingly rely on the compilation step.

Had this compilation been in place - reflecting how a `sphinx-build -b linkcheck ...` session would usually proceed -- then tests would have begun failing with the merge of #13452.

I think it suggests an unexpected change-in-default behaviour; confirming that tests fail for this PR could help to demonstrate the problem and discuss it.

## References
- Discovered during investigation of #13462.
- Relates to #13452.