### PR TITLE
intersphinx: Handle string interpolation failures in ``_fetch_inventory_group()``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,8 @@ Features added
   Note that MathJax v3 is mostly compatible with MathJax v4, so existing
   :confval:`mathjax3_config` settings should not need to change.
   Patch by Matthias Geier.
+* #14029: intersphinx: Fix error in format string interpolation.
+  Patch by Matthieu de Cibeins.
 
 Bugs fixed
 ----------

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -226,6 +226,14 @@ class _InvConfig:
         )
 
 
+def _display_failures(failures: list[tuple[str]]) -> str:
+    """Format a list of failure tuples into a readable multi-line string."""
+    return '\n'.join(
+        f[0] % f[1:] if len(f) > 1 and '%' in f[0] else ' - '.join(f for f in f)
+        for f in failures
+    )
+
+
 def _fetch_inventory_group(
     *,
     project: _IntersphinxProject,
@@ -315,10 +323,7 @@ def _fetch_inventory_group(
         for fail in failures:
             LOGGER.info(*fail)
     else:
-        issues = '\n'.join(
-            f[0] % f[1:] if len(f) > 1 and '%' in f[0] else ' -'.join(f for f in f)
-            for f in failures
-        )
+        issues = _display_failures(failures)
         LOGGER.warning(
             '%s\n%s',
             __('failed to reach any of the inventories with the following issues:'),

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -315,7 +315,10 @@ def _fetch_inventory_group(
         for fail in failures:
             LOGGER.info(*fail)
     else:
-        issues = '\n'.join(f[0] % f[1:] for f in failures)
+        issues = '\n'.join(
+            f[0] % f[1:] if len(f) > 1 and '%' in f[0] else ' -'.join(f for f in f)
+            for f in failures
+        )
         LOGGER.warning(
             '%s\n%s',
             __('failed to reach any of the inventories with the following issues:'),

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -19,6 +19,7 @@ from sphinx.util import requests
 from sphinx.util.inventory import InventoryFile
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from sphinx.application import Sphinx
@@ -226,12 +227,15 @@ class _InvConfig:
         )
 
 
-def _display_failures(failures: list[tuple[str]]) -> str:
+def _display_failures(failures: Sequence[tuple[str, ...]]) -> str:
     """Format a list of failure tuples into a readable multi-line string."""
-    return '\n'.join(
-        f[0] % f[1:] if len(f) > 1 and '%' in f[0] else ' - '.join(f for f in f)
-        for f in failures
-    )
+    formatted = []
+    for failure_args in failures:
+        try:
+            formatted.append(failure_args[0] % failure_args[1:])
+        except TypeError:
+            formatted.append(' - '.join(failure_args))
+    return '\n'.join(formatted)
 
 
 def _fetch_inventory_group(
@@ -323,11 +327,9 @@ def _fetch_inventory_group(
         for fail in failures:
             LOGGER.info(*fail)
     else:
-        issues = _display_failures(failures)
         LOGGER.warning(
-            '%s\n%s',
-            __('failed to reach any of the inventories with the following issues:'),
-            issues,
+            __('failed to reach any of the inventories with the following issues:\n%s'),
+            _display_failures(failures),
         )
     return updated
 

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -18,6 +18,7 @@ from sphinx.errors import ConfigError
 from sphinx.ext.intersphinx import setup as intersphinx_setup
 from sphinx.ext.intersphinx._cli import inspect_main
 from sphinx.ext.intersphinx._load import (
+    _display_failures,
     _fetch_inventory_data,
     _fetch_inventory_group,
     _get_safe_url,
@@ -923,3 +924,22 @@ def test_inventory_text_version(tmp_path, app):
     assert rn['refuri'] == 'https://docs.python.org/foo.html#module-module1'
     assert rn['reftitle'] == '(in foo stable)'
     assert rn[0].astext() == 'Long Module desc'
+
+
+def test_display_failures():
+    failures_args = [
+        ('Failed to fetch %s from %s', 'inventory', 'http://example.com'),
+        ('Timeout after %d seconds',),  # Only one argument
+        (
+            'intersphinx inventory has moved:',
+            'http://example.com',
+            'http://proxyhost.net',
+        ),  # No '%'
+    ]
+    issues = _display_failures(failures_args)
+    assert 'Failed to fetch inventory from http://example.com' in issues
+    assert 'Timeout after %d seconds' in issues
+    assert (
+        'intersphinx inventory has moved: - http://example.com - http://proxyhost.net'
+        in issues
+    )


### PR DESCRIPTION
## Purpose
Fix issue [14029](https://github.com/sphinx-doc/sphinx/issues/14029)
See discussion there for more details

## Problematic line
```
File "C:\<path>\.nox\doc\Lib\site-packages\sphinx\ext\intersphinx\_load.py", line 294, in _fetch_inventory_group
	issues = '\n'.join(f[0] % f[1:] for f in failures)
```

works if `failures` looks like 
```
failures = [
    ("Failed to fetch %s from %s", "inventory", "https://docs.python.org/3/objects.inv"),
    ("Timeout after %d seconds", 30)
]
```

but fails if `failures` looks like

```
[('unknown or unsupported inventory version: ValueError(\'invalid inventory header: <!--samlchecks_get.html --><!DOCTYPE html><html> ... (very long html file) ... ,)]
```

## Suggested fix
- Account for 1-element tuples in the `failures` array
- Account for strings not having the % format string syntax
