### PR TITLE
docutils: allow overriding warning and log level

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -103,6 +103,7 @@ Contributors
 * Pauli Virtanen -- autodoc improvements, autosummary extension
 * Rafael Fontenelle -- internationalisation
 * \A. Rafey Khan -- improved intersphinx typing
+* Randolph Sapp -- docutils logging configuration options
 * Rui Pinheiro -- Python 3.14 forward references support
 * Roland Meister -- epub builder
 * Sebastian Wiesner -- image handling, distutils support

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Features added
 * Add :meth:`~sphinx.application.Sphinx.add_static_dir` for copying static
   assets from extensions to the build output.
   Patch by Jared Dillard
+* Docutils: Add :confval:`docutils_report_level` for changing the default
+  reporting level of Docutils. Also add :confval:`docutils_warning_level` to
+  change the level of Docutils logs to be interpreted as warnings.
+  Patch by Randolph Sapp
 
 Bugs fixed
 ----------

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -317,6 +317,35 @@ General configuration
    (or, if translation is enabled with :confval:`language`,
    an equivalent format for the selected locale).
 
+.. confval:: docutils_report_level
+   :type: :code-py:`int`
+   :default: :code-py:`2`
+
+   This value sets the minimum Docutils reporting level. This numeric value
+   follows the level values reported in `Docutils PEP-0258 Error Handling`_.
+   Defaults to :code-py:`2`, which is ``WARNING``.
+
+   This can be useful if you want to extract additional information from
+   Docutils builds.
+
+   .. versionadded:: 1.9
+
+.. confval:: docutils_warning_level
+   :type: :code-py:`int`
+   :default: :code-py:`2`
+
+   This value sets the minimum internal Docutils reporting level to be
+   interpreted as a Sphinx warning. This numeric value follows the level values
+   reported in `Docutils PEP-0258 Error Handling`_. Defaults to :code-py:`2`,
+   which is ``WARNING``.
+
+   This can be useful if you want to use the warning stream created by Sphinx as
+   a linter check and would like some additional reporting from Docutils to be
+   included.
+
+   .. versionadded:: 1.9
+
+.. _`Docutils PEP-0258 Error Handling`: https://www.docutils.org/docs/peps/pep-0258.html#error-handling
 
 Options for figure numbering
 ----------------------------

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -294,6 +294,9 @@ class Config:
             frozenset((dict,)),
         ),
         'option_emphasise_placeholders': _Opt(False, 'env', frozenset((bool,))),
+        # docutils overrides
+        'docutils_report_level': _Opt(2, 'env', frozenset((int,))),
+        'docutils_warning_level': _Opt(2, 'env', frozenset((int,))),
     }
 
     def __init__(

--- a/sphinx/environment/__init__.py
+++ b/sphinx/environment/__init__.py
@@ -377,6 +377,7 @@ class BuildEnvironment:
             config.trim_footnote_reference_space
         )
         self.settings['language_code'] = config.language
+        self.settings['report_level'] = config.docutils_report_level
 
         # Allow to disable by 3rd party extension (workaround)
         self.settings.setdefault('smart_quotes', True)
@@ -658,7 +659,7 @@ class BuildEnvironment:
 
         doctree = pickle.loads(serialised)
         doctree.settings.env = self
-        doctree.reporter = LoggingReporter(str(self.doc2path(docname)))
+        doctree.reporter = LoggingReporter(str(self.doc2path(docname)), self)
         return doctree
 
     @functools.cached_property
@@ -691,7 +692,7 @@ class BuildEnvironment:
             try:
                 doctree = self._write_doc_doctree_cache.pop(docname)
                 doctree.settings.env = self
-                doctree.reporter = LoggingReporter(str(self.doc2path(docname)))
+                doctree.reporter = LoggingReporter(str(self.doc2path(docname)), self)
             except KeyError:
                 doctree = self.get_doctree(docname)
 

--- a/sphinx/io.py
+++ b/sphinx/io.py
@@ -71,7 +71,7 @@ class SphinxBaseReader(standalone.Reader):  # type: ignore[type-arg]
 
         # substitute reporter
         reporter = document.reporter
-        document.reporter = LoggingReporter.from_reporter(reporter)
+        document.reporter = LoggingReporter.from_reporter(reporter, self.settings.env)
 
         return document
 

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -74,7 +74,7 @@ def _publish_msgstr(
     doc = docutils.utils.new_document(
         f'{source_path}:{source_line}:<translated>', settings
     )
-    doc.reporter = LoggingReporter.from_reporter(doc.reporter)
+    doc.reporter = LoggingReporter.from_reporter(doc.reporter, env)
 
     # clear rst_prolog temporarily
     rst_prolog = config.rst_prolog

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -383,6 +383,11 @@ class sphinx_domains(CustomReSTDispatcher):
 
 
 class WarningStream:
+    env: BuildEnvironment
+
+    def __init__(self, env: BuildEnvironment):
+        self.env = env
+
     def write(self, text: str) -> None:
         matched = report_re.search(text)
         if not matched:
@@ -390,17 +395,21 @@ class WarningStream:
         else:
             location, type, _level = matched.groups()
             message = report_re.sub('', text).rstrip()
+            numeric_level = Reporter.levels.index(type)
+            if numeric_level >= self.env.config.docutils_warning_level:
+                type = max(logging.LEVEL_NAMES["WARNING"], logging.LEVEL_NAMES[message])
             logger.log(type, message, location=location, type='docutils')
 
 
 class LoggingReporter(Reporter):
     @classmethod
     def from_reporter(
-        cls: type[LoggingReporter], reporter: Reporter
+        cls: type[LoggingReporter], reporter: Reporter, env: BuildEnvironment,
     ) -> LoggingReporter:
         """Create an instance of LoggingReporter from other reporter object."""
         return cls(
             reporter.source,
+            env,
             reporter.report_level,
             reporter.halt_level,
             reporter.debug_flag,
@@ -410,12 +419,13 @@ class LoggingReporter(Reporter):
     def __init__(
         self,
         source: str,
+        env: BuildEnvironment,
         report_level: int = Reporter.WARNING_LEVEL,
         halt_level: int = Reporter.SEVERE_LEVEL,
         debug: bool = False,
         error_handler: str = 'backslashreplace',
     ) -> None:
-        stream = WarningStream()
+        stream = WarningStream(env)
         super().__init__(
             source, report_level, halt_level, stream, debug, error_handler=error_handler
         )
@@ -867,6 +877,7 @@ def _parse_str_to_doctree(
     # Create root document node
     reporter = LoggingReporter(
         source=str(filename),
+        env=env,
         report_level=settings.report_level,
         halt_level=settings.halt_level,
         debug=settings.debug,


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Add configuration parameters to increase the logging from Docutils, as it often reports useful messages as "INFO". Also provide an override parameter to bump these messages to "WARNING" if inclined.

Examples include when improper formatting causes numbered lists to break up into separate entities. Also alerts where duplicate implicit / targets begin to break HTML permalinks and other reference mechanics.