### PR TITLE
sphinx_highlight.js: remove `?highlight=` query param handling

### DIFF
--- a/sphinx/themes/basic/static/sphinx_highlight.js
+++ b/sphinx/themes/basic/static/sphinx_highlight.js
@@ -74,14 +74,8 @@ const SphinxHighlight = {
     if (!SPHINX_HIGHLIGHT_ENABLED) return; // bail if no highlight
 
     // get and clear terms from localstorage
-    const url = new URL(window.location);
-    const highlight =
-      localStorage.getItem("sphinx_highlight_terms")
-      || url.searchParams.get("highlight")
-      || "";
+    const highlight = localStorage.getItem("sphinx_highlight_terms") || "";
     localStorage.removeItem("sphinx_highlight_terms");
-    url.searchParams.delete("highlight");
-    window.history.replaceState({}, "", url);
 
     // get individual terms from highlight string
     const terms = highlight
@@ -91,11 +85,10 @@ const SphinxHighlight = {
     if (terms.length === 0) return; // nothing to do
 
     // There should never be more than one element matching "div.body"
-    const divBody = document.querySelectorAll("div.body");
-    const body = divBody.length ? divBody[0] : document.querySelector("body");
-    window.setTimeout(() => {
+    const body = document.querySelector("div.body") || document.body;
+    window.requestAnimationFrame(() => {
       terms.forEach((term) => _highlightText(body, term, "highlighted"));
-    }, 10);
+    });
 
     const searchBox = document.getElementById("searchbox");
     if (searchBox === null) return;


### PR DESCRIPTION
Closes #13916

Alternative to #13918

* Remove support for `?highlight=` query param as a (manual) fallback for search highlighting.

While at it:
* Simplify `document.querySelectorAll("div.body")[0]` to `document.querySelector("div.body")`
* Simplify `document.querySelector("body")` with `document.body`
* Replace `setTimeout` with `requestAnimationFrame`

## Purpose

This PR removes the `?highlight=` related code, for two reasons:

1. Sphinx does not use `?highlight=` links internally.
2. Browser native support for Text Fragments `#:~:text=...` is a decent replacement for `?highlight=...` for adding highlighting manually.
3. The current logic runs `window.history.replaceState` unconditionally. This has an unpleasant side effect: it removes `#:~:text=...` fragments from the URL, making it hard to purposefully share URLs that include highlighted text.


## References

- Back in 2022 Sphinx moved from `<url>?highlight=search-term` to `localStorage.setItem("sphinx_highlight_terms", "search-term")` to support highlighting of search terms on a page: #10854
- In https://github.com/sphinx-doc/sphinx/pull/10854#issuecomment-1256915352 it was requested that `?highlight=...` URLs were still supported, cause you could add that manually.
- Another somewhat conflicting request from https://github.com/sphinx-doc/sphinx/issues/10833, `?highlight=...` was to always remove `?highlight=` from the URL.
- #13916
- #13918
