### PR TITLE
linkcheck: retain default do-not-follow for redirects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,9 @@ Features added
 * #13332: Add :confval:`doctest_fail_fast` option to exit after the first failed
   test.
   Patch by Till Hoffmann.
-* #13439: linkcheck: Permit warning on every redirect with
+* #13439, #13462: linkcheck: Permit warning on every redirect with
   ``linkcheck_allowed_redirects = {}``.
-  Patch by Adam Turner.
+  Patch by Adam Turner and James Addison.
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -3642,6 +3642,7 @@ and which failures and redirects it ignores.
 
 .. confval:: linkcheck_allowed_redirects
    :type: :code-py:`dict[str, str]`
+   :default: :code-py:`{}` (do not follow)
 
    A dictionary that maps a pattern of the source URI
    to a pattern of the canonical URI.
@@ -3654,6 +3655,10 @@ and which failures and redirects it ignores.
    it finds redirected links that don't meet the rules above.
    It can be useful to detect unexpected redirects when using
    :option:`the fail-on-warnings mode <sphinx-build --fail-on-warning>`.
+
+   To deny all redirects, configure an empty dictionary (the default).
+
+   To follow all redirections, configure a value of :code-py:`None`.
 
    Example:
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -715,6 +715,7 @@ def make_redirect_handler(*, support_head: bool) -> type[BaseHTTPRequestHandler]
 )
 def test_follows_redirects_on_HEAD(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=True)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')
@@ -738,6 +739,7 @@ def test_follows_redirects_on_HEAD(app, capsys):
 )
 def test_follows_redirects_on_GET(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=False)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -714,6 +714,7 @@ def make_redirect_handler(*, support_head: bool = True) -> type[BaseHTTPRequestH
 )
 def test_follows_redirects_on_HEAD(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=True)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')
@@ -735,6 +736,7 @@ def test_follows_redirects_on_HEAD(app, capsys):
 )
 def test_follows_redirects_on_GET(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=False)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -714,7 +714,6 @@ def make_redirect_handler(*, support_head: bool = True) -> type[BaseHTTPRequestH
 )
 def test_follows_redirects_on_HEAD(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=True)) as address:
-        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')
@@ -736,7 +735,6 @@ def test_follows_redirects_on_HEAD(app, capsys):
 )
 def test_follows_redirects_on_GET(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=False)) as address:
-        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')


### PR DESCRIPTION
## Purpose
From some [recent notes I've made](https://github.com/sphinx-doc/sphinx/issues/13439#issuecomment-2779471517) about this draft, the behaviour is:

* `linkcheck_allowed_redirects:{}`: **default** warn and log redirects without following them
* `linkcheck_allowed_redirects:None`: follow all redirects, do not warn about them
* `linkcheck_allowed_redirects:{...}`: unmodified

## References
- Resolves #13462.
- Relates-to #13439.
- Tests should succeed both with and without #13466.