### PR TITLE
Improve root document exclude pattern error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Features added
 Bugs fixed
 ----------
 
+* #11873: Improve the error message when the root document is excluded by
+  ``exclude_patterns``.
+  Patch by hansu650
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
   Patch by Adam Turner
 * #13713: Fix compatibility with MyST-Parser.

--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -529,7 +529,9 @@ class Builder:
             from sphinx.util.matching import _translate_pattern
 
             master_doc_path = self.env.doc2path(self.config.master_doc)
-            master_doc_canon = master_doc_path.as_posix()
+            master_doc_canon = self.env.doc2path(
+                self.config.master_doc, base=False
+            ).as_posix()
             for pat in EXCLUDE_PATHS:
                 if not re.match(_translate_pattern(pat), master_doc_canon):
                     continue

--- a/tests/test_builders/test_build.py
+++ b/tests/test_builders/test_build.py
@@ -29,6 +29,23 @@ def test_root_doc_not_found(
         app.build(force_all=True)  # no index.rst
 
 
+def test_root_doc_excluded_by_exclude_patterns(
+    tmp_path: Path, make_app: Callable[..., SphinxTestApp]
+) -> None:
+    (tmp_path / 'conf.py').write_text(
+        "exclude_patterns = ['index.rst']\n", encoding='utf-8'
+    )
+    (tmp_path / 'index.rst').write_text('Hello\n=====\n', encoding='utf-8')
+
+    app = make_app('dummy', srcdir=tmp_path)
+    with pytest.raises(SphinxError) as exc_info:
+        app.build(force_all=True)
+
+    msg = str(exc_info.value)
+    assert 'because it matches an exclude pattern specified in conf.py' in msg
+    assert "'index.rst'" in msg
+
+
 @pytest.mark.sphinx('text', testroot='circular')
 def test_circular_toctree(app: SphinxTestApp) -> None:
     app.build(force_all=True)


### PR DESCRIPTION
Closes #11873.

This improves the error shown when the root document is excluded by `exclude_patterns`.

The existing check was matching the root document's absolute path against relative exclude patterns, so `exclude_patterns = ['index.rst']` fell through to the generic "must be within the source directory" error.

This keeps the absolute path for the displayed error message, but uses the source-relative path when checking include/exclude patterns.

Tests run locally:

```text
python -m pytest tests/test_builders/test_build.py -k "root_doc" -q
python -m pytest tests/test_builders/test_build.py -q
python -m ruff check sphinx/builders/__init__.py tests/test_builders/test_build.py
python -m py_compile sphinx/builders/__init__.py tests/test_builders/test_build.py
git diff --check