### PR TITLE
Do not index substitution definitions in the search index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Features added
 Bugs fixed
 ----------
 
+* #4248: Do not add substitution definitions (such as those inserted into every
+  document via ``rst_prolog`` or ``rst_epilog``) to the search index.
+  Patch by kyo5uke
 * #14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
   Patch by Adam Turner
 * #13713: Fix compatibility with MyST-Parser.

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -598,6 +598,11 @@ def _feed_visit_nodes(
 ) -> None:
     if isinstance(node, nodes.comment):
         return
+    elif isinstance(node, nodes.substitution_definition):
+        # skip substitution definitions (e.g. those added to every document via
+        # rst_prolog / rst_epilog); the substituted text is still indexed
+        # wherever the substitution is actually used
+        return
     elif isinstance(node, nodes.Element) and 'no-search' in node['classes']:
         # skip nodes marked with a 'no-search' class
         return


### PR DESCRIPTION
## Purpose

Substitution definitions added to every document via `rst_prolog` / `rst_epilog` were being walked when building the search index, so their text was indexed on every page even though the substitution may never be used. As reported, this makes the search return every page for a word that only appears in such a definition.

This skips `substitution_definition` nodes in `_feed_visit_nodes`, the same way `comment` and `no-search` nodes are already skipped. Text from a substitution is still indexed wherever the substitution is actually *used*, since that expands to inline text during parsing.

A `CHANGES.rst` entry is included.

## References

- Closes #4248
