### PR TITLE
Deprecate replacing non-decodable source bytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Deprecated
 * #13665: Deprecate support for non-UTF 8 source encodings,
   scheduled for removal in Sphinx 10.
   Patch by Adam Turner.
+* #13679: Non-decodable characters in source files will raise an error in Sphinx 9.
+  Currently, such bytes are replaced with '?' along with logging a warning.
+  Patch by Adam Turner.
 
 Features added
 --------------

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -23,7 +23,7 @@ file '{root}/wrongenc.inc' seems to be wrong, try giving an :encoding: option \\
 {root}/index.rst:\\d+: WARNING: image file not readable: foo.png \\[image.not_readable\\]
 {root}/index.rst:\\d+: WARNING: download file not readable: {root}/nonexisting.png \\[download.not_readable\\]
 {root}/undecodable.rst:\\d+: WARNING: undecodable source characters, replacing \
-with "\\?": b?'here: >>>(\\\\|/)xbb<<<((\\\\|/)r)?'
+with '\\?': 'here: >>>(\\\\|/)xbb<<<'
 """
 
 HTML_WARNINGS = (

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -23,7 +23,7 @@ file '{root}/wrongenc.inc' seems to be wrong, try giving an :encoding: option \\
 {root}/index.rst:\\d+: WARNING: image file not readable: foo.png \\[image.not_readable\\]
 {root}/index.rst:\\d+: WARNING: download file not readable: {root}/nonexisting.png \\[download.not_readable\\]
 {root}/undecodable.rst:\\d+: WARNING: undecodable source characters, replacing \
-with '\\?': 'here: >>>(\\\\|/)xbb<<<'
+with '\\?': 'here: >>>(\\\\|/)xbb<<<'\\. This will become an error in Sphinx 9\\.0\\.
 """
 
 HTML_WARNINGS = (


### PR DESCRIPTION
## Purpose

Replacing invalid bytes in the source file with `?` allows for some error recovery, but means that the text is not faithful to the underlying source. To afford users some time, announce the change now. It is already at the warning level, so those enabling warnings as errors will see build failures.

## References

- 2d0345a7d9ad1ddfd9203db7e1e0cb0ce558da8a
- #71 