### PR TITLE
make: Let Python interpreter load Sphinx from local repository first

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,9 @@
 #
 PYTHON ?= python3
 
+# Let Python interpreter load Sphinx from local repository first.
+export PYTHONPATH=../:$$PYTHONPATH
+
 # You can set these variables from the command line.
 SPHINXOPTS   =
 SPHINXBUILD  = $(PYTHON) ../sphinx/cmd/build.py


### PR DESCRIPTION


## Purpose

I noticed that `doc/Makefile` uses system-installed Sphinx instead of the local repository version  

Is this intentional? If not, this PR inserts the local repository path to `PYTHONPATH` to ask the Python interpreter to load Sphinx from the local repository first.