### PR TITLE
Add aria-label to graphviz object

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -388,7 +388,8 @@ def render_dot_html(
         if format == 'svg':
             self.body.append('<div class="graphviz">')
             self.body.append(
-                f'<object data="{src}" type="image/svg+xml" class="{imgcls}">\n'
+                f'<object data="{src}" type="image/svg+xml"'
+                f' class="{imgcls}" aria-label="{alt}">\n'
             )
             self.body.append(f'<p class="warning">{alt}</p>')
             self.body.append('</object></div>\n')


### PR DESCRIPTION
The "alt" attribute for a graphviz object is now also added as an "aria-label" attribute to the graphviz svg object, and not just as a fallback element within the object element. This allows screen readers to properly pick it up.

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Ensure HTML pages using `.. graphviz::` are accessible.

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

N/A