### PR TITLE
add `linkcheck_allow_forbidden` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,7 @@ Features added
   Patch by Till Hoffmann.
 * #13439: linkcheck: Permit warning on every redirect with
   ``linkcheck_allowed_redirects = {}``.
-  Patch by Adam Turner.
+  Patch by Adam Turner and James Addison.
 * #13497: Support C domain objects in the table of contents.
 * #13500: LaTeX: add support for ``fontawesome6`` package.
   Patch by Jean-François B.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Deprecated
 Features added
 --------------
 
+* #13860: lickcheck: add :confval:`linkcheck_allow_forbidden` option to
+  let HTTP 403 responses be marked as "working".
 * #13332: Add :confval:`doctest_fail_fast` option to exit after the first failed
   test.
   Patch by Till Hoffmann.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -3812,6 +3812,17 @@ and the number of workers to use.
 
    .. versionadded:: 7.3
 
+.. confval:: linkcheck_allow_forbidden
+   :type: :code-py:`bool`
+   :default: :code-py:`False`
+
+   When a webserver responds with an HTTP 403 (forbidden) response,
+   the current default behaviour of the *linkcheck* builder is
+   to treat the link as "broken".
+   To change that behaviour, set this option to :code-py:`True`.
+
+   .. versionadded:: 8.3
+
 .. confval:: linkcheck_rate_limit_timeout
    :type: :code-py:`int`
    :default: :code-py:`300`

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -473,8 +473,8 @@ and the generic :rst:dir:`admonition` directive.
 
    .. seealso::
 
-      Module :py:mod:`zipfile`
-         Documentation of the :py:mod:`zipfile` standard module.
+      Python's :py:mod:`zipfile` module
+         Documentation of Python's standard :py:mod:`zipfile` module.
 
       `GNU tar manual, Basic Tar Format <https://example.org>`_
          Documentation for tar archive files, including GNU tar extensions.

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -604,7 +604,7 @@ class HyperlinkAvailabilityCheckWorker(Thread):
 
                 # Forbidden: the request was forbidden (access or refused)
                 if status_code == 403:
-                    if self._allow_forbbiden:
+                    if self._allow_forbidden:
                         return _Status.WORKING, 'forbidden', 0
                     else:
                         return _Status.BROKEN, 'forbidden', 0

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -680,7 +680,7 @@ def test_linkcheck_request_headers_default(app: SphinxTestApp) -> None:
     assert content['status'] == 'working'
 
 
-def make_redirect_handler(*, support_head: bool) -> type[BaseHTTPRequestHandler]:
+def make_redirect_handler(*, support_head: bool = True) -> type[BaseHTTPRequestHandler]:
     class RedirectOnceHandler(BaseHTTPRequestHandler):
         protocol_version = 'HTTP/1.1'
 
@@ -715,6 +715,7 @@ def make_redirect_handler(*, support_head: bool) -> type[BaseHTTPRequestHandler]
 )
 def test_follows_redirects_on_HEAD(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=True)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')
@@ -728,6 +729,9 @@ def test_follows_redirects_on_HEAD(app, capsys):
         127.0.0.1 - - [] "HEAD /?redirected=1 HTTP/1.1" 204 -
         """,
     )
+    assert (
+        f'redirect  http://{address}/ - with Found to http://{address}/?redirected=1\n'
+    ) in strip_escape_sequences(app.status.getvalue())
     assert app.warning.getvalue() == ''
 
 
@@ -738,6 +742,7 @@ def test_follows_redirects_on_HEAD(app, capsys):
 )
 def test_follows_redirects_on_GET(app, capsys):
     with serve_application(app, make_redirect_handler(support_head=False)) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
         app.build()
     _stdout, stderr = capsys.readouterr()
     content = (app.outdir / 'output.txt').read_text(encoding='utf8')
@@ -752,7 +757,35 @@ def test_follows_redirects_on_GET(app, capsys):
         127.0.0.1 - - [] "GET /?redirected=1 HTTP/1.1" 204 -
         """,
     )
+    assert (
+        f'redirect  http://{address}/ - with Found to http://{address}/?redirected=1\n'
+    ) in strip_escape_sequences(app.status.getvalue())
     assert app.warning.getvalue() == ''
+
+
+@pytest.mark.sphinx(
+    'linkcheck',
+    testroot='linkcheck-localserver',
+    freshenv=True,
+    confoverrides={'linkcheck_allowed_redirects': {}},  # warn about any redirects
+)
+def test_warns_disallowed_redirects(app, capsys):
+    with serve_application(app, make_redirect_handler()) as address:
+        compile_linkcheck_allowed_redirects(app, app.config)
+        app.build()
+    _stdout, stderr = capsys.readouterr()
+    content = (app.outdir / 'output.txt').read_text(encoding='utf8')
+    assert content == (
+        'index.rst:1: [redirected with Found] '
+        f'http://{address}/ to http://{address}/?redirected=1\n'
+    )
+    assert stderr == textwrap.dedent(
+        """\
+        127.0.0.1 - - [] "HEAD / HTTP/1.1" 302 -
+        127.0.0.1 - - [] "HEAD /?redirected=1 HTTP/1.1" 204 -
+        """,
+    )
+    assert len(app.warning.getvalue().splitlines()) == 1
 
 
 def test_linkcheck_allowed_redirects_config(

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -587,6 +587,50 @@ def test_unauthorized_broken(app: SphinxTestApp) -> None:
     'linkcheck',
     testroot='linkcheck-localserver',
     freshenv=True,
+    confoverrides={
+        'linkcheck_allow_forbidden': False,
+        'linkcheck_auth': [('.*', ('user1', 'bad'))],
+    },
+)
+def test_forbidden_broken(app: SphinxTestApp) -> None:
+    with serve_application(
+        app, custom_handler(valid_credentials=('user1', 'password'))
+    ):
+        app.build()
+
+    with open(app.outdir / 'output.json', encoding='utf-8') as fp:
+        content = json.load(fp)
+
+    assert content['info'] == 'forbidden'
+    assert content['status'] == 'broken'
+
+
+@pytest.mark.sphinx(
+    'linkcheck',
+    testroot='linkcheck-localserver',
+    freshenv=True,
+    confoverrides={
+        'linkcheck_allow_forbidden': True,
+        'linkcheck_auth': [('.*', ('user1', 'bad'))],
+    },
+)
+def test_forbidden_allowed(app: SphinxTestApp) -> None:
+    with serve_application(
+        app, custom_handler(valid_credentials=('user1', 'password'))
+    ):
+        app.build()
+
+    with open(app.outdir / 'output.json', encoding='utf-8') as fp:
+        content = json.load(fp)
+
+    assert content['info'] == 'forbidden'
+    assert content['status'] == 'working'
+    
+
+@pytest.mark.sphinx(
+    'linkcheck',
+    testroot='linkcheck-localserver',
+    freshenv=True,
     confoverrides={'linkcheck_auth': [(r'^$', ('user1', 'password'))]},
 )
 def test_auth_header_no_match(app: SphinxTestApp) -> None:


### PR DESCRIPTION
## Purpose

Add `linkcheck_allow_forbidden` option to let 403 be marked as "working".

Defining it as a properly configurable option, as requested: https://github.com/sphinx-doc/sphinx/pull/9762#issuecomment-1268682998

## References

- https://github.com/sphinx-doc/sphinx/pull/9762
- https://github.com/sphinx-doc/sphinx/issues/9761
