### PR TITLE
Docs: document :yields: info field

### DIFF
--- a/doc/usage/domains/python.rst
+++ b/doc/usage/domains/python.rst
@@ -673,6 +673,7 @@ are recognized and formatted nicely:
 * ``var``, ``ivar``, ``cvar``: Description of a variable.
 * ``vartype``: Type of a variable.  Creates a link if possible.
 * ``returns``, ``return``: Description of the return value.
+* ``yields``, ``yield``: Description of the yielded value(s) of a generator.
 * ``rtype``: Return type.  Creates a link if possible.
 * ``meta``: Add metadata to description of the python object.  The metadata will
   not be shown on output document.  For example, ``:meta private:`` indicates

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -15,7 +15,7 @@ language, this will not take too long.
 .. seealso::
 
    The authoritative `reStructuredText User Documentation
-   <https://docutils.sourceforge.io/rst.html>`_.
+   <https://docutils.sourceforge.io/rst.html>`__(note double trailing underscores).
    The "ref" links in this document link to the description of
    the individual constructs in the reStructuredText reference.
 


### PR DESCRIPTION
This PR documents the supported ``:yields:`` info field in the "Info field lists" section of the Python domain documentation as discussed in #13850.This is a documentation-only change. The failing `ty` check appears unrelated to the modified file.
Happy to make any doc adjustments if needed.

