### PR TITLE
Removed autosummary non existing templates

### DIFF
--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -301,9 +301,6 @@ Autosummary uses the following Jinja template files:
 - :file:`autosummary/base.rst` -- fallback template
 - :file:`autosummary/module.rst` -- template for modules
 - :file:`autosummary/class.rst` -- template for classes
-- :file:`autosummary/function.rst` -- template for functions
-- :file:`autosummary/attribute.rst` -- template for class attributes
-- :file:`autosummary/method.rst` -- template for class methods
 
 The following variables are available in the templates:
 


### PR DESCRIPTION
## Purpose

Reading `autosummary` extension documentation, "Customizing templates", I noticed some of the templates files described did not exist in `sphinx/ext/autosummary/templates/autosummary/`.

- `autosummary/function.rst` – template for functions
- `autosummary/attribute.rst` – template for class attributes
- `autosummary/method.rst` – template for class methods

This pull request removed this part from the `autosummary`  documentation page.