### PR TITLE
autodoc: Ensure type statements don't inherit docstrings

### DIFF
--- a/sphinx/ext/autodoc/_docstrings.py
+++ b/sphinx/ext/autodoc/_docstrings.py
@@ -244,7 +244,7 @@ def _get_docstring_lines(
             return []
         return [prepare_docstring(docstring, tab_width)]
 
-    if props.obj_type == 'attribute':
+    if props.obj_type in {'attribute', 'type'}:
         # Check the attribute has a docstring-comment
         comment = _get_attribute_comment(
             parent=parent, obj_path=props.parts, attrname=props.parts[-1]

--- a/sphinx/ext/autodoc/_docstrings.py
+++ b/sphinx/ext/autodoc/_docstrings.py
@@ -88,7 +88,7 @@ def _prepare_docstrings(
 ) -> list[list[str]] | None:
     """Add content from docstrings, attribute documentation and user."""
     # add content from attribute documentation
-    if props.obj_type not in {'data', 'attribute'} and props.parts:
+    if props.obj_type not in {'data', 'attribute', 'type'} and props.parts:
         key = ('.'.join(props.parent_names), props.name)
         try:
             # make a copy of docstring for attributes to avoid cache
@@ -244,7 +244,7 @@ def _get_docstring_lines(
             return []
         return [prepare_docstring(docstring, tab_width)]
 
-    if props.obj_type in {'attribute', 'type'}:
+    if props.obj_type == 'attribute':
         # Check the attribute has a docstring-comment
         comment = _get_attribute_comment(
             parent=parent, obj_path=props.parts, attrname=props.parts[-1]
@@ -297,6 +297,20 @@ def _get_docstring_lines(
         if not docstring:
             return []
         return [prepare_docstring(docstring, tab_width)]
+
+    if props.obj_type == 'type':
+        try:
+            analyzer = ModuleAnalyzer.for_module(props.module_name)
+            analyzer.analyze()
+        except PycodeError:
+            return None
+
+        key = ('', props.name)
+        if key in analyzer.attr_docs:
+            if comment := list(analyzer.attr_docs[key]):
+                return [comment]
+
+        return None
 
     docstring = getdoc(
         obj,

--- a/tests/roots/test-ext-autodoc/target/pep695.py
+++ b/tests/roots/test-ext-autodoc/target/pep695.py
@@ -22,6 +22,8 @@ class Foo:
 type Pep695Alias = Foo
 """This is PEP695 type alias."""
 
+type Pep695AliasUndoced = Foo
+
 TypeAliasTypeExplicit = TypeAliasType('TypeAliasTypeExplicit', Foo)  # NoQA: UP040
 """This is an explicitly constructed typing.TypeAlias."""
 

--- a/tests/roots/test-ext-autodoc/target/pep695.py
+++ b/tests/roots/test-ext-autodoc/target/pep695.py
@@ -22,7 +22,7 @@ class Foo:
 type Pep695Alias = Foo
 """This is PEP695 type alias."""
 
-type Pep695AliasUndoced = Foo
+type Pep695AliasUndocumented = Foo
 
 TypeAliasTypeExplicit = TypeAliasType('TypeAliasTypeExplicit', Foo)  # NoQA: UP040
 """This is an explicitly constructed typing.TypeAlias."""

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -2292,8 +2292,8 @@ def test_autodoc_pep695_type_alias() -> None:
         '   This is PEP695 type alias of PEP695 alias.',
         '',
         '',
-        # Undocumented alias should not inherit any documentations
-        '.. py:type:: Pep695AliasUndoced',
+        # Undocumented alias should not inherit any documentation
+        '.. py:type:: Pep695AliasUndocumented',
         '   :module: target.pep695',
         '   :canonical: ~target.pep695.Foo',
         '',

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -2292,6 +2292,12 @@ def test_autodoc_pep695_type_alias() -> None:
         '   This is PEP695 type alias of PEP695 alias.',
         '',
         '',
+        # Undocumented alias should not inherit any documentations
+        '.. py:type:: Pep695AliasUndoced',
+        '   :module: target.pep695',
+        '   :canonical: ~target.pep695.Foo',
+        '',
+        '',
         '.. py:type:: Pep695AliasUnion',
         '   :module: target.pep695',
         '   :canonical: str | int',


### PR DESCRIPTION
## Purpose

Make sure Pep695 TypeAlias does not inherit any docstrings, but are still documented by autodoc

## References

- https://github.com/sphinx-doc/sphinx/issues/11561#issuecomment-3543816778
