### PR TITLE
Add the options from code-blocks to doctest-related directives

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -119,6 +119,7 @@ Contributors
 * Till Hoffmann -- doctest option to exit after first failed test
 * Tim Hoffmann -- theme improvements
 * Valentin Heinisch -- warning types improvement
+* Valerian Rey -- doctest options coming from code-block
 * Victor Wheeler -- documentation improvements
 * Vince Salvino -- JavaScript search improvements
 * Will Maier -- directory HTML builder

--- a/doc/usage/extensions/doctest.rst
+++ b/doc/usage/extensions/doctest.rst
@@ -40,6 +40,9 @@ There are two kinds of test blocks:
 * *code-output-style* blocks consist of an ordinary piece of Python code, and
   optionally, a piece of output for that code.
 
+The following directives that build visible code blocks all also have the
+options from :rst:dir:`code-block` (e.g. ``emphasize-lines``, ``caption``,
+etc.).
 
 Directives
 ----------

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import textwrap
 from difflib import unified_diff
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -183,9 +183,10 @@ class CodeBlock(BaseCodeBlock):
         result = super().run()[0]
         # If caption wrapping occurred, the literal_block is inside the container
         if isinstance(result, nodes.container):
-            literal = result[1]  # result[0] is caption, result[1] is literal_block
+            # result[0] is caption, result[1] is literal_block
+            literal = cast('Element', result[1])
         else:
-            literal = result
+            literal = cast('Element', result)
         if self.arguments:
             # highlight language specified
             literal['language'] = self.arguments[0]

--- a/sphinx/directives/code.py
+++ b/sphinx/directives/code.py
@@ -96,15 +96,14 @@ def container_wrapper(
     raise RuntimeError  # never reached
 
 
-class CodeBlock(SphinxDirective):
+class BaseCodeBlock(SphinxDirective):
     """Directive for a code block with special highlighting or line numbering
     settings.
     """
 
     has_content = True
     required_arguments = 0
-    optional_arguments = 1
-    final_argument_whitespace = False
+    optional_arguments = 0
     option_spec: ClassVar[OptionSpec] = {
         'force': directives.flag,
         'linenos': directives.flag,
@@ -153,17 +152,6 @@ class CodeBlock(SphinxDirective):
             literal['linenos'] = True
         literal['classes'] += self.options.get('class', [])
         literal['force'] = 'force' in self.options
-        if self.arguments:
-            # highlight language specified
-            literal['language'] = self.arguments[0]
-        else:
-            # no highlight language specified.  Then this directive refers the current
-            # highlight setting via ``highlight`` directive or ``highlight_language``
-            # configuration.
-            literal['language'] = (
-                self.env.current_document.highlight_language
-                or self.config.highlight_language
-            )
         extra_args = literal['highlight_args'] = {}
         if hl_lines is not None:
             extra_args['hl_lines'] = hl_lines
@@ -183,6 +171,33 @@ class CodeBlock(SphinxDirective):
         self.add_name(literal)
 
         return [literal]
+
+
+class CodeBlock(BaseCodeBlock):
+    """BaseCodeBlock with an optional language argument for syntax highlighting"""
+
+    optional_arguments = 1
+    final_argument_whitespace = False
+
+    def run(self) -> list[Node]:
+        result = super().run()[0]
+        # If caption wrapping occurred, the literal_block is inside the container
+        if isinstance(result, nodes.container):
+            literal = result[1]  # result[0] is caption, result[1] is literal_block
+        else:
+            literal = result
+        if self.arguments:
+            # highlight language specified
+            literal['language'] = self.arguments[0]
+        else:
+            # no highlight language specified.  Then this directive refers the current
+            # highlight setting via ``highlight`` directive or ``highlight_language``
+            # configuration.
+            literal['language'] = (
+                self.env.current_document.highlight_language
+                or self.config.highlight_language
+            )
+        return [result]
 
 
 class LiteralIncludeReader:

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -11,7 +11,7 @@ import re
 import sys
 import time
 from io import StringIO
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from docutils import nodes
 from docutils.parsers.rst import directives

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -11,7 +11,7 @@ import re
 import sys
 import time
 from io import StringIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -21,6 +21,7 @@ from packaging.version import Version
 import sphinx
 from sphinx._cli.util.colour import bold
 from sphinx.builders import Builder
+from sphinx.directives.code import BaseCodeBlock
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Set
     from typing import Any, ClassVar
 
-    from docutils.nodes import Element, Node, TextElement
+    from docutils.nodes import Element, Node
 
     from sphinx.application import Sphinx
     from sphinx.util.typing import ExtensionMetadata, OptionSpec
@@ -63,7 +64,7 @@ def is_allowed_version(spec: str, version: str) -> bool:
 # set up the necessary directives
 
 
-class TestDirective(SphinxDirective):
+class TestDirective(BaseCodeBlock, SphinxDirective):
     """Base class for doctest-related directives."""
 
     has_content = True
@@ -74,32 +75,54 @@ class TestDirective(SphinxDirective):
     def run(self) -> list[Node]:
         # use ordinary docutils nodes for test code: they get special attributes
         # so that our builder recognizes them, and the other builders are happy.
-        code = '\n'.join(self.content)
-        test = None
-        if self.name == 'doctest':
-            if '<BLANKLINE>' in code:
-                # convert <BLANKLINE>s to ordinary blank lines for presentation
-                test = code
-                code = blankline_re.sub('', code)
-            if (
-                doctestopt_re.search(code)
-                and 'no-trim-doctest-flags' not in self.options
-            ):
-                if not test:
-                    test = code
-                code = doctestopt_re.sub('', code)
-        nodetype: type[TextElement] = nodes.literal_block
-        if self.name in {'testsetup', 'testcleanup'} or 'hide' in self.options:
-            nodetype = nodes.comment
+        test = '\n'.join(self.content)  # This is the code that doctest will run
+
         if self.arguments:
             groups = [x.strip() for x in self.arguments[0].split(',')]
         else:
             groups = ['default']
-        node = nodetype(code, code, testnodetype=self.name, groups=groups)
+
+        if self.name in {'testsetup', 'testcleanup'} or 'hide' in self.options:
+            # Invisible block: content can be the unformatted test
+            node = nodes.comment(test, test)
+        else:
+            # Visible block: content has to be formatted according to the BaseCodeBlock
+            # options. This uses the node built by BaseCodeBlock.run and adapts it.
+            node = super().run()[0]
+
+            if self.name == 'doctest':
+                # Step 1: get the actual code from the built node. The structure of the node
+                # differs if there's a caption.
+
+                # If caption wrapping occurred, the literal_block is inside the container
+                if isinstance(node, nodes.container):
+                    literal = node[1]  # node[0] is caption, node[1] is literal_block
+                else:
+                    literal = node
+                assert isinstance(literal, nodes.literal_block)
+                rawsource = literal.rawsource
+
+                # Step 2: modify the source code to remove <BLANKLINE> tags and optionally
+                # remove doctest flags.
+                if '<BLANKLINE>' in rawsource:
+                    # convert <BLANKLINE>s to ordinary blank lines for presentation
+                    rawsource = blankline_re.sub('', rawsource)
+                if (
+                    doctestopt_re.search(rawsource)
+                    and 'no-trim-doctest-flags' not in self.options
+                ):
+                    rawsource = doctestopt_re.sub('', rawsource)
+
+                # Step 3: update the rawsource and text content of the literal_block.
+                # rawsource is metadata; the displayed text comes from the Text child node,
+                # which is immutable (Text subclasses str) and must be replaced.
+                literal.rawsource = rawsource
+                literal[:] = [nodes.Text(rawsource)]
+
+        node['testnodetype'] = self.name
+        node['groups'] = groups
         self.set_source_info(node)
-        if test is not None:
-            # only save if it differs from code
-            node['test'] = test
+        node['test'] = test
         if self.name == 'doctest':
             node['language'] = 'pycon'
         elif self.name == 'testcode':
@@ -160,7 +183,8 @@ class TestcleanupDirective(TestDirective):
 
 
 class DoctestDirective(TestDirective):
-    option_spec: ClassVar[OptionSpec] = {
+    option_spec: ClassVar[OptionSpec] = TestDirective.option_spec.copy()
+    option_spec |= {
         'hide': directives.flag,
         'no-trim-doctest-flags': directives.flag,
         'options': directives.unchanged,
@@ -171,7 +195,8 @@ class DoctestDirective(TestDirective):
 
 
 class TestcodeDirective(TestDirective):
-    option_spec: ClassVar[OptionSpec] = {
+    option_spec: ClassVar[OptionSpec] = TestDirective.option_spec.copy()
+    option_spec |= {
         'hide': directives.flag,
         'no-trim-doctest-flags': directives.flag,
         'pyversion': directives.unchanged_required,
@@ -181,7 +206,8 @@ class TestcodeDirective(TestDirective):
 
 
 class TestoutputDirective(TestDirective):
-    option_spec: ClassVar[OptionSpec] = {
+    option_spec: ClassVar[OptionSpec] = TestDirective.option_spec.copy()
+    option_spec |= {
         'hide': directives.flag,
         'no-trim-doctest-flags': directives.flag,
         'options': directives.unchanged,
@@ -654,8 +680,10 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
 
 def _condition_default(node: Node) -> bool:
+    # literal_block is for visible block of code, comment if for invisible block of code, and
+    # container is for visible block of code with a caption.
     return (
-        isinstance(node, (nodes.literal_block, nodes.comment))
+        isinstance(node, (nodes.literal_block, nodes.comment, nodes.container))
         and 'testnodetype' in node
     )
 

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -11,7 +11,7 @@ import re
 import sys
 import time
 from io import StringIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -82,13 +82,14 @@ class TestDirective(BaseCodeBlock, SphinxDirective):
         else:
             groups = ['default']
 
+        node: Element
         if self.name in {'testsetup', 'testcleanup'} or 'hide' in self.options:
             # Invisible block: content can be the unformatted test
             node = nodes.comment(test, test)
         else:
             # Visible block: content has to be formatted according to the BaseCodeBlock
             # options. This uses the node built by BaseCodeBlock.run and adapts it.
-            node = super().run()[0]
+            node = cast('Element', super().run()[0])
 
             if self.name == 'doctest':
                 # Step 1: get the actual code from the built node. The structure of the node

--- a/tests/test_extensions/test_ext_doctest.py
+++ b/tests/test_extensions/test_ext_doctest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections import Counter
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,9 +12,19 @@ from docutils import nodes
 from packaging.specifiers import InvalidSpecifier
 from packaging.version import InvalidVersion
 
-from sphinx.ext.doctest import DocTestBuilder, is_allowed_version
+from sphinx.directives.code import BaseCodeBlock, CodeBlock
+from sphinx.ext.doctest import (
+    DocTestBuilder,
+    DoctestDirective,
+    TestcodeDirective,
+    TestoutputDirective,
+    _condition_default,
+    is_allowed_version,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sphinx.testing.util import SphinxTestApp
 
 cleanup_called = 0
@@ -201,3 +212,234 @@ def test_doctest_block_group_name(
     assert f'File "dir/bar.py", line ?, in {group_name}' in failures
     assert f'File "foo.py", line ?, in {group_name}' in failures
     assert f'File "index.rst", line 4, in {group_name}' in failures
+
+
+# Tests for the new BaseCodeBlock-derived TestDirective features
+
+
+def test_condition_default_literal_block() -> None:
+    node = nodes.literal_block('code', 'code')
+    node['testnodetype'] = 'doctest'
+    assert _condition_default(node) is True
+
+
+def test_condition_default_comment() -> None:
+    node = nodes.comment('code', 'code')
+    node['testnodetype'] = 'testsetup'
+    assert _condition_default(node) is True
+
+
+def test_condition_default_container_with_testnodetype() -> None:
+    """Container nodes (produced when :caption: is used) must also match."""
+    container = nodes.container()
+    container['testnodetype'] = 'doctest'
+    assert _condition_default(container) is True
+
+
+def test_condition_default_container_without_testnodetype() -> None:
+    """Plain container nodes (no testnodetype) must not match."""
+    container = nodes.container()
+    assert _condition_default(container) is False
+
+
+def test_condition_default_plain_literal_block() -> None:
+    """A literal_block without testnodetype must not match."""
+    node = nodes.literal_block('code', 'code')
+    assert _condition_default(node) is False
+
+
+def test_test_directive_option_spec_includes_basecodeblock_options() -> None:
+    """Doctest directives should inherit BaseCodeBlock options."""
+    for directive_cls in (DoctestDirective, TestcodeDirective, TestoutputDirective):
+        for option in ('linenos', 'caption', 'emphasize-lines', 'dedent', 'force'):
+            assert option in directive_cls.option_spec, (
+                f'{directive_cls.__name__} missing option {option!r}'
+            )
+
+
+def test_basecodeblock_has_no_language_argument() -> None:
+    assert BaseCodeBlock.optional_arguments == 0
+
+
+def test_codeblock_has_language_argument() -> None:
+    assert CodeBlock.optional_arguments == 1
+
+
+def _make_doctest_app(
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+    rst_content: str,
+) -> SphinxTestApp:
+    """Create a minimal Sphinx app with doctest extension from RST content."""
+    (tmp_path / 'conf.py').write_text(
+        "extensions = ['sphinx.ext.doctest']\n", encoding='utf-8'
+    )
+    (tmp_path / 'index.rst').write_text(rst_content, encoding='utf-8')
+    app = make_app(buildername='dummy', srcdir=tmp_path)
+    app.build(force_all=True)
+    return app
+
+
+def test_doctest_directive_with_linenos(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """The :linenos: option from BaseCodeBlock should be accepted by doctest directives."""
+    rst = """\
+Test
+====
+
+.. doctest::
+   :linenos:
+
+   >>> 1 + 1
+   2
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    literal_blocks = list(doctree.findall(nodes.literal_block))
+    assert literal_blocks, 'expected at least one literal_block'
+    assert literal_blocks[0].get('linenos') is True
+
+
+def test_doctest_directive_with_caption_produces_container(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """:caption: on a doctest directive wraps the literal_block in a container."""
+    rst = """\
+Test
+====
+
+.. doctest::
+   :caption: My caption
+
+   >>> 1 + 1
+   2
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    containers = list(doctree.findall(nodes.container))
+    assert containers, 'expected a container node when :caption: is used'
+    container = containers[0]
+    assert 'testnodetype' in container
+    assert container['testnodetype'] == 'doctest'
+    # The literal_block is the second child (first is the caption)
+    assert isinstance(container[1], nodes.literal_block)
+
+
+def test_testcode_directive_with_caption_produces_container(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """:caption: on a testcode directive also wraps in a container."""
+    rst = """\
+Test
+====
+
+.. testcode::
+   :caption: My testcode caption
+
+   print(1 + 1)
+
+.. testoutput::
+
+   2
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    containers = list(doctree.findall(nodes.container))
+    assert containers, 'expected a container node when :caption: is used'
+    container = containers[0]
+    assert container['testnodetype'] == 'testcode'
+
+
+def test_doctest_node_test_attribute_always_set(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """node['test'] must always be set, even without BLANKLINE or doctest flags."""
+    rst = """\
+Test
+====
+
+.. doctest::
+
+   >>> x = 1
+   >>> x
+   1
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    literal_blocks = list(doctree.findall(nodes.literal_block))
+    assert literal_blocks
+    node = literal_blocks[0]
+    assert 'test' in node
+    assert node['test'] == '>>> x = 1\n>>> x\n1'
+
+
+def test_doctest_blankline_trimmed_in_display_but_kept_in_test(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """<BLANKLINE> is removed from the displayed literal but kept in node['test']."""
+    rst = """\
+Test
+====
+
+.. doctest::
+
+   >>> print()
+   <BLANKLINE>
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    literal_blocks = list(doctree.findall(nodes.literal_block))
+    assert literal_blocks
+    node = literal_blocks[0]
+    # The raw test code retains <BLANKLINE>
+    assert '<BLANKLINE>' in node['test']
+    # The displayed text has it removed
+    assert '<BLANKLINE>' not in node.astext()
+
+
+def test_doctest_flags_trimmed_in_display_but_kept_in_test(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """Doctest flags are removed from the displayed literal but kept in node['test']."""
+    rst = """\
+Test
+====
+
+.. doctest::
+
+   >>> 1 + 1  # doctest: +ELLIPSIS
+   2
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    literal_blocks = list(doctree.findall(nodes.literal_block))
+    assert literal_blocks
+    node = literal_blocks[0]
+    # The raw test code retains the doctest flag
+    assert '# doctest: +ELLIPSIS' in node['test']
+    # The displayed text has it trimmed
+    assert '# doctest:' not in node.astext()
+
+
+def test_doctest_flags_kept_with_no_trim_option(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    """:no-trim-doctest-flags: preserves flags in both test and displayed text."""
+    rst = """\
+Test
+====
+
+.. doctest::
+   :no-trim-doctest-flags:
+
+   >>> 1 + 1  # doctest: +ELLIPSIS
+   2
+"""
+    app = _make_doctest_app(tmp_path, make_app, rst)
+    doctree = app.env.get_doctree('index')
+    literal_blocks = list(doctree.findall(nodes.literal_block))
+    assert literal_blocks
+    node = literal_blocks[0]
+    assert '# doctest: +ELLIPSIS' in node['test']
+    assert '# doctest: +ELLIPSIS' in node.astext()

--- a/tests/test_extensions/test_ext_doctest.py
+++ b/tests/test_extensions/test_ext_doctest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from collections import Counter
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -24,6 +23,7 @@ from sphinx.ext.doctest import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from sphinx.testing.util import SphinxTestApp
 


### PR DESCRIPTION
This PR gives the options of the `.. code-block::` directive to the `.. doctest::`, `.. testcode::` and `.. test_output::` directives from the `doctest` extension.

These options are:
- `linenos`
- `lineno-start`
- `emphasize-lines`
- `force`
- `caption`
- `name`
- `class`
- `dedent`

## Purpose

The goal behind this is for users to be able to switch from `code-block` to `testcode` or `doctest` directives extremely easily, so that they can test their documentation's code without losing the super nice display options that `code-block` offers. Note that this was a problem that I recently had myself, and that prevented me from using `doctest`.

I also think that it makes sense for the `testcode`, `testoutput` and `doctest` directives to be strongly coupled with the `code-block` directive (I think we want them to be code blocks with some extra testing), which is why I decided to use inheritance.

## Implementation details

To avoid code duplication and ensure that the options supported by the doctest-related directives will not diverge from those of `code-block` over time, this makes the `TestDirective` class extend a new `BaseCodeBlock` class, that contains what was in `CodeBlock`, but without the `language` argument (language can only be python for doctests, so it doesn't make sense to have a language argument for doctest-related directives).

`CodeBlock` usage should not change at all: it now extends `BaseCodeBlock` + adds the `language` optional argument that it already had before, that was stripped from `BaseCodeBlock`.

There is some special care for when there is a caption: this is because when a caption is provided, the `literal_block` created by `BaseCodeBlock` is wrapped in a `container`. Changes to this `literal_block` should thus be made to the wrapped `literal_block` and not to the `container` itself.

## Examples

`example.rst`:
```rst
Some examples
=============

These examples shows how the directives from ``sphinx.ext.doctest`` can now be used with the options
from the ``.. code-block::`` directive.

The first example (:ref:`example`) is made using the ``.. testcode::`` directive, and the second
example (:ref:`example-2`) uses the ``.. doctest::`` directive.

.. testcode:: group
    :emphasize-lines: 3
    :linenos:
    :name: example
    :caption: Code block 1

    a = 5
    b = 6
    assert True


.. doctest:: group-2
    :emphasize-lines: 3
    :linenos:
    :name: example-2
    :caption: Code block 2

    >>> a = 5
    >>> b = 6
    >>> print(a + b)
    11
```

built html page (using furo theme):
<img width="1733" height="1148" alt="image" src="https://github.com/user-attachments/assets/8ae10613-9541-43d7-8a1a-d46643f374f4" />


## Disclaimers

- This is my first time contributing to sphinx. I have very limited knowledge of the codebase, so I may have made some bad choices.
- I used claude code to fix a few bugs that I originally introduced (improper care of the caption, improper handling of the `<BLANKLINE>`. I also used it to generated all of the unit tests. The rest was manually coded, and the architectural decisions were mine.
- I think some of the unit tests that claude introduced may be deleted, and maybe we could add some new ones. I would appreciate guidance from a maintainer to know what to do there.
- I didn't find how to update `CHANGES.rst`. It seems to be only for changes that were already released.
- I only added a single sentence to `doc/usage/extensions/doctest.rst`, saying that all of the options from `code-block` are also available in the doctest directives that build visible code blocks. We could instead list all of those options like the other options of those directives. This would be a bit more work to maintain, because it would lead to some duplication. But it would also make it easier for users to see that these options exist.
- Feel free to edit my branch!

## References

- Fixes #6915
- Fixes #6858
