### PR TITLE
Fix bug of default bool_option in autodoc

### DIFF
--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -173,7 +173,7 @@ def bool_option(arg: Any) -> bool:
     """Used to convert flag options to auto directives.  (Instead of
     directives.flag(), which returns None).
     """
-    return True
+    return arg
 
 
 def merge_members_option(options: dict[str, Any]) -> None:


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Now setting
```
autodoc_default_options = {
    "show-inheritance": False,
}
```
is not working correctly. The doc will still generate inheritance.

Reason:

`show-inheritance` is defined as a bool_option:

https://github.com/sphinx-doc/sphinx/blob/a15c149a607a1dcbc07e0058108194726d382d9f/sphinx/ext/autodoc/__init__.py#L1659

https://github.com/sphinx-doc/sphinx/blob/a15c149a607a1dcbc07e0058108194726d382d9f/sphinx/ext/autodoc/__init__.py#L172-L176

The bool option always returns True.

We are using `process_documenter_options` to process `autodoc_default_options`. `process_documenter_options` is calling `assemble_option_dict`, which calls the corresponding `options_spec` of the field to convert the value. In this case, the field is `show-inheritance`, the `options_spec` is `bool_option`.

https://github.com/sphinx-doc/sphinx/blob/a15c149a607a1dcbc07e0058108194726d382d9f/sphinx/ext/autodoc/directive.py#L86

https://github.com/docutils/docutils/blob/dd0acf5c62bb6295c9719a9ec1a71099056bea84/docutils/docutils/utils/__init__.py#L365

So no matter what value of `show-inheritance` set in `autodoc_default_options`, the result of `process_documenter_options` will always true.

I think this is a bug and updated the logic of `bool_option` to fix it.