### PR TITLE
Repeat graphviz errors on subsequent builds

### DIFF
--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -351,6 +351,16 @@ def render_dot(
     return relfn, outfn
 
 
+def _mark_graphviz_error_for_reread(
+    self: HTML5Translator | LaTeXTranslator | TexinfoTranslator,
+    options: dict[str, Any],
+) -> None:
+    """Force the source document to be re-read on the next build."""
+    docname = options.get('docname', getattr(self.builder, 'current_docname', None))
+    if isinstance(docname, str):
+        self.builder.env.reread_always.add(docname)
+
+
 def render_dot_html(
     self: HTML5Translator,
     node: graphviz,
@@ -370,6 +380,7 @@ def render_dot_html(
     try:
         fname, outfn = render_dot(self, code, options, format, prefix, filename)
     except GraphvizError as exc:
+        _mark_graphviz_error_for_reread(self, options)
         logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode from exc
 
@@ -433,6 +444,7 @@ def render_dot_latex(
     try:
         fname, _outfn = render_dot(self, code, options, 'pdf', prefix, filename)
     except GraphvizError as exc:
+        _mark_graphviz_error_for_reread(self, options)
         logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode from exc
 
@@ -477,6 +489,7 @@ def render_dot_texinfo(
     try:
         fname, _outfn = render_dot(self, code, options, 'png', prefix)
     except GraphvizError as exc:
+        _mark_graphviz_error_for_reread(self, options)
         logger.warning(__('dot code %r: %s'), code, exc)
         raise nodes.SkipNode from exc
     if fname is not None:

--- a/tests/test_extensions/test_ext_graphviz.py
+++ b/tests/test_extensions/test_ext_graphviz.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from sphinx.ext.graphviz import ClickableMapDefinition
+from sphinx.ext import graphviz as graphviz_ext
+from sphinx.ext.graphviz import ClickableMapDefinition, GraphvizError
 
 if TYPE_CHECKING:
     from sphinx.testing.util import SphinxTestApp
@@ -161,6 +162,28 @@ def test_graphviz_i18n(app: SphinxTestApp) -> None:
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
     html = '<img src=".*?" alt="digraph {\n  BAR -&gt; BAZ\n}" class="graphviz" />'
     assert re.search(html, content, re.MULTILINE)
+
+
+@pytest.mark.sphinx('html', testroot='ext-graphviz')
+def test_graphviz_error_is_reported_on_next_build(
+    app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def render_dot_with_error(*args: object, **kwargs: object) -> None:
+        msg = 'broken graph'
+        raise GraphvizError(msg)
+
+    monkeypatch.setattr(graphviz_ext, 'render_dot', render_dot_with_error)
+
+    app.build(force_all=True)
+    assert 'broken graph' in app.warning.getvalue()
+    assert app.env.reread_always == {'index'}
+
+    app.warning.seek(0)
+    app.warning.truncate(0)
+    app.build()
+
+    assert 'broken graph' in app.warning.getvalue()
+    assert app.env.reread_always == {'index'}
 
 
 def test_graphviz_parse_mapfile() -> None:


### PR DESCRIPTION
## Summary
- mark documents with Graphviz render failures for re-read on the next build
- fall back to the current document name for Graphviz callers that do not pass `docname` explicitly
- add a regression test showing the warning is emitted again on an incremental rebuild

This intentionally addresses the repeated-warning part of #14361 only; stale generated images are a separate concern.

## Validation
- Not run locally
- static validation: `git diff --check`

Refs #14361