### PR TITLE
Fix intersphinx reftitle for non-numeric versions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -103,6 +103,7 @@ Contributors
 * Stefan Seefeld -- toctree improvements
 * Stefan van der Walt -- autosummary extension
 * Steve Piercy -- documentation improvements
+* Szymon Karpinski -- intersphinx improvements
 * \T. Powers -- HTML output improvements
 * Taku Shimizu -- epub3 builder
 * Thomas Lamb -- linkcheck builder

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,7 +95,7 @@ Bugs fixed
   Patch by Jean-François B.
 * #13685: gettext: Correctly ignore trailing backslashes.
   Patch by Bénédikt Tran.
-* #13712: intersphinx: Don't add `v` prefix to non-numeric versions.
+* #13712: intersphinx: Don't add "v" prefix to non-numeric versions.
   Patch by Szymon Karpinski.
 
 Testing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,8 @@ Bugs fixed
   Patch by Jean-François B.
 * #13685: gettext: Correctly ignore trailing backslashes.
   Patch by Bénédikt Tran.
+* #13712: intersphinx: Don't add `v` prefix to non-numeric versions.
+  Patch by Szymon Karpinski.
 
 Testing
 -------

--- a/sphinx/ext/intersphinx/_resolve.py
+++ b/sphinx/ext/intersphinx/_resolve.py
@@ -50,7 +50,7 @@ def _create_element_from_result(
             # Do not append 'v' to non-numeric version
             version = inv_item.project_version
         else:
-            version = 'v%s' % inv_item.project_version
+            version = f'v{inv_item.project_version}'
         reftitle = _('(in %s %s)') % (inv_item.project_name, version)
     else:
         reftitle = _('(in %s)') % (inv_item.project_name,)

--- a/sphinx/ext/intersphinx/_resolve.py
+++ b/sphinx/ext/intersphinx/_resolve.py
@@ -50,7 +50,7 @@ def _create_element_from_result(
             # Do not append 'v' to non-numeric version
             version = inv_item.project_version
         else:
-            version = _('v%s') % inv_item.project_version
+            version = 'v%s' % inv_item.project_version
         reftitle = _('(in %s %s)') % (inv_item.project_name, version)
     else:
         reftitle = _('(in %s)') % (inv_item.project_name,)

--- a/sphinx/ext/intersphinx/_resolve.py
+++ b/sphinx/ext/intersphinx/_resolve.py
@@ -46,7 +46,12 @@ def _create_element_from_result(
         # get correct path in case of subdirectories
         uri = (_relative_path(Path(), Path(node['refdoc']).parent) / uri).as_posix()
     if inv_item.project_version:
-        reftitle = _('(in %s v%s)') % (inv_item.project_name, inv_item.project_version)
+        if not inv_item.project_version[0].isdigit():
+            # Do not append 'v' to non-numeric version
+            version = inv_item.project_version
+        else:
+            version = _('v%s') % inv_item.project_version
+        reftitle = _('(in %s %s)') % (inv_item.project_name, version)
     else:
         reftitle = _('(in %s)') % (inv_item.project_name,)
 

--- a/tests/test_extensions/test_ext_intersphinx.py
+++ b/tests/test_extensions/test_ext_intersphinx.py
@@ -35,6 +35,7 @@ from tests.test_util.intersphinx_data import (
     INVENTORY_V2,
     INVENTORY_V2_AMBIGUOUS_TERMS,
     INVENTORY_V2_NO_VERSION,
+    INVENTORY_V2_TEXT_VERSION,
 )
 from tests.utils import http_server
 
@@ -900,3 +901,25 @@ def test_intersphinx_fetch_inventory_group_url():
             srcdir=None,
             cache_path=None,
         )
+
+
+@pytest.mark.sphinx('html', testroot='root')
+def test_inventory_text_version(tmp_path, app):
+    inv_file = tmp_path / 'inventory'
+    inv_file.write_bytes(INVENTORY_V2_TEXT_VERSION)
+    set_config(
+        app,
+        {
+            'python': ('https://docs.python.org/', str(inv_file)),
+        },
+    )
+
+    # load the inventory and check if non-numeric version is handled correctly
+    validate_intersphinx_mapping(app, app.config)
+    load_mappings(app)
+
+    rn = reference_check(app, 'py', 'mod', 'module1', 'foo')
+    assert isinstance(rn, nodes.reference)
+    assert rn['refuri'] == 'https://docs.python.org/foo.html#module-module1'
+    assert rn['reftitle'] == '(in foo stable)'
+    assert rn[0].astext() == 'Long Module desc'

--- a/tests/test_util/intersphinx_data.py
+++ b/tests/test_util/intersphinx_data.py
@@ -62,3 +62,12 @@ A term std:term -1 glossary.html#term-a-term -
 b term std:term -1 document.html#id5 -
 B term std:term -1 document.html#B -
 """)
+
+INVENTORY_V2_TEXT_VERSION: Final[bytes] = b"""\
+# Sphinx inventory version 2
+# Project: foo
+# Version: stable
+# The remainder of this file is compressed with zlib.
+""" + zlib.compress(b"""\
+module1 py:module 0 foo.html#module-module1 Long Module desc
+""")


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

This PR removes 'v' prefix from non-numeric versions in reftitles in intersphinx. Appending it resulted in strange version names like "vstable" instead of just "stable".

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Closes #13712 

