### PR TITLE
latex tables: Fix rendering for grid filled merged vertical cells

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Features added
 Bugs fixed
 ----------
 
+* LaTeX: Fix rendering for grid filled merged vertical cell
+  (PR #14024).
+  Patch by Tim Nordell
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
   Patch by Adam Turner
 * #13713: Fix compatibility with MyST-Parser.

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1298,9 +1298,10 @@ class LaTeXTranslator(SphinxTranslator):
                 # insert suitable strut for equalizing row heights in given multirow
                 self.body.append(r'\sphinxtablestrut{%d}' % cell.cell_id)
             else:  # use \multicolumn for wide multirow cell
+                left_colsep = _colsep if cell.col == 0 else ''
                 self.body.append(
                     r'\multicolumn{%d}{%sl%s}{\sphinxtablestrut{%d}}'
-                    % (cell.width, _colsep, _colsep, cell.cell_id)
+                    % (cell.width, left_colsep, _colsep, cell.cell_id)
                 )
 
     def depart_row(self, node: Element) -> None:


### PR DESCRIPTION
The table from issue #9313:

    .. table::
       :class: standard nocolorrows

       +--------------------+----------------+
       |  2 rows and 2 cols | 1 row x 3 cols |
       |                    +----+-----+-----+
       |                    |  A |  B  |  C  |
       +---+----------------+----+-----+-----+
       | 1 |       2        |  3 |  4  |  5  |
       +---+----------------+----+-----+-----+

has merged vertical cells that notably needs to draw a vertical line on the left and right-hand side of the cells in the 2x2 grid area.  If you add a column to the left of this:

```
    .. table::
       :class: standard nocolorrows

       +---+---+----------------+----------------+
       | X |  2 rows and 2 cols | 1 row x 3 cols |
       |   |                    +----+-----+-----+
       |   |                    |  A |  B  |  C  |
       +---+---+----------------+----+-----+-----+
       | Y | 1 |       2        |  3 |  4  |  5  |
       +---+---+----------------+----+-----+-----+
```

then the 2x2 area should *not* draw a column line to the left of the area.

We can fix this by adjusting the \multicolumn invocation to adjust when it emits the colspec.

Notably, this commit does *not* consider the other broken case where a person maybe just wants the table borders like:

```
    .. tabularcolumns:: |llllll|

    .. table::
       :class: standard nocolorrows

       +---+---+----------------+----------------+
       |   |  2 rows and 2 cols | 1 row x 3 cols |
       | X |                    +----+-----+-----+
       |   |                    |  A |  B  |  C  |
       +---+---+----------------+----+-----+-----+
       | Y | 1 |       2        |  3 |  4  |  5  |
       +---+---+----------------+----+-----+-----+
```

That has an impact in this area of the code, but to correctly consider that one has to parse out the given colspec to determine which columns have borders between them.  (This line of code has a bug for this case as the colspec being emitted should be conditional if the specific column actually has it enabled, but the supporting code only determines if a vertical line is enabled anywhere rather than which columns.)

Here are the three tables mentioned prior to this fix:

<img width="1167" height="897" alt="image" src="https://github.com/user-attachments/assets/dc481305-e91c-4c1e-8200-fe2cb2475a51" />

And after the fix (which just fixes the second case):

<img width="1139" height="876" alt="image" src="https://github.com/user-attachments/assets/6b0a6bc1-56cf-4911-a9a7-97e9ba777cf7" />

Notably, the 3rd case (which is not a full grid fill) leaves extra vertical lines, and an extraneous "dot".