### PR TITLE
std domain: parse conjoined option placeholders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Features added
 Bugs fixed
 ----------
 
+* #14323: std domain: Fix parsing and references for option directives with
+  conjoined placeholders, such as ``-S<value>``.
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
   Patch by Adam Turner
 * #13713: Fix compatibility with MyST-Parser.

--- a/sphinx/domains/std/__init__.py
+++ b/sphinx/domains/std/__init__.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # RE for option descriptions
-option_desc_re = re.compile(r'((?:/|--|-|\+)?[^\s=]+)(=?\s*.*)')
+option_desc_re = re.compile(r'((?:(?:/|--|-|\+)[^\s=<]+)|[^\s=]+)(=?\s*.*)')
 # RE for grammar tokens
 token_re = re.compile(r'`((~?[\w-]*:)?\w+)`')
 
@@ -1227,7 +1227,8 @@ class StandardDomain(Domain):
             # * :option:`-foo=bar`
             # * :option:`-foo[=bar]`
             # * :option:`-foo bar`
-            for needle in ('=', '[=', ' '):
+            # * :option:`-foo<bar>`
+            for needle in ('=', '[=', ' ', '<'):
                 if needle in target:
                     stem, _, _ = target.partition(needle)
                     docname, labelid = self.progoptions.get((progname, stem), ('', ''))

--- a/tests/test_domains/test_domain_std.py
+++ b/tests/test_domains/test_domain_std.py
@@ -123,6 +123,45 @@ def test_cmd_option_with_optional_value(app: SphinxTestApp) -> None:
 
 
 @pytest.mark.sphinx('html', testroot='_blank')
+def test_cmd_option_with_conjoined_placeholder(app: SphinxTestApp) -> None:
+    text = '.. option:: -S<value>'
+    doctree = restructuredtext.parse(app, text)
+    assert_node(
+        doctree,
+        (
+            index,
+            [
+                desc,
+                (
+                    [desc_signature, ([desc_name, '-S'], [desc_addname, '<value>'])],
+                    [desc_content, ()],
+                ),
+            ],
+        ),
+    )
+    assert_node(
+        doctree[0],
+        addnodes.index,
+        entries=[('pair', 'command line option; -S', 'cmdoption-S', '', None)],
+    )
+
+    domain = app.env.domains.standard_domain
+    objects = list(domain.get_objects())
+    assert ('-S', '-S', 'cmdoption', 'index', 'cmdoption-S', 1) in objects
+
+    refnode = domain.resolve_xref(
+        app.env,
+        'index',
+        app.builder,
+        'option',
+        '-S<other>',
+        pending_xref(),
+        nodes.paragraph(),
+    )
+    assert_node(refnode, nodes.reference, refid='cmdoption-S')
+
+
+@pytest.mark.sphinx('html', testroot='_blank')
 def test_cmd_option_starting_with_bracket(app: SphinxTestApp) -> None:
     text = '.. option:: [enable=]PATTERN'
     doctree = restructuredtext.parse(app, text)

--- a/tests/test_domains/test_domain_std.py
+++ b/tests/test_domains/test_domain_std.py
@@ -158,6 +158,7 @@ def test_cmd_option_with_conjoined_placeholder(app: SphinxTestApp) -> None:
         pending_xref(),
         nodes.paragraph(),
     )
+    assert refnode is not None
     assert_node(refnode, nodes.reference, refid='cmdoption-S')
 
 


### PR DESCRIPTION
## Purpose

Fix std-domain option parsing for conjoined angle-bracket placeholders such as `-S<value>`.

Previously, the parser treated the whole string as the option name, so the directive registered `-S<value>` instead of `-S`. This keeps the placeholder in the argument portion, and extends `:option:` resolution so references like `-S<other>` resolve through the registered option stem.

Validation:

- `.venv/bin/python -m pytest tests/test_domains/test_domain_std.py -q`
- `.venv/bin/python -m pytest tests/test_directives/test_directive_option.py tests/test_domains/test_domain_std.py -q`
- `.venv/bin/ruff check sphinx/domains/std/__init__.py tests/test_domains/test_domain_std.py`
- `.venv/bin/ruff format --check sphinx/domains/std/__init__.py tests/test_domains/test_domain_std.py`

## References

- Closes #14323