### PR TITLE
Fix typos found by codespell

### DIFF
--- a/doc/changes/8.2.rst
+++ b/doc/changes/8.2.rst
@@ -97,7 +97,7 @@ Features added
   Patch by Adam Turner.
 * #13065: Enable colour by default in when running on CI.
   Patch by Adam Turner.
-* #13230: Allow supressing warnings from the :rst:dir:`toctree` directive
+* #13230: Allow suppressing warnings from the :rst:dir:`toctree` directive
   when a glob pattern doesn't match any documents,
   via the new ``toc.empty_glob`` warning sub-type.
   Patch by Slawek Figiel.

--- a/sphinx/texinputs/sphinxlatexadmonitions.sty
+++ b/sphinx/texinputs/sphinxlatexadmonitions.sty
@@ -19,7 +19,7 @@
 %   Since 7.4.0 all admonitions use sphinxheavybox.
 %
 % - All environments sphinxnote, sphinxwarning, etc... can be redefined as
-%   will by user. Thay have a single parameter #1 which is the title.
+%   will by user. They have a single parameter #1 which is the title.
 %
 % - Also redefinable by user are the one-argument commands
 %   * \sphinxstylenotetitle,

--- a/sphinx/texinputs/sphinxlatexstyletext.sty
+++ b/sphinx/texinputs/sphinxlatexstyletext.sty
@@ -83,7 +83,7 @@
 % Special characters
 %
 \def\sphinxparamcomma{, }% by default separate parameters with comma + space
-% If the signature is rendered with one line per param, this wil be used
+% If the signature is rendered with one line per param, this will be used
 % instead (this \texttt makes the comma slightly more distinctive).
 \def\sphinxparamcommaoneperline{\texttt{,}}
 %


### PR DESCRIPTION
## Purpose

Three small typo fixes spotted by codespell:

- `Thay` → `They` in a LaTeX comment in `sphinxlatexadmonitions.sty`
- `wil` → `will` in a LaTeX comment in `sphinxlatexstyletext.sty`
- `supressing` → `suppressing` in the 8.2 changelog entry for #13230

All three are in non-translation files and are unambiguously misspellings.
These follow the pattern of #13992 and #14211.

## References

- Follow-up to #13992 ("Fix typos found by codespell")