### PR TITLE
Fix URLs in search results

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -112,6 +112,7 @@ Contributors
 * Steve Piercy -- documentation improvements
 * Szymon Karpinski -- intersphinx improvements
 * \T. Powers -- HTML output improvements
+* Taiki Ohno -- bug fixes in search results
 * Taku Shimizu -- epub3 builder
 * Tamika Nomara -- bug fixes
 * Thomas Lamb -- linkcheck builder

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -9,6 +9,7 @@ import json
 import os
 import pickle
 import re
+import urllib.parse
 from importlib import import_module
 from typing import TYPE_CHECKING
 
@@ -425,6 +426,7 @@ class IndexBuilder:
     def freeze(self) -> dict[str, Any]:
         """Create a usable data structure for serializing."""
         docnames, titles = zip(*sorted(self._titles.items()), strict=True)
+        quoted_docnames = tuple(map(urllib.parse.quote, docnames))
         filenames = [self._filenames.get(docname) for docname in docnames]
         fn2index = {f: i for (i, f) in enumerate(docnames)}
         terms, title_terms = self.get_terms(fn2index)
@@ -448,7 +450,7 @@ class IndexBuilder:
                 ))
 
         return {
-            'docnames': docnames,
+            'docnames': quoted_docnames,
             'filenames': filenames,
             'titles': titles,
             'terms': terms,

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -98,7 +98,8 @@ const _displayItem = (item, searchTerms, highlightTerms) => {
     linkUrl = docName + docLinkSuffix;
   }
   let linkEl = listItem.appendChild(document.createElement("a"));
-  linkEl.href = linkUrl + anchor;
+  const encodedLinkUrl = linkUrl.split("/").map(encodeURIComponent).join("/");
+  linkEl.href = encodedLinkUrl + anchor;
   linkEl.dataset.score = score;
   linkEl.innerHTML = _escapeHTML(title);
   if (descr) {

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -98,8 +98,7 @@ const _displayItem = (item, searchTerms, highlightTerms) => {
     linkUrl = docName + docLinkSuffix;
   }
   let linkEl = listItem.appendChild(document.createElement("a"));
-  const encodedLinkUrl = linkUrl.split("/").map(encodeURIComponent).join("/");
-  linkEl.href = encodedLinkUrl + anchor;
+  linkEl.href = linkUrl + anchor;
   linkEl.dataset.score = score;
   linkEl.innerHTML = _escapeHTML(title);
   if (descr) {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -177,6 +177,7 @@ def test_term_in_raw_directive(app: SphinxTestApp) -> None:
 
 
 def test_IndexBuilder():
+
     settings = frontend.get_default_settings(rst.Parser)
     parser = rst.Parser()
 
@@ -483,3 +484,33 @@ def test_check_js_search_indexes(make_app, sphinx_test_tempdir, directory):
         f'Search index fixture {existing_searchindex} does not match regenerated copy.'
     )
     assert fresh_searchindex.read_bytes() == existing_searchindex.read_bytes(), msg
+
+
+def test_quoted_docname():
+
+    settings = frontend.get_default_settings(rst.Parser)
+    parser = rst.Parser()
+
+    domain = DummyDomain(
+        'dummy',
+        [
+            ('objname', 'objdispname', 'objtype', 'docname', '#anchor', 1),
+        ],
+    )
+    env = DummyEnvironment('1.0', DummyDomainsContainer(dummy=domain))
+    doc = utils.new_document('test data', settings)
+    doc['file'] = 'dummy'
+    parser.parse(FILE_CONTENTS, doc)
+
+    index = IndexBuilder(env, 'en', {}, '')
+    index.feed('doc#name', 'filename', 'title', doc)
+    index.feed('doc$name', 'filename', 'title', doc)
+    index.feed('doc%name', 'filename', 'title', doc)
+    index.feed('doc?name', 'filename', 'title', doc)
+    print(index.freeze()['docnames'])
+    assert index.freeze()['docnames'] == (
+        'doc%23name',
+        'doc%24name',
+        'doc%25name',
+        'doc%3Fname',
+    )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -177,7 +177,6 @@ def test_term_in_raw_directive(app: SphinxTestApp) -> None:
 
 
 def test_IndexBuilder():
-
     settings = frontend.get_default_settings(rst.Parser)
     parser = rst.Parser()
 


### PR DESCRIPTION
## Purpose

This PR ensures that URLs in search results are properly encoded.  
Previously, search result URLs containing characters such as `#` or `?` were not encoded correctly.  
This change adds URL encoding in the `_displayItem` of search results to fix this issue.

## References

- Fixes #14028
