### PR TITLE
autodoc: Fix duplicate ``:no-index-entry:`` for modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,5 +20,8 @@ Features added
 Bugs fixed
 ----------
 
+* #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
+  Patch by Adam Turner
+
 Testing
 -------

--- a/sphinx/ext/autodoc/_renderer.py
+++ b/sphinx/ext/autodoc/_renderer.py
@@ -61,8 +61,6 @@ def _directive_header_lines(
             yield f'   :platform: {options.platform}'
         if options.deprecated:
             yield '   :deprecated:'
-        if options.no_index_entry:
-            yield '   :no-index-entry:'
 
     if props.obj_type in {'class', 'exception'}:
         assert isinstance(props, _ClassDefProperties)


### PR DESCRIPTION
## Purpose

Fixes #14189.

## References

- #14189
- #13720
- #13807
- #13931
