### PR TITLE
Fix inherited theme layout template lookup

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@ Contributors
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils
 * Kurt McKee -- documentation updates
 * Lars Hupfeldt Nielsen - OpenSSL FIPS mode md5 bug fix
+* Lin Hongkuan -- theme inheritance fixes
 * Louis Maddox -- better docstrings
 * Łukasz Langa -- partial support for autodoc
 * Marco Buttu -- doctest extension (pyversion option)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Bugs fixed
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.
+* #12049: HTML themes: Fix ``!`` template inheritance for custom themes
+  extending built-in themes whose layouts are inherited from ``basic``.
+  Patch by Lin Hongkuan.
 
 
 Release 9.1.0 (released Dec 31, 2025)

--- a/sphinx/jinja2glue.py
+++ b/sphinx/jinja2glue.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
     from sphinx.theming import Theme
 
 
+_TEMPLATE_SKIP_PREFIX = '__sphinx_skip_loader__:'
+
+
 def _tobool(val: str) -> bool:
     if isinstance(val, str):
         return val.lower() in {'true', '1', 'yes', 'on'}
@@ -196,10 +199,13 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
 
         # make the paths into loaders
         self.loaders = [SphinxFileSystemLoader(x) for x in loaderchain]
+        self._template_loader_indices: dict[str, int] = {}
 
         use_i18n = builder._translator is not None
         extensions = ['jinja2.ext.i18n'] if use_i18n else []
-        self.environment = SandboxedEnvironment(loader=self, extensions=extensions)
+        self.environment = _SphinxSandboxedEnvironment(
+            loader=self, extensions=extensions
+        )
         self.environment.filters['tobool'] = _tobool
         self.environment.filters['toint'] = _toint
         self.environment.filters['todim'] = _todim
@@ -235,18 +241,47 @@ class BuiltinTemplateLoader(TemplateBridge, BaseLoader):
 
     # Loader interface
 
+    def join_path(self, template: str, parent: str) -> str:
+        if template.startswith('!') and parent in self._template_loader_indices:
+            parent_loader_index = self._template_loader_indices[parent]
+            if parent_loader_index < self.templatepathlen:
+                start_at = self.templatepathlen
+            else:
+                start_at = parent_loader_index + 1
+            return f'{_TEMPLATE_SKIP_PREFIX}{start_at}:{template[1:]}'
+        return template
+
     def get_source(
         self, environment: Environment, template: str
     ) -> tuple[str, str, Callable[[], bool]]:
+        requested_template = template
+        start_at = 0
         loaders = self.loaders
         # exclamation mark starts search from theme
-        if template.startswith('!'):
-            loaders = loaders[self.templatepathlen :]
+        if template.startswith(_TEMPLATE_SKIP_PREFIX):
+            skip_count, _, template = template.removeprefix(
+                _TEMPLATE_SKIP_PREFIX
+            ).partition(':')
+            start_at = int(skip_count)
+            loaders = loaders[start_at:]
+        elif template.startswith('!'):
+            start_at = self.templatepathlen
+            loaders = loaders[start_at:]
             template = template[1:]
-        for loader in loaders:
+        for i, loader in enumerate(loaders, start_at):
             try:
-                return loader.get_source(environment, template)
+                result = loader.get_source(environment, template)
+                self._template_loader_indices[requested_template] = i
+                return result
             except TemplateNotFound:
                 pass
         msg = f'{template!r} not found in {self.environment.loader.pathchain}'  # type: ignore[union-attr]
         raise TemplateNotFound(msg)
+
+
+class _SphinxSandboxedEnvironment(SandboxedEnvironment):
+    def join_path(self, template: str, parent: str) -> str:
+        loader = self.loader
+        if isinstance(loader, BuiltinTemplateLoader):
+            return loader.join_path(template, parent)
+        return super().join_path(template, parent)

--- a/tests/roots/test-double-inheriting-theme/base_themes_dir/base_theme2/layout.html
+++ b/tests/roots/test-double-inheriting-theme/base_themes_dir/base_theme2/layout.html
@@ -1,0 +1,6 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<meta name="base-theme2-layout" content="true" />
+{% endblock %}

--- a/tests/test_theming/test_theming.py
+++ b/tests/test_theming/test_theming.py
@@ -111,7 +111,10 @@ def test_nonexistent_theme_settings(tmp_path: Path) -> None:
 def test_double_inheriting_theme(app: SphinxTestApp) -> None:
     assert isinstance(app.builder, StandaloneHTMLBuilder)  # type-checking
     assert app.builder.theme.name == 'base_theme2'
-    app.build()  # => not raises TemplateNotFound
+    app.build()  # => not raises ThemeError
+
+    result = (app.outdir / 'index.html').read_text(encoding='utf8')
+    assert '<meta name="base-theme2-layout" content="true" />' in result
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
## Summary

- Track which loader produced a template so `{% extends "!layout.html" %}` can skip the current template loader during inheritance.
- Preserve the existing behavior where `!` skips project template paths and starts at theme loaders.
- Add a regression assertion for a custom theme inheriting through a built-in theme whose `layout.html` comes from `basic`.

Fixes #12049

## Tests

- `python -m ruff check sphinx/jinja2glue.py tests/test_theming/test_theming.py`
- In a temporary venv with `pip install -e . pytest "pytest-xdist[psutil]" cython defusedxml "setuptools>=70.0" "typing_extensions>=4.9"`:
  - `python -m pytest tests/test_theming/test_theming.py::test_double_inheriting_theme -q`
  - `python -m pytest tests/test_theming/test_theming.py -q`