### PR TITLE
LaTeX: fix the #13525 fix of code-tex markup in docs

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -500,7 +500,7 @@ Keys that don't need to be overridden unless in special cases are:
    .. hint::
 
       If the key value is set to
-      :code-tex:`r'\\newcommand\\sphinxbackoftitlepage{<Extra
+      :code-tex:`'\\newcommand\\sphinxbackoftitlepage{<Extra
       material>}\\sphinxmaketitle'`, then ``<Extra material>`` will be
       typeset on back of title page (``'manual'`` docclass only).
 


### PR DESCRIPTION
#13525 added some missing backslash to LaTeX mark-up provided in our docs but then the `r` must be removed.  Else:

```text
! LaTeX Error: There's no line here to end.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.80 \\n
        ewcommand\\sphinxbackoftitlepage{Hello}\\sphinxmaketitle
? X
No pages of output.
```

