### PR TITLE
fix: versionadded (etc) directives had incorrect paragraph line numbers

### DIFF
--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -313,10 +313,10 @@ Version markup
 
    Second paragraph of version-changed.
 
-.. version-added:: 0.6
+.. versionadded:: 0.6
    Deprecated alias for version-added.
 
-.. version-changed:: 0.6
+.. versionchanged:: 0.6
    Deprecated alias for version-changed.
 
 .. deprecated:: 0.6

--- a/tests/roots/test-root/markup.txt
+++ b/tests/roots/test-root/markup.txt
@@ -295,6 +295,11 @@ Version markup
 .. version-added:: 0.6
    Some funny **stuff**.
 
+.. version-added:: 0.6.1
+   Some more funny **stuff**
+   that took much more text
+   to describe.
+
 .. version-changed:: 0.6
    Even more funny stuff.
 
@@ -308,10 +313,21 @@ Version markup
 
    First paragraph of version-added.
 
+.. version-added:: 1.2.1
+
+   First paragraph of version-added.
+   With multiple lines.
+
 .. version-changed:: 1.2
    First paragraph of version-changed.
 
    Second paragraph of version-changed.
+
+.. version-changed:: 3.14 This was the pi release.
+
+.. version-changed:: 3.1416 This was the pi release.
+   It was great because pi is trancendental
+   and has a lot of digits.
 
 .. versionadded:: 0.6
    Deprecated alias for version-added.


### PR DESCRIPTION
In using the docutils doctree to analyze links in .rst files, I found that the paragraphs following `versionadded` directives had the wrong line numbers: instead of being the number of the first line of the paragraph, they has the number of the first line after the paragraph.

I believe this fixes the problem.

I don't know why, but without this fix, errors in `versionadded` paragraphs have the correct line numbers, and with this fix, they still have the correct line numbers. Insights appreciated.