### PR TITLE
Fix incorrect assertion in test_extract_messages_without_rawsource

### DIFF
--- a/tests/test_util/test_util_nodes.py
+++ b/tests/test_util/test_util_nodes.py
@@ -182,7 +182,7 @@ def test_extract_messages_without_rawsource() -> None:
     document.append(p)
     _transform(document)
     assert_node_count(extract_messages(document), nodes.TextElement, 1)
-    assert next(m for n, m in extract_messages(document)), 'text sentence'
+    assert next(m for n, m in extract_messages(document)) == 'text sentence'
 
 
 def test_clean_astext() -> None:


### PR DESCRIPTION
The assertion was checking truthiness instead of comparing the extracted message to the expected value 'text sentence'. Changed to properly compare using == operator.

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- <...>
- <...>
- <...>
