### PR TITLE
Fix intersphinx leaking basic auth credentials in error and info messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Features added
 Bugs fixed
 ----------
 
-* #14365: intersphinx: Fix leaking basic auth credentials in error and
+* #14342: intersphinx: Fix leaking basic auth credentials in error and
   redirect log messages.
   Patch by Joshua Swanson
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Features added
 Bugs fixed
 ----------
 
+* #14365: intersphinx: Fix leaking basic auth credentials in error and
+  redirect log messages.
+  Patch by Joshua Swanson
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
   Patch by Adam Turner
 * #13713: Fix compatibility with MyST-Parser.

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -399,11 +399,12 @@ def _fetch_inventory_url(
             raw_data = r.content
             new_inv_location = r.url
     except Exception as err:
+        safe_url = _get_safe_url(inv_location)
         err.args = (
             'intersphinx inventory %r not fetchable due to %s: %s',
-            _get_safe_url(inv_location),
+            safe_url,
             err.__class__,
-            str(err),
+            str(err).replace(inv_location, safe_url),
         )
         raise
 

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -401,7 +401,7 @@ def _fetch_inventory_url(
     except Exception as err:
         err.args = (
             'intersphinx inventory %r not fetchable due to %s: %s',
-            inv_location,
+            _get_safe_url(inv_location),
             err.__class__,
             str(err),
         )
@@ -409,7 +409,7 @@ def _fetch_inventory_url(
 
     if inv_location != new_inv_location:
         msg = __('intersphinx inventory has moved: %s -> %s')
-        LOGGER.info(msg, inv_location, new_inv_location)
+        LOGGER.info(msg, _get_safe_url(inv_location), _get_safe_url(new_inv_location))
 
         if target_uri in {
             inv_location,

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -400,11 +400,20 @@ def _fetch_inventory_url(
             new_inv_location = r.url
     except Exception as err:
         safe_url = _get_safe_url(inv_location)
+        # The URLs retained by the exception may be normalised forms of
+        # *inv_location* (e.g. percent-decoded), so redact them separately.
+        err_msg = str(err).replace(inv_location, safe_url)
+        for unsafe_url in (
+            getattr(getattr(err, 'request', None), 'url', None),
+            getattr(getattr(err, 'response', None), 'url', None),
+        ):
+            if unsafe_url:
+                err_msg = err_msg.replace(unsafe_url, _get_safe_url(unsafe_url))
         err.args = (
             'intersphinx inventory %r not fetchable due to %s: %s',
             safe_url,
             err.__class__,
-            str(err).replace(inv_location, safe_url),
+            err_msg,
         )
         raise
 

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -669,10 +669,10 @@ def test_getsafeurl_unauthed() -> None:
 @mock.patch('sphinx.ext.intersphinx._load.requests.get')
 def test_fetch_inventory_url_error_hides_credentials(get_request):
     """Credentials should not appear in error messages on fetch failure."""
-    get_request.side_effect = Exception('connection refused')
-    with pytest.raises(Exception) as exc_info:
-        from sphinx.ext.intersphinx._load import _fetch_inventory_url
+    from sphinx.ext.intersphinx._load import _fetch_inventory_url
 
+    get_request.side_effect = ConnectionError('connection refused')
+    with pytest.raises(ConnectionError, match='connection refused'):
         _fetch_inventory_url(
             target_uri='https://hostname/',
             inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
@@ -684,10 +684,23 @@ def test_fetch_inventory_url_error_hides_credentials(get_request):
                 user_agent='',
             ),
         )
-    # The password must not appear in the error args
-    error_text = str(exc_info.value.args)
-    assert 'secret' not in error_text
-    assert 'user@hostname' in error_text
+    # Also verify the rewritten error args don't contain the password
+    try:
+        _fetch_inventory_url(
+            target_uri='https://hostname/',
+            inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
+            config=_InvConfig(
+                intersphinx_cache_limit=5,
+                intersphinx_timeout=None,
+                tls_verify=False,
+                tls_cacerts=None,
+                user_agent='',
+            ),
+        )
+    except ConnectionError as exc:
+        error_text = str(exc.args)
+        assert 'secret' not in error_text
+        assert 'user@hostname' in error_text
 
 
 @mock.patch('sphinx.ext.intersphinx._load.InventoryFile')
@@ -702,7 +715,7 @@ def test_fetch_inventory_redirect_hides_credentials(get_request, InventoryFile, 
     mocked_get.url = 'https://user:secret@hostname/new/' + INVENTORY_FILENAME
 
     target_uri = 'https://hostname/'
-    raw_data, target_uri = _fetch_inventory_data(
+    _, target_uri = _fetch_inventory_data(
         target_uri=target_uri,
         inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
         config=_InvConfig.from_config(app.config),

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -685,28 +685,41 @@ def test_fetch_inventory_url_error_hides_credentials(capsys):
     assert 'user@localhost' in stderr
 
 
-@mock.patch('sphinx.ext.intersphinx._load.InventoryFile')
-@mock.patch('sphinx.ext.intersphinx._load.requests.get')
 @pytest.mark.sphinx('html', testroot='root')
-def test_fetch_inventory_redirect_hides_credentials(get_request, InventoryFile, app):
+def test_fetch_inventory_redirect_hides_credentials(app):
     """Credentials should not appear in redirect log messages."""
-    mocked_get = get_request.return_value.__enter__.return_value
+
+    class RedirectHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if '/new/' not in self.path:
+                self.send_response(302)
+                new_url = f'http://localhost:{self.server.server_port}/new/{INVENTORY_FILENAME}'
+                self.send_header('Location', new_url)
+                self.end_headers()
+            else:
+                self.send_response(200, 'OK')
+                self.end_headers()
+                self.wfile.write(INVENTORY_V2)
+
+        def log_message(*args, **kwargs):
+            pass
+
     intersphinx_setup(app)
-    mocked_get.content = b'# Sphinx inventory version 2'
 
-    mocked_get.url = 'https://user:secret@hostname/new/' + INVENTORY_FILENAME
+    with http_server(RedirectHandler) as server:
+        port = server.server_port
+        inv_location = f'http://user:secret@localhost:{port}/{INVENTORY_FILENAME}'
+        _fetch_inventory_data(
+            target_uri=f'http://localhost:{port}/',
+            inv_location=inv_location,
+            config=_InvConfig.from_config(app.config),
+            srcdir=app.srcdir,
+            cache_path=None,
+        )
 
-    target_uri = 'https://hostname/'
-    _, target_uri = _fetch_inventory_data(
-        target_uri=target_uri,
-        inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
-        config=_InvConfig.from_config(app.config),
-        srcdir=app.srcdir,
-        cache_path=None,
-    )
     status_output = app.status.getvalue()
     assert 'secret' not in status_output
-    assert 'user@hostname' in status_output
+    assert 'user@localhost' in status_output
 
 
 def test_inspect_main_noargs(capsys):

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -666,41 +666,23 @@ def test_getsafeurl_unauthed() -> None:
     assert actual == expected
 
 
-@mock.patch('sphinx.ext.intersphinx._load.requests.get')
-def test_fetch_inventory_url_error_hides_credentials(get_request):
+def test_fetch_inventory_url_error_hides_credentials(capsys):
     """Credentials should not appear in error messages on fetch failure."""
-    from sphinx.ext.intersphinx._load import _fetch_inventory_url
 
-    get_request.side_effect = ConnectionError('connection refused')
-    with pytest.raises(ConnectionError, match='connection refused'):
-        _fetch_inventory_url(
-            target_uri='https://hostname/',
-            inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
-            config=_InvConfig(
-                intersphinx_cache_limit=5,
-                intersphinx_timeout=None,
-                tls_verify=False,
-                tls_cacerts=None,
-                user_agent='',
-            ),
-        )
-    # Also verify the rewritten error args don't contain the password
-    try:
-        _fetch_inventory_url(
-            target_uri='https://hostname/',
-            inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
-            config=_InvConfig(
-                intersphinx_cache_limit=5,
-                intersphinx_timeout=None,
-                tls_verify=False,
-                tls_cacerts=None,
-                user_agent='',
-            ),
-        )
-    except ConnectionError as exc:
-        error_text = str(exc.args)
-        assert 'secret' not in error_text
-        assert 'user@hostname' in error_text
+    class ErrorHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_error(500, 'Internal Server Error')
+
+        def log_message(*args, **kwargs):
+            pass
+
+    with http_server(ErrorHandler) as server:
+        url = f'http://user:secret@localhost:{server.server_port}/{INVENTORY_FILENAME}'
+        inspect_main([url])
+
+    _, stderr = capsys.readouterr()
+    assert 'secret' not in stderr
+    assert 'user@localhost' in stderr
 
 
 @mock.patch('sphinx.ext.intersphinx._load.InventoryFile')
@@ -724,6 +706,7 @@ def test_fetch_inventory_redirect_hides_credentials(get_request, InventoryFile, 
     )
     status_output = app.status.getvalue()
     assert 'secret' not in status_output
+    assert 'user@hostname' in status_output
 
 
 def test_inspect_main_noargs(capsys):

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -686,8 +686,7 @@ def test_fetch_inventory_url_error_hides_credentials(capsys):
     assert 'user@localhost' in stderr
 
 
-@pytest.mark.sphinx('html', testroot='root')
-def test_fetch_inventory_redirect_hides_credentials(app):
+def test_fetch_inventory_redirect_hides_credentials(capsys, caplog):
     """Credentials should not appear in redirect log messages."""
 
     class RedirectHandler(http.server.BaseHTTPRequestHandler):
@@ -705,22 +704,15 @@ def test_fetch_inventory_redirect_hides_credentials(app):
         def log_message(*args, **kwargs):
             pass
 
-    intersphinx_setup(app)
-
     with http_server(RedirectHandler) as server:
         port = server.server_port
-        inv_location = f'http://user:secret@localhost:{port}/{INVENTORY_FILENAME}'
-        _fetch_inventory_data(
-            target_uri=f'http://localhost:{port}/',
-            inv_location=inv_location,
-            config=_InvConfig.from_config(app.config),
-            srcdir=app.srcdir,
-            cache_path=None,
-        )
+        url = f'http://user:secret@localhost:{port}/{INVENTORY_FILENAME}'
+        inspect_main([url])
 
-    status_output = app.status.getvalue()
-    assert 'secret' not in status_output
-    assert 'user@localhost' in status_output
+    stdout, stderr = capsys.readouterr()
+    full_output = stdout + stderr + '\n'.join(caplog.messages)
+    assert 'secret' not in full_output
+    assert 'user@localhost' in full_output
 
 
 def test_inspect_main_noargs(capsys):

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import http.server
+import logging
 import time
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -666,8 +667,11 @@ def test_getsafeurl_unauthed() -> None:
     assert actual == expected
 
 
-def test_fetch_inventory_url_error_hides_credentials(capsys, caplog):
+def test_fetch_inventory_url_error_hides_credentials(capsys, caplog, monkeypatch):
     """Credentials should not appear in error messages on fetch failure."""
+    # A previously created Sphinx app disables propagation on the 'sphinx'
+    # logger; caplog needs it to capture the messages.
+    monkeypatch.setattr(logging.getLogger('sphinx'), 'propagate', True)
 
     class ErrorHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
@@ -677,24 +681,37 @@ def test_fetch_inventory_url_error_hides_credentials(capsys, caplog):
             pass
 
     with http_server(ErrorHandler) as server:
-        url = f'http://user:secret@localhost:{server.server_port}/{INVENTORY_FILENAME}'
+        # %65 is an 'e'; requests normalises the URL it retains on the
+        # exception, so the password can leak in a form ('secret') that
+        # differs from the one passed in ('s%65cret').
+        url = (
+            f'http://user:s%65cret@localhost:{server.server_port}/{INVENTORY_FILENAME}'
+        )
         inspect_main([url])
 
     stdout, stderr = capsys.readouterr()
-    assert 'secret' not in stdout
-    assert 'secret' not in stderr
-    assert not any('secret' in message for message in caplog.messages)
+    for leak in ('secret', 's%65cret'):
+        assert leak not in stdout
+        assert leak not in stderr
+        assert not any(leak in message for message in caplog.messages)
     assert 'user@localhost' in stderr
 
 
-def test_fetch_inventory_redirect_hides_credentials(capsys, caplog):
+def test_fetch_inventory_redirect_hides_credentials(capsys, caplog, monkeypatch):
     """Credentials should not appear in redirect log messages."""
+    # A previously created Sphinx app disables propagation on the 'sphinx'
+    # logger; caplog needs it to capture the messages.
+    monkeypatch.setattr(logging.getLogger('sphinx'), 'propagate', True)
 
     class RedirectHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             if '/new/' not in self.path:
                 self.send_response(302)
-                new_url = f'http://localhost:{self.server.server_port}/new/{INVENTORY_FILENAME}'
+                assert isinstance(self.server, http.server.HTTPServer)
+                new_url = (
+                    'http://redirect-user:redirect-secret@localhost:'
+                    f'{self.server.server_port}/new/{INVENTORY_FILENAME}'
+                )
                 self.send_header('Location', new_url)
                 self.end_headers()
             else:
@@ -714,6 +731,7 @@ def test_fetch_inventory_redirect_hides_credentials(capsys, caplog):
     assert 'secret' not in stderr
     assert not any('secret' in message for message in caplog.messages)
     assert any('user@localhost' in message for message in caplog.messages)
+    assert any('redirect-user@localhost' in message for message in caplog.messages)
 
 
 def test_inspect_main_noargs(capsys):

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -710,9 +710,10 @@ def test_fetch_inventory_redirect_hides_credentials(capsys, caplog):
         inspect_main([url])
 
     stdout, stderr = capsys.readouterr()
-    full_output = stdout + stderr + '\n'.join(caplog.messages)
-    assert 'secret' not in full_output
-    assert 'user@localhost' in full_output
+    assert 'secret' not in stdout
+    assert 'secret' not in stderr
+    assert not any('secret' in message for message in caplog.messages)
+    assert any('user@localhost' in message for message in caplog.messages)
 
 
 def test_inspect_main_noargs(capsys):

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -680,7 +680,8 @@ def test_fetch_inventory_url_error_hides_credentials(capsys):
         url = f'http://user:secret@localhost:{server.server_port}/{INVENTORY_FILENAME}'
         inspect_main([url])
 
-    _, stderr = capsys.readouterr()
+    stdout, stderr = capsys.readouterr()
+    assert 'secret' not in stdout
     assert 'secret' not in stderr
     assert 'user@localhost' in stderr
 

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -666,6 +666,53 @@ def test_getsafeurl_unauthed() -> None:
     assert actual == expected
 
 
+@mock.patch('sphinx.ext.intersphinx._load.requests.get')
+def test_fetch_inventory_url_error_hides_credentials(get_request):
+    """Credentials should not appear in error messages on fetch failure."""
+    get_request.side_effect = Exception('connection refused')
+    with pytest.raises(Exception) as exc_info:
+        from sphinx.ext.intersphinx._load import _fetch_inventory_url
+
+        _fetch_inventory_url(
+            target_uri='https://hostname/',
+            inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
+            config=_InvConfig(
+                intersphinx_cache_limit=5,
+                intersphinx_timeout=None,
+                tls_verify=False,
+                tls_cacerts=None,
+                user_agent='',
+            ),
+        )
+    # The password must not appear in the error args
+    error_text = str(exc_info.value.args)
+    assert 'secret' not in error_text
+    assert 'user@hostname' in error_text
+
+
+@mock.patch('sphinx.ext.intersphinx._load.InventoryFile')
+@mock.patch('sphinx.ext.intersphinx._load.requests.get')
+@pytest.mark.sphinx('html', testroot='root')
+def test_fetch_inventory_redirect_hides_credentials(get_request, InventoryFile, app):
+    """Credentials should not appear in redirect log messages."""
+    mocked_get = get_request.return_value.__enter__.return_value
+    intersphinx_setup(app)
+    mocked_get.content = b'# Sphinx inventory version 2'
+
+    mocked_get.url = 'https://user:secret@hostname/new/' + INVENTORY_FILENAME
+
+    target_uri = 'https://hostname/'
+    raw_data, target_uri = _fetch_inventory_data(
+        target_uri=target_uri,
+        inv_location='https://user:secret@hostname/' + INVENTORY_FILENAME,
+        config=_InvConfig.from_config(app.config),
+        srcdir=app.srcdir,
+        cache_path=None,
+    )
+    status_output = app.status.getvalue()
+    assert 'secret' not in status_output
+
+
 def test_inspect_main_noargs(capsys):
     """inspect_main interface, without arguments"""
     assert inspect_main([]) == 1

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -666,7 +666,7 @@ def test_getsafeurl_unauthed() -> None:
     assert actual == expected
 
 
-def test_fetch_inventory_url_error_hides_credentials(capsys):
+def test_fetch_inventory_url_error_hides_credentials(capsys, caplog):
     """Credentials should not appear in error messages on fetch failure."""
 
     class ErrorHandler(http.server.BaseHTTPRequestHandler):
@@ -683,6 +683,7 @@ def test_fetch_inventory_url_error_hides_credentials(capsys):
     stdout, stderr = capsys.readouterr()
     assert 'secret' not in stdout
     assert 'secret' not in stderr
+    assert not any('secret' in message for message in caplog.messages)
     assert 'user@localhost' in stderr
 
 
@@ -705,8 +706,7 @@ def test_fetch_inventory_redirect_hides_credentials(capsys, caplog):
             pass
 
     with http_server(RedirectHandler) as server:
-        port = server.server_port
-        url = f'http://user:secret@localhost:{port}/{INVENTORY_FILENAME}'
+        url = f'http://user:secret@localhost:{server.server_port}/{INVENTORY_FILENAME}'
         inspect_main([url])
 
     stdout, stderr = capsys.readouterr()


### PR DESCRIPTION
Fixes #14342.

When intersphinx fails to fetch an inventory or detects a redirect, the error and info messages include the raw URL with basic auth credentials. The `_get_safe_url` helper already exists in this file (and is used for the initial "loading inventory" info message) but wasn't applied to the error path in `_fetch_inventory_url` or the "inventory has moved" log message.