### PR TITLE
Add LaTeX admonition \needspace test for PR #13939

### DIFF
--- a/tests/roots/test-latex-admonition/conf.py
+++ b/tests/roots/test-latex-admonition/conf.py
@@ -1,0 +1,2 @@
+project = 'admonition test'
+extensions = []

--- a/tests/roots/test-latex-admonition/index.rst
+++ b/tests/roots/test-latex-admonition/index.rst
@@ -1,0 +1,6 @@
+Admonition Test
+===============
+
+.. note::
+
+    This is a test note that should trigger a \needspace command in LaTeX output.

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -2311,3 +2311,21 @@ def test_latex_contents_topic_sidebar(app: SphinxTestApp) -> None:
         'text of sidebar\n'
         '\\end{sphinxsidebar}\n'
     ) in result
+
+
+@pytest.mark.sphinx('latex', testroot='latex-admonition')
+def test_latex_admonition_needspace(app: SphinxTestApp) -> None:
+    """Test that admonitions use \needspace to avoid page breaks between title and content."""
+    assert app.builder.name == "latex"
+
+    app.build(force_all=True)
+    result = (app.outdir / 'admonitiontest.tex').read_text(encoding='utf8')
+
+    # Look for the \sphinxheavyboxneedspacecommand followed immediately
+    # by the \begin{sphinxheavybox} environment.
+    pattern = re.compile(r'\\sphinxheavyboxneedspacecommand\s*\\begin{sphinxheavybox}')
+
+    assert pattern.search(result) is not None, (
+        "The \\sphinxheavyboxneedspacecommand was not found immediately "
+        "before the sphinxheavybox environment."
+    )


### PR DESCRIPTION
## Purpose

This PR adds a new regression test for the issue described in #13939, where a page break can occur between an admonition's title and its content in the LaTeX output.

This PR adds the test case to verify the fix.

The new test, test_latex_admonition_needspace, does the following:

1. Adds a new test root, test-latex-admonition, to generate a document with an admonition.
2. Builds the LaTeX output.
3. Reads the resulting .tex file and uses a regular expression to assert that the \sphinxheavyboxneedspacecommand is inserted immediately before the \begin{sphinxheavybox} environment.

This test will fail without the corresponding fix and will pass once the fix is applied, preventing this issue from happening again.


## References
- Relates to #13939
- <...>
- <...>
