### PR TITLE
Fix tests for Python 3.15.0a5+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14399: Fix tests for Python 3.15.0a5+
+  Patch by Edgar Ramírez-Mondragón
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,13 +27,20 @@ def _init_console(
     locale_dir: str | os.PathLike[str] | None = sphinx.locale._LOCALE_DIR,
     catalog: str = 'sphinx',
 ) -> tuple[gettext.NullTranslations, bool]:
-    """Monkeypatch ``init_console`` to skip its action.
+    """Monkeypatch ``init_console`` to skip locale loading.
 
     Some tests rely on warning messages in English. We don't want
     CLI tests to bleed over those tests and make their warnings
     translated.
+
+    We still register a NullTranslations so that ``__()`` (the console
+    translation function) returns a plain ``str`` rather than a lazy
+    ``_TranslationProxy``.  NullTranslations passes every message through
+    unchanged, so all strings stay in English.
     """
-    return gettext.NullTranslations(), False
+    null = gettext.NullTranslations()
+    sphinx.locale.translators['console', catalog] = null
+    return null, False
 
 
 sphinx.locale.init_console = _init_console


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

Fixes this exception in the tests:

```
TypeError: expected string or bytes-like object, got '_TranslationProxy'
```

and

```
FAILED tests/test_builders/test_build_linkcheck.py::test_too_many_requests_retry_after_without_header - assert '\x1b[90m127.0.0.1 - - []\x1b[0m "HEAD \x1b[36m/\x1b[0m HTTP/1.1" \x1b[33m429 \x1b[90m-\x1b[0m\n\x1b[90m127.0.0.1 - - []\x1b[0m "HEAD \x1b[36m/\x1b[0m HTTP/1.1" \x1b[32m200 \x1b[90m-\x1b[0m\n' == '127.0.0.1 - - [] "HEAD / HTTP/1.1" 429 -\n127.0.0.1 - - [] "HEAD / HTTP/1.1" 200 -\n'
```

The outstanding failures are unrelated:

- Lint/type checks (ty)
- ~Testing with the latest Docutils from source~
- ~LaTeX (same as the one above)~

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- https://github.com/python/cpython/pull/146293
- https://github.com/python/cpython/issues/148468
