### PR TITLE
Let LaTeX writer support the standard role "acronym".

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,6 +60,7 @@ Contributors
 * Florian Best -- log improvements
 * Glenn Matthews -- python domain signature improvements
 * Gregory Szorc -- performance improvements
+* Günter Milde -- various small fixes
 * Henrique Bastos -- SVG support for graphviz extension
 * Hernan Grecco -- search improvements
 * Hong Xu -- svg support in imgmath extension and various bug fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@ Bugs fixed
   Patch by Adam Turner
 * Remove incorrect static typing assertions.
   Patch by Adam Turner
+* #14050: LaTeXTranslator fails to build documents 
+  using the "acronym" standard role.
+  Patch by Günter Milde
+
 
 Testing
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,9 +33,9 @@ Bugs fixed
   Patch by Adam Turner
 * Remove incorrect static typing assertions.
   Patch by Adam Turner
-* #14050: LaTeXTranslator fails to build documents 
-  using the "acronym" standard role.
-  Patch by Günter Milde
+* #14050: LaTeXTranslator fails to build documents using the "acronym"
+  standard role.
+  Patch (PR #14202) by Günter Milde
 
 
 Testing

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -2107,6 +2107,12 @@ class LaTeXTranslator(SphinxTranslator):
     def depart_abbreviation(self, node: Element) -> None:
         self.body.append(self.context.pop())
 
+    def visit_acronym(self, node: Element) -> None:
+        self.visit_abbreviation(node)
+
+    def depart_acronym(self, node: Element) -> None:
+        self.depart_abbreviation(node)
+
     def visit_manpage(self, node: Element) -> None:
         return self.visit_literal_emphasis(node)
 


### PR DESCRIPTION
## Purpose

Prevent aborting LaTeX generation with "severe" error when a document uses the standard role
["acronym"](https://docutils.sourceforge.io/docs/ref/rst/roles.html#acronym>) .

Handle the "acronym" standard role similar to "abbreviation" - cf. the [recommendation for HTML](https://html.spec.whatwg.org/multipage/obsolete.html#acronym).

## References

Closes #14050 "LaTeXTranslator fails to build documents using the "acronym" standard role."
