### PR TITLE
Fix typos in translations of config value message

### DIFF
--- a/sphinx/locale/el/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/el/LC_MESSAGES/sphinx.po
@@ -588,14 +588,14 @@ msgstr "Η τιμή παραμετροποίησης '{name}' πρέπει να 
 msgid ""
 "The config value `{name}' has type `{current.__name__}'; expected "
 "{permitted}."
-msgstr "Η τιμή παραμετροποίησης '{name]' έχει τύπο '[current__name__}'; αναμενόμενη {permitted}."
+msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current.__name__}'; αναμενόμενη {permitted}."
 
 #: config.py:846
 #, python-brace-format
 msgid ""
 "The config value `{name}' has type `{current.__name__}', defaults to "
 "`{default.__name__}'."
-msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current__name__}', αρχικοποίηση σε '{default__name__}'."
+msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current.__name__}', αρχικοποίηση σε '{default.__name__}'."
 
 #: config.py:858
 #, python-format

--- a/sphinx/locale/fa/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fa/LC_MESSAGES/sphinx.po
@@ -596,7 +596,7 @@ msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name_
 msgid ""
 "The config value `{name}' has type `{current.__name__}', defaults to "
 "`{default.__name__}'."
-msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name__}' است، حالت پیش‌فرض {permitted} است."
+msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name__}' است، حالت پیش‌فرض {default.__name__} است."
 
 #: config.py:858
 #, python-format


### PR DESCRIPTION
I don't know why this makes my (completely unrelated project's) build fail, but it does.
