### PR TITLE
fix: use correct singular/plural forms for source file count strings

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -364,7 +364,12 @@ class Builder:
 
         self.build(
             docnames,
-            summary=__('%d source files given on command line') % len(docnames),
+            summary=__(
+                '%d source file given on command line'
+                if len(docnames) == 1
+                else '%d source files given on command line'
+            )
+            % len(docnames),
             method='specific',
         )
 
@@ -380,7 +385,11 @@ class Builder:
             to_build = set(to_build)
             self.build(
                 to_build,
-                summary=__('targets for %d source files that are out of date')
+                summary=__(
+                    'target for %d source file that is out of date'
+                    if len(to_build) == 1
+                    else 'targets for %d source files that are out of date'
+                )
                 % len(to_build),
                 method='update',
             )

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -176,3 +176,15 @@ def test_build_specific(app: SphinxTestApp) -> None:
         method='specific',
         summary='3 source files given on command line',
     )
+
+
+@pytest.mark.sphinx('dummy', testroot='root')
+def test_build_specific_single_file(app: SphinxTestApp) -> None:
+    app.builder.build = Mock()  # type: ignore[method-assign,misc]
+    app.build(False, [app.srcdir / 'index.txt'])
+
+    app.builder.build.assert_called_with(
+        ['index'],
+        method='specific',
+        summary='1 source file given on command line',
+    )


### PR DESCRIPTION
## Summary

The build status messages for ``build_specific`` and ``build_update`` use hardcoded plural strings (``"%d source files given on command line"``) even when the count is 1, producing grammar errors like ``"1 source files given on command line"``.

## Fix

Use conditional string selection so the correct singular/plural form is used based on the actual file count:

- ``"1 source file given on command line"`` for a single file
- ``"%d source files given on command line"`` for multiple files
- Same treatment for the ``build_update`` summary string

## Test Plan

- New test ``test_build_specific_single_file`` verifies the singular case
- Existing ``test_build_specific`` (multi-file) still passes
- 9/9 tests pass in ``tests/test_application.py``

Closes #12903
