### PR TITLE
Use consistent ordering for user defined ids

### DIFF
--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -215,13 +215,13 @@ class AutoNumbering(SphinxTransform):
 
 
 class SortIds(SphinxTransform):
-    """Sort section IDs so that the "id[0-9]+" one comes last."""
+    """Sort section IDs so that the custom id comes first."""
 
     default_priority = 261
 
     def apply(self, **kwargs: Any) -> None:
         for node in self.document.findall(nodes.section):
-            if len(node['ids']) > 1 and node['ids'][0].startswith('id'):
+            if len(node['ids']) > 1:
                 node['ids'] = [*node['ids'][1:], node['ids'][0]]
 
 

--- a/tests/test_builders/test_build_epub.py
+++ b/tests/test_builders/test_build_epub.py
@@ -418,7 +418,7 @@ def test_epub_anchor_id(app: SphinxTestApp) -> None:
     html = (app.outdir / 'index.xhtml').read_text(encoding='utf8')
     assert '<p id="std-setting-STATICFILES_FINDERS">blah blah blah</p>' in html
     assert (
-        '<span id="std-setting-STATICFILES_SECTION"></span><h1>blah blah blah</h1>'
+        '<section id="std-setting-STATICFILES_SECTION">\n<span id="blah-blah-blah"></span><h1>blah blah blah</h1>'
     ) in html
     assert (
         'see <a class="reference internal" href="#std-setting-STATICFILES_FINDERS">'

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -1963,14 +1963,14 @@ def test_latex_labels(app: SphinxTestApp) -> None:
     # sections
     assert (
         '\\chapter{subsection}\n'
-        r'\label{\detokenize{index:subsection}}'
         r'\label{\detokenize{index:section2}}'
         r'\label{\detokenize{index:section1}}'
+        r'\label{\detokenize{index:subsection}}'
     ) in result
     assert (
         '\\section{subsubsection}\n'
-        r'\label{\detokenize{index:subsubsection}}'
         r'\label{\detokenize{index:section3}}'
+        r'\label{\detokenize{index:subsubsection}}'
     ) in result
     assert (
         '\\subsection{otherdoc}\n'

--- a/tests/test_transforms/test_transforms_move_module_targets.py
+++ b/tests/test_transforms/test_transforms_move_module_targets.py
@@ -44,8 +44,8 @@ def test_move_module_targets(tmp_path: Path, content: str) -> None:
     document = app.env.get_doctree('index')
     section: nodes.section = document[0]  # type: ignore[assignment]
 
-    # target ID has been lifted into the section node
-    assert section['ids'] == ['module-fish_licence.halibut', 'move-module-targets']
+    # target ID is not lifted into the section node
+    assert section['ids'] == ['move-module-targets', 'module-fish_licence.halibut']
     # nodes.target has been removed from 'section'
     assert isinstance(section[0], nodes.title)
     assert isinstance(section[1], addnodes.index)


### PR DESCRIPTION
## Purpose

When a label is placed directly before a section title, it is inconsistently used in html when section names are repeated.

Fixes #13905 by using user defined `id` always for `section`. The output for the example in the issue becomes
```html
<section id="label1">
<span id="section"></span><h3>Section<a class="headerlink" href="#label1" title="Link to this heading">¶</a></h3>
<section id="id1">
<h4>Section<a class="headerlink" href="#id1" title="Link to this heading">¶</a></h4>
<section id="label2">
<span id="id2"></span><h5>Section<a class="headerlink" href="#label2" title="Link to this heading">¶</a></h5>
</section>
</section>
</section>
```

This is the opposite of what docutils generates by default though. Where, the user defined `id` is always applied to `span`. Which I think is the better solution. Because `span` is only there when there is a user-defined `id`. But sphinx for some reason has `SortIds` which is explicitly designed to keep `idx` away from `section`.