### PR TITLE
Fix flaky test_numfig_disabled_warn by ensuring fresh build

### DIFF
--- a/sphinx/testing/fixtures.py
+++ b/sphinx/testing/fixtures.py
@@ -98,7 +98,10 @@ def app_params(
             pytest.fail(msg)
         kwargs['srcdir'] = test_params['shared_result']
         restore = shared_result.restore(test_params['shared_result'])
-        kwargs.update(restore)
+        if restore:
+            kwargs.update(restore)
+        else:
+            kwargs['freshenv'] = True
 
     # ##### prepare Application params
 
@@ -193,10 +196,11 @@ def make_app(test_params: dict[str, Any]) -> Iterator[Callable[..., SphinxTestAp
 
     def make(*args: Any, **kwargs: Any) -> SphinxTestApp:
         status, warning = StringIO(), StringIO()
+        restored = 'status' in kwargs
         kwargs.setdefault('status', status)
         kwargs.setdefault('warning', warning)
         app_: SphinxTestApp
-        if test_params['shared_result']:
+        if test_params['shared_result'] and restored:
             app_ = SphinxTestAppWrapperForSkipBuilding(*args, **kwargs)
         else:
             app_ = SphinxTestApp(*args, **kwargs)


### PR DESCRIPTION
When shared_result cache is empty but artifacts exist, the build was incorrectly skipped, leaving app.warning empty. Force freshenv=True and disable build skipping in this case to ensure warnings are generated.

Fixes sphinx-doc/sphinx#14104

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- <...>
- <...>
- <...>
