### PR TITLE
Fix docstring of sphinx.util.parsing.nested_parse_to_nodes().

### DIFF
--- a/sphinx/util/parsing.py
+++ b/sphinx/util/parsing.py
@@ -39,8 +39,7 @@ def nested_parse_to_nodes(
         Note that this option bypasses Docutils' usual checks on
         doctree structure, and misuse of this option can lead to
         an incoherent doctree. In Docutils, section nodes should
-        only be children of ``Structural`` nodes, which includes
-        ``document``, ``section``, and ``sidebar`` nodes.
+        only be children of ``document`` or ``section`` nodes.
     :param keep_title_context:
         If this is False (the default), then *content* is parsed as if it were
         an independent document, meaning that title decorations (e.g. underlines)

--- a/sphinx/util/parsing.py
+++ b/sphinx/util/parsing.py
@@ -48,6 +48,9 @@ def nested_parse_to_nodes(
         a completely different context, such as docstrings.
         If this is True, then title underlines must match those in
         the surrounding document, otherwise the behaviour is undefined.
+        Warning: Up to Docutils 0.21, sections with an decoration style
+        matching a level that is higher than the current section level are
+        silently discarded!
 
     .. versionadded:: 7.4
     """

--- a/sphinx/util/parsing.py
+++ b/sphinx/util/parsing.py
@@ -50,7 +50,7 @@ def nested_parse_to_nodes(
         the surrounding document, otherwise the behaviour is undefined.
         Warning: Up to Docutils 0.21, sections with an decoration style
         matching a level that is higher than the current section level are
-        silently discarded!
+        silently discarded! Since Docutils 0.22.1, an error is reported.
 
     .. versionadded:: 7.4
     """

--- a/tests/roots/test-root/wrongenc.inc
+++ b/tests/roots/test-root/wrongenc.inc
@@ -1,3 +1,3 @@
 This file is encoded in latin-1 but at first read as utf-8.
 
-Max Strauß aß in München eine Leberkässemmel.
+Max StrauÃŸ aÃŸ in MÃ¼nchen eine LeberkÃ¤ssemmel.

--- a/tests/roots/test-warnings/wrongenc.inc
+++ b/tests/roots/test-warnings/wrongenc.inc
@@ -1,3 +1,3 @@
 This file is encoded in latin-1 but at first read as utf-8.
 
-Max Strauß aß in München eine Leberkässemmel.
+Max StrauÃŸ aÃŸ in MÃ¼nchen eine LeberkÃ¤ssemmel.


### PR DESCRIPTION
"section" elements can only be children of "document" or "section" elements, not "sidebar".
Cf. https://docutils.sourceforge.io/docs/ref/doctree.html#section

## Purpose

Prevent users of the function from producing invalid documents by giving accurate information.

## References
- https://docutils.sourceforge.io/docs/ref/doctree.html#section
- closes #13828