### PR TITLE
Add static types for the HTML context dict

### DIFF
--- a/sphinx/builders/epub3.py
+++ b/sphinx/builders/epub3.py
@@ -22,11 +22,19 @@ from sphinx.util.osutil import make_filename
 
 if TYPE_CHECKING:
     from collections.abc import Set
-    from typing import Any
+    from typing import Any, Literal
 
     from sphinx.application import Sphinx
+    from sphinx.builders.html._ctx import _GlobalContextHTML
     from sphinx.config import Config
     from sphinx.util.typing import ExtensionMetadata
+
+    class _GlobalContextEpub3(_GlobalContextHTML):
+        theme_writing_mode: str | None
+        html_tag: str
+        use_meta_charset: bool
+        skip_ua_compatible: Literal[True]
+
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +96,8 @@ class Epub3Builder(_epub_base.EpubBuilder):
     doctype = DOCTYPE
     html_tag = HTML_TAG
     use_meta_charset = True
+
+    globalcontext: _GlobalContextEpub3
 
     # Finish by building the epub file
     def handle_finish(self) -> None:

--- a/sphinx/builders/html/_ctx.py
+++ b/sphinx/builders/html/_ctx.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from typing import Any, Literal, Protocol, TypedDict
+
+    from sphinx.builders.html._assets import _CascadingStyleSheet, _JavaScript
+
+    class _NavigationRelation(TypedDict):
+        link: str
+        title: str
+
+    class _GlobalContextHTML(TypedDict):
+        embedded: bool
+        project: str
+        release: str
+        version: str
+        last_updated: str | None
+        copyright: str
+        master_doc: str
+        root_doc: str
+        use_opensearch: bool
+        docstitle: str | None
+        shorttitle: str
+        show_copyright: bool
+        show_search_summary: bool
+        show_sphinx: bool
+        has_source: bool
+        show_source: bool
+        sourcelink_suffix: str
+        file_suffix: str
+        link_suffix: str
+        script_files: Sequence[_JavaScript]
+        language: str | None
+        css_files: Sequence[_CascadingStyleSheet]
+        sphinx_version: str
+        sphinx_version_tuple: tuple[int, int, int, str, int]
+        docutils_version_info: tuple[int, int, int, str, int]
+        styles: Sequence[str]
+        rellinks: Sequence[tuple[str, str, str, str]]
+        builder: str
+        parents: Sequence[_NavigationRelation]
+        logo_url: str
+        logo_alt: str
+        favicon_url: str
+        html5_doctype: Literal[True]
+
+    class _PathtoCallable(Protocol):
+        def __call__(
+            self, otheruri: str, resource: bool = False, baseuri: str = ...
+        ) -> str: ...
+
+    class _ToctreeCallable(Protocol):
+        def __call__(self, **kwargs: Any) -> str: ...
+
+    class _PageContextHTML(_GlobalContextHTML):
+        # get_doc_context()
+        prev: Sequence[_NavigationRelation]
+        next: Sequence[_NavigationRelation]
+        title: str
+        meta: dict[str, Any] | None
+        body: str
+        metatags: str
+        sourcename: str
+        toc: str
+        display_toc: bool
+        page_source_suffix: str
+
+        # handle_page()
+        pagename: str
+        current_page_name: str
+        encoding: str
+        pageurl: str | None
+        pathto: _PathtoCallable
+        hasdoc: Callable[[str], bool]
+        toctree: _ToctreeCallable
+        content_root: str
+        css_tag: Callable[[_CascadingStyleSheet], str]
+        js_tag: Callable[[_JavaScript], str]
+
+        # add_sidebars()
+        sidebars: Sequence[str] | None
+
+else:
+    _NavigationRelation = dict
+    _GlobalContextHTML = dict
+    _PageContextHTML = dict

--- a/tests/test_builders/test_build_html.py
+++ b/tests/test_builders/test_build_html.py
@@ -30,8 +30,7 @@ from tests.test_builders.xpath_data import FIGURE_CAPTION
 from tests.test_builders.xpath_util import check_xpath
 
 if TYPE_CHECKING:
-    from typing import Any
-
+    from sphinx.builders.html._ctx import _PageContextHTML
     from sphinx.testing.util import SphinxTestApp
 
 
@@ -416,7 +415,7 @@ def test_html_style(app: SphinxTestApp) -> None:
     },
 )
 def test_html_sidebar(app: SphinxTestApp) -> None:
-    ctx: dict[str, Any] = {}
+    ctx: _PageContextHTML = {}  # type: ignore[typeddict-item]
 
     # default for alabaster
     app.build(force_all=True)


### PR DESCRIPTION
## Purpose

Improves static typing for the various `ctx` / `addctx` / `globalcontext` dicts that we use in the HTML builder.


## References

- None