### PR TITLE
Close #13597 (LaTeX table in merged cell of parent table)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Features added
   Patch by Jean-François B.
 * #13535: html search: Update to the latest version of Snowball (v3.0.1).
   Patch by Adam Turner.
+* #13597: LaTeX: table nested in a merged cell leads to invalid LaTeX mark-up
+  and PDF cannot be built.
+  Patch by Jean-François B.
 * #13704: autodoc: Detect :py:func:`typing_extensions.overload <typing.overload>`
   and :py:func:`~typing.final` decorators.
   Patch by Spencer Brown.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -134,6 +134,7 @@ class Table:
         self.has_problematic = False
         self.has_oldproblematic = False
         self.has_verbatim = False
+        self.entry_needs_linetrimming = 0
         self.caption: list[str] = []
         self.stubs: list[int] = []
 
@@ -327,7 +328,6 @@ class LaTeXTranslator(SphinxTranslator):
         self.in_footnote = 0
         self.in_caption = 0
         self.in_term = 0
-        self.needs_linetrimming = 0
         self.in_minipage = 0
         # only used by figure inside an admonition
         self.no_latex_floats = 0
@@ -1331,7 +1331,7 @@ class LaTeXTranslator(SphinxTranslator):
                 r'\par' + CR + r'\vskip-\baselineskip'
                 r'\vbox{\hbox{\strut}}\end{varwidth}%' + CR + context
             )
-            self.needs_linetrimming = 1
+            self.table.entry_needs_linetrimming = 1
         if len(list(node.findall(nodes.paragraph))) >= 2:
             self.table.has_oldproblematic = True
         if (
@@ -1346,13 +1346,14 @@ class LaTeXTranslator(SphinxTranslator):
                 pass
             else:
                 self.body.append(r'\sphinxstyletheadfamily ')
-        if self.needs_linetrimming:
+        if self.table.entry_needs_linetrimming:
             self.pushbody([])
         self.context.append(context)
 
     def depart_entry(self, node: Element) -> None:
-        if self.needs_linetrimming:
-            self.needs_linetrimming = 0
+        assert self.table is not None
+        if self.table.entry_needs_linetrimming:
+            self.table.entry_needs_linetrimming = 0
             body = self.popbody()
 
             # Remove empty lines from top of merged cell
@@ -1362,7 +1363,6 @@ class LaTeXTranslator(SphinxTranslator):
 
         self.body.append(self.context.pop())
 
-        assert self.table is not None
         cell = self.table.cell()
         assert cell is not None
         self.table.col += cell.width

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -223,6 +223,12 @@ Tables with multirow and multicol:
    |    |
    +----+
 
+   +---+---+
+   | +---+ |
+   | | h | |
+   | +---+ |
+   +---+---+
+
 .. list-table::
    :header-rows: 0
 


### PR DESCRIPTION
The position of the nested table will not be optimal, but it seems that generally speaking contents of multicolumn cells are rendered aligned left in general anyhow.

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Fix #13597 

The produced LaTeX mark-up was completely mangled.  With this patch, LaTeX mark-up compiles to PDF.

TODO: customize placement of contents (here a table) if in a multi-column cell. It seems alignment is always left (`l` type column) and can't be customized.

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


I have tested this on my stock of table tests for PDF rendering and no changes appear to be induced.  So I will merge after testing completes.

*sorry for multiple forcepush, but I am on a new system and I had not yet installed the testing infrastructure at my locale and mypy has tortured me*