### PR TITLE
Fix autodoc IndexError on classes with custom __module__

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_type_comments.py
+++ b/sphinx/ext/autodoc/_dynamic/_type_comments.py
@@ -151,6 +151,8 @@ def get_type_comment(obj: Any, bound_method: bool = False) -> Signature | None:
         return None
     except SyntaxError:  # failed to parse type_comments
         return None
+    except IndexError:  # ast.parse returned empty module (e.g. source is whitespace)
+        return None
 
 
 def signature_from_ast(


### PR DESCRIPTION
## Problem

On Python 3.14, autodoc raises `IndexError` when formatting arguments for classes with a custom `__module__` attribute:

```
error while formatting arguments for pytest.PytestUnraisableExceptionWarning: list index out of range [autodoc]
```

## Root Cause

`inspect.getsource()` may return whitespace (e.g. `"\\n"`) for classes with a custom `__module__`. `ast.parse()` then returns an empty `Module` (no body), causing `module.body[0]` to raise `IndexError`.

## Fix

Add `IndexError` to the exception handlers in `get_type_comment()`, alongside the existing `OSError`, `TypeError`, and `SyntaxError` handlers.

2 lines changed.

Closes #14345