### PR TITLE
Test refactor changes builder

### DIFF
--- a/tests/test_builders/test_build_changes.py
+++ b/tests/test_builders/test_build_changes.py
@@ -9,28 +9,53 @@ import pytest
 if TYPE_CHECKING:
     from sphinx.testing.util import SphinxTestApp
 
+import re   # <--- IMPORT ADDED
+
+from bs4 import BeautifulSoup   # <--- IMPORT ADDED
+
 
 @pytest.mark.sphinx('changes', testroot='changes')
 def test_build(app: SphinxTestApp) -> None:
+    """Test the 'changes' builder and resolve TODO for better HTML checking."""
     app.build()
 
-    # TODO: Use better checking of html content
     htmltext = (app.outdir / 'changes.html').read_text(encoding='utf8')
-    assert 'Added in version 0.6: Some funny stuff.' in htmltext
-    assert 'Changed in version 0.6: Even more funny stuff.' in htmltext
-    assert 'Deprecated since version 0.6: Boring stuff.' in htmltext
+    soup = BeautifulSoup(htmltext, 'html.parser')
 
-    path_html = (
-        '<b>Path</b>: <i>deprecated:</i> Deprecated since version 0.6:'
-        ' So, that was a bad idea it turns out.'
-    )
-    assert path_html in htmltext
+    def find_change_item(type_text: str, version: str, content: str) -> dict:
+        """Helper to find and validate change items."""
+        # Use regex to find text content, ignoring surrounding whitespace/newlines
+        item = soup.find('li', string=re.compile(r'\s*' + re.escape(content) + r'\s*'))
+        assert item is not None, f"Could not find change item containing '{content}'"
 
-    malloc_html = (
-        '<b>void *Test_Malloc(size_t n)</b>: <i>changed:</i> Changed in version 0.6:'
-        ' Can now be replaced with a different allocator.</a>'
-    )
-    assert malloc_html in htmltext
+        type_elem = item.find('i')
+        assert type_elem is not None, f"Missing type indicator for '{content}'"
+        assert type_text in type_elem.text, f"Expected type '{type_text}' for '{content}'"
+
+        assert f"version {version}" in item.text, f"Version {version} not found in '{content}'"
+
+        return {'item': item, 'type': type_elem}
+
+    # Test simple changes
+    changes = [
+        ('added', '0.6', 'Some funny stuff.'),
+        ('changed', '0.6', 'Even more funny stuff.'),
+        ('deprecated', '0.6', 'Boring stuff.')
+    ]
+
+    for change_type, version, content in changes:
+        find_change_item(change_type, version, content)
+
+    # Test Path deprecation (Search by unique text)
+    path_change = find_change_item('deprecated', '0.6', 'So, that was a bad idea it turns out.')
+    assert path_change['item'].find('b').text == 'Path'
+
+    # Test Malloc function change (Search by unique text)
+    malloc_change = find_change_item('changed', '0.6', 'Can now be replaced with a different allocator.')
+    assert malloc_change['item'].find('b').text == 'void *Test_Malloc(size_t n)'
+
+    # Test the other test function still works
+    assert len(soup.find_all('li')) >= 5  # Make sure we found all items
 
 
 @pytest.mark.sphinx(

--- a/tests/test_builders/test_build_changes.py
+++ b/tests/test_builders/test_build_changes.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Any
 
 import pytest
+from bs4 import BeautifulSoup  # type: ignore[import-not-found]
 
 if TYPE_CHECKING:
     from sphinx.testing.util import SphinxTestApp
-
-import re   # <--- IMPORT ADDED
-
-from bs4 import BeautifulSoup   # <--- IMPORT ADDED
 
 
 @pytest.mark.sphinx('changes', testroot='changes')
@@ -22,7 +20,7 @@ def test_build(app: SphinxTestApp) -> None:
     htmltext = (app.outdir / 'changes.html').read_text(encoding='utf8')
     soup = BeautifulSoup(htmltext, 'html.parser')
 
-    def find_change_item(type_text: str, version: str, content: str) -> dict:
+    def find_change_item(type_text: str, version: str, content: str) -> dict[str, Any]:
         """Helper to find and validate change items."""
         # Use regex to find text content, ignoring surrounding whitespace/newlines
         item = soup.find('li', string=re.compile(r'\s*' + re.escape(content) + r'\s*'))
@@ -32,7 +30,7 @@ def test_build(app: SphinxTestApp) -> None:
         assert type_elem is not None, f"Missing type indicator for '{content}'"
         assert type_text in type_elem.text, f"Expected type '{type_text}' for '{content}'"
 
-        assert f"version {version}" in item.text, f"Version {version} not found in '{content}'"
+        assert f'version {version}' in item.text, f'Version {version} not found in {content!r}'
 
         return {'item': item, 'type': type_elem}
 


### PR DESCRIPTION
## Purpose

This PR resolves the `TODO` in `test_build_changes.py` which suggested using better HTML content checking.

The previous test implementation used simple `string in htmltext` assertions. This method is brittle and can easily fail if HTML tags, CSS classes, or attributes are changed in the future.

This commit refactors the `test_build` function to:
1.  Parse the generated HTML using **BeautifulSoup**.
2.  Validate the document structure, not just the raw text.
3.  Introduce a `find_change_item` helper function to make the test cleaner, more robust, and easier to maintain.

This makes the test more resilient to future template changes.