### PR TITLE
Clarify env_version state handling guidance

### DIFF
--- a/doc/extdev/index.rst
+++ b/doc/extdev/index.rst
@@ -192,6 +192,14 @@ Metadata keys currently recognized are:
   of the stored data change, to ensure Sphinx does not try and load invalid data
   from a cached environment.
 
+  Extensions that store data on ``env`` should use a unique attribute name to
+  avoid clashing with Sphinx or other extensions.  They must also remove
+  per-document data when Sphinx emits :event:`env-purge-doc`, and merge data
+  from subprocess environments when Sphinx emits :event:`env-merge-info` during
+  parallel reading.  See :ref:`tutorial-extend-build` for a complete example, or
+  use :class:`~sphinx.environment.collectors.EnvironmentCollector` when the
+  extension needs a dedicated collector for environment data.
+
   .. versionadded:: 1.8
 
 ``'parallel_read_safe'``


### PR DESCRIPTION
## Summary

- clarify that extensions storing state on `env` should use a unique attribute name
- point extension authors to `env-purge-doc` and `env-merge-info` for cleanup and parallel-read merging
- link larger environment-data use cases to `EnvironmentCollector`

## Verification

- focused docs check that the `env_version` section links the relevant purge, merge, collector, and tutorial guidance
- `git diff --check`
- `.venv-docs/bin/sphinx-build -M html ./doc ./build/sphinx --fail-on-warning`
  - completed the HTML build and failed only because local Graphviz `dot` is unavailable

Closes #12237.
