### PR TITLE
Do not warn on references to in-scope PEP 695 type parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,6 +27,7 @@ Contributors
 * Andi Albrecht -- agogo theme
 * Antonio Valentino -- qthelp builder, docstring inheritance
 * Antti Kaihola -- doctest extension (skipif option)
+* Apoorv Darshan -- PEP 695 type parameter scoping in the Python domain
 * Barry Warsaw -- setup command improvements
 * Bart Kamphorst -- warning improvements
 * Ben Egan -- Napoleon improvements & viewcode improvements

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Bugs fixed
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.
+* #14462: Python domain: Stop reporting spurious ``ref.class`` warnings for
+  PEP 695 type parameters referenced in type parameter bounds, argument
+  lists, return annotations, and the bodies of generic classes.
+  Type parameters in scope now render as plain text instead of
+  unresolvable cross-references.
+  Patch by Apoorv Darshan.
 
 
 Release 9.1.0 (released Dec 31, 2025)

--- a/sphinx/domains/python/_annotations.py
+++ b/sphinx/domains/python/_annotations.py
@@ -57,8 +57,14 @@ def parse_reftarget(
 
 def type_to_xref(
     target: str, env: BuildEnvironment, *, suppress_prefix: bool = False
-) -> addnodes.pending_xref:
+) -> addnodes.pending_xref | nodes.Text:
     """Convert a type string to a cross reference node."""
+    if '.' not in target and target in env.ref_context.get('py:type_params', ()):
+        # PEP 695 type parameters in scope shadow any documented object
+        # with the same name and have no link target of their own, so
+        # render them as plain text (#14462).
+        return nodes.Text(target)
+
     if env:
         kwargs = {
             'py:module': env.ref_context.get('py:module'),

--- a/sphinx/domains/python/_object.py
+++ b/sphinx/domains/python/_object.py
@@ -15,6 +15,7 @@ from sphinx.domains.python._annotations import (
     _parse_arglist,
     _parse_type_list,
     _pseudo_parse_arglist,
+    _TypeParameterListParser,
     parse_reftarget,
 )
 from sphinx.locale import _
@@ -168,6 +169,10 @@ class PyObject(ObjectDescription[tuple[str, str]]):
     :cvar allow_nesting: Class is an object that allows for nested namespaces
     :vartype allow_nesting: bool
     """
+
+    #: the ``py:type_params`` reference context of the enclosing object,
+    #: saved when this object introduces PEP 695 type parameters
+    _outer_type_params: tuple[str, ...]
 
     option_spec: ClassVar[OptionSpec] = {
         'no-index': directives.flag,
@@ -332,6 +337,28 @@ class PyObject(ObjectDescription[tuple[str, str]]):
         signode += addnodes.desc_name(name, name)
 
         if tp_list:
+            # Bring the PEP 695 type parameters into scope while parsing the
+            # type parameter list, argument list and return annotation, so
+            # that references to them are not reported as unresolvable
+            # classes (#14462). The scope lasts until :py:meth:`after_content`
+            # to also cover e.g. methods of a generic class referring to the
+            # class type parameters.
+            try:
+                tp_parser = _TypeParameterListParser(tp_list)
+                tp_parser.parse()
+                tp_names = tuple(tp[0] for tp in tp_parser.type_params)
+            except Exception:
+                tp_names = ()
+            if tp_names:
+                if not hasattr(self, '_outer_type_params'):
+                    self._outer_type_params = self.env.ref_context.get(
+                        'py:type_params', ()
+                    )
+                current = self.env.ref_context.get('py:type_params', ())
+                self.env.ref_context['py:type_params'] = tuple(
+                    dict.fromkeys((*current, *tp_names))
+                )
+
             try:
                 signode += _parse_type_list(
                     tp_list,
@@ -501,6 +528,12 @@ class PyObject(ObjectDescription[tuple[str, str]]):
                 self.env.ref_context['py:module'] = modules.pop()
             else:
                 self.env.ref_context.pop('py:module')
+        if hasattr(self, '_outer_type_params'):
+            # restore the type parameter scope of the enclosing object
+            if self._outer_type_params:
+                self.env.ref_context['py:type_params'] = self._outer_type_params
+            else:
+                self.env.ref_context.pop('py:type_params', None)
 
     def _toc_entry_name(self, sig_node: desc_signature) -> str:
         if not sig_node.get('_toc_parts'):

--- a/tests/roots/test-domain-py-type-param-scope/index.rst
+++ b/tests/roots/test-domain-py-type-param-scope/index.rst
@@ -1,0 +1,23 @@
+test-domain-py-type-param-scope
+===============================
+
+.. py:function:: func[T](x: T, /) -> tuple[T, ...]
+                 func[T](x: T, y: T, /) -> tuple[T, T]
+
+.. py:class:: Spam[T]
+
+   A powerful frobnicator.
+
+   .. py:method:: eggs(arg: int) -> T
+
+      Return the result after frobnicating.
+
+.. py:class:: RealT
+
+   A documented class.
+
+.. py:class:: Box[RealT]
+
+   .. py:method:: get() -> RealT
+
+.. py:function:: outside(x: T) -> RealT

--- a/tests/test_domains/test_domain_py.py
+++ b/tests/test_domains/test_domain_py.py
@@ -1526,7 +1526,9 @@ def test_class_def_pep_695(app):
                                                 (
                                                     [pending_xref, 'Sequence'],
                                                     [desc_sig_punctuation, '['],
-                                                    [pending_xref, 'T'],
+                                                    # in-scope type parameters
+                                                    # are not cross-references
+                                                    'T',
                                                     [desc_sig_punctuation, ']'],
                                                 ),
                                             ],
@@ -1628,14 +1630,14 @@ def test_class_def_pep_696(app):
                                             [
                                                 desc_sig_name,
                                                 (
-                                                    # T
-                                                    [pending_xref, 'T'],
+                                                    # T (in scope: no xref)
+                                                    'T',
                                                     [desc_sig_punctuation, ','],
                                                     desc_sig_space,
                                                     # tuple[T, ...]
                                                     [pending_xref, 'tuple'],
                                                     [desc_sig_punctuation, '['],
-                                                    [pending_xref, 'T'],
+                                                    'T',
                                                     [desc_sig_punctuation, ','],
                                                     desc_sig_space,
                                                     [desc_sig_punctuation, '...'],
@@ -1648,7 +1650,7 @@ def test_class_def_pep_696(app):
                                                         'collections.abc.Iterable',
                                                     ],
                                                     [desc_sig_punctuation, '['],
-                                                    [pending_xref, 'T'],
+                                                    'T',
                                                     [desc_sig_punctuation, ']'],
                                                 ),
                                             ],
@@ -1673,10 +1675,12 @@ def test_class_def_pep_696(app):
                                                         'collections.abc.Mapping',
                                                     ],
                                                     [desc_sig_punctuation, '['],
-                                                    [pending_xref, 'KT'],
+                                                    # in-scope type parameters
+                                                    # are not cross-references
+                                                    'KT',
                                                     [desc_sig_punctuation, ','],
                                                     desc_sig_space,
-                                                    [pending_xref, 'VT'],
+                                                    'VT',
                                                     [desc_sig_punctuation, ']'],
                                                 ),
                                             ],
@@ -1900,3 +1904,35 @@ def test_type_alias_xref_resolution(app: SphinxTestApp) -> None:
         '<a class="reference internal" href="#alias_module.HandlerType"'
         in process_error_signature
     ), 'HandlerType type alias link not found in process_error function signature'
+
+
+def test_pep_695_type_params_render_as_text(app):
+    # in-scope PEP 695 type parameters are not turned into cross references
+    # https://github.com/sphinx-doc/sphinx/issues/14462
+    text = '.. py:function:: func[T](x: T, /) -> tuple[T, ...]'
+    doctree = restructuredtext.parse(app, text)
+    reftargets = [n['reftarget'] for n in doctree.findall(addnodes.pending_xref)]
+    assert 'T' not in reftargets
+    assert 'tuple' in reftargets
+
+
+@pytest.mark.sphinx('html', testroot='domain-py-type-param-scope')
+def test_pep_695_type_param_scope_nitpicky(app: SphinxTestApp) -> None:
+    """References to in-scope PEP 695 type parameters do not warn in
+    nitpicky mode, while out-of-scope names still do.
+
+    See https://github.com/sphinx-doc/sphinx/issues/14462
+    """
+    app.config.nitpicky = True
+    app.build()
+
+    warnings = [
+        line
+        for line in app.warning.getvalue().splitlines()
+        if 'reference target not found' in line
+    ]
+    # the only unresolvable reference is ``T`` in ``outside()``, which is
+    # not within the scope of any type parameter list
+    assert len(warnings) == 1, warnings
+    assert 'reference target not found: T [ref.class]' in warnings[0]
+    assert 'index.rst:23' in warnings[0]


### PR DESCRIPTION
Fixes #14462

## Problem

References to PEP 695 type parameters — in type parameter bounds, argument lists, return annotations, and the bodies of generic classes — are converted into `py:class` pending cross-references. Type parameters have no link target and, per [PEP 695 scoping](https://peps.python.org/pep-0695/#type-parameter-scopes), shadow any documented object of the same name, so every such reference produces a spurious `reference target not found` warning under `-n` (the reporter counts ~1000 in an 8k LoC project). Reproduced on `master` with the issue's snippet (3 spurious warnings).

## Fix

- `PyObject.handle_signature()` records the type parameter names introduced by a signature in `env.ref_context['py:type_params']` (saving the enclosing scope on the directive instance), so they are visible while parsing the type parameter list itself (bounds/constraints/defaults), the argument list, and the return annotation.
- `PyObject.after_content()` restores the enclosing scope, so the names also cover the object's body — e.g. `py:method:: eggs(arg: int) -> T` inside `py:class:: Spam[T]` — and never leak past the directive (mirrors the existing `py:class`/`py:module` ref-context handling, including nesting).
- `type_to_xref()` renders an in-scope, un-dotted name as plain `Text` instead of a `pending_xref`. Rendered output is unchanged — an unresolvable reference already fell back to plain text — but no warning is emitted, and a documented class shadowed by a type parameter is no longer (incorrectly) linked.

Out-of-scope references still warn: `py:function:: outside(x: T)` after a generic class continues to report `T`.

Two existing doctree-shape tests (`test_class_def_pep_695`, `test_class_def_pep_696`) pinned the old behavior of in-scope names inside bounds/constraints (e.g. `S: Sequence[T]`) being pending xrefs; they were updated to expect plain text for exactly those names (`Sequence`, `tuple`, `int` etc. remain xrefs).

This is complementary to #14504, which handles the autodoc/runtime-`TypeVar` side via `missing-reference`; this PR covers the directive-syntax layer, where scope is known at parse time.

## Verification

- New testroot `test-domain-py-type-param-scope` + `test_pep_695_type_param_scope_nitpicky` (asserts the only remaining warning is the genuinely out-of-scope `T`) and `test_pep_695_type_params_render_as_text` — both fail on `master`.
- Full test suite (minus `test_intl`): ~2,900 passed, failure set byte-identical to `master` in my environment (6 pre-existing environment-dependent failures).
- `ruff check`/`ruff format` clean on changed files; `mypy` clean on both changed modules.

## AI policy disclosure

Per the [AI policy](https://www.sphinx-doc.org/en/master/internals/ai-policy.html): this contribution was prepared with the assistance of an AI tool (Claude Code), used for the investigation, the patch, and the tests. I reproduced the issue, reviewed and verified the change and all test results, and take responsibility for the contribution — I'll respond to review feedback personally.
