### PR TITLE
Fix typographical mistake for linkcheck_allowed_redirects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -102,6 +102,7 @@ Contributors
 * Slawek Figiel -- additional warning suppression
 * Stefan Seefeld -- toctree improvements
 * Stefan van der Walt -- autosummary extension
+* Steve Piercy -- documentation improvements
 * \T. Powers -- HTML output improvements
 * Taku Shimizu -- epub3 builder
 * Thomas Lamb -- linkcheck builder

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ Bugs fixed
 
 * #13369: Correctly parse and cross-reference unpacked type annotations.
   Patch by Alicia Garcia-Raboso.
-* #13550: Fix typographical mistake for `linkcheck_allowed_redirects`.
+* #13550: Fix typographical mistake for ``linkcheck_allowed_redirects``.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,6 @@ Bugs fixed
 
 * #13369: Correctly parse and cross-reference unpacked type annotations.
   Patch by Alicia Garcia-Raboso.
-* #13550: Fix typographical mistake for ``linkcheck_allowed_redirects``.
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Bugs fixed
 
 * #13369: Correctly parse and cross-reference unpacked type annotations.
   Patch by Alicia Garcia-Raboso.
+* #13550: Fix typographical mistake for `linkcheck_allowed_redirects`.
 
 Testing
 -------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -3668,7 +3668,7 @@ and which failures and redirects it ignores.
    .. versionadded:: 4.1
 
    .. versionchanged:: 8.3
-      Setting :confval:`!linkcheck_allowed_redirects` to the empty directory
+      Setting :confval:`!linkcheck_allowed_redirects` to an empty dictionary
       may now be used to warn on all redirects encountered
       by the *linkcheck* builder.
 


### PR DESCRIPTION
## Purpose

Fix typographical mistake in `versionchanged` 8.3 admonition for `linkcheck_allowed_redirects` in user-facing documentation at https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_allowed_redirects.

This might need to be backported to other branches.
