### PR TITLE
Use first-party software to publish GitHub Releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -97,20 +97,18 @@ jobs:
     environment: release
     if: github.repository_owner == 'sphinx-doc'
     permissions:
-      contents: write  # for softprops/action-gh-release to create GitHub release
+      contents: write  # needed to create a GitHub release
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Get release version
-        id: get_version
-        uses: actions/github-script@v8
-        with:
-          script: core.setOutput('version', context.ref.replace("refs/tags/v", ""))
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          name: "Sphinx ${{ steps.get_version.outputs.version }}"
-          body: "Changelog: https://www.sphinx-doc.org/en/master/changes.html"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: >-
+          gh release create "${TAG}"
+          --title "Sphinx ${TAG#v}"
+          --notes "Changelog: https://www.sphinx-doc.org/en/master/changes.html"


### PR DESCRIPTION
## Purpose

Limit the write access granted for creating GitHub releases to first-party software (software officially maintained by GitHub).

## References

- https://github.com/sphinx-doc/sphinx/issues/14125#issuecomment-3592129247
