### PR TITLE
Remove ``ComplainOnUnhighlighted``

### DIFF
--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -39,11 +39,6 @@ class MyFormatter(HtmlFormatter[str]):
             outfile.write(tok[1])
 
 
-class ComplainOnUnhighlighted(PygmentsBridge):
-    def unhighlighted(self, source):
-        raise AssertionError('should highlight %r' % source)
-
-
 @pytest.mark.sphinx('html', testroot='root')
 def test_add_lexer(app: SphinxTestApp) -> None:
     app.add_lexer('test', MyLexer)
@@ -54,7 +49,7 @@ def test_add_lexer(app: SphinxTestApp) -> None:
 
 
 def test_detect_interactive() -> None:
-    bridge = ComplainOnUnhighlighted('html')
+    bridge = PygmentsBridge('html')
     blocks = [
         """
         >>> testing()


### PR DESCRIPTION
## Purpose

Uses of the ``unhighlighted()`` method were removed in 2014, with the method itself removed in Sphinx 2.0.

As noticed by @adamtheturtle in #13761.


## References

- https://github.com/sphinx-doc/sphinx/pull/13761/files#r2232697633
* b29226a0609d5803afd51c01f6d522bd30592dbf ("Drop features and APIs deprecated in 1.8")
* db1cf80a69778d882f5c39b8966dc9fd5af256ac ("Make pygments unconditional, it is required by setup.py anyway.")
* 61098a0ae2e696a804459d36bd74ca57db76eda5 ("In code blocks, when the selected lexer fails, display line numbers nevertheless if configured.")