### PR TITLE
remove 'target-version' from ruff config

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,3 @@
-target-version = "py311"  # Pin Ruff to Python 3.11
 line-length = 88
 output-format = "full"
 


### PR DESCRIPTION
this value is not needed when 'requires-python' version is set in pyproject.toml