### PR TITLE
Reduce autodoc test duration by up to four times

### DIFF
--- a/sphinx/ext/autodoc/_directive_options.py
+++ b/sphinx/ext/autodoc/_directive_options.py
@@ -241,7 +241,7 @@ _OPTION_SPECS: Final[Mapping[_AutodocObjType, OptionSpec]] = {
 def _process_documenter_options(
     *,
     obj_type: _AutodocObjType,
-    default_options: dict[str, str | bool],
+    default_options: Mapping[str, str | bool],
     options: dict[str, str | None],
 ) -> _AutoDocumenterOptions:
     """Recognize options of object type from user input."""

--- a/tests/test_ext_autodoc/conftest.py
+++ b/tests/test_ext_autodoc/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from tests.utils import TEST_ROOTS_DIR
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(scope='module')
+def inject_autodoc_root_into_sys_path() -> Iterator[None]:
+    autodoc_root_path = str(TEST_ROOTS_DIR / 'test-ext-autodoc')
+
+    sys.path.insert(0, autodoc_root_path)
+    yield
+    sys.path[:] = [p for p in sys.path if p != autodoc_root_path]

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -255,6 +255,7 @@ def test_py_module(caplog: pytest.LogCaptureFixture) -> None:
     # work around sphinx.util.logging.setup()
     logger = logging.getLogger('sphinx')
     logger.handlers[:] = [caplog.handler]
+    caplog.set_level(logging.WARNING)
 
     # without py:module
     actual = do_autodoc('method', 'Class.meth', expect_import_error=True)
@@ -317,6 +318,7 @@ def test_autodoc_warnings(caplog: pytest.LogCaptureFixture) -> None:
     # work around sphinx.util.logging.setup()
     logger = logging.getLogger('sphinx')
     logger.handlers[:] = [caplog.handler]
+    caplog.set_level(logging.WARNING)
 
     current_document = _CurrentDocument(docname='dummy')
 
@@ -2855,6 +2857,7 @@ def test_autodoc(caplog: pytest.LogCaptureFixture) -> None:
     # work around sphinx.util.logging.setup()
     logger = logging.getLogger('sphinx')
     logger.handlers[:] = [caplog.handler]
+    caplog.set_level(logging.WARNING)
 
     config = _AutodocConfig(autodoc_mock_imports=['dummy'])
     options = {'members': None}

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -7,6 +7,7 @@ source file translated by test_build.
 from __future__ import annotations
 
 import itertools
+import logging
 import pathlib
 import sys
 from typing import TYPE_CHECKING
@@ -15,7 +16,7 @@ from warnings import catch_warnings
 import pytest
 from docutils.statemachine import StringList
 
-from sphinx import addnodes
+from sphinx.environment import _CurrentDocument
 from sphinx.ext.autodoc._directive_options import (
     _AutoDocumenterOptions,
     inherited_members_option,
@@ -29,7 +30,7 @@ from sphinx.ext.autodoc._sentinels import ALL
 from sphinx.ext.autodoc._shared import _AutodocAttrGetter, _AutodocConfig
 from sphinx.util.inspect import safe_getattr
 
-from tests.test_ext_autodoc.autodoc_util import do_autodoc
+from tests.test_ext_autodoc.autodoc_util import FakeEvents, do_autodoc
 
 try:
     # Enable pyximport to test cython module
@@ -42,11 +43,17 @@ except ImportError:
 if TYPE_CHECKING:
     from typing import Any
 
+    from sphinx.ext.autodoc._property_types import _AutodocObjType
+    from sphinx.ext.autodoc._shared import _AttrGetter
+
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 processed_signatures: list[tuple[str, str]] = []
 
 
-def get_docstring_lines(obj_type, obj, *, config):
+def get_docstring_lines(obj_type, obj):
+    config = _AutodocConfig()
+
     parent = object  # dummy
     props = _ItemProperties(
         obj_type=obj_type,
@@ -71,28 +78,25 @@ def get_docstring_lines(obj_type, obj, *, config):
     return tuple(res)
 
 
-@pytest.mark.sphinx('html', testroot='root')
-def test_get_docstring_lines(app):
-    config = _AutodocConfig.from_config(app.config)
-
+def test_get_docstring_lines():
     # objects without docstring
     def f():
         pass
 
-    assert get_docstring_lines('function', f, config=config) == ()
+    assert get_docstring_lines('function', f) == ()
 
     # standard function, diverse docstring styles...
     def f():
         """Docstring"""
 
-    assert get_docstring_lines('function', f, config=config) == ('Docstring',)
+    assert get_docstring_lines('function', f) == ('Docstring',)
 
     def f():
         """
         Docstring
         """  # NoQA: D212
 
-    assert get_docstring_lines('function', f, config=config) == ('Docstring',)
+    assert get_docstring_lines('function', f) == ('Docstring',)
 
     # first line vs. other lines indentation
     def f():
@@ -102,7 +106,7 @@ def test_get_docstring_lines(app):
           lines
         """
 
-    assert get_docstring_lines('function', f, config=config) == (
+    assert get_docstring_lines('function', f) == (
         'First line',
         '',
         'Other',
@@ -113,7 +117,7 @@ def test_get_docstring_lines(app):
     def f():
         """Döcstring"""
 
-    assert get_docstring_lines('function', f, config=config) == ('Döcstring',)
+    assert get_docstring_lines('function', f) == ('Döcstring',)
 
     # verify that method docstrings get extracted in both normal case
     # and in case of bound method posing as a function
@@ -122,8 +126,8 @@ def test_get_docstring_lines(app):
             """Method docstring"""
 
     expected = ('Method docstring',)
-    assert get_docstring_lines('method', J.foo, config=config) == expected
-    assert get_docstring_lines('function', J().foo, config=config) == expected
+    assert get_docstring_lines('method', J.foo) == expected
+    assert get_docstring_lines('function', J().foo) == expected
 
 
 class _MyDocumenter(Documenter):
@@ -139,15 +143,15 @@ class _MyDocumenter(Documenter):
         return
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_new_documenter(app):
-    app.add_autodocumenter(_MyDocumenter)
+def test_new_documenter():
+    config = _AutodocConfig()
+    # app.add_autodocumenter(_MyDocumenter)
 
     options = {'members': 'integer'}
     # TODO: Fix! Perhaps add a way to signal module/class-level?
-    actual = do_autodoc(app, 'module', 'target', options)
+    actual = do_autodoc('module', 'target', config=config, options=options)
     return
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:module:: target',
         '',
@@ -163,8 +167,7 @@ def test_new_documenter(app):
 getattr_spy = []
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_attrgetter_using(app):
+def test_attrgetter_using():
     attrs = []
 
     def _special_getattr(obj, attr_name, *defargs):
@@ -173,32 +176,46 @@ def test_attrgetter_using(app):
             return None
         return getattr(obj, attr_name, *defargs)
 
-    app.add_autodoc_attrgetter(type, _special_getattr)
-
-    get_attr = _AutodocAttrGetter(app.registry.autodoc_attrgetters)
+    # See Sphinx.add_autodoc_attrgetter()
+    autodoc_attrgetters = {type: _special_getattr}
+    get_attr = _AutodocAttrGetter(autodoc_attrgetters)
     options = _AutoDocumenterOptions(members=ALL)
 
     options.inherited_members = inherited_members_option(False)
     attrs[:] = ['meth']
     with catch_warnings(record=True):
-        _assert_getter_works(app, get_attr, options, 'class', 'target.Class', *attrs)
+        _assert_getter_works(
+            'class',
+            'target.Class',
+            *attrs,
+            get_attr=get_attr,
+            options=options,
+        )
 
     options.inherited_members = inherited_members_option(True)
     attrs[:] = ['inheritedmeth']
     with catch_warnings(record=True):
         _assert_getter_works(
-            app, get_attr, options, 'class', 'target.inheritance.Derived', *attrs
+            'class',
+            'target.inheritance.Derived',
+            *attrs,
+            get_attr=get_attr,
+            options=options,
         )
 
 
-def _assert_getter_works(app, get_attr, options, objtype, name, *attrs):
-    env = app.env
-    config = _AutodocConfig.from_config(app.config)
-    current_document = env.current_document
-    events = app.events
-    ref_context = env.ref_context
-    reread_always = env.reread_always
+def _assert_getter_works(
+    objtype: _AutodocObjType,
+    name: str,
+    *attrs: str,
+    get_attr: _AttrGetter,
+    options: _AutoDocumenterOptions,
+) -> None:
     getattr_spy.clear()
+
+    config = _AutodocConfig()
+    current_document = _CurrentDocument()
+    events = FakeEvents()
 
     props = _load_object_by_name(
         name=name,
@@ -208,8 +225,8 @@ def _assert_getter_works(app, get_attr, options, objtype, name, *attrs):
         events=events,
         get_attr=get_attr,
         options=options,
-        ref_context=ref_context,
-        reread_always=reread_always,
+        ref_context={},
+        reread_always=set(),
     )
     if props is not None:
         _generate_directives(
@@ -221,8 +238,8 @@ def _assert_getter_works(app, get_attr, options, objtype, name, *attrs):
             options=options,
             props=props,
             record_dependencies=set(),
-            ref_context=ref_context,
-            reread_always=reread_always,
+            ref_context={},
+            reread_always=set(),
             result=StringList(),
         )
 
@@ -234,21 +251,24 @@ def _assert_getter_works(app, get_attr, options, objtype, name, *attrs):
         assert fullname not in documented_members, f'{fullname!r} not intercepted'
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_py_module(app):
+def test_py_module(caplog: pytest.LogCaptureFixture) -> None:
+    # work around sphinx.util.logging.setup()
+    logger = logging.getLogger('sphinx')
+    logger.handlers[:] = [caplog.handler]
+
     # without py:module
-    actual = do_autodoc(app, 'method', 'Class.meth')
-    assert list(actual) == []
+    actual = do_autodoc('method', 'Class.meth', expect_import_error=True)
+    assert actual == []
+    assert len(set(caplog.messages)) == 1
     assert (
         "don't know which module to import for autodocumenting 'Class.meth'"
-    ) in app.warning.getvalue()
+    ) in caplog.messages[0]
+    caplog.clear()
 
     # with py:module
-    app.env.ref_context['py:module'] = 'target'
-    app.warning.truncate(0)
-
-    actual = do_autodoc(app, 'method', 'Class.meth')
-    assert list(actual) == [
+    ref_context: dict[str, Any] = {'py:module': 'target'}
+    actual = do_autodoc('method', 'Class.meth', ref_context=ref_context)
+    assert actual == [
         '',
         '.. py:method:: Class.meth()',
         '   :module: target',
@@ -256,15 +276,12 @@ def test_py_module(app):
         '   Function.',
         '',
     ]
-    assert (
-        "don't know which module to import for autodocumenting 'Class.meth'"
-    ) not in app.warning.getvalue()
+    assert len(caplog.records) == 0
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_decorator(app):
-    actual = do_autodoc(app, 'decorator', 'target.decorator.deco1')
-    assert list(actual) == [
+def test_autodoc_decorator() -> None:
+    actual = do_autodoc('decorator', 'target.decorator.deco1')
+    assert actual == [
         '',
         '.. py:decorator:: deco1',
         '   :module: target.decorator',
@@ -273,8 +290,8 @@ def test_autodoc_decorator(app):
         '',
     ]
 
-    actual = do_autodoc(app, 'decorator', 'target.decorator.deco2')
-    assert list(actual) == [
+    actual = do_autodoc('decorator', 'target.decorator.deco2')
+    assert actual == [
         '',
         '.. py:decorator:: deco2(condition, message)',
         '   :module: target.decorator',
@@ -284,10 +301,9 @@ def test_autodoc_decorator(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_exception(app):
-    actual = do_autodoc(app, 'exception', 'target.CustomEx')
-    assert list(actual) == [
+def test_autodoc_exception() -> None:
+    actual = do_autodoc('exception', 'target.CustomEx')
+    assert actual == [
         '',
         '.. py:exception:: CustomEx',
         '   :module: target',
@@ -297,37 +313,62 @@ def test_autodoc_exception(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_warnings(app):
-    app.env.current_document.docname = 'dummy'
+def test_autodoc_warnings(caplog: pytest.LogCaptureFixture) -> None:
+    # work around sphinx.util.logging.setup()
+    logger = logging.getLogger('sphinx')
+    logger.handlers[:] = [caplog.handler]
+
+    current_document = _CurrentDocument(docname='dummy')
 
     # can't import module
-    do_autodoc(app, 'module', 'unknown')
-    assert "failed to import 'unknown'" in app.warning.getvalue()
+    caplog.clear()
+    do_autodoc(
+        'module', 'unknown', current_document=current_document, expect_import_error=True
+    )
+    assert len(set(caplog.messages)) == 1
+    assert "failed to import 'unknown'" in caplog.messages[0]
 
     # missing function
-    do_autodoc(app, 'function', 'unknown')
-    assert "import for autodocumenting 'unknown'" in app.warning.getvalue()
+    caplog.clear()
+    do_autodoc(
+        'function',
+        'unknown',
+        current_document=current_document,
+        expect_import_error=True,
+    )
+    assert len(set(caplog.messages)) == 1
+    assert "import for autodocumenting 'unknown'" in caplog.messages[0]
 
-    do_autodoc(app, 'function', 'target.unknown')
-    assert "failed to import 'unknown' from module 'target'" in app.warning.getvalue()
+    caplog.clear()
+    do_autodoc(
+        'function',
+        'target.unknown',
+        current_document=current_document,
+        expect_import_error=True,
+    )
+    assert len(set(caplog.messages)) == 1
+    assert "failed to import 'unknown' from module 'target'" in caplog.messages[0]
 
     # missing method
-    do_autodoc(app, 'method', 'target.Class.unknown')
-    assert (
-        "failed to import 'Class.unknown' from module 'target'"
-    ) in app.warning.getvalue()
+    caplog.clear()
+    do_autodoc(
+        'method',
+        'target.Class.unknown',
+        current_document=current_document,
+        expect_import_error=True,
+    )
+    assert len(set(caplog.messages)) == 1
+    assert "failed to import 'Class.unknown' from module 'target'" in caplog.messages[0]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_attributes(app):
+def test_autodoc_attributes() -> None:
     options = {
         'synopsis': 'Synopsis',
         'platform': 'Platform',
         'deprecated': None,
     }
-    actual = do_autodoc(app, 'module', 'target', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target', options=options)
+    assert actual == [
         '',
         '.. py:module:: target',
         '   :synopsis: Synopsis',
@@ -337,18 +378,19 @@ def test_autodoc_attributes(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_members(app):
+def test_autodoc_members() -> None:
+    options: dict[str, Any]
+
     # default (no-members)
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base')
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Base')
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
     ]
 
     # default ALL-members
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Base', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -358,8 +400,8 @@ def test_autodoc_members(app):
 
     # default specific-members
     options = {'members': 'inheritedmeth,inheritedstaticmeth'}
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Base', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:method:: Base.inheritedmeth()',
         '   .. py:method:: Base.inheritedstaticmeth(cls)',
@@ -367,9 +409,11 @@ def test_autodoc_members(app):
 
     # ALL-members override autodoc_default_options
     options = {'members': None}
-    app.config.autodoc_default_options['members'] = 'inheritedstaticmeth'
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    config = _AutodocConfig(autodoc_default_options={'members': 'inheritedstaticmeth'})
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -379,32 +423,33 @@ def test_autodoc_members(app):
 
     # members override autodoc_default_options
     options = {'members': 'inheritedmeth'}
-    app.config.autodoc_default_options['members'] = 'inheritedstaticmeth'
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:method:: Base.inheritedmeth()',
     ]
 
     # members extends autodoc_default_options
     options = {'members': '+inheritedmeth'}
-    app.config.autodoc_default_options['members'] = 'inheritedstaticmeth'
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:method:: Base.inheritedmeth()',
         '   .. py:method:: Base.inheritedstaticmeth(cls)',
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_exclude_members(app):
+def test_autodoc_exclude_members() -> None:
     options = {
         'members': None,
         'exclude-members': 'inheritedmeth,inheritedstaticmeth',
     }
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Base', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -415,8 +460,8 @@ def test_autodoc_exclude_members(app):
         'members': 'inheritedmeth',
         'exclude-members': 'inheritedmeth',
     }
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Base', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
     ]
 
@@ -425,8 +470,8 @@ def test_autodoc_exclude_members(app):
         'members': None,
         'exclude-members': '+inheritedmeth,inheritedstaticmeth',
     }
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Base', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -437,9 +482,13 @@ def test_autodoc_exclude_members(app):
         'members': None,
         'exclude-members': 'inheritedmeth',
     }
-    app.config.autodoc_default_options['exclude-members'] = 'inheritedstaticmeth'
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    config = _AutodocConfig(
+        autodoc_default_options={'exclude-members': 'inheritedstaticmeth'}
+    )
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -451,9 +500,13 @@ def test_autodoc_exclude_members(app):
         'members': None,
         'exclude-members': '+inheritedmeth',
     }
-    app.config.autodoc_default_options['exclude-members'] = 'inheritedstaticmeth'
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    config = _AutodocConfig(
+        autodoc_default_options={'exclude-members': 'inheritedstaticmeth'}
+    )
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -461,11 +514,13 @@ def test_autodoc_exclude_members(app):
 
     # no exclude-members causes use autodoc_default_options
     options = {'members': None}
-    app.config.autodoc_default_options['exclude-members'] = (
-        'inheritedstaticmeth,inheritedmeth'
+    config = _AutodocConfig(
+        autodoc_default_options={'exclude-members': 'inheritedstaticmeth,inheritedmeth'}
     )
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -476,11 +531,13 @@ def test_autodoc_exclude_members(app):
         'members': None,
         'exclude-members': None,
     }
-    app.config.autodoc_default_options['exclude-members'] = (
-        'inheritedstaticmeth,inheritedmeth'
+    config = _AutodocConfig(
+        autodoc_default_options={'exclude-members': 'inheritedstaticmeth,inheritedmeth'}
     )
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc(
+        'class', 'target.inheritance.Base', config=config, options=options
+    )
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Base()',
         '   .. py:attribute:: Base.inheritedattr',
         '   .. py:method:: Base.inheritedclassmeth()',
@@ -489,14 +546,13 @@ def test_autodoc_exclude_members(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_undoc_members(app):
+def test_autodoc_undoc_members() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.a_staticmeth()',
         '   .. py:attribute:: Class.attr',
@@ -518,9 +574,9 @@ def test_autodoc_undoc_members(app):
 
     # use autodoc_default_options
     options = {'members': None}
-    app.config.autodoc_default_options['undoc-members'] = None
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    config = _AutodocConfig(autodoc_default_options={'undoc-members': True})
+    actual = do_autodoc('class', 'target.Class', config=config, options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.a_staticmeth()',
         '   .. py:attribute:: Class.attr',
@@ -545,9 +601,8 @@ def test_autodoc_undoc_members(app):
         'members': None,
         'no-undoc-members': None,
     }
-    app.config.autodoc_default_options['undoc-members'] = None
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', config=config, options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:attribute:: Class.attr',
         '   .. py:attribute:: Class.docattr',
@@ -563,12 +618,11 @@ def test_autodoc_undoc_members(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_undoc_members_for_metadata_only(app):
+def test_autodoc_undoc_members_for_metadata_only() -> None:
     # metadata only member is not displayed
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.metadata', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.metadata', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.metadata',
         '',
@@ -579,8 +633,8 @@ def test_autodoc_undoc_members_for_metadata_only(app):
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.metadata', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.metadata', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.metadata',
         '',
@@ -593,14 +647,13 @@ def test_autodoc_undoc_members_for_metadata_only(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_inherited_members(app):
+def test_autodoc_inherited_members() -> None:
     options = {
         'members': None,
         'inherited-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.inheritance.Derived', options)
-    assert list(filter(lambda l: 'method::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.inheritance.Derived', options=options)
+    assert [line for line in actual if 'method::' in line] == [
         '   .. py:method:: Derived.another_inheritedmeth()',
         '   .. py:method:: Derived.inheritedclassmeth()',
         '   .. py:method:: Derived.inheritedmeth()',
@@ -608,8 +661,7 @@ def test_autodoc_inherited_members(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_inherited_members_Base(app):
+def test_autodoc_inherited_members_Base() -> None:
     options = {
         'members': None,
         'inherited-members': 'Base',
@@ -617,13 +669,12 @@ def test_autodoc_inherited_members_Base(app):
     }
 
     # check methods for object class are shown
-    actual = do_autodoc(app, 'class', 'target.inheritance.Derived', options)
+    actual = do_autodoc('class', 'target.inheritance.Derived', options=options)
     assert '   .. py:method:: Derived.inheritedmeth()' in actual
     assert '   .. py:method:: Derived.inheritedclassmeth' not in actual
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_inherited_members_None(app):
+def test_autodoc_inherited_members_None() -> None:
     options = {
         'members': None,
         'inherited-members': 'None',
@@ -631,33 +682,31 @@ def test_autodoc_inherited_members_None(app):
     }
 
     # check methods for object class are shown
-    actual = do_autodoc(app, 'class', 'target.inheritance.Derived', options)
+    actual = do_autodoc('class', 'target.inheritance.Derived', options=options)
     assert '   .. py:method:: Derived.__init__()' in actual
     assert '   .. py:method:: Derived.__str__()' in actual
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_imported_members(app):
+def test_autodoc_imported_members() -> None:
     options = {
         'members': None,
         'imported-members': None,
         'ignore-module-all': None,
     }
-    actual = do_autodoc(app, 'module', 'target', options)
+    actual = do_autodoc('module', 'target', options=options)
     assert (
         '.. py:function:: function_to_be_imported(app: ~sphinx.application.Sphinx | None) -> str'
     ) in actual
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_special_members(app):
+def test_autodoc_special_members() -> None:
     # specific special methods
     options = {
         'undoc-members': None,
         'special-members': '__init__,__special1__',
     }
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.__init__(arg)',
         '   .. py:method:: Class.__special1__()',
@@ -669,8 +718,8 @@ def test_autodoc_special_members(app):
         'undoc-members': None,
         'special-members': '__init__,__special1__',
     }
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.__init__(arg)',
         '   .. py:method:: Class.__special1__()',
@@ -687,14 +736,14 @@ def test_autodoc_special_members(app):
     if sys.version_info >= (3, 13, 0, 'alpha', 5):
         options['exclude-members'] = '__static_attributes__,__firstlineno__'
     if sys.version_info >= (3, 14, 0, 'alpha', 7):
-        ann_attrs = (
+        ann_attrs: tuple[str, ...] = (
             '   .. py:attribute:: Class.__annotate_func__',
             '   .. py:attribute:: Class.__annotations_cache__',
         )
     else:
         ann_attrs = ('   .. py:attribute:: Class.__annotations__',)
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         *ann_attrs,
         '   .. py:attribute:: Class.__dict__',
@@ -723,9 +772,9 @@ def test_autodoc_special_members(app):
 
     # specific special methods from autodoc_default_options
     options = {'undoc-members': None}
-    app.config.autodoc_default_options['special-members'] = '__special2__'
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    config = _AutodocConfig(autodoc_default_options={'special-members': '__special2__'})
+    actual = do_autodoc('class', 'target.Class', config=config, options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.__special2__()',
     ]
@@ -735,9 +784,8 @@ def test_autodoc_special_members(app):
         'undoc-members': None,
         'special-members': '__init__,__special1__',
     }
-    app.config.autodoc_default_options['special-members'] = '__special2__'
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', config=config, options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.__init__(arg)',
         '   .. py:method:: Class.__special1__()',
@@ -748,9 +796,8 @@ def test_autodoc_special_members(app):
         'undoc-members': None,
         'special-members': '+__init__,__special1__',
     }
-    app.config.autodoc_default_options['special-members'] = '__special2__'
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', config=config, options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.__init__(arg)',
         '   .. py:method:: Class.__special1__()',
@@ -758,12 +805,11 @@ def test_autodoc_special_members(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_ignore_module_all(app):
+def test_autodoc_ignore_module_all() -> None:
     # default (no-ignore-module-all)
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target', options)
-    assert list(filter(lambda l: 'class::' in l, actual)) == [
+    actual = do_autodoc('module', 'target', options=options)
+    assert [line for line in actual if 'class::' in line] == [
         '.. py:class:: Class(arg)',
     ]
 
@@ -772,8 +818,8 @@ def test_autodoc_ignore_module_all(app):
         'members': None,
         'ignore-module-all': None,
     }
-    actual = do_autodoc(app, 'module', 'target', options)
-    assert list(filter(lambda l: 'class::' in l, actual)) == [
+    actual = do_autodoc('module', 'target', options=options)
+    assert [line for line in actual if 'class::' in line] == [
         '.. py:class:: Class(arg)',
         '.. py:class:: CustomDict',
         '.. py:class:: InnerChild()',
@@ -784,11 +830,10 @@ def test_autodoc_ignore_module_all(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_noindex(app):
+def test_autodoc_noindex() -> None:
     options = {'no-index': None}
-    actual = do_autodoc(app, 'module', 'target', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target', options=options)
+    assert actual == [
         '',
         '.. py:module:: target',
         '   :no-index:',
@@ -797,8 +842,8 @@ def test_autodoc_noindex(app):
 
     # TODO: :no-index: should be propagated to children of target item.
 
-    actual = do_autodoc(app, 'class', 'target.inheritance.Base', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.inheritance.Base', options=options)
+    assert actual == [
         '',
         '.. py:class:: Base()',
         '   :no-index:',
@@ -807,11 +852,10 @@ def test_autodoc_noindex(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_subclass_of_builtin_class(app):
+def test_autodoc_subclass_of_builtin_class() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.CustomDict', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.CustomDict', options=options)
+    assert actual == [
         '',
         '.. py:class:: CustomDict',
         '   :module: target',
@@ -821,11 +865,10 @@ def test_autodoc_subclass_of_builtin_class(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_inner_class(app):
+def test_autodoc_inner_class() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.Outer', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.Outer', options=options)
+    assert actual == [
         '',
         '.. py:class:: Outer()',
         '   :module: target',
@@ -851,8 +894,8 @@ def test_autodoc_inner_class(app):
         '      alias of :py:class:`dict`',
     ]
 
-    actual = do_autodoc(app, 'class', 'target.Outer.Inner', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.Outer.Inner', options=options)
+    assert actual == [
         '',
         '.. py:class:: Inner()',
         '   :module: target.Outer',
@@ -868,8 +911,8 @@ def test_autodoc_inner_class(app):
     ]
 
     options['show-inheritance'] = None
-    actual = do_autodoc(app, 'class', 'target.InnerChild', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.InnerChild', options=options)
+    assert actual == [
         '',
         '.. py:class:: InnerChild()',
         '   :module: target',
@@ -881,10 +924,9 @@ def test_autodoc_inner_class(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_classmethod(app):
-    actual = do_autodoc(app, 'method', 'target.inheritance.Base.inheritedclassmeth')
-    assert list(actual) == [
+def test_autodoc_classmethod() -> None:
+    actual = do_autodoc('method', 'target.inheritance.Base.inheritedclassmeth')
+    assert actual == [
         '',
         '.. py:method:: Base.inheritedclassmeth()',
         '   :module: target.inheritance',
@@ -895,10 +937,9 @@ def test_autodoc_classmethod(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_staticmethod(app):
-    actual = do_autodoc(app, 'method', 'target.inheritance.Base.inheritedstaticmeth')
-    assert list(actual) == [
+def test_autodoc_staticmethod() -> None:
+    actual = do_autodoc('method', 'target.inheritance.Base.inheritedstaticmeth')
+    assert actual == [
         '',
         '.. py:method:: Base.inheritedstaticmeth(cls)',
         '   :module: target.inheritance',
@@ -909,14 +950,13 @@ def test_autodoc_staticmethod(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_descriptor(app):
+def test_autodoc_descriptor() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.descriptor.Class', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.descriptor.Class', options=options)
+    assert actual == [
         '',
         '.. py:class:: Class()',
         '   :module: target.descriptor',
@@ -936,14 +976,13 @@ def test_autodoc_descriptor(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_cached_property(app):
+def test_autodoc_cached_property() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.cached_property.Foo', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.cached_property.Foo', options=options)
+    assert actual == [
         '',
         '.. py:class:: Foo()',
         '   :module: target.cached_property',
@@ -961,8 +1000,7 @@ def test_autodoc_cached_property(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_member_order(app):
+def test_autodoc_member_order() -> None:
     # case member-order='bysource'
     options = {
         'members': None,
@@ -970,8 +1008,8 @@ def test_autodoc_member_order(app):
         'undoc-members': None,
         'private-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.meth()',
         '   .. py:method:: Class.undocmeth()',
@@ -999,8 +1037,8 @@ def test_autodoc_member_order(app):
         'undoc-members': None,
         'private-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         # class methods
         '   .. py:method:: Class.moore(a, e, f) -> happiness',
@@ -1030,8 +1068,8 @@ def test_autodoc_member_order(app):
         'undoc-members': None,
         'private-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.Class', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('class', 'target.Class', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:attribute:: Class._private_inst_attr',
         '   .. py:method:: Class.a_staticmeth()',
@@ -1053,16 +1091,15 @@ def test_autodoc_member_order(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_module_member_order(app):
+def test_autodoc_module_member_order() -> None:
     # case member-order='bysource'
     options = {
         'members': 'foo, Bar, baz, qux, Quux, foobar',
         'member-order': 'bysource',
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.sort_by_all', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('module', 'target.sort_by_all', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:module:: target.sort_by_all',
         '.. py:function:: baz()',
         '.. py:function:: foo()',
@@ -1079,8 +1116,8 @@ def test_autodoc_module_member_order(app):
         'undoc-members': None,
         'ignore-module-all': None,
     }
-    actual = do_autodoc(app, 'module', 'target.sort_by_all', options)
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    actual = do_autodoc('module', 'target.sort_by_all', options=options)
+    assert [line for line in actual if '::' in line] == [
         '.. py:module:: target.sort_by_all',
         '.. py:function:: foo()',
         '.. py:class:: Bar()',
@@ -1091,11 +1128,13 @@ def test_autodoc_module_member_order(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_module_scope(app):
-    app.env.current_document.autodoc_module = 'target'
-    actual = do_autodoc(app, 'attribute', 'Class.mdocattr')
-    assert list(actual) == [
+def test_autodoc_module_scope() -> None:
+    current_document = _CurrentDocument(docname='index')
+    current_document.autodoc_module = 'target'
+    actual = do_autodoc(
+        'attribute', 'Class.mdocattr', current_document=current_document
+    )
+    assert actual == [
         '',
         '.. py:attribute:: Class.mdocattr',
         '   :module: target',
@@ -1106,12 +1145,12 @@ def test_autodoc_module_scope(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_class_scope(app):
-    app.env.current_document.autodoc_module = 'target'
-    app.env.current_document.autodoc_class = 'Class'
-    actual = do_autodoc(app, 'attribute', 'mdocattr')
-    assert list(actual) == [
+def test_autodoc_class_scope() -> None:
+    current_document = _CurrentDocument(docname='index')
+    current_document.autodoc_module = 'target'
+    current_document.autodoc_class = 'Class'
+    actual = do_autodoc('attribute', 'mdocattr', current_document=current_document)
+    assert actual == [
         '',
         '.. py:attribute:: Class.mdocattr',
         '   :module: target',
@@ -1122,14 +1161,13 @@ def test_autodoc_class_scope(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_attributes(app):
+def test_class_attributes() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.AttCls', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.AttCls', options=options)
+    assert actual == [
         '',
         '.. py:class:: AttCls()',
         '   :module: target',
@@ -1147,11 +1185,11 @@ def test_class_attributes(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_instance_attributes(app):
+def test_autoclass_instance_attributes() -> None:
+    options: dict[str, Any]
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.InstAttCls', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.InstAttCls', options=options)
+    assert actual == [
         '',
         '.. py:class:: InstAttCls()',
         '   :module: target',
@@ -1195,11 +1233,9 @@ def test_autoclass_instance_attributes(app):
     ]
 
     # pick up arbitrary attributes
-    options = {
-        'members': 'ca1,ia1',
-    }
-    actual = do_autodoc(app, 'class', 'target.InstAttCls', options)
-    assert list(actual) == [
+    options = {'members': 'ca1,ia1'}
+    actual = do_autodoc('class', 'target.InstAttCls', options=options)
+    assert actual == [
         '',
         '.. py:class:: InstAttCls()',
         '   :module: target',
@@ -1223,10 +1259,9 @@ def test_autoclass_instance_attributes(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_instance_attributes(app):
-    actual = do_autodoc(app, 'attribute', 'target.InstAttCls.ia1')
-    assert list(actual) == [
+def test_autoattribute_instance_attributes() -> None:
+    actual = do_autodoc('attribute', 'target.InstAttCls.ia1')
+    assert actual == [
         '',
         '.. py:attribute:: InstAttCls.ia1',
         '   :module: target',
@@ -1236,14 +1271,13 @@ def test_autoattribute_instance_attributes(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_slots(app):
+def test_slots() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.slots', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.slots', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.slots',
         '',
@@ -1429,13 +1463,12 @@ def autodoc_enum_options() -> dict[str, object]:
     return {'members': None, 'undoc-members': None}
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_class(app, autodoc_enum_options):
+def test_enum_class(autodoc_enum_options):
     fmt = _EnumFormatter('EnumCls')
     options = autodoc_enum_options | {'private-members': None}
 
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method(
             'say_goodbye', 'a classmethod says good-bye to you.', 'classmethod'
@@ -1450,8 +1483,10 @@ def test_enum_class(app, autodoc_enum_options):
     # Inherited members exclude the native Enum API (in particular
     # the 'name' and 'value' properties), unless they were explicitly
     # redefined by the user in one of the bases.
-    actual = do_autodoc(app, 'class', fmt.target, options | {'inherited-members': None})
-    assert list(actual) == [
+    actual = do_autodoc(
+        'class', fmt.target, options=options | {'inherited-members': None}
+    )
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method(
             'say_goodbye', 'a classmethod says good-bye to you.', 'classmethod'
@@ -1464,16 +1499,15 @@ def test_enum_class(app, autodoc_enum_options):
     ]
 
     # checks for an attribute of EnumCls
-    actual = do_autodoc(app, 'attribute', fmt.subtarget('val1'))
-    assert list(actual) == fmt.member('val1', 12, 'doc for val1', indent=0)
+    actual = do_autodoc('attribute', fmt.subtarget('val1'))
+    assert actual == fmt.member('val1', 12, 'doc for val1', indent=0)
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_class_with_data_type(app, autodoc_enum_options):
+def test_enum_class_with_data_type(autodoc_enum_options):
     fmt = _EnumFormatter('EnumClassWithDataType')
 
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('say_goodbye', 'docstring', 'classmethod'),
         *fmt.method('say_hello', 'docstring'),
@@ -1481,8 +1515,8 @@ def test_enum_class_with_data_type(app, autodoc_enum_options):
     ]
 
     options = autodoc_enum_options | {'inherited-members': None}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.entry('dtype', 'docstring', role='property'),
         *fmt.method('isupper', 'inherited'),
@@ -1492,12 +1526,11 @@ def test_enum_class_with_data_type(app, autodoc_enum_options):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_class_with_mixin_type(app, autodoc_enum_options):
+def test_enum_class_with_mixin_type(autodoc_enum_options):
     fmt = _EnumFormatter('EnumClassWithMixinType')
 
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('say_goodbye', 'docstring', 'classmethod'),
         *fmt.method('say_hello', 'docstring'),
@@ -1505,8 +1538,8 @@ def test_enum_class_with_mixin_type(app, autodoc_enum_options):
     ]
 
     options = autodoc_enum_options | {'inherited-members': None}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('say_goodbye', 'docstring', 'classmethod'),
         *fmt.method('say_hello', 'docstring'),
@@ -1515,19 +1548,18 @@ def test_enum_class_with_mixin_type(app, autodoc_enum_options):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_class_with_mixin_type_and_inheritence(app, autodoc_enum_options):
+def test_enum_class_with_mixin_type_and_inheritence(autodoc_enum_options):
     fmt = _EnumFormatter('EnumClassWithMixinTypeInherit')
 
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.member('x', 'X', ''),
     ]
 
     options = autodoc_enum_options | {'inherited-members': None}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('say_goodbye', 'inherited', 'classmethod'),
         *fmt.method('say_hello', 'inherited'),
@@ -1536,12 +1568,11 @@ def test_enum_class_with_mixin_type_and_inheritence(app, autodoc_enum_options):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_class_with_mixin_enum_type(app, autodoc_enum_options):
+def test_enum_class_with_mixin_enum_type(autodoc_enum_options):
     fmt = _EnumFormatter('EnumClassWithMixinEnumType')
 
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         # override() is overridden at the class level so it should be rendered
         *fmt.method('override', 'overridden'),
@@ -1550,8 +1581,8 @@ def test_enum_class_with_mixin_enum_type(app, autodoc_enum_options):
     ]
 
     options = autodoc_enum_options | {'inherited-members': None}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('override', 'overridden'),
         *fmt.method('say_goodbye', 'inherited', 'classmethod'),
@@ -1560,12 +1591,11 @@ def test_enum_class_with_mixin_enum_type(app, autodoc_enum_options):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_class_with_mixin_and_data_type(app, autodoc_enum_options):
+def test_enum_class_with_mixin_and_data_type(autodoc_enum_options):
     fmt = _EnumFormatter('EnumClassWithMixinAndDataType')
 
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('isupper', 'overridden'),
         *fmt.method('say_goodbye', 'overridden', 'classmethod'),
@@ -1575,8 +1605,8 @@ def test_enum_class_with_mixin_and_data_type(app, autodoc_enum_options):
 
     # add the special member __str__ (but not the inherited members)
     options = autodoc_enum_options | {'special-members': '__str__'}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('__str__', 'overridden'),
         *fmt.method('isupper', 'overridden'),
@@ -1586,8 +1616,8 @@ def test_enum_class_with_mixin_and_data_type(app, autodoc_enum_options):
     ]
 
     options = autodoc_enum_options | {'inherited-members': None}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.entry('dtype', 'docstring', role='property'),
         *fmt.method('isupper', 'overridden'),
@@ -1598,12 +1628,11 @@ def test_enum_class_with_mixin_and_data_type(app, autodoc_enum_options):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_with_parent_enum(app, autodoc_enum_options):
+def test_enum_with_parent_enum(autodoc_enum_options):
     fmt = _EnumFormatter('EnumClassWithParentEnum')
 
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('isupper', 'overridden'),
         *fmt.member('x', 'X', ''),
@@ -1611,8 +1640,8 @@ def test_enum_with_parent_enum(app, autodoc_enum_options):
 
     # add the special member __str__ (but not the inherited members)
     options = autodoc_enum_options | {'special-members': '__str__'}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.method('__str__', 'overridden'),
         *fmt.method('isupper', 'overridden'),
@@ -1620,8 +1649,8 @@ def test_enum_with_parent_enum(app, autodoc_enum_options):
     ]
 
     options = autodoc_enum_options | {'inherited-members': None}
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_lookup('this is enum class'),
         *fmt.entry('dtype', 'docstring', role='property'),
         *fmt.method('isupper', 'overridden'),
@@ -1633,62 +1662,60 @@ def test_enum_with_parent_enum(app, autodoc_enum_options):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_sunder_method(app, autodoc_enum_options):
+def test_enum_sunder_method(autodoc_enum_options):
     PRIVATE = {'private-members': None}  # sunder methods are recognized as private
 
     fmt = _EnumFormatter('EnumSunderMissingInNonEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options | PRIVATE)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options | PRIVATE)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
 
     fmt = _EnumFormatter('EnumSunderMissingInEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options | PRIVATE)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options | PRIVATE)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
 
     fmt = _EnumFormatter('EnumSunderMissingInDataType')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options | PRIVATE)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options | PRIVATE)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
 
     fmt = _EnumFormatter('EnumSunderMissingInClass')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options | PRIVATE)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options | PRIVATE)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.method('_missing_', 'docstring', 'classmethod', args='(value)'),
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_inherited_sunder_method(app, autodoc_enum_options):
+def test_enum_inherited_sunder_method(autodoc_enum_options):
     options = autodoc_enum_options | {
         'private-members': None,
         'inherited-members': None,
     }
 
     fmt = _EnumFormatter('EnumSunderMissingInNonEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.method('_missing_', 'inherited', 'classmethod', args='(value)'),
     ]
 
     fmt = _EnumFormatter('EnumSunderMissingInEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.method('_missing_', 'inherited', 'classmethod', args='(value)'),
     ]
 
     fmt = _EnumFormatter('EnumSunderMissingInDataType')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.method('_missing_', 'inherited', 'classmethod', args='(value)'),
         *fmt.entry('dtype', 'docstring', role='property'),
@@ -1696,56 +1723,54 @@ def test_enum_inherited_sunder_method(app, autodoc_enum_options):
     ]
 
     fmt = _EnumFormatter('EnumSunderMissingInClass')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.method('_missing_', 'docstring', 'classmethod', args='(value)'),
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_custom_name_property(app, autodoc_enum_options):
+def test_enum_custom_name_property(autodoc_enum_options):
     fmt = _EnumFormatter('EnumNamePropertyInNonEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
 
     fmt = _EnumFormatter('EnumNamePropertyInEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
 
     fmt = _EnumFormatter('EnumNamePropertyInDataType')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [*fmt.preamble_constructor('this is enum class')]
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [*fmt.preamble_constructor('this is enum class')]
 
     fmt = _EnumFormatter('EnumNamePropertyInClass')
-    actual = do_autodoc(app, 'class', fmt.target, autodoc_enum_options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=autodoc_enum_options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.entry('name', 'docstring', role='property'),
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_enum_inherited_custom_name_property(app, autodoc_enum_options):
+def test_enum_inherited_custom_name_property(autodoc_enum_options):
     options = autodoc_enum_options | {'inherited-members': None}
 
     fmt = _EnumFormatter('EnumNamePropertyInNonEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.entry('name', 'inherited', role='property'),
     ]
 
     fmt = _EnumFormatter('EnumNamePropertyInEnumMixin')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.entry('name', 'inherited', role='property'),
     ]
 
     fmt = _EnumFormatter('EnumNamePropertyInDataType')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.entry('dtype', 'docstring', role='property'),
         *fmt.method('isupper', 'inherited'),
@@ -1753,20 +1778,17 @@ def test_enum_inherited_custom_name_property(app, autodoc_enum_options):
     ]
 
     fmt = _EnumFormatter('EnumNamePropertyInClass')
-    actual = do_autodoc(app, 'class', fmt.target, options)
-    assert list(actual) == [
+    actual = do_autodoc('class', fmt.target, options=options)
+    assert actual == [
         *fmt.preamble_constructor('this is enum class'),
         *fmt.entry('name', 'docstring', role='property'),
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_descriptor_class(app):
-    options = {
-        'members': 'CustomDataDescriptor,CustomDataDescriptor2',
-    }
-    actual = do_autodoc(app, 'module', 'target.descriptor', options)
-    assert list(actual) == [
+def test_descriptor_class() -> None:
+    options = {'members': 'CustomDataDescriptor,CustomDataDescriptor2'}
+    actual = do_autodoc('module', 'target.descriptor', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.descriptor',
         '',
@@ -1791,10 +1813,9 @@ def test_descriptor_class(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_automethod_for_builtin(app):
-    actual = do_autodoc(app, 'method', 'builtins.int.__add__')
-    assert list(actual) == [
+def test_automethod_for_builtin() -> None:
+    actual = do_autodoc('method', 'builtins.int.__add__')
+    assert actual == [
         '',
         '.. py:method:: int.__add__(value, /)',
         '   :module: builtins',
@@ -1804,10 +1825,9 @@ def test_automethod_for_builtin(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_automethod_for_decorated(app):
-    actual = do_autodoc(app, 'method', 'target.decorator.Bar.meth')
-    assert list(actual) == [
+def test_automethod_for_decorated() -> None:
+    actual = do_autodoc('method', 'target.decorator.Bar.meth')
+    assert actual == [
         '',
         '.. py:method:: Bar.meth(name=None, age=None)',
         '   :module: target.decorator',
@@ -1815,14 +1835,13 @@ def test_automethod_for_decorated(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_abstractmethods(app):
+def test_abstractmethods() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.abstractmethods', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.abstractmethods', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.abstractmethods',
         '',
@@ -1865,11 +1884,10 @@ def test_abstractmethods(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_partialfunction(app):
+def test_partialfunction() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.partialfunction', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.partialfunction', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.partialfunction',
         '',
@@ -1900,22 +1918,20 @@ def test_partialfunction(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_imported_partialfunction_should_not_shown_without_imported_members(app):
+def test_imported_partialfunction_should_not_shown_without_imported_members() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.imported_members', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.imported_members', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.imported_members',
         '',
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_bound_method(app):
+def test_bound_method() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.bound_method', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.bound_method', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.bound_method',
         '',
@@ -1928,8 +1944,7 @@ def test_bound_method(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_partialmethod(app):
+def test_partialmethod() -> None:
     expected = [
         '',
         '.. py:class:: Cell()',
@@ -1954,12 +1969,11 @@ def test_partialmethod(app):
     ]
 
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.partialmethod.Cell', options)
-    assert list(actual) == expected
+    actual = do_autodoc('class', 'target.partialmethod.Cell', options=options)
+    assert actual == expected
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_partialmethod_undoc_members(app):
+def test_partialmethod_undoc_members() -> None:
     expected = [
         '',
         '.. py:class:: Cell()',
@@ -1991,12 +2005,11 @@ def test_partialmethod_undoc_members(app):
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.partialmethod.Cell', options)
-    assert list(actual) == expected
+    actual = do_autodoc('class', 'target.partialmethod.Cell', options=options)
+    assert actual == expected
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_typed_instance_variables(app):
+def test_autodoc_typed_instance_variables() -> None:
     options = {
         'members': None,
         'undoc-members': None,
@@ -2005,9 +2018,9 @@ def test_autodoc_typed_instance_variables(app):
     # doesn't result in inherited members in
     # `Derived.__annotations__`.
     # https://github.com/sphinx-doc/sphinx/issues/13934
-    do_autodoc(app, 'attribute', 'target.typed_vars.Derived.attr2')
-    actual = do_autodoc(app, 'module', 'target.typed_vars', options)
-    assert list(actual) == [
+    do_autodoc('attribute', 'target.typed_vars.Derived.attr2')
+    actual = do_autodoc('module', 'target.typed_vars', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.typed_vars',
         '',
@@ -2100,15 +2113,14 @@ def test_autodoc_typed_instance_variables(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_typed_inherited_instance_variables(app):
+def test_autodoc_typed_inherited_instance_variables() -> None:
     options = {
         'members': None,
         'undoc-members': None,
         'inherited-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.typed_vars.Derived', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.typed_vars.Derived', options=options)
+    assert actual == [
         '',
         '.. py:class:: Derived()',
         '   :module: target.typed_vars',
@@ -2164,14 +2176,13 @@ def test_autodoc_typed_inherited_instance_variables(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_GenericAlias(app):
+def test_autodoc_GenericAlias() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.genericalias', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.genericalias', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.genericalias',
         '',
@@ -2211,14 +2222,20 @@ def test_autodoc_GenericAlias(app):
     sys.version_info[:2] < (3, 12),
     reason='type statement introduced in Python 3.12',
 )
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_pep695_type_alias(app):
+def test_autodoc_pep695_type_alias() -> None:
+    config = _AutodocConfig(
+        autodoc_type_aliases={
+            'buffer_like': 'buffer_like',
+            'pathlike': 'pathlike',
+            'Handler': 'Handler',
+        }
+    )
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.pep695', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.pep695', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.pep695',
         '',
@@ -2340,14 +2357,13 @@ def test_autodoc_pep695_type_alias(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_TypeVar(app):
+def test_autodoc_TypeVar() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.typevar', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.typevar', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.typevar',
         '',
@@ -2422,14 +2438,13 @@ def test_autodoc_TypeVar(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_Annotated(app):
+def test_autodoc_Annotated() -> None:
     options = {
         'members': None,
         'member-order': 'bysource',
     }
-    actual = do_autodoc(app, 'module', 'target.annotated', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.annotated', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.annotated',
         '',
@@ -2486,14 +2501,13 @@ def test_autodoc_Annotated(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_TYPE_CHECKING(app):
+def test_autodoc_TYPE_CHECKING() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.TYPE_CHECKING', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.TYPE_CHECKING', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.TYPE_CHECKING',
         '',
@@ -2513,14 +2527,13 @@ def test_autodoc_TYPE_CHECKING(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_TYPE_CHECKING_circular_import(app):
+def test_autodoc_TYPE_CHECKING_circular_import() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'circular_import', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'circular_import', options=options)
+    assert actual == [
         '',
         '.. py:module:: circular_import',
         '',
@@ -2528,11 +2541,10 @@ def test_autodoc_TYPE_CHECKING_circular_import(app):
     assert sys.modules['circular_import'].a is sys.modules['circular_import.a']
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_singledispatch(app):
+def test_singledispatch() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.singledispatch', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.singledispatch', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.singledispatch',
         '',
@@ -2549,11 +2561,10 @@ def test_singledispatch(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_singledispatchmethod(app):
+def test_singledispatchmethod() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.singledispatchmethod', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.singledispatchmethod', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.singledispatchmethod',
         '',
@@ -2576,11 +2587,9 @@ def test_singledispatchmethod(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_singledispatchmethod_automethod(app):
-    options = {}
-    actual = do_autodoc(app, 'method', 'target.singledispatchmethod.Foo.meth', options)
-    assert list(actual) == [
+def test_singledispatchmethod_automethod() -> None:
+    actual = do_autodoc('method', 'target.singledispatchmethod.Foo.meth')
+    assert actual == [
         '',
         '.. py:method:: Foo.meth(arg, kwarg=None)',
         '               Foo.meth(arg: float, kwarg=None)',
@@ -2594,14 +2603,12 @@ def test_singledispatchmethod_automethod(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_singledispatchmethod_classmethod(app):
+def test_singledispatchmethod_classmethod() -> None:
     options = {'members': None}
     actual = do_autodoc(
-        app, 'module', 'target.singledispatchmethod_classmethod', options
+        'module', 'target.singledispatchmethod_classmethod', options=options
     )
-
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:module:: target.singledispatchmethod_classmethod',
         '',
@@ -2625,14 +2632,11 @@ def test_singledispatchmethod_classmethod(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_singledispatchmethod_classmethod_automethod(app):
-    options = {}
+def test_singledispatchmethod_classmethod_automethod() -> None:
     actual = do_autodoc(
-        app, 'method', 'target.singledispatchmethod_classmethod.Foo.class_meth', options
+        'method', 'target.singledispatchmethod_classmethod.Foo.class_meth'
     )
-
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:method:: Foo.class_meth(arg, kwarg=None)',
         '               Foo.class_meth(arg: float, kwarg=None)',
@@ -2652,14 +2656,13 @@ def test_singledispatchmethod_classmethod_automethod(app):
     reason='Cython does not support Python 3.13 yet.',
 )
 @pytest.mark.skipif(pyximport is None, reason='cython is not installed')
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_cython(app):
+def test_cython() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.cython', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.cython', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.cython',
         '',
@@ -2684,11 +2687,10 @@ def test_cython(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_final(app):
+def test_final() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.final', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.final', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.final',
         '',
@@ -2729,11 +2731,10 @@ def test_final(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_overload(app):
+def test_overload() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.overload', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.overload', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.overload',
         '',
@@ -2783,11 +2784,10 @@ def test_overload(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_overload2(app):
+def test_overload2() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.overload2', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.overload2', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.overload2',
         '',
@@ -2799,11 +2799,10 @@ def test_overload2(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_overload3(app):
+def test_overload3() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.overload3', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.overload3', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.overload3',
         '',
@@ -2819,11 +2818,10 @@ def test_overload3(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_pymodule_for_ModuleLevelDocumenter(app):
-    app.env.ref_context['py:module'] = 'target.classes'
-    actual = do_autodoc(app, 'class', 'Foo')
-    assert list(actual) == [
+def test_pymodule_for_ModuleLevelDocumenter() -> None:
+    ref_context: dict[str, Any] = {'py:module': 'target.classes'}
+    actual = do_autodoc('class', 'Foo', ref_context=ref_context)
+    assert actual == [
         '',
         '.. py:class:: Foo()',
         '   :module: target.classes',
@@ -2831,11 +2829,10 @@ def test_pymodule_for_ModuleLevelDocumenter(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_pymodule_for_ClassLevelDocumenter(app):
-    app.env.ref_context['py:module'] = 'target.methods'
-    actual = do_autodoc(app, 'method', 'Base.meth')
-    assert list(actual) == [
+def test_pymodule_for_ClassLevelDocumenter() -> None:
+    ref_context: dict[str, Any] = {'py:module': 'target.methods'}
+    actual = do_autodoc('method', 'Base.meth', ref_context=ref_context)
+    assert actual == [
         '',
         '.. py:method:: Base.meth()',
         '   :module: target.methods',
@@ -2843,12 +2840,10 @@ def test_pymodule_for_ClassLevelDocumenter(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_pyclass_for_ClassLevelDocumenter(app):
-    app.env.ref_context['py:module'] = 'target.methods'
-    app.env.ref_context['py:class'] = 'Base'
-    actual = do_autodoc(app, 'method', 'meth')
-    assert list(actual) == [
+def test_pyclass_for_ClassLevelDocumenter() -> None:
+    ref_context: dict[str, Any] = {'py:module': 'target.methods', 'py:class': 'Base'}
+    actual = do_autodoc('method', 'meth', ref_context=ref_context)
+    assert actual == [
         '',
         '.. py:method:: Base.meth()',
         '   :module: target.methods',
@@ -2856,32 +2851,54 @@ def test_pyclass_for_ClassLevelDocumenter(app):
     ]
 
 
-@pytest.mark.sphinx('dummy', testroot='ext-autodoc')
-def test_autodoc(app):
-    app.build(force_all=True)
+def test_autodoc(caplog: pytest.LogCaptureFixture) -> None:
+    # work around sphinx.util.logging.setup()
+    logger = logging.getLogger('sphinx')
+    logger.handlers[:] = [caplog.handler]
 
-    content = app.env.get_doctree('index')
-    assert isinstance(content[3], addnodes.desc)
-    assert content[3][0].astext() == 'autodoc_dummy_module.test()'
-    assert content[3][1].astext() == 'Dummy function using dummy.*'
+    config = _AutodocConfig(autodoc_mock_imports=['dummy'])
+    options = {'members': None}
+    actual = do_autodoc(
+        'module', 'autodoc_dummy_module', config=config, options=options
+    )
+    assert actual == [
+        '',
+        '.. py:module:: autodoc_dummy_module',
+        '',
+        '',
+        '.. py:function:: test()',
+        '   :module: autodoc_dummy_module',
+        '',
+        '   Dummy function using dummy.*',
+        '',
+    ]
 
     # See: https://github.com/sphinx-doc/sphinx/issues/2437
-    assert content[11][-1].astext() == (
-        """Dummy class Bar with alias.
+    do_autodoc('module', 'bug2437.autodoc_dummy_foo', options=options)
+    actual = do_autodoc('module', 'autodoc_dummy_bar', options=options)
+    assert actual == [
+        '',
+        '.. py:module:: autodoc_dummy_bar',
+        '',
+        '',
+        '.. py:class:: Bar()',
+        '   :module: autodoc_dummy_bar',
+        '',
+        '   Dummy class Bar with alias.',
+        '',
+        '',
+        '   .. py:attribute:: Bar.my_name',
+        '      :module: autodoc_dummy_bar',
+        '',
+        '      alias of :py:class:`~bug2437.autodoc_dummy_foo.Foo`',
+    ]
+
+    assert not caplog.records
 
 
-
-my_name
-
-alias of Foo"""
-    )
-    assert app.warning.getvalue() == ''
-
-
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_name_conflict(app):
-    actual = do_autodoc(app, 'class', 'target.name_conflict.foo')
-    assert list(actual) == [
+def test_name_conflict() -> None:
+    actual = do_autodoc('class', 'target.name_conflict.foo')
+    assert actual == [
         '',
         '.. py:class:: foo()',
         '   :module: target.name_conflict',
@@ -2890,8 +2907,8 @@ def test_name_conflict(app):
         '',
     ]
 
-    actual = do_autodoc(app, 'class', 'target.name_conflict.foo.bar')
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.name_conflict.foo.bar')
+    assert actual == [
         '',
         '.. py:class:: bar()',
         '   :module: target.name_conflict.foo',
@@ -2901,15 +2918,14 @@ def test_name_conflict(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_name_mangling(app):
+def test_name_mangling() -> None:
     options = {
         'members': None,
         'undoc-members': None,
         'private-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.name_mangling', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.name_mangling', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.name_mangling',
         '',
@@ -2948,11 +2964,10 @@ def test_name_mangling(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_type_union_operator(app):
+def test_type_union_operator() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.pep604', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.pep604', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.pep604',
         '',
@@ -2991,11 +3006,10 @@ def test_type_union_operator(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_hide_value(app):
+def test_hide_value() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.hide_value', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.hide_value', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.hide_value',
         '',
@@ -3036,14 +3050,13 @@ def test_hide_value(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_canonical(app):
+def test_canonical() -> None:
     options = {
         'members': None,
         'imported-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.canonical', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.canonical', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.canonical',
         '',
@@ -3093,8 +3106,9 @@ def function_rst(name, sig):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc', freshenv=True)
-def test_literal_render(app):
+def test_literal_render() -> None:
+    config = _AutodocConfig(autodoc_typehints_format='short')
+
     # autodoc_typehints_format can take 'short' or 'fully-qualified' values
     # and this will be interpreted as 'smart' or 'fully-qualified-except-typing' by restify()
     # and 'smart' or 'fully-qualified' by stringify_annotation().
@@ -3103,9 +3117,8 @@ def test_literal_render(app):
         'members': None,
         'exclude-members': 'MyEnum',
     }
-    app.config.autodoc_typehints_format = 'short'
-    actual = do_autodoc(app, 'module', 'target.literal', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.literal', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.literal',
         '',
@@ -3122,9 +3135,9 @@ def test_literal_render(app):
 
     # restify() assumes that 'fully-qualified' is 'fully-qualified-except-typing'
     # because it is more likely that a user wants to suppress 'typing.*'
-    app.config.autodoc_typehints_format = 'fully-qualified'
-    actual = do_autodoc(app, 'module', 'target.literal', options)
-    assert list(actual) == [
+    config = _AutodocConfig(autodoc_typehints_format='fully-qualified')
+    actual = do_autodoc('module', 'target.literal', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.literal',
         '',
@@ -3143,20 +3156,17 @@ def test_literal_render(app):
     ]
 
 
-@pytest.mark.sphinx(
-    'html',
-    testroot='ext-autodoc',
-    freshenv=True,
-    confoverrides={'python_display_short_literal_types': True},
-)
-def test_literal_render_pep604(app):
+def test_literal_render_pep604() -> None:
+    config = _AutodocConfig(
+        python_display_short_literal_types=True,
+        autodoc_typehints_format='short',
+    )
     options = {
         'members': None,
         'exclude-members': 'MyEnum',
     }
-    app.config.autodoc_typehints_format = 'short'
-    actual = do_autodoc(app, 'module', 'target.literal', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.literal', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.literal',
         '',
@@ -3173,9 +3183,12 @@ def test_literal_render_pep604(app):
 
     # restify() assumes that 'fully-qualified' is 'fully-qualified-except-typing'
     # because it is more likely that a user wants to suppress 'typing.*'
-    app.config.autodoc_typehints_format = 'fully-qualified'
-    actual = do_autodoc(app, 'module', 'target.literal', options)
-    assert list(actual) == [
+    config = _AutodocConfig(
+        python_display_short_literal_types=True,
+        autodoc_typehints_format='fully-qualified',
+    )
+    actual = do_autodoc('module', 'target.literal', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.literal',
         '',
@@ -3191,30 +3204,29 @@ def test_literal_render_pep604(app):
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_no_index_entry(app):
+def test_no_index_entry() -> None:
     # modules can use no-index-entry
     options = {'no-index-entry': None}
-    actual = do_autodoc(app, 'module', 'target.module', options)
-    assert '   :no-index-entry:' in list(actual)
+    actual = do_autodoc('module', 'target.module', options=options)
+    assert '   :no-index-entry:' in actual
 
     # classes can use no-index-entry
-    actual = do_autodoc(app, 'class', 'target.classes.Foo', options)
-    assert '   :no-index-entry:' in list(actual)
+    actual = do_autodoc('class', 'target.classes.Foo', options=options)
+    assert '   :no-index-entry:' in actual
 
     # functions can use no-index-entry
-    actual = do_autodoc(app, 'function', 'target.functions.func', options)
-    assert '   :no-index-entry:' in list(actual)
+    actual = do_autodoc('function', 'target.functions.func', options=options)
+    assert '   :no-index-entry:' in actual
 
     # modules respect no-index-entry in autodoc_default_options
-    app.config.autodoc_default_options = {'no-index-entry': True}
-    actual = do_autodoc(app, 'module', 'target.module')
-    assert '   :no-index-entry:' in list(actual)
+    config = _AutodocConfig(autodoc_default_options={'no-index-entry': True})
+    actual = do_autodoc('module', 'target.module', config=config)
+    assert '   :no-index-entry:' in actual
 
     # classes respect config-level no-index-entry
-    actual = do_autodoc(app, 'class', 'target.classes.Foo')
-    assert '   :no-index-entry:' in list(actual)
+    actual = do_autodoc('class', 'target.classes.Foo', config=config)
+    assert '   :no-index-entry:' in actual
 
     # functions respect config-level no-index-entry
-    actual = do_autodoc(app, 'function', 'target.functions.func')
-    assert '   :no-index-entry:' in list(actual)
+    actual = do_autodoc('function', 'target.functions.func', config=config)
+    assert '   :no-index-entry:' in actual

--- a/tests/test_ext_autodoc/test_ext_autodoc_autoattribute.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autoattribute.py
@@ -6,20 +6,16 @@ source file translated by test_build.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.Class.attr')
-    assert list(actual) == [
+def test_autoattribute() -> None:
+    actual = do_autodoc('attribute', 'target.Class.attr')
+    assert actual == [
         '',
         '.. py:attribute:: Class.attr',
         '   :module: target',
@@ -30,11 +26,10 @@ def test_autoattribute(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_novalue(app: SphinxTestApp) -> None:
+def test_autoattribute_novalue() -> None:
     options = {'no-value': None}
-    actual = do_autodoc(app, 'attribute', 'target.Class.attr', options)
-    assert list(actual) == [
+    actual = do_autodoc('attribute', 'target.Class.attr', options=options)
+    assert actual == [
         '',
         '.. py:attribute:: Class.attr',
         '   :module: target',
@@ -44,10 +39,9 @@ def test_autoattribute_novalue(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_typed_variable(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.typed_vars.Class.attr2')
-    assert list(actual) == [
+def test_autoattribute_typed_variable() -> None:
+    actual = do_autodoc('attribute', 'target.typed_vars.Class.attr2')
+    assert actual == [
         '',
         '.. py:attribute:: Class.attr2',
         '   :module: target.typed_vars',
@@ -56,10 +50,9 @@ def test_autoattribute_typed_variable(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_typed_variable_in_alias(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.typed_vars.Alias.attr2')
-    assert list(actual) == [
+def test_autoattribute_typed_variable_in_alias() -> None:
+    actual = do_autodoc('attribute', 'target.typed_vars.Alias.attr2')
+    assert actual == [
         '',
         '.. py:attribute:: Alias.attr2',
         '   :module: target.typed_vars',
@@ -68,10 +61,9 @@ def test_autoattribute_typed_variable_in_alias(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_instance_variable(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.typed_vars.Class.attr4')
-    assert list(actual) == [
+def test_autoattribute_instance_variable() -> None:
+    actual = do_autodoc('attribute', 'target.typed_vars.Class.attr4')
+    assert actual == [
         '',
         '.. py:attribute:: Class.attr4',
         '   :module: target.typed_vars',
@@ -82,10 +74,9 @@ def test_autoattribute_instance_variable(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_instance_variable_in_alias(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.typed_vars.Alias.attr4')
-    assert list(actual) == [
+def test_autoattribute_instance_variable_in_alias() -> None:
+    actual = do_autodoc('attribute', 'target.typed_vars.Alias.attr4')
+    assert actual == [
         '',
         '.. py:attribute:: Alias.attr4',
         '   :module: target.typed_vars',
@@ -96,10 +87,9 @@ def test_autoattribute_instance_variable_in_alias(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_instance_variable_without_comment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.instance_variable.Bar.attr4')
-    assert list(actual) == [
+def test_autoattribute_instance_variable_without_comment() -> None:
+    actual = do_autodoc('attribute', 'target.instance_variable.Bar.attr4')
+    assert actual == [
         '',
         '.. py:attribute:: Bar.attr4',
         '   :module: target.instance_variable',
@@ -107,10 +97,9 @@ def test_autoattribute_instance_variable_without_comment(app: SphinxTestApp) -> 
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_slots_variable_list(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.slots.Foo.attr')
-    assert list(actual) == [
+def test_autoattribute_slots_variable_list() -> None:
+    actual = do_autodoc('attribute', 'target.slots.Foo.attr')
+    assert actual == [
         '',
         '.. py:attribute:: Foo.attr',
         '   :module: target.slots',
@@ -118,10 +107,9 @@ def test_autoattribute_slots_variable_list(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_slots_variable_dict(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.slots.Bar.attr1')
-    assert list(actual) == [
+def test_autoattribute_slots_variable_dict() -> None:
+    actual = do_autodoc('attribute', 'target.slots.Bar.attr1')
+    assert actual == [
         '',
         '.. py:attribute:: Bar.attr1',
         '   :module: target.slots',
@@ -132,10 +120,9 @@ def test_autoattribute_slots_variable_dict(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_slots_variable_str(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.slots.Baz.attr')
-    assert list(actual) == [
+def test_autoattribute_slots_variable_str() -> None:
+    actual = do_autodoc('attribute', 'target.slots.Baz.attr')
+    assert actual == [
         '',
         '.. py:attribute:: Baz.attr',
         '   :module: target.slots',
@@ -143,10 +130,9 @@ def test_autoattribute_slots_variable_str(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_GenericAlias(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.genericalias.Class.T')
-    assert list(actual) == [
+def test_autoattribute_GenericAlias() -> None:
+    actual = do_autodoc('attribute', 'target.genericalias.Class.T')
+    assert actual == [
         '',
         '.. py:attribute:: Class.T',
         '   :module: target.genericalias',
@@ -158,10 +144,9 @@ def test_autoattribute_GenericAlias(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_hide_value(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'attribute', 'target.hide_value.Foo.SENTINEL1')
-    assert list(actual) == [
+def test_autoattribute_hide_value() -> None:
+    actual = do_autodoc('attribute', 'target.hide_value.Foo.SENTINEL1')
+    assert actual == [
         '',
         '.. py:attribute:: Foo.SENTINEL1',
         '   :module: target.hide_value',
@@ -172,8 +157,8 @@ def test_autoattribute_hide_value(app: SphinxTestApp) -> None:
         '',
     ]
 
-    actual = do_autodoc(app, 'attribute', 'target.hide_value.Foo.SENTINEL2')
-    assert list(actual) == [
+    actual = do_autodoc('attribute', 'target.hide_value.Foo.SENTINEL2')
+    assert actual == [
         '',
         '.. py:attribute:: Foo.SENTINEL2',
         '   :module: target.hide_value',

--- a/tests/test_ext_autodoc/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autoclass.py
@@ -10,40 +10,38 @@ import typing
 
 import pytest
 
-from tests.test_ext_autodoc.autodoc_util import do_autodoc
+from tests.test_ext_autodoc.autodoc_util import FakeEvents, do_autodoc
 
-if typing.TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_classes(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.classes.Foo')
-    assert list(actual) == [
+def test_classes() -> None:
+    actual = do_autodoc('function', 'target.classes.Foo')
+    assert actual == [
         '',
         '.. py:function:: Foo()',
         '   :module: target.classes',
         '',
     ]
 
-    actual = do_autodoc(app, 'function', 'target.classes.Bar')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.classes.Bar')
+    assert actual == [
         '',
         '.. py:function:: Bar(x, y)',
         '   :module: target.classes',
         '',
     ]
 
-    actual = do_autodoc(app, 'function', 'target.classes.Baz')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.classes.Baz')
+    assert actual == [
         '',
         '.. py:function:: Baz(x, y)',
         '   :module: target.classes',
         '',
     ]
 
-    actual = do_autodoc(app, 'function', 'target.classes.Qux')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.classes.Qux')
+    assert actual == [
         '',
         '.. py:function:: Qux(foo, bar)',
         '   :module: target.classes',
@@ -51,11 +49,10 @@ def test_classes(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_instance_variable(app: SphinxTestApp) -> None:
+def test_instance_variable() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.instance_variable.Bar', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.instance_variable.Bar', options=options)
+    assert actual == [
         '',
         '.. py:class:: Bar()',
         '   :module: target.instance_variable',
@@ -75,14 +72,13 @@ def test_instance_variable(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_inherited_instance_variable(app: SphinxTestApp) -> None:
+def test_inherited_instance_variable() -> None:
     options = {
         'members': None,
         'inherited-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.instance_variable.Bar', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.instance_variable.Bar', options=options)
+    assert actual == [
         '',
         '.. py:class:: Bar()',
         '   :module: target.instance_variable',
@@ -108,16 +104,15 @@ def test_inherited_instance_variable(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_uninitialized_attributes(app: SphinxTestApp) -> None:
+def test_uninitialized_attributes() -> None:
     options = {
         'members': None,
         'inherited-members': None,
     }
     actual = do_autodoc(
-        app, 'class', 'target.uninitialized_attributes.Derived', options
+        'class', 'target.uninitialized_attributes.Derived', options=options
     )
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:class:: Derived()',
         '   :module: target.uninitialized_attributes',
@@ -139,17 +134,16 @@ def test_uninitialized_attributes(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_undocumented_uninitialized_attributes(app: SphinxTestApp) -> None:
+def test_undocumented_uninitialized_attributes() -> None:
     options = {
         'members': None,
         'inherited-members': None,
         'undoc-members': None,
     }
     actual = do_autodoc(
-        app, 'class', 'target.uninitialized_attributes.Derived', options
+        'class', 'target.uninitialized_attributes.Derived', options=options
     )
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:class:: Derived()',
         '   :module: target.uninitialized_attributes',
@@ -181,26 +175,25 @@ def test_undocumented_uninitialized_attributes(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_decorators(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.decorator.Baz')
-    assert list(actual) == [
+def test_decorators() -> None:
+    actual = do_autodoc('class', 'target.decorator.Baz')
+    assert actual == [
         '',
         '.. py:class:: Baz(name=None, age=None)',
         '   :module: target.decorator',
         '',
     ]
 
-    actual = do_autodoc(app, 'class', 'target.decorator.Qux')
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.decorator.Qux')
+    assert actual == [
         '',
         '.. py:class:: Qux(name=None, age=None)',
         '   :module: target.decorator',
         '',
     ]
 
-    actual = do_autodoc(app, 'class', 'target.decorator.Quux')
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.decorator.Quux')
+    assert actual == [
         '',
         '.. py:class:: Quux(name=None, age=None)',
         '   :module: target.decorator',
@@ -208,11 +201,10 @@ def test_decorators(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_properties(app: SphinxTestApp) -> None:
+def test_properties() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.properties.Foo', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.properties.Foo', options=options)
+    assert actual == [
         '',
         '.. py:class:: Foo()',
         '   :module: target.properties',
@@ -252,11 +244,10 @@ def test_properties(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_slots_attribute(app: SphinxTestApp) -> None:
+def test_slots_attribute() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.slots.Bar', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.slots.Bar', options=options)
+    assert actual == [
         '',
         '.. py:class:: Bar()',
         '   :module: target.slots',
@@ -279,11 +270,10 @@ def test_slots_attribute(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_show_inheritance_for_subclass_of_generic_type(app: SphinxTestApp) -> None:
+def test_show_inheritance_for_subclass_of_generic_type() -> None:
     options = {'show-inheritance': None}
-    actual = do_autodoc(app, 'class', 'target.classes.Quux', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.classes.Quux', options=options)
+    assert actual == [
         '',
         '.. py:class:: Quux(iterable=(), /)',
         '   :module: target.classes',
@@ -295,11 +285,10 @@ def test_show_inheritance_for_subclass_of_generic_type(app: SphinxTestApp) -> No
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_show_inheritance_for_decendants_of_generic_type(app: SphinxTestApp) -> None:
+def test_show_inheritance_for_decendants_of_generic_type() -> None:
     options = {'show-inheritance': None}
-    actual = do_autodoc(app, 'class', 'target.classes.Corge', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.classes.Corge', options=options)
+    assert actual == [
         '',
         '.. py:class:: Corge(iterable=(), /)',
         '   :module: target.classes',
@@ -309,8 +298,7 @@ def test_show_inheritance_for_decendants_of_generic_type(app: SphinxTestApp) -> 
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_process_bases(app: SphinxTestApp) -> None:
+def test_autodoc_process_bases() -> None:
     def autodoc_process_bases(app, name, obj, options, bases):
         assert name == 'target.classes.Quux'
         assert obj.__module__ == 'target.classes'
@@ -321,11 +309,12 @@ def test_autodoc_process_bases(app: SphinxTestApp) -> None:
         bases.pop()
         bases.extend([int, str])
 
-    app.connect('autodoc-process-bases', autodoc_process_bases)
+    events = FakeEvents()
+    events.connect('autodoc-process-bases', autodoc_process_bases)
 
     options = {'show-inheritance': None}
-    actual = do_autodoc(app, 'class', 'target.classes.Quux', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.classes.Quux', events=events, options=options)
+    assert actual == [
         '',
         '.. py:class:: Quux(iterable=(), /)',
         '   :module: target.classes',
@@ -337,14 +326,13 @@ def test_autodoc_process_bases(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_doc_from_class(app: SphinxTestApp) -> None:
+def test_class_doc_from_class() -> None:
     options = {
         'members': None,
         'class-doc-from': 'class',
     }
-    actual = do_autodoc(app, 'class', 'target.autoclass_content.C', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.autoclass_content.C', options=options)
+    assert actual == [
         '',
         '.. py:class:: C()',
         '   :module: target.autoclass_content',
@@ -354,14 +342,13 @@ def test_class_doc_from_class(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_doc_from_init(app: SphinxTestApp) -> None:
+def test_class_doc_from_init() -> None:
     options = {
         'members': None,
         'class-doc-from': 'init',
     }
-    actual = do_autodoc(app, 'class', 'target.autoclass_content.C', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.autoclass_content.C', options=options)
+    assert actual == [
         '',
         '.. py:class:: C()',
         '   :module: target.autoclass_content',
@@ -371,14 +358,13 @@ def test_class_doc_from_init(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_doc_from_both(app: SphinxTestApp) -> None:
+def test_class_doc_from_both() -> None:
     options = {
         'members': None,
         'class-doc-from': 'both',
     }
-    actual = do_autodoc(app, 'class', 'target.autoclass_content.C', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.autoclass_content.C', options=options)
+    assert actual == [
         '',
         '.. py:class:: C()',
         '   :module: target.autoclass_content',
@@ -390,17 +376,17 @@ def test_class_doc_from_both(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_alias(app: SphinxTestApp) -> None:
+def test_class_alias() -> None:
     def autodoc_process_docstring(*args):
         """A handler always raises an error.
         This confirms this handler is never called for class aliases.
         """
         raise RuntimeError
 
-    app.connect('autodoc-process-docstring', autodoc_process_docstring)
-    actual = do_autodoc(app, 'class', 'target.classes.Alias')
-    assert list(actual) == [
+    events = FakeEvents()
+    events.connect('autodoc-process-docstring', autodoc_process_docstring)
+    actual = do_autodoc('class', 'target.classes.Alias', events=events)
+    assert actual == [
         '',
         '.. py:attribute:: Alias',
         '   :module: target.classes',
@@ -409,10 +395,9 @@ def test_class_alias(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_alias_having_doccomment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.classes.OtherAlias')
-    assert list(actual) == [
+def test_class_alias_having_doccomment() -> None:
+    actual = do_autodoc('class', 'target.classes.OtherAlias')
+    assert actual == [
         '',
         '.. py:attribute:: OtherAlias',
         '   :module: target.classes',
@@ -422,10 +407,9 @@ def test_class_alias_having_doccomment(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_alias_for_imported_object_having_doccomment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.classes.IntAlias')
-    assert list(actual) == [
+def test_class_alias_for_imported_object_having_doccomment() -> None:
+    actual = do_autodoc('class', 'target.classes.IntAlias')
+    assert actual == [
         '',
         '.. py:attribute:: IntAlias',
         '   :module: target.classes',
@@ -435,11 +419,10 @@ def test_class_alias_for_imported_object_having_doccomment(app: SphinxTestApp) -
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_coroutine(app: SphinxTestApp) -> None:
+def test_coroutine() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.coroutine.AsyncClass', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.coroutine.AsyncClass', options=options)
+    assert actual == [
         '',
         '.. py:class:: AsyncClass()',
         '   :module: target.coroutine',
@@ -477,10 +460,9 @@ def test_coroutine(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_NewType_module_level(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.typevar.T6')
-    assert list(actual) == [
+def test_autodata_NewType_module_level() -> None:
+    actual = do_autodoc('class', 'target.typevar.T6')
+    assert actual == [
         '',
         '.. py:class:: T6',
         '   :module: target.typevar',
@@ -492,10 +474,9 @@ def test_autodata_NewType_module_level(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_NewType_class_level(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.typevar.Class.T6')
-    assert list(actual) == [
+def test_autoattribute_NewType_class_level() -> None:
+    actual = do_autodoc('class', 'target.typevar.Class.T6')
+    assert actual == [
         '',
         '.. py:class:: Class.T6',
         '   :module: target.typevar',
@@ -507,10 +488,9 @@ def test_autoattribute_NewType_class_level(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_TypeVar_class_level(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.typevar.T1')
-    assert list(actual) == [
+def test_autodata_TypeVar_class_level() -> None:
+    actual = do_autodoc('class', 'target.typevar.T1')
+    assert actual == [
         '',
         '.. py:class:: T1',
         '   :module: target.typevar',
@@ -522,10 +502,9 @@ def test_autodata_TypeVar_class_level(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoattribute_TypeVar_module_level(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'class', 'target.typevar.Class.T1')
-    assert list(actual) == [
+def test_autoattribute_TypeVar_module_level() -> None:
+    actual = do_autodoc('class', 'target.typevar.Class.T1')
+    assert actual == [
         '',
         '.. py:class:: Class.T1',
         '   :module: target.typevar',
@@ -537,16 +516,15 @@ def test_autoattribute_TypeVar_module_level(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_inherited_instance_variable_with_annotations(app: SphinxTestApp) -> None:
+def test_inherited_instance_variable_with_annotations() -> None:
     options = {
         'members': None,
         'inherited-members': None,
     }
     actual = do_autodoc(
-        app, 'class', 'target.inherited_annotations.NoTypeAnnotation', options
+        'class', 'target.inherited_annotations.NoTypeAnnotation', options=options
     )
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:class:: NoTypeAnnotation()',
         '   :module: target.inherited_annotations',
@@ -568,13 +546,12 @@ def test_inherited_instance_variable_with_annotations(app: SphinxTestApp) -> Non
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_no_inherited_instance_variable_with_annotations(app: SphinxTestApp) -> None:
+def test_no_inherited_instance_variable_with_annotations() -> None:
     options = {'members': None}
     actual = do_autodoc(
-        app, 'class', 'target.inherited_annotations.NoTypeAnnotation2', options
+        'class', 'target.inherited_annotations.NoTypeAnnotation2', options=options
     )
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:class:: NoTypeAnnotation2()',
         '   :module: target.inherited_annotations',

--- a/tests/test_ext_autodoc/test_ext_autodoc_autodata.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autodata.py
@@ -6,22 +6,16 @@ source file translated by test_build.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
-
-from sphinx.testing.util import SphinxTestApp
 
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'data', 'target.integer')
-    assert list(actual) == [
+def test_autodata() -> None:
+    actual = do_autodoc('data', 'target.integer')
+    assert actual == [
         '',
         '.. py:data:: integer',
         '   :module: target',
@@ -32,11 +26,10 @@ def test_autodata(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_novalue(app: SphinxTestApp) -> None:
+def test_autodata_novalue() -> None:
     options = {'no-value': None}
-    actual = do_autodoc(app, 'data', 'target.integer', options)
-    assert list(actual) == [
+    actual = do_autodoc('data', 'target.integer', options=options)
+    assert actual == [
         '',
         '.. py:data:: integer',
         '   :module: target',
@@ -46,10 +39,9 @@ def test_autodata_novalue(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_typed_variable(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'data', 'target.typed_vars.attr2')
-    assert list(actual) == [
+def test_autodata_typed_variable() -> None:
+    actual = do_autodoc('data', 'target.typed_vars.attr2')
+    assert actual == [
         '',
         '.. py:data:: attr2',
         '   :module: target.typed_vars',
@@ -60,10 +52,9 @@ def test_autodata_typed_variable(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_type_comment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'data', 'target.typed_vars.attr3')
-    assert list(actual) == [
+def test_autodata_type_comment() -> None:
+    actual = do_autodoc('data', 'target.typed_vars.attr3')
+    assert actual == [
         '',
         '.. py:data:: attr3',
         '   :module: target.typed_vars',
@@ -75,10 +66,9 @@ def test_autodata_type_comment(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_GenericAlias(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'data', 'target.genericalias.T')
-    assert list(actual) == [
+def test_autodata_GenericAlias() -> None:
+    actual = do_autodoc('data', 'target.genericalias.T')
+    assert actual == [
         '',
         '.. py:data:: T',
         '   :module: target.genericalias',
@@ -90,10 +80,9 @@ def test_autodata_GenericAlias(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodata_hide_value(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'data', 'target.hide_value.SENTINEL1')
-    assert list(actual) == [
+def test_autodata_hide_value() -> None:
+    actual = do_autodoc('data', 'target.hide_value.SENTINEL1')
+    assert actual == [
         '',
         '.. py:data:: SENTINEL1',
         '   :module: target.hide_value',
@@ -104,8 +93,8 @@ def test_autodata_hide_value(app: SphinxTestApp) -> None:
         '',
     ]
 
-    actual = do_autodoc(app, 'data', 'target.hide_value.SENTINEL2')
-    assert list(actual) == [
+    actual = do_autodoc('data', 'target.hide_value.SENTINEL2')
+    assert actual == [
         '',
         '.. py:data:: SENTINEL2',
         '   :module: target.hide_value',

--- a/tests/test_ext_autodoc/test_ext_autodoc_autofunction.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autofunction.py
@@ -6,46 +6,40 @@ source file translated by test_build.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    from sphinx.testing.util import SphinxTestApp
-
 import pytest
 
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_classes(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.classes.Foo')
-    assert list(actual) == [
+
+def test_classes() -> None:
+    actual = do_autodoc('function', 'target.classes.Foo')
+    assert actual == [
         '',
         '.. py:function:: Foo()',
         '   :module: target.classes',
         '',
     ]
 
-    actual = do_autodoc(app, 'function', 'target.classes.Bar')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.classes.Bar')
+    assert actual == [
         '',
         '.. py:function:: Bar(x, y)',
         '   :module: target.classes',
         '',
     ]
 
-    actual = do_autodoc(app, 'function', 'target.classes.Baz')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.classes.Baz')
+    assert actual == [
         '',
         '.. py:function:: Baz(x, y)',
         '   :module: target.classes',
         '',
     ]
 
-    actual = do_autodoc(app, 'function', 'target.classes.Qux')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.classes.Qux')
+    assert actual == [
         '',
         '.. py:function:: Qux(foo, bar)',
         '   :module: target.classes',
@@ -53,10 +47,9 @@ def test_classes(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_callable(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.callable.function')
-    assert list(actual) == [
+def test_callable() -> None:
+    actual = do_autodoc('function', 'target.callable.function')
+    assert actual == [
         '',
         '.. py:function:: function(arg1, arg2, **kwargs)',
         '   :module: target.callable',
@@ -66,10 +59,9 @@ def test_callable(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_method(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.callable.method')
-    assert list(actual) == [
+def test_method() -> None:
+    actual = do_autodoc('function', 'target.callable.method')
+    assert actual == [
         '',
         '.. py:function:: method(arg1, arg2)',
         '   :module: target.callable',
@@ -79,10 +71,9 @@ def test_method(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_builtin_function(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'os.umask')
-    assert list(actual) == [
+def test_builtin_function() -> None:
+    actual = do_autodoc('function', 'os.umask')
+    assert actual == [
         '',
         '.. py:function:: umask(mask, /)',
         '   :module: os',
@@ -92,10 +83,9 @@ def test_builtin_function(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_methoddescriptor(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'builtins.int.__add__')
-    assert list(actual) == [
+def test_methoddescriptor() -> None:
+    actual = do_autodoc('function', 'builtins.int.__add__')
+    assert actual == [
         '',
         '.. py:function:: __add__(self, value, /)',
         '   :module: builtins.int',
@@ -105,10 +95,9 @@ def test_methoddescriptor(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_decorated(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.decorator.foo')
-    assert list(actual) == [
+def test_decorated() -> None:
+    actual = do_autodoc('function', 'target.decorator.foo')
+    assert actual == [
         '',
         '.. py:function:: foo(name=None, age=None)',
         '   :module: target.decorator',
@@ -116,11 +105,9 @@ def test_decorated(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_singledispatch(app: SphinxTestApp) -> None:
-    options: dict[str, Any] = {}
-    actual = do_autodoc(app, 'function', 'target.singledispatch.func', options)
-    assert list(actual) == [
+def test_singledispatch() -> None:
+    actual = do_autodoc('function', 'target.singledispatch.func')
+    assert actual == [
         '',
         '.. py:function:: func(arg, kwarg=None)',
         '                 func(arg: float, kwarg=None)',
@@ -134,10 +121,9 @@ def test_singledispatch(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_cfunction(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'time.asctime')
-    assert list(actual) == [
+def test_cfunction() -> None:
+    actual = do_autodoc('function', 'time.asctime')
+    assert actual == [
         '',
         '.. py:function:: asctime([tuple]) -> string',
         '   :module: time',
@@ -149,10 +135,9 @@ def test_cfunction(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_wrapped_function(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.wrappedfunction.slow_function')
-    assert list(actual) == [
+def test_wrapped_function() -> None:
+    actual = do_autodoc('function', 'target.wrappedfunction.slow_function')
+    assert actual == [
         '',
         '.. py:function:: slow_function(message, timeout)',
         '   :module: target.wrappedfunction',
@@ -162,10 +147,9 @@ def test_wrapped_function(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_wrapped_function_contextmanager(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.wrappedfunction.feeling_good')
-    assert list(actual) == [
+def test_wrapped_function_contextmanager() -> None:
+    actual = do_autodoc('function', 'target.wrappedfunction.feeling_good')
+    assert actual == [
         '',
         '.. py:function:: feeling_good(x: int, y: int) -> ~typing.Generator',
         '   :module: target.wrappedfunction',
@@ -175,10 +159,9 @@ def test_wrapped_function_contextmanager(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_coroutine(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.functions.coroutinefunc')
-    assert list(actual) == [
+def test_coroutine() -> None:
+    actual = do_autodoc('function', 'target.functions.coroutinefunc')
+    assert actual == [
         '',
         '.. py:function:: coroutinefunc()',
         '   :module: target.functions',
@@ -187,10 +170,9 @@ def test_coroutine(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_synchronized_coroutine(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.coroutine.sync_func')
-    assert list(actual) == [
+def test_synchronized_coroutine() -> None:
+    actual = do_autodoc('function', 'target.coroutine.sync_func')
+    assert actual == [
         '',
         '.. py:function:: sync_func()',
         '   :module: target.coroutine',
@@ -198,10 +180,9 @@ def test_synchronized_coroutine(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_async_generator(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.functions.asyncgenerator')
-    assert list(actual) == [
+def test_async_generator() -> None:
+    actual = do_autodoc('function', 'target.functions.asyncgenerator')
+    assert actual == [
         '',
         '.. py:function:: asyncgenerator()',
         '   :module: target.functions',
@@ -210,10 +191,9 @@ def test_async_generator(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_slice_function_arg(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'function', 'target.functions.slice_arg_func')
-    assert list(actual) == [
+def test_slice_function_arg() -> None:
+    actual = do_autodoc('function', 'target.functions.slice_arg_func')
+    assert actual == [
         '',
         '.. py:function:: slice_arg_func(arg: float64[:, :])',
         '   :module: target.functions',

--- a/tests/test_ext_autodoc/test_ext_autodoc_automodule.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_automodule.py
@@ -12,17 +12,18 @@ import typing
 
 import pytest
 
+from sphinx.ext.autodoc._shared import _AutodocConfig
+from sphinx.ext.autodoc.mock import _MockObject
+
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if typing.TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_empty_all(app: SphinxTestApp) -> None:
+def test_empty_all() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.empty_all', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.empty_all', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.empty_all',
         '',
@@ -31,11 +32,10 @@ def test_empty_all(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_automodule(app: SphinxTestApp) -> None:
+def test_automodule() -> None:
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.module', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.module', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.module',
         '',
@@ -56,14 +56,13 @@ def test_automodule(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_automodule_undoc_members(app: SphinxTestApp) -> None:
+def test_automodule_undoc_members() -> None:
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.module', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.module', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.module',
         '',
@@ -89,14 +88,13 @@ def test_automodule_undoc_members(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_automodule_special_members(app: SphinxTestApp) -> None:
+def test_automodule_special_members() -> None:
     options = {
         'members': None,
         'special-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.module', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.module', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.module',
         '',
@@ -124,15 +122,14 @@ def test_automodule_special_members(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_automodule_inherited_members(app: SphinxTestApp) -> None:
+def test_automodule_inherited_members() -> None:
     options = {
         'members': None,
         'undoc-members': None,
         'inherited-members': 'Base, list',
     }
-    actual = do_autodoc(app, 'module', 'target.inheritance', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.inheritance', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.inheritance',
         '',
@@ -206,29 +203,26 @@ def test_automodule_inherited_members(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx(
-    'html',
-    testroot='ext-autodoc',
-    confoverrides={
-        'autodoc_mock_imports': [
+@pytest.mark.usefixtures('rollback_sysmodules')
+def test_subclass_of_mocked_object() -> None:
+    config = _AutodocConfig(
+        autodoc_mock_imports=[
             'missing_module',
             'missing_package1',
             'missing_package2',
             'missing_package3',
             'sphinx.missing_module4',
         ]
-    },
-)
-@pytest.mark.usefixtures('rollback_sysmodules')
-def test_subclass_of_mocked_object(app: SphinxTestApp) -> None:
-    from sphinx.ext.autodoc.mock import _MockObject
+    )
 
     sys.modules.pop('target', None)  # unload target module to clear the module cache
 
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.need_mocks', options)
+    actual = do_autodoc('module', 'target.need_mocks', config=config, options=options)
     # ``typing.Any`` is not available at runtime on ``_MockObject.__new__``
-    assert '.. py:class:: Inherited(*args: Any, **kwargs: Any)' in actual
+    assert actual[10:11] == [
+        '.. py:class:: Inherited(*args: Any, **kwargs: Any)',
+    ]
 
     # make ``typing.Any`` available at runtime on ``_MockObject.__new__``
     sig = inspect.signature(_MockObject.__new__)
@@ -239,7 +233,7 @@ def test_subclass_of_mocked_object(app: SphinxTestApp) -> None:
     _MockObject.__new__.__signature__ = sig  # type: ignore[attr-defined]
 
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.need_mocks', options)
-    assert (
-        '.. py:class:: Inherited(*args: ~typing.Any, **kwargs: ~typing.Any)'
-    ) in actual
+    actual = do_autodoc('module', 'target.need_mocks', config=config, options=options)
+    assert actual[10:11] == [
+        '.. py:class:: Inherited(*args: ~typing.Any, **kwargs: ~typing.Any)',
+    ]

--- a/tests/test_ext_autodoc/test_ext_autodoc_autoproperty.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autoproperty.py
@@ -6,20 +6,16 @@ source file translated by test_build.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_properties(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'property', 'target.properties.Foo.prop1')
-    assert list(actual) == [
+def test_properties() -> None:
+    actual = do_autodoc('property', 'target.properties.Foo.prop1')
+    assert actual == [
         '',
         '.. py:property:: Foo.prop1',
         '   :module: target.properties',
@@ -30,10 +26,9 @@ def test_properties(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_properties(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'property', 'target.properties.Foo.prop2')
-    assert list(actual) == [
+def test_class_properties() -> None:
+    actual = do_autodoc('property', 'target.properties.Foo.prop2')
+    assert actual == [
         '',
         '.. py:property:: Foo.prop2',
         '   :module: target.properties',
@@ -45,12 +40,9 @@ def test_class_properties(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_properties_with_type_comment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(
-        app, 'property', 'target.properties.Foo.prop1_with_type_comment'
-    )
-    assert list(actual) == [
+def test_properties_with_type_comment() -> None:
+    actual = do_autodoc('property', 'target.properties.Foo.prop1_with_type_comment')
+    assert actual == [
         '',
         '.. py:property:: Foo.prop1_with_type_comment',
         '   :module: target.properties',
@@ -61,12 +53,9 @@ def test_properties_with_type_comment(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_class_properties_with_type_comment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(
-        app, 'property', 'target.properties.Foo.prop2_with_type_comment'
-    )
-    assert list(actual) == [
+def test_class_properties_with_type_comment() -> None:
+    actual = do_autodoc('property', 'target.properties.Foo.prop2_with_type_comment')
+    assert actual == [
         '',
         '.. py:property:: Foo.prop2_with_type_comment',
         '   :module: target.properties',
@@ -78,10 +67,9 @@ def test_class_properties_with_type_comment(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_cached_properties(app: SphinxTestApp) -> None:
-    actual = do_autodoc(app, 'property', 'target.cached_property.Foo.prop')
-    assert list(actual) == [
+def test_cached_properties() -> None:
+    actual = do_autodoc('property', 'target.cached_property.Foo.prop')
+    assert actual == [
         '',
         '.. py:property:: Foo.prop',
         '   :module: target.cached_property',
@@ -90,12 +78,9 @@ def test_cached_properties(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_cached_properties_with_type_comment(app: SphinxTestApp) -> None:
-    actual = do_autodoc(
-        app, 'property', 'target.cached_property.Foo.prop_with_type_comment'
-    )
-    assert list(actual) == [
+def test_cached_properties_with_type_comment() -> None:
+    actual = do_autodoc('property', 'target.cached_property.Foo.prop_with_type_comment')
+    assert actual == [
         '',
         '.. py:property:: Foo.prop_with_type_comment',
         '   :module: target.cached_property',

--- a/tests/test_ext_autodoc/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_configs.py
@@ -638,6 +638,7 @@ def test_mocked_module_imports(caplog: pytest.LogCaptureFixture) -> None:
     # work around sphinx.util.logging.setup()
     logger = logging.getLogger('sphinx')
     logger.handlers[:] = [caplog.handler]
+    caplog.set_level(logging.WARNING)
 
     sys.modules.pop('target', None)  # unload target module to clear the module cache
 

--- a/tests/test_ext_autodoc/test_ext_autodoc_configs.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_configs.py
@@ -2,26 +2,28 @@
 
 from __future__ import annotations
 
+import logging
 import platform
 import sys
-from typing import TYPE_CHECKING
 
 import pytest
 
+from sphinx.ext.autodoc._shared import _AutodocConfig
+
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_content_class(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_autoclass_content_class() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.autoclass_content', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.autoclass_content', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.autoclass_content',
         '',
@@ -76,12 +78,13 @@ def test_autoclass_content_class(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_content_init(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'init'
+def test_autoclass_content_init() -> None:
+    config = _AutodocConfig(autoclass_content='init')
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.autoclass_content', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.autoclass_content', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.autoclass_content',
         '',
@@ -136,15 +139,14 @@ def test_autoclass_content_init(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_class_signature_mixed(app: SphinxTestApp) -> None:
-    app.config.autodoc_class_signature = 'mixed'
+def test_autodoc_class_signature_mixed() -> None:
+    config = _AutodocConfig(autodoc_class_signature='mixed')
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.classes.Bar', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.classes.Bar', config=config, options=options)
+    assert actual == [
         '',
         '.. py:class:: Bar(x, y)',
         '   :module: target.classes',
@@ -152,15 +154,14 @@ def test_autodoc_class_signature_mixed(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_class_signature_separated_init(app: SphinxTestApp) -> None:
-    app.config.autodoc_class_signature = 'separated'
+def test_autodoc_class_signature_separated_init() -> None:
+    config = _AutodocConfig(autodoc_class_signature='separated')
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.classes.Bar', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.classes.Bar', config=config, options=options)
+    assert actual == [
         '',
         '.. py:class:: Bar',
         '   :module: target.classes',
@@ -172,15 +173,14 @@ def test_autodoc_class_signature_separated_init(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_class_signature_separated_new(app: SphinxTestApp) -> None:
-    app.config.autodoc_class_signature = 'separated'
+def test_autodoc_class_signature_separated_new() -> None:
+    config = _AutodocConfig(autodoc_class_signature='separated')
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.classes.Baz', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.classes.Baz', config=config, options=options)
+    assert actual == [
         '',
         '.. py:class:: Baz',
         '   :module: target.classes',
@@ -193,12 +193,13 @@ def test_autodoc_class_signature_separated_new(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_content_both(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'both'
+def test_autoclass_content_both() -> None:
+    config = _AutodocConfig(autoclass_content='both')
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.autoclass_content', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.autoclass_content', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.autoclass_content',
         '',
@@ -263,11 +264,13 @@ def test_autoclass_content_both(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_inherit_docstrings(app: SphinxTestApp) -> None:
-    assert app.config.autodoc_inherit_docstrings is True  # default
-    actual = do_autodoc(app, 'method', 'target.inheritance.Derived.inheritedmeth')
-    assert list(actual) == [
+def test_autodoc_inherit_docstrings() -> None:
+    config = _AutodocConfig()
+    assert config.autodoc_inherit_docstrings is True  # default
+    actual = do_autodoc(
+        'method', 'target.inheritance.Derived.inheritedmeth', config=config
+    )
+    assert actual == [
         '',
         '.. py:method:: Derived.inheritedmeth()',
         '   :module: target.inheritance',
@@ -277,9 +280,11 @@ def test_autodoc_inherit_docstrings(app: SphinxTestApp) -> None:
     ]
 
     # disable autodoc_inherit_docstrings
-    app.config.autodoc_inherit_docstrings = False
-    actual = do_autodoc(app, 'method', 'target.inheritance.Derived.inheritedmeth')
-    assert list(actual) == [
+    config = _AutodocConfig(autodoc_inherit_docstrings=False)
+    actual = do_autodoc(
+        'method', 'target.inheritance.Derived.inheritedmeth', config=config
+    )
+    assert actual == [
         '',
         '.. py:method:: Derived.inheritedmeth()',
         '   :module: target.inheritance',
@@ -287,16 +292,18 @@ def test_autodoc_inherit_docstrings(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_inherit_docstrings_for_inherited_members(app: SphinxTestApp) -> None:
+def test_autodoc_inherit_docstrings_for_inherited_members() -> None:
+    config = _AutodocConfig()
     options = {
         'members': None,
         'inherited-members': None,
     }
 
-    assert app.config.autodoc_inherit_docstrings is True  # default
-    actual = do_autodoc(app, 'class', 'target.inheritance.Derived', options)
-    assert list(actual) == [
+    assert config.autodoc_inherit_docstrings is True  # default
+    actual = do_autodoc(
+        'class', 'target.inheritance.Derived', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:class:: Derived()',
         '   :module: target.inheritance',
@@ -337,9 +344,11 @@ def test_autodoc_inherit_docstrings_for_inherited_members(app: SphinxTestApp) ->
     ]
 
     # disable autodoc_inherit_docstrings
-    app.config.autodoc_inherit_docstrings = False
-    actual = do_autodoc(app, 'class', 'target.inheritance.Derived', options)
-    assert list(actual) == [
+    config = _AutodocConfig(autodoc_inherit_docstrings=False)
+    actual = do_autodoc(
+        'class', 'target.inheritance.Derived', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:class:: Derived()',
         '   :module: target.inheritance',
@@ -367,11 +376,13 @@ def test_autodoc_inherit_docstrings_for_inherited_members(app: SphinxTestApp) ->
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_docstring_signature(app: SphinxTestApp) -> None:
-    options = {'members': None, 'special-members': '__init__, __new__'}
-    actual = do_autodoc(app, 'class', 'target.DocstringSig', options)
-    assert list(actual) == [
+def test_autodoc_docstring_signature() -> None:
+    options = {
+        'members': None,
+        'special-members': '__init__, __new__',
+    }
+    actual = do_autodoc('class', 'target.DocstringSig', options=options)
+    assert actual == [
         '',
         # FIXME: Ideally this would instead be: `DocstringSig(d, e=1)` but
         # currently `ClassDocumenter` does not apply the docstring signature
@@ -429,9 +440,9 @@ def test_autodoc_docstring_signature(app: SphinxTestApp) -> None:
     ]
 
     # disable autodoc_docstring_signature
-    app.config.autodoc_docstring_signature = False
-    actual = do_autodoc(app, 'class', 'target.DocstringSig', options)
-    assert list(actual) == [
+    config = _AutodocConfig(autodoc_docstring_signature=False)
+    actual = do_autodoc('class', 'target.DocstringSig', config=config, options=options)
+    assert actual == [
         '',
         '.. py:class:: DocstringSig(*new_args, **new_kwargs)',
         '   :module: target',
@@ -490,15 +501,16 @@ def test_autodoc_docstring_signature(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_content_and_docstring_signature_class(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_autoclass_content_and_docstring_signature_class() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.docstring_signature', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.docstring_signature', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.docstring_signature',
         '',
@@ -529,15 +541,16 @@ def test_autoclass_content_and_docstring_signature_class(app: SphinxTestApp) -> 
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_content_and_docstring_signature_init(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'init'
+def test_autoclass_content_and_docstring_signature_init() -> None:
+    config = _AutodocConfig(autoclass_content='init')
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.docstring_signature', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.docstring_signature', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.docstring_signature',
         '',
@@ -572,15 +585,16 @@ def test_autoclass_content_and_docstring_signature_init(app: SphinxTestApp) -> N
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autoclass_content_and_docstring_signature_both(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'both'
+def test_autoclass_content_and_docstring_signature_both() -> None:
+    config = _AutodocConfig(autoclass_content='both')
     options = {
         'members': None,
         'undoc-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.docstring_signature', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.docstring_signature', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.docstring_signature',
         '',
@@ -619,29 +633,37 @@ def test_autoclass_content_and_docstring_signature_both(app: SphinxTestApp) -> N
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
 @pytest.mark.usefixtures('rollback_sysmodules')
-def test_mocked_module_imports(app: SphinxTestApp) -> None:
+def test_mocked_module_imports(caplog: pytest.LogCaptureFixture) -> None:
+    # work around sphinx.util.logging.setup()
+    logger = logging.getLogger('sphinx')
+    logger.handlers[:] = [caplog.handler]
+
     sys.modules.pop('target', None)  # unload target module to clear the module cache
 
     # no autodoc_mock_imports
     options = {'members': 'TestAutodoc,decorated_function,func,Alias'}
-    actual = do_autodoc(app, 'module', 'target.need_mocks', options)
-    assert list(actual) == []
-    assert "autodoc: failed to import 'need_mocks'" in app.warning.getvalue()
+    actual = do_autodoc(
+        'module', 'target.need_mocks', expect_import_error=True, options=options
+    )
+    assert actual == []
+    assert len(set(caplog.messages)) == 1
+    assert "autodoc: failed to import 'need_mocks'" in caplog.messages[0]
 
     # with autodoc_mock_imports
-    app.config.autodoc_mock_imports = [
-        'missing_module',
-        'missing_package1',
-        'missing_package2',
-        'missing_package3',
-        'sphinx.missing_module4',
-    ]
+    config = _AutodocConfig(
+        autodoc_mock_imports=[
+            'missing_module',
+            'missing_package1',
+            'missing_package2',
+            'missing_package3',
+            'sphinx.missing_module4',
+        ]
+    )
 
-    app.warning.truncate(0)
-    actual = do_autodoc(app, 'module', 'target.need_mocks', options)
-    assert list(actual) == [
+    caplog.clear()
+    actual = do_autodoc('module', 'target.need_mocks', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.need_mocks',
         '',
@@ -682,15 +704,14 @@ def test_mocked_module_imports(app: SphinxTestApp) -> None:
         '   a function takes mocked object as an argument',
         '',
     ]
-    assert app.warning.getvalue() == ''
+    assert len(caplog.records) == 0
 
 
-@pytest.mark.sphinx('text', testroot='ext-autodoc')
-def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
+def test_autodoc_type_aliases() -> None:
     # default
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.autodoc_type_aliases', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.autodoc_type_aliases', options=options)
+    assert actual == [
         '',
         '.. py:module:: target.autodoc_type_aliases',
         '',
@@ -758,12 +779,16 @@ def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
     ]
 
     # define aliases
-    app.config.autodoc_type_aliases = {
-        'myint': 'myint',
-        'io.StringIO': 'my.module.StringIO',
-    }
-    actual = do_autodoc(app, 'module', 'target.autodoc_type_aliases', options)
-    assert list(actual) == [
+    config = _AutodocConfig(
+        autodoc_type_aliases={
+            'myint': 'myint',
+            'io.StringIO': 'my.module.StringIO',
+        }
+    )
+    actual = do_autodoc(
+        'module', 'target.autodoc_type_aliases', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.autodoc_type_aliases',
         '',
@@ -831,50 +856,47 @@ def test_autodoc_type_aliases(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_default_options(app: SphinxTestApp) -> None:
+def test_autodoc_default_options() -> None:
     if (3, 11, 7) <= sys.version_info < (3, 12) or sys.version_info >= (3, 12, 1):
         list_of_weak_references = '      list of weak references to the object'
     else:
         list_of_weak_references = '      list of weak references to the object (if defined)'  # fmt: skip
 
     # no settings
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    actual = do_autodoc('class', 'target.enums.EnumCls')
     assert '   .. py:attribute:: EnumCls.val1' not in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
-    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    actual = do_autodoc('class', 'target.CustomIter')
     assert '   .. py:method:: target.CustomIter' not in actual
-    actual = do_autodoc(app, 'module', 'target')
+    actual = do_autodoc('module', 'target')
     assert '.. py:function:: function_to_be_imported(app)' not in actual
 
     # with :members:
-    app.config.autodoc_default_options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    config = _AutodocConfig(autodoc_default_options={'members': True})
+    actual = do_autodoc('class', 'target.enums.EnumCls', config=config)
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
 
     # with :members: = True
-    app.config.autodoc_default_options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    config = _AutodocConfig(autodoc_default_options={'members': True})
+    actual = do_autodoc('class', 'target.enums.EnumCls', config=config)
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
 
     # with :members: and :undoc-members:
-    app.config.autodoc_default_options = {
-        'members': None,
-        'undoc-members': None,
-    }
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    config = _AutodocConfig(
+        autodoc_default_options={'members': True, 'undoc-members': True}
+    )
+    actual = do_autodoc('class', 'target.enums.EnumCls', config=config)
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val4' in actual
 
     # with :special-members:
     # Note that :members: must be *on* for :special-members: to work.
-    app.config.autodoc_default_options = {
-        'members': None,
-        'special-members': None,
-    }
-    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    config = _AutodocConfig(
+        autodoc_default_options={'members': True, 'special-members': True}
+    )
+    actual = do_autodoc('class', 'target.CustomIter', config=config)
     assert '   .. py:method:: CustomIter.__init__()' in actual
     assert '      Create a new `CustomIter`.' in actual
     assert '   .. py:method:: CustomIter.__iter__()' in actual
@@ -886,19 +908,20 @@ def test_autodoc_default_options(app: SphinxTestApp) -> None:
     # :exclude-members: None - has no effect. Unlike :members:,
     # :special-members:, etc. where None == "include all", here None means
     # "no/false/off".
-    app.config.autodoc_default_options = {
-        'members': None,
-        'exclude-members': None,
-    }
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    config = _AutodocConfig(
+        autodoc_default_options={'members': True, 'exclude-members': True}
+    )
+    actual = do_autodoc('class', 'target.enums.EnumCls', config=config)
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
-    app.config.autodoc_default_options = {
-        'members': None,
-        'special-members': None,
-        'exclude-members': None,
-    }
-    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    config = _AutodocConfig(
+        autodoc_default_options={
+            'members': True,
+            'special-members': True,
+            'exclude-members': True,
+        }
+    )
+    actual = do_autodoc('class', 'target.CustomIter', config=config)
     assert '   .. py:method:: CustomIter.__init__()' in actual
     assert '      Create a new `CustomIter`.' in actual
     assert '   .. py:method:: CustomIter.__iter__()' in actual
@@ -910,28 +933,26 @@ def test_autodoc_default_options(app: SphinxTestApp) -> None:
     assert '      Makes this snafucated.' in actual
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_autodoc_default_options_with_values(app: SphinxTestApp) -> None:
+def test_autodoc_default_options_with_values() -> None:
     if (3, 11, 7) <= sys.version_info < (3, 12) or sys.version_info >= (3, 12, 1):
         list_of_weak_references = '      list of weak references to the object'
     else:
         list_of_weak_references = '      list of weak references to the object (if defined)'  # fmt: skip
 
     # with :members:
-    app.config.autodoc_default_options = {'members': 'val1,val2'}
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    config = _AutodocConfig(autodoc_default_options={'members': 'val1,val2'})
+    actual = do_autodoc('class', 'target.enums.EnumCls', config=config)
     assert '   .. py:attribute:: EnumCls.val1' in actual
     assert '   .. py:attribute:: EnumCls.val2' in actual
     assert '   .. py:attribute:: EnumCls.val3' not in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
 
     # with :member-order:
-    app.config.autodoc_default_options = {
-        'members': None,
-        'member-order': 'bysource',
-    }
-    actual = do_autodoc(app, 'class', 'target.Class')
-    assert list(filter(lambda l: '::' in l, actual)) == [
+    config = _AutodocConfig(
+        autodoc_default_options={'members': True, 'member-order': 'bysource'}
+    )
+    actual = do_autodoc('class', 'target.Class', config=config)
+    assert [line for line in actual if '::' in line] == [
         '.. py:class:: Class(arg)',
         '   .. py:method:: Class.meth()',
         '   .. py:method:: Class.skipmeth()',
@@ -947,10 +968,10 @@ def test_autodoc_default_options_with_values(app: SphinxTestApp) -> None:
     ]
 
     # with :special-members:
-    app.config.autodoc_default_options = {
-        'special-members': '__init__,__iter__',
-    }
-    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    config = _AutodocConfig(
+        autodoc_default_options={'special-members': '__init__,__iter__'}
+    )
+    actual = do_autodoc('class', 'target.CustomIter', config=config)
     assert '   .. py:method:: CustomIter.__init__()' in actual
     assert '      Create a new `CustomIter`.' in actual
     assert '   .. py:method:: CustomIter.__iter__()' in actual
@@ -960,21 +981,22 @@ def test_autodoc_default_options_with_values(app: SphinxTestApp) -> None:
         assert list_of_weak_references not in actual
 
     # with :exclude-members:
-    app.config.autodoc_default_options = {
-        'members': None,
-        'exclude-members': 'val1',
-    }
-    actual = do_autodoc(app, 'class', 'target.enums.EnumCls')
+    config = _AutodocConfig(
+        autodoc_default_options={'members': True, 'exclude-members': 'val1'}
+    )
+    actual = do_autodoc('class', 'target.enums.EnumCls', config=config)
     assert '   .. py:attribute:: EnumCls.val1' not in actual
     assert '   .. py:attribute:: EnumCls.val2' in actual
     assert '   .. py:attribute:: EnumCls.val3' in actual
     assert '   .. py:attribute:: EnumCls.val4' not in actual
-    app.config.autodoc_default_options = {
-        'members': None,
-        'special-members': None,
-        'exclude-members': '__weakref__,snafucate',
-    }
-    actual = do_autodoc(app, 'class', 'target.CustomIter')
+    config = _AutodocConfig(
+        autodoc_default_options={
+            'members': True,
+            'special-members': True,
+            'exclude-members': '__weakref__,snafucate',
+        }
+    )
+    actual = do_autodoc('class', 'target.CustomIter', config=config)
     assert '   .. py:method:: CustomIter.__init__()' in actual
     assert '      Create a new `CustomIter`.' in actual
     assert '   .. py:method:: CustomIter.__iter__()' in actual

--- a/tests/test_ext_autodoc/test_ext_autodoc_events.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_events.py
@@ -2,28 +2,25 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 from sphinx.ext.autodoc import between, cut_lines
 
-from tests.test_ext_autodoc.autodoc_util import do_autodoc
+from tests.test_ext_autodoc.autodoc_util import FakeEvents, do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_process_docstring(app: SphinxTestApp) -> None:
+def test_process_docstring() -> None:
     def on_process_docstring(app, what, name, obj, options, lines):
         lines.clear()
         lines.append('my docstring')
 
-    app.connect('autodoc-process-docstring', on_process_docstring)
+    events = FakeEvents()
+    events.connect('autodoc-process-docstring', on_process_docstring)
 
-    actual = do_autodoc(app, 'function', 'target.process_docstring.func')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.process_docstring.func', events=events)
+    assert actual == [
         '',
         '.. py:function:: func()',
         '   :module: target.process_docstring',
@@ -33,15 +30,15 @@ def test_process_docstring(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_process_docstring_for_nondatadescriptor(app: SphinxTestApp) -> None:
+def test_process_docstring_for_nondatadescriptor() -> None:
     def on_process_docstring(app, what, name, obj, options, lines):
         raise RuntimeError
 
-    app.connect('autodoc-process-docstring', on_process_docstring)
+    events = FakeEvents()
+    events.connect('autodoc-process-docstring', on_process_docstring)
 
-    actual = do_autodoc(app, 'attribute', 'target.AttCls.a1')
-    assert list(actual) == [
+    actual = do_autodoc('attribute', 'target.AttCls.a1', events=events)
+    assert actual == [
         '',
         '.. py:attribute:: AttCls.a1',
         '   :module: target',
@@ -50,12 +47,12 @@ def test_process_docstring_for_nondatadescriptor(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_cut_lines(app: SphinxTestApp) -> None:
-    app.connect('autodoc-process-docstring', cut_lines(2, 2, ['function']))
+def test_cut_lines() -> None:
+    events = FakeEvents()
+    events.connect('autodoc-process-docstring', cut_lines(2, 2, ['function']))
 
-    actual = do_autodoc(app, 'function', 'target.process_docstring.func')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.process_docstring.func', events=events)
+    assert actual == [
         '',
         '.. py:function:: func()',
         '   :module: target.process_docstring',
@@ -85,12 +82,12 @@ def test_cut_lines_no_objtype():
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_between(app: SphinxTestApp) -> None:
-    app.connect('autodoc-process-docstring', between('---', ['function']))
+def test_between() -> None:
+    events = FakeEvents()
+    events.connect('autodoc-process-docstring', between('---', ['function']))
 
-    actual = do_autodoc(app, 'function', 'target.process_docstring.func')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.process_docstring.func', events=events)
+    assert actual == [
         '',
         '.. py:function:: func()',
         '   :module: target.process_docstring',
@@ -100,12 +97,14 @@ def test_between(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_between_exclude(app: SphinxTestApp) -> None:
-    app.connect('autodoc-process-docstring', between('---', ['function'], exclude=True))
+def test_between_exclude() -> None:
+    events = FakeEvents()
+    events.connect(
+        'autodoc-process-docstring', between('---', ['function'], exclude=True)
+    )
 
-    actual = do_autodoc(app, 'function', 'target.process_docstring.func')
-    assert list(actual) == [
+    actual = do_autodoc('function', 'target.process_docstring.func', events=events)
+    assert actual == [
         '',
         '.. py:function:: func()',
         '   :module: target.process_docstring',
@@ -116,8 +115,7 @@ def test_between_exclude(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_skip_module_member(app: SphinxTestApp) -> None:
+def test_skip_module_member() -> None:
     def autodoc_skip_member(app, what, name, obj, skip, options):
         if name == 'Class':
             return True  # Skip "Class" class in __all__
@@ -125,11 +123,12 @@ def test_skip_module_member(app: SphinxTestApp) -> None:
             return False  # Show "raises()" function (not in __all__)
         return None
 
-    app.connect('autodoc-skip-member', autodoc_skip_member)
+    events = FakeEvents()
+    events.connect('autodoc-skip-member', autodoc_skip_member)
 
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target', events=events, options=options)
+    assert actual == [
         '',
         '.. py:module:: target',
         '',

--- a/tests/test_ext_autodoc/test_ext_autodoc_names.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_names.py
@@ -45,6 +45,7 @@ def test_parse_module_names(caplog: pytest.LogCaptureFixture) -> None:
     # work around sphinx.util.logging.setup()
     logger = logging.getLogger('sphinx')
     logger.handlers[:] = [caplog.handler]
+    caplog.set_level(logging.WARNING)
 
     parsed = parse_name('module', 'test_ext_autodoc')
     assert parsed == ('test_ext_autodoc', [], None, None)

--- a/tests/test_ext_autodoc/test_ext_autodoc_preserve_defaults.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_preserve_defaults.py
@@ -2,27 +2,25 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+
+from sphinx.ext.autodoc._shared import _AutodocConfig
 
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx(
-    'html',
-    testroot='ext-autodoc',
-    confoverrides={'autodoc_preserve_defaults': True},
-)
-def test_preserve_defaults(app: SphinxTestApp) -> None:
+def test_preserve_defaults() -> None:
+    config = _AutodocConfig(autodoc_preserve_defaults=True)
+
     color = '0xFFFFFF'
 
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.preserve_defaults', options)
-    assert list(actual) == [
+    actual = do_autodoc(
+        'module', 'target.preserve_defaults', config=config, options=options
+    )
+    assert actual == [
         '',
         '.. py:module:: target.preserve_defaults',
         '',
@@ -102,15 +100,15 @@ def test_preserve_defaults(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx(
-    'html',
-    testroot='ext-autodoc',
-    confoverrides={'autodoc_preserve_defaults': True},
-)
-def test_preserve_defaults_special_constructs(app: SphinxTestApp) -> None:
+def test_preserve_defaults_special_constructs() -> None:
+    config = _AutodocConfig(autodoc_preserve_defaults=True)
+
     options = {'members': None}
     actual = do_autodoc(
-        app, 'module', 'target.preserve_defaults_special_constructs', options
+        'module',
+        'target.preserve_defaults_special_constructs',
+        config=config,
+        options=options,
     )
 
     # * dataclasses.dataclass:
@@ -127,8 +125,7 @@ def test_preserve_defaults_special_constructs(app: SphinxTestApp) -> None:
     # In the future, it might be possible to find some additional default
     # values by parsing the source code of the annotations but the task is
     # rather complex.
-
-    assert list(actual) == [
+    assert actual == [
         '',
         '.. py:module:: target.preserve_defaults_special_constructs',
         '',

--- a/tests/test_ext_autodoc/test_ext_autodoc_private_members.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_private_members.py
@@ -2,22 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+
+from sphinx.ext.autodoc._shared import _AutodocConfig
 
 from tests.test_ext_autodoc.autodoc_util import do_autodoc
 
-if TYPE_CHECKING:
-    from sphinx.testing.util import SphinxTestApp
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_private_field(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_private_field() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {'members': None}
-    actual = do_autodoc(app, 'module', 'target.private', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.private', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.private',
         '',
@@ -39,15 +37,14 @@ def test_private_field(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_private_field_and_private_members(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_private_field_and_private_members() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {
         'members': None,
         'private-members': None,
     }
-    actual = do_autodoc(app, 'module', 'target.private', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.private', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.private',
         '',
@@ -84,15 +81,14 @@ def test_private_field_and_private_members(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_private_members(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_private_members() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {
         'members': None,
         'private-members': '_PUBLIC_CONSTANT,_public_function',
     }
-    actual = do_autodoc(app, 'module', 'target.private', options)
-    assert list(actual) == [
+    actual = do_autodoc('module', 'target.private', config=config, options=options)
+    assert actual == [
         '',
         '.. py:module:: target.private',
         '',
@@ -114,12 +110,11 @@ def test_private_members(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_private_attributes(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_private_attributes() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {'members': None}
-    actual = do_autodoc(app, 'class', 'target.private.Foo', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.private.Foo', config=config, options=options)
+    assert actual == [
         '',
         '.. py:class:: Foo()',
         '   :module: target.private',
@@ -136,15 +131,14 @@ def test_private_attributes(app: SphinxTestApp) -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc')
-def test_private_attributes_and_private_members(app: SphinxTestApp) -> None:
-    app.config.autoclass_content = 'class'
+def test_private_attributes_and_private_members() -> None:
+    config = _AutodocConfig(autoclass_content='class')
     options = {
         'members': None,
         'private-members': None,
     }
-    actual = do_autodoc(app, 'class', 'target.private.Foo', options)
-    assert list(actual) == [
+    actual = do_autodoc('class', 'target.private.Foo', config=config, options=options)
+    assert actual == [
         '',
         '.. py:class:: Foo()',
         '   :module: target.private',


### PR DESCRIPTION
We construct and use `_AutodocConfig`, `EventManager`, etc instances ourselves in the tests rather than using the (slow) `pytest.mark.sphinx()` / `app` fixture injection. On repeated benchmarks I get a speed-up of ~3.8-4.4x, from ~24.9s to ~6.0s.

A

## References

- #13751