### PR TITLE
Permit `_AttrGetter` to override absent docstrings from `__slots__`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -124,6 +124,7 @@ Contributors
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder
 * Zac Hatfield-Dodds -- doctest reporting improvements, intersphinx performance
+* Zachary Spector -- member finder fix for custom ``attrgetter`` with ``__slots__``
 
 Former maintainers
 ==================

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -123,6 +123,7 @@ Contributors
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder
 * Zac Hatfield-Dodds -- doctest reporting improvements, intersphinx performance
+* Zachary Spector -- member finder fix for custom ``attrgetter`` with ``__slots__``
 
 Former maintainers
 ==================

--- a/sphinx/ext/autodoc/_dynamic/_member_finder.py
+++ b/sphinx/ext/autodoc/_dynamic/_member_finder.py
@@ -329,7 +329,10 @@ def _get_members_to_document(
                 unmangled = unmangle(props._obj, name)
                 if (
                     unmangled
-                    and unmangled not in object_members_map
+                    and (
+                        unmangled not in object_members_map
+                        or object_members_map[unmangled].docstring is None
+                    )
                     and unmangled in wanted_members
                 ):
                     if name in obj_dict:


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

Last year, [attrs](https://github.com/python-attrs/attrs) changed its implementation of `@cached_property` on classes with slots in a way that made those properties invisible to Sphinx's autodoc. It now writes a custom `__getattr__` that accesses the slot by the same name as the property.

Sphinx has an easy solution: the `add_autodoc_attrgetter` hook lets us swap in the original `cached_property` for documentation purposes. This works fine for the `.. autoproperty` directive. However, I also wanted the `:members:` option of `.. autoclass` to pick up any `@cached_property` decorated in the class definition. This did not work, because the member-finder code didn't anticipate the necessity. Once it finds the slots member, it considers the member found, even if there's no docstring for it.

This PR lets the general member-finding code for classes override an earlier result, in the case that the prior `ObjectMember` has no `docstring`. The special `attrgetter` code gets a chance to run, and delivers the object we really want to document.

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- attrs issue [#1325](https://github.com/python-attrs/attrs/issues/1325)
