### PR TITLE
Restore Sphinx manpage reference rendering with Docutils 0.22

### DIFF
--- a/sphinx/writers/manpage.py
+++ b/sphinx/writers/manpage.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Any
 
-    from docutils.nodes import Element
+    from docutils.nodes import Element, Node
 
     from sphinx.builders import Builder
 
@@ -78,6 +78,7 @@ class ManualPageTranslator(SphinxTranslator, manpage.Translator):
 
     def __init__(self, document: nodes.document, builder: Builder) -> None:
         super().__init__(document, builder)
+        self.defs.setdefault('reference', (r'\fI\%', r'\fP'))
 
         # first title is the manpage title
         self.section_level = -1
@@ -106,6 +107,16 @@ class ManualPageTranslator(SphinxTranslator, manpage.Translator):
         # Overwrite admonition label translations with our own
         for label, translation in admonitionlabels.items():
             self.language.labels[label] = self.deunicode(translation)
+
+    def dispatch_visit(self, node: Node) -> None:
+        if isinstance(node, nodes.reference):
+            # Docutils 0.22 installs its own instance-level ``visit_reference``
+            # handler based on the ``text_references`` setting. Route
+            # references through Sphinx's renderer before the generic visitor
+            # dispatch can see that handler.
+            self._visit_reference(node)
+        else:
+            super().dispatch_visit(node)
 
     # overwritten -- added quotes around all .TH arguments
     def header(self) -> str:
@@ -291,7 +302,7 @@ class ManualPageTranslator(SphinxTranslator, manpage.Translator):
         raise nodes.SkipNode
 
     # overwritten -- don't visit inner marked up nodes
-    def visit_reference(self, node: nodes.reference) -> None:
+    def _visit_reference(self, node: nodes.reference) -> None:
         uri = node.get('refuri', '')
         is_safe_to_click = uri.startswith(('mailto:', 'http:', 'https:', 'ftp:'))
         if is_safe_to_click:

--- a/tests/roots/test-manpage-references/conf.py
+++ b/tests/roots/test-manpage-references/conf.py
@@ -1,0 +1,1 @@
+project = 'foo'

--- a/tests/roots/test-manpage-references/index.rst
+++ b/tests/roots/test-manpage-references/index.rst
@@ -1,0 +1,1 @@
+A :ref:`ref <other-ref>`. A :doc:`doc <other>`

--- a/tests/roots/test-manpage-references/other.rst
+++ b/tests/roots/test-manpage-references/other.rst
@@ -1,0 +1,3 @@
+:orphan:
+
+.. _other-ref:

--- a/tests/test_builders/test_build_manpage.py
+++ b/tests/test_builders/test_build_manpage.py
@@ -82,6 +82,15 @@ end
     assert expected in content
 
 
+@pytest.mark.sphinx('man', testroot='manpage-references')
+def test_references_render_as_text(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    content = (app.outdir / 'foo.1').read_text(encoding='utf8')
+    assert r'A \fI\%ref\fP\&. A \fI\%doc\fP' in content
+    assert r'<#\:other-ref>' not in content
+    assert r'\%<>' not in content
+
+
 def test_default_man_pages() -> None:
     config = Config({
         'project': 'STASI™ Documentation',


### PR DESCRIPTION
﻿## Summary

- restore Sphinx's custom manpage reference renderer after Docutils 0.22 installs an instance-level `visit_reference`
- preserve the historical reference styling tuple when newer Docutils versions no longer expose it
- add a regression test for `:ref:` and `:doc:` rendering in man pages

## Root cause

Docutils 0.22 assigns `visit_reference` on the manpage translator instance according to its `text_references` setting. That shadows `ManualPageTranslator`'s specialized Sphinx implementation, so internal references render as raw `<uri>` fragments such as `<#other-ref>` and `<>` instead of styled text.

Fixes #14427.

## Validation

- Not run locally
- relying on the repository's GitHub Actions / Read the Docs checks for remote validation