### PR TITLE
Fix autodoc event handler in sphinx.ext.napoleon

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -356,7 +356,13 @@ class GoogleDocstring:
         self._what = what
         self._name = name
         self._obj = obj
-        self._opt = options
+        if options:
+            try:
+                self._no_index = options.no_index or options.noindex
+            except (AttributeError, TypeError):
+                self._no_index = False
+        else:
+            self._no_index = False
         if isinstance(docstring, str):
             lines = docstring.splitlines()
         else:
@@ -875,9 +881,8 @@ class GoogleDocstring:
                     lines.append(f':vartype {_name}: {_type}')
             else:
                 lines.append('.. attribute:: ' + _name)
-                if self._opt:
-                    if 'no-index' in self._opt or 'noindex' in self._opt:
-                        lines.append('   :no-index:')
+                if self._no_index:
+                    lines.append('   :no-index:')
                 lines.append('')
 
                 fields = self._format_field('', '', _desc)
@@ -943,9 +948,8 @@ class GoogleDocstring:
         lines: list[str] = []
         for _name, _type, _desc in self._consume_fields(parse_type=False):
             lines.append(f'.. method:: {_name}')
-            if self._opt:
-                if 'no-index' in self._opt or 'noindex' in self._opt:
-                    lines.append('   :no-index:')
+            if self._no_index:
+                lines.append('   :no-index:')
             if _desc:
                 lines.extend(['', *self._indent(_desc, 3)])
             lines.append('')

--- a/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
@@ -8,11 +8,13 @@ from collections import namedtuple
 from inspect import cleandoc
 from itertools import product
 from textwrap import dedent
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 
+from sphinx.ext.autodoc import Options
 from sphinx.ext.intersphinx._load import load_mappings, validate_intersphinx_mapping
 from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon.docstring import (
@@ -1238,7 +1240,7 @@ Returns Style:
             actual = GoogleDocstring(docstring, test_config)
             assert str(actual) == expected
 
-    def test_noindex(self):
+    def test_no_index(self):
         docstring = """
 Attributes:
     arg
@@ -1267,7 +1269,7 @@ Methods:
             config=config,
             app=None,
             what='module',
-            options={'no-index': True},
+            options=SimpleNamespace(no_index=True),
         )
         assert str(actual) == expected
 

--- a/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
@@ -14,7 +14,6 @@ from unittest import mock
 
 import pytest
 
-from sphinx.ext.autodoc import Options
 from sphinx.ext.intersphinx._load import load_mappings, validate_intersphinx_mapping
 from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon.docstring import (


### PR DESCRIPTION
## Purpose

The 'options' argument is documented as supporting attribute access, not indexed accessing.

## References

- Fixes #14120.
