### PR TITLE
Document `graphviz` requirement for `sphinx.ext.graphviz`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -118,6 +118,7 @@ Contributors
 * Thomas Waldmann -- apidoc module fixes
 * Till Hoffmann -- doctest option to exit after first failed test
 * Tim Hoffmann -- theme improvements
+* Tim Pillinger -- documentation improvements
 * Valentin Heinisch -- warning types improvement
 * Victor Wheeler -- documentation improvements
 * Vince Salvino -- JavaScript search improvements

--- a/doc/usage/extensions/graphviz.rst
+++ b/doc/usage/extensions/graphviz.rst
@@ -8,6 +8,11 @@
 
 .. versionadded:: 0.6
 
+.. important::
+
+   Graphviz must be available on your computer.
+   If it is not you may need to install it yourself.
+
 .. role:: code-py(code)
    :language: Python
 

--- a/doc/usage/extensions/graphviz.rst
+++ b/doc/usage/extensions/graphviz.rst
@@ -8,16 +8,16 @@
 
 .. versionadded:: 0.6
 
-.. important::
-
-   Graphviz must be available on your computer.
-   If it is not you may need to install it yourself.
-
 .. role:: code-py(code)
    :language: Python
 
 This extension allows you to embed `Graphviz <https://graphviz.org/>`_ graphs in
 your documents.
+
+.. important::
+
+   Graphviz must be present on your machine; please refer to the `official
+   instructions <https://graphviz.org/download/>`_ if it is not the case.
 
 It adds these directives:
 


### PR DESCRIPTION
## Purpose

Tries to help others avoid the same mistakes I have made.

Closes #14486 by adding a note to the documentation that graphviz must be installed to use the graphviz extension, and that installing it is the responsibility of the user.

AI was not used. Perhaps given my English you will wish it had been. 😜