### PR TITLE
Be explicit with replacement in RemovedInSphinx10Warning

### DIFF
--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -311,7 +311,9 @@ class _InventoryItem:
 
     def __getitem__(self, key: int | slice) -> str | tuple[str, ...]:
         warnings.warn(
-            'The tuple interface for _InventoryItem objects is deprecated.',
+            'The tuple interface for _InventoryItem objects is deprecated.'
+            ' Please directly access `.project_name`, `.project_version`, '
+            '`.uri` and `.displayname`.',
             RemovedInSphinx10Warning,
             stacklevel=2,
         )
@@ -320,7 +322,9 @@ class _InventoryItem:
 
     def __iter__(self) -> Iterator[str]:
         warnings.warn(
-            'The iter() interface for _InventoryItem objects is deprecated.',
+            'The iter() interface for _InventoryItem objects is deprecated.'
+            ' Please directly access `.project_name`, `.project_version`, '
+            '`.uri` and `.displayname`.',
             RemovedInSphinx10Warning,
             stacklevel=2,
         )

--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -312,8 +312,8 @@ class _InventoryItem:
     def __getitem__(self, key: int | slice) -> str | tuple[str, ...]:
         warnings.warn(
             'The tuple interface for _InventoryItem objects is deprecated.'
-            ' Please directly access `.project_name`, `.project_version`, '
-            '`.uri` and `.displayname`.',
+            ' Please access the `project_name`, `project_version`, '
+            '`uri`, and `displayname` attributes directly.',
             RemovedInSphinx10Warning,
             stacklevel=2,
         )
@@ -323,8 +323,8 @@ class _InventoryItem:
     def __iter__(self) -> Iterator[str]:
         warnings.warn(
             'The iter() interface for _InventoryItem objects is deprecated.'
-            ' Please directly access `.project_name`, `.project_version`, '
-            '`.uri` and `.displayname`.',
+            ' Please access the `project_name`, `project_version`, '
+            '`uri`, and `displayname` attributes directly.',
             RemovedInSphinx10Warning,
             stacklevel=2,
         )


### PR DESCRIPTION
I'm more likely to fix the deprecation warning
if I know what is the replacement.

