### PR TITLE
Update roman-numerals-py to use roman-numerals. bug 13825

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     "alabaster>=0.7.14",
     "imagesize>=1.3",
     "requests>=2.30.0",
-    "roman-numerals-py>=1.0.0",
+    "roman-numerals>=1.0.0",
     "packaging>=23.0",
     "colorama>=0.4.6; sys_platform == 'win32'",
     "ipython>=9.6.0",


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->
This is a bugfix for issue outlined here
https://github.com/sphinx-doc/sphinx/issues/13825

This will update the roman-numerals-py package got renamed upstream to roman-numerals.

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

https://github.com/sphinx-doc/sphinx/issues/13825

- <...>
- <...>
- <...>
