### PR TITLE
Fix: use config value as default group name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,9 @@ Bugs fixed
 * #10785: Autodoc: Allow type aliases defined in the project to be properly
   cross-referenced when used as type annotations. This makes it possible
   for objects documented as ``:py:data:`` to be hyperlinked in function signatures.
+* #13858: doctest: doctest blocks are now correctly added to a group defined by the
+  configuration variable ``doctest_test_doctest_blocks``.
+
 
 Testing
 -------

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -460,7 +460,7 @@ class DocTestBuilder(Builder):
                 lineno=line_number,  # type: ignore[arg-type]
                 options=node.get('options'),  # type: ignore[attr-defined]
             )
-            node_groups = node.get('groups', ['default'])  # type: ignore[attr-defined]
+            node_groups = node.get('groups', [self.config.doctest_test_doctest_blocks])  # type: ignore[attr-defined]
             if '*' in node_groups:
                 add_to_all_groups.append(code)
                 continue

--- a/tests/test_extensions/test_ext_doctest.py
+++ b/tests/test_extensions/test_ext_doctest.py
@@ -170,7 +170,10 @@ def test_fail_fast(app, fail_fast, capsys):
 
 
 @pytest.mark.sphinx('doctest', testroot='ext-doctest-with-autodoc')
-@pytest.mark.parametrize(('test_doctest_blocks', 'group_name'), [(None, 'default'), ('CustomGroupName', 'CustomGroupName')])
+@pytest.mark.parametrize(
+    ('test_doctest_blocks', 'group_name'),
+    [(None, 'default'), ('CustomGroupName', 'CustomGroupName')],
+)
 def test_doctest_block_group_name(app, test_doctest_blocks, group_name, capfd):
     if test_doctest_blocks is not None:
         app.config.doctest_test_doctest_blocks = test_doctest_blocks

--- a/tests/test_extensions/test_ext_doctest.py
+++ b/tests/test_extensions/test_ext_doctest.py
@@ -167,3 +167,26 @@ def test_fail_fast(app, fail_fast, capsys):
     else:
         assert 'Doctest summary\n' in written
         assert '2 failures in tests' in written
+
+
+@pytest.mark.sphinx('doctest', testroot='ext-doctest-with-autodoc')
+@pytest.mark.parametrize(('test_doctest_blocks', 'group_name'), [(None, 'default'), ('CustomGroupName', 'CustomGroupName')])
+def test_doctest_block_group_name(app, test_doctest_blocks, group_name, capfd):
+    if test_doctest_blocks is not None:
+        app.config.doctest_test_doctest_blocks = test_doctest_blocks
+
+    # Patch builder to get a copy of the output
+    written = []
+    app.builder._warn_out = written.append
+    app.build(force_all=True)
+
+    failures = [
+        line.replace(os.sep, '/')
+        for line in '\n'.join(written).splitlines()
+        if line.startswith('File')
+    ]
+
+    assert f'File "dir/inner.rst", line 1, in {group_name}' in failures
+    assert f'File "dir/bar.py", line ?, in {group_name}' in failures
+    assert f'File "foo.py", line ?, in {group_name}' in failures
+    assert f'File "index.rst", line 4, in {group_name}' in failures


### PR DESCRIPTION
## Purpose
Closes #13858

Use the `doctest_test_doctest_blocks` config value as the default group for doctest blocks.


## References

- <...>
- <...>
- <...>
