### PR TITLE
Add a file-based cache for remote intersphinx inventories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,10 @@ Features added
   Patch by Adam Turner.
 * #13647: LaTeX: allow more cases of table nesting.
   Patch by Jean-François B.
+* #13684: intersphinx: Add a file-based cache for remote inventories.
+  The location of the cache directory must not be relied upon externally,
+  as it may change without notice or warning in future releases.
+  Patch by Adam Turner.
 
 Bugs fixed
 ----------

--- a/sphinx/ext/intersphinx/_cli.py
+++ b/sphinx/ext/intersphinx/_cli.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from sphinx.ext.intersphinx._load import _fetch_inventory, _InvConfig
+from sphinx.ext.intersphinx._load import (
+    _fetch_inventory_data,
+    _InvConfig,
+    _load_inventory,
+)
 
 
 def inspect_main(argv: list[str], /) -> int:
@@ -28,12 +32,14 @@ def inspect_main(argv: list[str], /) -> int:
     )
 
     try:
-        inv = _fetch_inventory(
+        raw_data = _fetch_inventory_data(
             target_uri='',
             inv_location=filename,
             config=config,
             srcdir=Path(),
+            cache_path=None,
         )
+        inv = _load_inventory(raw_data, target_uri='')
         for key in sorted(inv.data):
             print(key)
             inv_entries = sorted(inv.data[key].items())

--- a/sphinx/ext/intersphinx/_cli.py
+++ b/sphinx/ext/intersphinx/_cli.py
@@ -32,7 +32,7 @@ def inspect_main(argv: list[str], /) -> int:
     )
 
     try:
-        raw_data = _fetch_inventory_data(
+        raw_data, _ = _fetch_inventory_data(
             target_uri='',
             inv_location=filename,
             config=config,

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -791,7 +791,8 @@ def test_intersphinx_cache_limit(app, monkeypatch, cache_limit, expected_expired
     # We replace it with a mock to test whether it has been called.
     # If it has been called, it means the cache had expired.
     monkeypatch.setattr(
-        'sphinx.ext.intersphinx._load._fetch_inventory_data', mock.Mock()
+        'sphinx.ext.intersphinx._load._fetch_inventory_data',
+        mock.Mock(return_value=(b'', '')),
     )
     mock_fetch_inventory = mock.Mock(return_value=_Inventory({}))
     monkeypatch.setattr(

--- a/tests/test_extensions/test_ext_intersphinx_cache.py
+++ b/tests/test_extensions/test_ext_intersphinx_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import posixpath
 import re
+import shutil
 import zlib
 from http.server import BaseHTTPRequestHandler
 from io import BytesIO
@@ -261,12 +262,14 @@ def test_load_mappings_cache_update(tmp_path):
         app1 = SphinxTestApp('dummy', srcdir=tmp_path, confoverrides=confoverrides1)
         app1.build()
         app1.cleanup()
+        shutil.rmtree(app1.doctreedir / '__intersphinx_cache__', ignore_errors=True)
 
         # switch to new url and assert that the old URL is no more stored
         confoverrides2 = BASE_CONFIG | {'intersphinx_mapping': new_project.record}
         app2 = SphinxTestApp('dummy', srcdir=tmp_path, confoverrides=confoverrides2)
         app2.build()
         app2.cleanup()
+        shutil.rmtree(app2.doctreedir / '__intersphinx_cache__', ignore_errors=True)
 
     entry = new_project.make_entry()
     item = dict((new_project.normalise(entry),))


### PR DESCRIPTION
## Purpose

I am frequently in situations with a poor internet connection, or entirely offline for brief periods. I also frequently rebuild with ``--fresh-env`` to force re-reading documents, theme files, etc. In this situation, the build fails as the HTTP request for the remote inventory fails, and then intersphinx references fail to resolve.

Currently, the only cache for remote intersphinx inventories is stored on the environment object, expiring after five days [by default](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_cache_limit). This PR adds a local file-based cache for remote `objects.inv` files. It is used when all of the following criteria are met:

* The inventory location is a URL, not a local file,
* The inventory has not already been cached in the environment,
* The local cache file exists, and
* The local cache file is not older than the cache expiry time

Currently, I've used `{doctreedir}/__intersphinx_cache__/` as the folder for this file-based cache. An alternative idea is to use a user-wide cache directory, such as `~/.cache/intersphinx`. Thoughts on this?

A

## References

- None.
