### PR TITLE
Allow reordered refs and translated display text in pending_xref

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 9.0.4 (in development)
 Bugs fixed
 ----------
 
+* #14143: Fix spurious build warnings when translators reorder references
+  in strings, or use translated display text in references.
+  Patch by Matt Wang.
 
 Release 9.0.3 (released Dec 04, 2025)
 =====================================

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -150,8 +150,10 @@ class _NodeUpdater:
         new_ref_keys = list(map(key_func, new_refs))
 
         if ignore_order:
-            old_ref_keys = sorted(old_ref_keys, key=lambda x: (x is None, x))
-            new_ref_keys = sorted(new_ref_keys, key=lambda x: (x is None, x))
+            # The ref_keys lists may contain ``None``, so compare hashes.
+            # Recall objects which compare equal have the same hash value.
+            old_ref_keys.sort(key=hash)
+            new_ref_keys.sort(key=hash)
 
         if not self.noqa and old_ref_keys != new_ref_keys:
             old_ref_rawsources = [ref.rawsource for ref in old_refs]

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from operator import attrgetter
 from re import DOTALL, match
 from textwrap import indent
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -28,7 +29,7 @@ from sphinx.util.nodes import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from docutils.frontend import Values
 
@@ -133,11 +134,31 @@ class _NodeUpdater:
         old_refs: Sequence[nodes.Element],
         new_refs: Sequence[nodes.Element],
         warning_msg: str,
+        *,
+        key_func: Callable[[nodes.Element], Any] | None = None,
+        ignore_order: bool = False,
     ) -> None:
-        """Warn about mismatches between references in original and translated content."""
-        old_ref_rawsources = [ref.rawsource for ref in old_refs]
-        new_ref_rawsources = [ref.rawsource for ref in new_refs]
-        if not self.noqa and old_ref_rawsources != new_ref_rawsources:
+        """Warn about mismatches between references in original and translated content.
+
+        :param key_func: A function to extract the comparison key from each reference.
+            Defaults to extracting the ``rawsource`` attribute.
+        :param ignore_order: If True, ignore the order of references when comparing.
+            This allows translators to reorder references while still catching
+            missing or extra references.
+        """
+        if key_func is None:
+            key_func = attrgetter('rawsource')
+
+        old_ref_keys = [key_func(ref) for ref in old_refs]
+        new_ref_keys = [key_func(ref) for ref in new_refs]
+
+        if ignore_order:
+            old_ref_keys = sorted(old_ref_keys, key=lambda x: (x is None, x))
+            new_ref_keys = sorted(new_ref_keys, key=lambda x: (x is None, x))
+
+        if not self.noqa and old_ref_keys != new_ref_keys:
+            old_ref_rawsources = [ref.rawsource for ref in old_refs]
+            new_ref_rawsources = [ref.rawsource for ref in new_refs]
             logger.warning(
                 warning_msg.format(old_ref_rawsources, new_ref_rawsources),
                 location=self.node,
@@ -347,6 +368,10 @@ class _NodeUpdater:
                 'inconsistent term references in translated message.'
                 ' original: {0}, translated: {1}'
             ),
+            # Compare by reftarget only, allowing translated display text.
+            # Ignore order since translators may legitimately reorder references.
+            key_func=lambda ref: ref.get('reftarget'),
+            ignore_order=True,
         )
 
         xref_reftarget_map: dict[tuple[str, str, str] | None, dict[str, Any]] = {}

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -135,7 +135,7 @@ class _NodeUpdater:
         new_refs: Sequence[nodes.Element],
         warning_msg: str,
         *,
-        key_func: Callable[[nodes.Element], Any] | None = None,
+        key_func: Callable[[nodes.Element], Any] = attrgetter('rawsource'),
         ignore_order: bool = False,
     ) -> None:
         """Warn about mismatches between references in original and translated content.
@@ -146,11 +146,8 @@ class _NodeUpdater:
             This allows translators to reorder references while still catching
             missing or extra references.
         """
-        if key_func is None:
-            key_func = attrgetter('rawsource')
-
-        old_ref_keys = [key_func(ref) for ref in old_refs]
-        new_ref_keys = [key_func(ref) for ref in new_refs]
+        old_ref_keys = list(map(key_func, old_refs))
+        new_ref_keys = list(map(key_func, new_refs))
 
         if ignore_order:
             old_ref_keys = sorted(old_ref_keys, key=lambda x: (x is None, x))

--- a/tests/roots/test-intl/index.txt
+++ b/tests/roots/test-intl/index.txt
@@ -33,6 +33,7 @@ CONTENTS
    topic
    markup
    backslashes
+   refs_reordered
 
 .. toctree::
    :maxdepth: 2

--- a/tests/roots/test-intl/refs_reordered.txt
+++ b/tests/roots/test-intl/refs_reordered.txt
@@ -1,0 +1,16 @@
+:tocdepth: 2
+
+i18n with reordered and translated references
+==============================================
+
+.. glossary::
+
+   term one
+      First glossary term
+
+   term two
+      Second glossary term
+
+1. Multiple refs reordered: :term:`term one` and :term:`term two`.
+
+2. Single ref with translated display text: :term:`term one`.

--- a/tests/roots/test-intl/xx/LC_MESSAGES/refs_reordered.po
+++ b/tests/roots/test-intl/xx/LC_MESSAGES/refs_reordered.po
@@ -1,0 +1,31 @@
+# Test for reordered and translated references.
+# These should NOT trigger inconsistency warnings.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: sphinx 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Last-Translator: Test\n"
+"Language-Team: xx\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "i18n with reordered and translated references"
+msgstr "I18N WITH REORDERED AND TRANSLATED REFERENCES"
+
+msgid "First glossary term"
+msgstr "FIRST GLOSSARY TERM"
+
+msgid "Second glossary term"
+msgstr "SECOND GLOSSARY TERM"
+
+# Reordered references - should NOT warn because targets are the same
+msgid "Multiple refs reordered: :term:`term one` and :term:`term two`."
+msgstr "MULTIPLE REFS REORDERED: :term:`term two` AND :term:`term one`."
+
+# Translated display text - should NOT warn because reftarget is the same
+msgid "Single ref with translated display text: :term:`term one`."
+msgstr "SINGLE REF WITH TRANSLATED DISPLAY TEXT: :term:`TRANSLATED TERM ONE <term one>`."

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -379,6 +379,25 @@ def test_text_glossary_term_inconsistencies(app):
 
 
 @sphinx_intl
+@pytest.mark.sphinx('text', testroot='intl')
+@pytest.mark.test_params(shared_result='test_intl_basic')
+def test_text_refs_reordered_no_warning(app):
+    app.build()
+    # --- refs_reordered: verify no inconsistency warnings
+    result = (app.outdir / 'refs_reordered.txt').read_text(encoding='utf8')
+    # Verify the translation was applied
+    assert 'MULTIPLE REFS REORDERED' in result
+    assert 'SINGLE REF WITH TRANSLATED DISPLAY TEXT' in result
+
+    warnings = getwarning(app.warning)
+    # Should NOT have any inconsistent_references warnings for refs_reordered.txt
+    unexpected_warning_expr = '.*/refs_reordered.txt.*inconsistent.*references'
+    assert not re.search(unexpected_warning_expr, warnings), (
+        f'Unexpected warning found: {warnings!r}'
+    )
+
+
+@sphinx_intl
 @pytest.mark.sphinx('gettext', testroot='intl')
 @pytest.mark.test_params(shared_result='test_intl_gettext')
 def test_gettext_section(app):


### PR DESCRIPTION


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

Reduce false positive `i18n.inconsistent_references` warnings for `pending_xref` nodes.

For `pending_xref`, compare by `reftarget` only (not full `rawsource`) and ignore order. This allows translators to:
- Reorder references for natural sentence flow
- Translate display text

Other reference types retain the original behavior.

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Fixes #14143
- Related: #14001 (introduced the stricter checking in Sphinx v9)
