### PR TITLE
ext/imgmath: batch LaTeX compilation

### DIFF
--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -188,7 +188,20 @@ are built:
    If true, encode LaTeX output images within HTML files
    (base64 encoded) and do not save separate png/svg files to disk.
 
-   .. versionadded:: 5.2
+    .. versionadded:: 5.2
+
+.. confval:: imgmath_batch_size
+   :type: :code-py:`int`
+   :default: :code-py:`1`
+
+   Number of math expressions to compile in a single LaTeX invocation.
+   When set to a value greater than 1, equations are accumulated and
+   compiled into one multi-page DVI document, then split into individual
+   images.
+   This could greatly reduce the number of LaTeX process fired
+   for documents with many equations.
+
+   .. versionadded:: 9.2
 
 :mod:`sphinx.ext.mathjax` -- Render math via JavaScript
 -------------------------------------------------------

--- a/doc/usage/extensions/math.rst
+++ b/doc/usage/extensions/math.rst
@@ -190,6 +190,19 @@ are built:
 
    .. versionadded:: 5.2
 
+.. confval:: imgmath_batch_size
+   :type: :code-py:`int`
+   :default: :code-py:`1`
+
+   Number of math expressions to compile in a single LaTeX invocation.
+   When greater than 1, equations are collected after reading and
+   compiled into multi-page DVI documents before writing,
+   reducing *N* LaTeX processes to *ceil(N / batch_size)*.
+   Batching is disabled when a custom ``template.tex``/``preview.tex``
+   template is detected.
+
+   .. versionadded:: 9.2
+
 :mod:`sphinx.ext.mathjax` -- Render math via JavaScript
 -------------------------------------------------------
 

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -29,6 +29,8 @@ from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.template import LaTeXRenderer
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from docutils.nodes import Element
 
     from sphinx.application import Sphinx
@@ -156,6 +158,64 @@ def compile_math(latex: str, *, config: Config) -> Path:
         raise MathExtError(msg, exc.stderr, exc.stdout) from exc
 
 
+def compile_math_batch(latex_bodies: list[str], *, config: Config) -> Path:
+    r"""Compile a batch of math expressions into a single multi-page DVI.
+
+    Each entry in *latex_bodies* is the body content for one equation
+    (e.g. ``\\fontsize{12}{14}\\selectfont E=mc^2``).
+    They are compiled into one document with each equation separated by
+    ``\\clearpage``, producing a multi-page DVI where each page
+    corresponds to one equation.
+    """
+    tempdir = Path(tempfile.mkdtemp(suffix='-sphinx-imgmath-batch'))
+
+    combined = '\\documentclass[12pt]{article}\n'
+    combined += '\\usepackage[utf8]{inputenc}\n'
+    combined += '\\usepackage{amsmath, amsthm, amssymb, amsfonts, anyfontsize, bm}\n'
+    combined += '\\pagestyle{empty}\n'
+    if config.imgmath_latex_preamble:
+        combined += config.imgmath_latex_preamble + '\n'
+    combined += '\\begin{document}\n'
+    for i, body in enumerate(latex_bodies):
+        combined += body
+        combined += '\n'
+        if i < len(latex_bodies) - 1:
+            combined += '\\clearpage\n'
+    combined += '\\end{document}\n'
+
+    filename = tempdir / 'math.tex'
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(combined)
+
+    imgmath_latex_name = os.path.basename(config.imgmath_latex)
+    command = [config.imgmath_latex]
+    if imgmath_latex_name != 'tectonic':
+        command.append('--interaction=nonstopmode')
+    command.extend(config.imgmath_latex_args)
+    command.append('math.tex')
+
+    try:
+        subprocess.run(
+            command, capture_output=True, cwd=tempdir, check=True, encoding='ascii'
+        )
+        if imgmath_latex_name in {'xelatex', 'tectonic'}:
+            return tempdir / 'math.xdv'
+        else:
+            return tempdir / 'math.dvi'
+    except OSError as exc:
+        logger.warning(
+            __(
+                'LaTeX command %r cannot be run (needed for math '
+                'display), check the imgmath_latex setting'
+            ),
+            config.imgmath_latex,
+        )
+        raise InvokeError from exc
+    except CalledProcessError as exc:
+        msg = 'latex exited with error'
+        raise MathExtError(msg, exc.stderr, exc.stdout) from exc
+
+
 def convert_dvi_to_image(command: list[str], name: str) -> tuple[str, str]:
     """Convert DVI file to specific image format."""
     try:
@@ -177,11 +237,19 @@ def convert_dvi_to_image(command: list[str], name: str) -> tuple[str, str]:
         raise MathExtError(msg, exc.stderr, exc.stdout) from exc
 
 
-def convert_dvi_to_png(dvipath: Path, out_path: Path, *, config: Config) -> int | None:
+def convert_dvi_to_png(
+    dvipath: Path,
+    out_path: Path,
+    *,
+    config: Config,
+    page: int | None = None,
+) -> int | None:
     """Convert DVI file to PNG image."""
     name = 'dvipng'
     command = [config.imgmath_dvipng, '-o', out_path, '-T', 'tight', '-z9']
     command.extend(config.imgmath_dvipng_args)
+    if page is not None:
+        command.extend(['-page', str(page)])
     if config.imgmath_use_preview:
         command.append('--depth')
     command.append(dvipath)
@@ -200,11 +268,19 @@ def convert_dvi_to_png(dvipath: Path, out_path: Path, *, config: Config) -> int 
     return depth
 
 
-def convert_dvi_to_svg(dvipath: Path, out_path: Path, *, config: Config) -> int | None:
+def convert_dvi_to_svg(
+    dvipath: Path,
+    out_path: Path,
+    *,
+    config: Config,
+    page: int | None = None,
+) -> int | None:
     """Convert DVI file to SVG image."""
     name = 'dvisvgm'
     command = [config.imgmath_dvisvgm, '-o', out_path]
     command.extend(config.imgmath_dvisvgm_args)
+    if page is not None:
+        command.append(f'--page={page}')
     command.append(dvipath)
 
     _stdout, stderr = convert_dvi_to_image(command, name)
@@ -242,10 +318,12 @@ def render_math(
         unsupported_format_msg = 'imgmath_image_format must be either "png" or "svg"'
         raise MathExtError(unsupported_format_msg)
 
-    latex = generate_latex_macro(image_format, math, config, self.builder.confdir)
-
+    body_latex = (
+        f'\\fontsize{config.imgmath_font_size}'
+        f'{{{round(config.imgmath_font_size * 1.2)}}}\\selectfont {math}'
+    )
     filename = (
-        f'{sha1(latex.encode(), usedforsecurity=False).hexdigest()}.{image_format}'
+        f'{sha1(body_latex.encode(), usedforsecurity=False).hexdigest()}.{image_format}'
     )
     generated_path = self.builder.outdir / self.builder.imagedir / 'math' / filename
     generated_path.parent.mkdir(parents=True, exist_ok=True)
@@ -261,6 +339,36 @@ def render_math(
     trans_failed = hasattr(self.builder, '_imgmath_warned_image_translator')
     if latex_failed or trans_failed:
         return None, None
+
+    batch_size = config.imgmath_batch_size
+
+    if batch_size > 1:
+        # Batch accumulation mode
+        if not hasattr(self.builder, '_imgmath_batch'):
+            self.builder._imgmath_batch = []  # type: ignore[attr-defined]
+            self.builder._imgmath_batch_results = {}  # type: ignore[attr-defined]
+            self.builder._imgmath_translator = self  # type: ignore[attr-defined]
+
+        batch: list[str] = self.builder._imgmath_batch  # type: ignore[attr-defined]
+        results: dict[str, tuple[_StrPath, int | None]] = (
+            self.builder._imgmath_batch_results  # type: ignore[attr-defined]
+        )
+
+        if math in results:
+            return results[math]
+
+        batch.append(math)
+
+        if len(batch) >= batch_size:
+            _process_batch(self.builder, batch, results, config)
+            batch.clear()
+
+        if math in results:
+            return results[math]
+        return None, None
+
+    # Single-equation mode (batch_size == 1)
+    latex = generate_latex_macro(image_format, math, config, self.builder.confdir)
 
     # .tex -> .dvi
     try:
@@ -282,6 +390,142 @@ def render_math(
     return generated_path, depth
 
 
+def _suppress_unlink(path: Path) -> None:
+    with contextlib.suppress(OSError):
+        path.unlink()
+
+
+def _populate_from_file(
+    math: str,
+    path: Path,
+    image_format: str,
+    results: dict[str, tuple[_StrPath, int | None]],
+) -> None:
+    """Read depth from an already-compiled image file and store in *results*."""
+    if image_format == 'png':
+        depth = read_png_depth(path)
+    else:
+        depth = read_svg_depth(path)
+    results[math] = (path, depth)  # type: ignore[assignment]
+
+
+def _compile_single(
+    math: str,
+    path: Path,
+    image_format: str,
+    config: Config,
+    confdir: _StrPath,
+    results: dict[str, tuple[_StrPath, int | None]],
+) -> None:
+    """Compile a single equation and store the result in *results*."""
+    latex = generate_latex_macro(image_format, math, config, confdir)
+    dvipath = compile_math(latex, config=config)
+    if image_format == 'png':
+        depth = convert_dvi_to_png(dvipath, path, config=config)
+    else:
+        depth = convert_dvi_to_svg(dvipath, path, config=config)
+    results[math] = (path, depth)  # type: ignore[assignment]
+    _suppress_unlink(path.with_suffix(f'.{image_format}.pending'))
+
+
+def _process_batch(
+    builder: Any,
+    batch: list[str],
+    results: dict[str, tuple[_StrPath, int | None]],
+    config: Config,
+) -> None:
+    """Compile a batch of math expressions in one LaTeX invocation."""
+    image_format = config.imgmath_image_format.lower()
+
+    out_paths = []
+    for math in batch:
+        body = (
+            f'\\fontsize{config.imgmath_font_size}'
+            f'{{{round(config.imgmath_font_size * 1.2)}}}\\selectfont {math}'
+        )
+        filename = (
+            f'{sha1(body.encode(), usedforsecurity=False).hexdigest()}.{image_format}'
+        )
+        path = builder.outdir / builder.imagedir / 'math' / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        out_paths.append(path)
+
+    # All cached?
+    all_cached = all(p.is_file() for p in out_paths)
+    if all_cached:
+        for math, p in zip(batch, out_paths, strict=True):
+            if image_format == 'png':
+                depth = read_png_depth(p)
+            else:
+                depth = read_svg_depth(p)
+            results[math] = (p, depth)
+        return
+
+    # Build per-equation body LaTeX
+    bodies = []
+    for math in batch:
+        body = (
+            f'\\fontsize{config.imgmath_font_size}'
+            f'{{{round(config.imgmath_font_size * 1.2)}}}\\selectfont {math}'
+        )
+        bodies.append(body)
+
+    try:
+        dvipath = compile_math_batch(bodies, config=config)
+    except (InvokeError, MathExtError) as exc:
+        if isinstance(exc, InvokeError):
+            builder._imgmath_warned_latex = True
+        logger.warning(
+            __(
+                'Batch LaTeX compilation failed, falling back to '
+                'per-equation compilation'
+            )
+        )
+        logger.info(str(exc))
+        for math_entry, path in zip(batch, out_paths, strict=True):
+            if path.is_file():
+                _populate_from_file(math_entry, path, image_format, results)
+                _suppress_unlink(path.with_suffix(f'.{image_format}.pending'))
+                continue
+            try:
+                _compile_single(
+                    math_entry,
+                    path,
+                    image_format,
+                    config,
+                    getattr(builder, 'confdir', None),  # type: ignore[arg-type]
+                    results,
+                )
+            except (InvokeError, MathExtError):
+                results[math_entry] = (None, None)  # type: ignore[assignment]
+        return
+
+    # Extract each page from the multi-page DVI
+    for idx, (math, path) in enumerate(zip(batch, out_paths, strict=True)):
+        if path.is_file():
+            if image_format == 'png':
+                depth = read_png_depth(path)
+            else:
+                depth = read_svg_depth(path)
+            results[math] = (path, depth)
+            _suppress_unlink(path.with_suffix(f'.{image_format}.pending'))
+            continue
+
+        try:
+            if image_format == 'png':
+                depth = convert_dvi_to_png(dvipath, path, config=config, page=idx + 1)
+            else:
+                depth = convert_dvi_to_svg(dvipath, path, config=config, page=idx + 1)
+            results[math] = (path, depth)
+        except InvokeError:
+            logger.warning(
+                __('Failed to convert batch page %d to %s'), idx + 1, image_format
+            )
+            results[math] = (None, None)  # type: ignore[assignment]
+        else:
+            _suppress_unlink(path.with_suffix(f'.{image_format}.pending'))
+
+
 def render_maths_to_base64(image_format: str, generated_path: Path) -> str:
     with open(generated_path, 'rb') as f:
         content = f.read()
@@ -298,11 +542,29 @@ def clean_up_files(app: Sphinx, exc: Exception) -> None:
     if exc:
         return
 
-    if app.config.imgmath_embed:
+    # Flush any remaining equations in the batch
+    builder = app.builder
+    remaining_batch = getattr(builder, '_imgmath_batch', None)
+    if remaining_batch:
+        _process_batch(
+            builder,
+            remaining_batch,
+            getattr(builder, '_imgmath_batch_results', {}),
+            builder.config,
+        )
+        remaining_batch.clear()
+
+    # Remove .pending placeholder files left by batch visitors
+    math_dir = builder.outdir / builder.imagedir / 'math'
+    if math_dir.is_dir():
+        for p in math_dir.glob('*.pending'):
+            _suppress_unlink(p)
+
+    if app.config.imgmath_embed and app.config.imgmath_batch_size <= 1:
         # in embed mode, the images are still generated in the math output dir
         # to be shared across workers, but are not useful to the final document
         with contextlib.suppress(Exception):
-            shutil.rmtree(app.builder.outdir / app.builder.imagedir / 'math')
+            shutil.rmtree(math_dir)
 
 
 def get_tooltip(self: HTML5Translator, node: Element, *, config: Config) -> str:
@@ -327,10 +589,35 @@ def html_visit_math(self: HTML5Translator, node: nodes.math) -> None:
         raise nodes.SkipNode from exc
 
     if rendered_path is None:
-        # something failed -- use text-only as a bad substitute
-        self.body.append(
-            f'<span class="math">{self.encode(node.astext()).strip()}</span>'
-        )
+        if config.imgmath_batch_size > 1:
+            # Batch mode: compute the image path and write a placeholder
+            # so the HTML references the correct final filename.
+            math_str = '$' + node.astext() + '$'
+            body_latex = (
+                f'\\fontsize{config.imgmath_font_size}'
+                f'{{{round(config.imgmath_font_size * 1.2)}}}'
+                f'\\selectfont {math_str}'
+            )
+            filename = (
+                f'{sha1(body_latex.encode(), usedforsecurity=False).hexdigest()}'
+                f'.{config.imgmath_image_format.lower()}'
+            )
+            math_dir = self.builder.outdir / self.builder.imagedir / 'math'
+            math_dir.mkdir(parents=True, exist_ok=True)
+            placeholder = math_dir / (filename + '.pending')
+            placeholder.touch()
+            if config.imgmath_embed:
+                img_src = (Path(self.builder.imgpath) / 'math' / filename).as_posix()
+            else:
+                relative_path = Path(self.builder.imgpath, 'math', filename)
+                img_src = relative_path.as_posix()
+            tooltip = get_tooltip(self, node, config=config)
+            self.body.append(f'<img class="math" src="{img_src}"{tooltip}/>')
+        else:
+            # something failed -- use text-only as a bad substitute
+            self.body.append(
+                f'<span class="math">{self.encode(node.astext()).strip()}</span>'
+            )
     else:
         if config.imgmath_embed:
             image_format = config.imgmath_image_format.lower()
@@ -370,10 +657,32 @@ def html_visit_displaymath(self: HTML5Translator, node: nodes.math_block) -> Non
         self.body.append('</span>')
 
     if rendered_path is None:
-        # something failed -- use text-only as a bad substitute
-        self.body.append(
-            f'<span class="math">{self.encode(node.astext()).strip()}</span></p>\n</div>'
-        )
+        if config.imgmath_batch_size > 1:
+            # Batch mode: compute the image path and write a placeholder
+            body_latex = (
+                f'\\fontsize{config.imgmath_font_size}'
+                f'{{{round(config.imgmath_font_size * 1.2)}}}'
+                f'\\selectfont {latex}'
+            )
+            filename = (
+                f'{sha1(body_latex.encode(), usedforsecurity=False).hexdigest()}'
+                f'.{config.imgmath_image_format.lower()}'
+            )
+            math_dir = self.builder.outdir / self.builder.imagedir / 'math'
+            math_dir.mkdir(parents=True, exist_ok=True)
+            placeholder = math_dir / (filename + '.pending')
+            placeholder.touch()
+            if config.imgmath_embed:
+                img_src = (Path(self.builder.imgpath) / 'math' / filename).as_posix()
+            else:
+                relative_path = Path(self.builder.imgpath, 'math', filename)
+                img_src = relative_path.as_posix()
+            tooltip = get_tooltip(self, node, config=config)
+            self.body.append(f'<img src="{img_src}"{tooltip}/></p>\n</div>')
+        else:
+            # something failed -- use text-only as a bad substitute
+            text = self.encode(node.astext()).strip()
+            self.body.append(f'<span class="math">{text}</span></p>\n</div>')
     else:
         if config.imgmath_embed:
             image_format = config.imgmath_image_format.lower()
@@ -415,6 +724,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value('imgmath_add_tooltips', True, 'html', types=frozenset({bool}))
     app.add_config_value('imgmath_font_size', 12, 'html', types=frozenset({int}))
     app.add_config_value('imgmath_embed', False, 'html', types=frozenset({bool}))
+    app.add_config_value('imgmath_batch_size', 1, 'html', types=frozenset({int}))
     app.connect('build-finished', clean_up_files)
     return {
         'version': sphinx.__display_version__,

--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha1
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -24,6 +25,7 @@ from sphinx import package_dir
 from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
+from sphinx.util.display import status_iterator
 from sphinx.util.math import get_node_equation_number, wrap_displaymath
 from sphinx.util.png import read_png_depth, write_png_depth
 from sphinx.util.template import LaTeXRenderer
@@ -61,8 +63,8 @@ class InvokeError(SphinxError):
 
 SUPPORT_FORMAT = ('png', 'svg')
 
-depth_re = re.compile(r'\[\d+ depth=(-?\d+)\]')
-depthsvg_re = re.compile(r'.*, depth=(.*)pt')
+depth_re = re.compile(r'\[\d+[^\]]*?depth=(-?\d+)\]')
+depthsvg_re = re.compile(r'.*depth=(.*)pt')
 depthsvgcomment_re = re.compile(r'<!-- DEPTH=(-?\d+) -->')
 
 
@@ -177,11 +179,19 @@ def convert_dvi_to_image(command: list[str], name: str) -> tuple[str, str]:
         raise MathExtError(msg, exc.stderr, exc.stdout) from exc
 
 
-def convert_dvi_to_png(dvipath: Path, out_path: Path, *, config: Config) -> int | None:
+def convert_dvi_to_png(
+    dvipath: Path,
+    out_path: Path,
+    *,
+    config: Config,
+    page: int | None = None,
+) -> int | None:
     """Convert DVI file to PNG image."""
     name = 'dvipng'
     command = [config.imgmath_dvipng, '-o', out_path, '-T', 'tight', '-z9']
     command.extend(config.imgmath_dvipng_args)
+    if page is not None:
+        command.extend(['-pp', str(page)])
     if config.imgmath_use_preview:
         command.append('--depth')
     command.append(dvipath)
@@ -191,7 +201,7 @@ def convert_dvi_to_png(dvipath: Path, out_path: Path, *, config: Config) -> int 
     depth = None
     if config.imgmath_use_preview:
         for line in stdout.splitlines():
-            matched = depth_re.match(line)
+            matched = depth_re.search(line)
             if matched:
                 depth = int(matched.group(1))
                 write_png_depth(out_path, depth)
@@ -200,11 +210,19 @@ def convert_dvi_to_png(dvipath: Path, out_path: Path, *, config: Config) -> int 
     return depth
 
 
-def convert_dvi_to_svg(dvipath: Path, out_path: Path, *, config: Config) -> int | None:
+def convert_dvi_to_svg(
+    dvipath: Path,
+    out_path: Path,
+    *,
+    config: Config,
+    page: int | None = None,
+) -> int | None:
     """Convert DVI file to SVG image."""
     name = 'dvisvgm'
     command = [config.imgmath_dvisvgm, '-o', out_path]
     command.extend(config.imgmath_dvisvgm_args)
+    if page is not None:
+        command.append(f'--page={page}')
     command.append(dvipath)
 
     _stdout, stderr = convert_dvi_to_image(command, name)
@@ -280,6 +298,297 @@ def render_math(
         return None, None
 
     return generated_path, depth
+
+
+def _has_custom_template(config: Config, confdir: _StrPath) -> bool:
+    """Return True if the user overrides the default imgmath LaTeX template."""
+    template_names = (
+        'template.tex.jinja',
+        'template.tex_t',
+        'preview.tex.jinja',
+        'preview.tex_t',
+    )
+    for template_dir in config.templates_path:
+        for template_name in template_names:
+            if (Path(confdir) / template_dir / template_name).exists():
+                return True
+    return False
+
+
+def _collect_math_expressions(env: object) -> list[str]:
+    """Collect unique math expressions from all doctrees in document order."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    all_docs: dict[str, object] = getattr(env, 'all_docs', {})
+
+    def _add(math: str) -> None:
+        if math not in seen:
+            seen.add(math)
+            ordered.append(math)
+
+    for docname in all_docs:
+        try:
+            doctree = env.get_doctree(docname)  # type: ignore[attr-defined]
+        except Exception as exc:
+            logger.debug(
+                __('Failed to load doctree %r for imgmath batch: %s'), docname, exc
+            )
+            continue
+        for node in doctree.findall(nodes.math):
+            _add('$' + node.astext() + '$')
+        for node in doctree.findall(nodes.math_block):
+            if node.get('no-wrap', node.get('nowrap', False)):
+                latex = node.astext()
+            else:
+                latex = wrap_displaymath(node.astext(), None, False)
+            _add(latex)
+    return ordered
+
+
+def _build_batch_document(
+    maths: list[str], *, config: Config, image_format: str
+) -> str:
+    """Build a multi-page LaTeX document matching the default templates."""
+    fontsize = config.imgmath_font_size
+    baselineskip = round(fontsize * 1.2)
+    preamble = config.imgmath_latex_preamble
+    tightpage = '' if image_format == 'png' else ',dvips,tightpage'
+    use_preview = config.imgmath_use_preview
+
+    lines = [
+        r'\documentclass[12pt]{article}',
+        r'\usepackage[utf8]{inputenc}',
+        r'\usepackage{amsmath}',
+        r'\usepackage{amsthm}',
+        r'\usepackage{amssymb}',
+        r'\usepackage{amsfonts}',
+        r'\usepackage{anyfontsize}',
+        r'\usepackage{bm}',
+        r'\pagestyle{empty}',
+        preamble,
+        '',
+    ]
+    if use_preview:
+        lines.extend([rf'\usepackage[active{tightpage}]{{preview}}', ''])
+    lines.append(r'\begin{document}')
+    for i, math in enumerate(maths):
+        body = rf'\fontsize{{{fontsize}}}{{{baselineskip}}}\selectfont {math}'
+        if use_preview:
+            lines.extend([r'\begin{preview}', body, r'\end{preview}'])
+        else:
+            lines.append(body)
+        if i < len(maths) - 1:
+            lines.append(r'\clearpage')
+    lines.append(r'\end{document}')
+    return '\n'.join(lines) + '\n'
+
+
+def _compile_batch_document(combined: str, *, config: Config) -> Path:
+    """Compile a combined LaTeX document to DVI/XDV."""
+    tempdir = Path(tempfile.mkdtemp(suffix='-sphinx-imgmath-batch'))
+    filename = tempdir / 'math.tex'
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(combined)
+
+    imgmath_latex_name = os.path.basename(config.imgmath_latex)
+    command = [config.imgmath_latex]
+    if imgmath_latex_name != 'tectonic':
+        command.append('--interaction=nonstopmode')
+    command.extend(config.imgmath_latex_args)
+    command.append('math.tex')
+
+    try:
+        subprocess.run(
+            command, capture_output=True, cwd=tempdir, check=True, encoding='ascii'
+        )
+        if imgmath_latex_name in {'xelatex', 'tectonic'}:
+            return tempdir / 'math.xdv'
+        else:
+            return tempdir / 'math.dvi'
+    except OSError as exc:
+        logger.warning(
+            __(
+                'LaTeX command %r cannot be run (needed for math '
+                'display), check the imgmath_latex setting'
+            ),
+            config.imgmath_latex,
+        )
+        raise InvokeError from exc
+    except CalledProcessError as exc:
+        msg = 'latex exited with error'
+        raise MathExtError(msg, exc.stderr, exc.stdout) from exc
+
+
+def _compile_single_math(
+    math: str,
+    image_format: str,
+    out_path: Path,
+    *,
+    config: Config,
+    confdir: _StrPath,
+) -> None:
+    latex = generate_latex_macro(image_format, math, config, confdir)
+    dvipath = compile_math(latex, config=config)
+    if image_format == 'png':
+        convert_dvi_to_png(dvipath, out_path, config=config)
+    else:
+        convert_dvi_to_svg(dvipath, out_path, config=config)
+
+
+def _render_batch_chunk(
+    maths: list[str],
+    out_paths: list[Path],
+    *,
+    config: Config,
+    confdir: _StrPath,
+    builder: object,
+    image_format: str,
+    max_workers: int = 1,
+) -> None:
+    uncached = [
+        (m, p) for m, p in zip(maths, out_paths, strict=True) if not p.is_file()
+    ]
+    if not uncached:
+        return
+    uncached_maths = [m for m, _p in uncached]
+
+    try:
+        combined = _build_batch_document(
+            uncached_maths, config=config, image_format=image_format
+        )
+        dvipath = _compile_batch_document(combined, config=config)
+    except InvokeError:
+        builder._imgmath_warned_latex = True  # type: ignore[attr-defined]
+        return
+    except MathExtError as exc:
+        logger.warning(
+            __('Batch LaTeX compilation failed, falling back to single compilation')
+        )
+        logger.info(str(exc))
+        for math, path in uncached:
+            try:
+                _compile_single_math(
+                    math, image_format, path, config=config, confdir=confdir
+                )
+            except (InvokeError, MathExtError) as exc2:
+                if isinstance(exc2, InvokeError):
+                    builder._imgmath_warned_latex = True  # type: ignore[attr-defined]
+                    return
+                logger.info(str(exc2))
+        return
+
+    def _convert_page(
+        idx: int, math: str, path: Path
+    ) -> tuple[int, str, Path, Exception | None]:
+        page = idx + 1
+        try:
+            if image_format == 'png':
+                convert_dvi_to_png(dvipath, path, config=config, page=page)
+            else:
+                convert_dvi_to_svg(dvipath, path, config=config, page=page)
+        except (InvokeError, MathExtError) as exc:
+            return page, math, path, exc
+        return page, math, path, None
+
+    workers = max(1, min(len(uncached), max_workers))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(
+            executor.map(
+                lambda args: _convert_page(*args),
+                [(idx, math, path) for idx, (math, path) in enumerate(uncached)],
+            )
+        )
+
+    for page, math, path, exc in results:
+        if exc is None:
+            continue
+        if isinstance(exc, InvokeError):
+            builder._imgmath_warned_image_translator = True  # type: ignore[attr-defined]
+            return
+        logger.warning(
+            __('Failed to convert batch page %d, retrying singly: %s'),
+            page,
+            exc,
+        )
+        try:
+            _compile_single_math(
+                math, image_format, path, config=config, confdir=confdir
+            )
+        except (InvokeError, MathExtError) as exc2:
+            if isinstance(exc2, InvokeError):
+                builder._imgmath_warned_image_translator = True  # type: ignore[attr-defined]
+                return
+            logger.info(str(exc2))
+
+
+def pre_render_batch(app: Sphinx, env: object) -> None:
+    """Pre-render all math expressions in batches before the write phase.
+
+    Runs on ``env-updated`` so that by the time HTML translation calls
+    :func:`render_math`, images already exist on disk. This keeps
+    ``imgmath_embed``, depth handling, and error reporting identical to
+    single-equation mode, and is safe for parallel writes.
+    """
+    config = app.config
+    batch_size: int = getattr(config, 'imgmath_batch_size', 1)
+    if not isinstance(batch_size, int) or batch_size <= 1:
+        return
+    builder = app.builder
+    if not hasattr(builder, 'outdir') or not hasattr(builder, 'imagedir'):
+        return
+    if getattr(builder, 'format', 'html') != 'html':
+        return
+
+    image_format = config.imgmath_image_format.lower()
+    if image_format not in SUPPORT_FORMAT:
+        return
+
+    confdir = getattr(builder, 'confdir', app.confdir)
+    if _has_custom_template(config, confdir):
+        logger.info(__('imgmath batch disabled: custom LaTeX template detected'))
+        return
+
+    maths = _collect_math_expressions(env)
+    if not maths:
+        return
+
+    out_paths: list[Path] = []
+    for math in maths:
+        latex = generate_latex_macro(image_format, math, config, confdir)
+        filename = (
+            f'{sha1(latex.encode(), usedforsecurity=False).hexdigest()}.{image_format}'
+        )
+        path = Path(builder.outdir) / builder.imagedir / 'math' / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        out_paths.append(path)
+
+    parallel = getattr(app, 'parallel', 0)
+    max_workers = parallel if parallel and parallel > 1 else 1
+
+    chunks = [
+        (maths[i : i + batch_size], out_paths[i : i + batch_size])
+        for i in range(0, len(maths), batch_size)
+    ]
+    for idx in status_iterator(
+        range(len(chunks)),
+        __('pre-rendering math... '),
+        length=len(chunks),
+        stringify_func=lambda i: f'batch {i + 1}/{len(chunks)}',
+    ):
+        if hasattr(builder, '_imgmath_warned_latex') or hasattr(
+            builder, '_imgmath_warned_image_translator'
+        ):
+            break
+        chunk_maths, chunk_paths = chunks[idx]
+        _render_batch_chunk(
+            chunk_maths,
+            chunk_paths,
+            config=config,
+            confdir=confdir,
+            builder=builder,
+            image_format=image_format,
+            max_workers=max_workers,
+        )
 
 
 def render_maths_to_base64(image_format: str, generated_path: Path) -> str:
@@ -415,6 +724,8 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value('imgmath_add_tooltips', True, 'html', types=frozenset({bool}))
     app.add_config_value('imgmath_font_size', 12, 'html', types=frozenset({int}))
     app.add_config_value('imgmath_embed', False, 'html', types=frozenset({bool}))
+    app.add_config_value('imgmath_batch_size', 1, 'html', types=frozenset({int}))
+    app.connect('env-updated', pre_render_batch)
     app.connect('build-finished', clean_up_files)
     return {
         'version': sphinx.__display_version__,

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -87,6 +87,89 @@ def test_imgmath_svg(app: SphinxTestApp) -> None:
 
 
 @pytest.mark.skipif(
+    not has_binary('dvipng'),
+    reason='Requires dvipng" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math',
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_batch_size': 100,
+    },
+)
+def test_imgmath_batch_png(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvipng command 'dvipng' cannot be run" in app.warning.getvalue():
+        msg = 'dvipng command "dvipng" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    shutil.rmtree(app.outdir)
+    assert re.search(r'<img class="math" src="_images/math/\w+\.png"', content)
+
+
+@pytest.mark.skipif(
+    not has_binary('dvisvgm'),
+    reason='Requires dvisvgm" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math',
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_image_format': 'svg',
+        'imgmath_batch_size': 100,
+    },
+)
+def test_imgmath_batch_svg(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvisvgm command 'dvisvgm' cannot be run" in app.warning.getvalue():
+        msg = 'dvisvgm command "dvisvgm" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    shutil.rmtree(app.outdir)
+    assert re.search(r'<img class="math" src="_images/math/\w+\.svg"', content)
+
+
+@pytest.mark.skipif(
+    not has_binary('dvisvgm'),
+    reason='Requires dvisvgm" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math',
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_image_format': 'svg',
+        'imgmath_embed': True,
+        'imgmath_batch_size': 100,
+    },
+)
+def test_imgmath_batch_svg_embed(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvisvgm command 'dvisvgm' cannot be run" in app.warning.getvalue():
+        msg = 'dvisvgm command "dvisvgm" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    assert re.search(r'<img class="math" src="_images/math/\w+\.svg"', content)
+    svg_files = list((app.outdir / '_images' / 'math').glob('*.svg'))
+    shutil.rmtree(app.outdir)
+    assert len(svg_files) > 0
+
+
+@pytest.mark.skipif(
     not has_binary('dvisvgm'),
     reason='Requires dvisvgm" binary',
 )

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -87,6 +87,91 @@ def test_imgmath_svg(app: SphinxTestApp) -> None:
 
 
 @pytest.mark.skipif(
+    not has_binary('dvipng'),
+    reason='Requires dvipng" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math',
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_batch_size': 2,
+    },
+)
+def test_imgmath_batch_png(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvipng command 'dvipng' cannot be run" in app.warning.getvalue():
+        msg = 'dvipng command "dvipng" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    math_images = list((app.outdir / '_images' / 'math').glob('*.png'))
+    shutil.rmtree(app.outdir)
+    assert re.search(r'<img class="math" src="_images/math/\w+\.png"', content)
+    assert len(math_images) >= 2
+
+
+@pytest.mark.skipif(
+    not has_binary('dvisvgm'),
+    reason='Requires dvisvgm" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math',
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_image_format': 'svg',
+        'imgmath_batch_size': 2,
+    },
+)
+def test_imgmath_batch_svg(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvisvgm command 'dvisvgm' cannot be run" in app.warning.getvalue():
+        msg = 'dvisvgm command "dvisvgm" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    math_images = list((app.outdir / '_images' / 'math').glob('*.svg'))
+    shutil.rmtree(app.outdir)
+    assert re.search(r'<img class="math" src="_images/math/\w+\.svg"', content)
+    assert len(math_images) >= 2
+
+
+@pytest.mark.skipif(
+    not has_binary('dvisvgm'),
+    reason='Requires dvisvgm" binary',
+)
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-math',
+    confoverrides={
+        'extensions': ['sphinx.ext.imgmath'],
+        'imgmath_image_format': 'svg',
+        'imgmath_embed': True,
+        'imgmath_batch_size': 2,
+    },
+)
+def test_imgmath_batch_svg_embed(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    if "LaTeX command 'latex' cannot be run" in app.warning.getvalue():
+        msg = 'LaTeX command "latex" is not available'
+        raise pytest.skip.Exception(msg)
+    if "dvisvgm command 'dvisvgm' cannot be run" in app.warning.getvalue():
+        msg = 'dvisvgm command "dvisvgm" is not available'
+        raise pytest.skip.Exception(msg)
+
+    content = (app.outdir / 'index.html').read_text(encoding='utf8')
+    shutil.rmtree(app.outdir)
+    assert re.search(r'<img src="data:image/svg\+xml;base64,[\w+/=]+"', content)
+
+
+@pytest.mark.skipif(
     not has_binary('dvisvgm'),
     reason='Requires dvisvgm" binary',
 )


### PR DESCRIPTION
Add ``imgmath_batch_size`` config option (default 1).  When set to a value greater than 1, equations are accumulated and compiled in a single LaTeX invocation using a multi-page DVI with ``preview`` environments, then split via ``dvipng -page`` / ``dvisvgm --page``.

For a build with N equations and batch_size=B, this reduces N LaTeX process launches to ceil(N/B), keeping resource usage manageable.

For the openturns project (with 8k+ equations), this reduces the sphinx build time from 22m30 to 10m25 (with imgmath_batch_size=128)
