### PR TITLE
Fix toc.empty_glob warning not suppressible via suppress_warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Features added
 Bugs fixed
 ----------
 
+* #13230: Fix the ``toc.empty_glob`` warning sub-type not being suppressible
+  via :confval:`suppress_warnings`, due to a missing ``type='toc'`` argument
+  in the toctree directive's warning call.
+  Patch by Ferdinand Schwenk.
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
   Patch by Adam Turner
 * #13713: Fix compatibility with MyST-Parser.

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -119,6 +119,7 @@ class TocTree(SphinxDirective):
                         __("toctree glob pattern %r didn't match any documents"),
                         entry,
                         location=toctree,
+                        type='toc',
                         subtype='empty_glob',
                     )
 

--- a/tests/test_directives/test_directive_other.py
+++ b/tests/test_directives/test_directive_other.py
@@ -128,6 +128,31 @@ def test_toctree_glob_and_url(app):
 
 
 @pytest.mark.sphinx('html', testroot='toctree-glob')
+def test_toctree_glob_empty_emits_warning(app):
+    """An unmatched glob pattern emits a toc.empty_glob warning."""
+    text = '.. toctree::\n   :glob:\n\n   nonexistent*\n'
+    app.env.find_files(app.config, app.builder)
+    restructuredtext.parse(app, text, 'index')
+    assert (
+        "toctree glob pattern 'nonexistent*' didn't match any documents"
+        in app._warning.getvalue()
+    )
+
+
+@pytest.mark.sphinx(
+    'html',
+    testroot='toctree-glob',
+    confoverrides={'suppress_warnings': ['toc.empty_glob']},
+)
+def test_toctree_glob_empty_suppressed(app):
+    """suppress_warnings=['toc.empty_glob'] must suppress the empty glob warning."""
+    text = '.. toctree::\n   :glob:\n\n   nonexistent*\n'
+    app.env.find_files(app.config, app.builder)
+    restructuredtext.parse(app, text, 'index')
+    assert app._warning.getvalue() == ''
+
+
+@pytest.mark.sphinx('html', testroot='toctree-glob')
 def test_reversed_toctree(app):
     text = '.. toctree::\n   :reversed:\n\n   foo\n   bar/index\n   baz\n'
 


### PR DESCRIPTION
## Purpose

Fix the `toc.empty_glob` warning sub-type introduced in 8.2.0 (#13230) being impossible to suppress via `suppress_warnings = ['toc.empty_glob']`.

### Root cause

In `sphinx/directives/other.py`, the `logger.warning()` call that fires when a toctree glob pattern matches no documents was missing the `type='toc'` keyword argument:

```python
# Before (broken)
logger.warning(
    __("toctree glob pattern %r didn't match any documents"),
    entry,
    location=toctree,
    subtype='empty_glob',   # type='toc' missing!
)
```

`SphinxLoggerAdapter.process()` stores every keyword argument into `record.extra`, so the log record ends up with `type=None`. `is_suppressed_warning()` in `sphinx/util/logging.py` short-circuits to `False` whenever `warning_type is None`, meaning the warning bypasses suppression entirely regardless of `suppress_warnings`.

The same pattern affects `show_warning_types=True`: the `[toc.empty_glob]` tag is silently omitted from the warning message because the code uses `if log_type := getattr(record, 'type', '')`, which is falsy for `None`.

Every other toctree warning in the same function correctly passes `type='toc'`.

### Fix

Add `type='toc'` to the warning call:

```python
# After (fixed)
logger.warning(
    __("toctree glob pattern %r didn't match any documents"),
    entry,
    location=toctree,
    type='toc',
    subtype='empty_glob',
)
```

### Tests added

Two new tests in `tests/test_directives/test_directive_other.py`:

- `test_toctree_glob_empty_emits_warning` — confirms the warning fires for an unmatched pattern
- `test_toctree_glob_empty_suppressed` — confirms `suppress_warnings=['toc.empty_glob']` successfully suppresses it

## References

- #13230 — PR that introduced `toc.empty_glob` (8.2.0)