### PR TITLE
Update CHANGES to indicate fix of #1327

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,10 @@ Features added
 Bugs fixed
 ----------
 
+* #1327: LaTeX: tables using longtable raise error if
+  :rst:dir:`tabularcolumns` specifies automatic widths
+  (``L``, ``R``, ``C``, or ``J``).
+  Patch by Jean-François B.
 * #3447: LaTeX: when assigning longtable class to table for PDF, it may render
   "horizontally" and overflow in right margin.
   Patch by Jean-François B.


### PR DESCRIPTION
Close #1327.  It was fixed as part of PR #13647.

There is now no PDF build error but only a Sphinx warning during build.