### PR TITLE
Update arg lists for 2 events in ``event_callbacks.rst``

### DIFF
--- a/doc/extdev/event_callbacks.rst
+++ b/doc/extdev/event_callbacks.rst
@@ -70,8 +70,8 @@ Below is an overview of the core event that happens during a build.
       14. apply post-transforms (by priority): docutils.document -> docutils.document
       15. event.doctree-resolved(app, doctree, docname)
           - In the event that any reference nodes fail to resolve, the following may emit:
-          - event.missing-reference(env, node, contnode)
-          - event.warn-missing-reference(domain, node)
+          - event.missing-reference(app, env, node, contnode)
+          - event.warn-missing-reference(app, domain, node)
 
    16. Generate output files
    17. event.build-finished(app, exception)


### PR DESCRIPTION
## Purpose

Documentation in `./doc/extdev/event_callbacks.rst` showed 2 events with an old (or incomplete) list of arguments in the "Core events overview" section, specifically their leading `app` argument.  This was remedied.

## References

- Python/Lib/site-packages/sphinx/domains/std/__init__.py line 1443 function:
  ```python
  def warn_missing_reference(
      app: Sphinx,
      domain: Domain,
      node: pending_xref,
  ) -> bool | None:
      ...
  ```
- Python/Lib/site-packages/sphinx/ext/intersphinx/_resolve.py line 339 function:
  ```python
  def missing_reference(
      app: Sphinx, env: BuildEnvironment, node: pending_xref, contnode: TextElement
  ) -> nodes.reference | None:
      """Attempt to resolve a missing reference via intersphinx references."""
      return resolve_reference_detect_inventory(env, node, contnode)
  ```
