### PR TITLE
Run the ty type checker in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install dependencies
       run: uv pip install -r pyproject.toml --group package --group test --group types
     - name: Type check with ty
-      run: ty check
+      run: ty check --color=always --output-format=github
 
   docs-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,27 @@ jobs:
     - name: Type check with pyright
       run: pyright
 
+  ty:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+    - name: Install dependencies
+      run: uv pip install -r pyproject.toml --group package --group test --group types
+    - name: Type check with ty
+      run: ty check
+
   docs-lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install dependencies
       run: uv pip install -r pyproject.toml --group package --group test --group types
     - name: Type check with ty
-      run: ty check --color=always --output-format=github
+      run: ty check --color=always
 
   docs-lint:
     runs-on: ubuntu-latest

--- a/tests/test_ext_autodoc/test_ext_autodoc_mock.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_mock.py
@@ -131,7 +131,7 @@ def test_abc_MockObject():
         def __init__(self):
             pass
 
-    class Derived(Base, mock.SubClass):
+    class Derived(Base, mock.SubClass):  # ty: ignore[unsupported-base]
         pass
 
     obj = Derived()

--- a/tests/test_util/typing_test_data.py
+++ b/tests/test_util/typing_test_data.py
@@ -39,7 +39,7 @@ def f6(x: int, *args, y: str, z: str) -> None:
     pass
 
 
-def f7(x: int = None, y: dict = {}) -> None:  # NoQA: B006,RUF013
+def f7(x: int = None, y: dict = {}) -> None:  # NoQA: B006,RUF013  # ty: ignore[invalid-parameter-default]
     pass
 
 

--- a/ty.toml
+++ b/ty.toml
@@ -19,6 +19,7 @@ exclude = [
 
 [rules]
 call-non-callable = "ignore"
+inconsistent-mro = "ignore"
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 invalid-method-override = "ignore"

--- a/ty.toml
+++ b/ty.toml
@@ -14,8 +14,20 @@ include = [
     "utils",
 ]
 exclude = [
-    "tests/roots/test-pycode/cp_1251_coded.py",  # Not UTF-8
-    # This panics (2025-08-18; ty 0.0.1-alpha.18).
-    # See https://github.com/astral-sh/ty/issues/256
-    "tests/test_config/test_config.py",
+    "tests/roots",
 ]
+
+[rules]
+call-non-callable = "ignore"
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+invalid-method-override = "ignore"
+invalid-return-type = "ignore"
+invalid-type-form = "ignore"
+no-matching-overload = "ignore"
+non-subscriptable = "ignore"
+possibly-missing-attribute = "ignore"
+unresolved-attribute = "ignore"
+unresolved-import = "ignore"
+unresolved-reference = "ignore"
+unsupported-operator = "ignore"


### PR DESCRIPTION
## Purpose

Ty is a performant type checker in the early stages of development. It can now pass with 0 errors with several rules disabled, similarly to Pyright, so we should run it in CI.

## References

- #13843
