### PR TITLE
autodoc: do not add :no-index-entry: twice

### DIFF
--- a/sphinx/ext/autodoc/_documenters.py
+++ b/sphinx/ext/autodoc/_documenters.py
@@ -1061,8 +1061,6 @@ class ModuleDocumenter(Documenter):
             self.add_line('   :platform: ' + self.options.platform, sourcename)
         if self.options.deprecated:
             self.add_line('   :deprecated:', sourcename)
-        if self.options.no_index_entry:
-            self.add_line('   :no-index-entry:', sourcename)
 
     def get_module_members(self) -> dict[str, ObjectMember]:
         """Get members of target module."""

--- a/sphinx/ext/autodoc/_documenters.py
+++ b/sphinx/ext/autodoc/_documenters.py
@@ -1050,7 +1050,7 @@ class ModuleDocumenter(Documenter):
         return self.__all__
 
     def add_directive_header(self, sig: str) -> None:
-        Documenter.add_directive_header(self, sig)
+        super().add_directive_header(sig)
 
         sourcename = self.get_sourcename()
 


### PR DESCRIPTION
Closes #13720

On line 1053 `Documenter.add_directive_header(self, sig)` is called, which already adds a `:no-index-entry:` line.

Adding it a second time causes sphinx to error (pedantically).