### PR TITLE
docs: mention CRC32 checksum for add_js_file and add_css_file (7.1)

### DIFF
--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -67,12 +67,19 @@ package.
 
 .. automethod:: Sphinx.add_post_transform
 
-.. automethod:: Sphinx.add_js_file
-.. versionchanged:: 7.1  Added CRC32 checksums to asset URIs for improved caching and integrity. When JavaScript files are added, a CRC32 checksum is now appended to the URI (e.g. ``_static/example.js?abcd1234``). This helps browsers detect when files have changed and refresh cached versions automatically. For more details, see the 7.1.0 changelog entry: https://www.sphinx-doc.org/en/master/changes.html#release-7-1-0-released-jul-24-2023 Site authors can also use the configuration options :confval:`html_js_files` and :confval:`html_static_path` to manage static JS files. Files in ``html_static_path`` override those added by extensions.
-.. automethod:: Sphinx.add_css_file
-.. versionchanged:: 7.1
-Added CRC32 checksums to asset URIs for CSS files as well, following the same caching and integrity improvements as :meth:`.Sphinx.add_js_file`.h:`.Sphinx.add_js_file`.
+.. automethod::  Sphinx.add_js_file
 
+   .. versionchanged:: 7.1
+      Added automatic CRC32 checksum for static files.
+      This ensures browsers reload updated JS assets automatically
+      instead of relying on manual cache clearing.
+
+.. automethod:: Sphinx.add_css_file
+   
+   .. versionchanged:: 7.1
+     Added automatic CRC32 checksum for static files.
+     This ensures browsers reload updated CSS assets automatically
+     instead of relying on manual cache clearing.
 .. automethod:: Sphinx.add_latex_package
 
 .. automethod:: Sphinx.add_lexer

--- a/doc/extdev/appapi.rst
+++ b/doc/extdev/appapi.rst
@@ -68,8 +68,10 @@ package.
 .. automethod:: Sphinx.add_post_transform
 
 .. automethod:: Sphinx.add_js_file
-
+.. versionchanged:: 7.1  Added CRC32 checksums to asset URIs for improved caching and integrity. When JavaScript files are added, a CRC32 checksum is now appended to the URI (e.g. ``_static/example.js?abcd1234``). This helps browsers detect when files have changed and refresh cached versions automatically. For more details, see the 7.1.0 changelog entry: https://www.sphinx-doc.org/en/master/changes.html#release-7-1-0-released-jul-24-2023 Site authors can also use the configuration options :confval:`html_js_files` and :confval:`html_static_path` to manage static JS files. Files in ``html_static_path`` override those added by extensions.
 .. automethod:: Sphinx.add_css_file
+.. versionchanged:: 7.1
+Added CRC32 checksums to asset URIs for CSS files as well, following the same caching and integrity improvements as :meth:`.Sphinx.add_js_file`.h:`.Sphinx.add_js_file`.
 
 .. automethod:: Sphinx.add_latex_package
 


### PR DESCRIPTION
This pull request updates the documentation in `doc/extdev/appapi.rst` to reflect recent changes introduced in **Sphinx 7.1**, where `app.add_js_file()` and `app.add_css_file()` now automatically include a **CRC32 checksum** for static files.

### Summary of Changes
- Updated the documentation to mention the new CRC32 checksum behavior.  
- Clarified how this affects browser caching and file updates for JS and CSS assets.

### Why This Matters
Adding the CRC32 checksum ensures that browsers automatically reload updated assets without relying on manual cache clearing, improving developer experience and reliability in extension development.

### References
- Related code: [`sphinx/application.py`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/application.py)  
- Introduced in: **Sphinx 7.1**  
- Inspired by: discussions in [#12223](https://github.com/sphinx-doc/sphinx/pull/12223)

---

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->

## Purpose
This PR improves developer-facing documentation by clarifying recent updates to the JavaScript and CSS inclusion APIs (`add_js_file` and `add_css_file`).  
No code changes are made — this is a documentation-only update.

## References
- Related PR: [#12223](https://github.com/sphinx-doc/sphinx/pull/12223)
- Related file: [`sphinx/application.py`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/application.py)
