### PR TITLE
docs: document the translatable node class

### DIFF
--- a/doc/extdev/nodes.rst
+++ b/doc/extdev/nodes.rst
@@ -96,6 +96,7 @@ Special nodes
 
 You should not need to generate the nodes below in extensions.
 
+.. autoclass:: translatable
 .. autoclass:: glossary
 .. autoclass:: toctree
 .. autoclass:: start_of_file


### PR DESCRIPTION
The `translatable` node class in `sphinx.addnodes` allows extensions to supply custom translation strings, but was not documented on the "Doctree node classes added by Sphinx" page.

This PR adds the `translatable` autoclass directive to `doc/extdev/nodes.rst` in the "Special nodes" section, where other special base classes like `glossary` and `toctree` are documented.

The class already has good docstrings in the source code, so the `autoclass` directive will automatically render them.

Fixes #9409