### PR TITLE
Tests: isolate a pair of HTML build 'numfig' test cases

### DIFF
--- a/tests/test_builders/test_build_html_numfig.py
+++ b/tests/test_builders/test_build_html_numfig.py
@@ -578,7 +578,6 @@ def test_numfig_with_numbered_toctree(
         },
     },
 )
-@pytest.mark.test_params(shared_result='test_build_html_numfig_format_warn')
 def test_numfig_with_prefix_warn(app: SphinxTestApp) -> None:
     app.build()
     warnings = app.warning.getvalue()
@@ -800,7 +799,6 @@ def test_numfig_with_prefix_warn(app: SphinxTestApp) -> None:
         },
     },
 )
-@pytest.mark.test_params(shared_result='test_build_html_numfig_format_warn')
 def test_numfig_with_prefix(
     app: SphinxTestApp,
     cached_etree_parse: Callable[[Path], ElementTree],


### PR DESCRIPTION
## Purpose

Recently the [`test_numfig_disabled_warn` test case](https://github.com/sphinx-doc/sphinx/blob/45e1ae646cd89fc0e7a6b1187c22d9a4964f75fa/tests/test_builders/test_build_html_numfig.py#L21-L28) has been flaky; although some of the intermittent failures have been noted for `docutils` `HEAD`, I've also noticed it occurring with other versions of `docutils` too.

Some example failure logs include:

 - `docutils` `HEAD`: https://github.com/sphinx-doc/sphinx/actions/runs/18772174723/job/53603139421#step:10:4828
 - `docutils` `v0.20`: https://github.com/sphinx-doc/sphinx/actions/runs/19662374866/job/56311219423#step:10:4879

This pull request experiments with removal of the use of a shared build for the problem test case and another test that it shares with.

NB: I am **not certain** that this will fix the problem; we may need to re-run the tests a few times with this in place (or perhaps GitHub Actions CI will fail first time after I open this pull request...?).

cc @jfbu @haampie 

## References

- Related to #13996.