### PR TITLE
Update AutoNumbering transform.

### DIFF
--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -206,12 +206,18 @@ class AutoNumbering(SphinxTransform):
         domain: StandardDomain = self.env.domains.standard_domain
 
         for node in self.document.findall(nodes.Element):
-            if (
-                domain.is_enumerable_node(node)
-                and domain.get_numfig_title(node) is not None
-                and node['ids'] == []
-            ):
+            if not domain.is_enumerable_node(node):
+                continue
+            refname = domain.get_numfig_title(node)
+            if refname and node['ids'] == []:
+                if not node['names'] and getattr(self.document.settings, 'legacy_ids', True):
+                    # cf. https://docutils.sf.net/docs/user/config.html#legacy-ids
+                    node['names'].append(nodes.fully_normalize_name(refname))
                 self.document.note_implicit_target(node)
+                # Since Docutils 0.23, implicit targets don't get an ID
+                # at registration if "legacy_ids" is False:
+                if not getattr(self.document.settings, 'legacy_ids', True):
+                    self.document.set_id(node)
 
 
 class SortIds(SphinxTransform):

--- a/sphinx/writers/html5.py
+++ b/sphinx/writers/html5.py
@@ -452,7 +452,7 @@ class HTML5Translator(SphinxTranslator, BaseTranslator):
 
         figtype = self._domains.standard_domain.get_enumerable_node_type(node)
         if figtype:
-            if len(node['ids']) == 0:
+            if not node['ids']:
                 msg = __('Any IDs not assigned for %s node') % node.tagname
                 logger.warning(msg, location=node)
             else:


### PR DESCRIPTION
## Purpose

a) Ensure that enumerable elements (tables, figures and literal_blocks)
   have an ID. (In Docutils > 0.22, `nodes.document.note_implicit_target()`
   does not genereate an ID if `legacy_ids`_ is False.)

b) Title-derived IDs for enumerable elements:

   "Enumerable elements" get an auto-ID in the `AutoNumbering` SphinxTransform
   and a self-link (¶) after the caption/title in the HTML document.

   Currently, the ID is made of the "auto-id-prefix" + a running number
   (id1, id2, ...).  The generated IDs are not stable -- inserting/removing
   an enuerable element, footnote, or section with non-Lating heading will
   change the running number!

   Base the generated IDs on the caption or title text instead (similar to
   sections).  To avoid changed IDs when documents are re-compiled, this
   only happens if `legacy_ids`_ is False.

## References

.. _legacy_ids: https://docutils.sf.net/docs/user/config.html#legacy-ids

