### PR TITLE
Fix sphinx.js discovery for when documentation source is in a subdir

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -69,6 +69,7 @@ Contributors
 * Ian Lee -- quickstart improvements
 * Jacob Mason -- websupport library (GSOC project)
 * James Addison -- linkcheck and HTML search improvements
+* Janne Cederberg -- sphinx.js discovery bug-fix
 * Jeppe Pihl -- literalinclude improvements
 * Jeremy Maitin-Shepard -- C++ domain improvements
 * Joel Wurtz -- cellspanning support in LaTeX

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -190,7 +190,7 @@ class StandaloneHTMLBuilder(Builder):
 
     def _get_translations_js(self) -> Path | None:
         for dir_ in self.config.locale_dirs:
-            js_file = Path(dir_, self.config.language, 'LC_MESSAGES', 'sphinx.js')
+            js_file = Path(self.srcdir, dir_, self.config.language, 'LC_MESSAGES', 'sphinx.js')
             if js_file.is_file():
                 return js_file
 

--- a/sphinx/builders/html/__init__.py
+++ b/sphinx/builders/html/__init__.py
@@ -190,7 +190,9 @@ class StandaloneHTMLBuilder(Builder):
 
     def _get_translations_js(self) -> Path | None:
         for dir_ in self.config.locale_dirs:
-            js_file = Path(self.srcdir, dir_, self.config.language, 'LC_MESSAGES', 'sphinx.js')
+            js_file = Path(
+                self.srcdir, dir_, self.config.language, 'LC_MESSAGES', 'sphinx.js'
+            )
             if js_file.is_file():
                 return js_file
 


### PR DESCRIPTION
If .rst etc source files (and conf.py) are placed in a subdirectory of Sphinx project root, such as "src", "source" or similar (instead of in the Sphinx root), then when building html documentation, the html builder will not find a custom localized sphinx.js file even if the file exists in the correct path (&lt;conf.py::locale_dirs[index]&gt;/&lt;LANG&gt;/LC_MESSAGES/sphinx.js).

The above has the result of causing JavaScript errors when Sphinx-generated HTML+JavaScript attempts to dynamically translate (in browser/client-side) parts of the UI, such as the string describing how many results a given search yielded.

This commit fixes the aforementioned problem.

With a [quick search](https://github.com/sphinx-doc/sphinx/issues?q=is%3Aissue%20state%3Aopen%20sphinx.js) I did not find an open issue that seemed to be related to this.