### PR TITLE
autodoc: Fix subclassing a MockObject together with ``typing.Generic``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,9 @@ Bugs fixed
 * #10785: Autodoc: Allow type aliases defined in the project to be properly
   cross-referenced when used as type annotations. This makes it possible
   for objects documented as ``:py:data:`` to be hyperlinked in function signatures.
+* #12797: Fix
+  ``TypeError: Some type variables (...) are not listed in Generic[...]``
+  when inheriting from both Generic and autodoc mocked class.
 
 Testing
 -------

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -29,6 +29,8 @@ class _MockObject:
     __name__ = ''
     __sphinx_mock__ = True
     __sphinx_decorator_args__: tuple[Any, ...] = ()
+    # Attributes listed here should not be mocked and rather raise an Attribute error:
+    __sphinx_empty_attrs__: set[str] = {'__typing_subst__'}
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Any:  # NoQA: ARG004
         if len(args) == 3 and isinstance(args[1], tuple):
@@ -63,6 +65,8 @@ class _MockObject:
         return _make_subclass(str(key), self.__display_name__, self.__class__)()
 
     def __getattr__(self, key: str) -> _MockObject:
+        if key in self.__sphinx_empty_attrs__:
+            raise AttributeError
         return _make_subclass(key, self.__display_name__, self.__class__)()
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:

--- a/tests/test_extensions/test_ext_autodoc_mock.py
+++ b/tests/test_extensions/test_ext_autodoc_mock.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import sys
 from importlib import import_module
-from typing import TypeVar
+from typing import TypeVar, Generic
 
 import pytest
 
@@ -56,6 +56,28 @@ def test_MockObject():
     obj2 = SubClass2()
     assert SubClass2.__doc__ == 'docstring of SubClass'
     assert isinstance(obj2, SubClass2)
+
+    # test subclass with typing.Generic
+    # Creating this class would raise an error on Python3.11+
+    # as mock objects are detected as typevars if hasattr(__typing_subst__) is True.
+
+    assert not hasattr(mock.SomeClass, '__typing_subst__')
+    S = TypeVar('S')
+
+    class GenericClass(mock.SomeClass, Generic[T, S]):
+        """docstring of GenericSubclass"""
+
+    obj3 = GenericClass()
+    assert isinstance(obj3, _MockObject)
+    assert isinstance(obj3.some_attr, _MockObject)
+    assert isinstance(obj3.some_method(), _MockObject)
+    assert isinstance(obj3.attr1.attr2, _MockObject)
+    assert isinstance(obj3.attr1.attr2.meth(), _MockObject)
+
+    # check that Generic Subscriptions still works
+
+    class GenericSubclass(GenericClass[mock.MockedClass, S]):
+        """docstring of GenericSubclass"""
 
 
 def test_mock() -> None:

--- a/tests/test_extensions/test_ext_autodoc_mock.py
+++ b/tests/test_extensions/test_ext_autodoc_mock.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import sys
 from importlib import import_module
-from typing import TypeVar, Generic
+from typing import Generic, TypeVar
 
 import pytest
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->

## Purpose

When subclassing a MockObject and typing.Generic the mock object will be detected as a `TypeVar` by `typing` when subclassing `Generic`, see: https://github.com/python/cpython/blob/31d3836f26096f9503ca68f4e89d927bc1e060cd/Lib/typing.py#L1175

Especially this line in the utility function to gather TypeVars should not be True: [`elif hasattr(t, '__typing_subst__'):`](https://github.com/python/cpython/blob/31d3836f26096f9503ca68f4e89d927bc1e060cd/Lib/typing.py#L297). 
But, as it is a mock object, `hasattr` will return True which will raise an error on Python 3.11/12. (3.10 is fine). I did not test 3.13 or 3.14.




<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

Fixes #12797
Continues PR #12850 by @IkorJefocur with a slight reinterpretation and added tests.
