### PR TITLE
Resolved a TMPLDIR inconsistency and added some error reporting.

### DIFF
--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -204,7 +204,7 @@ class QuickstartRenderer(SphinxRenderer):
             custom_template = os.path.join(self.templatedir, template_name)
             return self.render_from_file(custom_template, context)
         else:
-            if (bool(self.templatedir)):
+            if bool(self.templatedir):
                 print(
                     __('Ignoreing TEMPLATEDIR=%s for %s')
                     % (self.templatedir, template_name)

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -207,7 +207,8 @@ class QuickstartRenderer(SphinxRenderer):
             return self.render_from_file(custom_template, context)
         else:
             if (bool(self.templatedir)):
-                print(__('Ignoreing TEMPLATEDIR=%s for %s') % (self.templatedir, template_name))
+                print(__('Ignoreing TEMPLATEDIR=%s for %s') %
+                      (self.templatedir, template_name))
             return super().render(template_name, context)
 
 
@@ -479,7 +480,7 @@ def generate(
     conf_path = os.path.join(templatedir, TMPLSUBDIR, 'conf.py.jinja') if templatedir else None
     if not conf_path or not os.path.isfile(conf_path):
         if (bool(templatedir)):
-            print(__("%s does not exist, reverting to default template.") % (conf_path,))
+            print(__('%s does not exist, reverting to default template.') % (conf_path,))
         conf_path = os.path.join(
             package_dir, 'templates', TMPLSUBDIR, 'conf.py.jinja'
         )

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -201,14 +201,14 @@ class QuickstartRenderer(SphinxRenderer):
 
     def render(self, template_name: str, context: dict[str, Any]) -> str:
         if self._has_custom_template(template_name):
-            custom_template = os.path.join(
-                self.templatedir, template_name
-            )
+            custom_template = os.path.join(self.templatedir, template_name)
             return self.render_from_file(custom_template, context)
         else:
             if (bool(self.templatedir)):
-                print(__('Ignoreing TEMPLATEDIR=%s for %s') %
-                      (self.templatedir, template_name))
+                print(
+                    __('Ignoreing TEMPLATEDIR=%s for %s')
+                    % (self.templatedir, template_name)
+                )
             return super().render(template_name, context)
 
 
@@ -477,13 +477,15 @@ def generate(
             if 'quiet' not in d:
                 print(__('File %s already exists, skipping.') % fpath)
 
-    conf_path = os.path.join(templatedir, TMPLSUBDIR, 'conf.py.jinja') if templatedir else None
+    conf_path = (
+        os.path.join(templatedir, TMPLSUBDIR, 'conf.py.jinja') if templatedir else None
+    )
     if not conf_path or not os.path.isfile(conf_path):
-        if (bool(templatedir)):
-            print(__('%s does not exist, reverting to default template.') % (conf_path,))
-        conf_path = os.path.join(
-            package_dir, 'templates', TMPLSUBDIR, 'conf.py.jinja'
-        )
+        if bool(templatedir):
+            print(
+                __('%s does not exist, reverting to default template.') % (conf_path,)
+            )
+        conf_path = os.path.join(package_dir, 'templates', TMPLSUBDIR, 'conf.py.jinja')
     with open(conf_path, encoding='utf-8') as f:
         conf_text = f.read()
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose
* Bugfix.
<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

The -t/--templatedir option is currently inconsistent and hard to use, failing silently. This patch fixes that inconsistency and adds error reporting when falling back to the package-provided templates.

I initially considered implementing PATH-like behavior, but comments suggest this file is mid-refactoring. This diff therefore only addresses the inconsistency. If there’s a plan or preferred direction for quickstart.py development, I’m happy to follow it.

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- <...>
- <...>
- <...>
