### PR TITLE
Tests: unpick patch for Py314a7 no longer required with Py314b2

### DIFF
--- a/tests/test_extensions/test_ext_autodoc_configs.py
+++ b/tests/test_extensions/test_ext_autodoc_configs.py
@@ -1348,11 +1348,6 @@ def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
     # default
     options = {'members': None}
     actual = do_autodoc(app, 'module', 'target.autodoc_type_aliases', options)
-    attr2_typeinfo: tuple[str, ...]
-    if sys.version_info >= (3, 14, 0, 'alpha', 7):
-        attr2_typeinfo = ()
-    else:
-        attr2_typeinfo = ('      :type: int',)
     assert list(actual) == [
         '',
         '.. py:module:: target.autodoc_type_aliases',
@@ -1373,7 +1368,7 @@ def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
         '',
         '   .. py:attribute:: Foo.attr2',
         '      :module: target.autodoc_type_aliases',
-        *attr2_typeinfo,
+        '      :type: int',
         '',
         '      docstring',
         '',
@@ -1426,10 +1421,6 @@ def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
         'io.StringIO': 'my.module.StringIO',
     }
     actual = do_autodoc(app, 'module', 'target.autodoc_type_aliases', options)
-    if sys.version_info >= (3, 14, 0, 'alpha', 7):
-        attr2_typeinfo = ()
-    else:
-        attr2_typeinfo = ('      :type: myint',)
     assert list(actual) == [
         '',
         '.. py:module:: target.autodoc_type_aliases',
@@ -1450,7 +1441,7 @@ def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
         '',
         '   .. py:attribute:: Foo.attr2',
         '      :module: target.autodoc_type_aliases',
-        *attr2_typeinfo,
+        '      :type: myint',
         '',
         '      docstring',
         '',


### PR DESCRIPTION
## Purpose

This changeset is intended to get the Sphinx unit tests for Python 3.14 passing again in pull requests.  A recent test suite failure on Py3.14b2 can be found at: https://github.com/sphinx-doc/sphinx/actions/runs/15389148337/job/43294393665

## References

- Partially reverts #13527.
- TODO: figure out why hyperlink label IDs in `./tests/roots/test-latex-labels/index.rst` change and/or why a `phantomlabel` is created as a result of `docutils` [`b25db649a5d073d76424e6434e12cdba53ed57e8`](https://repo.or.cz/docutils.git/commit/b25db649a5d073d76424e6434e12cdba53ed57e8).