### PR TITLE
Add LibreJS and SPDX license headers to bundled JavaScript files

### DIFF
--- a/sphinx/themes/basic/static/doctools.js
+++ b/sphinx/themes/basic/static/doctools.js
@@ -1,5 +1,10 @@
 /*
  * Base JavaScript utilities for all Sphinx HTML documentation.
+ *
+ * SPDX-FileCopyrightText: Sphinx team (see AUTHORS file)
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * @license magnet:?xt=urn:btih:87f119ba0b429ba17a44b4bffcab33165ebdacc0&dn=freebsd.txt BSD-2-Clause
  */
 "use strict";
 
@@ -148,3 +153,5 @@ const Documentation = {
 const _ = Documentation.gettext;
 
 _ready(Documentation.init);
+
+// @license-end

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -1,5 +1,10 @@
 /*
  * Sphinx JavaScript utilities for the full-text search.
+ *
+ * SPDX-FileCopyrightText: Sphinx team (see AUTHORS file)
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * @license magnet:?xt=urn:btih:87f119ba0b429ba17a44b4bffcab33165ebdacc0&dn=freebsd.txt BSD-2-Clause
  */
 "use strict";
 
@@ -691,3 +696,5 @@ const Search = {
 };
 
 _ready(Search.init);
+
+// @license-end

--- a/sphinx/themes/basic/static/sphinx_highlight.js
+++ b/sphinx/themes/basic/static/sphinx_highlight.js
@@ -1,4 +1,11 @@
-/* Highlighting utilities for Sphinx HTML documentation. */
+/*
+ * Highlighting utilities for Sphinx HTML documentation.
+ *
+ * SPDX-FileCopyrightText: Sphinx team (see AUTHORS file)
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * @license magnet:?xt=urn:btih:87f119ba0b429ba17a44b4bffcab33165ebdacc0&dn=freebsd.txt BSD-2-Clause
+ */
 "use strict";
 
 const SPHINX_HIGHLIGHT_ENABLED = true;
@@ -157,3 +164,5 @@ _ready(() => {
   if (typeof Search === "undefined") SphinxHighlight.highlightSearchWords();
   SphinxHighlight.initEscapeListener();
 });
+
+// @license-end


### PR DESCRIPTION
Closes #12323

Adds machine-readable license information to the three JavaScript files shipped with the basic Sphinx theme (`doctools.js`, `searchtools.js`, `sphinx_highlight.js`).

Each file now includes:
- **SPDX headers** (`SPDX-FileCopyrightText` and `SPDX-License-Identifier: BSD-2-Clause`) per the [REUSE specification](https://reuse.software/)
- **LibreJS tags** (`@license` / `@license-end`) with the BSD-2-Clause magnet link per the [GNU LibreJS format](https://www.gnu.org/software/librejs/manual/html_node/Setting-Your-JavaScript-Free.html#License-tags)

This allows [LibreJS](https://www.gnu.org/software/librejs/) (a browser extension that verifies JavaScript is free software before running it) to recognize Sphinx-generated JS as freely licensed instead of blocking it.

The magnet link `magnet:?xt=urn:btih:87f119ba0b429ba17a44b4bffcab33165ebdacc0&dn=freebsd.txt` corresponds to the BSD-2-Clause license in the [LibreJS license list](https://www.gnu.org/software/librejs/manual/html_node/Setting-Your-JavaScript-Free.html#License-tags).