### PR TITLE
fix: render TypeVar as plain text in restify to avoid broken cross-references

### DIFF
--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -371,6 +371,10 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
             return f':py:obj:`~{cls.__module__}.{cls.__name__}`'
         elif hasattr(cls, '__qualname__'):
             return f':py:class:`{module_prefix}{cls.__module__}.{cls.__qualname__}`'
+        elif isinstance(cls, typing.TypeVar):
+            # TypeVars are not documentable objects; render as plain text name
+            # to avoid broken cross-references in nitpicky mode.
+            return cls.__name__
         elif isinstance(cls, typing.ForwardRef):
             return f':py:class:`{cls.__forward_arg__}`'
         else:


### PR DESCRIPTION
When `restify()` encounters a `TypeVar` (e.g., as a type argument in `Generic[_T]`), it falls through to the generic else clause and generates a `:py:obj:` cross-reference. Since TypeVars are not documentable objects in Sphinx, this cross-reference can never resolve, causing a WARNING in nitpicky mode:
```
WARNING: py:obj reference target not found: mod._T [ref.obj]
```

This change adds an explicit `isinstance(cls, typing.TypeVar)` check before the else fallback to render TypeVars as their plain name instead of a cross-reference.

Fixes #14502

---

**AI Disclosure:** AI tooling (Hermes Agent / LLM) was used to assist in identifying the root cause and drafting the initial code fix. The logic was reviewed and verified by the contributor before submission. The `isinstance` check and its placement in the control flow were validated against the existing `restify()` behavior.