### PR TITLE
linkcheck: netiquette: autoignore RFC2606 reserved domain names

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -295,7 +295,6 @@ class Hyperlink(NamedTuple):
 
 
 class HyperlinkAvailabilityChecker:
-
     # https://datatracker.ietf.org/doc/html/rfc2606#section-2
     # ... minus https://github.com/sphinx-doc/sphinx/issues/14307#issuecomment-3910787066
     IETF_RESERVED_TLDS = frozenset({

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -295,6 +295,23 @@ class Hyperlink(NamedTuple):
 
 
 class HyperlinkAvailabilityChecker:
+
+    # https://datatracker.ietf.org/doc/html/rfc2606#section-2
+    # ... minus https://github.com/sphinx-doc/sphinx/issues/14307#issuecomment-3910787066
+    IETF_RESERVED_TLDS = frozenset({
+        # "test",
+        'example',
+        'invalid',
+        # "localhost",
+    })
+
+    # https://datatracker.ietf.org/doc/html/rfc2606#section-3
+    IETF_RESERVED_DOMAINS = frozenset({
+        'example.com',
+        'example.net',
+        'example.org',
+    })
+
     def __init__(self, config: Config) -> None:
         self.config = config
         self.rate_limits: dict[str, RateLimit] = {}
@@ -346,6 +363,14 @@ class HyperlinkAvailabilityChecker:
             self.wqueue.put(CheckRequest(CHECK_IMMEDIATELY, None), False)
 
     def is_ignored_uri(self, uri: str) -> bool:
+        netloc = urlsplit(uri).netloc
+        if any(netloc.endswith(domain) for domain in self.IETF_RESERVED_DOMAINS):
+            return True
+
+        domain, _, tld = netloc.rpartition('.')
+        if domain and tld and tld in self.IETF_RESERVED_TLDS:
+            return True
+
         return any(pat.match(uri) for pat in self.to_ignore)
 
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1328,7 +1328,7 @@ def test_limit_rate_doubles_previous_wait_time(app: SphinxTestApp) -> None:
         (None, 'https://subdomain.of.invalid/yet/another/ignorable/url.html', True),
     ],
 )
-def test_uri_should_be_ignored(ignore_pattern, input_url, url_should_be_ignored):
+def test_uri_should_be_ignored(ignore_pattern, input_url, url_should_be_ignored) -> None:
     """Test the logic that determines whether URLs should be ignored"""
     ignore_patterns = [ignore_pattern] if ignore_pattern else []
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1328,7 +1328,11 @@ def test_limit_rate_doubles_previous_wait_time(app: SphinxTestApp) -> None:
         (None, 'https://subdomain.of.invalid/yet/another/ignorable/url.html', True),
     ],
 )
-def test_uri_should_be_ignored(ignore_pattern, input_url, url_should_be_ignored) -> None:
+def test_uri_should_be_ignored(
+    ignore_pattern: str | None,
+    input_url: str,
+    url_should_be_ignored: bool
+) -> None:
     """Test the logic that determines whether URLs should be ignored"""
     ignore_patterns = [ignore_pattern] if ignore_pattern else []
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1325,6 +1325,7 @@ def test_limit_rate_doubles_previous_wait_time(app: SphinxTestApp) -> None:
         (None, 'https://example.org', True),
         (None, 'https://example.com/some/random/path.html', True),
         (None, 'https://unresolvable.invalid/another/invalid/url.html#fragment', True),
+        (None, 'https://subdomain.of.invalid/yet/another/ignorable/url.html', True),
     ],
 )
 def test_uri_should_be_ignored(ignore_pattern, input_url, url_should_be_ignored):

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1322,7 +1322,9 @@ def test_limit_rate_doubles_previous_wait_time(app: SphinxTestApp) -> None:
         (None, 'http://www.sphinx-doc.org', False),
         (r'http://www.sphinx-doc.org/', 'http://www.sphinx-doc.org', False),
         (r'http://www.sphinx-doc.org/.*', 'http://www.sphinx-doc.org/robots.txt', True),
-        # (None, 'https://example.org', True),  # TODO: automatically ignore IETF reserved domains
+        (None, 'https://example.org', True),
+        (None, 'https://example.com/some/random/path.html', True),
+        (None, 'https://unresolvable.invalid/another/invalid/url.html#fragment', True),
     ],
 )
 def test_uri_should_be_ignored(ignore_pattern, input_url, url_should_be_ignored):

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1331,7 +1331,7 @@ def test_limit_rate_doubles_previous_wait_time(app: SphinxTestApp) -> None:
 def test_uri_should_be_ignored(
     ignore_pattern: str | None,
     input_url: str,
-    url_should_be_ignored: bool
+    url_should_be_ignored: bool,
 ) -> None:
     """Test the logic that determines whether URLs should be ignored"""
     ignore_patterns = [ignore_pattern] if ignore_pattern else []

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -23,10 +23,12 @@ from sphinx._cli.util.errors import strip_escape_sequences
 from sphinx.builders.linkcheck import (
     CheckRequest,
     Hyperlink,
+    HyperlinkAvailabilityChecker,
     HyperlinkAvailabilityCheckWorker,
     RateLimit,
     compile_linkcheck_allowed_redirects,
 )
+from sphinx.config import Config
 from sphinx.errors import ConfigError
 from sphinx.testing.util import SphinxTestApp
 from sphinx.util import requests
@@ -1312,6 +1314,29 @@ def test_limit_rate_doubles_previous_wait_time(app: SphinxTestApp) -> None:
             FakeResponse.url, FakeResponse.headers.get('Retry-After')
         )
     assert next_check == 120.0
+
+
+@pytest.mark.parametrize(
+    ('ignore_pattern', 'input_url', 'url_should_be_ignored'),
+    [
+        (None, 'http://www.sphinx-doc.org', False),
+        (r'http://www.sphinx-doc.org/', 'http://www.sphinx-doc.org', False),
+        (r'http://www.sphinx-doc.org/.*', 'http://www.sphinx-doc.org/robots.txt', True),
+        # (None, 'https://example.org', True),  # TODO: automatically ignore IETF reserved domains
+    ],
+)
+def test_uri_should_be_ignored(ignore_pattern, input_url, url_should_be_ignored):
+    """Test the logic that determines whether URLs should be ignored"""
+    ignore_patterns = [ignore_pattern] if ignore_pattern else []
+
+    config = Config()
+    config.linkcheck_workers = None
+    config.linkcheck_ignore = ignore_patterns
+    checker = HyperlinkAvailabilityChecker(config=config)
+
+    result = checker.is_ignored_uri(input_url)
+
+    assert result == url_should_be_ignored
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
## Purpose
I don't think that it is useful for the `linkcheck` builder to make HTTP requests to the IETF-reserved domain names outlined in [RFC2606](https://datatracker.ietf.org/doc/html/rfc2606).  This recently came up as a tangential discussion from: https://github.com/sphinx-doc/sphinx/issues/12985#issuecomment-3904398311

This pull request implements some logic to ignore the relevant top-level-domains (TLDs) and second-level domains automatically.

## References
Resolves #14307.