### PR TITLE
Do not run `window.history.replaceState` unconditionally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,8 @@ Bugs fixed
 * #14059: LaTeX: Footnotes cause pdflatex error with French language
   (since late June 2025 upstream change to LaTeX ``babel-french``).
   Patch by Jean-François B.
+* #13916: HTML Search: do not clear text fragments from the URL on page load.
+  Patch by Harmen Stoppels.
 
 
 Testing

--- a/sphinx/themes/basic/static/sphinx_highlight.js
+++ b/sphinx/themes/basic/static/sphinx_highlight.js
@@ -80,8 +80,10 @@ const SphinxHighlight = {
       || url.searchParams.get("highlight")
       || "";
     localStorage.removeItem("sphinx_highlight_terms");
-    url.searchParams.delete("highlight");
-    window.history.replaceState({}, "", url);
+    if (url.searchParams.has("highlight")) {
+      url.searchParams.delete("highlight");
+      window.history.replaceState({}, "", url);
+    }
 
     // get individual terms from highlight string
     const terms = highlight

--- a/sphinx/themes/basic/static/sphinx_highlight.js
+++ b/sphinx/themes/basic/static/sphinx_highlight.js
@@ -80,6 +80,8 @@ const SphinxHighlight = {
       || url.searchParams.get("highlight")
       || "";
     localStorage.removeItem("sphinx_highlight_terms");
+    // run replaceState only if "highlight" is present; otherwise it
+    // clears text fragments (not set in window.location by the browser)
     if (url.searchParams.has("highlight")) {
       url.searchParams.delete("highlight");
       window.history.replaceState({}, "", url);

--- a/sphinx/themes/basic/static/sphinx_highlight.js
+++ b/sphinx/themes/basic/static/sphinx_highlight.js
@@ -80,7 +80,7 @@ const SphinxHighlight = {
       || url.searchParams.get("highlight")
       || "";
     localStorage.removeItem("sphinx_highlight_terms");
-    // run replaceState only if "highlight" is present; otherwise it
+    // Update history only if '?highlight' is present; otherwise it
     // clears text fragments (not set in window.location by the browser)
     if (url.searchParams.has("highlight")) {
       url.searchParams.delete("highlight");


### PR DESCRIPTION
Closes #13916 

Currently every Sphinx documentation page *always* drops `#:~:text=...` [Text Fragments](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments) due to an unconditional `window.history.replaceState()` call. That `replaceState()` is almost always redundant, since it happens when handling `?highlight=...` search term highlighting, which is rarely present in the URL.

It's undesirable, because it prevents users from sharing the URL verbatim including the text fragment from the browser's URL bar. Text fragments are increasingly popular these days as they're used by Google Search and various LLMs to scroll to and highlight specific content on a longer page.

The solution is to only call `window.history.replaceState` when a Sphinx's custom `?highlight=...` search param is part of the URL.

