### PR TITLE
Fix `test_search.py` with long-word splitting

### DIFF
--- a/tests/roots/test-search/index.rst
+++ b/tests/roots/test-search/index.rst
@@ -19,6 +19,7 @@ International
 
 .. tip::
    :class: no-search
+
    bat cat
 
 .. toctree::

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,7 +77,7 @@ def is_registered_term(index: Any, keyword: str) -> bool:
 
 
 def is_registered_prefix(index: Any, prefix: str) -> bool:
-    terms = index["terms"]
+    terms = index['terms']
     for key, value in terms.items():
         if key.startswith(prefix) and value != []:
             return True

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -76,6 +76,14 @@ def is_registered_term(index: Any, keyword: str) -> bool:
     return index['terms'].get(keyword, []) != []
 
 
+def is_registered_prefix(index: Any, prefix: str) -> bool:
+    terms = index["terms"]
+    for key, value in terms.items():
+        if key.startswith(prefix) and value != []:
+            return True
+    return False
+
+
 FILE_CONTENTS = """\
 section_title
 =============
@@ -144,7 +152,7 @@ def test_stemmer(app: SphinxTestApp) -> None:
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
     print(searchindex)
     assert is_registered_term(searchindex, 'findthisstemmedkey')
-    assert is_registered_term(searchindex, 'internat')
+    assert is_registered_prefix(searchindex, 'intern')
 
 
 @pytest.mark.sphinx('html', testroot='search')

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -78,10 +78,10 @@ def is_registered_term(index: Any, keyword: str) -> bool:
 
 def is_registered_prefix(index: Any, prefix: str) -> bool:
     terms = index['terms']
-    for key, value in terms.items():
-        if key.startswith(prefix) and value != []:
-            return True
-    return False
+    return any(
+        key.startswith(prefix) and value != []
+        for key, value in terms.items()
+    )
 
 
 FILE_CONTENTS = """\

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -78,10 +78,7 @@ def is_registered_term(index: Any, keyword: str) -> bool:
 
 def is_registered_prefix(index: Any, prefix: str) -> bool:
     terms = index['terms']
-    return any(
-        key.startswith(prefix) and value != []
-        for key, value in terms.items()
-    )
+    return any(k.startswith(prefix) and v != [] for k, v in terms.items())
 
 
 FILE_CONTENTS = """\

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -144,7 +144,7 @@ def test_stemmer(app: SphinxTestApp) -> None:
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
     print(searchindex)
     assert is_registered_term(searchindex, 'findthisstemmedkey')
-    assert is_registered_term(searchindex, 'intern')
+    assert is_registered_term(searchindex, 'internat')
 
 
 @pytest.mark.sphinx('html', testroot='search')


### PR DESCRIPTION
Fix a CI test.