### PR TITLE
Use PEP 654 ``ExceptionGroup`` for autosummary import errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ Features added
   Patch by Jean-François B.
 * #13508: Initial support for :pep:`695` type aliases.
   Patch by Martin Matouš, Jeremy Maitin-Shepard, and Adam Turner.
+* #14075: autosummary: Provide more context in import exception stack traces.
+  Patch by Philipp A.
 
 Bugs fixed
 ----------

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -275,7 +275,7 @@ class Autosummary(SphinxDirective):
                     return import_ivar_by_name(name, prefixes)
                 except ImportError as exc2:
                     if exc2.__cause__:
-                        errors: list[Exception] = [*exc.exceptions, exc2.__cause__]
+                        errors: list[BaseException] = [*exc.exceptions, exc2.__cause__]
                     else:
                         errors = [*exc.exceptions, exc2]
 
@@ -609,7 +609,7 @@ def limited_join(
 
 # -- Importing items -----------------------------------------------------------
 
-class ImportExceptionGroup(ExceptionGroup):
+class ImportExceptionGroup(BaseExceptionGroup):
     """Exceptions raised during importing the target objects.
 
     It contains an error message and a list of exceptions as its arguments.
@@ -674,7 +674,7 @@ def import_by_name(
             tried.append(prefixed_name)
             errors.append(exc)
 
-    exceptions: list[Exception] = functools.reduce(
+    exceptions: list[BaseException] = functools.reduce(
         operator.iadd, (e.exceptions for e in errors), []
     )
     msg = f'could not import {" or ".join(tried)}'
@@ -683,7 +683,7 @@ def import_by_name(
 
 def _import_by_name(name: str, grouped_exception: bool = True) -> tuple[Any, Any, str]:
     """Import a Python object given its full name."""
-    errors: list[Exception] = []
+    errors: list[BaseException] = []
 
     try:
         name_parts = name.split('.')

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -609,6 +609,7 @@ def limited_join(
 
 # -- Importing items -----------------------------------------------------------
 
+
 class ImportExceptionGroup(BaseExceptionGroup):
     """Exceptions raised during importing the target objects.
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -670,7 +670,7 @@ def generate_autosummary_docs(
                 qualname = name.replace(modname + '.', '')
             except ImportError as exc2:
                 if exc2.__cause__:
-                    exceptions: list[BaseException] = [*exc.exceptions, exc2.__cause__]
+                    exceptions: list[Exception] = [*exc.exceptions, exc2.__cause__]
                 else:
                     exceptions = [*exc.exceptions, exc2]
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -670,7 +670,7 @@ def generate_autosummary_docs(
                 qualname = name.replace(modname + '.', '')
             except ImportError as exc2:
                 if exc2.__cause__:
-                    exceptions: list[Exception] = [*exc.exceptions, exc2.__cause__]
+                    exceptions: list[BaseException] = [*exc.exceptions, exc2.__cause__]
                 else:
                     exceptions = [*exc.exceptions, exc2]
 


### PR DESCRIPTION
## Purpose
Since the MRPV is 3.11, we can just use the `BaseExceptionGroup` class as base class for the `ImportExceptionGroup`, which will result in much more context being included in the traceback.

This allows people to more easily debug why autosummary fails when it does.

## References

- Fixes #14056
- Closes #14057
