### PR TITLE
Test with Docutils 0.22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
         docutils:
         - "0.20"
         - "0.21"
+        - "0.22"
 #        include:
 #        # test every supported Docutils version for the latest supported Python
 #        - python: "3.13"
@@ -93,6 +94,7 @@ jobs:
         docutils:
         - "0.20"
         - "0.21"
+        - "0.22"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose

Docutils 0.22 has just been released (cc @gmilde @grubert).

## References

- https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-22-2026-07-29
- https://pypi.org/project/docutils/0.22/
- https://docutils.sourceforge.io/HISTORY.html#release-0-22-2026-07-29
