### PR TITLE
Render undocumented TypeVars as text

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ Contributors
 * Bart Kamphorst -- warning improvements
 * Ben Egan -- Napoleon improvements & viewcode improvements
 * Benjamin Peterson -- unittests
+* Bernát Gábor -- undocumented TypeVars render as text
 * Blaise Laflamme -- pyramid theme
 * Brecht Machiels -- builder entry-points
 * Bruce Mitchener -- Minor epub improvement

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Bugs fixed
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.
+* #14502: Render an undocumented :class:`~typing.TypeVar` as plain text instead
+  of a dangling cross-reference, so generic base classes that use one no longer
+  emit ``nitpicky`` warnings. A documented type variable (or one reachable via
+  intersphinx) still links.
+  Patch by Bernát Gábor.
 
 
 Release 9.1.0 (released Dec 31, 2025)

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import inspect
+import sys
 import typing
 from types import NoneType
 from typing import TYPE_CHECKING, NamedTuple, cast
@@ -1094,6 +1095,40 @@ def builtin_resolver(
     return None
 
 
+def typevar_resolver(
+    app: Sphinx, env: BuildEnvironment, node: pending_xref, contnode: Element
+) -> Element | None:
+    """Resolve a reference to an undocumented TypeVar to plain text.
+
+    ``restify`` links a TypeVar by name, so a documented one (or one reachable
+    via intersphinx) resolves on its own. A private or undocumented TypeVar has
+    no target, so emit its text here instead of a nitpicky warning.
+    """
+    if node.get('refdomain') != 'py' or node.get('reftype') not in {'class', 'obj'}:
+        return None
+    if isinstance(
+        _lookup_dotted_object(node.get('reftarget', '')),
+        typing.TypeVar | typing.ParamSpec,
+    ):
+        return contnode
+    return None
+
+
+def _lookup_dotted_object(target: str, /) -> object | None:
+    """Resolve a dotted path to an already-imported object without importing."""
+    parts = target.split('.')
+    for split in range(len(parts) - 1, 0, -1):
+        if (obj := sys.modules.get('.'.join(parts[:split]))) is None:
+            continue
+        try:
+            for attr in parts[split:]:
+                obj = getattr(obj, attr)
+        except AttributeError:
+            return None
+        return obj
+    return None
+
+
 def _is_typing(s: str, /) -> bool:
     return s.removeprefix('typing.') in _TYPING_ALL
 
@@ -1122,6 +1157,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     )
     app.connect('object-description-transform', filter_meta_fields)
     app.connect('missing-reference', builtin_resolver, priority=900)
+    app.connect('missing-reference', typevar_resolver, priority=900)
 
     return {
         'version': 'builtin',

--- a/tests/roots/test-ext-autodoc-typevar/conf.py
+++ b/tests/roots/test-ext-autodoc-typevar/conf.py
@@ -1,0 +1,3 @@
+extensions = ['sphinx.ext.autodoc']
+
+nitpicky = True

--- a/tests/roots/test-ext-autodoc-typevar/index.rst
+++ b/tests/roots/test-ext-autodoc-typevar/index.rst
@@ -1,0 +1,2 @@
+.. autoclass:: target.private_typevar.Holder
+   :show-inheritance:

--- a/tests/roots/test-ext-autodoc-typevar/index.rst
+++ b/tests/roots/test-ext-autodoc-typevar/index.rst
@@ -1,2 +1,23 @@
-.. autoclass:: target.private_typevar.Holder
+.. autodata:: target.typevar_autodoc.Documented
+
+.. autoclass:: target.typevar_autodoc.DocumentedHolder
+   :members:
    :show-inheritance:
+
+.. autoclass:: target.typevar_autodoc.UndocumentedHolder
+   :members:
+   :show-inheritance:
+
+.. autoclass:: target.typevar_autodoc.CovariantHolder
+   :show-inheritance:
+
+.. autoclass:: target.typevar_autodoc.BoundHolder
+   :show-inheritance:
+
+.. autoclass:: target.typevar_autodoc.ConstrainedHolder
+   :show-inheritance:
+
+.. autoclass:: target.typevar_autodoc.ParamSpecHolder
+   :show-inheritance:
+
+.. autofunction:: target.typevar_autodoc.identity

--- a/tests/roots/test-ext-autodoc/target/private_typevar.py
+++ b/tests/roots/test-ext-autodoc/target/private_typevar.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from typing import Generic, TypeVar
-
-_T = TypeVar('_T')
-
-
-class Holder(Generic[_T]):  # NoQA: UP046
-    """A generic class parametrised by a private, undocumented type variable."""

--- a/tests/roots/test-ext-autodoc/target/private_typevar.py
+++ b/tests/roots/test-ext-autodoc/target/private_typevar.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+_T = TypeVar('_T')
+
+
+class Holder(Generic[_T]):  # NoQA: UP046
+    """A generic class parametrised by a private, undocumented type variable."""

--- a/tests/roots/test-ext-autodoc/target/typevar_autodoc.py
+++ b/tests/roots/test-ext-autodoc/target/typevar_autodoc.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Generic, ParamSpec, TypeVar
+
+#: A documented type variable.
+Documented = TypeVar('Documented')
+
+_T = TypeVar('_T')
+_T_co = TypeVar('_T_co', covariant=True)
+_T_bound = TypeVar('_T_bound', bound=int)
+_T_constrained = TypeVar('_T_constrained', int, str)
+_P = ParamSpec('_P')
+
+
+class DocumentedHolder(Generic[Documented]):  # NoQA: UP046
+    """Use a documented type variable in the base and a method."""
+
+    def echo(self, item: Documented) -> Documented:
+        """Return *item* unchanged."""
+        raise NotImplementedError
+
+
+class UndocumentedHolder(Generic[_T]):  # NoQA: UP046
+    """Use an undocumented type variable in the base and a method."""
+
+    def echo(self, item: _T) -> _T:
+        """Return *item* unchanged."""
+        raise NotImplementedError
+
+
+class CovariantHolder(Generic[_T_co]):  # NoQA: UP046
+    """Use a covariant type variable."""
+
+
+class BoundHolder(Generic[_T_bound]):  # NoQA: UP046
+    """Use a bound type variable."""
+
+
+class ConstrainedHolder(Generic[_T_constrained]):  # NoQA: UP046
+    """Use a constrained type variable."""
+
+
+class ParamSpecHolder(Generic[_P]):  # NoQA: UP046
+    """Use a ParamSpec as a generic parameter."""
+
+
+def identity(value: _T) -> _T:  # NoQA: UP047
+    """Return *value* unchanged from a module-level function."""
+    raise NotImplementedError

--- a/tests/test_domains/test_domain_py.py
+++ b/tests/test_domains/test_domain_py.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import ParamSpec, TypeVar
 from unittest.mock import Mock
 
 import docutils.utils
@@ -31,7 +32,7 @@ from sphinx.addnodes import (
     pending_xref,
 )
 from sphinx.domains import IndexEntry
-from sphinx.domains.python import PythonDomain, PythonModuleIndex
+from sphinx.domains.python import PythonDomain, PythonModuleIndex, typevar_resolver
 from sphinx.domains.python._annotations import _parse_annotation, _pseudo_parse_arglist
 from sphinx.domains.python._object import py_sig_re
 from sphinx.testing import restructuredtext
@@ -1900,3 +1901,30 @@ def test_type_alias_xref_resolution(app: SphinxTestApp) -> None:
         '<a class="reference internal" href="#alias_module.HandlerType"'
         in process_error_signature
     ), 'HandlerType type alias link not found in process_error function signature'
+
+
+RESOLVER_TYPEVAR = TypeVar('RESOLVER_TYPEVAR')
+RESOLVER_PARAMSPEC = ParamSpec('RESOLVER_PARAMSPEC')
+
+
+@pytest.mark.parametrize(
+    ('refdomain', 'reftype', 'target', 'resolves'),
+    [
+        pytest.param('py', 'class', f'{__name__}.RESOLVER_TYPEVAR', True, id='typevar'),
+        pytest.param(
+            'py', 'obj', f'{__name__}.RESOLVER_PARAMSPEC', True, id='paramspec'
+        ),
+        pytest.param('py', 'class', f'{__name__}.PythonModuleIndex', False, id='class'),
+        pytest.param('py', 'class', f'{__name__}.RESOLVER_TYPEVAR.x', False, id='attr'),
+        pytest.param('py', 'class', 'no_such_module.x', False, id='no-module'),
+        pytest.param('py', 'data', f'{__name__}.RESOLVER_TYPEVAR', False, id='reftype'),
+        pytest.param('std', 'ref', f'{__name__}.RESOLVER_TYPEVAR', False, id='domain'),
+    ],
+)
+def test_typevar_resolver(
+    refdomain: str, reftype: str, target: str, resolves: bool
+) -> None:
+    contnode = nodes.inline('', 'x')
+    node = pending_xref('', refdomain=refdomain, reftype=reftype, reftarget=target)
+    resolved = typevar_resolver(Mock(), Mock(), node, contnode)
+    assert resolved is (contnode if resolves else None)

--- a/tests/test_ext_autodoc/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autoclass.py
@@ -589,11 +589,27 @@ def test_no_inherited_instance_variable_with_annotations() -> None:
     ]
 
 
-@pytest.mark.sphinx('html', testroot='ext-autodoc-typevar')
-def test_show_inheritance_undocumented_typevar(app: SphinxTestApp) -> None:
+@pytest.mark.parametrize(
+    ('name', 'links'),
+    [
+        pytest.param('Documented', True, id='documented'),
+        pytest.param('_T', False, id='undocumented'),
+        pytest.param('_T_co', False, id='covariant'),
+        pytest.param('_T_bound', False, id='bound'),
+        pytest.param('_T_constrained', False, id='constrained'),
+        pytest.param('_P', False, id='paramspec'),
+    ],
+)
+@pytest.mark.sphinx('html', testroot='ext-autodoc-typevar', freshenv=True)
+def test_autodoc_typevar_reference(app: SphinxTestApp, name: str, links: bool) -> None:
     app.build()
+    target = f'target.typevar_autodoc.{name}'
+    assert target not in app.warning.getvalue()
     content = (app.outdir / 'index.html').read_text(encoding='utf-8')
-    # the private TypeVar in the base renders as text, not a dangling cross-reference
-    assert '<span class="pre">_T</span>' in content
-    assert 'href="#target.private_typevar._T"' not in content
-    assert 'reference target not found' not in app.warning.getvalue()
+    # a documented type variable links wherever it is referenced (base, method,
+    # function); an undocumented one renders as text instead of a dangling reference
+    if links:
+        assert f'href="#{target}"' in content
+    else:
+        assert f'href="#{target}"' not in content
+        assert f'<span class="pre">{name}</span>' in content

--- a/tests/test_ext_autodoc/test_ext_autodoc_autoclass.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_autoclass.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from sphinx.application import Sphinx
+    from sphinx.testing.util import SphinxTestApp
 
 pytestmark = pytest.mark.usefixtures('inject_autodoc_root_into_sys_path')
 
@@ -586,3 +587,13 @@ def test_no_inherited_instance_variable_with_annotations() -> None:
         '      Local',
         '',
     ]
+
+
+@pytest.mark.sphinx('html', testroot='ext-autodoc-typevar')
+def test_show_inheritance_undocumented_typevar(app: SphinxTestApp) -> None:
+    app.build()
+    content = (app.outdir / 'index.html').read_text(encoding='utf-8')
+    # the private TypeVar in the base renders as text, not a dangling cross-reference
+    assert '<span class="pre">_T</span>' in content
+    assert 'href="#target.private_typevar._T"' not in content
+    assert 'reference target not found' not in app.warning.getvalue()


### PR DESCRIPTION
Documenting a class that derives from `Generic[_T]` with `show-inheritance` failed a `nitpicky` or `-W` build whenever `_T` is private or otherwise undocumented, reporting `py:obj reference target not found`. `restify()` links a type variable by its qualified name, and a name with no documentable target leaves a dangling cross-reference, as reported in #14502.

A new `missing-reference` handler resolves that reference to plain text once it sees the target is a `TypeVar` or `ParamSpec`. A documented type variable, or one reachable through intersphinx, still links as before, and the rendering stays the bare name rather than an expanded `TypeVar(...)` form.

Generic base classes that use an undocumented type variable no longer warn, and documented references keep their links.

AI disclosure: I drafted this description with Claude Code (Anthropic), then reviewed and tested it. The change is mine and I take responsibility for it.
