### PR TITLE
autosummary: Add support for Exception subclasses

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@ Contributors
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils
 * Kurt McKee -- documentation updates
 * Lars Hupfeldt Nielsen - OpenSSL FIPS mode md5 bug fix
+* Lisandro Dalcin - autodoc/autosummary improvements
 * Louis Maddox -- better docstrings
 * Łukasz Langa -- partial support for autodoc
 * Marco Buttu -- doctest extension (pyversion option)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,6 +83,7 @@ Contributors
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils
 * Kurt McKee -- documentation updates
 * Lars Hupfeldt Nielsen - OpenSSL FIPS mode md5 bug fix
+* Lisandro Dalcin - autodoc/autosummary improvements
 * Louis Maddox -- better docstrings
 * Łukasz Langa -- partial support for autodoc
 * Marco Buttu -- doctest extension (pyversion option)

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -301,9 +301,15 @@ Autosummary uses the following Jinja template files:
 - :file:`autosummary/base.rst` -- fallback template
 - :file:`autosummary/module.rst` -- template for modules
 - :file:`autosummary/class.rst` -- template for classes
+- :file:`autosummary/exception.rst` -- template for exceptions
 - :file:`autosummary/function.rst` -- template for functions
 - :file:`autosummary/attribute.rst` -- template for class attributes
 - :file:`autosummary/method.rst` -- template for class methods
+
+.. versionadded:: 9.2
+
+   Exception templates now receive class-related variables such as
+   members, inherited members, methods, and attributes.
 
 The following variables are available in the templates:
 
@@ -343,15 +349,23 @@ The following variables are available in the templates:
 
 .. data:: members
 
-   List containing names of all members of the module or class.  Only available
-   for modules and classes.
+   List containing names of all members of the module, class, or exception.
+   Only available for modules, classes, and exceptions.
+
+   .. versionchanged:: 9.2
+
+      Members of exceptions are supported.
 
 .. data:: inherited_members
 
-   List containing names of all inherited members of class.  Only available for
-   classes.
+   List containing names of all inherited members of the class or exception.
+   Only available for classes and exceptions.
 
    .. versionadded:: 1.8.0
+
+   .. versionchanged:: 9.2
+
+      Inherited members of exceptions are supported.
 
 .. data:: functions
 
@@ -371,17 +385,25 @@ The following variables are available in the templates:
 
 .. data:: methods
 
-   List containing names of "public" methods in the class.  Only available for
-   classes.
+   List containing names of "public" methods in the class or exception.  Only
+   available for classes and exceptions.
+
+   .. versionchanged:: 9.2
+
+      Methods of exceptions are supported.
 
 .. data:: attributes
 
-   List containing names of "public" attributes in the class/module.  Only
-   available for classes and modules.
+   List containing names of "public" attributes in the class/exception/module.
+   Only available for classes, exceptions, and modules.
 
    .. versionchanged:: 3.1
 
       Attributes of modules are supported.
+
+   .. versionchanged:: 9.2
+
+      Attributes of exceptions are supported.
 
 .. data:: modules
 

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -368,7 +368,7 @@ def generate_autosummary_content(
             )
             ns['modules'] = imported_modules + modules
             ns['all_modules'] = all_imported_modules + all_modules
-    elif obj_type == 'class':
+    elif obj_type in {'class', 'exception'}:
         ns['members'] = dir(obj)
         ns['inherited_members'] = set(dir(obj)) - set(obj.__dict__.keys())
         ns['methods'], ns['all_methods'] = _get_members(
@@ -393,7 +393,7 @@ def generate_autosummary_content(
     if obj_type in {'method', 'attribute', 'property'}:
         ns['class'] = qualname.rsplit('.', 1)[0]
 
-    if obj_type == 'class':
+    if obj_type in {'class', 'exception'}:
         shortname = qualname
     else:
         shortname = qualname.rsplit('.', 1)[-1]
@@ -520,7 +520,7 @@ def _get_all_members(
 ) -> dict[str, Any]:
     if obj_type == 'module':
         return _get_module_members(obj, config=config)
-    elif obj_type == 'class':
+    elif obj_type in {'class', 'exception'}:
         return _get_class_members(obj)
     return {}
 

--- a/sphinx/ext/autosummary/templates/autosummary/class.rst
+++ b/sphinx/ext/autosummary/templates/autosummary/class.rst
@@ -2,7 +2,7 @@
 
 .. currentmodule:: {{ module }}
 
-.. autoclass:: {{ objname }}
+.. auto{{ objtype }}:: {{ objname }}
 
    {% block methods %}
    .. automethod:: __init__

--- a/tests/roots/test-ext-autosummary-template/_templates/autosummary/exception.rst
+++ b/tests/roots/test-ext-autosummary-template/_templates/autosummary/exception.rst
@@ -1,0 +1,43 @@
+{%- extends "autosummary/class.rst" %}
+
+{%- block methods %}
+..
+   name: {{ name }}
+   methods:
+   {%- for item in methods %}
+   {%- if item in members %}
+   {%- if item not in inherited_members %}
+     - {{ item }}
+   {%- endif %}
+   {%- endif %}
+   {%- endfor %}
+   inherited_methods:
+   {%- for item in methods %}
+   {%- if item in members %}
+   {%- if item in inherited_members %}
+     - {{ item }}
+   {%- endif %}
+   {%- endif %}
+   {%- endfor %}
+{% endblock %}
+
+{%- block attributes %}
+..
+   name: {{ name }}
+   attributes:
+   {%- for item in attributes %}
+   {%- if item in members %}
+   {%- if item not in inherited_members %}
+     - {{ item }}
+   {%- endif %}
+   {%- endif %}
+   {%- endfor %}
+   inherited_attributes:
+   {%- for item in attributes %}
+   {%- if item in members %}
+   {%- if item in inherited_members %}
+     - {{ item }}
+   {%- endif %}
+   {%- endif %}
+   {%- endfor %}
+{% endblock %}

--- a/tests/roots/test-ext-autosummary-template/index.rst
+++ b/tests/roots/test-ext-autosummary-template/index.rst
@@ -3,3 +3,9 @@
    :template: empty.rst
 
    target.Foo
+
+.. autosummary::
+   :toctree: generate
+
+   target.Exc
+   target.Outer.Exc

--- a/tests/roots/test-ext-autosummary-template/target.py
+++ b/tests/roots/test-ext-autosummary-template/target.py
@@ -1,2 +1,21 @@
 class Foo:
     """docstring of Foo."""
+
+
+class Exc(Exception):
+    """docstring of Exc."""
+
+    attribute = None
+    """docstring of attribute."""
+
+    def method(self):
+        """docstring of method."""
+        pass
+
+
+class Outer:
+    """docstring of Class"""
+
+    class Exc(Exception):
+        """docstring of Class.Exc."""
+        pass

--- a/tests/test_ext_autosummary/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary/test_ext_autosummary.py
@@ -953,6 +953,50 @@ def test_autosummary_template(app):
     content = (app.srcdir / 'generate' / 'target.Foo.rst').read_text(encoding='utf8')
     assert 'EMPTY' in content
 
+    content = (app.srcdir / 'generate' / 'target.Exc.rst').read_text(encoding='utf8')
+    assert 'target.Exc\n=' in content
+    assert '.. currentmodule:: target\n' in content
+    assert '.. autoexception:: Exc\n' in content
+    assert (
+        '..\n'
+        '   name: Exc\n'
+        '   methods:\n'
+        '     - method\n'
+        '   inherited_methods:\n'
+        '     - __init__\n'
+        '     - add_note\n'
+        '     - with_traceback\n'
+    ) in content  # fmt: skip
+    assert (
+        '..\n'
+        '   name: Exc\n'
+        '   attributes:\n'
+        '     - attribute\n'
+        '   inherited_attributes:\n'
+        '     - args\n'
+    ) in content  # fmt: skip
+
+    content = (app.srcdir / 'generate' / 'target.Outer.Exc.rst').read_text(encoding='utf8')
+    assert 'target.Outer.Exc\n=' in content
+    assert '.. currentmodule:: target\n' in content
+    assert '.. autoexception:: Outer.Exc\n' in content
+    assert (
+        '..\n'
+        '   name: Outer.Exc\n'
+        '   methods:\n'
+        '   inherited_methods:\n'
+        '     - __init__\n'
+        '     - add_note\n'
+        '     - with_traceback\n'
+    ) in content  # fmt: skip
+    assert (
+        '..\n'
+        '   name: Outer.Exc\n'
+        '   attributes:\n'
+        '   inherited_attributes:\n'
+        '     - args\n'
+    ) in content  # fmt: skip
+
 
 @pytest.mark.sphinx(
     'dummy',


### PR DESCRIPTION
## Purpose

Traditionally, Sphinx's autosummary generation for exceptions is quite succinct: just the class name and the docstring if any. This make sense in general, as `Exception` subclasses typically do not add attributes and methods. However, in the case of a more complex exception class with additional attributes and methods, users could create a custom `autosummary/exception.rst` template to render additional content in the `Exception` subclass. 

The second commit in this PR enhances autodoc to populate members/attributes/methods in exceptions, treating them similarly as a class. By default, the template machinery will still render exceptions in a succinct way (through the fallback to the `autosummary/base.rst` template). However, users can now implement their own `autosummary/exception.rst` template for a more detailed rendering of their `Exception` subclasses.
