### PR TITLE
Add missing 'toc' type for 'empty_glob' subtype

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -75,6 +75,7 @@ Contributors
 * Joel Wurtz -- cellspanning support in LaTeX
 * John Waltman -- Texinfo builder
 * Jon Dufresne -- modernisation
+* Jorge Marques -- warning suppression
 * Josip Dzolonga -- coverage builder
 * Juan Luis Cano Rodríguez -- new tutorial (2021)
 * Julien Palard -- Colspan and rowspan in text builder

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,3 +58,4 @@ Bugs fixed
 * LaTeX: Fix accidental removal at ``3.5.0`` (#8854) of the documentation of
   ``literalblockcappos`` key of  :ref:`'sphinxsetup' <latexsphinxsetup>`.
   Patch by Jean-François B.
+* Add missing 'toc' type for 'empty_glob' subtype.

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -119,6 +119,7 @@ class TocTree(SphinxDirective):
                         __("toctree glob pattern %r didn't match any documents"),
                         entry,
                         location=toctree,
+                        type='toc',
                         subtype='empty_glob',
                     )
 


### PR DESCRIPTION
## Purpose

#13230 introduced `toc.empty_glob` subtype, but forgot to set the type.
Due to this, the type has no effect.

The purpose of the suppressed warning is for "sparse" documentation builds, like this
```
# + intersphinx_disabled_reftypes set to []
exclude_patterns = [
    # ...
    'large_path',
    'huge_docs',
    # ...
]

suppress_warnings = [
    'toc.excluded',
    'toc.empty_glob',
]
```
This allows to work on huge docs as if they were a few pages (with the magic trick of deferring the inventory using intersphinx)

## References

- https://github.com/sphinx-doc/sphinx/pull/13230
