### PR TITLE
Fix image files not re-copied during incremental rebuilds

### DIFF
--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -114,8 +114,12 @@ def copyfile(
         msg = f'{source} does not exist'
         raise FileNotFoundError(msg)
 
+    dest_exists = dest.exists()
     if (
-        not (dest_exists := dest.exists())
+        not dest_exists
+        # When force is True, always overwrite (even if content is identical)
+        # so that modification times are updated.
+        or force
         # comparison must be done using shallow=False since
         # two different files might have the same size
         or not filecmp.cmp(source, dest, shallow=False)

--- a/tests/test_util/test_util.py
+++ b/tests/test_util/test_util.py
@@ -42,6 +42,38 @@ def test_ensuredir(tmp_path: Path) -> None:
     assert path.is_dir()
 
 
+def test_copyfile_force_overwrites_identical_content(tmp_path: Path) -> None:
+    """When force=True, copyfile should overwrite even if content is identical.
+
+    This ensures that modification times are updated for image files
+    during incremental rebuilds.  See sphinx-doc/sphinx#14312.
+    """
+    import os
+    import time
+
+    source = tmp_path / 'source.png'
+    dest = tmp_path / 'dest.png'
+
+    # Create source and dest with identical content
+    source.write_bytes(b'image data')
+    dest.write_bytes(b'image data')
+
+    # Set dest mtime to the past so we can detect updates
+    old_mtime = os.path.getmtime(dest)
+    os.utime(dest, (old_mtime - 10, old_mtime - 10))
+    old_mtime = os.path.getmtime(dest)
+
+    # Without force, identical files should NOT be copied
+    copyfile(source, dest, force=False)
+    assert os.path.getmtime(dest) == old_mtime
+
+    # With force, identical files SHOULD be copied (mtime updated)
+    time.sleep(0.05)  # ensure mtime resolution
+    copyfile(source, dest, force=True)
+    new_mtime = os.path.getmtime(dest)
+    assert new_mtime != old_mtime
+
+
 def test_exported_attributes() -> None:
     # RemovedInSphinx10Warning
     with pytest.warns(RemovedInSphinx10Warning, match=r'deprecated.'):


### PR DESCRIPTION
## Summary

Fixes #14312 — image files referenced by documents are not overwritten during incremental rebuilds when the image's modification time changes.

### Root cause

`copyfile(force=True)` checks `filecmp.cmp(source, dest, shallow=False)` *before* considering the `force` flag. When source and destination have identical content (e.g. `touch` updated the mtime but not the bytes), the function short-circuits and skips the copy entirely — even though `force=True` was passed.

During incremental builds, `copy_image_files()` calls `copyfile(..., force=True)` for each image. The intent of `force=True` is to always overwrite, but the `filecmp.cmp` gate prevented this.

### Fix

When `force=True`, skip the `filecmp.cmp` content comparison and always copy the file (updating both content and modification times). This makes `force=True` behave as documented: "Overwrite the destination file even if it exists."

### Test

Added `test_copyfile_force_overwrites_identical_content` to verify that:
- Without `force`, identical-content files are **not** re-copied (preserving the optimization)
- With `force=True`, identical-content files **are** re-copied (mtime is updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)