### PR TITLE
Remove accidental dependency on ipython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ dependencies = [
     "roman-numerals>=1.0.0",
     "packaging>=23.0",
     "colorama>=0.4.6; sys_platform == 'win32'",
-    "ipython>=9.6.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
It was added unintentionally in https://github.com/sphinx-doc/sphinx/pull/13941

See https://github.com/sphinx-doc/sphinx/issues/14092#issuecomment-3587622383