### PR TITLE
CI: GHA: Major version bump and fully-qualify astral-sh action semvers

### DIFF
--- a/.github/workflows/builddoc.yml
+++ b/.github/workflows/builddoc.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/builddoc.yml
+++ b/.github/workflows/builddoc.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/builddoc.yml
+++ b/.github/workflows/builddoc.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: "3"
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v10.0.0.1
         with:
           version: latest
           enable-cache: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: "3"
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.0.1
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: latest
           enable-cache: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: "3"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version: latest
           enable-cache: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         persist-credentials: false
 
     - name: Install Ruff
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4.0.0
       with:
         args: --version
 
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -71,7 +71,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -92,7 +92,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -114,7 +114,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -135,7 +135,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         persist-credentials: false
 
     - name: Install Ruff
-      uses: astral-sh/ruff-action@v4.0.0
+      uses: astral-sh/ruff-action@v4.1.0
       with:
         args: --version
 
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -71,7 +71,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -92,7 +92,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -114,7 +114,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -135,7 +135,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -71,7 +71,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -92,7 +92,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -114,7 +114,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -135,7 +135,7 @@ jobs:
       with:
         python-version: "3"
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -177,7 +177,7 @@ jobs:
     - name: Install graphviz
       run: choco install --no-progress graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -206,7 +206,7 @@ jobs:
     - name: Install graphviz
       run: brew install graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -241,7 +241,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -274,7 +274,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -305,7 +305,7 @@ jobs:
     - name: Check Python version
       run: python --version --version
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -338,7 +338,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -177,7 +177,7 @@ jobs:
     - name: Install graphviz
       run: choco install --no-progress graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -206,7 +206,7 @@ jobs:
     - name: Install graphviz
       run: brew install graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -241,7 +241,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -274,7 +274,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -305,7 +305,7 @@ jobs:
     - name: Check Python version
       run: python --version --version
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -338,7 +338,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -177,7 +177,7 @@ jobs:
     - name: Install graphviz
       run: choco install --no-progress graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -206,7 +206,7 @@ jobs:
     - name: Install graphviz
       run: brew install graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -241,7 +241,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -274,7 +274,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -305,7 +305,7 @@ jobs:
     - name: Check Python version
       run: python --version --version
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -338,7 +338,7 @@ jobs:
     - name: Install graphviz
       run: sudo apt-get install --no-install-recommends --yes graphviz
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -36,7 +36,7 @@ jobs:
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
       shell: bash
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false
@@ -72,7 +72,7 @@ jobs:
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
       shell: bash
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.0.0
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -36,7 +36,7 @@ jobs:
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
       shell: bash
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false
@@ -72,7 +72,7 @@ jobs:
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
       shell: bash
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v10.0.0.1
       with:
         version: latest
         enable-cache: false

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -36,7 +36,7 @@ jobs:
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
       shell: bash
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false
@@ -72,7 +72,7 @@ jobs:
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
       shell: bash
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.0.1
+      uses: astral-sh/setup-uv@v10.0.1
       with:
         version: latest
         enable-cache: false


### PR DESCRIPTION
## Purpose

Given the current state-of-affairs, Dependabot won't automatically upgrade to the recently-published immutable `astral-sh` GitHub Actions releases, because they do not have major-version-only semver tags (`v7` exists for `astral-sh/setup-uv`, for example, but `v8` does not -- instead only `v8.0.0` does).

~~I'm opening this as a draft pull request because I haven't yet reviewed the diffs in the source repositories for the actions~~ -- and also because it'd be worthwhile to build a collective sense about whether this is a worthwhile change before applying it.

## References

Refs:
 - https://github.com/dependabot/dependabot-core/issues/14713
 - https://github.com/astral-sh/setup-uv/issues/830

Edit: action-name fixup (was: uv, intended: setup-uv)
Edit: pull request is now flagged ready-for-review, so add strikethrough to part of this description