### PR TITLE
sphinx.util.logging: Make write() methods return int

### DIFF
--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -583,13 +583,13 @@ class SafeEncodingWriter:
         self.stream = stream
         self.encoding = getattr(stream, 'encoding', 'ascii') or 'ascii'
 
-    def write(self, data: str) -> None:
+    def write(self, data: str) -> int:
         try:
-            self.stream.write(data)
+            return self.stream.write(data)
         except UnicodeEncodeError:
             # stream accept only str, not bytes.  So, we encode and replace
             # non-encodable characters, then decode them.
-            self.stream.write(
+            return self.stream.write(
                 data.encode(self.encoding, 'replace').decode(self.encoding)
             )
 
@@ -604,8 +604,9 @@ class LastMessagesWriter:
     def __init__(self, app: Sphinx, stream: IO[str]) -> None:
         self.app = app
 
-    def write(self, data: str) -> None:
+    def write(self, data: str) -> int:
         self.app.messagelog.append(data)
+        return len(data)
 
 
 def setup(app: Sphinx, status: IO[str], warning: IO[str]) -> None:


### PR DESCRIPTION
## Purpose

In typeshed, we're currently switching from our old custom protocol `_typeshed.SupportsWrite` to the new `Writer` protocol (in Python 3.14's `io` module and backported to `typing_extensions` starting with 4.14.0). One incompatibility is that `Writer.write()` expects an `int` return type, while `SupportsWrite.write()` was using `object`. This leads to a few new type errors in Sphinx (as pointed out by mypy_primer).

This PR fixes upcoming type check errors in Sphinx, but also makes the two logging writer classes more compatible by returning the number of written bytes from `write()`.

Does this require an entry in `CHANGES.rst` or are the classes in util internal-facing?

## References

See python/typeshed#14149 for background.
