### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Sphinx, please **do not** open a public
+GitHub issue. Instead, use one of the following private channels:
+
+### GitHub Security Advisories (preferred)
+
+Report vulnerabilities directly via
+[GitHub Security Advisories](https://github.com/sphinx-doc/sphinx/security/advisories/new).
+This is the preferred method as it keeps the report private and allows coordinated
+disclosure.
+
+### Email
+
+You may also contact the Sphinx maintainers by email at `admin@sphinx-doc.org`.
+
+## Supported Versions
+
+Security fixes are applied to the latest stable release. We strongly recommend
+keeping Sphinx up to date.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest stable | ✅ |
+| Older releases | ❌ |
+
+## Disclosure Policy
+
+Once a vulnerability is reported, the maintainers will:
+
+1. Acknowledge receipt within a few business days.
+2. Investigate and determine the impact.
+3. Prepare a fix and release it as soon as possible.
+4. Credit the reporter in the release notes (unless they prefer to remain anonymous).


### PR DESCRIPTION
## Purpose

Adds `.github/SECURITY.md` to publish Sphinx's security vulnerability reporting policy.

Closes #13063

GitHub automatically surfaces this file in the repository's Security tab and shows a "Report a vulnerability" button to users, replacing the generic GitHub message with project-specific guidance.

The policy documents:
- **GitHub Security Advisories** as the preferred private reporting channel
- **Email contact** as an alternative (`admin@sphinx-doc.org` — please update if this is incorrect)
- Which versions receive security fixes (latest stable only)
- The disclosure process outline

> **Note to maintainers:** Please verify the email address is correct or update it to the preferred contact. The issue mentioned emailing the lead maintainer directly; if you'd prefer that, replace `admin@sphinx-doc.org` with the appropriate address.

## References

- Closes #13063