### PR TITLE
docs: add translatable node to doctree node classes page

### DIFF
--- a/doc/extdev/nodes.rst
+++ b/doc/extdev/nodes.rst
@@ -94,6 +94,8 @@ Special nodes
 .. autoclass:: only
 .. autoclass:: highlightlang
 
+.. autoclass:: translatable
+
 You should not need to generate the nodes below in extensions.
 
 .. autoclass:: glossary


### PR DESCRIPTION
Add the 	ranslatable node class to the documented list of Sphinx addnodes. This node is an abstract base class for nodes that support translation (e.g., toctree).

Closes #9409