### PR TITLE
Fix inline links

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -14,8 +14,8 @@ language, this will not take too long.
 
 .. seealso::
 
-   The authoritative `reStructuredText User Documentation
-   <https://docutils.sourceforge.io/rst.html>`__ (note double trailing underscores).
+   The authoritative `reStructuredText User Documentation <https://docutils.sourceforge.io/rst.html>`__
+   explains the reference syntax (note double trailing underscores).
 
    The "ref" links in this document link to the description of
    the individual constructs in the reStructuredText reference.

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -15,7 +15,7 @@ language, this will not take too long.
 .. seealso::
 
    The authoritative `reStructuredText User Documentation
-   <https://docutils.sourceforge.io/rst.html>`_.
+   <https://docutils.sourceforge.io/rst.html>`__(note double trailing underscores).
    The "ref" links in this document link to the description of
    the individual constructs in the reStructuredText reference.
 

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -14,8 +14,11 @@ language, this will not take too long.
 
 .. seealso::
 
-   The authoritative `reStructuredText User Documentation <https://docutils.sourceforge.io/rst.html>`__
-   explains the reference syntax (note double trailing underscores).
+   The authoritative
+   ``reStructuredText User Documentation
+   <https://docutils.sourceforge.io/rst.html>`__
+   explains the reference syntax
+   (note double trailing underscores).
 
    The "ref" links in this document link to the description of
    the individual constructs in the reStructuredText reference.

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -14,8 +14,9 @@ language, this will not take too long.
 
 .. seealso::
 
-   The authoritative `reStructuredText User Documentation
-   <https://docutils.sourceforge.io/rst.html>`__(note double trailing underscores).
+The authoritative `reStructuredText User Documentation <https://docutils.sourceforge.io/rst.html>`__
+(note double trailing underscores).
+
    The "ref" links in this document link to the description of
    the individual constructs in the reStructuredText reference.
 

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -14,8 +14,8 @@ language, this will not take too long.
 
 .. seealso::
 
-The authoritative `reStructuredText User Documentation <https://docutils.sourceforge.io/rst.html>`__
-(note double trailing underscores).
+   The authoritative `reStructuredText User Documentation
+   <https://docutils.sourceforge.io/rst.html>`__ (note double trailing underscores).
 
    The "ref" links in this document link to the description of
    the individual constructs in the reStructuredText reference.


### PR DESCRIPTION
Clarifies the recommended syntax for  inline hyperlinks in the reStructuredText primer by using double trailing underscores to avoid named-reference conflicts.
Fixes #14011
