### PR TITLE
Fix #10899: Restore None hyperlink in py domain

### DIFF
--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -151,7 +151,24 @@ class PyXrefMixin:
 
 
 class PyField(PyXrefMixin, Field):
-    pass
+    def make_xref(
+        self,
+        rolename: str,
+        domain: str,
+        target: str,
+        innernode: type[TextlikeNode] = nodes.emphasis,
+        contnode: Node | None = None,
+        env: BuildEnvironment | None = None,
+        inliner: Inliner | None = None,
+        location: Node | None = None,
+    ) -> Node:
+        if rolename == 'class' and target == 'None':
+            # None is not a type, so use obj role instead.
+            rolename = 'obj'
+
+        return super().make_xref(
+            rolename, domain, target, innernode, contnode, env, inliner, location
+        )
 
 
 class PyGroupedField(PyXrefMixin, GroupedField):
@@ -159,7 +176,24 @@ class PyGroupedField(PyXrefMixin, GroupedField):
 
 
 class PyTypedField(PyXrefMixin, TypedField):
-    pass
+    def make_xref(
+        self,
+        rolename: str,
+        domain: str,
+        target: str,
+        innernode: type[TextlikeNode] = nodes.emphasis,
+        contnode: Node | None = None,
+        env: BuildEnvironment | None = None,
+        inliner: Inliner | None = None,
+        location: Node | None = None,
+    ) -> Node:
+        if rolename == 'class' and target == 'None':
+            # None is not a type, so use obj role instead.
+            rolename = 'obj'
+
+        return super().make_xref(
+            rolename, domain, target, innernode, contnode, env, inliner, location
+        )
 
 
 class PyObject(ObjectDescription[tuple[str, str]]):

--- a/tests/test_domains/test_domain_py_fields.py
+++ b/tests/test_domains/test_domain_py_fields.py
@@ -609,3 +609,29 @@ def test_type_field(app):
         reftarget='typing.Any',
         refspecific=False,
     )
+
+
+@pytest.mark.sphinx('html', testroot='_blank')
+def test_none_type_xref(app):
+    """Test that None type is properly linked with the obj role."""
+    text = (
+        '.. py:module:: example\n'
+        '.. py:function:: func(param: str | None) -> None\n'
+        '\n'
+        '   :param param: A parameter\n'
+        '   :return: Nothing\n'
+    )
+    doctree = restructuredtext.parse(app, text)
+
+    # Find the None xref nodes in the function signature
+    # They should use the 'obj' role, not 'class'
+    xrefs = [node for node in doctree.traverse() if isinstance(node, pending_xref)]
+    
+    # Check that there are xref nodes for None
+    none_xrefs = [xref for xref in xrefs if xref.astext() == 'None']
+    assert len(none_xrefs) >= 1, 'Expected at least one None xref'
+    
+    # Verify that None xrefs have the correct role
+    for none_xref in none_xrefs:
+        # The reftype should be 'obj' not 'class' for None
+        assert none_xref.get('reftype') in ['obj', 'class'] or 'reftype' not in none_xref

--- a/tests/test_domains/test_domain_py_fields.py
+++ b/tests/test_domains/test_domain_py_fields.py
@@ -619,19 +619,21 @@ def test_none_type_xref(app):
         '.. py:function:: func(param: str | None) -> None\n'
         '\n'
         '   :param param: A parameter\n'
+        '   :type param: str | None\n'
         '   :return: Nothing\n'
+        '   :rtype: None\n'
     )
     doctree = restructuredtext.parse(app, text)
 
-    # Find the None xref nodes in the function signature
+    # Find the None xref nodes in the function signature and docstring fields
     # They should use the 'obj' role, not 'class'
     xrefs = [node for node in doctree.traverse() if isinstance(node, pending_xref)]
-    
+
     # Check that there are xref nodes for None
     none_xrefs = [xref for xref in xrefs if xref.astext() == 'None']
     assert len(none_xrefs) >= 1, 'Expected at least one None xref'
-    
-    # Verify that None xrefs have the correct role
+
+    # Verify that all None xrefs have the correct role
     for none_xref in none_xrefs:
-        # The reftype should be 'obj' not 'class' for None
-        assert none_xref.get('reftype') in ['obj', 'class'] or 'reftype' not in none_xref
+        # The reftype should be exactly 'obj' for None
+        assert none_xref.get('reftype') == 'obj'


### PR DESCRIPTION
## Description

Since Sphinx 4.4.0, the `None` singleton is no longer hyperlinked in type annotations.

This occurs because `None` is currently treated using the `class` role instead of the `obj` role during cross-reference generation.

However, `None` is not a type — it is a singleton object. Therefore, it should be referenced using the `:obj:` role to generate correct cross-references.

## Changes

- Override the `make_xref()` method in `PyField` and `PyTypedField`
- Detect when `rolename == "class"` and `target == "None"`
- Switch the role from `"class"` to `"obj"` to ensure proper linking
- Add test coverage to verify correct cross-referencing of `None`

## Related Issues

Closes #10899  
Closes collective/icalendar#1152