### PR TITLE
Avoid captionless figures in intl test fixture

### DIFF
--- a/tests/roots/test-intl/figure.txt
+++ b/tests/roots/test-intl/figure.txt
@@ -34,6 +34,8 @@ image url and alt
 .. figure:: img.png
    :alt: img
 
+   ..
+
 
 image on substitution
 ---------------------
@@ -51,3 +53,4 @@ image under note
    .. figure:: img.png
       :alt: img under note
 
+      ..

--- a/tests/test_builders/test_build_epub.py
+++ b/tests/test_builders/test_build_epub.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import xml.etree.ElementTree as ET
 from collections import Counter
@@ -418,9 +419,11 @@ def test_epub_anchor_id(app: SphinxTestApp) -> None:
 
     html = (app.outdir / 'index.xhtml').read_text(encoding='utf8')
     assert '<p id="std-setting-STATICFILES_FINDERS">blah blah blah</p>' in html
-    assert (
-        '<span id="std-setting-STATICFILES_SECTION"></span><h1>blah blah blah</h1>'
-    ) in html
+    assert re.search(
+        r'<span id="std-setting-STATICFILES_SECTION"></span>\s*'
+        r'<h1>blah blah blah</h1>',
+        html,
+    )
     assert (
         'see <a class="reference internal" href="#std-setting-STATICFILES_FINDERS">'
     ) in html


### PR DESCRIPTION
### Summary
- add comment-only legends to the captionless figures in the intl fixture
- keep the text builder output unchanged while satisfying Docutils HEAD figure validation

### Testing
- `python -m pytest tests/test_intl/test_intl.py::test_text_figure_captions -q` with Docutils HEAD (`docutils-1.0b1.dev0`) failed before the change with `Figure without caption and legend` system messages in `figure.txt`
- `python -m pytest tests/test_intl/test_intl.py::test_text_figure_captions -q` with Docutils HEAD passed after the change
- `python -m pytest tests/test_intl/test_intl.py::test_text_figure_captions -q` with supported Docutils `0.22.4` passed

Closes #14508