### PR TITLE
add "refdoc" attribute to most pending_xrefs

### DIFF
--- a/sphinx/domains/c/_ast.py
+++ b/sphinx/domains/c/_ast.py
@@ -98,6 +98,7 @@ class ASTIdentifier(ASTBaseBase):
             target_text = prefix + self.name
             pnode = addnodes.pending_xref(
                 '',
+                refdoc=env.docname,
                 refdomain='c',
                 reftype='identifier',
                 reftarget=target_text,

--- a/sphinx/domains/citation.py
+++ b/sphinx/domains/citation.py
@@ -160,6 +160,7 @@ class CitationReferenceTransform(SphinxTransform):
             target = node.astext()
             ref = pending_xref(
                 target,
+                refdoc=self.env.docname,
                 refdomain='citation',
                 reftype='ref',
                 reftarget=target,

--- a/sphinx/domains/cpp/_ast.py
+++ b/sphinx/domains/cpp/_ast.py
@@ -117,6 +117,7 @@ class ASTIdentifier(ASTBase):
             target_text = prefix + self.name + templateArgs
             pnode = addnodes.pending_xref(
                 '',
+                refdoc=env.docname,
                 refdomain='cpp',
                 reftype='identifier',
                 reftarget=target_text,
@@ -143,6 +144,7 @@ class ASTIdentifier(ASTBase):
             target_text = 'operator""' + self.name
             pnode = addnodes.pending_xref(
                 '',
+                refdoc=env.docname,
                 refdomain='cpp',
                 reftype='identifier',
                 reftarget=target_text,
@@ -1617,6 +1619,7 @@ class ASTOperator(ASTBase):
             target_text = prefix + str(self) + templateArgs
             pnode = addnodes.pending_xref(
                 '',
+                refdoc=env.docname,
                 refdomain='cpp',
                 reftype='identifier',
                 reftarget=target_text,

--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -84,6 +84,7 @@ def type_to_xref(
     return pending_xref(
         '',
         *contnodes,
+        refdoc=env.docname,
         refdomain='py',
         reftype=reftype,
         reftarget=target,


### PR DESCRIPTION
## Purpose

Hello, and thanks for this great project!

I'm currently writing a [single-file builder for Typst](https://github.com/minijackson/sphinxcontrib-typstbuilder/), and I stumbled upon a problem:

In some cases, when a an object was defined in a file and referenced from another, the reference node would have a `refid` attribute, but no `refuri`, so my builder couldn't figure out the correct reference.

I found out that it was because the `pending_xref` didn't have a `refdoc` attribute indicating the document where the reference was written, and the [`_resolve_pending_xref` function assumes that this must be the current document](https://github.com/sphinx-doc/sphinx/blob/aa413156f3a8ae8b98771b60292ae11de45057d4/sphinx/transforms/post_transforms/__init__.py#L101), which isn't correct if we inline all toctrees.

This PR adds provenance information (`refdoc`) to `pending_xref`s.


<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->



<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

None?
