### PR TITLE
docs: fix intersphinx wording typo

### DIFF
--- a/doc/usage/extensions/intersphinx.rst
+++ b/doc/usage/extensions/intersphinx.rst
@@ -149,7 +149,7 @@ linking:
 
       intersphinx_resolve_self = 'astropy'
 
-   Projects re-using *Astropy*'s documentation or inheriting their docstrings
+   Projects reusing *Astropy*'s documentation or inheriting their docstrings
    would then configure their :confval:`!intersphinx_mapping` with
    an :code-py:`'astropy'` key, pointing to *astropy*'s :file:`objects.inv`.
    For example:


### PR DESCRIPTION
## Summary
- fix a wording typo in the intersphinx docs

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- Reviewed `doc/internals/contributing.rst`
- Kept the change to one documentation file and skipped `CHANGES.rst` because this is a trivial docs update

## Validation
- `git diff --check`