### PR TITLE
Reduce Windows runtime duration of some linkcheck tests by enabling timeouts

### DIFF
--- a/tests/roots/test-linkcheck-case-check/conf.py
+++ b/tests/roots/test-linkcheck-case-check/conf.py
@@ -1,1 +1,1 @@
-# Empty config for linkcheck case sensitivity tests
+linkcheck_timeout = 0.25

--- a/tests/roots/test-root/conf.py
+++ b/tests/roots/test-root/conf.py
@@ -35,6 +35,7 @@ keep_warnings = True
 pygments_style = 'sphinx'
 show_authors = True
 numfig = True
+linkcheck_timeout = 0.25
 
 html_sidebars = {
     '**': [


### PR DESCRIPTION
## Purpose

This pull request is an experiment to prove/disprove a [theory](https://github.com/sphinx-doc/sphinx/pull/14046#issuecomment-3591860549) I have about the reason for some recently-added `linkcheck` builder case sensitivity tests taking unexpectedly long durations of time (4 seconds plus) to run on Windows in GitHub Actions CI.

I think that there may be some network/resource-cleanup side-effects from calling `socket.setdefaulttimeout` in an earlier test -- and I would like to confirm whether this is the case, and also if it is, then whether we can undo the effects of that (and/or report upstream if it is not already a known problem).

**Result:** the theory was disproven; the `socket.setdefaulttimeout` is not the direct cause.  The absence of configured `linkcheck_timeout` settings for the `linkcheck-case-check` was determined to be the fault.

~~To reduce the cost of this experiment, non-Windows GitHub Actions CI workflows and jobs are disabled.~~

## References

- Relates to #14046.