### PR TITLE
Un-deprecate ``Parser.config`` and ``Parser.env``

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ Contributors
 * Erik Bedard -- config options for :mod:`sphinx.ext.duration`
 * Etienne Desautels -- apidoc module
 * Ezio Melotti -- collapsible sidebar JavaScript
+* Fazeel Usmani -- parser API fixes
 * Filip Vavera -- napoleon todo directive
 * Florian Best -- log improvements
 * Glenn Matthews -- python domain signature improvements

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+Release 9.2.0 (in development)
+==============================
+
+Bugs fixed
+----------
+
+* #14371: Un-deprecate :py:attr:`!Parser.config` and :py:attr:`!Parser.env`,
+  the supported way for a custom parser to access the build configuration
+  and environment.  Only :py:meth:`!Parser.set_application` remains deprecated.
+  Patch by Fazeel Usmani
+
 Release 9.1.0 (released Dec 31, 2025)
 =====================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,15 @@
 Release 9.2.0 (in development)
 ==============================
 
-Bugs fixed
+Deprecated
 ----------
 
-* #14371: Un-deprecate :py:attr:`!Parser.config` and :py:attr:`!Parser.env`,
-  the supported way for a custom parser to access the build configuration
-  and environment.  Only :py:meth:`!Parser.set_application` remains deprecated.
-  Patch by Fazeel Usmani
+* #14371: Un-deprecate :py:attr:`!Parser.config` and :py:attr:`!Parser.env`.
+  These remain the supported way for a custom parser to read the build
+  configuration and environment.
+  :py:meth:`!Parser.set_application` continues to be deprecated and is
+  scheduled for removal in Sphinx 10.
+  Patch by Fazeel Usmani.
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/doc/extdev/parserapi.rst
+++ b/doc/extdev/parserapi.rst
@@ -42,10 +42,10 @@ Accessing the Sphinx config and environment
 
 A custom parser can read Sphinx :class:`~sphinx.config.Config` values and the
 :class:`~sphinx.environment.BuildEnvironment` through the inherited
-:attr:`Parser.config` and :attr:`Parser.env` properties.  Sphinx sets the
-backing ``_config`` and ``_env`` attributes when it constructs the parser via
+``Parser.config`` and ``Parser.env`` properties.  Sphinx sets the backing
+``_config`` and ``_env`` attributes when it constructs the parser via
 :meth:`.Sphinx.add_source_parser`, so they are available from the moment
-:meth:`Parser.parse` is called.
+``parse()`` is called.
 
 .. code-block:: python
 
@@ -62,7 +62,7 @@ backing ``_config`` and ``_env`` attributes when it constructs the parser via
            ...
 
 .. versionchanged:: 9.0
-   The :meth:`Parser.set_application` hook is deprecated.  Sphinx now sets
+   The ``Parser.set_application`` hook is deprecated.  Sphinx now sets
    ``_config`` and ``_env`` directly when the parser instance is created, so
    custom parsers no longer need to override ``set_application`` to capture
    these objects.

--- a/doc/extdev/parserapi.rst
+++ b/doc/extdev/parserapi.rst
@@ -36,3 +36,33 @@ to configure their settings appropriately.
 
 .. autoclass:: Parser
    :members:
+
+Accessing the Sphinx config and environment
+-------------------------------------------
+
+A custom parser can read Sphinx :class:`~sphinx.config.Config` values and the
+:class:`~sphinx.environment.BuildEnvironment` through the inherited
+:attr:`Parser.config` and :attr:`Parser.env` properties.  Sphinx sets the
+backing ``_config`` and ``_env`` attributes when it constructs the parser via
+:meth:`.Sphinx.add_source_parser`, so they are available from the moment
+:meth:`Parser.parse` is called.
+
+.. code-block:: python
+
+   from sphinx.parsers import Parser
+
+
+   class MyParser(Parser):
+       supported = ('mytype',)
+
+       def parse(self, inputstring, document):
+           # ``self.config`` and ``self.env`` are populated by Sphinx
+           encoding = self.config.source_encoding
+           docname = self.env.docname
+           ...
+
+.. versionchanged:: 9.0
+   The :meth:`Parser.set_application` hook is deprecated.  Sphinx now sets
+   ``_config`` and ``_env`` directly when the parser instance is created, so
+   custom parsers no longer need to override ``set_application`` to capture
+   these objects.

--- a/doc/extdev/parserapi.rst
+++ b/doc/extdev/parserapi.rst
@@ -42,10 +42,10 @@ Accessing the Sphinx config and environment
 
 A custom parser can read Sphinx :class:`~sphinx.config.Config` values and the
 :class:`~sphinx.environment.BuildEnvironment` through the inherited
-``Parser.config`` and ``Parser.env`` properties.  Sphinx sets the backing
-``_config`` and ``_env`` attributes when it constructs the parser via
-:meth:`.Sphinx.add_source_parser`, so they are available from the moment
-``parse()`` is called.
+``Parser.config`` and ``Parser.env`` properties.  Sphinx populates the
+backing ``_config`` and ``_env`` attributes when it instantiates a parser
+registered via :meth:`.Sphinx.add_source_parser`, so they are available
+from the start of ``parse()``.
 
 .. code-block:: python
 
@@ -61,8 +61,11 @@ A custom parser can read Sphinx :class:`~sphinx.config.Config` values and the
            docname = self.env.docname
            ...
 
-.. versionchanged:: 9.0
-   The ``Parser.set_application`` hook is deprecated.  Sphinx now sets
-   ``_config`` and ``_env`` directly when the parser instance is created, so
-   custom parsers no longer need to override ``set_application`` to capture
-   these objects.
+.. versionchanged:: 9.2
+   ``Parser.config`` and ``Parser.env`` are no longer deprecated.
+
+.. deprecated:: 9.0
+   The ``Parser.set_application`` hook is deprecated and will be removed in
+   Sphinx 10.  Sphinx now populates ``_config`` and ``_env`` directly when
+   the parser instance is created, so custom parsers no longer need to
+   override ``set_application`` to capture these objects.

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -36,24 +36,33 @@ class Parser(docutils.parsers.Parser):
 
     @property
     def config(self) -> Config:
-        """The config object."""
-        cls_module = self.__class__.__module__
-        cls_name = self.__class__.__qualname__
-        _deprecation_warning(cls_module, f'{cls_name}.config', remove=(10, 0))
+        """The config object.
+
+        Sphinx sets this attribute when constructing the parser via
+        :meth:`.Sphinx.add_source_parser`, so it is available throughout
+        :meth:`parse`.
+        """
         return self._config
 
     @property
     def env(self) -> BuildEnvironment:
-        """The environment object."""
-        cls_module = self.__class__.__module__
-        cls_name = self.__class__.__qualname__
-        _deprecation_warning(cls_module, f'{cls_name}.env', remove=(10, 0))
+        """The environment object.
+
+        Sphinx sets this attribute when constructing the parser via
+        :meth:`.Sphinx.add_source_parser`, so it is available throughout
+        :meth:`parse`.
+        """
         return self._env
 
     def set_application(self, app: Sphinx) -> None:
         """set_application will be called from Sphinx to set app and other instance variables
 
         :param sphinx.application.Sphinx app: Sphinx application object
+
+        .. versionchanged:: 9.0
+           Deprecated.  Sphinx now sets :attr:`_config` and :attr:`_env`
+           directly when the parser is created, so this hook is no longer
+           needed.  It will be removed in Sphinx 10.
         """
         cls_module = self.__class__.__module__
         cls_name = self.__class__.__qualname__

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -38,9 +38,12 @@ class Parser(docutils.parsers.Parser):
     def config(self) -> Config:
         """The config object.
 
-        Sphinx sets this attribute when constructing the parser via
-        :meth:`.Sphinx.add_source_parser`, so it is available throughout
-        ``parse()``.
+        Populated by Sphinx when it instantiates a parser registered via
+        :meth:`.Sphinx.add_source_parser`, so this is available from the
+        start of ``parse()``.
+
+        .. versionchanged:: 9.2
+           No longer deprecated.
         """
         return self._config
 
@@ -48,21 +51,25 @@ class Parser(docutils.parsers.Parser):
     def env(self) -> BuildEnvironment:
         """The environment object.
 
-        Sphinx sets this attribute when constructing the parser via
-        :meth:`.Sphinx.add_source_parser`, so it is available throughout
-        ``parse()``.
+        Populated by Sphinx when it instantiates a parser registered via
+        :meth:`.Sphinx.add_source_parser`, so this is available from the
+        start of ``parse()``.
+
+        .. versionchanged:: 9.2
+           No longer deprecated.
         """
         return self._env
 
     def set_application(self, app: Sphinx) -> None:
-        """set_application will be called from Sphinx to set app and other instance variables
+        """Legacy compatibility hook for receiving the Sphinx application.
 
         :param sphinx.application.Sphinx app: Sphinx application object
 
-        .. versionchanged:: 9.0
-           Deprecated.  Sphinx now sets ``_config`` and ``_env`` directly
-           when the parser is created, so this hook is no longer needed.
-           It will be removed in Sphinx 10.
+        .. deprecated:: 9.0
+           Sphinx now makes ``config`` and ``env`` available on the parser
+           instance automatically, so custom parsers no longer need to
+           override this method to capture the application.  It will be
+           removed in Sphinx 10.
         """
         cls_module = self.__class__.__module__
         cls_name = self.__class__.__qualname__

--- a/sphinx/parsers.py
+++ b/sphinx/parsers.py
@@ -40,7 +40,7 @@ class Parser(docutils.parsers.Parser):
 
         Sphinx sets this attribute when constructing the parser via
         :meth:`.Sphinx.add_source_parser`, so it is available throughout
-        :meth:`parse`.
+        ``parse()``.
         """
         return self._config
 
@@ -50,7 +50,7 @@ class Parser(docutils.parsers.Parser):
 
         Sphinx sets this attribute when constructing the parser via
         :meth:`.Sphinx.add_source_parser`, so it is available throughout
-        :meth:`parse`.
+        ``parse()``.
         """
         return self._env
 
@@ -60,9 +60,9 @@ class Parser(docutils.parsers.Parser):
         :param sphinx.application.Sphinx app: Sphinx application object
 
         .. versionchanged:: 9.0
-           Deprecated.  Sphinx now sets :attr:`_config` and :attr:`_env`
-           directly when the parser is created, so this hook is no longer
-           needed.  It will be removed in Sphinx 10.
+           Deprecated.  Sphinx now sets ``_config`` and ``_env`` directly
+           when the parser is created, so this hook is no longer needed.
+           It will be removed in Sphinx 10.
         """
         cls_module = self.__class__.__module__
         cls_name = self.__class__.__qualname__

--- a/tests/test_markup/test_parser.py
+++ b/tests/test_markup/test_parser.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import pytest
 
+from sphinx.deprecation import RemovedInSphinx10Warning
 from sphinx.parsers import RSTParser
 from sphinx.util.docutils import new_document
 
@@ -68,3 +70,16 @@ def test_RSTParser_prolog_epilog(RSTStateMachine: Mock, app: SphinxTestApp) -> N
         ('dummy.rst', 0, '        hello Sphinx world'),
         ('dummy.rst', 1, '  Sphinx is a document generator'),
     ]
+
+
+@pytest.mark.sphinx('html', testroot='basic')
+def test_parser_config_env_not_deprecated(app: SphinxTestApp) -> None:
+    """Reading ``Parser.config`` / ``Parser.env`` must not warn (#14371)."""
+    parser = RSTParser()
+    parser._config = app.config
+    parser._env = app.env
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RemovedInSphinx10Warning)
+        assert parser.config is app.config
+        assert parser.env is app.env

--- a/tests/test_markup/test_parser.py
+++ b/tests/test_markup/test_parser.py
@@ -73,13 +73,29 @@ def test_RSTParser_prolog_epilog(RSTStateMachine: Mock, app: SphinxTestApp) -> N
 
 
 @pytest.mark.sphinx('html', testroot='basic')
-def test_parser_config_env_not_deprecated(app: SphinxTestApp) -> None:
-    """Reading ``Parser.config`` / ``Parser.env`` must not warn (#14371)."""
-    parser = RSTParser()
-    parser._config = app.config
-    parser._env = app.env
+def test_parser_config_env_populated_by_registry(app: SphinxTestApp) -> None:
+    """Parsers built via the registry expose config/env without warning (#14371).
+
+    This goes through the real construction path in
+    :meth:`.SphinxComponentRegistry.create_source_parser` so a regression in
+    that code path (for example, removal of the ``isinstance(..., SphinxParser)``
+    gate) would be caught here.
+    """
+    parser = app.registry.create_source_parser(
+        'restructuredtext', config=app.config, env=app.env
+    )
 
     with warnings.catch_warnings():
         warnings.simplefilter('error', RemovedInSphinx10Warning)
         assert parser.config is app.config
         assert parser.env is app.env
+
+
+@pytest.mark.sphinx('html', testroot='basic')
+def test_parser_set_application_still_deprecated(app: SphinxTestApp) -> None:
+    """``Parser.set_application`` must still emit a deprecation warning (#14371)."""
+    parser = RSTParser()
+    with pytest.warns(RemovedInSphinx10Warning, match='set_application'):
+        parser.set_application(app)
+    assert parser.config is app.config
+    assert parser.env is app.env

--- a/tests/test_markup/test_parser.py
+++ b/tests/test_markup/test_parser.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from sphinx.deprecation import RemovedInSphinx10Warning
-from sphinx.parsers import RSTParser
+from sphinx.parsers import Parser, RSTParser
 from sphinx.util.docutils import new_document
 
 if TYPE_CHECKING:
@@ -84,6 +84,10 @@ def test_parser_config_env_populated_by_registry(app: SphinxTestApp) -> None:
     parser = app.registry.create_source_parser(
         'restructuredtext', config=app.config, env=app.env
     )
+    # ``create_source_parser`` is typed as ``docutils.parsers.Parser``; narrow
+    # to the Sphinx base class so ``config`` / ``env`` access type-checks and
+    # so a future regression that stops wrapping Sphinx parsers is caught here.
+    assert isinstance(parser, Parser)
 
     with warnings.catch_warnings():
         warnings.simplefilter('error', RemovedInSphinx10Warning)


### PR DESCRIPTION
Fixes #14371.

`Parser.config`, `Parser.env`, and `Parser.set_application` were all deprecated in 9.0 (PRs #13644 and #13637), scheduled for removal in 10.0. The `set_application` deprecation makes sense — the registry now sets `_config` and `_env` directly when it constructs the parser, so there's nothing left for the hook to do. But the property deprecations are a different story: they're the only public way a custom parser can read the Sphinx config and build environment.

- `_config` / `_env` are private and not part of the API contract.
- Third-party parsers like `sphinx_bib_domain` read `config` / `env` inside `parse()`.
- Anything running `-W error` in CI (pretty common) now breaks outright on the deprecation warning.

Adam flagged this himself in the original PR body:

> It's unclear if these attributes are used in third-party projects, and removing them would allow for a great deal of simplification. I'm open to reversing this deprecation if the impact is too large.

#14371 is the impact report, so this un-deprecates `config` and `env`. `set_application` stays deprecated.

## Changes

`sphinx/parsers.py`
- Removes the deprecation warnings from the `config` and `env` properties and adds `.. versionchanged:: 9.2` notes on both.
- Property docstrings rewritten to actually describe what happens: the registry populates `_config` / `_env` when it *instantiates* a registered parser, not at `add_source_parser` registration time. (The first version I wrote got this wrong; a reviewer caught it.)
- `set_application`'s docstring still opened with "set_application will be called from Sphinx...", which contradicted its own deprecation note. Rewrote it to lead with "Legacy compatibility hook for receiving the Sphinx application", and switched `.. versionchanged:: 9.0` to `.. deprecated:: 9.0` so the deprecation index picks it up.

`doc/extdev/parserapi.rst`
- New "Accessing the Sphinx config and environment" section with a small `MyParser` example showing `self.config` / `self.env` use inside `parse()`.
- Trailing note split into a 9.2 un-deprecation block and a 9.0 `.. deprecated::` block for `set_application`.

`CHANGES.rst` — entry under `Deprecated`, matching the 8.2 release-notes precedent for un-deprecations (#13083). I initially filed it under `Bugs fixed`, which didn't match convention.

`tests/test_markup/test_parser.py`
- `test_parser_config_env_populated_by_registry` exercises `app.registry.create_source_parser(...)` directly instead of manually assigning `parser._config` / `parser._env`. The earlier version of the test would have missed any regression in the `isinstance(parser, SphinxParser)` gate inside `create_source_parser`, which is exactly the code path this PR is trying to protect. I also needed `assert isinstance(parser, Parser)` to narrow the return type (mypy sees it as `docutils.parsers.Parser`), which doubles as a runtime contract check.
- `test_parser_set_application_still_deprecated` pins the other half of the policy: `set_application` must keep emitting `RemovedInSphinx10Warning` so we don't accidentally un-deprecate that one too.

`AUTHORS.rst` — added myself.

## Testing

- `pytest tests/test_markup/test_parser.py -q` passes on Python 3.13 / 3.14 with Docutils 0.21 and 0.22, visible in CI.
- `mypy`, `pyright`, and `docs-lint` clean on the changed files.
- Doc build is clean; the Read the Docs preview is green.

## CI noise

A few checks are red, but none of them look like they're caused by this PR:

- `Python 3.15` (all variants) — `test_ext_autosummary::test_autogen*`, nothing to do with parsers.
- `LaTeX` — `test_build_latex.py::test_writer`, `test_latex_raw_directive`, `test_latex_labels`.
- `Python 3.12 (Docutils 0.21)` — `test_build_html_numfig.py::test_numfig_disabled_warn`. This one looks like a flake — it was green on the previous run of the same branch.
- `Docutils HEAD` — upstream drift.
- `ty` — ~300 pre-existing diagnostics in `test_util_typing.py`, `test_versioning.py`, and a typo in `ty.toml`. The new parser tests aren't in the error list.

Let me know if rebasing on master would clear any of them. I held off so I wouldn't churn the branch for nothing.

## Commits

There are a few fixup commits on top of the initial one because I iterated on review feedback (cross-reference cleanup, docstring mechanism, CHANGES category, test rewrite, mypy narrowing). Squash at merge is fine with me.
