### PR TITLE
Avoid EOFError in parallel builds

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -75,6 +75,7 @@ Contributors
 * Joel Wurtz -- cellspanning support in LaTeX
 * John Waltman -- Texinfo builder
 * Jon Dufresne -- modernisation
+* Jonathon Reinhart -- bugfixes
 * Josip Dzolonga -- coverage builder
 * Juan Luis Cano Rodríguez -- new tutorial (2021)
 * Julien Palard -- Colspan and rowspan in text builder

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -82,12 +82,19 @@ def convert_serializable(records: list[logging.LogRecord]) -> None:
     """Convert LogRecord serializable."""
     for r in records:
         # extract arguments to a message and clear them
-        r.msg = r.getMessage()
+        try:
+            r.msg = r.getMessage()
+        except Exception as err:
+            r.msg += f"\n  ^^^ Failed to format log message: {err}"
+            r.msg += f"\n      args: {r.args}"
         r.args = ()
 
         location = getattr(r, 'location', None)
         if isinstance(location, nodes.Node):
-            r.location = get_node_location(location)
+            try:
+                r.location = get_node_location(location)
+            except Exception:
+                r.location = "<invalid location>"
 
 
 class SphinxLogRecord(logging.LogRecord):

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -99,7 +99,18 @@ class ParallelTasks:
             )
             ret = (errmsg, traceback.format_exc())
 
-        pipe.send((failed, logs, ret))
+        try:
+            pipe.send((failed, logs, ret))
+        except Exception as err:
+            failed = True
+            errmsg = (
+                "Failed to send results: " +
+                traceback.format_exception_only(err.__class__, err)[0].strip()
+            )
+            ret = (errmsg, traceback.format_exc())
+
+            # Fallback to avoid EOF
+            pipe.send((failed, [], ret))
 
     def add_task(
         self,

--- a/sphinx/util/parallel.py
+++ b/sphinx/util/parallel.py
@@ -86,8 +86,20 @@ class ParallelTasks:
             failed = True
             errmsg = traceback.format_exception_only(err.__class__, err)[0].strip()
             ret = (errmsg, traceback.format_exc())
-        logging.convert_serializable(collector.logs)
-        pipe.send((failed, collector.logs, ret))
+
+        try:
+            logging.convert_serializable(collector.logs)
+            logs = collector.logs
+        except Exception as err:
+            logs = []
+            failed = True
+            errmsg = (
+                "Failed to serialize logs: " +
+                traceback.format_exception_only(err.__class__, err)[0].strip()
+            )
+            ret = (errmsg, traceback.format_exc())
+
+        pipe.send((failed, logs, ret))
 
     def add_task(
         self,


### PR DESCRIPTION
## Purpose
This hopefully avoids all all possible "`EOFError` when running in parallel mode" issues. It does so by handling (hopefully) all possible uncaught exceptions in the multiprocessing child.

We address this at three layers:
1. `logging.convert_serializable()` is updated to avoid two places where exceptions could be raised. If an exception is raised, the `LogRecord` is updated to convey that information.
2. The call to `logging.convert_serializable()` is wrapped in `try`/`except` just in case 1. was (or becomes) insufficient.
3. The call to `pipe.send()` is itself wrapped in a `try`/`except` in case there is anything in the logs (e.g. `exc_info`) which cannot be pickled.

## Testing
AFAICT there is no facility for automated tests in this area of the code.

This was tested manually by raising exceptions in the locations mentioned above, and verifying that the exception was always displayed -- `EOFError` was never raised.

## References

- Fixes #14458

This probably fixes other previous issues:
- #8973
- #7802 

While other fixes have resolved the underlying exceptions, they have not addressed the `EOFError` itself.
