### PR TITLE
Fix none type link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -191,3 +191,4 @@ usecase-driven documentation, see :ref:`get-started` or :ref:`user-guides`.
    glossary
    changes/index
    examples
+      

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -191,4 +191,4 @@ usecase-driven documentation, see :ref:`get-started` or :ref:`user-guides`.
    glossary
    changes/index
    examples
-      
+

--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -151,16 +151,24 @@ class PyXrefMixin:
 
 
 class PyField(PyXrefMixin, Field):
-    def make_xref(self, rolename: str, domain: str, target: str,
-                  innernode: type[TextlikeNode] = nodes.emphasis,
-                  contnode: Node | None = None, env: BuildEnvironment | None = None,
-                  inliner: Inliner | None = None, location: Node | None = None) -> Node:
+    def make_xref(
+        self,
+        rolename: str,
+        domain: str,
+        target: str,
+        innernode: type[TextlikeNode] = nodes.emphasis,
+        contnode: Node | None = None,
+        env: BuildEnvironment | None = None,
+        inliner: Inliner | None = None,
+        location: Node | None = None,
+    ) -> Node:
         if rolename == 'class' and target == 'None':
             # None is not a type, so use obj role instead.
             rolename = 'obj'
 
-        return super().make_xref(rolename, domain, target, innernode, contnode,
-                                 env, inliner, location)
+        return super().make_xref(
+            rolename, domain, target, innernode, contnode, env, inliner, location
+        )
 
 
 class PyGroupedField(PyXrefMixin, GroupedField):
@@ -168,16 +176,24 @@ class PyGroupedField(PyXrefMixin, GroupedField):
 
 
 class PyTypedField(PyXrefMixin, TypedField):
-    def make_xref(self, rolename: str, domain: str, target: str,
-                  innernode: type[TextlikeNode] = nodes.emphasis,
-                  contnode: Node | None = None, env: BuildEnvironment | None = None,
-                  inliner: Inliner | None = None, location: Node | None = None) -> Node:
+    def make_xref(
+        self,
+        rolename: str,
+        domain: str,
+        target: str,
+        innernode: type[TextlikeNode] = nodes.emphasis,
+        contnode: Node | None = None,
+        env: BuildEnvironment | None = None,
+        inliner: Inliner | None = None,
+        location: Node | None = None,
+    ) -> Node:
         if rolename == 'class' and target == 'None':
             # None is not a type, so use obj role instead.
             rolename = 'obj'
 
-        return super().make_xref(rolename, domain, target, innernode, contnode,
-                                 env, inliner, location)
+        return super().make_xref(
+            rolename, domain, target, innernode, contnode, env, inliner, location
+        )
 
 
 class PyObject(ObjectDescription[tuple[str, str]]):

--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import re
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -152,9 +152,9 @@ class PyXrefMixin:
 
 class PyField(PyXrefMixin, Field):
     def make_xref(self, rolename: str, domain: str, target: str,
-                  innernode: Type[TextlikeNode] = nodes.emphasis,
-                  contnode: Node = None, env: BuildEnvironment = None,
-                  inliner: Inliner = None, location: Node = None) -> Node:
+                  innernode: type[TextlikeNode] = nodes.emphasis,
+                  contnode: Node | None = None, env: BuildEnvironment | None = None,
+                  inliner: Inliner | None = None, location: Node | None = None) -> Node:
         if rolename == 'class' and target == 'None':
             # None is not a type, so use obj role instead.
             rolename = 'obj'
@@ -169,9 +169,9 @@ class PyGroupedField(PyXrefMixin, GroupedField):
 
 class PyTypedField(PyXrefMixin, TypedField):
     def make_xref(self, rolename: str, domain: str, target: str,
-                  innernode: Type[TextlikeNode] = nodes.emphasis,
-                  contnode: Node = None, env: BuildEnvironment = None,
-                  inliner: Inliner = None, location: Node = None) -> Node:
+                  innernode: type[TextlikeNode] = nodes.emphasis,
+                  contnode: Node | None = None, env: BuildEnvironment | None = None,
+                  inliner: Inliner | None = None, location: Node | None = None) -> Node:
         if rolename == 'class' and target == 'None':
             # None is not a type, so use obj role instead.
             rolename = 'obj'

--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -151,7 +151,16 @@ class PyXrefMixin:
 
 
 class PyField(PyXrefMixin, Field):
-    pass
+    def make_xref(self, rolename: str, domain: str, target: str,
+                  innernode: Type[TextlikeNode] = nodes.emphasis,
+                  contnode: Node = None, env: BuildEnvironment = None,
+                  inliner: Inliner = None, location: Node = None) -> Node:
+        if rolename == 'class' and target == 'None':
+            # None is not a type, so use obj role instead.
+            rolename = 'obj'
+
+        return super().make_xref(rolename, domain, target, innernode, contnode,
+                                 env, inliner, location)
 
 
 class PyGroupedField(PyXrefMixin, GroupedField):
@@ -159,7 +168,16 @@ class PyGroupedField(PyXrefMixin, GroupedField):
 
 
 class PyTypedField(PyXrefMixin, TypedField):
-    pass
+    def make_xref(self, rolename: str, domain: str, target: str,
+                  innernode: Type[TextlikeNode] = nodes.emphasis,
+                  contnode: Node = None, env: BuildEnvironment = None,
+                  inliner: Inliner = None, location: Node = None) -> Node:
+        if rolename == 'class' and target == 'None':
+            # None is not a type, so use obj role instead.
+            rolename = 'obj'
+
+        return super().make_xref(rolename, domain, target, innernode, contnode,
+                                 env, inliner, location)
 
 
 class PyObject(ObjectDescription[tuple[str, str]]):

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -239,6 +239,7 @@ def _is_unpack_form(obj: Any) -> bool:
 
 
 def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> str:
+    
     """Convert a type-like object to a reST reference.
 
     :param mode: Specify a method how annotations will be stringified.
@@ -249,8 +250,10 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                  'smart'
                      Show the name of the annotation.
     """
+    
     from sphinx.ext.autodoc._dynamic._mock import ismock, ismockmodule  # lazy loading
     from sphinx.util.inspect import isgenericalias, object_description  # lazy loading
+    
 
     valid_modes = {'fully-qualified-except-typing', 'smart'}
     if mode not in valid_modes:
@@ -261,6 +264,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
     # things that are not types
     if cls is None or cls == types.NoneType:
         return ':py:obj:`None`'
+
     if cls is Ellipsis:
         return '...'
     if isinstance(cls, str):

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -239,7 +239,6 @@ def _is_unpack_form(obj: Any) -> bool:
 
 
 def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> str:
-    
     """Convert a type-like object to a reST reference.
 
     :param mode: Specify a method how annotations will be stringified.
@@ -250,10 +249,8 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                  'smart'
                      Show the name of the annotation.
     """
-    
     from sphinx.ext.autodoc._dynamic._mock import ismock, ismockmodule  # lazy loading
     from sphinx.util.inspect import isgenericalias, object_description  # lazy loading
-    
 
     valid_modes = {'fully-qualified-except-typing', 'smart'}
     if mode not in valid_modes:


### PR DESCRIPTION
This PR restores the hyperlink for None in type annotations, which stopped working after Sphinx 4.4.0.

The previous commit (5da68c3) removed special handling for None. I added that logic back in PyField and PyTypedField classes. None should be handled as an object reference (:obj:) not as a class reference (:class:).

##Testing
I ran all Python domain tests (98 tests passed).
I created a small test document using None in type hints.
Verified that None is now clickable and properly linked again.

## Note on failing CI checks

The following test failures appear to be pre existing issues unrelated to this PR:

- test_autogen
- test_autogen_remove_old
- test_numfig_disabled_warn

These tests are failing on the main branch as well and are not caused by the changes in this PR. 

##My changes only touch:
- sphinx/domains/python/_object.py - restored `None` hyperlink handling
- sphinx/util/typing.py  and doc/index.rst - fixed formatting issues

References
fixes #10899