### PR TITLE
Fix autosummary heading width for East Asian text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #3591: autosummary: Fix generated heading underlines for East Asian
+  characters.
+  Patch by popsiclelmlm.
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -110,7 +110,7 @@ def _underline(title: str, line: str = '=') -> str:
     if '\n' in title:
         msg = 'Can only underline single lines'
         raise ValueError(msg)
-    return title + '\n' + line * len(title)
+    return title + '\n' + line * rst.textwidth(title)
 
 
 class AutosummaryRenderer:

--- a/tests/test_ext_autosummary/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary/test_ext_autosummary.py
@@ -21,6 +21,7 @@ from sphinx.ext.autosummary import (
 )
 from sphinx.ext.autosummary.generate import (
     AutosummaryEntry,
+    _underline,
     generate_autosummary_content,
     generate_autosummary_docs,
 )
@@ -83,6 +84,10 @@ def test_mangle_signature() -> None:
     for inp, outp in TEST:
         res = mangle_signature(inp).strip().replace('\u00a0', ' ')
         assert res == outp, f"'{inp}' -> '{res}' != '{outp}'"
+
+
+def test_underline_east_asian_characters() -> None:
+    assert _underline('日本語') == '日本語\n======'
 
 
 def test_extract_summary(capsys):

--- a/tests/test_extensions/test_ext_apidoc.py
+++ b/tests/test_extensions/test_ext_apidoc.py
@@ -515,6 +515,24 @@ def test_module_file(tmp_path):
     )
 
 
+def test_module_file_east_asian_heading(tmp_path):
+    outdir = tmp_path
+    (outdir / '日本語.py').touch()
+    apidoc_main(['-o', str(tmp_path), str(tmp_path)])
+    assert (outdir / '日本語.rst').exists()
+
+    content = (outdir / '日本語.rst').read_text(encoding='utf8')
+    assert content == (
+        '日本語 module\n'
+        '=============\n'
+        '\n'
+        '.. automodule:: 日本語\n'
+        '   :members:\n'
+        '   :show-inheritance:\n'
+        '   :undoc-members:\n'
+    )
+
+
 def test_module_file_noheadings(tmp_path):
     outdir = tmp_path
     (outdir / 'example.py').touch()


### PR DESCRIPTION
## Summary

Fixes #3591.

This updates autosummary-generated headings so East Asian wide/full-width characters use their display width when creating the underline.

## Reproduction

Generate an autosummary page for an object whose generated title contains East Asian text, such as `日本語`. Before this change, autosummary used the Python string length for the underline, producing an underline that is too short for reStructuredText display width.

## Root cause

`autosummary.generate._underline()` used `len(title)`, which counts code points. Sphinx already has `sphinx.util.rst.textwidth()` for section underline width, including East Asian wide/full-width characters, but autosummary was not using it.

## Changes

- Use `rst.textwidth(title)` when autosummary renders heading underlines.
- Add an autosummary regression test for an East Asian title.
- Add an apidoc regression test covering an East Asian module heading, which already goes through the shared heading helper.
- Add a changelog entry.

## Tests

- `git diff --check`
- `.venv/bin/python -m ruff check sphinx/ext/autosummary/generate.py tests/test_ext_autosummary/test_ext_autosummary.py tests/test_extensions/test_ext_apidoc.py`
- `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 .venv/bin/python -m pytest tests/test_ext_autosummary/test_ext_autosummary.py::test_underline_east_asian_characters tests/test_extensions/test_ext_apidoc.py::test_module_file_east_asian_heading tests/test_extensions/test_ext_apidoc.py::test_multibyte_parameters`
- `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 .venv/bin/python -m pytest tests/test_ext_autosummary/test_ext_autosummary.py tests/test_extensions/test_ext_apidoc.py`

## AI Disclosure

OpenAI Codex was used as an assistant for repository inspection, patch drafting, and local command execution. I reviewed the diff, tests, and behavior, and I can explain and maintain the change.

AI-assisted parts: the small code change in `_underline`, the related tests, the changelog entry, and the initial PR description. No external code was copied.

## Screenshots/Logs

Not applicable; no UI changes. The full relevant pytest run passed with `58 passed`.
