### PR TITLE
With nanobind, nb_method is like instancemethod, a specific __name__ for methods

### DIFF
--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -374,8 +374,8 @@ def isattributedescriptor(obj: Any) -> bool:
         if isinstance(unwrapped, _DESCRIPTOR_LIKE):
             # attribute must not be a method descriptor
             return False
-        # attribute must not be an instancemethod (C-API)
-        return type(unwrapped).__name__ != 'instancemethod'
+        # attribute must not be an instancemethod (C-API) nor nb_method (specific for nanobind)
+        return type(unwrapped).__name__ not in {'instancemethod', 'nb_method'}
     return False
 
 


### PR DESCRIPTION
## Purpose

Fix #13823
I did not add any unitary test as it would imply to package a class with NanoBind.
But I tested it with this minimal project to reproduce the bug: https://gitlab.inria.fr/vrouvrea/sphinx_nanobind_investigation

This modification makes each method of the class `Hello` to be seen as a `MethodDocumenter` and not as `AttributeDocumenter`

## References

This comes from that with C-API (or even PyBind11):
```pycon
>>> from osmium.io import File # A PyBind11 example
>>> File.__dict__
mappingproxy({'__init__': <instancemethod __init__ at 0x79777556ad40>, '__doc__': None, '__module__': 'osmium.io', 'has_multiple_object_versions': <property object at 0x79777556df30>, 'parse_format': <instancemethod parse_format at 0x79777556ac20>})
```

But with NanoBind:
```pycon
>>> from sphinx_nanobind_investigation import Hello # cf. https://gitlab.inria.fr/vrouvrea/sphinx_nanobind_investigation
>>> Hello.__dict__
mappingproxy({'__new__': <built-in method __new__ of nanobind.nb_type_0 object at 0x64ba8b1bc6e0>, '__init__': <nanobind.nb_method object at 0x7977754ddcf0>, '__doc__': 'Hello class', '__module__': 'sphinx_nanobind_investigation.hello_ext', 'speak': <nanobind.nb_method object at 0x7977754df780>, 'date_and_time': <nanobind.nb_func object at 0x7977754df890>, 'name': <nanobind.nb_method object at 0x7977754df9a0>})
```
