### PR TITLE
docs(referencing.rst):  add additional data about :doc: role

### DIFF
--- a/doc/usage/referencing.rst
+++ b/doc/usage/referencing.rst
@@ -136,17 +136,14 @@ There is also a way to directly link to documents:
 
 .. rst:role:: doc
 
-   Link to the specified document; the document name can be specified in
-   absolute or relative fashion.  For example, if the reference
+   Link to the specified document; the document name is a case-sensitive
+   relative or absolute path.  For example, if the reference
    ``:doc:`parrot``` occurs in the document ``sketches/index``, then the link
    refers to ``sketches/parrot``.  If the reference is ``:doc:`/people``` or
    ``:doc:`../people```, the link refers to ``people``.
 
    If no explicit link text is given (like usual: ``:doc:`Monty Python members
    </people>```), the link caption will be the title of the given document.
-
-   Note that the string inside the single quotes must be a case-sensitive with
-   the file name, even on Windows.
 
 
 Referencing downloadable files

--- a/doc/usage/referencing.rst
+++ b/doc/usage/referencing.rst
@@ -145,6 +145,9 @@ There is also a way to directly link to documents:
    If no explicit link text is given (like usual: ``:doc:`Monty Python members
    </people>```), the link caption will be the title of the given document.
 
+   Note that the string inside the single quotes must be a case-sensitive with
+   the file name, even on Windows.
+
 
 Referencing downloadable files
 ------------------------------

--- a/doc/usage/referencing.rst
+++ b/doc/usage/referencing.rst
@@ -136,8 +136,8 @@ There is also a way to directly link to documents:
 
 .. rst:role:: doc
 
-   Link to the specified document; the document name is a case-sensitive
-   relative or absolute path.  For example, if the reference
+   Link to the specified document; the document name can be a relative or absolute
+   path and is always case-sensitive, even on Windows.  For example, if the reference
    ``:doc:`parrot``` occurs in the document ``sketches/index``, then the link
    refers to ``sketches/parrot``.  If the reference is ``:doc:`/people``` or
    ``:doc:`../people```, the link refers to ``people``.


### PR DESCRIPTION
## Purpose

I just this morning discovered (by investigating a `WARNING: unknown document: '<name>' [ref.doc]` message) that the `:doc:` needs to perform a case-sensitive filename match, even on Windows!  That is good to know, and if it had been mentioned in the documentation, would not have cost me the time it cost to resolve.  So I want to leave a helpful trail behind me that will help others who need to know this.

## References

n/a