### PR TITLE
Document changes for HTML builder render_partial method

### DIFF
--- a/doc/changes/9.0.rst
+++ b/doc/changes/9.0.rst
@@ -71,7 +71,8 @@ Incompatible changes
   Patches by Adam Turner.
 * #13355: Don't include escaped title content in the search index.
   Patch by Will Lachance.
-* #13664: HTML builder: :meth:`!sphinx.builders.html.StandaloneHTMLBuilder.render_partial`
+* #13664: HTML builder:
+  :meth:`!sphinx.builders.html.StandaloneHTMLBuilder.render_partial`
   now returns ``fragment`` and ``title`` keys only.
   Patch by Adam Turner.
 

--- a/doc/changes/9.0.rst
+++ b/doc/changes/9.0.rst
@@ -71,6 +71,9 @@ Incompatible changes
   Patches by Adam Turner.
 * #13355: Don't include escaped title content in the search index.
   Patch by Will Lachance.
+* #13664: HTML builder: :meth:`!sphinx.builders.html.StandaloneHTMLBuilder.render_partial`
+  now returns ``fragment`` and ``title`` keys only.
+  Patch by Adam Turner.
 
 Deprecated
 ----------


### PR DESCRIPTION

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

Added note to the 9.0 Incompatible changes about HTML builder's `render_partial` method returning `fragment` and `title` keys now instead of `body`.

Docs preview build: https://sphinx--14488.org.readthedocs.build/en/14488/changes/9.0.html#incompatible-changes

Fixes https://github.com/sphinx-doc/sphinx/issues/14272

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- https://github.com/sphinx-doc/sphinx/issues/14272
- https://github.com/sphinx-doc/sphinx/pull/13664


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->

I used AI to draft the message and then hand edited it down.