### PR TITLE
Fix spurious "more than one target found" warnings for annotation xrefs

### DIFF
--- a/sphinx/domains/javascript.py
+++ b/sphinx/domains/javascript.py
@@ -532,6 +532,9 @@ class JavaScriptDomain(Domain):
     ) -> nodes.reference | None:
         mod_name = node.get('js:module')
         prefix = node.get('js:object')
+        # TODO(stephenfin): Consider replacing this with getattr so users can
+        # set this to False and get expected behavior. This should be done as
+        # part of a major version as it may impact plugins.
         searchorder = 1 if node.hasattr('refspecific') else 0
         name, obj = self.find_obj(env, mod_name, prefix, target, typ, searchorder)
         if not obj:

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -939,6 +939,9 @@ class PythonDomain(Domain):
     ) -> nodes.reference | None:
         modname = node.get('py:module')
         clsname = node.get('py:class')
+        # TODO(stephenfin): Consider replacing this with getattr so users can
+        # set this to False and get expected behavior. This should be done as
+        # part of a major version as it may impact plugins.
         searchmode = 1 if node.hasattr('refspecific') else 0
         matches = self.find_obj(env, modname, clsname, target, type, searchmode)
 

--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -81,13 +81,15 @@ def type_to_xref(
     else:
         contnodes = [nodes.Text(title)]
 
+    if refspecific:
+        kwargs['refspecific'] = True
+
     return pending_xref(
         '',
         *contnodes,
         refdomain='py',
         reftype=reftype,
         reftarget=target,
-        refspecific=refspecific,
         **kwargs,
     )
 

--- a/tests/roots/test-domain-py-xref-ambiguous-annotation/conf.py
+++ b/tests/roots/test-domain-py-xref-ambiguous-annotation/conf.py
@@ -1,0 +1,1 @@
+exclude_patterns = ['_build']

--- a/tests/roots/test-domain-py-xref-ambiguous-annotation/index.rst
+++ b/tests/roots/test-domain-py-xref-ambiguous-annotation/index.rst
@@ -1,0 +1,19 @@
+test-domain-py-xref-ambiguous-annotation
+=========================================
+
+Multiple classes have an attribute called ``type``, and a data directive
+uses ``type[...]`` in its annotation. The bare ``type`` in the annotation
+should not trigger "more than one target found" warnings.
+
+.. py:class:: Connector
+
+   .. py:attribute:: type
+      :type: str
+
+.. py:class:: ConnectorPayload
+
+   .. py:attribute:: type
+      :type: str
+
+.. py:data:: default
+   :type: str | type[Sentinel]

--- a/tests/test_domains/test_domain_py.py
+++ b/tests/test_domains/test_domain_py.py
@@ -560,6 +560,35 @@ def test_parse_annotation_suppress(app):
 
 
 @pytest.mark.sphinx('html', testroot='_blank')
+def test_parse_annotation_refspecific(app):
+    # bare names should NOT have refspecific
+    doctree = _parse_annotation('type[int]', app.env)
+    assert_node(
+        doctree,
+        (
+            [pending_xref, 'type'],
+            [desc_sig_punctuation, '['],
+            [pending_xref, 'int'],
+            [desc_sig_punctuation, ']'],
+        ),
+    )
+    assert_node(
+        doctree[0], pending_xref, refdomain='py', reftype='class', reftarget='type'
+    )
+    assert not doctree[0].hasattr('refspecific')
+    assert not doctree[2].hasattr('refspecific')
+
+    # dot-prefixed names SHOULD have refspecific (context-relative lookup)
+    doctree = _parse_annotation('.MyClass', app.env)
+    assert_node(doctree, ([pending_xref, 'MyClass'],))
+    assert_node(
+        doctree[0], pending_xref, refdomain='py', reftype='class', reftarget='MyClass'
+    )
+    assert doctree[0].hasattr('refspecific')
+    assert doctree[0]['refspecific'] is True
+
+
+@pytest.mark.sphinx('html', testroot='_blank')
 def test_parse_annotation_Literal(app):
     doctree = _parse_annotation('Literal[True, False]', app.env)
     assert_node(
@@ -925,6 +954,12 @@ def test_warn_missing_reference(app):
         'index.rst:6: WARNING: Failed to create a cross reference. '
         "A title or caption not found: 'existing-label'"
     ) in app.warning.getvalue()
+
+
+@pytest.mark.sphinx('html', testroot='domain-py-xref-ambiguous-annotation')
+def test_annotation_does_not_trigger_ambiguous_xref(app):
+    app.build()
+    assert 'more than one target found' not in app.warning.getvalue()
 
 
 @pytest.mark.parametrize('include_options', [True, False])

--- a/tests/test_domains/test_domain_py_fields.py
+++ b/tests/test_domains/test_domain_py_fields.py
@@ -573,39 +573,28 @@ def test_type_field(app):
             ],
         ),
     )
+    # .int -> refspecific=True (dot-prefix requests context-relative lookup)
     assert_node(
         extract_node(doctree, 1, 0, 1, 2),
         pending_xref,
         reftarget='int',
         refspecific=True,
     )
-    assert_node(
-        extract_node(doctree, 3, 0, 1, 2),
-        pending_xref,
-        reftarget='builtins.int',
-        refspecific=False,
-    )
-    assert_node(
-        extract_node(doctree, 5, 0, 1, 2),
-        pending_xref,
-        reftarget='typing.Optional',
-        refspecific=False,
-    )
-    assert_node(
-        extract_node(doctree, 5, 0, 1, 4),
-        pending_xref,
-        reftarget='typing.Tuple',
-        refspecific=False,
-    )
-    assert_node(
-        extract_node(doctree, 5, 0, 1, 6),
-        pending_xref,
-        reftarget='int',
-        refspecific=False,
-    )
-    assert_node(
-        extract_node(doctree, 5, 0, 1, 9),
-        pending_xref,
-        reftarget='typing.Any',
-        refspecific=False,
-    )
+    # bare/qualified names should NOT have refspecific set at all, so that
+    # resolve_xref uses exact matching (searchmode=0) rather than fuzzy
+    # suffix matching (searchmode=1)
+    node = extract_node(doctree, 3, 0, 1, 2)
+    assert_node(node, pending_xref, reftarget='builtins.int')
+    assert not node.hasattr('refspecific')
+    node = extract_node(doctree, 5, 0, 1, 2)
+    assert_node(node, pending_xref, reftarget='typing.Optional')
+    assert not node.hasattr('refspecific')
+    node = extract_node(doctree, 5, 0, 1, 4)
+    assert_node(node, pending_xref, reftarget='typing.Tuple')
+    assert not node.hasattr('refspecific')
+    node = extract_node(doctree, 5, 0, 1, 6)
+    assert_node(node, pending_xref, reftarget='int')
+    assert not node.hasattr('refspecific')
+    node = extract_node(doctree, 5, 0, 1, 9)
+    assert_node(node, pending_xref, reftarget='typing.Any')
+    assert not node.hasattr('refspecific')


### PR DESCRIPTION
## Purpose

`type_to_xref()` unconditionally sets the `refspecific` attribute on `pending_xref` nodes, even when its value is `False`. In `resolve_xref()`, the check `node.hasattr('refspecific')` returns `True` whenever the attribute is present on the node, regardless of the value. This caused all annotation cross-references to use `searchmode=1` (fuzzy suffix matching), where bare names like e.g. `type` would match any documented object ending with the same name like e.g. `MyClass.type`. This is not correct and conflicts with how we conditionally set `refspecific` in `PyXRefRole.process_link`.

Fix this by only setting the `refspecific` attribute when it is truthy, so that bare names correctly use exact matching and do not produce ambiguous cross-reference warnings.

An alternative approach would be to replace the `node.hasattr('refspecific')` check with a e.g. `node.getattr(('refspecific', False)` check, but this is arguably an API change that could have implications for out-of-tree plugins building these nodes. This is better left to a future major version bump, so a TODO is added for now.

## References

Closes #14223
