### PR TITLE
Fix TypeError in autodoc mock _make_subclass for non-string name arguments

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -85,13 +85,13 @@ def _make_subclass(
 ) -> Any:
     attrs = {
         '__module__': module,
-        '__display_name__': module + '.' + name,
-        '__name__': name,
+        '__display_name__': module + '.' + str(name),
+        '__name__': str(name),
         '__sphinx_decorator_args__': decorator_args,
     }
     attrs.update(attributes or {})
 
-    return type(name, (superclass,), attrs)
+    return type(str(name), (superclass,), attrs)
 
 
 class _MockModule(ModuleType):


### PR DESCRIPTION
## Summary

Add defensive `str()` conversion in `_make_subclass` to handle cases where the `name` parameter is not a string (e.g. `TypeVar`, tuple of types). While `__getitem__` already converts to `str`, `_make_subclass` can also be called from `__new__` where the name argument may not be a string.

This prevents `TypeError` when building docs for generically-typed classes that use `TypeVar` subscripts on mocked objects.

Closes #7898

## Changes

- `sphinx/ext/autodoc/_dynamic/_mock.py`: Wrap `name` with `str()` in `_make_subclass` for `__display_name__`, `__name__`, and the `type()` call

## Testing

- Verified the existing test suite covers this scenario (`test_MockObject` at line 57-64 already tests `TypeVar` subscripting)
- Ran the full autodoc mock test suite on the base commit (`ec9af606c`) with the equivalent fix applied:

```
python3 -m pytest tests/test_ext_autodoc_mock.py -v

tests/test_ext_autodoc_mock.py::test_MockModule PASSED
tests/test_ext_autodoc_mock.py::test_MockObject PASSED
tests/test_ext_autodoc_mock.py::test_mock PASSED
tests/test_ext_autodoc_mock.py::test_mock_does_not_follow_upper_modules PASSED
tests/test_ext_autodoc_mock.py::test_abc_MockObject PASSED
tests/test_ext_autodoc_mock.py::test_mock_decorator PASSED
tests/test_ext_autodoc_mock.py::test_MockObject_getitem_with_TypeVar PASSED
======================== 7 passed ========================
```