### PR TITLE
Fix #13939: LaTeX: page break after admonition title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,8 @@ Bugs fixed
   directly defined in certain cases, depending on autodoc processing
   order.
   Patch by Jeremy Maitin-Shepard.
+* #13939: LaTeX: page break can separate admonition title from contents.
+  Patch by Jean-François B.
 
 
 Testing

--- a/sphinx/texinputs/sphinxlatexadmonitions.sty
+++ b/sphinx/texinputs/sphinxlatexadmonitions.sty
@@ -1,7 +1,7 @@
 %% NOTICES AND ADMONITIONS
 %
 % change this info string if making any custom modification
-\ProvidesPackage{sphinxlatexadmonitions}[2025/04/24 v8.3.0 admonitions]
+\ProvidesPackage{sphinxlatexadmonitions}[2025/10/24 v8.3.0 admonitions]
 
 % Provides support for this output mark-up from Sphinx latex writer:
 %
@@ -53,6 +53,7 @@
 % - \spx@boxes@fcolorbox@setup from sphinxpackageboxes.sty
 %
 \RequirePackage{framed}
+\RequirePackage{needspace}
 % Those are required either before or after by sphinx.sty anyhow, but for
 % clarity we list them here:
 \RequirePackage{sphinxlatexgraphics}
@@ -107,7 +108,12 @@
 %
 % Code adapted from framed.sty's "snugshade" environment.
 % Nesting works (inner frames do not allow page breaks).
+%
+% At 8.3.0, avoid admonition title getting separated from contents at a
+% page break.
+\newcommand\sphinxheavyboxneedspacecommand{\needspace{5\baselineskip}}
 \newenvironment{sphinxheavybox}{\par
+   \sphinxheavyboxneedspacecommand
    % (MEMO: it is not a problem here if there is no sphinx<type>ShadowColor,
    %  as it used only if set)
    \spx@boxes@fcolorbox@setup{\spx@noticetype}%


### PR DESCRIPTION
Fix #13939