### PR TITLE
Fix #5844: How about using issue hunting service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,7 @@ information.
 .. _the documentation: https://www.sphinx-doc.org/
 .. _the contributors guide: https://www.sphinx-doc.org/en/master/internals/contributing.html
 .. _Python Package Index: https://pypi.org/project/Sphinx/
+
+
+.. image:: https://issuehunt.io/repos/sphinx-doc/sphinx/badge.svg
+   :target: https://issuehunt.io/r/sphinx-doc/sphinx


### PR DESCRIPTION
Fix for #5844: How about using issue hunting service

This pull request adds the IssueHunt badge to the README.rst file.
IssueHunt is a platform for funding open source projects, and adding this badge 
will allow developers to discover bounties attached to Sphinx issues directly from the repository's front page.

Changes made:
- Appended the IssueHunt SVG badge and target link to `README.rst`

Closes #5844
