### PR TITLE
Add `intersphinx_request_headers` confval

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -105,6 +105,7 @@ Contributors
 * \A. Rafey Khan -- improved intersphinx typing
 * Rui Pinheiro -- Python 3.14 forward references support
 * Roland Meister -- epub builder
+* Samuel Dowling -- Intersphinx request header support
 * Sebastian Wiesner -- image handling, distutils support
 * Slawek Figiel -- additional warning suppression
 * Stefan Seefeld -- toctree improvements

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Dependencies
 Features added
 --------------
 
+* Add :confval:`intersphinx_request_headers` to allow custom HTTP headers
+  to be set when resolving ``objects.inv`` on remote hosts. In particular,
+  this enables Bearer authorization to allow access to privately hosted
+  documentation on platforms such as GitLab.
+  Patch by Samuel Dowling
+
 * Add :meth:`~sphinx.application.Sphinx.add_static_dir` for copying static
   assets from extensions to the build output.
   Patch by Jared Dillard

--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -212,6 +212,24 @@ linking:
    If ``*`` is in the list of domains, then no non-:rst:role:`external`
    references will be resolved by intersphinx.
 
+.. confval:: intersphinx_request_headers
+   :type: :code-py:`dict[str, dict[str, str]]`
+   :default: :code-py:`{}`
+
+   Headers to pass to the HTTP request for a project's :file:`objects.inv` file.
+   For example:
+
+   .. code-block:: python
+
+      token = "abcde"
+      intersphinx_request_headers = {
+          'python': {
+              "Authorization": f"Bearer {token}",
+          }
+      }
+
+   .. versionadded:: 9.2.0
+
 Explicitly Reference External Objects
 -------------------------------------
 

--- a/sphinx/ext/intersphinx/__init__.py
+++ b/sphinx/ext/intersphinx/__init__.py
@@ -65,6 +65,9 @@ if TYPE_CHECKING:
 
 def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value('intersphinx_mapping', {}, 'env', types=frozenset({dict}))
+    app.add_config_value(
+        'intersphinx_request_headers', {}, 'env', types=frozenset({dict})
+    )
     app.add_config_value('intersphinx_resolve_self', '', 'env', types=frozenset({str}))
     app.add_config_value('intersphinx_cache_limit', 5, '', types=frozenset({int}))
     app.add_config_value(

--- a/sphinx/ext/intersphinx/_cli.py
+++ b/sphinx/ext/intersphinx/_cli.py
@@ -38,6 +38,7 @@ def inspect_main(argv: list[str], /) -> int:
             config=config,
             srcdir=Path(),
             cache_path=None,
+            headers=None,
         )
         inv = _load_inventory(raw_data, target_uri='')
         for key in sorted(inv.data):

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -146,12 +146,18 @@ def load_mappings(app: Sphinx) -> None:
     inventories = InventoryAdapter(env)
     intersphinx_cache: dict[InventoryURI, InventoryCacheEntry] = inventories.cache
     intersphinx_mapping: IntersphinxMapping = app.config.intersphinx_mapping
+    intersphinx_request_headers: dict[str, dict[str, str]] = (
+        app.config.intersphinx_request_headers
+    )
 
     projects = []
     for name, (uri, locations) in intersphinx_mapping.values():
         try:
             project = _IntersphinxProject(
-                name=name, target_uri=uri, locations=locations
+                name=name,
+                target_uri=uri,
+                headers=intersphinx_request_headers.get(name, {}),
+                locations=locations,
             )
         except ValueError as err:
             msg = __(
@@ -302,6 +308,7 @@ def _fetch_inventory_group(
             try:
                 raw_data, target_uri = _fetch_inventory_data(
                     target_uri=project.target_uri,
+                    headers=project.headers,
                     inv_location=inv_location,
                     config=config,
                     srcdir=srcdir,
@@ -335,7 +342,9 @@ def _fetch_inventory_group(
     return updated
 
 
-def fetch_inventory(app: Sphinx, uri: InventoryURI, inv: str) -> Inventory:
+def fetch_inventory(
+    app: Sphinx, uri: InventoryURI, inv: str, *, headers: dict[str, str] | None = None
+) -> Inventory:
     """Fetch, parse and return an intersphinx inventory file."""
     raw_data, uri = _fetch_inventory_data(
         target_uri=uri,
@@ -343,6 +352,7 @@ def fetch_inventory(app: Sphinx, uri: InventoryURI, inv: str) -> Inventory:
         config=_InvConfig.from_config(app.config),
         srcdir=app.srcdir,
         cache_path=None,
+        headers=headers,
     )
     return _load_inventory(raw_data, target_uri=uri).data
 
@@ -354,6 +364,7 @@ def _fetch_inventory_data(
     config: _InvConfig,
     srcdir: Path,
     cache_path: Path | None,
+    headers: dict[str, str] | None = None,
 ) -> tuple[bytes, str]:
     """Fetch inventory data from a local or remote source."""
     # both *target_uri* (base URI of the links to generate)
@@ -364,7 +375,10 @@ def _fetch_inventory_data(
         target_uri = _strip_basic_auth(target_uri)
     if '://' in inv_location:
         raw_data, target_uri = _fetch_inventory_url(
-            target_uri=target_uri, inv_location=inv_location, config=config
+            target_uri=target_uri,
+            headers=headers,
+            inv_location=inv_location,
+            config=config,
         )
         if cache_path is not None:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -386,7 +400,11 @@ def _load_inventory(raw_data: bytes, /, *, target_uri: InventoryURI) -> _Invento
 
 
 def _fetch_inventory_url(
-    *, target_uri: InventoryURI, inv_location: str, config: _InvConfig
+    *,
+    target_uri: InventoryURI,
+    headers: dict[str, str] | None,
+    inv_location: str,
+    config: _InvConfig,
 ) -> tuple[bytes, str]:
     try:
         with requests.get(
@@ -394,6 +412,7 @@ def _fetch_inventory_url(
             timeout=config.intersphinx_timeout,
             _user_agent=config.user_agent,
             _tls_info=(config.tls_verify, config.tls_cacerts),
+            headers=headers,
         ) as r:
             r.raise_for_status()
             raw_data = r.content

--- a/sphinx/ext/intersphinx/_shared.py
+++ b/sphinx/ext/intersphinx/_shared.py
@@ -44,6 +44,7 @@ LOGGER: Final[logging.SphinxLoggerAdapter] = logging.getLogger('sphinx.ext.inter
 class _IntersphinxProject:
     name: InventoryName
     target_uri: InventoryURI
+    headers: dict[str, str]
     locations: tuple[InventoryLocation, ...]
 
     __slots__ = {
@@ -51,6 +52,7 @@ class _IntersphinxProject:
                       'It is unique and in bijection with an remote inventory URL.',
         'target_uri': 'The inventory project URL to which links are resolved. '
                       'It is unique and in bijection with an inventory name.',
+        'headers':    'The headers to use in the HTTP request',
         'locations':  'A tuple of local or remote targets containing '
                       'the inventory data to fetch. '
                       'None indicates the default inventory file name.',
@@ -61,6 +63,7 @@ class _IntersphinxProject:
         *,
         name: InventoryName,
         target_uri: InventoryURI,
+        headers: dict[str, str],
         locations: Sequence[InventoryLocation],
     ) -> None:
         if not name or not isinstance(name, str):
@@ -80,13 +83,24 @@ class _IntersphinxProject:
             raise ValueError(msg)
         object.__setattr__(self, 'name', name)
         object.__setattr__(self, 'target_uri', target_uri)
+        object.__setattr__(self, 'headers', headers)
         object.__setattr__(self, 'locations', tuple(locations))
 
     def __repr__(self) -> str:
+        def redact(headers: dict[str, str]) -> dict[str, str]:
+            sensitive_keywords = ['auth', 'key', 'token', 'cookie', 'digest']
+            return {
+                key: 'redacted'
+                if any(s in key.lower() for s in sensitive_keywords)
+                else value
+                for key, value in headers.items()
+            }
+
         return (
             f'{self.__class__.__name__}('
             f'name={self.name!r}, '
             f'target_uri={self.target_uri!r}, '
+            f'headers={redact(self.headers)!r}, '
             f'locations={self.locations!r})'
         )
 

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -25,6 +25,7 @@ from sphinx.ext.intersphinx._load import (
     _InvConfig,
     _load_inventory,
     _strip_basic_auth,
+    fetch_inventory,
     load_mappings,
     validate_intersphinx_mapping,
 )
@@ -72,6 +73,11 @@ def reference_check(app, *args, **kwds):
 def set_config(app, mapping):
     # copy *mapping* so that normalization does not alter it
     app.config.intersphinx_mapping = mapping.copy()
+    app.config.intersphinx_request_headers = {
+        'python': {
+            'Authorization': 'Bearer abcde',
+        }
+    }
     app.config.intersphinx_cache_limit = 0
     app.config.intersphinx_disabled_reftypes = []
     app.config.intersphinx_resolve_self = ''
@@ -802,7 +808,9 @@ def test_intersphinx_cache_limit(app, monkeypatch, cache_limit, expected_expired
     )
 
     for name, (uri, locations) in app.config.intersphinx_mapping.values():
-        project = _IntersphinxProject(name=name, target_uri=uri, locations=locations)
+        project = _IntersphinxProject(
+            name=name, target_uri=uri, headers={}, locations=locations
+        )
         updated = _fetch_inventory_group(
             project=project,
             cache=intersphinx_cache,
@@ -836,6 +844,7 @@ def test_intersphinx_fetch_inventory_group_url():
     with http_server(InventoryHandler) as server:
         url1 = f'http://localhost:{server.server_port}'
         url2 = f'http://localhost:{server.server_port}/'
+        headers = {'Authorization': 'Bearer abcde'}
 
         config = Config()
         config.intersphinx_cache_limit = -1
@@ -858,7 +867,7 @@ def test_intersphinx_fetch_inventory_group_url():
         side_effect = ValueError('')
 
         project1 = _IntersphinxProject(
-            name='1', target_uri=url1, locations=(url1, None)
+            name='1', target_uri=url1, headers=headers, locations=(url1, None)
         )
         with mock.patch(
             'sphinx.ext.intersphinx._load._fetch_inventory_data',
@@ -867,6 +876,7 @@ def test_intersphinx_fetch_inventory_group_url():
             assert not _fetch_inventory_group(project=project1, **kwds)
         mockfn.assert_any_call(
             target_uri=url1,
+            headers=headers,
             inv_location=url1,
             config=config,
             srcdir=None,
@@ -874,6 +884,7 @@ def test_intersphinx_fetch_inventory_group_url():
         )
         mockfn.assert_any_call(
             target_uri=url1,
+            headers=headers,
             inv_location=url1 + '/' + INVENTORY_FILENAME,
             config=config,
             srcdir=None,
@@ -881,7 +892,7 @@ def test_intersphinx_fetch_inventory_group_url():
         )
 
         project2 = _IntersphinxProject(
-            name='2', target_uri=url2, locations=(url2, None)
+            name='2', target_uri=url2, headers=headers, locations=(url2, None)
         )
         with mock.patch(
             'sphinx.ext.intersphinx._load._fetch_inventory_data',
@@ -890,6 +901,7 @@ def test_intersphinx_fetch_inventory_group_url():
             assert not _fetch_inventory_group(project=project2, **kwds)
         mockfn.assert_any_call(
             target_uri=url2,
+            headers=headers,
             inv_location=url2,
             config=config,
             srcdir=None,
@@ -897,6 +909,7 @@ def test_intersphinx_fetch_inventory_group_url():
         )
         mockfn.assert_any_call(
             target_uri=url2,
+            headers=headers,
             inv_location=url2 + INVENTORY_FILENAME,
             config=config,
             srcdir=None,
@@ -943,3 +956,76 @@ def test_display_failures():
         'intersphinx inventory has moved: - http://example.com - http://proxyhost.net'
         in issues
     )
+
+
+def test_intersphinx_project_repr_redacts_sensitive_headers():
+    url = 'http://localhost'
+    headers = {
+        'Authorization': 'Bearer abcde',
+        'X-API-Key': 'abcd123',
+        'Api-Key': 'abcd123',
+        'X-GitHub-Token': 'abcd123',
+        'X-Access-Token': '`abcd123',
+        'X-Auth-Token': 'abcd123',
+        'Private-Token': 'abcd123',
+        'Cookie': 'abcd123',
+        'X-Amz-Security-Token': 'abcd123',
+        'Proxy-Authorization': 'Basic abcd123',
+        'Digest': 'abcd123',
+        'Host': 'api.example.com',
+        'Accept': '*/*',
+        'Accept-Encoding': 'gzip',
+        'Connection': 'keep-alive',
+    }
+    project = _IntersphinxProject(
+        name='1', target_uri=url, headers=headers, locations=(url, None)
+    )
+
+    expected = {
+        'Authorization': 'redacted',
+        'X-API-Key': 'redacted',
+        'Api-Key': 'redacted',
+        'X-GitHub-Token': 'redacted',
+        'X-Access-Token': 'redacted',
+        'X-Auth-Token': 'redacted',
+        'Private-Token': 'redacted',
+        'Cookie': 'redacted',
+        'X-Amz-Security-Token': 'redacted',
+        'Proxy-Authorization': 'redacted',
+        'Digest': 'redacted',
+        'Host': 'api.example.com',
+        'Accept': '*/*',
+        'Accept-Encoding': 'gzip',
+        'Connection': 'keep-alive',
+    }
+    result = repr(project)
+
+    for k, v in expected.items():
+        assert f"'{k}': '{v}'" in result
+
+
+@pytest.mark.parametrize(
+    'args',
+    [
+        {'uri': 'https://hostname', 'inv': 'https://hostname/' + INVENTORY_FILENAME},
+        {
+            'uri': 'https://hostname',
+            'inv': 'https://hostname/' + INVENTORY_FILENAME,
+            'headers': {'Authorization': 'Bearer abcd'},
+        },
+    ],
+    ids=[
+        'positional arguments only',
+        'optional header argument',
+    ],
+)
+@mock.patch('sphinx.ext.intersphinx._load.InventoryFile')
+@mock.patch('sphinx.ext.intersphinx._load.requests.get')
+def test_fetch_inventory_interface_regression(get_request, InventoryFile, app, args):
+    mocked_get = get_request.return_value.__enter__.return_value
+    intersphinx_setup(app)
+    mocked_get.content = b'# Sphinx inventory version 2'
+    mocked_get.url = args.get('inv')
+
+    result = fetch_inventory(app, **args)
+    assert result


### PR DESCRIPTION




<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose
Add `intersphinx_request_headers` confval to allow custom HTTP headers to be set when resolving `objects.inv` on remote hosts. In particular, this enables Bearer authorization to allow access to private GitLab pages.
<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

Closes #14269
