### PR TITLE
Napoleon: Fix skip_member logic

### DIFF
--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -293,7 +293,7 @@ sure that "sphinx.ext.napoleon" is enabled in ``conf.py``:
     napoleon_numpy_docstring = True
     napoleon_include_init_with_doc = False
     napoleon_include_private_with_doc = False
-    napoleon_include_special_with_doc = True
+    napoleon_include_special_with_doc = False
     napoleon_use_admonition_for_examples = False
     napoleon_use_admonition_for_notes = False
     napoleon_use_admonition_for_references = False
@@ -367,7 +367,7 @@ sure that "sphinx.ext.napoleon" is enabled in ``conf.py``:
 
 .. confval:: napoleon_include_special_with_doc
    :type: :code-py:`bool`
-   :default: :code-py:`True`
+   :default: :code-py:`False`
 
    True to include special members (like ``__membername__``) with
    docstrings in the documentation. False to fall back to Sphinx's

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -421,7 +421,12 @@ def _process_docstring(
 
 
 def _skip_member(
-    app: Sphinx, obj_type: _AutodocObjType, name: str, obj: Any, skip: bool, options: Any
+    app: Sphinx,
+    obj_type: _AutodocObjType,
+    name: str,
+    obj: Any,
+    skip: bool,
+    options: Any,
 ) -> bool | None:
     """Determine if private and special class members are included in docs.
 
@@ -465,7 +470,9 @@ def _skip_member(
 
     """
     has_doc = getattr(obj, '__doc__', False)
-    is_module_member = obj_type == "data" or getattr(obj, "__module__", None) is not None
+    is_module_member = (
+        obj_type == 'data' or getattr(obj, '__module__', None) is not None
+    )
 
     if name != '__weakref__' and has_doc:
         cls_is_owner = False

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -421,7 +421,7 @@ def _process_docstring(
 
 
 def _skip_member(
-    app: Sphinx, what: _AutodocObjType, name: str, obj: Any, skip: bool, options: Any
+    app: Sphinx, obj_type: _AutodocObjType, name: str, obj: Any, skip: bool, options: Any
 ) -> bool | None:
     """Determine if private and special class members are included in docs.
 
@@ -439,10 +439,10 @@ def _skip_member(
     ----------
     app : sphinx.application.Sphinx
         Application object representing the Sphinx process
-    what : str
-        A string specifying the type of the object to which the member
-        belongs. Valid values: "module", "class", "exception", "function",
-        "method", "attribute".
+    obj_type : str
+        The type of the object which the docstring belongs to (one of "module",
+        "class", "exception", "function", "decorator", "method", "property",
+        "attribute", "data", or "type")
     name : str
         The name of the member.
     obj : module, class, exception, function, method, or attribute.
@@ -465,35 +465,33 @@ def _skip_member(
 
     """
     has_doc = getattr(obj, '__doc__', False)
-    is_member = what in {'class', 'exception', 'module'}
-    if name != '__weakref__' and has_doc and is_member:
+    is_class_member = obj_type in {'method', 'property', 'attribute'}
+
+    if name != '__weakref__' and has_doc:
         cls_is_owner = False
-        if what in {'class', 'exception'}:
-            qualname = getattr(obj, '__qualname__', '')
-            cls_path, _, _ = qualname.rpartition('.')
-            if cls_path:
-                try:
-                    if '.' in cls_path:
-                        import functools
-                        import importlib
+        qualname = getattr(obj, '__qualname__', '')
+        cls_path, _, _ = qualname.rpartition('.')
+        if is_class_member and cls_path:
+            try:
+                if '.' in cls_path:
+                    import functools
+                    import importlib
 
-                        mod = importlib.import_module(obj.__module__)
-                        mod_path = cls_path.split('.')
-                        cls = functools.reduce(getattr, mod_path, mod)
-                    else:
-                        cls = inspect.unwrap(obj).__globals__[cls_path]
-                except Exception:
-                    cls_is_owner = False
+                    mod = importlib.import_module(obj.__module__)
+                    mod_path = cls_path.split('.')
+                    cls = functools.reduce(getattr, mod_path, mod)
                 else:
-                    cls_is_owner = (
-                        cls  # type: ignore[assignment]
-                        and hasattr(cls, name)
-                        and name in cls.__dict__
-                    )
-            else:
+                    cls = inspect.unwrap(obj).__globals__[cls_path]
+            except Exception:
                 cls_is_owner = False
+            else:
+                cls_is_owner = (
+                    cls  # type: ignore[assignment]
+                    and hasattr(cls, name)
+                    and name in cls.__dict__
+                )
 
-        if what == 'module' or cls_is_owner:
+        if not is_class_member or cls_is_owner:
             is_init = name == '__init__'
             is_special = not is_init and name.startswith('__') and name.endswith('__')
             is_private = not is_init and not is_special and name.startswith('_')

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -465,13 +465,14 @@ def _skip_member(
 
     """
     has_doc = getattr(obj, '__doc__', False)
-    is_class_member = obj_type in {'method', 'property', 'attribute'}
+    is_module_member = obj_type == "data" or getattr(obj, "__module__", None) is not None
 
     if name != '__weakref__' and has_doc:
         cls_is_owner = False
         qualname = getattr(obj, '__qualname__', '')
         cls_path, _, _ = qualname.rpartition('.')
-        if is_class_member and cls_path:
+        if cls_path:
+            is_module_member = False
             try:
                 if '.' in cls_path:
                     import functools
@@ -491,7 +492,7 @@ def _skip_member(
                     and name in cls.__dict__
                 )
 
-        if not is_class_member or cls_is_owner:
+        if is_module_member or cls_is_owner:
             is_init = name == '__init__'
             is_special = not is_init and name.startswith('__') and name.endswith('__')
             is_private = not is_init and not is_special and name.startswith('_')

--- a/tests/test_ext_napoleon/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon.py
@@ -173,7 +173,7 @@ class TestSkipMember:
         # raise an error on building document
         # See: https://github.com/sphinx-doc/sphinx/issues/1455
         self.assert_skip(
-            'class',
+            'method',
             '_asdict',
             SampleNamedTuple._asdict,
             True,
@@ -182,7 +182,7 @@ class TestSkipMember:
 
     def test_class_private_doc(self) -> None:
         self.assert_skip(
-            'class',
+            'method',
             '_private_doc',
             SampleClass._private_doc,
             False,
@@ -191,7 +191,7 @@ class TestSkipMember:
 
     def test_class_private_undoc(self) -> None:
         self.assert_skip(
-            'class',
+            'method',
             '_private_undoc',
             SampleClass._private_undoc,
             True,
@@ -200,7 +200,7 @@ class TestSkipMember:
 
     def test_class_special_doc(self) -> None:
         self.assert_skip(
-            'class',
+            'method',
             '__special_doc__',
             SampleClass.__special_doc__,
             False,
@@ -209,7 +209,7 @@ class TestSkipMember:
 
     def test_class_special_undoc(self) -> None:
         self.assert_skip(
-            'class',
+            'method',
             '__special_undoc__',
             SampleClass.__special_undoc__,
             True,
@@ -218,7 +218,7 @@ class TestSkipMember:
 
     def test_class_decorated_doc(self) -> None:
         self.assert_skip(
-            'class',
+            'method',
             '__decorated_func__',
             SampleClass.__decorated_func__,
             False,
@@ -227,7 +227,7 @@ class TestSkipMember:
 
     def test_exception_private_doc(self) -> None:
         self.assert_skip(
-            'exception',
+            'method',
             '_private_doc',
             SampleError._private_doc,
             False,
@@ -236,7 +236,7 @@ class TestSkipMember:
 
     def test_exception_private_undoc(self) -> None:
         self.assert_skip(
-            'exception',
+            'method',
             '_private_undoc',
             SampleError._private_undoc,
             True,
@@ -245,7 +245,7 @@ class TestSkipMember:
 
     def test_exception_special_doc(self) -> None:
         self.assert_skip(
-            'exception',
+            'method',
             '__special_doc__',
             SampleError.__special_doc__,
             False,
@@ -254,7 +254,7 @@ class TestSkipMember:
 
     def test_exception_special_undoc(self) -> None:
         self.assert_skip(
-            'exception',
+            'method',
             '__special_undoc__',
             SampleError.__special_undoc__,
             True,
@@ -263,7 +263,7 @@ class TestSkipMember:
 
     def test_module_private_doc(self) -> None:
         self.assert_skip(
-            'module',
+            'function',
             '_private_doc',
             _private_doc,
             False,
@@ -272,7 +272,7 @@ class TestSkipMember:
 
     def test_module_private_undoc(self) -> None:
         self.assert_skip(
-            'module',
+            'function',
             '_private_undoc',
             _private_undoc,
             True,
@@ -281,7 +281,7 @@ class TestSkipMember:
 
     def test_module_special_doc(self) -> None:
         self.assert_skip(
-            'module',
+            'function',
             '__special_doc__',
             __special_doc__,
             False,
@@ -290,7 +290,7 @@ class TestSkipMember:
 
     def test_module_special_undoc(self) -> None:
         self.assert_skip(
-            'module',
+            'function',
             '__special_undoc__',
             __special_undoc__,
             True,


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose
Napoleon's logic for skipping members is broken: It assumes that the second argument to `_skip_member` (`what`) is the type of the object whose member is being documented (e.g. if the a method is being documented, `what` would be `class`), while in reality it is the type of the object that itself is being documented. This results in options like `napoleon_include_special_with_doc` having no effect.
<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- closes #14515

## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->
No AI tools used