### PR TITLE
ENH: Implement `sphinx quickstart` subcommand

### DIFF
--- a/sphinx/_cli/__init__.py
+++ b/sphinx/_cli/__init__.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 
 # Map of command name to import path.
-_COMMANDS: dict[str, str] = {}
+_COMMANDS: dict[str, str] = {'quickstart': 'sphinx.cmd._quickstart'}
 
 
 def _load_subcommand_descriptions() -> Iterator[tuple[str, str]]:

--- a/sphinx/cmd/_quickstart.py
+++ b/sphinx/cmd/_quickstart.py
@@ -1,0 +1,24 @@
+"""The module implementing the subcommand ``sphinx quickstart``.
+
+This delegates everything to the module :mod:`sphinx.cmd.quickstart`, which
+is the implementation for the historic standalone ``sphinx-quickstart`` command.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import quickstart
+
+if TYPE_CHECKING:
+    import argparse
+
+parser_description = quickstart.COMMAND_DESCRIPTION.lstrip()
+
+
+def set_up_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    return quickstart.set_up_parser(parser)
+
+
+def run(args: argparse.Namespace) -> int:
+    return quickstart.run(args)

--- a/sphinx/cmd/quickstart.py
+++ b/sphinx/cmd/quickstart.py
@@ -48,6 +48,15 @@ else:
     else:
         readline.parse_and_bind('tab: complete')
 
+COMMAND_DESCRIPTION = __(
+    '\n'
+    'Generate required files for a Sphinx project.\n'
+    '\n'
+    'sphinx-quickstart is an interactive tool that asks some questions about your\n'
+    'project and then generates a complete documentation directory and sample\n'
+    'Makefile to be used with sphinx-build.\n',
+)
+
 EXTENSIONS = {
     'autodoc': __('automatically insert docstrings from modules'),
     'doctest': __('automatically test code snippets in doctest blocks'),
@@ -569,20 +578,15 @@ def valid_dir(d: dict[str, Any]) -> bool:
 
 
 def get_parser() -> argparse.ArgumentParser:
-    description = __(
-        '\n'
-        'Generate required files for a Sphinx project.\n'
-        '\n'
-        'sphinx-quickstart is an interactive tool that asks some questions about your\n'
-        'project and then generates a complete documentation directory and sample\n'
-        'Makefile to be used with sphinx-build.\n',
-    )
     parser = argparse.ArgumentParser(
         usage='%(prog)s [OPTIONS] <PROJECT_DIR>',
         epilog=__('For more information, visit <https://www.sphinx-doc.org/>.'),
-        description=description,
+        description=str(COMMAND_DESCRIPTION),  # str() for resolving TranslationProxy
     )
+    return set_up_parser(parser)
 
+
+def set_up_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument(
         '-q',
         '--quiet',
@@ -748,6 +752,10 @@ def main(argv: Sequence[str] = (), /) -> int:
     except SystemExit as err:
         return err.code  # type: ignore[return-value]
 
+    return run(args)
+
+
+def run(args: argparse.Namespace) -> int:
     d = vars(args)
     # delete None or False value
     d = {k: v for k, v in d.items() if v is not None}


### PR DESCRIPTION
`sphinx quickstart` is now equivalent to `sphinx-quickstart`

A first step towards #5618, i.e. having a top-level `sphinx` command with subcommands such as `sphinx quickstart`, `sphinx build`, ...

Implementation note: For clarity, To clearly mark the subcommand interface, I've created a separate module `sphinx.cmds._quickstart`, but we could alternatively enrich the existing `sphinx.cmds.quickstart` module with the neccesary information and use it for both `sphinx-quickstart` and `sphinx quickstart`.


