### PR TITLE
Fix: add usage example with -M flag in sphinx-build help

### DIFF
--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -70,7 +70,7 @@ def jobs_argument(value: str) -> int:
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         usage='%(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]\n'
-              '       %(prog)s -M BUILDER SOURCEDIR OUTPUTDIR [OPTIONS]',
+        '       %(prog)s -M BUILDER SOURCEDIR OUTPUTDIR [OPTIONS]',
         epilog=__('For more information, visit <https://www.sphinx-doc.org/>.'),
         description=__("""
 Generate documentation from source files.
@@ -109,18 +109,6 @@ files can be built by specifying individual filenames.
         help=__(
             '(optional) a list of specific files to rebuild. '
             'Ignored if --write-all is specified'
-        ),
-    )
-
-    parser.add_argument(
-        '-M',
-        dest='make_mode',
-        metavar='BUILDER',
-        help=__(
-            'alternative approach to command-line invocation. '
-            'Must always come first. Manages build and cache paths. '
-            'If more flexibility is needed, use -b instead and keep '
-            'in mind different signatures.'
         ),
     )
 

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -69,7 +69,8 @@ def jobs_argument(value: str) -> int:
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        usage='%(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]',
+        usage='%(prog)s [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]\n'
+              '       %(prog)s -M BUILDER SOURCEDIR OUTPUTDIR [OPTIONS]',
         epilog=__('For more information, visit <https://www.sphinx-doc.org/>.'),
         description=__("""
 Generate documentation from source files.
@@ -108,6 +109,18 @@ files can be built by specifying individual filenames.
         help=__(
             '(optional) a list of specific files to rebuild. '
             'Ignored if --write-all is specified'
+        ),
+    )
+
+    parser.add_argument(
+        '-M',
+        dest='make_mode',
+        metavar='BUILDER',
+        help=__(
+            'alternative approach to command-line invocation. '
+            'Must always come first. Manages build and cache paths. '
+            'If more flexibility is needed, use -b instead and keep '
+            'in mind different signatures.'
         ),
     )
 

--- a/sphinx/cmd/build.py
+++ b/sphinx/cmd/build.py
@@ -80,6 +80,9 @@ in OUTPUTDIR. It looks for 'conf.py' in SOURCEDIR for the configuration
 settings. The 'sphinx-quickstart' tool may be used to generate template files,
 including 'conf.py'
 
+Use '-M' for make mode, which manages build and cache directories. It must be
+the first command-line argument. For finer control, use '-b/--builder' instead.
+
 sphinx-build can create documentation in different formats. A format is
 selected by specifying the builder name on the command line; it defaults to
 HTML. Builders can also perform other tasks related to documentation

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -99,11 +99,11 @@ def parse_arguments(args: list[str]) -> dict[str, Any]:
 def test_build_main_usage_includes_make_mode() -> None:
     parser = get_parser()
     parser.prog = 'sphinx-build'
+    usage = strip_escape_sequences(parser.format_usage())
 
     assert (
         'usage: sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]\n'
-        '       sphinx-build -M BUILDER SOURCEDIR OUTPUTDIR [OPTIONS]'
-        in parser.format_usage()
+        '       sphinx-build -M BUILDER SOURCEDIR OUTPUTDIR [OPTIONS]' in usage
     )
 
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -96,6 +96,17 @@ def parse_arguments(args: list[str]) -> dict[str, Any]:
     return {k: v for k, v in parsed.items() if k not in DEFAULTS or v != DEFAULTS[k]}
 
 
+def test_build_main_usage_includes_make_mode() -> None:
+    parser = get_parser()
+    parser.prog = 'sphinx-build'
+
+    assert (
+        'usage: sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]\n'
+        '       sphinx-build -M BUILDER SOURCEDIR OUTPUTDIR [OPTIONS]'
+        in parser.format_usage()
+    )
+
+
 def test_build_main_parse_arguments_pos_first() -> None:
     # <positional...> <opts>
     args = [


### PR DESCRIPTION
Adds the make-mode signature to `sphinx-build --help` and explains that `-M` must be the first argument. The existing make-mode dispatch remains unchanged.

Adds a focused test for the displayed usage.

Refs #12671.