### PR TITLE
Linting: ty: resolve typechecking failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ types = [
     "mypy==1.19.1",
     "pyrefly",
     "pyright==1.1.407",
-    "ty",
+    "ty==0.0.9",
     { include-group = "type-stubs" },
 ]
 type-stubs = [

--- a/sphinx/ext/apidoc/_generate.py
+++ b/sphinx/ext/apidoc/_generate.py
@@ -42,7 +42,7 @@ def is_initpy(filename: str | Path) -> bool:
     return any(
         basename == '__init__' + suffix
         for suffix in sorted(PY_SUFFIXES, key=len, reverse=True)
-    )
+    )  # ty: ignore[unsupported-operator]
 
 
 def module_join(*modnames: str | None) -> str:

--- a/sphinx/ext/apidoc/_generate.py
+++ b/sphinx/ext/apidoc/_generate.py
@@ -40,9 +40,9 @@ def is_initpy(filename: str | Path) -> bool:
     """Check *filename* is __init__ file or not."""
     basename = Path(filename).name
     return any(
-        basename == '__init__' + suffix
+        basename == '__init__' + suffix  # ty: ignore[unsupported-operator]
         for suffix in sorted(PY_SUFFIXES, key=len, reverse=True)
-    )  # ty: ignore[unsupported-operator]
+    )
 
 
 def module_join(*modnames: str | None) -> str:

--- a/sphinx/util/_serialise.py
+++ b/sphinx/util/_serialise.py
@@ -46,7 +46,7 @@ def _stable_str_prep(obj: Any) -> dict[str, Any] | list[Any] | str:
         return dict(lst)
     if isinstance(obj, (list, tuple, set, frozenset)):
         # Convert to a sorted list
-        return sorted(map(_stable_str_prep, obj), key=str)
+        return sorted(map(_stable_str_prep, obj), key=str)  # ty: ignore[no-matching-overload]  # https://github.com/astral-sh/ty/issues/1970
     if isinstance(obj, (type, types.FunctionType)):
         # The default repr() of functions includes the ID, which is not ideal.
         # We use the fully qualified name instead.

--- a/sphinx/util/matching.py
+++ b/sphinx/util/matching.py
@@ -109,7 +109,7 @@ def patfilter(names: Iterable[str], pat: str) -> list[str]:
     if pat not in _pat_cache:
         _pat_cache[pat] = re.compile(_translate_pattern(pat))
     match = _pat_cache[pat].match
-    return list(filter(match, names))
+    return list(filter(match, names))  # ty: ignore[no-matching-overload]  # https://github.com/astral-sh/ty/issues/1970
 
 
 def get_matching_files(

--- a/ty.toml
+++ b/ty.toml
@@ -22,5 +22,5 @@ exclude = [
 invalid-argument-type = "ignore"
 invalid-assignment = "ignore"
 invalid-method-override = "ignore"
-non-subscriptable = "ignore"
+not-subscriptable = "ignore"
 possibly-missing-attribute = "ignore"


### PR DESCRIPTION
## Purpose

Aims to restore a passing result from the `ty` linting job, by fixing some false-positive error reports, so that commits and pull requests are not misleadingly marked as failures.

Does this by:

  - Fixing a typo in our `ty.toml` configuration file, deactivating `not-subscriptable` rulechecking.
  - Suppressing the few remaining failure cases, some of which appear to be due to upstream bug: https://github.com/astral-sh/ty/issues/1970

NB: Also pins the version of `ty`, to improve development environment typechecking consistency.

## References

- Resolves #14238

Edit: update description to mention added version-pinning.