### PR TITLE
Fix LaTeX builder crash on tables with no body rows

### DIFF
--- a/sphinx/builders/latex/transforms.py
+++ b/sphinx/builders/latex/transforms.py
@@ -440,10 +440,20 @@ class LaTeXFootnoteVisitor(nodes.NodeVisitor):
         self.unrestrict(node)
 
     def depart_table(self, node: nodes.table) -> None:
-        tbody = next(node.findall(nodes.tbody))
-        for footnote in reversed(self.table_footnotes):
-            fntext = footnotetext('', *footnote.children, ids=footnote['ids'])
-            tbody.insert(0, fntext)
+        tbody = next(node.findall(nodes.tbody), None)
+        if tbody is not None:
+            for footnote in reversed(self.table_footnotes):
+                fntext = footnotetext('', *footnote.children, ids=footnote['ids'])
+                tbody.insert(0, fntext)
+        else:
+            # If there is no tbody (e.g. a table with only header rows),
+            # place any collected footnotes after the table node instead.
+            table_parent = node.parent
+            if table_parent is not None:
+                idx = table_parent.index(node)
+                for i, footnote in enumerate(self.table_footnotes):
+                    fntext = footnotetext('', *footnote.children, ids=footnote['ids'])
+                    table_parent.insert(idx + i + 1, fntext)
 
         self.table_footnotes = []
 

--- a/tests/test_builders/test_build_latex.py
+++ b/tests/test_builders/test_build_latex.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import docutils
 import pygments
 import pytest
+from docutils import nodes
 
 from sphinx.builders.latex import default_latex_documents
 from sphinx.config import Config
@@ -2095,6 +2096,47 @@ def test_latex_elements_extrapackages(app: SphinxTestApp) -> None:
 def test_latex_nested_tables(app: SphinxTestApp) -> None:
     app.build(force_all=True)
     assert app.warning.getvalue() == ''
+
+
+def test_latex_table_empty_body() -> None:
+    """Regression test for issue #14271.
+
+    Tables with header rows but no body rows (as produced by e.g.
+    myst_parser from Markdown) should not crash the LaTeX builder
+    with a StopIteration in LaTeXFootnoteVisitor.depart_table.
+    """
+    from docutils.utils import new_document
+
+    from sphinx.builders.latex.transforms import LaTeXFootnoteVisitor
+
+    document = new_document('<test>')
+
+    # Build a table node with thead but no tbody, as myst_parser would
+    # generate from a Markdown table with only a header row.
+    table = nodes.table()
+    tgroup = nodes.tgroup(cols=2)
+    table += tgroup
+    tgroup += nodes.colspec(colwidth=50)
+    tgroup += nodes.colspec(colwidth=50)
+    thead = nodes.thead()
+    tgroup += thead
+    row = nodes.row()
+    thead += row
+    entry1 = nodes.entry()
+    entry1 += nodes.paragraph(text='Header 1')
+    row += entry1
+    entry2 = nodes.entry()
+    entry2 += nodes.paragraph(text='Header 2')
+    row += entry2
+
+    section = nodes.section()
+    section += table
+    document += section
+
+    # This should not raise StopIteration
+    visitor = LaTeXFootnoteVisitor(document, [])
+    visitor.table_footnotes = []
+    table.walkabout(visitor)
 
 
 @pytest.mark.sphinx('latex', testroot='latex-container')


### PR DESCRIPTION
## Summary

Fixes #14271.

`LaTeXFootnoteVisitor.depart_table()` unconditionally calls `next(node.findall(nodes.tbody))`, which raises `StopIteration` when a table has header rows but no body rows. This happens when external parsers like myst_parser produce a docutils table node tree from Markdown tables that have only a header row (e.g. `| Key | P | Summary |\n| --- | --- | --- |`).

**The fix:**
- Use `next(..., None)` to safely handle the missing `tbody`
- When `tbody` is present, behavior is unchanged (footnotes are inserted at the head of tbody)
- When `tbody` is absent, any collected table footnotes are placed after the table node instead, preserving footnote rendering

**Test:**
- Added `test_latex_table_empty_body` which constructs a table node with `thead` but no `tbody` (mirroring what myst_parser produces) and verifies that `LaTeXFootnoteVisitor` processes it without raising `StopIteration`
- Verified the test fails with `StopIteration` on the unfixed code and passes with the fix
- All existing LaTeX builder tests continue to pass

## Test plan

- [x] New unit test `test_latex_table_empty_body` passes
- [x] All existing LaTeX table tests pass (9/9)
- [x] All existing LaTeX footnote tests pass (5/5)
- [x] Full LaTeX test suite passes (82 passed, 11 skipped for missing LaTeX styles)
- [x] `ruff check` passes on both modified files