### PR TITLE
Add regression tests for needs_extensions version comparison fix

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,70 @@
+"""
+    test_extension
+    ~~~~~~~~~~~~~~
+
+    Test sphinx.extension module.
+
+    :copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from unittest import mock
+
+import pytest
+
+from sphinx.errors import VersionRequirementError
+from sphinx.extension import Extension, verify_needs_extensions
+
+
+def test_verify_needs_extensions_version_comparison():
+    """Test that needs_extensions compares versions properly, not as strings.
+
+    This is a regression test for the bug where '0.10.0' was considered
+    less than '0.6.0' because string comparison was used instead of
+    proper version comparison.
+    """
+    extension = Extension('test_ext', mock.Mock(), version='0.10.0')
+
+    app = mock.Mock()
+    app.extensions = {'test_ext': extension}
+
+    config = mock.Mock()
+
+    # Should pass: installed 0.10.0 >= required 0.6.0
+    config.needs_extensions = {'test_ext': '0.6.0'}
+    verify_needs_extensions(app, config)
+
+    # Should pass: installed 0.10.0 >= required 0.10.0 (equal)
+    config.needs_extensions = {'test_ext': '0.10.0'}
+    verify_needs_extensions(app, config)
+
+    # Should fail: installed 0.10.0 < required 0.11.0
+    config.needs_extensions = {'test_ext': '0.11.0'}
+    with pytest.raises(VersionRequirementError):
+        verify_needs_extensions(app, config)
+
+
+def test_verify_needs_extensions_unknown_version():
+    """Test that unknown version always raises."""
+    extension = Extension('test_ext', mock.Mock(), version='unknown version')
+
+    app = mock.Mock()
+    app.extensions = {'test_ext': extension}
+
+    config = mock.Mock()
+    config.needs_extensions = {'test_ext': '0.1'}
+
+    with pytest.raises(VersionRequirementError):
+        verify_needs_extensions(app, config)
+
+
+def test_verify_needs_extensions_missing_extension():
+    """Test that missing extension logs a warning but doesn't raise."""
+    app = mock.Mock()
+    app.extensions = {}
+
+    config = mock.Mock()
+    config.needs_extensions = {'missing_ext': '0.1'}
+
+    # Should not raise, just warn
+    verify_needs_extensions(app, config)


### PR DESCRIPTION
## Summary

Add regression tests for the `needs_extensions` version comparison fix in `sphinx/extension.py`.

## Background

The `needs_extensions` check previously compared version strings lexicographically, which produced incorrect results for versions with components >= 10. For example:
- As strings: `'0.6.0' > '0.10.0'` evaluates to `True` (wrong)  
- As versions: `Version('0.6.0') > Version('0.10.0')` evaluates to `False` (correct)

This caused extensions like sphinx-gallery 0.10.0 to be rejected when 0.6.0 was the minimum required version.

The fix in `sphinx/extension.py` (using `packaging.version.Version` for proper semantic version comparison) has already been applied to master. This PR adds regression tests to prevent the bug from recurring.

## Files Changed

- `tests/test_extension.py` -- New test file with regression tests for `verify_needs_extensions`:
  - `test_verify_needs_extensions_version_comparison`: Tests that version 0.10.0 satisfies a 0.6.0 requirement (the original bug scenario)
  - `test_verify_needs_extensions_unknown_version`: Tests that unknown versions always raise
  - `test_verify_needs_extensions_missing_extension`: Tests that missing extensions warn but don't raise

## Testing

```
$ python3 -m pytest tests/test_extension.py -v
tests/test_extension.py::test_verify_needs_extensions_version_comparison PASSED
tests/test_extension.py::test_verify_needs_extensions_unknown_version PASSED
tests/test_extension.py::test_verify_needs_extensions_missing_extension PASSED
3 passed
```