### PR TITLE
Fix needs_extensions version comparison to use packaging.Version

### DIFF
--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -1,21 +1,24 @@
-"""Utilities for Sphinx extensions."""
+"""
+    sphinx.extension
+    ~~~~~~~~~~~~~~~~
 
-from __future__ import annotations
+    Utilities for Sphinx extensions.
 
-from typing import TYPE_CHECKING
+    :copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
 
-from packaging.version import InvalidVersion, Version
+from typing import TYPE_CHECKING, Any, Dict
 
+from packaging.version import Version
+
+from sphinx.config import Config
 from sphinx.errors import VersionRequirementError
 from sphinx.locale import __
 from sphinx.util import logging
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from sphinx.application import Sphinx
-    from sphinx.config import Config
-    from sphinx.util.typing import ExtensionMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +27,7 @@ class Extension:
     def __init__(self, name: str, module: Any, **kwargs: Any) -> None:
         self.name = name
         self.module = module
-        self.metadata: ExtensionMetadata = kwargs  # type: ignore[assignment]
+        self.metadata = kwargs
         self.version = kwargs.pop('version', 'unknown version')
 
         # The extension supports parallel read or not.  The default value
@@ -38,53 +41,26 @@ class Extension:
         self.parallel_write_safe = kwargs.pop('parallel_write_safe', True)
 
 
-def verify_needs_extensions(app: Sphinx, config: Config) -> None:
-    """Check that extensions mentioned in :confval:`needs_extensions` satisfy the version
-    requirement, and warn if an extension is not loaded.
-
-    Warns if an extension in :confval:`needs_extension` is not loaded.
-
-    :raises VersionRequirementError: if the version of an extension in
-    :confval:`needs_extension` is unknown or older than the required version.
-    """
+def verify_needs_extensions(app: "Sphinx", config: Config) -> None:
+    """Verify the required Sphinx extensions are loaded."""
     if config.needs_extensions is None:
         return
 
     for extname, reqversion in config.needs_extensions.items():
         extension = app.extensions.get(extname)
         if extension is None:
-            logger.warning(
-                __(
-                    'The %s extension is required by needs_extensions settings, '
-                    'but it is not loaded.'
-                ),
-                extname,
-            )
+            logger.warning(__('The %s extension is required by needs_extensions settings, '
+                              'but it is not loaded.'), extname)
             continue
 
-        fulfilled = True
-        if extension.version == 'unknown version':
-            fulfilled = False
-        else:
-            try:
-                if Version(reqversion) > Version(extension.version):
-                    fulfilled = False
-            except InvalidVersion:
-                if reqversion > extension.version:
-                    fulfilled = False
-
-        if not fulfilled:
-            raise VersionRequirementError(
-                __(
-                    'This project needs the extension %s at least in '
-                    'version %s and therefore cannot be built with '
-                    'the loaded version (%s).'
-                )
-                % (extname, reqversion, extension.version)
-            )
+        if extension.version == 'unknown version' or Version(reqversion) > Version(extension.version):
+            raise VersionRequirementError(__('This project needs the extension %s at least in '
+                                             'version %s and therefore cannot be built with '
+                                             'the loaded version (%s).') %
+                                          (extname, reqversion, extension.version))
 
 
-def setup(app: Sphinx) -> ExtensionMetadata:
+def setup(app: "Sphinx") -> Dict[str, Any]:
     app.connect('config-inited', verify_needs_extensions, priority=800)
 
     return {

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,70 @@
+"""
+    test_extension
+    ~~~~~~~~~~~~~~
+
+    Test sphinx.extension module.
+
+    :copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from unittest import mock
+
+import pytest
+
+from sphinx.errors import VersionRequirementError
+from sphinx.extension import Extension, verify_needs_extensions
+
+
+def test_verify_needs_extensions_version_comparison():
+    """Test that needs_extensions compares versions properly, not as strings.
+
+    This is a regression test for the bug where '0.10.0' was considered
+    less than '0.6.0' because string comparison was used instead of
+    proper version comparison.
+    """
+    extension = Extension('test_ext', mock.Mock(), version='0.10.0')
+
+    app = mock.Mock()
+    app.extensions = {'test_ext': extension}
+
+    config = mock.Mock()
+
+    # Should pass: installed 0.10.0 >= required 0.6.0
+    config.needs_extensions = {'test_ext': '0.6.0'}
+    verify_needs_extensions(app, config)
+
+    # Should pass: installed 0.10.0 >= required 0.10.0 (equal)
+    config.needs_extensions = {'test_ext': '0.10.0'}
+    verify_needs_extensions(app, config)
+
+    # Should fail: installed 0.10.0 < required 0.11.0
+    config.needs_extensions = {'test_ext': '0.11.0'}
+    with pytest.raises(VersionRequirementError):
+        verify_needs_extensions(app, config)
+
+
+def test_verify_needs_extensions_unknown_version():
+    """Test that unknown version always raises."""
+    extension = Extension('test_ext', mock.Mock(), version='unknown version')
+
+    app = mock.Mock()
+    app.extensions = {'test_ext': extension}
+
+    config = mock.Mock()
+    config.needs_extensions = {'test_ext': '0.1'}
+
+    with pytest.raises(VersionRequirementError):
+        verify_needs_extensions(app, config)
+
+
+def test_verify_needs_extensions_missing_extension():
+    """Test that missing extension logs a warning but doesn't raise."""
+    app = mock.Mock()
+    app.extensions = {}
+
+    config = mock.Mock()
+    config.needs_extensions = {'missing_ext': '0.1'}
+
+    # Should not raise, just warn
+    verify_needs_extensions(app, config)


### PR DESCRIPTION
## Summary

Fix the `needs_extensions` check to compare versions using `packaging.version.Version` instead of string comparison.

## Problem

The `needs_extensions` check compared version strings lexicographically, which produced incorrect results for versions with components >= 10. For example:
- As strings: `'0.6.0' > '0.10.0'` evaluates to `True` (wrong)
- As versions: `Version('0.6.0') > Version('0.10.0')` evaluates to `False` (correct)

This caused extensions like sphinx-gallery 0.10.0 to be rejected when 0.6.0 was the minimum required version.

## Fix

Replace the string comparison `reqversion > extension.version` with `Version(reqversion) > Version(extension.version)` using `packaging.version.Version`, which is already a dependency of Sphinx.

## Files Changed

- `sphinx/extension.py` -- Use `packaging.version.Version` for proper semantic version comparison
- `tests/test_extension.py` -- New test file with regression tests for the version comparison fix

## Testing

### Unit tests (new)
```
$ python3 -m pytest tests/test_extension.py -v
tests/test_extension.py::test_verify_needs_extensions_version_comparison PASSED
tests/test_extension.py::test_verify_needs_extensions_unknown_version PASSED
tests/test_extension.py::test_verify_needs_extensions_missing_extension PASSED
3 passed
```

### Manual verification
```python
>>> from packaging.version import Version
>>> Version('0.6.0') > Version('0.10.0')
False  # Correct! 0.6.0 < 0.10.0
>>> '0.6.0' > '0.10.0'
True   # Bug! String comparison is wrong
```

### Existing tests
Ran `tests/test_config.py` -- all pre-existing failures are unrelated (sphinxcontrib.applehelp version mismatch with this old Sphinx version). Verified by running the same tests on the base commit without changes.