### PR TITLE
Revert "Tests: isolate a pair of HTML build 'numfig' test cases"

### DIFF
--- a/tests/test_builders/test_build_html_numfig.py
+++ b/tests/test_builders/test_build_html_numfig.py
@@ -578,6 +578,7 @@ def test_numfig_with_numbered_toctree(
         },
     },
 )
+@pytest.mark.test_params(shared_result='test_build_html_numfig_format_warn')
 def test_numfig_with_prefix_warn(app: SphinxTestApp) -> None:
     app.build()
     warnings = app.warning.getvalue()
@@ -799,6 +800,7 @@ def test_numfig_with_prefix_warn(app: SphinxTestApp) -> None:
         },
     },
 )
+@pytest.mark.test_params(shared_result='test_build_html_numfig_format_warn')
 def test_numfig_with_prefix(
     app: SphinxTestApp,
     cached_etree_parse: Callable[[Path], ElementTree],


### PR DESCRIPTION
Reverts #14100, a pull request that was intended to reduce isolation of some HTML builder `numfig` tests -- but did not modify the correct test cases (specifically `test_numfig_disabled_warn`, that is currently a flaky test in GHA CI).