### PR TITLE
Tests: linkcheck: ensure Python clock timezone is reset during test teardown

### DIFF
--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1144,6 +1144,8 @@ def test_too_many_requests_retry_after_HTTP_date(tz, app, monkeypatch, capsys):
         """,
     )
 
+    # Teardown: the monkeypatch context manager clears the TZ environment variable, but
+    # we also need to reset Python's internal notion of the current timezone.
     if sys.platform != 'win32':
         time.tzset()
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1127,6 +1127,12 @@ def test_too_many_requests_retry_after_HTTP_date(tz, app, monkeypatch, capsys):
         ) as address:
             app.build()
 
+    # Undo side-effects: the monkeypatch context manager clears the TZ environment
+    # variable, but we also need to reset Python's internal notion of the current
+    # timezone.
+    if sys.platform != 'win32':
+        time.tzset()
+
     content = (app.outdir / 'output.json').read_text(encoding='utf8')
     assert json.loads(content) == {
         'filename': 'index.rst',
@@ -1143,11 +1149,6 @@ def test_too_many_requests_retry_after_HTTP_date(tz, app, monkeypatch, capsys):
         127.0.0.1 - - [] "HEAD / HTTP/1.1" 200 -
         """,
     )
-
-    # Teardown: the monkeypatch context manager clears the TZ environment variable, but
-    # we also need to reset Python's internal notion of the current timezone.
-    if sys.platform != 'win32':
-        time.tzset()
 
 
 @pytest.mark.sphinx(

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1144,6 +1144,9 @@ def test_too_many_requests_retry_after_HTTP_date(tz, app, monkeypatch, capsys):
         """,
     )
 
+    if sys.platform != 'win32':
+        time.tzset()
+
 
 @pytest.mark.sphinx(
     'linkcheck',


### PR DESCRIPTION
## Purpose

Resolves a small quirk in the `test_too_many_requests_retry_after_HTTP_date` test case; after [monkeypatching](https://docs.pytest.org/en/stable/how-to/monkeypatch.html) the `TZ` environment variable and calling [`time.tzset`](https://docs.python.org/3/library/time.html#time.tzset), the internal state is prepared correctly for each parameterized run of the test case.

The context manager for the monkeypatch clears the `TZ` environment variable, but doesn't intrinsically know that another `time.tzset` call is required to properly reset Python's system clock / timezone state.

## References

- Relates to #11649.

cc @mitya57 