### PR TITLE
Fixup: allow directory path separators in slowest-read-duration timing pattern regexes

### DIFF
--- a/tests/test_extensions/test_ext_duration.py
+++ b/tests/test_extensions/test_ext_duration.py
@@ -51,7 +51,7 @@ def test_duration(app: SphinxTestApp) -> None:
 def test_n_slowest_value(app: SphinxTestApp) -> None:
     app.build()
 
-    matches = re.findall(r'\d+\.\d{3}s\s+[A-Za-z0-9]+\n', app.status.getvalue())
+    matches = re.findall(r'\d+\.\d{3}s\s+[A-Za-z0-9/]+\n', app.status.getvalue())
     assert len(matches) == 2
 
 
@@ -65,7 +65,7 @@ def test_n_slowest_all(app: SphinxTestApp) -> None:
     app.build()
 
     assert 'slowest reading durations' in app.status.getvalue()
-    matches = re.findall(r'\d+\.\d{3}s\s+[A-Za-z0-9]+\n', app.status.getvalue())
+    matches = re.findall(r'\d+\.\d{3}s\s+[A-Za-z0-9/]+\n', app.status.getvalue())
     assert len(matches) > 0
 
 


### PR DESCRIPTION
## Purpose

Some of the `duration` extension tests use regular expressions to pattern-match document-processing time durations that appear in the Sphinx build output.

These didn't accommodate for a few of the documents that are in subdirectories; if those are processed slowest, then the regexes would fail to catch those timings.

## References

- Resolves #14109.