### PR TITLE
LaTeX: render hyperlinks which are in titles 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so
 *.swp
 
+.auto/
 .dir-locals.el
 .cache/
 .idea

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Features added
 Bugs fixed
 ----------
 
+* #12821: LaTeX: URLs/links in section titles should render in PDF.
+  Patch by Jean-François B.
 * #13369: Correctly parse and cross-reference unpacked type annotations.
   Patch by Alicia Garcia-Raboso.
 * #13528: Add tilde ``~`` prefix support for :rst:role:`py:deco`.

--- a/sphinx/texinputs/sphinxlatexstyletext.sty
+++ b/sphinx/texinputs/sphinxlatexstyletext.sty
@@ -1,7 +1,7 @@
 %% TEXT STYLING
 %
 % change this info string if making any custom modification
-\ProvidesPackage{sphinxlatexstyletext}[2024/07/28 v8.1.0 text styling]
+\ProvidesPackage{sphinxlatexstyletext}[2025/05/24 v8.3.0 text styling]
 
 % 7.4.0 has moved all that is related to admonitions to sphinxlatexadmonitions.sty
 % 8.1.0 has moved topic/contents/sidebar to sphinxlatexshadowbox.sty
@@ -57,7 +57,11 @@
 % reduce hyperref "Token not allowed in a PDF string" warnings on PDF builds
 \AtBeginDocument{\pdfstringdefDisableCommands{%
 % all "protected" macros possibly ending up in section titles should be here
-% TODO: examine if \sphinxhref, \sphinxurl, \sphinnolinkurl should be handled
+% next four were added so that URLs and internal links in titles can be allowed
+    \let\sphinxurl      \@firstofone
+    \let\sphinxnolinkurl\@firstofone
+    \let\sphinxhref     \@secondoftwo
+    \def\hyperref[#1]#2{#2}% for PDF bookmark to ignore #1
     \let\sphinxstyleemphasis        \@firstofone
     \let\sphinxstyleliteralemphasis \@firstofone
     \let\sphinxstylestrong          \@firstofone

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1962,7 +1962,7 @@ class LaTeXTranslator(SphinxTranslator):
         uri = node.get('refuri', '')
         if not uri and node.get('refid'):
             uri = '%' + self.curfilestack[-1] + '#' + node['refid']
-        if self.in_title or not uri:
+        if not uri:
             self.context.append('')
         elif uri.startswith('#'):
             # references to labels in the same document

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -469,3 +469,9 @@ Smart quotes
 
 .. [#] Like footnotes.
 
+
+Link in a title: `Field lists <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#field-lists>`_
+---------------------------------------------------------------------------------------------------------------------
+
+Again: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#field-lists
+------------------------------------------------------------------------------------------

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -72,6 +72,17 @@ def compile_latex_document(app, filename='projectnamenotset.tex', docclass='manu
                 filename,
             ]
             subprocess.run(args, capture_output=True, check=True)
+            # Run a second time (if engine is pdflatex), to have a chance to
+            # detect problems caused on second LaTeX pass (for example, this
+            # is required for the TOC in PDF to show up, for internal
+            # hyperlinks to actually work).  Of course, this increases
+            # duration of test, but also its usefulness.
+            # TODO: in theory the correct way is to run Latexmk with options
+            # as configured in the Makefile and in presence of latexmkrc
+            # or latexmkjarc and also sphinx.xdy and other xindy support.
+            # And two passes are not enough except for simplest documents.
+            if app.config.latex_engine == 'pdflatex':
+                subprocess.run(args, capture_output=True, check=True)
     except OSError as exc:  # most likely the latex executable was not found
         raise pytest.skip.Exception from exc
     except CalledProcessError as exc:


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Fix #12821 per the discussion there (sorry for delay).

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

- I added a test along the lines of https://github.com/sphinx-doc/sphinx/issues/12821#issuecomment-2308750051 i.e. with an URL using `#` as this is potentially dangerous in LaTeX,
- I included a commit to execute `pdflatex` twice when building a PDF document during our CI/LaTeX tests; this is not quite yet an exact mirroring of what happens in real world which uses `Latexmk`, but such a change is required in the context of this PR, as hyperlinks in section titles navigate to the auxiliary `.toc` file and only in second LaTeX pass are parsed again by LaTeX and it is needed to test nothing bad happens at that stage,
- This PR also includes an unrelated `.gitignore` update which is for my comfort when using Emacs/AUCTeX for the editing of LaTeX files in `sphinx/texinputs`.


