### PR TITLE
Avoid deprecated autodoc options mapping access in Napoleon

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -358,7 +358,7 @@ class GoogleDocstring:
         self._what: _AutodocObjType | Literal['object'] = what
         self._name = name
         self._obj = obj
-        if options:
+        if options is not None:
             try:
                 self._no_index = options.no_index or options.noindex
             except (AttributeError, TypeError):

--- a/tests/test_ext_napoleon/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import functools
-import warnings
 from collections import namedtuple
 from unittest import mock
 
 import pytest
 
 from sphinx.application import Sphinx
-from sphinx.deprecation import RemovedInSphinx11Warning
-from sphinx.ext.autodoc._directive_options import _AutoDocumenterOptions
 from sphinx.ext.napoleon import Config, _process_docstring, _skip_member, setup
-from sphinx.ext.napoleon.docstring import NumpyDocstring
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -116,11 +112,6 @@ class TestProcessDocstring:
             '',
         ]
         assert lines == expected
-
-    def test_autodoc_options_do_not_use_mapping_interface(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter('error', RemovedInSphinx11Warning)
-            NumpyDocstring('', Config(), options=_AutoDocumenterOptions())
 
 
 class TestSetup:

--- a/tests/test_ext_napoleon/test_ext_napoleon.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import functools
+import warnings
 from collections import namedtuple
 from unittest import mock
 
 import pytest
 
 from sphinx.application import Sphinx
+from sphinx.deprecation import RemovedInSphinx11Warning
+from sphinx.ext.autodoc._directive_options import _AutoDocumenterOptions
 from sphinx.ext.napoleon import Config, _process_docstring, _skip_member, setup
+from sphinx.ext.napoleon.docstring import NumpyDocstring
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -112,6 +116,11 @@ class TestProcessDocstring:
             '',
         ]
         assert lines == expected
+
+    def test_autodoc_options_do_not_use_mapping_interface(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', RemovedInSphinx11Warning)
+            NumpyDocstring('', Config(), options=_AutoDocumenterOptions())
 
 
 class TestSetup:


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

This code only needs to distinguish “no options were supplied” (`None`) from “an autodoc options object was supplied”, so `if options is not None` states the intended condition directly. This avoids the deprecated mapping protocol, preserves the relevant behavior, and leaves warnings in place for third-party extensions that still use the deprecated mapping interface.

As a comparison to the suggested in the original issue, adding `__bool__` to `_AutoDocumenterOptions` would broaden the object’s public behavior to hide this one caller’s use of its deprecated mapping interface. In particular, its current `__len__` counts public attributes, so even an options instance with no configured options is effectively truthy. An always-true `__bool__` would preserve that surprising behavior.

## Testing

- I committed [the test](https://github.com/sphinx-doc/sphinx/pull/14534/changes/2c464ef13a934182f78074d4c56d07479f94cf4e) first (with no fix yet) to confirm the warning with a failing test.
  - [Example test failure](https://github.com/sphinx-doc/sphinx/actions/runs/29443309297/job/87447427773#step:10:4983)
- Then I committed the fix to show the test passed.
  - Same test [passed](https://github.com/sphinx-doc/sphinx/actions/runs/29443493513/job/87448129001?pr=14534#step:10:2603) with fix
- Then I [reverted the test](https://github.com/sphinx-doc/sphinx/pull/14534/changes/bf97195f227d2fec25c620f2d7c800a37993320b) since it seemed overkill to me to have on master

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

Fixes https://github.com/sphinx-doc/sphinx/issues/14270


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->

I used AI to come up with the fix, the test, and the comparison to the fix suggested in the original issue. The fix is simple and the explanation makes sense to me.
