### PR TITLE
Add filename caption to tutorial code block

### DIFF
--- a/doc/tutorial/first-steps.rst
+++ b/doc/tutorial/first-steps.rst
@@ -73,6 +73,7 @@ shown right after the corresponding link, in parentheses.  You can change that
 behavior by adding the following code at the end of your ``conf.py``:
 
 .. code-block:: python
+   :caption: docs/source/conf.py
 
    # EPUB options
    epub_show_urls = 'footnote'


### PR DESCRIPTION

## Purpose
In the Build your first project tutorial. This is the only file code block that's missing a filename caption.
https://www.sphinx-doc.org/en/master/tutorial/first-steps.html#:~:text=conf.py%3A-,%23%20EPUB%20options,-epub_show_urls%20%3D%20%27footnote