### PR TITLE
autodoc: Add support for ``typing.TypeAlias`` declarations

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_loader.py
+++ b/sphinx/ext/autodoc/_dynamic/_loader.py
@@ -464,9 +464,10 @@ def _make_props_from_imported_object(
             parts = tuple(bases) + parts
             module_name = obj_module_name
 
+        obj_value = getattr(obj, '__value__', obj)
         short_literals = config.python_display_short_literal_types
         ann = stringify_annotation(
-            obj.__value__, render_mode, short_literals=short_literals
+            obj_value, render_mode, short_literals=short_literals
         )
         return _TypeStatementProperties(
             obj_type=objtype,

--- a/tests/test_ext_autodoc/test_ext_autodoc_autotype.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autotype.py
@@ -1,0 +1,37 @@
+"""Test the autodoc extension.
+
+This tests mainly the Documenters; the auto directives are tested in a test
+source file translated by test_build.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_ext_autodoc.autodoc_util import do_autodoc
+
+pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
+
+
+def test_autotype_TypeAlias() -> None:
+    actual = do_autodoc('type', 'target.typed_vars.Alias')
+    assert actual == [
+        '',
+        '.. py:type:: Alias',
+        '   :module: target.typed_vars',
+        '   :canonical: ~target.typed_vars.Derived',
+        '',
+    ]
+
+
+def test_autotype_GenericAlias() -> None:
+    actual = do_autodoc('type', 'target.genericalias.T')
+    assert actual == [
+        '',
+        '.. py:type:: T',
+        '   :module: target.genericalias',
+        '   :canonical: ~typing.List[int]',
+        '',
+        '   A list of int',
+        '',
+    ]


### PR DESCRIPTION
## Purpose

The new implementation of autodoc expects the target of `autotype` to be a proper `type` statement as introduced in 
Python 3.12. Legacy type aliases are deprecated since 3.12 in favor of type statements. However, they are still supported and according to Python docs, there are no current plans for removal. 

Without the first commit in this PR, Python code like the following

```python
from typing import TypeAlias
IntOrStr: TypeAlias = int | str
```

cannot be documented with the `autotype` directive:

```rst
.. autotype:: IntOrStr
```

as this will lead to a runtime failure.

```python
Traceback
=========

      File "<rootdir>/sphinx/sphinx/ext/autodoc/_dynamic/_loader.py", line 469, in _make_props_from_imported_object
        obj.__value__, render_mode, short_literals=short_literals
        ^^^^^^^^^^^^^
    AttributeError: 'typing.Union' object has no attribute '__value__'. Did you mean: '__le__'?
```