### PR TITLE
Support snowball 3.1.0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -109,6 +109,7 @@ Contributors
 * Slawek Figiel -- additional warning suppression
 * Stefan Seefeld -- toctree improvements
 * Stefan van der Walt -- autosummary extension
+* Stefano Rivera -- test improvements
 * Steve Piercy -- documentation improvements
 * Szymon Karpinski -- intersphinx improvements
 * \T. Powers -- HTML output improvements

--- a/tests/roots/test-search/index.rst
+++ b/tests/roots/test-search/index.rst
@@ -15,7 +15,7 @@ findthisstemmedkey
 
 textinheading
 
-International
+Internationalize
 
 .. tip::
    :class: no-search

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -144,7 +144,7 @@ def test_stemmer(app: SphinxTestApp) -> None:
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
     print(searchindex)
     assert is_registered_term(searchindex, 'findthisstemmedkey')
-    assert is_registered_term(searchindex, 'intern')
+    assert is_registered_term(searchindex, 'internation')
 
 
 @pytest.mark.sphinx('html', testroot='search')


### PR DESCRIPTION
Snowball 3.1.0 explicitly adds an exception for the term 'inter' so don't test for it. Use a variant of "international" instead.

See: https://github.com/snowballstem/snowball/commit/d23a20f0be487b711020b99a6cef575961eb9c1c