### PR TITLE
doc: Fix duplicate 'the the' typos in configuration and autodoc docs

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -2213,7 +2213,7 @@ and also make use of these options.
    scale option (*scale*, *width*, or *height*)
    to their original full-resolution image.
    This will not overwrite any link given by the *target* option
-   on the the :dudir:`image` directive, if present.
+   on the :dudir:`image` directive, if present.
 
    .. tip::
 

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -205,7 +205,7 @@ For example, all three of the following variables have valid doc-comments:
 Alternatively, ``autodoc`` can recognise a docstring
 on the line immediately following the definition.
 
-In the the following class definition,
+In the following class definition,
 all attributes have documentation recognised by ``autodoc``:
 
 .. code-block:: python


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- <...>
- <...>
- <...>


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->
