### PR TITLE
Show token locations on highlighting errors

### DIFF
--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -204,18 +204,47 @@ class PygmentsBridge:
             if lang == 'default':
                 lang = 'none'  # automatic highlighting failed.
             else:
-                logger.warning(
-                    __(
-                        'Lexing literal_block %r as "%s" resulted in an error at token: %r. '
-                        'Retrying in relaxed mode.'
-                    ),
-                    source,
-                    lang,
-                    str(err),
-                    type='misc',
-                    subtype='highlighting_failure',
-                    location=location,
-                )
+                if self.dest == 'latex':
+                    # LaTeX builder includes location information
+                    loc_source = (
+                        location.parent.source
+                        if location and location.parent
+                        else location.source
+                        if location
+                        else None
+                    )
+                    loc_line = location.line if location else None
+                    logger.warning(
+                        __(
+                            'Lexing literal_block %r as "%s" resulted in an '
+                            'error at token: %r '
+                            'at location: %r:%r . '
+                            'Retrying in relaxed mode.',
+                        ),
+                        source,
+                        lang,
+                        str(err),
+                        loc_source,
+                        loc_line,
+                        type='misc',
+                        subtype='highlighting_failure',
+                        location=location,
+                    )
+                else:
+                    # HTML and other builders don't include location in message
+                    logger.warning(
+                        __(
+                            'Lexing literal_block %r as "%s" resulted in an '
+                            'error at token: %r. '
+                            'Retrying in relaxed mode.',
+                        ),
+                        source,
+                        lang,
+                        str(err),
+                        type='misc',
+                        subtype='highlighting_failure',
+                        location=location,
+                    )
                 if force:
                     lang = 'none'
                 else:

--- a/tests/test_builders/test_build_warnings.py
+++ b/tests/test_builders/test_build_warnings.py
@@ -43,7 +43,7 @@ LATEX_WARNINGS = (
 {root}/index.rst:\\d+: WARNING: unknown option: '&option' \\[ref.option\\]
 {root}/index.rst:\\d+: WARNING: citation not found: missing \\[ref.ref\\]
 {root}/index.rst:\\d+: WARNING: a suitable image for latex builder not found: foo.\\*
-{root}/index.rst:\\d+: WARNING: Lexing literal_block ".*" as "c" resulted in an error at token: ".*". Retrying in relaxed mode. \\[misc.highlighting_failure\\]
+{root}/index.rst:\\d+: WARNING: Lexing literal_block ".*" as "c" resulted in an error at token: ".*" at location: '/[\\w\\d/_-]+/warnings/index.rst':[\\d]+ . Retrying in relaxed mode. \\[misc.highlighting_failure\\]
 """
 )
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose
Show token locations on highlighting errors, in order to make it easy to Ctrl-Click path:lineno references
(in order to find obscure issues with unbalanced appostrophes in comments in bash syntax-highligted docs)

This adds to the one line error message regex.

I've tried to update the translation files too. As noted on that commit, I've attempted to auto-updated the translation files with the model. Please do correct as necessary.

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->



## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->

- AI tools used:
  - GitHub Copilot (in vscode with a devcontainer)
    - Claude Haiku 4.5 (0.33x but)
    - Gemini 3.1 Pro (6x for translations)
