### PR TITLE
Work-in-progress: resolve docutils v0.22-dev test regressions

### DIFF
--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -40,6 +40,7 @@ def make_directive_and_state(
     inliner.init_customizations(state.document.settings)
     state.inliner = inliner
     state.parent = None
+    # https://repo.or.cz/docutils.git/blob/2310dd9b468e9f86b00401b1aa60d47aabc199ac:/docutils/docutils/parsers/rst/states.py#l162
     state.memo = Struct(document=state.document,
                         reporter=state.document.reporter,
                         language=english,

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -40,7 +40,6 @@ def make_directive_and_state(
     inliner.init_customizations(state.document.settings)
     state.inliner = inliner
     state.parent = None
-    # https://repo.or.cz/docutils.git/blob/2310dd9b468e9f86b00401b1aa60d47aabc199ac:/docutils/docutils/parsers/rst/states.py#l162
     state.memo = Struct(document=state.document,
                         reporter=state.document.reporter,
                         language=english,

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -8,6 +8,7 @@ from docutils.parsers.rst.states import (
     Inliner,
     RSTState,
     RSTStateMachine,
+    Struct,
     state_classes,
 )
 from docutils.statemachine import StringList
@@ -39,14 +40,14 @@ def make_directive_and_state(
     inliner.init_customizations(state.document.settings)
     state.inliner = inliner
     state.parent = None
-    state.memo = SimpleNamespace(
-        document=state.document,
-        language=english,
-        inliner=state.inliner,
-        reporter=state.document.reporter,
-        section_level=0,
-        title_styles=[],
-    )
+    state.memo = Struct(document=state.document,
+                        reporter=state.document.reporter,
+                        language=english,
+                        title_styles=[],
+                        section_parents=[],
+                        section_level=0,  # will be removed in Docutils 2.0
+                        section_bubble_up_kludge=False,  # will be removed
+                        inliner=inliner)
     directive = SphinxDirective(
         name='test_directive',
         arguments=[],

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -46,6 +46,7 @@ def make_directive_and_state(
         reporter=state.document.reporter,
         section_level=0,
         title_styles=[],
+        section_parents=[],
     )
     directive = SphinxDirective(
         name='test_directive',

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -8,7 +8,6 @@ from docutils.parsers.rst.states import (
     Inliner,
     RSTState,
     RSTStateMachine,
-    Struct,
     state_classes,
 )
 from docutils.statemachine import StringList
@@ -40,14 +39,14 @@ def make_directive_and_state(
     inliner.init_customizations(state.document.settings)
     state.inliner = inliner
     state.parent = None
-    state.memo = Struct(document=state.document,
-                        reporter=state.document.reporter,
-                        language=english,
-                        title_styles=[],
-                        section_parents=[],
-                        section_level=0,  # will be removed in Docutils 2.0
-                        section_bubble_up_kludge=False,  # will be removed
-                        inliner=inliner)
+    state.memo = SimpleNamespace(
+        document=state.document,
+        language=english,
+        inliner=state.inliner,
+        reporter=state.document.reporter,
+        section_level=0,
+        title_styles=[],
+    )
     directive = SphinxDirective(
         name='test_directive',
         arguments=[],

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -41,16 +41,14 @@ def make_directive_and_state(
     state.inliner = inliner
     state.parent = None
     # https://repo.or.cz/docutils.git/blob/2310dd9b468e9f86b00401b1aa60d47aabc199ac:/docutils/docutils/parsers/rst/states.py#l162
-    state.memo = Struct(
-        document=state.document,
-        reporter=state.document.reporter,
-        language=english,
-        title_styles=[],
-        section_parents=[],
-        section_level=0,  # will be removed in Docutils 2.0
-        section_bubble_up_kludge=False,  # will be removed
-        inliner=inliner,
-    )
+    state.memo = Struct(document=state.document,
+                        reporter=state.document.reporter,
+                        language=english,
+                        title_styles=[],
+                        section_parents=[],
+                        section_level=0,  # will be removed in Docutils 2.0
+                        section_bubble_up_kludge=False,  # will be removed
+                        inliner=inliner)
     directive = SphinxDirective(
         name='test_directive',
         arguments=[],

--- a/tests/test_util/test_util_docutils_sphinx_directive.py
+++ b/tests/test_util/test_util_docutils_sphinx_directive.py
@@ -41,14 +41,16 @@ def make_directive_and_state(
     state.inliner = inliner
     state.parent = None
     # https://repo.or.cz/docutils.git/blob/2310dd9b468e9f86b00401b1aa60d47aabc199ac:/docutils/docutils/parsers/rst/states.py#l162
-    state.memo = Struct(document=state.document,
-                        reporter=state.document.reporter,
-                        language=english,
-                        title_styles=[],
-                        section_parents=[],
-                        section_level=0,  # will be removed in Docutils 2.0
-                        section_bubble_up_kludge=False,  # will be removed
-                        inliner=inliner)
+    state.memo = Struct(
+        document=state.document,
+        reporter=state.document.reporter,
+        language=english,
+        title_styles=[],
+        section_parents=[],
+        section_level=0,  # will be removed in Docutils 2.0
+        section_bubble_up_kludge=False,  # will be removed
+        inliner=inliner,
+    )
     directive = SphinxDirective(
         name='test_directive',
         arguments=[],


### PR DESCRIPTION
## Purpose

Get the unit test suite passing again for the [`docutils` HEAD](https://github.com/sphinx-doc/sphinx/blob/c4929d026c8d22ba229b39cfc2250a9eb1476282/.github/workflows/main.yml#L217-L254) workflow job.

## References

- Resolves #13539.