### PR TITLE
Allow anchors to wrap anywhere

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,8 @@ Bugs fixed
   Patch by Jeremy Maitin-Shepard.
 * #13939: LaTeX: page break can separate admonition title from contents.
   Patch by Jean-François B.
+* #13989: Allow anchors to wrap anywhere.
+  Patch by Nadav Tasher.
 
 
 Testing

--- a/sphinx/themes/basic/static/basic.css.jinja
+++ b/sphinx/themes/basic/static/basic.css.jinja
@@ -230,6 +230,10 @@ a:visited {
     color: #551A8B;
 }
 
+a {
+    overflow-wrap: break-word;
+}
+
 h1:hover > a.headerlink,
 h2:hover > a.headerlink,
 h3:hover > a.headerlink,


### PR DESCRIPTION
## Purpose
Anchors with very long unbreakable links cause pages to be horizontally scrollable on mobile.
Fix this by allowing anchors to break anywhere.

This was observed on the following page:
https://docs.kernel.org/filesystems/ramfs-rootfs-initramfs.html#why-cpio-rather-than-tar

### Screenshots
Without the proposed changes:
<img width="446" height="870" alt="image" src="https://github.com/user-attachments/assets/4701a1fa-ecca-46ae-befc-41f734ff0bf3" />

With the proposed changes:
<img width="446" height="870" alt="image" src="https://github.com/user-attachments/assets/b51c0481-9b95-40e5-86df-1356cc622728" />