### PR TITLE
Update `.gitattributes` for the wrongencoding files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,8 +51,11 @@ tests/roots/test-pycode/cp_1251_coded.py dos
 
 # Non UTF-8 encodings
 tests/roots/test-pycode/cp_1251_coded.py working-tree-encoding=windows-1251
-tests/roots/test-root/wrongenc.inc working-tree-encoding=latin-1
-tests/roots/test-warnings/wrongenc.inc working-tree-encoding=latin-1
+
+# Encoding test files - treated as binary to prevent encoding conversion issues
+# These files contain intentional Latin-1 encoded content for testing Sphinx's encoding handling
+tests/roots/test-root/wrongenc.inc binary
+tests/roots/test-warnings/wrongenc.inc binary
 
 # Generated files
 # https://github.com/github/linguist/blob/master/docs/overrides.md


### PR DESCRIPTION
## Purpose

There was an existing `.gitattributes` for these files, but it wasn't working on my system (M2 mac). I was unable to restore or stash these files. Which made rebasing difficulty. This approach fixed the git issues for me. 

I was getting errors like:
```
error: failed to encode 'tests/roots/test-root/wrongenc.inc' from UTF-8 to latin-1
error: failed to encode 'tests/roots/test-warnings/wrongenc.inc' from UTF-8 to latin-1
```

whenever I tried to restore, stash, or rebase.

Full disclosure - this was a level of git that was beyond me so this is an AI assisted PR. Claude summarizes the downsides as:

  ⚠️ Considerations:

  - Diff viewing - These files will show as "binary" in git diffs instead of text changes
  - Text editors - Some editors might treat them as binary files

Although I was able to open them in neovim without issue.

## References
It looks like there was a recent similar change: https://github.com/sphinx-doc/sphinx/commit/5cf62e55c96824545c157372d741b595d8c98c7f