### PR TITLE
fix: correct format specifiers in fa and el PO translations

### DIFF
--- a/sphinx/locale/el/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/el/LC_MESSAGES/sphinx.po
@@ -588,14 +588,14 @@ msgstr "Η τιμή παραμετροποίησης '{name}' πρέπει να 
 msgid ""
 "The config value `{name}' has type `{current.__name__}'; expected "
 "{permitted}."
-msgstr "Η τιμή παραμετροποίησης '{name]' έχει τύπο '[current__name__}'; αναμενόμενη {permitted}."
+msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current.__name__}'; αναμενόμενη {permitted}."
 
 #: config.py:846
 #, python-brace-format
 msgid ""
 "The config value `{name}' has type `{current.__name__}', defaults to "
 "`{default.__name__}'."
-msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current__name__}', αρχικοποίηση σε '{default__name__}'."
+msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current.__name__}', αρχικοποίηση σε '{default.__name__}'."
 
 #: config.py:858
 #, python-format

--- a/sphinx/locale/fa/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fa/LC_MESSAGES/sphinx.po
@@ -596,7 +596,7 @@ msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name_
 msgid ""
 "The config value `{name}' has type `{current.__name__}', defaults to "
 "`{default.__name__}'."
-msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name__}' است، حالت پیش‌فرض {permitted} است."
+msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name__}' است، حالت پیش‌فرض {default.__name__} است."
 
 #: config.py:858
 #, python-format


### PR DESCRIPTION
## Summary

Fixes three Python brace-format string errors in Sphinx locale `.po` files that cause `msgfmt` compilation failures.

## Problem

Building Sphinx translations with `msgfmt` fails for `fa` and `el` locales because the `msgstr` format specifiers don't match the `msgid`:

- **`fa/LC_MESSAGES/sphinx.po`**: `msgstr` uses `{permitted}` instead of `{default.__name__}` (matches `msgid`)
- **`el/LC_MESSAGES/sphinx.po`**: `msgstr` uses `'{name]'` (unterminated brace) and `'[current__name__}'` (wrong bracket type) instead of `'{name}'` and `'{current.__name__}'`
- **`el/LC_MESSAGES/sphinx.po`**: `msgstr` uses `{current__name__}` and `{default__name__}` (underscore, no dot) instead of `{current.__name__}` and `{default.__name__}` (with dot to match `msgid`)

## Fix

Changed the `msgstr` lines to use the exact same format field names as their corresponding `msgid`. The translations remain otherwise unchanged.

## Test Plan

Verified with Python's `string.Formatter`: each fixed `msgstr` now parses to the same set of format fields as its `msgid`.

Closes #14347