### PR TITLE
Add type annotations for napoleon config attributes

### DIFF
--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -290,6 +290,7 @@ class Config:
     napoleon_attr_annotations: bool
 
     if TYPE_CHECKING:
+
         def __getattr__(self, name: str) -> Any: ...
 
     _config_values: Sequence[tuple[str, bool | None, _ConfigRebuild, Set[type]]] = (

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -272,6 +272,26 @@ class Config:
 
     """
 
+    napoleon_google_docstring: bool
+    napoleon_numpy_docstring: bool
+    napoleon_include_init_with_doc: bool
+    napoleon_include_private_with_doc: bool
+    napoleon_include_special_with_doc: bool
+    napoleon_use_admonition_for_examples: bool
+    napoleon_use_admonition_for_notes: bool
+    napoleon_use_admonition_for_references: bool
+    napoleon_use_ivar: bool
+    napoleon_use_param: bool
+    napoleon_use_rtype: bool
+    napoleon_use_keyword: bool
+    napoleon_preprocess_types: bool
+    napoleon_type_aliases: dict[str, str] | None
+    napoleon_custom_sections: list[str | tuple[str, str]] | None
+    napoleon_attr_annotations: bool
+
+    if TYPE_CHECKING:
+        def __getattr__(self, name: str) -> Any: ...
+
     _config_values: Sequence[tuple[str, bool | None, _ConfigRebuild, Set[type]]] = (
         ('napoleon_google_docstring', True, 'env', frozenset({bool})),
         ('napoleon_numpy_docstring', True, 'env', frozenset({bool})),


### PR DESCRIPTION
## Purpose

The attributes in this class are set dynamically, so they are not visible to type checkers.

Unlike sphinx.Config, this one does not have a `__getattr__` declared, so given a value of this type a type checker would not allow any fields to be accessed since it doesn't know about them.

I don't think this causes any issues in the codebase today, but that is due to an implementation quirk in those 3 type checkers (I believe mypy takes the first branch's type and `napoleon.Config` is in the second branch when it does get used, while pyright and ty give up and infer `Any` for the whole thing)

## Testing

Locally ruff/mypy/pyright/ty all pass. I'm not sure why the CI job for ty does not pass, but based on reading past issues & the job output it seems like a misconfiguration/errors that were previously committed?

## AI Disclosure

Used claude code for the mechanical part of converting `_config_values` to attribute decls, reviewed/edited manually
