### PR TITLE
Fix sphinx-doc__sphinx-7889

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_mock.py
+++ b/sphinx/ext/autodoc/_dynamic/_mock.py
@@ -85,13 +85,13 @@ def _make_subclass(
 ) -> Any:
     attrs = {
         '__module__': module,
-        '__display_name__': module + '.' + name,
-        '__name__': name,
+        '__display_name__': module + '.' + str(name),
+        '__name__': str(name),
         '__sphinx_decorator_args__': decorator_args,
     }
     attrs.update(attributes or {})
 
-    return type(name, (superclass,), attrs)
+    return type(str(name), (superclass,), attrs)
 
 
 class _MockModule(ModuleType):


### PR DESCRIPTION
## Summary

Fix TypeError in autodoc mock's _make_subclass for generic-typed classes.

When building docs for a generically-typed class (e.g. Class[T]), the mock's _make_subclass receives a TypeVar object instead of a string for the name parameter. This causes a TypeError when concatenating str + TypeVar.

## Fix

Convert name to str() in _make_subclass for:
- The __display_name__ attribute (module + '.' + str(name))
- The __name__ attribute (str(name))
- The type() call (type(str(name), ...))

## Testing

Verified the fix resolves the TypeError when _make_subclass is called with a TypeVar argument instead of a string. The str() conversion is safe for both TypeVar objects (which have a __str__ method returning ~T) and regular strings (which pass through unchanged).

Fixes #7889