### PR TITLE
Remove ``env`` from autodoc interfaces

### DIFF
--- a/sphinx/ext/autodoc/_generate.py
+++ b/sphinx/ext/autodoc/_generate.py
@@ -16,11 +16,11 @@ from sphinx.util import inspect, logging
 from sphinx.util.typing import restify, stringify_annotation
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping, MutableSet
     from typing import Literal
 
     from sphinx.config import Config
-    from sphinx.environment import BuildEnvironment, _CurrentDocument
+    from sphinx.environment import _CurrentDocument
     from sphinx.events import EventManager
     from sphinx.ext.autodoc._directive_options import _AutoDocumenterOptions
     from sphinx.ext.autodoc._property_types import _ItemProperties
@@ -38,13 +38,14 @@ def _generate_directives(
     *,
     config: Config,
     current_document: _CurrentDocument,
-    env: BuildEnvironment,
     events: EventManager,
     get_attr: _AttrGetter,
     indent: str,
     options: _AutoDocumenterOptions,
     props: _ItemProperties,
     record_dependencies: set[str],
+    ref_context: Mapping[str, str | None],
+    reread_always: MutableSet[str],
     result: StringList,
 ) -> None:
     """Generate reST for the object given by *props*, and possibly for its members.
@@ -136,7 +137,6 @@ def _generate_directives(
         attr_docs=analyzer.attr_docs if analyzer is not None else {},
         config=config,
         current_document=current_document,
-        env=env,
         events=events,
         get_attr=get_attr,
         indent=indent,
@@ -145,6 +145,8 @@ def _generate_directives(
         real_modname=real_modname,
         record_dependencies=record_dependencies,
         result=result,
+        ref_context=ref_context,
+        reread_always=reread_always,
     )
 
 
@@ -204,7 +206,6 @@ def _document_members(
     attr_docs: dict[tuple[str, str], list[str]],
     config: Config,
     current_document: _CurrentDocument,
-    env: BuildEnvironment,
     events: EventManager,
     get_attr: _AttrGetter,
     indent: str,
@@ -212,6 +213,8 @@ def _document_members(
     props: _ItemProperties,
     real_modname: str,
     record_dependencies: set[str],
+    ref_context: Mapping[str, str | None],
+    reread_always: MutableSet[str],
     result: StringList,
 ) -> None:
     """Generate reST for member documentation.
@@ -233,12 +236,13 @@ def _document_members(
         attr_docs=attr_docs,
         config=config,
         current_document=current_document,
-        env=env,
         events=events,
         get_attr=get_attr,
         options=options,
         parent_modname=real_modname,
         props=props,
+        ref_context=ref_context,
+        reread_always=reread_always,
     )
 
     # for implicit module members, check __module__ to avoid
@@ -259,13 +263,14 @@ def _document_members(
             all_members=True,
             config=config,
             current_document=current_document,
-            env=env,
             events=events,
             get_attr=get_attr,
             indent=member_indent,
             options=options,
             props=member_props,
             record_dependencies=record_dependencies,
+            ref_context=ref_context,
+            reread_always=reread_always,
             result=result,
         )
 

--- a/sphinx/ext/autodoc/_generate.py
+++ b/sphinx/ext/autodoc/_generate.py
@@ -144,9 +144,9 @@ def _generate_directives(
         props=props,
         real_modname=real_modname,
         record_dependencies=record_dependencies,
-        result=result,
         ref_context=ref_context,
         reread_always=reread_always,
+        result=result,
     )
 
 

--- a/sphinx/ext/autodoc/_member_finder.py
+++ b/sphinx/ext/autodoc/_member_finder.py
@@ -29,11 +29,11 @@ from sphinx.util.inspect import (
 from sphinx.util.typing import AnyTypeAliasType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
+    from collections.abc import Iterable, Iterator, Mapping, MutableSet, Sequence, Set
     from typing import Any, Literal
 
     from sphinx.config import Config
-    from sphinx.environment import BuildEnvironment, _CurrentDocument
+    from sphinx.environment import _CurrentDocument
     from sphinx.events import EventManager
     from sphinx.ext.autodoc._directive_options import _AutoDocumenterOptions
     from sphinx.ext.autodoc._property_types import _AutodocObjType, _ItemProperties
@@ -96,12 +96,13 @@ def _gather_members(
     attr_docs: dict[tuple[str, str], list[str]],
     config: Config,
     current_document: _CurrentDocument,
-    env: BuildEnvironment,
     events: EventManager,
     get_attr: _AttrGetter,
     options: _AutoDocumenterOptions,
     parent_modname: str,
     props: _ItemProperties,
+    ref_context: Mapping[str, str | None],
+    reread_always: MutableSet[str],
 ) -> list[tuple[_ItemProperties, bool, str]]:
     """Generate reST for member documentation.
 
@@ -179,11 +180,12 @@ def _gather_members(
             type_aliases=config.autodoc_type_aliases,
             current_document=current_document,
             config=config,
-            env=env,
             events=events,
             get_attr=get_attr,
             options=options,
             parent_modname=parent_modname,
+            ref_context=ref_context,
+            reread_always=reread_always,
         )
         if member_props is None:
             continue

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -171,9 +171,9 @@ class AutodocDirective(SphinxDirective):
             options=documenter_options,
             props=props,
             record_dependencies=record_dependencies,
-            result=result,
             ref_context=ref_context,
             reread_always=reread_always,
+            result=result,
         )
         if not result:
             return []

--- a/sphinx/ext/autodoc/directive.py
+++ b/sphinx/ext/autodoc/directive.py
@@ -140,6 +140,8 @@ class AutodocDirective(SphinxDirective):
         config = env.config
         current_document = env.current_document
         events = env.events
+        ref_context = env.ref_context
+        reread_always = env.reread_always
 
         props = _load_object_by_name(
             name=name,
@@ -148,10 +150,11 @@ class AutodocDirective(SphinxDirective):
             type_aliases=config.autodoc_type_aliases,
             current_document=current_document,
             config=config,
-            env=env,
             events=events,
             get_attr=get_attr,
             options=documenter_options,
+            ref_context=ref_context,
+            reread_always=reread_always,
         )
         if props is None:
             return []
@@ -162,7 +165,6 @@ class AutodocDirective(SphinxDirective):
             more_content=self.content,
             config=config,
             current_document=current_document,
-            env=env,
             events=events,
             get_attr=get_attr,
             indent='',
@@ -170,6 +172,8 @@ class AutodocDirective(SphinxDirective):
             props=props,
             record_dependencies=record_dependencies,
             result=result,
+            ref_context=ref_context,
+            reread_always=reread_always,
         )
         if not result:
             return []

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -307,6 +307,8 @@ class Autosummary(SphinxDirective):
         events = env.events
         get_attr = _AutodocAttrGetter(env._registry.autodoc_attrgetters)
         opts = _AutoDocumenterOptions()
+        ref_context = env.ref_context
+        reread_always = env.reread_always
 
         max_item_chars = 50
 
@@ -346,10 +348,11 @@ class Autosummary(SphinxDirective):
                 type_aliases=config.autodoc_type_aliases,
                 current_document=current_document,
                 config=config,
-                env=env,
                 events=events,
                 get_attr=get_attr,
                 options=opts,
+                ref_context=ref_context,
+                reread_always=reread_always,
             )
             if props is None:
                 logger.warning(

--- a/tests/test_ext_autodoc/autodoc_util.py
+++ b/tests/test_ext_autodoc/autodoc_util.py
@@ -62,8 +62,8 @@ def do_autodoc(
             options=doc_options,
             props=props,
             record_dependencies=set(),
-            result=result,
             ref_context=ref_context,
             reread_always=reread_always,
+            result=result,
         )
     return result

--- a/tests/test_ext_autodoc/autodoc_util.py
+++ b/tests/test_ext_autodoc/autodoc_util.py
@@ -35,8 +35,9 @@ def do_autodoc(
 
     config = app.config
     current_document = app.env.current_document
-    env = app.env
     events = app.events
+    ref_context = app.env.ref_context
+    reread_always: set[str] = set()
     props = _load_object_by_name(
         name=name,
         objtype=obj_type,
@@ -44,17 +45,17 @@ def do_autodoc(
         type_aliases=config.autodoc_type_aliases,
         current_document=current_document,
         config=config,
-        env=env,
         events=events,
         get_attr=safe_getattr,
         options=doc_options,
+        ref_context=ref_context,
+        reread_always=reread_always,
     )
     result = StringList()
     if props is not None:
         _generate_directives(
             config=config,
             current_document=current_document,
-            env=env,
             events=events,
             get_attr=safe_getattr,
             indent='',
@@ -62,5 +63,7 @@ def do_autodoc(
             props=props,
             record_dependencies=set(),
             result=result,
+            ref_context=ref_context,
+            reread_always=reread_always,
         )
     return result

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -82,7 +82,7 @@ def test_parse_name(caplog: pytest.LogCaptureFixture) -> None:
     assert parsed == ('test.test_ext_autodoc', [], None, None)
     parsed = parse('module', 'test(arg)')
     assert parsed is None
-    assert 'signature arguments' in caplog.text
+    assert 'signature arguments given for automodule' in caplog.messages[0]
 
     # for functions/classes
     parsed = parse('function', 'test_ext_autodoc.raises')

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -7,6 +7,7 @@ source file translated by test_build.
 from __future__ import annotations
 
 import itertools
+import logging
 import sys
 from typing import TYPE_CHECKING
 from warnings import catch_warnings
@@ -55,6 +56,10 @@ processed_signatures = []
 
 
 def test_parse_name(caplog: pytest.LogCaptureFixture) -> None:
+    # work around sphinx.util.logging.setup()
+    logger = logging.getLogger('sphinx')
+    logger.handlers[:] = [caplog.handler]
+
     current_document = _CurrentDocument()
     ref_context: dict[str, Any] = {}
 
@@ -586,9 +591,9 @@ def _assert_getter_works(app, get_attr, options, objtype, name, *attrs):
             options=options,
             props=props,
             record_dependencies=set(),
-            result=StringList(),
             ref_context=ref_context,
             reread_always=reread_always,
+            result=StringList(),
         )
 
     hooked_members = {s[1] for s in getattr_spy}


### PR DESCRIPTION
## References

- #13751