### PR TITLE
Permit filtering warnings generated during source code parsing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -117,6 +117,7 @@ Contributors
 * Thomas Waldmann -- apidoc module fixes
 * Till Hoffmann -- doctest option to exit after first failed test
 * Tim Hoffmann -- theme improvements
+* Valentin Heinisch -- warning types improvement
 * Victor Wheeler -- documentation improvements
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,8 +102,8 @@ Features added
   Patch by Matthias Geier.
 * #14029: intersphinx: Fix error in format string interpolation.
   Patch by Matthieu de Cibeins.
-* #13894: Add ``code_parser`` type to :confval:`suppress_warnings` for grouping
-  issues related to the ``c`` and ``cpp`` source code parsers.
+* #13894: Add ``source_code_parser`` type to :confval:`suppress_warnings`
+  for grouping issues related to the C and C++ parsers.
   Patch by Valentin H.
 
 Bugs fixed

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ Features added
   Patch by Matthias Geier.
 * #14029: intersphinx: Fix error in format string interpolation.
   Patch by Matthieu de Cibeins.
+* #13894: Add ``code_parser`` type to :confval:`suppress_warnings` for grouping
+  issues related to the ``c`` and ``cpp`` source code parsers.
+  Patch by Valentin H.
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1402,8 +1402,8 @@ Options for warning control
    * ``ref.python``
    * ``ref.ref``
    * ``ref.term``
-   * ``source_parser.c``
-   * ``source_parser.cpp``
+   * ``source_code_parser.c``
+   * ``source_code_parser.cpp``
    * ``toc.circular``
    * ``toc.duplicate_entry``
    * ``toc.empty_glob``

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1402,6 +1402,8 @@ Options for warning control
    * ``ref.python``
    * ``ref.ref``
    * ``ref.term``
+   * ``source_parser.c``
+   * ``source_parser.cpp``
    * ``toc.circular``
    * ``toc.duplicate_entry``
    * ``toc.empty_glob``

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -357,7 +357,9 @@ class BaseParser:
 
     def warn(self, msg: str) -> None:
         subtype = 'c' if self.language == 'C' else 'cpp'
-        logger.warning(msg, location=self.location, type='code_parser', subtype=subtype)
+        logger.warning(
+            msg, location=self.location, type='source_code_parser', subtype=subtype
+        )
 
     def match(self, regex: re.Pattern[str]) -> bool:
         match = regex.match(self.definition, self.pos)

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -356,7 +356,8 @@ class BaseParser:
         raise self._make_multi_error(errors, '')
 
     def warn(self, msg: str) -> None:
-        logger.warning(msg, location=self.location)
+        subtype = 'c' if self.language == 'C' else 'cpp'
+        logger.warning(msg, location=self.location, type='code_parser', subtype=subtype)
 
     def match(self, regex: re.Pattern[str]) -> bool:
         match = regex.match(self.definition, self.pos)


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

To allow filtering of warnings related to source code parsing by the `c` and `cpp` domains, I would like to add the `source_parser` logging type.