### PR TITLE
autodoc: Restore ``mock`` module for compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Release 9.0.2 (in development)
 Bugs fixed
 ----------
 
+* #14142: autodoc: Restore :mod:`!sphinx.ext.autodoc.mock`.
+  Patch by Adam Turner.
 
 Release 9.0.1 (released Dec 01, 2025)
 =====================================

--- a/sphinx/ext/autodoc/importer.py
+++ b/sphinx/ext/autodoc/importer.py
@@ -8,21 +8,18 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from sphinx.errors import PycodeError
 from sphinx.ext.autodoc._dynamic._importer import (
-    _find_type_stub_spec as _find_type_stub_spec,  # NoQA: PLC0414
+    _find_type_stub_spec,  # NoQA: F401
+    _reload_module,  # NoQA: F401
+    _StubFileLoader,  # NoQA: F401
 )
 from sphinx.ext.autodoc._dynamic._importer import (
     _import_module as import_module,
 )
 from sphinx.ext.autodoc._dynamic._importer import _mangle_name as mangle
-from sphinx.ext.autodoc._dynamic._importer import (
-    _reload_module as _reload_module,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._importer import (
-    _StubFileLoader as _StubFileLoader,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._member_finder import _filter_enum_dict, unmangle
 from sphinx.ext.autodoc._dynamic._member_finder import (
-    _is_native_enum_api as _is_native_enum_api,  # NoQA: PLC0414
+    _filter_enum_dict,
+    _is_native_enum_api,  # NoQA: F401
+    unmangle,
 )
 from sphinx.ext.autodoc._dynamic._mock import ismock, undecorate
 from sphinx.ext.autodoc._shared import LOGGER

--- a/sphinx/ext/autodoc/mock.py
+++ b/sphinx/ext/autodoc/mock.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from sphinx.ext.autodoc._dynamic._mock import (
+    MockFinder,  # NoQA: F401
+    MockLoader,  # NoQA: F401
+    _make_subclass,  # NoQA: F401
+    _MockModule,  # NoQA: F401
+    _MockObject,  # NoQA: F401
+    ismock,  # NoQA: F401
+    ismockmodule,  # NoQA: F401
+    mock,  # NoQA: F401
+    undecorate,  # NoQA: F401
+)

--- a/sphinx/ext/autodoc/preserve_defaults.py
+++ b/sphinx/ext/autodoc/preserve_defaults.py
@@ -9,21 +9,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sphinx.ext.autodoc._dynamic._preserve_defaults import (
-    DefaultValue as DefaultValue,  # NoQA: PLC0414
+    DefaultValue,  # NoQA: F401
+    _get_arguments,  # NoQA: F401
+    _get_arguments_inner,  # NoQA: F401
+    _is_lambda,  # NoQA: F401
+    get_default_value,  # NoQA: F401
+    update_default_value,
 )
-from sphinx.ext.autodoc._dynamic._preserve_defaults import (
-    _get_arguments as _get_arguments,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._preserve_defaults import (
-    _get_arguments_inner as _get_arguments_inner,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._preserve_defaults import (
-    _is_lambda as _is_lambda,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._preserve_defaults import (
-    get_default_value as get_default_value,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._preserve_defaults import update_default_value
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sphinx/ext/autodoc/type_comment.py
+++ b/sphinx/ext/autodoc/type_comment.py
@@ -6,12 +6,8 @@ from typing import TYPE_CHECKING
 
 from sphinx.ext.autodoc._dynamic._type_comments import (
     _update_annotations_using_type_comments,
-)
-from sphinx.ext.autodoc._dynamic._type_comments import (
-    not_suppressed as not_suppressed,  # NoQA: PLC0414
-)
-from sphinx.ext.autodoc._dynamic._type_comments import (
-    signature_from_ast as signature_from_ast,  # NoQA: PLC0414
+    not_suppressed,  # NoQA: F401
+    signature_from_ast,  # NoQA: F401
 )
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Purpose

Fix #14142. Forgot to restore this in #14091.

## References

- #14091
- #14142