### PR TITLE
doc: Add historical context about Web Support

### DIFF
--- a/doc/usage/advanced/websupport/index.rst
+++ b/doc/usage/advanced/websupport/index.rst
@@ -8,6 +8,20 @@ Sphinx Web Support
 Sphinx provides a Python API to easily integrate Sphinx documentation into your
 web application.  To learn more read the :ref:`websupportquickstart`.
 
+.. _Pocoo: https://www.pocoo.org
+.. _sphinx-websupport-app: https://github.com/shimizukawa/sphinx-websupport-app
+
+.. note::
+
+   **Historical context**: Web Support originated from the `Pocoo`_ community,
+   the original creators of Sphinx, Jinja, Flask, Pygments, and more. Web
+   Support was part of a plan to create a forum application that tied together
+   Jinja, Flask, Sphinx, etc. The core goal behind Web Support was to enable a
+   user editing and suggestion layer on top of documentation. While the concept
+   has merit, the feature has seen limited adoption and development over the
+   years. As of 2025, there are few real-world examples of its use. See
+   `sphinx-websupport-app`_ for one such example.
+
 .. toctree::
 
    quickstart


### PR DESCRIPTION
## Purpose

Explain the historical context about the Web Support feature.

## References

- https://writethedocs.slack.com/archives/C0899Q0G1/p1749650667678309?thread_ts=1748731182.202449&cid=C0899Q0G1

cc @AA-Turner 