### PR TITLE
Fix autodoc IndexError on class with custom __module__ on Python 3.14

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_type_comments.py
+++ b/sphinx/ext/autodoc/_dynamic/_type_comments.py
@@ -147,7 +147,7 @@ def get_type_comment(obj: Any, bound_method: bool = False) -> Signature | None:
             return signature_from_ast(subject, bound_method, function)
         else:
             return None
-    except (OSError, TypeError):  # failed to load source code
+    except (OSError, TypeError, IndexError):  # failed to load source code
         return None
     except SyntaxError:  # failed to parse type_comments
         return None


### PR DESCRIPTION
Fixes #14345.

On Python 3.14, `inspect.getsource` on a class with a custom `__module__` can return `"\n"` instead of raising `OSError`. `ast.parse("\n")` then produces an empty module body, and `module.body[0]` raises `IndexError`. Added `IndexError` to the existing except clause in `get_type_comment` so it returns `None` gracefully, matching the existing behavior for `OSError` and `TypeError`.