### PR TITLE
fix full-width semicolon which caused abnormal warning reported in #1…

### DIFF
--- a/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/zh_CN/LC_MESSAGES/sphinx.po
@@ -3214,7 +3214,7 @@ msgstr "环境变量; %s"
 #: domains/std/__init__.py:116
 #, python-format
 msgid "%s; configuration value"
-msgstr "%s；配置值"
+msgstr "%s; 配置值"
 
 #: domains/std/__init__.py:172
 msgid "Type"


### PR DESCRIPTION
issue described in https://github.com/sphinx-doc/sphinx/issues/14147
