### PR TITLE
Support XID_Start/XID_Continue Unicode chars in C++ identifiers (#14026)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -109,6 +109,7 @@ Contributors
 * Slawek Figiel -- additional warning suppression
 * Stefan Seefeld -- toctree improvements
 * Stefan van der Walt -- autosummary extension
+* Stefanos Carlström -- minor bug fix
 * Steve Piercy -- documentation improvements
 * Szymon Karpinski -- intersphinx improvements
 * \T. Powers -- HTML output improvements

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,19 @@
+Release 9.1.1 (in development)
+==============================
+
+Dependencies
+------------
+
+* #14026: Added `regex >= 2025.7.29`_, to support parsing for Unicode classes.
+
+  .. _regex >= 2025.7.29: _https://github.com/mrabarnett/mrab-regex
+
+Features added
+--------------
+
+Bugs fixed
+----------
+
 Release 9.1.0 (released Dec 31, 2025)
 =====================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ dependencies = [
     "roman-numerals>=1.0.0",
     "packaging>=23.0",
     "colorama>=0.4.6; sys_platform == 'win32'",
+    "ipython>=9.6.0",
+    "regex>=2025.7.29"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ type-stubs = [
     "types-Pygments==2.19.0.20251121",
     "types-requests==2.32.4.20250913",
     "types-urllib3==1.26.25.14",
+    "types-regex>=2025.7.29"
 ]
 
 [tool.flit.module]

--- a/sphinx/domains/c/_ids.py
+++ b/sphinx/domains/c/_ids.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
+
+import regex as re
 
 if TYPE_CHECKING:
     from collections.abc import Sequence, Set

--- a/sphinx/domains/cpp/__init__.py
+++ b/sphinx/domains/cpp/__init__.py
@@ -238,14 +238,6 @@ class CPPObject(ObjectDescription[ASTDeclaration]):
         ids.reverse()
         newest_id = ids[0]
         assert newest_id  # shouldn't be None
-        if not re.compile(r'^[a-zA-Z0-9_]*$').match(newest_id):
-            logger.warning(
-                'Index id generation for C++ object "%s" failed, please '
-                'report as bug (id=%s).',
-                ast,
-                newest_id,
-                location=self.get_location(),
-            )
 
         name = ast.symbol.get_full_nested_name().get_display_string().lstrip(':')
         # Add index entry, but not if it's a declaration inside a concept

--- a/sphinx/domains/cpp/__init__.py
+++ b/sphinx/domains/cpp/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from types import NoneType
 from typing import TYPE_CHECKING
 

--- a/sphinx/domains/cpp/_ids.py
+++ b/sphinx/domains/cpp/_ids.py
@@ -251,8 +251,9 @@ namespace_object:
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
+
+import regex as re
 
 if TYPE_CHECKING:
     from collections.abc import Sequence, Set

--- a/sphinx/domains/cpp/_parser.py
+++ b/sphinx/domains/cpp/_parser.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
+
+import regex as re
 
 from sphinx.domains.cpp._ast import (
     ASTAlignofExpr,

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import re
+import regex as re
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
@@ -30,9 +30,13 @@ identifier_re = re.compile(
     (   # This 'extends' _anon_identifier_re with the ordinary identifiers,
         # make sure they are in sync.
         (~?\b[a-zA-Z_])  # ordinary identifiers
+    |   \p{XID_Start}    # Unicode-allowed starting characters for identifiers
     |   (@[a-zA-Z0-9_])  # our extension for names of anonymous entities
     )
-    [a-zA-Z0-9_]*\b
+    (
+        [a-zA-Z0-9_]     # ordinary identifiers
+    |   \p{XID_Continue} # Unicode-allowed continuing characters for identifiers
+    )*\b
     """,
     flags=re.VERBOSE,
 )

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -31,12 +31,14 @@ identifier_re = re.compile(
         # make sure they are in sync.
         (~?\b[a-zA-Z_])  # ordinary identifiers
     |   \p{XID_Start}    # Unicode-allowed starting characters for identifiers
+    |   \p{ID_Compat_Math_Start}    # Unicode-allowed starting mathematical characters for identifiers
     |   (@[a-zA-Z0-9_])  # our extension for names of anonymous entities
     )
     (
         [a-zA-Z0-9_]     # ordinary identifiers
     |   \p{XID_Continue} # Unicode-allowed continuing characters for identifiers
-    )*\b
+    |   \p{ID_Compat_Math_Continue} # Unicode-allowed continuing mathematical characters for identifiers
+    )*
     """,
     flags=re.VERBOSE,
 )

--- a/sphinx/util/cfamily.py
+++ b/sphinx/util/cfamily.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import regex as re
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
+import regex as re
 from docutils import nodes
 
 from sphinx import addnodes
@@ -27,17 +27,17 @@ _whitespace_re = re.compile(r'\s+')
 anon_identifier_re = re.compile(r'(@[a-zA-Z0-9_])[a-zA-Z0-9_]*\b')
 identifier_re = re.compile(
     r"""
-    (   # This 'extends' _anon_identifier_re with the ordinary identifiers,
-        # make sure they are in sync.
-        (~?\b[a-zA-Z_])  # ordinary identifiers
-    |   \p{XID_Start}    # Unicode-allowed starting characters for identifiers
-    |   \p{ID_Compat_Math_Start}    # Unicode-allowed starting mathematical characters for identifiers
-    |   (@[a-zA-Z0-9_])  # our extension for names of anonymous entities
+    ( # This 'extends' _anon_identifier_re with the ordinary identifiers,
+      # make sure they are in sync.
+      (~?\b[a-zA-Z_])  # ordinary identifiers
+    | \p{XID_Start}    # Unicode-allowed starting characters for identifiers
+    | \p{ID_Compat_Math_Start} # Unicode-allowed starting math characters for identifiers
+    | (@[a-zA-Z0-9_])  # our extension for names of anonymous entities
     )
     (
-        [a-zA-Z0-9_]     # ordinary identifiers
-    |   \p{XID_Continue} # Unicode-allowed continuing characters for identifiers
-    |   \p{ID_Compat_Math_Continue} # Unicode-allowed continuing mathematical characters for identifiers
+      [a-zA-Z0-9_]     # ordinary identifiers
+    | \p{XID_Continue} # Unicode-allowed continuing characters for identifiers
+    | \p{ID_Compat_Math_Continue} # Unicode-allowed continuing math characters for identifiers
     )*
     """,
     flags=re.VERBOSE,

--- a/tests/test_domains/test_domain_cpp.py
+++ b/tests/test_domains/test_domain_cpp.py
@@ -863,9 +863,19 @@ def test_domain_cpp_ast_function_definitions() -> None:
 
     check('function', 'decltype(auto) f()', {1: 'f', 2: '1fv'})
 
-    # Test derived from https://github.com/sphinx-doc/sphinx/issues/14026
-    # Unicode identifiers
+    # Tests derived from
+    # https://github.com/sphinx-doc/sphinx/issues/14026 Unicode
+    # identifiers
     check('function', 'void f(int *const ξ)', {1: 'f__iPC', 2: '1fPCi'})
+    check('function', 'template<typename Ξ> Ξ ξcompute(Ξ ξ)',
+          {2: 'I0E8ξcompute1Ξ',
+           3: 'I0E8ξcompute1Ξ',
+           4: 'I0E8ξcompute1Ξ1Ξ'})
+    check('function', 'ΨStruct ψcompute(double i)',
+          {1: 'ψcompute__double',
+           2: '8ψcomputed',
+           3: '8ψcomputed',
+           4: '8ψcomputed'})
 
     # TODO: make tests for functions in a template, e.g., Test<int&&()>
     # such that the id generation for function type types is correct.
@@ -1055,6 +1065,13 @@ def test_domain_cpp_ast_class_definitions() -> None:
         'template<int... Is> {key}T<(Is)...>',
         {2: 'I_DpiE1TIJX(Is)EEE', 3: 'I_DpiE1TIJX2IsEEE'},
     )
+
+    # Test derived from
+    # https://github.com/sphinx-doc/sphinx/issues/14026 Unicode
+    # identifier
+    check('class', 'public ΨStruct', {1: 'ΨStruct', 2: '7ΨStruct',
+                                      3: '7ΨStruct', 4: '7ΨStruct'},
+          output='{key}ΨStruct')
 
 
 def test_domain_cpp_ast_union_definitions() -> None:

--- a/tests/test_domains/test_domain_cpp.py
+++ b/tests/test_domains/test_domain_cpp.py
@@ -876,6 +876,9 @@ def test_domain_cpp_ast_function_definitions() -> None:
            2: '8ψcomputed',
            3: '8ψcomputed',
            4: '8ψcomputed'})
+    check('function', 'norm₂(V x)', {1: 'norm₂__V', 2: '5norm₂1V', 3: '5norm₂1V', 4: '5norm₂1V'})
+    check('function', '∇(V x)', {1: '∇__V', 2: '1∇1V', 3: '1∇1V', 4: '1∇1V'})
+    check('function', 'compute∂(V x)', {1: 'compute∂__V', 2: '8compute∂1V', 3: '8compute∂1V', 4: '8compute∂1V'})
 
     # TODO: make tests for functions in a template, e.g., Test<int&&()>
     # such that the id generation for function type types is correct.

--- a/tests/test_domains/test_domain_cpp.py
+++ b/tests/test_domains/test_domain_cpp.py
@@ -863,6 +863,10 @@ def test_domain_cpp_ast_function_definitions() -> None:
 
     check('function', 'decltype(auto) f()', {1: 'f', 2: '1fv'})
 
+    # Test derived from https://github.com/sphinx-doc/sphinx/issues/14026
+    # Unicode identifiers
+    check('function', 'void f(int *const ξ)', {1: 'f__iPC', 2: '1fPCi'})
+
     # TODO: make tests for functions in a template, e.g., Test<int&&()>
     # such that the id generation for function type types is correct.
 

--- a/tests/test_domains/test_domain_cpp.py
+++ b/tests/test_domains/test_domain_cpp.py
@@ -867,18 +867,27 @@ def test_domain_cpp_ast_function_definitions() -> None:
     # https://github.com/sphinx-doc/sphinx/issues/14026 Unicode
     # identifiers
     check('function', 'void f(int *const ξ)', {1: 'f__iPC', 2: '1fPCi'})
-    check('function', 'template<typename Ξ> Ξ ξcompute(Ξ ξ)',
-          {2: 'I0E8ξcompute1Ξ',
-           3: 'I0E8ξcompute1Ξ',
-           4: 'I0E8ξcompute1Ξ1Ξ'})
-    check('function', 'ΨStruct ψcompute(double i)',
-          {1: 'ψcompute__double',
-           2: '8ψcomputed',
-           3: '8ψcomputed',
-           4: '8ψcomputed'})
-    check('function', 'norm₂(V x)', {1: 'norm₂__V', 2: '5norm₂1V', 3: '5norm₂1V', 4: '5norm₂1V'})
+    check(
+        'function',
+        'template<typename Ξ> Ξ ξcompute(Ξ ξ)',
+        {2: 'I0E8ξcompute1Ξ', 3: 'I0E8ξcompute1Ξ', 4: 'I0E8ξcompute1Ξ1Ξ'},
+    )
+    check(
+        'function',
+        'ΨStruct ψcompute(double i)',
+        {1: 'ψcompute__double', 2: '8ψcomputed', 3: '8ψcomputed', 4: '8ψcomputed'},
+    )
+    check(
+        'function',
+        'norm₂(V x)',
+        {1: 'norm₂__V', 2: '5norm₂1V', 3: '5norm₂1V', 4: '5norm₂1V'},
+    )
     check('function', '∇(V x)', {1: '∇__V', 2: '1∇1V', 3: '1∇1V', 4: '1∇1V'})
-    check('function', 'compute∂(V x)', {1: 'compute∂__V', 2: '8compute∂1V', 3: '8compute∂1V', 4: '8compute∂1V'})
+    check(
+        'function',
+        'compute∂(V x)',
+        {1: 'compute∂__V', 2: '8compute∂1V', 3: '8compute∂1V', 4: '8compute∂1V'},
+    )
 
     # TODO: make tests for functions in a template, e.g., Test<int&&()>
     # such that the id generation for function type types is correct.
@@ -1072,9 +1081,12 @@ def test_domain_cpp_ast_class_definitions() -> None:
     # Test derived from
     # https://github.com/sphinx-doc/sphinx/issues/14026 Unicode
     # identifier
-    check('class', 'public ΨStruct', {1: 'ΨStruct', 2: '7ΨStruct',
-                                      3: '7ΨStruct', 4: '7ΨStruct'},
-          output='{key}ΨStruct')
+    check(
+        'class',
+        'public ΨStruct',
+        {1: 'ΨStruct', 2: '7ΨStruct', 3: '7ΨStruct', 4: '7ΨStruct'},
+        output='{key}ΨStruct',
+    )
 
 
 def test_domain_cpp_ast_union_definitions() -> None:


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

I have fixed an issue in which valid C++ identifiers with Unicode characters were rejected. To this end, I have

- added the dependency [`regex`](https://github.com/mrabarnett/mrab-regex), which is a drop-in replacement for the standard Python module `re`, but with extended capabilities (most pertinently the character classes `\p{XID_Start}` and `\p{XID_Continue}`), and updated `CHANGES.rst` to reflect this fact;
- added a test that triggers the error without the fix;
- ensured all test suites pass locally.

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Closes #14026