### PR TITLE
Fix test setup for directive tests.

### DIFF
--- a/tests/roots/test-root/wrongenc.inc
+++ b/tests/roots/test-root/wrongenc.inc
@@ -1,3 +1,3 @@
 This file is encoded in latin-1 but at first read as utf-8.
 
-Max Strauß aß in München eine Leberkässemmel.
+Max StrauÃŸ aÃŸ in MÃ¼nchen eine LeberkÃ¤ssemmel.


### PR DESCRIPTION
Set the "parent" attribute of RSTState instances to the `document` instead of None. The attribute holds the state machines "current node" which is initialized to the `document` in `RSTStateMachine.run()` and required since Docutils 0.22.1 in `RSTState.nested_parse()` to correctly support sections in nested parsing.

## Purpose
Get the test with Docutils HEAD working again.
