### PR TITLE
Fix incorrect index treatment of :canonical: option in py:type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,9 @@ Features added
 Bugs fixed
 ----------
 
+* #13926: multiple py:type directives for the same canonical type no
+  longer result in spurious duplicate object description warnings.
+  Patch by Jeremy Maitin-Shepard.
 * #1327: LaTeX: tables using longtable raise error if
   :rst:dir:`tabularcolumns` specifies automatic widths
   (``L``, ``R``, ``C``, or ``J``).

--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -424,11 +424,17 @@ class PyObject(ObjectDescription[tuple[str, str]]):
         domain = self.env.domains.python_domain
         domain.note_object(fullname, self.objtype, node_id, location=signode)
 
-        canonical_name = self.options.get('canonical')
-        if canonical_name:
-            domain.note_object(
-                canonical_name, self.objtype, node_id, aliased=True, location=signode
-            )
+        if self.objtype != 'type':
+            # py:type directive uses `canonical` option for a different meaning
+            canonical_name = self.options.get('canonical')
+            if canonical_name:
+                domain.note_object(
+                    canonical_name,
+                    self.objtype,
+                    node_id,
+                    aliased=True,
+                    location=signode,
+                )
 
         if 'no-index-entry' not in self.options:
             if index_text := self.get_index_text(mod_name, name_cls):  # type: ignore[arg-type]

--- a/tests/test_domains/test_domain_py.py
+++ b/tests/test_domains/test_domain_py.py
@@ -1806,3 +1806,16 @@ def test_deco_role(app):
 
     doctree = restructuredtext.parse(app, text + '\n:py:deco:`~foo.bar`')
     assert doctree.astext() == '\n\n\n\n@bar'
+
+
+def test_pytype_canonical(app):
+    text = """\
+.. py:type:: A
+   :canonical: int
+
+.. py:type:: B
+   :canonical: int
+ """
+
+    doctree = restructuredtext.parse(app, text)
+    assert not app.warning.getvalue()


### PR DESCRIPTION
## Purpose

Previously, two aliases for the same canonical type resulted in a duplicate object description warning.
