### PR TITLE
CI: enable Dependabot Updates for NPM packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
## Purpose

Help to keep our `jasmine` and related dependencies from NPM up-to-date for the JS test suite.

## References

- Thought-of during #14394.
- Relates-to #12754.