### PR TITLE
doc: Update steps for "enable GitHub Pages on your repository"

### DIFF
--- a/doc/tutorial/deploying.rst
+++ b/doc/tutorial/deploying.rst
@@ -222,13 +222,14 @@ following contents:
 
    furo==2021.11.16
 
-And finally, you are ready to `enable GitHub Pages on your repository`_. For
+And finally, you are ready to `publish GitHub Pages from a branch`_. For
 that, go to :guilabel:`Settings`, then :guilabel:`Pages` on the left sidebar,
-select the ``gh-pages`` branch in the "Source" dropdown menu, and click
+select the ``Deploy from a branch`` item in the "Source" dropdown menu,
+select the ``gh-page`` branch in the "Barnch" dropdown menu, and click
 :guilabel:`Save`. After a few minutes, you should be able to see your HTML at
 the designated URL.
 
-.. _enable GitHub Pages on your repository: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
+.. _publish GitHub Pages from a branch: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch
 
 GitLab Pages
 ~~~~~~~~~~~~

--- a/doc/tutorial/deploying.rst
+++ b/doc/tutorial/deploying.rst
@@ -225,7 +225,7 @@ following contents:
 And finally, you are ready to `publish GitHub Pages from a branch`_. For
 that, go to :guilabel:`Settings`, then :guilabel:`Pages` on the left sidebar,
 select the ``Deploy from a branch`` item in the "Source" dropdown menu,
-select the ``gh-page`` branch in the "Barnch" dropdown menu, and click
+select the ``gh-page`` branch in the "Branch" dropdown menu, and click
 :guilabel:`Save`. After a few minutes, you should be able to see your HTML at
 the designated URL.
 


### PR DESCRIPTION
## Purpose

Over time, the GitHub Pages activation interface has undergone some minor changes, so the documentation has been updated to reflect these changes.

<img width="1208" height="583" alt="image" src="https://github.com/user-attachments/assets/305cecd2-2b86-4b89-9d21-e53fcaa90be2" />

## References

- https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch