### PR TITLE
Revert "LaTeX: fix the #13525 fix of code-tex markup in docs"

### DIFF
--- a/doc/latex.rst
+++ b/doc/latex.rst
@@ -500,7 +500,7 @@ Keys that don't need to be overridden unless in special cases are:
    .. hint::
 
       If the key value is set to
-      :code-tex:`'\\newcommand\\sphinxbackoftitlepage{<Extra
+      :code-tex:`r'\\newcommand\\sphinxbackoftitlepage{<Extra
       material>}\\sphinxmaketitle'`, then ``<Extra material>`` will be
       typeset on back of title page (``'manual'`` docclass only).
 


### PR DESCRIPTION
This reverts commit 05137c25acf99c07badd6de25379fcfd8a6a120c. (PR #13557)

Sorry about that @SilverRainZ

See https://github.com/sphinx-doc/sphinx/pull/13557#issuecomment-2879708729