### PR TITLE
Update _read_parallel to use a queue

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -610,7 +610,7 @@ class Builder:
             self.events.emit('env-purge-doc', self.env, docname)
             self.env.clear_doc(docname)
 
-        work_queue: multiprocessing.Queue[str] = multiprocessing.Queue()
+        work_queue: multiprocessing.Queue[str | None] = multiprocessing.Queue()
 
         # load up all docs to be processed
         for doc in docnames:

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import codecs
+import multiprocessing
 import pickle
+import queue
 import re
 import time
 from contextlib import nullcontext


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Instead of reading through the docnames in batches uses a queue and workers.

This is an alternative approach to #13738.
The difference is, that I did not actually need to touch parallel.py for this variant.

p.s.: I tried a similar approach for write, but it seems to be less performant because I 
needed to pickle the doctrees and send them via queues (instead of them being forked)

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- <...>
- <...>
- <...>
