### PR TITLE
Update autosectionlabel.rst add code-py role

### DIFF
--- a/doc/usage/extensions/autosectionlabel.rst
+++ b/doc/usage/extensions/autosectionlabel.rst
@@ -8,6 +8,9 @@
 
 .. versionadded:: 1.4
 
+.. role:: code-py(code)
+   :language: Python
+
 By default, cross-references to sections use labels (see :rst:role:`ref`).
 This extension allows you to instead refer to sections by their title.
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Fix missing :code-py: role definition in autosectionlabel.rst.

During experimental work on parallel processing variations, we discovered that autosectionlabel.rst uses the :code-py: role but lacks the proper role definition. This can cause intermittent build failures when no other document with the role definition is processed beforehand.

This error does not occur in the current version (probably because the role is read beforehand by "deterministic" accident).

I checked if there is any other such instance and it does not look like it.
