### PR TITLE
LaTeX: allow more cases of table nesting, fix #13646

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,11 +36,13 @@ Features added
 * #13497: Support C domain objects in the table of contents.
 * #13500: LaTeX: add support for ``fontawesome6`` package.
   Patch by Jean-François B.
-* #13535: html search: Update to the latest version of Snowball (v3.0.1).
-  Patch by Adam Turner.
-* #13704: autodoc: Detect :py:func:`typing_extensions.overload <typing.overload>`
+* #13509: autodoc: Detect :py:func:`typing_extensions.overload <typing.overload>`
   and :py:func:`~typing.final` decorators.
   Patch by Spencer Brown.
+* #13535: html search: Update to the latest version of Snowball (v3.0.1).
+  Patch by Adam Turner.
+* #13647: LaTeX: allow more cases of table nesting.
+  Patch by Jean-François B.
 
 Bugs fixed
 ----------

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -1472,6 +1472,15 @@ Check the :confval:`latex_table_style`.
    complex contents such as multiple paragraphs, blockquotes, lists, literal
    blocks, will render correctly to LaTeX output.
 
+.. versionchanged:: 8.3.0
+
+   The partial support for nesting a table in another has been extended.
+   Formerly Sphinx would raise an error if ``longtable`` class was specified
+   for a table containing a nested table, and some cases would not raise an
+   error at Sphinx level but fail at LaTeX level during PDF build.  This is a
+   complex topic in LaTeX rendering and the output can sometimes be improved
+   via the :rst:dir:`tabularcolumns` directive.
+
 .. rst:directive:: .. tabularcolumns:: column spec
 
    This directive influences only the LaTeX output for the next table in
@@ -1489,40 +1498,38 @@ Check the :confval:`latex_table_style`.
       :rst:dir:`tabularcolumns` conflicts with ``:widths:`` option of table
       directives.  If both are specified, ``:widths:`` option will be ignored.
 
-   Sphinx will render tables with more than 30 rows with ``longtable``.
-   Besides the ``l``, ``r``, ``c`` and ``p{width}`` column specifiers, one can
-   also use ``\X{a}{b}`` (new in version 1.5) which configures the column
-   width to be a fraction ``a/b`` of the total line width and ``\Y{f}`` (new
-   in version 1.6) where ``f`` is a decimal: for example ``\Y{0.2}`` means that
-   the column will occupy ``0.2`` times the line width.
+   Sphinx renders tables with at most 30 rows using ``tabulary``, and those
+   with more rows with ``longtable``.
 
-   When this directive is used for a table with at most 30 rows, Sphinx will
-   render it with ``tabulary``.  One can then use specific column types ``L``
-   (left), ``R`` (right), ``C`` (centered) and ``J`` (justified).  They have
-   the effect of a ``p{width}`` (i.e. each cell is a LaTeX ``\parbox``) with
-   the specified internal text alignment and an automatically computed
-   ``width``.
+   ``tabulary`` tries to compute automatically (internally to LaTeX) suitable
+   column widths.  However, cells are then not allowed to contain
+   "problematic" elements such as lists, object descriptions,
+   blockquotes... Sphinx will fall back to using ``tabular`` if such a cell is
+   encountered (or a nested ``tabulary``).  In such a case the table will have
+   a tendency to try to fill the whole available line width.
 
-   .. warning::
+   :rst:dir:`tabularcolumns` can help in coercing the usage of ``tabulary`` if
+   one is careful to not employ the ``tabulary`` column types (``L``, ``R``,
+   ``C`` or ``J``) for those columns with at least one "problematic" cell, but
+   only LaTeX's ``p{<width>}`` or Sphinx ``\X`` and ``\Y`` (described next).
 
-      - Cells that contain list-like elements such as object descriptions,
-        blockquotes or any kind of lists are not compatible with the ``LRCJ``
-        column types.  The column type must then be some ``p{width}`` with an
-        explicit ``width`` (or ``\X{a}{b}`` or ``\Y{f}``).
+   Literal blocks do not work at all with ``tabulary``.  Sphinx will fall back
+   to ``tabular`` or ``longtable`` environments depending on the number of
+   rows.  It will employ the :rst:dir:`tabularcolumns` specification only if it
+   contains no usage of the ``tabulary`` specific types.
 
-      - Literal blocks do not work with ``tabulary`` at all.  Sphinx will
-        fall back to ``tabular`` or ``longtable`` environments and generate a
-        suitable column specification.
-
-In absence of the :rst:dir:`tabularcolumns` directive, and for a table with at
-most 30 rows and no problematic cells as described in the above warning,
-Sphinx uses ``tabulary`` and the ``J`` column-type for every column.
+   Besides the LaTeX ``l``, ``r``, ``c`` and ``p{width}`` column specifiers,
+   one can also use ``\X{a}{b}`` which configures the column width to be a
+   fraction ``a/b`` of the total line width and ``\Y{f}`` where ``f`` is a
+   decimal: for example ``\Y{0.2}`` means that the column will occupy ``0.2``
+   times the line width.
 
 .. versionchanged:: 1.6
 
-   Formerly, the ``L`` column-type was used (text is flushed-left).  To revert
-   to this, include ``\newcolumntype{T}{L}`` in the LaTeX preamble, as in fact
-   Sphinx uses ``T`` and sets it by default to be an alias of ``J``.
+   Use ``J`` (justified) by default with ``tabulary``, not ``L``
+   (flushed-left).  To revert, include ``\newcolumntype{T}{L}`` in the LaTeX
+   preamble, as in fact Sphinx uses ``T`` and sets it by default to be an
+   alias of ``J``.
 
 .. hint::
 

--- a/sphinx/templates/latex/tabulary.tex.jinja
+++ b/sphinx/templates/latex/tabulary.tex.jinja
@@ -21,6 +21,9 @@
 <% if 'nocolorrows' in table.styles -%>
 \sphinxthistablewithnocolorrowsstyle
 <% endif -%>
+<% if table.is_nested -%>
+\sphinxthistabularywithnohlinesifinlongtable
+<% endif -%>
 <% if table.align -%>
   <%- if table.align in ('center', 'default') -%>
   \centering

--- a/sphinx/texinputs/sphinxlatextables.sty
+++ b/sphinx/texinputs/sphinxlatextables.sty
@@ -47,6 +47,8 @@
 % The method here is with no changes to neither writer nor templates.
 \newif\ifspx@intable
 \newif\ifspx@thistableisnested
+% Try to allow nested tables in a longtable.  But tabulary causes problems.
+\newif\ifspx@longtable
 % 
 % Also provides user command (see docs)
 % - \sphixncolorblend
@@ -115,6 +117,7 @@
     \edef\sphinxbaselineskip{\dimexpr\the\dimexpr\baselineskip\relax\relax}%
     \spx@inframedtrue % message to sphinxheavybox
     \spx@table@setnestedflags
+    \spx@longtabletrue
 }
 % Compatibility with caption package
 \def\sphinxthelongtablecaptionisattop{%
@@ -128,7 +131,10 @@
 \def\sphinxatlongtableend{\@nobreakfalse % latex3/latex2e#173
     \prevdepth\z@\vskip\sphinxtablepost\relax}%
 % B. Table with tabular or tabulary
-\def\sphinxattablestart{\par\vskip\dimexpr\sphinxtablepre\relax
+\def\sphinxattablestart{\par
+    \ifvmode % guard agains being nested in a table cell
+      \vskip\dimexpr\sphinxtablepre\relax
+    \fi
                         \spx@inframedtrue % message to sphinxheavybox
                         \spx@table@setnestedflags
                         }%
@@ -142,7 +148,12 @@
         \spx@intabletrue
     \fi
    }%
-\let\sphinxattableend\sphinxatlongtableend
+\def\sphinxattableend{%
+    \@nobreakfalse % <- probably unneeded as this is not a longtable
+    \ifvmode       % guard against being nested in a table cell
+      \prevdepth\z@\vskip\sphinxtablepost\relax
+    \fi
+}%
 % This is used by tabular and tabulary templates
 \newcommand*\sphinxcapstartof[1]{%
    \vskip\parskip
@@ -1083,6 +1094,10 @@ local use of booktabs table style}%
 
 % borderless style
 \def\sphinxthistablewithborderlessstyle{%
+    \sphinxthistablewithnohlines
+    \def\spx@arrayrulewidth{\z@}%
+}%
+\def\sphinxthistablewithnohlines{%
     \let\sphinxhline      \@empty
     \let\sphinxcline      \@gobble
     \let\sphinxvlinecrossing\@gobble
@@ -1090,7 +1105,9 @@ local use of booktabs table style}%
     \let\spx@toprule      \@empty
     \let\sphinxmidrule    \@empty
     \let\sphinxbottomrule \@empty
-    \def\spx@arrayrulewidth{\z@}%
+}%
+\def\sphinxthistabularywithnohlinesifinlongtable{%
+  \ifspx@longtable\sphinxthistablewithnohlines\fi
 }%
 
 % colorrows style

--- a/tests/roots/test-latex-table/expects/tabularcolumn.tex
+++ b/tests/roots/test-latex-table/expects/tabularcolumn.tex
@@ -4,7 +4,7 @@
 \sphinxthistablewithglobalstyle
 \sphinxthistablewithnovlinesstyle
 \centering
-\begin{tabulary}{\linewidth}[t]{cc}
+\begin{tabular}[t]{cc}
 \sphinxtoprule
 \sphinxstyletheadfamily 
 \sphinxAtStartPar
@@ -36,6 +36,6 @@ cell3\sphinxhyphen{}1
 cell3\sphinxhyphen{}2
 \\
 \sphinxbottomrule
-\end{tabulary}
+\end{tabular}
 \sphinxtableafterendhook\par
 \sphinxattableend\end{savenotes}

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -229,6 +229,14 @@ Tables with multirow and multicol:
    | +---+ |
    +---+---+
 
+   .. rst-class:: longtable
+
+   +---+---+
+   | +---+ |
+   | | h | |
+   | +---+ |
+   +---+---+
+
 .. list-table::
    :header-rows: 0
 


### PR DESCRIPTION
Tables using longtable can now contain nested tables inclusive of those rendered by tabulary, up to the suppression (done automatically) of the latter horizontal lines due to an upstream LaTeX bug (can not use `\hline` in a tabulary in a longtable).  A longtable can never itself be nested, and will fall-back to tabular.

Formerly longtable would raise (in principle) an error if it contained any sort of nested table, but the detection of being a longtable was faulty if not specified as class option.

Relates #6838.
Fix #13646.