### PR TITLE
LaTeX: Inhibit breaks for rows with merged vertical cells

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Bugs fixed
   Patch by Günter Milde
 * LaTeX: Fix rendering for grid filled merged vertical cell.
   Patch by Tim Nordell
+* #14228: LaTeX: Fix overrun footer for cases of merged vertical table cells.
+  Patch by Tim Nordell
 * #14207: Fix creating ``HTMLThemeFactory`` objects in third-party extensions.
   Patch by Adam Turner
 * #3099: LaTeX: PDF build crashes if a code-block contains more than

--- a/sphinx/texinputs/sphinxlatextables.sty
+++ b/sphinx/texinputs/sphinxlatextables.sty
@@ -1,7 +1,7 @@
 %% TABLES (WITH SUPPORT FOR MERGED CELLS OF GENERAL CONTENTS)
 %
 % change this info string if making any custom modification
-\ProvidesPackage{sphinxlatextables}[2025/06/30 v9.0.0 tables]%
+\ProvidesPackage{sphinxlatextables}[2025/12/30 v9.1.0 tables]%
 
 % Provides support for this output mark-up from Sphinx latex writer
 % and table templates:
@@ -776,7 +776,7 @@
   \leaders\hrule\@height\arrayrulewidth\hfill}%
   \cr
 % the last one will need to be compensated, this is job of \sphinxclines
-  \noalign{\vskip-\arrayrulewidth}%
+  \noalign{\nobreak\vskip-\arrayrulewidth}%
 }
 \def\spx@table@fixvlinejoin{%
   {\CT@arc@ % this is the color command set up by \arrayrulecolor
@@ -800,7 +800,7 @@
   \hfill
   \spx@table@fixvlinejoin
   \cr
-  \noalign{\vskip-\arrayrulewidth}%
+  \noalign{\nobreak\vskip-\arrayrulewidth}%
 }
 % This "fixclines" is also needed if no \sphinxcline emitted and is useful
 % even in extreme case with no \sphinxvlinecrossing either, to give correct
@@ -819,6 +819,7 @@
   \spx@table@fixvlinejoin% fill small gap at right-bordered table
   \cr
   % this final one does NO \vskip-\arrayrulewidth... that's the whole point
+  \noalign{\nobreak}%
 }
 %%%% end of \cline workarounds
 

--- a/sphinx/writers/latex.py
+++ b/sphinx/writers/latex.py
@@ -1307,15 +1307,16 @@ class LaTeXTranslator(SphinxTranslator):
 
     def depart_row(self, node: Element) -> None:
         assert self.table is not None
-        self.body.append(r'\\' + CR)
         cells = [self.table.cell(self.table.row, i) for i in range(self.table.colcount)]
         underlined = [
             cell.row + cell.height == self.table.row + 1  # type: ignore[union-attr]
             for cell in cells
         ]
         if all(underlined):
+            self.body.append(r'\\' + CR)
             self.body.append(r'\sphinxhline')
         else:
+            self.body.append(r'\\*' + CR)
             i = 0
             underlined.extend([False])  # sentinel
             if underlined[0] is False:

--- a/tests/roots/test-latex-table/expects/complex_spanning_cell.tex
+++ b/tests/roots/test-latex-table/expects/complex_spanning_cell.tex
@@ -52,7 +52,7 @@ cell1\sphinxhyphen{}5
 \sphinxbeforeendvarwidth
 \end{varwidth}%
 }%
-\\
+\\*
 \sphinxvlinecrossing{1}\sphinxcline{3-3}\sphinxvlinecrossing{4}\sphinxfixclines{5}\sphinxtablestrut{1}&\sphinxtablestrut{2}&\sphinxmultirow{2}{6}{%
 \begin{varwidth}[t]{\sphinxcolwidth{1}{5}}
 \sphinxAtStartPar
@@ -60,7 +60,7 @@ cell2\sphinxhyphen{}3
 \sphinxbeforeendvarwidth
 \end{varwidth}%
 }%
-&\sphinxtablestrut{4}&\sphinxtablestrut{5}\\
+&\sphinxtablestrut{4}&\sphinxtablestrut{5}\\*
 \sphinxvlinecrossing{1}\sphinxvlinecrossing{2}\sphinxvlinecrossing{3}\sphinxcline{5-5}\sphinxfixclines{5}\sphinxtablestrut{1}&\sphinxtablestrut{2}&\sphinxtablestrut{6}&\sphinxtablestrut{4}&\begin{varwidth}[t]{\sphinxcolwidth{1}{5}}
 \sphinxAtStartPar
 cell3\sphinxhyphen{}5

--- a/tests/roots/test-latex-table/expects/grid_table.tex
+++ b/tests/roots/test-latex-table/expects/grid_table.tex
@@ -40,7 +40,7 @@ cell1\sphinxhyphen{}2
 cell1\sphinxhyphen{}3
 \sphinxbeforeendvarwidth
 \end{varwidth}%
-\\
+\\*
 \sphinxcline{1-1}\sphinxcline{3-3}\sphinxfixclines{3}\sphinxmultirow{2}{7}{%
 \begin{varwidth}[t]{\sphinxcolwidth{1}{3}}
 \sphinxAtStartPar
@@ -53,7 +53,7 @@ cell2\sphinxhyphen{}1
 cell2\sphinxhyphen{}3
 \sphinxbeforeendvarwidth
 \end{varwidth}%
-\\
+\\*
 \sphinxcline{2-3}\sphinxfixclines{3}\sphinxtablestrut{7}&\sphinxstartmulticolumn{2}%
 \sphinxmultirow{2}{9}{%
 \begin{varwidth}[t]{\sphinxcolwidth{2}{3}}
@@ -66,7 +66,7 @@ cell3\sphinxhyphen{}2\sphinxhyphen{}par2
 \end{varwidth}%
 }%
 \sphinxstopmulticolumn
-\\
+\\*
 \sphinxcline{1-1}\sphinxfixclines{3}\begin{varwidth}[t]{\sphinxcolwidth{1}{3}}
 \sphinxAtStartPar
 cell4\sphinxhyphen{}1

--- a/tests/roots/test-latex-table/expects/grid_table_with_tabularcolumns.tex
+++ b/tests/roots/test-latex-table/expects/grid_table_with_tabularcolumns.tex
@@ -40,7 +40,7 @@ cell1\sphinxhyphen{}2
 cell1\sphinxhyphen{}3
 \sphinxbeforeendvarwidth
 \end{varwidth}%
-\\
+\\*
 \sphinxcline{1-1}\sphinxcline{3-3}\sphinxfixclines{3}\sphinxmultirow{2}{7}{%
 \begin{varwidth}[t]{\sphinxcolwidth{1}{3}}
 \sphinxAtStartPar
@@ -53,7 +53,7 @@ cell2\sphinxhyphen{}1
 cell2\sphinxhyphen{}3
 \sphinxbeforeendvarwidth
 \end{varwidth}%
-\\
+\\*
 \sphinxcline{2-3}\sphinxfixclines{3}\sphinxtablestrut{7}&\sphinxstartmulticolumn{2}%
 \sphinxmultirow{2}{9}{%
 \begin{varwidth}[t]{\sphinxcolwidth{2}{3}}
@@ -66,7 +66,7 @@ cell3\sphinxhyphen{}2\sphinxhyphen{}par2
 \end{varwidth}%
 }%
 \sphinxstopmulticolumn
-\\
+\\*
 \sphinxcline{1-1}\sphinxfixclines{3}\begin{varwidth}[t]{\sphinxcolwidth{1}{3}}
 \sphinxAtStartPar
 cell4\sphinxhyphen{}1

--- a/tests/roots/test-latex-table/expects/longtable_with_multirow_cell_near_page_footer.tex
+++ b/tests/roots/test-latex-table/expects/longtable_with_multirow_cell_near_page_footer.tex
@@ -1,0 +1,250 @@
+\label{\detokenize{longtable:longtable-with-multirow-cell-near-page-footer}}
+\sphinxAtStartPar
+table having …
+\begin{itemize}
+\item {} 
+\sphinxAtStartPar
+consecutive multirow near footer
+
+\end{itemize}
+
+\newpage
+\vspace*{\dimeval{\textheight - 5\baselineskip}}
+
+
+\begin{savenotes}
+\sphinxatlongtablestart
+\sphinxthistablewithglobalstyle
+\makeatletter
+  \LTleft \@totalleftmargin plus1fill
+  \LTright\dimexpr\columnwidth-\@totalleftmargin-\linewidth\relax plus1fill
+\makeatother
+\begin{longtable}{|l|l|}
+\sphinxtoprule
+\endfirsthead
+
+\multicolumn{2}{c}{\sphinxnorowcolor
+    \makebox[0pt]{\sphinxtablecontinued{\tablename\ \thetable{} \textendash{} continued from previous page}}%
+}\\
+\sphinxtoprule
+\endhead
+
+\sphinxbottomrule
+\multicolumn{2}{r}{\sphinxnorowcolor
+    \makebox[0pt][r]{\sphinxtablecontinued{continues on next page}}%
+}\\
+\endfoot
+
+\endlastfoot
+\sphinxtableatstartofbodyhook
+\sphinxmultirow{16}{1}{%
+\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 1
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 2
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 3
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 4
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 5
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 6
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 7
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 8
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 9
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 10
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 11
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 12
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 13
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 14
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 15
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\*
+\sphinxcline{2-2}\sphinxfixclines{2}\sphinxtablestrut{1}&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Cell 16
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxhline\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxAtStartPar
+Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+&\begin{varwidth}[t]{\sphinxcolwidth{1}{2}}
+\sphinxbeforeendvarwidth
+\end{varwidth}%
+\\
+\sphinxbottomrule
+\end{longtable}
+\sphinxtableafterendhook
+\sphinxatlongtableend
+\end{savenotes}

--- a/tests/roots/test-latex-table/longtable.rst
+++ b/tests/roots/test-latex-table/longtable.rst
@@ -154,3 +154,74 @@ longtable having stub columns and formerly problematic
    * - cell2-1
      - cell2-2
      - cell2-3
+
+longtable with multirow cell near page footer
+---------------------------------------------
+
+.. |lorem| replace::
+
+   Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex
+   sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis
+   convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus
+   fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada
+   lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti
+   sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.
+
+table having ...
+
+* consecutive multirow near footer
+
+.. raw:: latex
+
+   \newpage
+   \vspace*{\dimeval{\textheight - 5\baselineskip}}
+
+.. rst-class:: longtable
+
++-----------+-----------+
+| |lorem|   | Cell 1    |
+|           +-----------+
+|           | Cell 2    |
+|           +-----------+
+|           | Cell 3    |
+|           +-----------+
+|           | Cell 4    |
+|           +-----------+
+|           | Cell 5    |
+|           +-----------+
+|           | Cell 6    |
+|           +-----------+
+|           | Cell 7    |
+|           +-----------+
+|           | Cell 8    |
+|           +-----------+
+|           | Cell 9    |
+|           +-----------+
+|           | Cell 10   |
+|           +-----------+
+|           | Cell 11   |
+|           +-----------+
+|           | Cell 12   |
+|           +-----------+
+|           | Cell 13   |
+|           +-----------+
+|           | Cell 14   |
+|           +-----------+
+|           | Cell 15   |
+|           +-----------+
+|           | Cell 16   |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+
+| |lorem|   |           |
++-----------+-----------+

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -1673,6 +1673,7 @@ def test_latex_table_longtable(app: SphinxTestApp) -> None:
         'longtable having formerly problematic',
         'longtable having widths and formerly problematic',
         'longtable having stub columns and formerly problematic',
+        'longtable with multirow cell near page footer',
     ):
         actual = tables[sectname]
         expected = get_expected(sectname.replace(' ', '_'))


### PR DESCRIPTION
## Purpose

This inhibits breaking in rows with vertically merged cells per stack exchange [1].  Tested against longtable.

[1] https://tex.stackexchange.com/questions/52100/%20longtable-multirow-problem-with-cline-and-nopagebreak#answer-52101

## Discussion

I'm not sure of a good way of automating that the final output doesn't go into the margins as Sphinx doesn't build the PDF output from the .tex files during test, nor inspect these.  I also don't know if this is the correct approach for this, but I did add a test case demonstrating this along with the expected .tex snippet.  The colorrows and regular version is required to exercise all of the paths in the PDF output from within `sphinxlatextables.sty`, but not in the .tex output itself.

Without this fix you get this in the PDF output from the test case example:

<img width="451" height="835" alt="image" src="https://github.com/user-attachments/assets/a99c4f0d-b15c-4e42-8c50-35097b23c48b" />

And with the fix, you get this:

<img width="449" height="907" alt="image" src="https://github.com/user-attachments/assets/8b2cbb2d-9d9d-471d-a167-e87b063f6c4f" />

Notably, the problematic multiline section was moved, but a regular pagebreak still occurs during non-merged vertical cells.