### PR TITLE
Fix typo in "source-read" event parameter description

### DIFF
--- a/doc/extdev/event_callbacks.rst
+++ b/doc/extdev/event_callbacks.rst
@@ -161,7 +161,7 @@ Here is a more detailed list of these events.
    :param docname: ``str``
    :param content: ``list[str]``
       with a single element,
-      representing the content of the included file.
+      representing the content of the source file.
 
    Emitted when a source file has been read.
 


### PR DESCRIPTION
I think this line is directly copied from the "include-read" event.