### PR TITLE
Skip inconsistent sorting of ids

### DIFF
--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -214,17 +214,6 @@ class AutoNumbering(SphinxTransform):
                 self.document.note_implicit_target(node)
 
 
-class SortIds(SphinxTransform):
-    """Sort section IDs so that the "id[0-9]+" one comes last."""
-
-    default_priority = 261
-
-    def apply(self, **kwargs: Any) -> None:
-        for node in self.document.findall(nodes.section):
-            if len(node['ids']) > 1 and node['ids'][0].startswith('id'):
-                node['ids'] = [*node['ids'][1:], node['ids'][0]]
-
-
 TRANSLATABLE_NODES = {
     'literal-block': nodes.literal_block,
     'doctest-block': nodes.doctest_block,
@@ -514,7 +503,6 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_transform(DefaultSubstitutions)
     app.add_transform(MoveModuleTargets)
     app.add_transform(HandleCodeBlocks)
-    app.add_transform(SortIds)
     app.add_transform(DoctestTransform)
     app.add_transform(AutoNumbering)
     app.add_transform(AutoIndexUpgrader)


### PR DESCRIPTION
## Purpose

When a label is placed directly before a section title, it is inconsistently used in html when section names are repeated.

Fixes #13905 using an alternate, docutils preferred, solution. The output for the example in the issue becomes
```html
<section id="section">
<span id="label1"></span><h3>Section<a class="headerlink" href="#section" title="Link to this heading">¶</a></h3>
<section id="id1">
<h4>Section<a class="headerlink" href="#id1" title="Link to this heading">¶</a></h4>
<section id="id2">
<span id="label2"></span><h5>Section<a class="headerlink" href="#id2" title="Link to this heading">¶</a></h5>
</section>
</section>
</section>
```
`span` always uses user-defined `id`. And therefore, sometimes `section` and `href` gets `idx` (see `h5`). 