### PR TITLE
Fix sphinx-doc__sphinx-9711

### DIFF
--- a/sphinx/extension.py
+++ b/sphinx/extension.py
@@ -1,21 +1,24 @@
-"""Utilities for Sphinx extensions."""
+"""
+    sphinx.extension
+    ~~~~~~~~~~~~~~~~
 
-from __future__ import annotations
+    Utilities for Sphinx extensions.
 
-from typing import TYPE_CHECKING
+    :copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
 
-from packaging.version import InvalidVersion, Version
+from typing import TYPE_CHECKING, Any, Dict
 
+from packaging.version import parse as parse_version
+
+from sphinx.config import Config
 from sphinx.errors import VersionRequirementError
 from sphinx.locale import __
 from sphinx.util import logging
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from sphinx.application import Sphinx
-    from sphinx.config import Config
-    from sphinx.util.typing import ExtensionMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +27,7 @@ class Extension:
     def __init__(self, name: str, module: Any, **kwargs: Any) -> None:
         self.name = name
         self.module = module
-        self.metadata: ExtensionMetadata = kwargs  # type: ignore[assignment]
+        self.metadata = kwargs
         self.version = kwargs.pop('version', 'unknown version')
 
         # The extension supports parallel read or not.  The default value
@@ -38,53 +41,26 @@ class Extension:
         self.parallel_write_safe = kwargs.pop('parallel_write_safe', True)
 
 
-def verify_needs_extensions(app: Sphinx, config: Config) -> None:
-    """Check that extensions mentioned in :confval:`needs_extensions` satisfy the version
-    requirement, and warn if an extension is not loaded.
-
-    Warns if an extension in :confval:`needs_extension` is not loaded.
-
-    :raises VersionRequirementError: if the version of an extension in
-    :confval:`needs_extension` is unknown or older than the required version.
-    """
+def verify_needs_extensions(app: "Sphinx", config: Config) -> None:
+    """Verify the required Sphinx extensions are loaded."""
     if config.needs_extensions is None:
         return
 
     for extname, reqversion in config.needs_extensions.items():
         extension = app.extensions.get(extname)
         if extension is None:
-            logger.warning(
-                __(
-                    'The %s extension is required by needs_extensions settings, '
-                    'but it is not loaded.'
-                ),
-                extname,
-            )
+            logger.warning(__('The %s extension is required by needs_extensions settings, '
+                              'but it is not loaded.'), extname)
             continue
 
-        fulfilled = True
-        if extension.version == 'unknown version':
-            fulfilled = False
-        else:
-            try:
-                if Version(reqversion) > Version(extension.version):
-                    fulfilled = False
-            except InvalidVersion:
-                if reqversion > extension.version:
-                    fulfilled = False
-
-        if not fulfilled:
-            raise VersionRequirementError(
-                __(
-                    'This project needs the extension %s at least in '
-                    'version %s and therefore cannot be built with '
-                    'the loaded version (%s).'
-                )
-                % (extname, reqversion, extension.version)
-            )
+        if extension.version == 'unknown version' or parse_version(reqversion) > parse_version(extension.version):
+            raise VersionRequirementError(__('This project needs the extension %s at least in '
+                                             'version %s and therefore cannot be built with '
+                                             'the loaded version (%s).') %
+                                          (extname, reqversion, extension.version))
 
 
-def setup(app: Sphinx) -> ExtensionMetadata:
+def setup(app: "Sphinx") -> Dict[str, Any]:
     app.connect('config-inited', verify_needs_extensions, priority=800)
 
     return {


### PR DESCRIPTION
## Fix: needs_extensions checks versions using strings

### Problem
The `needs_extensions` check in `sphinx/extension.py` compared version strings lexicographically (`reqversion > extension.version`). This causes incorrect rejections when version numbers have components >= 10, e.g., `'0.6' > '0.10'` is `True` as a string comparison, but `0.6 < 0.10` semantically.

### Fix
Changed the version comparison on line 54 of `sphinx/extension.py` to use `packaging.version.parse()` for proper semantic version comparison instead of raw string comparison.

### Changes
- `sphinx/extension.py`: Import `packaging.version.parse` and use it to compare `reqversion` and `extension.version` in `verify_needs_extensions()`.

### Testing
Verified that `parse_version('0.6') > parse_version('0.10')` correctly returns `False` (whereas string comparison `'0.6' > '0.10'` incorrectly returns `True`).