### PR TITLE
fix mock objects not supporting | union type operator

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -72,6 +72,12 @@ class _MockObject:
         call.__sphinx_decorator_args__ = args
         return call
 
+    def __or__(self, other: Any) -> _MockObject:
+        return self
+
+    def __ror__(self, other: Any) -> _MockObject:
+        return self
+
     def __repr__(self) -> str:
         return self.__display_name__
 

--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
+import types
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from types import MethodType, ModuleType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sphinx.ext.autodoc._shared import LOGGER
 from sphinx.util.inspect import isboundmethod, safe_getattr
 
 if TYPE_CHECKING:
-    import types
     from collections.abc import Iterator, Sequence, Set
     from typing import Any
 
@@ -82,9 +82,9 @@ class _MockObject:
         # Construct a real types.UnionType. If 'other' supports |, use it;
         # otherwise fall back to a placeholder so the call doesn't recurse.
         try:
-            return other | type(self)
+            return cast(types.UnionType, other | type(self))
         except TypeError:
-            return object | type(self)
+            return cast(types.UnionType, object | type(self))
 
     def __repr__(self) -> str:
         return self.__display_name__

--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -5,20 +5,24 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-import types
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from types import MethodType, ModuleType
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from sphinx.ext.autodoc._shared import LOGGER
 from sphinx.util.inspect import isboundmethod, safe_getattr
 
 if TYPE_CHECKING:
+    import types
     from collections.abc import Iterator, Sequence, Set
     from typing import Any
 
     from typing_extensions import TypeIs
+
+
+def _as_union_type(value: Any) -> types.UnionType:
+    return value
 
 
 class _MockObject:
@@ -82,9 +86,9 @@ class _MockObject:
         # Construct a real types.UnionType. If 'other' supports |, use it;
         # otherwise fall back to a placeholder so the call doesn't recurse.
         try:
-            return cast(types.UnionType, other | type(self))
+            return _as_union_type(other | type(self))
         except TypeError:
-            return cast(types.UnionType, object | type(self))
+            return _as_union_type(object | type(self))
 
     def __repr__(self) -> str:
         return self.__display_name__

--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
+import typing
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from types import MethodType, ModuleType
@@ -14,6 +15,7 @@ from sphinx.ext.autodoc._shared import LOGGER
 from sphinx.util.inspect import isboundmethod, safe_getattr
 
 if TYPE_CHECKING:
+    import types
     from collections.abc import Iterator, Sequence, Set
     from typing import Any
 
@@ -72,11 +74,11 @@ class _MockObject:
         call.__sphinx_decorator_args__ = args
         return call
 
-    def __or__(self, other: Any) -> _MockObject:
-        return self
+    def __or__(self, other: Any) -> types.UnionType:
+        return typing.Union[self, other]  # noqa: UP007
 
-    def __ror__(self, other: Any) -> _MockObject:
-        return self
+    def __ror__(self, other: Any) -> types.UnionType:
+        return typing.Union[other, self]  # noqa: UP007
 
     def __repr__(self) -> str:
         return self.__display_name__

--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-import typing
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from types import MethodType, ModuleType
@@ -75,10 +74,17 @@ class _MockObject:
         return call
 
     def __or__(self, other: Any) -> types.UnionType:
-        return typing.Union[self, other]  # noqa: UP007
+        # Use the mock class itself in the | operator so the result is a real
+        # types.UnionType (PEP 604) rather than a typing._SpecialGenericAlias.
+        return type(self) | other
 
     def __ror__(self, other: Any) -> types.UnionType:
-        return typing.Union[other, self]  # noqa: UP007
+        # Construct a real types.UnionType. If 'other' supports |, use it;
+        # otherwise fall back to a placeholder so the call doesn't recurse.
+        try:
+            return other | type(self)
+        except TypeError:
+            return object | type(self)
 
     def __repr__(self) -> str:
         return self.__display_name__

--- a/tests/test_ext_autodoc/test_ext_autodoc_mock.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_mock.py
@@ -64,6 +64,20 @@ def test_MockObject() -> None:
     assert isinstance(obj2, SubClass2)
 
 
+def test_MockObject_union_type() -> None:
+    mock = _MockObject()
+
+    # PEP 604: X | Y union syntax should work with mock objects
+    result = mock.SomeClass | None
+    assert isinstance(result, _MockObject)
+
+    result = None | mock.SomeClass
+    assert isinstance(result, _MockObject)
+
+    result = mock.SomeClass | mock.OtherClass
+    assert isinstance(result, _MockObject)
+
+
 def test_MockObject_generic() -> None:
     mock = _MockObject()
 

--- a/tests/test_ext_autodoc/test_ext_autodoc_mock.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_mock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import sys
+import types
 from importlib import import_module
 from typing import Generic, TypeVar
 
@@ -67,15 +68,15 @@ def test_MockObject() -> None:
 def test_MockObject_union_type() -> None:
     mock = _MockObject()
 
-    # PEP 604: X | Y union syntax should work with mock objects
+    # PEP 604: X | Y union syntax should return proper Union types
     result = mock.SomeClass | None
-    assert isinstance(result, _MockObject)
+    assert isinstance(result, types.UnionType)
 
-    result = None | mock.SomeClass
-    assert isinstance(result, _MockObject)
+    result = None | mock.SomeClass  # noqa: RUF036
+    assert isinstance(result, types.UnionType)
 
     result = mock.SomeClass | mock.OtherClass
-    assert isinstance(result, _MockObject)
+    assert isinstance(result, types.UnionType)
 
 
 def test_MockObject_generic() -> None:


### PR DESCRIPTION
The `_MockObject` class used by `autodoc_mock_imports` didn't define `__or__` or `__ror__`, so PEP 604 union syntax like `mock_module.MyClass | None` raised `TypeError`. Python's data model requires these dunder methods on the class itself — `__getattr__` doesn't get called for operators.

Added `__or__` and `__ror__` to `_MockObject` so unions with mock objects work. Also added a test.

Closes #14300