### PR TITLE
Catch TypeError as well as ValueError in osutil.relpath

### DIFF
--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -166,7 +166,7 @@ def relpath(
     """
     try:
         return os.path.relpath(path, start)
-    except ValueError:
+    except (ValueError, TypeError):
         return str(path)
 
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

`docutils.utils.get_source_line()` can return `None` for path to the rst source file (particularly for generated files). Calling `osutil.relpath` on this value used to raise `ValueError`, but now raises `TypeError` on Python 3.13 and newer.

## References
- https://github.com/sphinx-contrib/spelling/pull/240
- https://github.com/python/cpython/pull/117585
- https://sourceforge.net/p/docutils/code/HEAD/tree/tags/docutils-0.17.1//docutils/utils/__init__.py#l560
