### PR TITLE
LaTeX: revisit and trim visit_target()

### DIFF
--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1889,35 +1889,14 @@ class LaTeXTranslator(SphinxTranslator):
                 and node['refid'] == prev_node['refid']
             ):
                 # a target for a hyperlink reference having alias
-                pass
+                return
             else:
                 add_target(node['refid'])
-        # Temporary fix for https://github.com/sphinx-doc/sphinx/issues/11093
-        # TODO: investigate if a more elegant solution exists
-        # (see comments of https://github.com/sphinx-doc/sphinx/issues/11093)
-        if node.get('ismod', False):
-            # Detect if the previous nodes are label targets. If so, remove
-            # the refid thereof from node['ids'] to avoid duplicated ids.
-            prev = get_prev_node(node)
-            if self._has_dup_label(prev, node):
-                ids = node['ids'][:]  # copy to avoid side-effects
-                while self._has_dup_label(prev, node):
-                    ids.remove(prev['refid'])  # type: ignore[index]
-                    prev = get_prev_node(prev)  # type: ignore[arg-type]
-            else:
-                ids = iter(node['ids'])  # read-only iterator
-        else:
-            ids = iter(node['ids'])  # read-only iterator
-
-        for id in ids:
+        for id in node['ids']:
             add_target(id)
 
     def depart_target(self, node: Element) -> None:
         pass
-
-    @staticmethod
-    def _has_dup_label(sib: Node | None, node: Element) -> bool:
-        return isinstance(sib, nodes.target) and sib.get('refid') in node['ids']
 
     def visit_attribution(self, node: Element) -> None:
         self.body.append(CR + r'\begin{flushright}' + CR)

--- a/tests/roots/test-latex-labels/index.rst
+++ b/tests/roots/test-latex-labels/index.rst
@@ -69,6 +69,6 @@ subsubsection
 
    otherdoc
 
-* Embedded standalone hyperlink reference: `subsection <section1_>`_.
+* Named hyperlink reference with embedded alias reference: `subsection <section1_>`_.
 
   .. See: https://github.com/sphinx-doc/sphinx/issues/5948

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -2019,9 +2019,11 @@ def test_latex_labels(app: SphinxTestApp) -> None:
         r'\label{\detokenize{otherdoc::doc}}'
     ) in result
 
-    # Embedded standalone hyperlink reference
+    # Named hyperlink reference with embedded alias reference
     # See: https://github.com/sphinx-doc/sphinx/issues/5948
     assert result.count(r'\label{\detokenize{index:section1}}') == 1
+    # https://github.com/sphinx-doc/sphinx/issues/13609
+    assert r'\phantomsection\label{\detokenize{index:id' not in result
 
 
 @pytest.mark.sphinx('latex', testroot='latex-figure-in-admonition')


### PR DESCRIPTION
Refs: #13609, #11093 (#11333), #6026 (#6051).

- Fix misnomer in test-latex-labels/index.rst text.

  Refs: https://github.com/sphinx-doc/sphinx/issues/13609#issuecomment-2934964031

- Patch writers/latex.py as per the proposal at end of: https://github.com/sphinx-doc/sphinx/issues/13609#issuecomment-2937087733

- Update test_latex_build.py::test_latex_labels to detect non desired extra label in LaTeX output.

Nota bene: this commit does not revert "Tests: update LaTeX label test expectations from Docutils r10151 (#13610)" (commit 68d56109ff50dd81dd31d4a01e3dccbd006c50ee) as it is still necessary for compatibility with both Docutils 0.21.2 and Docutils HEAD at their r10151.

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->



