### PR TITLE
Fix link to Docutils' ``.. class::`` directive

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -402,7 +402,8 @@ Docutils supports the following directives:
 
     .. _rstclass:
 
-  - :dudir:`class <setting-class-attributes>` (assign a class attribute to the next element)
+  - :dudir:`class <setting-class-attributes>`
+    (assign a class attribute to the next element)
 
     .. note::
 

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -402,7 +402,7 @@ Docutils supports the following directives:
 
     .. _rstclass:
 
-  - :dudir:`class` (assign a class attribute to the next element)
+  - :dudir:`class <setting-class-attributes>` (assign a class attribute to the next element)
 
     .. note::
 


### PR DESCRIPTION
the old :dudir:`class` could not link to the correct line of docutil document