### PR TITLE
Fix TypeError in ext.coverage logging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,8 @@ Bugs fixed
   for objects documented as ``:py:data:`` to be hyperlinked in function signatures.
 * #13858: doctest: doctest blocks are now correctly added to a group defined by the
   configuration variable ``doctest_test_doctest_blocks``.
+* #13885: Coverage builder: Fix TypeError when warning about missing modules.
+  Patch by Damien Ayers.
 
 
 Testing

--- a/sphinx/ext/coverage.py
+++ b/sphinx/ext/coverage.py
@@ -156,7 +156,7 @@ def _determine_py_coverage_modules(
         logger.warning(
             __(
                 'the following modules are specified in coverage_modules '
-                'but were not documented'
+                'but were not documented: %s'
             ),
             ', '.join(missing_modules),
         )


### PR DESCRIPTION

## Purpose

If there are any missing modules when using the coverage builder, a `TypeError` is thrown instead of a warning message being printed. 

The warning message is missing a `%s` to match the passed string of missing modules.


<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


