### PR TITLE
Expose graphviz stderr from successful renders

### DIFF
--- a/doc/_static/diagrams/sphinx_build_flow.dot
+++ b/doc/_static/diagrams/sphinx_build_flow.dot
@@ -41,7 +41,7 @@ digraph build {
 
     "Builder.build_all" -> "Builder.build";
     "Builder.build_specific" -> "Builder.build";
-    "Builder.build_update":p1 -> "Builder.build";
+    "Builder.build_update" -> "Builder.build";
 
     "Builder.read" [color=darkorange];
     "Builder.write" [color=darkorange];
@@ -61,13 +61,13 @@ digraph build {
     "Builder.copy_assets" [color=darkblue];
     "Builder.write_documents" [color=darkblue];
 
-    "Builder.write":p1 -> "Builder.prepare_writing";
-    "Builder.write":p1 -> "Builder.copy_assets";
+    "Builder.write" -> "Builder.prepare_writing";
+    "Builder.write" -> "Builder.copy_assets";
     "Builder.write_documents" [
         shape=record
         label = "<p1> Builder.write_documents | Builder._write_serial | Builder._write_parallel"
     ];
-    "Builder.write":p1 -> "Builder.write_documents";
+    "Builder.write" -> "Builder.write_documents";
 
     "Builder.write_doc" [color=darkgreen];
     "Builder.get_relative_uri" [color=darkblue];

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -339,6 +339,11 @@ def render_dot(
             __('dot exited with error:\n[stderr]\n%r\n[stdout]\n%r')
             % (exc.stderr, exc.stdout)
         ) from exc
+    if ret.stderr:
+        logger.warning(
+            __('dot emitted the following on stderr:\n%s'),
+            ret.stderr.decode(errors='replace').rstrip(),
+        )
     if not outfn.is_file():
         raise GraphvizError(
             __('dot did not produce an output file:\n[stderr]\n%r\n[stdout]\n%r')

--- a/tests/test_extensions/test_ext_graphviz.py
+++ b/tests/test_extensions/test_ext_graphviz.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
+from subprocess import CompletedProcess
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest import mock
 
 import pytest
 
-from sphinx.ext.graphviz import ClickableMapDefinition
+from sphinx.ext.graphviz import ClickableMapDefinition, render_dot
 
 if TYPE_CHECKING:
     from sphinx.testing.util import SphinxTestApp
+    from sphinx.writers.html5 import HTML5Translator
 
 
 @pytest.mark.sphinx('html', testroot='ext-graphviz')
@@ -218,3 +223,40 @@ def test_graphviz_parse_mapfile() -> None:
     assert cmap.id == 'inheritance66ff5471b9'
     assert len(cmap.clickable) == 0
     assert cmap.generate_clickable_map() == ''
+
+
+@mock.patch('sphinx.ext.graphviz.logger')
+def test_render_dot_warns_on_stderr(
+    logger: mock.Mock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    outdir = tmp_path / '_build'
+    srcdir = tmp_path / 'src'
+    srcdir.mkdir()
+    builder = SimpleNamespace(
+        config=SimpleNamespace(graphviz_dot='dot', graphviz_dot_args=()),
+        imgpath='_images',
+        imagedir='_images',
+        outdir=outdir,
+        srcdir=srcdir,
+    )
+    translator = cast('HTML5Translator', SimpleNamespace(builder=builder))
+
+    def fake_run(args: list[str], **_kwargs: object) -> CompletedProcess[bytes]:
+        output_path = next(Path(arg[2:]) for arg in args if arg.startswith('-o'))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b'png')
+        return CompletedProcess(
+            args,
+            returncode=0,
+            stdout=b'',
+            stderr=b'Warning: gvrender_set_style: unsupported style INVALID\n',
+        )
+
+    monkeypatch.setattr('sphinx.ext.graphviz.subprocess.run', fake_run)
+
+    render_dot(translator, 'digraph { a -> b }', {'docname': 'index'}, 'png')
+
+    logger.warning.assert_called_once_with(
+        'dot emitted the following on stderr:\n%s',
+        'Warning: gvrender_set_style: unsupported style INVALID',
+    )


### PR DESCRIPTION
﻿## Purpose

Surface Graphviz diagnostics that are currently lost when `dot` exits successfully but writes warnings to stderr.

This keeps successful renders successful, but forwards the captured stderr through Sphinx's warning channel so users can see messages such as unsupported-style warnings instead of having them silently discarded.

The change also adds a focused regression test for the successful-render-with-stderr path. While exercising the new behavior in Sphinx's own docs build, it exposed stale `p1` port references in the bundled build-flow diagram; those invalid references are removed so the diagram remains warning-clean under Graphviz.

## References

- Fixes #14362

## Validation

- Not run locally
- relying on the repository's GitHub Actions / Read the Docs checks for remote validation