### PR TITLE
Fix formatting of Configuration section in duration.rst

### DIFF
--- a/doc/usage/extensions/duration.rst
+++ b/doc/usage/extensions/duration.rst
@@ -23,7 +23,7 @@ the :confval:`extensions` list in your :file:`conf.py`:
 
 
 Configuration
-=============
+-------------
 
 .. confval:: duration_print_total
    :type: :code-py:`bool`


### PR DESCRIPTION
`==========` leads to an additional useless item in toc


## Purpose


## References

