### PR TITLE
fix: handle IndexError in get_type_comment for empty module body

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_type_comments.py
+++ b/sphinx/ext/autodoc/_dynamic/_type_comments.py
@@ -151,6 +151,8 @@ def get_type_comment(obj: Any, bound_method: bool = False) -> Signature | None:
         return None
     except SyntaxError:  # failed to parse type_comments
         return None
+    except IndexError:  # empty module body (e.g. getsource returned only whitespace)
+        return None
 
 
 def signature_from_ast(

--- a/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
@@ -355,3 +355,16 @@ def test_autodoc_process_signature_typehints() -> None:
     assert captured == [
         (app, 'function', '.func', func, options, '(x: int, y: int)', 'int')
     ]
+
+
+def test_get_type_comment_empty_module_body():
+    """get_type_comment returns None when getsource yields empty AST body."""
+    from unittest.mock import patch
+
+    from sphinx.ext.autodoc._dynamic._type_comments import get_type_comment
+
+    with patch(
+        'sphinx.ext.autodoc._dynamic._type_comments.getsource',
+        return_value='\n',
+    ):
+        assert get_type_comment(lambda: None) is None


### PR DESCRIPTION
Fixes #14345.

**Root cause:** On Python 3.14, `inspect.getsource` can return `"\n"` for classes with a custom `__module__`. `ast.parse("\n")` produces a `Module` with an empty `body`, and `module.body[0]` raises `IndexError`.

**Fix:** Added `IndexError` to the exception handler in `get_type_comment` so it returns `None` (same as `OSError`/`TypeError`).

## Changes
- `sphinx/ext/autodoc/_dynamic/_type_comments.py`: catch `IndexError` from empty `module.body`
- `tests/test_ext_autodoc/test_ext_autodoc_signatures.py`: test that mocks `getsource` returning `"\n"`