### PR TITLE
FIX: Fix stemmer test

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -142,9 +142,8 @@ def test_stemmer_does_not_remove_short_words(app: SphinxTestApp) -> None:
 def test_stemmer(app: SphinxTestApp) -> None:
     app.build(force_all=True)
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
-    print(searchindex)
     assert is_registered_term(searchindex, 'findthisstemmedkey')
-    assert is_registered_term(searchindex, 'intern')
+    assert is_registered_term(searchindex, 'internat')
 
 
 @pytest.mark.sphinx('html', testroot='search')


### PR DESCRIPTION
The term 'intern' is not found anymore in the search index. Based on the original commit https://github.com/sphinx-doc/sphinx/commit/e04fe845c7ad90fcf01738d67cca7401c06d0acf it was expected to be the stem of "International"

However, if you put "International" in https://snowballstem.org/demo.html, you get "internat" instead. I thus assume that stemming behavior has changed and we should just update the expected value.

While at it, I removed the debug print from the original commit.
