### PR TITLE
Fix `seealso` directive example

### DIFF
--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -473,7 +473,7 @@ and the generic :rst:dir:`admonition` directive.
 
    .. seealso::
 
-      Module :py:mod:`zipfile`
+      Python's :py:mod:`zipfile` module
          Documentation of the :py:mod:`zipfile` standard module.
 
       `GNU tar manual, Basic Tar Format <https://example.org>`_

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -474,7 +474,7 @@ and the generic :rst:dir:`admonition` directive.
    .. seealso::
 
       Python's :py:mod:`zipfile` module
-         Documentation of the :py:mod:`zipfile` standard module.
+         Documentation of Python's standard :py:mod:`zipfile` module.
 
       `GNU tar manual, Basic Tar Format <https://example.org>`_
          Documentation for tar archive files, including GNU tar extensions.


### PR DESCRIPTION
## Purpose

The rendered RST in the example for the `seealso` directive doesn't match the what would be produced from the sample RST. This PR will update the docs so that the rendered text matches what is expected from the sample text.

## References

[`seealso` directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-seealso)