### PR TITLE
docs: correct autodoc-skip-member obj_type and name descriptions

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -1477,10 +1477,11 @@ member should be included in the documentation by using the following event:
    autodoc and other enabled extensions.
 
    :param app: the Sphinx application object
-   :param obj_type: the type of the object which the docstring belongs to (one of
-      ``'module'``, ``'class'``, ``'exception'``, ``'function'``, ``'decorator'``,
-      ``'method'``, ``'property'``, ``'attribute'``, ``'data'``, or ``'type'``)
-   :param name: the fully qualified name of the object
+   :param obj_type: the type of the object whose members are being documented,
+      i.e. the enclosing container (one of ``'module'``, ``'class'``,
+      ``'exception'``, ``'function'``, ``'decorator'``, ``'method'``,
+      ``'property'``, ``'attribute'``, ``'data'``, or ``'type'``)
+   :param name: the (unqualified) name of the member
    :param obj: the object itself
    :param skip: a boolean indicating if autodoc will skip this member if the
       user handler does not override the decision


### PR DESCRIPTION
Fixes #14555.

The documented parameters for the `autodoc-skip-member` event were inaccurate:

- `obj_type` was described as "the type of the object which the docstring belongs to", but the event is emitted with the type of the **enclosing container** whose members are being documented (`module`, `class`, `exception`, …), not the member's own type. Iterating the members of a class emits `obj_type='class'` for each member.
- `name` was described as "the fully qualified name of the object", but the event receives the **unqualified** member name.

Both match the emit calls, in `sphinx/ext/autodoc/_dynamic/_member_finder.py`:

```python
skip_member = events.emit_firstresult(
    'autodoc-skip-member',
    props.obj_type,
    member_name,
    ...
```

and identically in `sphinx/ext/autodoc/_legacy_class_based/_documenters.py` (`self.objtype`, `membername`).

Only the `autodoc-skip-member` entry is changed. The other events (`autodoc-process-docstring`, `autodoc-process-signature`, …) genuinely do receive the fully-qualified name and are left alone.

Documentation wording only — no code changes.

---

## AI disclosure

Per the [AI policy](https://www.sphinx-doc.org/en/master/internals/ai-policy.html):

- **Was AI used?** Yes.
- **Which tool?** Claude Code (Anthropic), model Claude Opus 5.
- **How was it used, and what is AI-generated?** The tool was used to locate the `autodoc-skip-member` emit sites, read the arguments actually passed, and draft both the replacement wording for the two `:param:` lines in `doc/usage/extensions/autodoc.rst` and this description. The entire diff (5 added lines, 4 removed) and this PR description are therefore AI-generated text.
- **Human oversight:** I confirmed the claim against the source before submitting — both emit sites pass the container's `obj_type` and the unqualified member name, matching the reporter's observed output in #14555 (`what = class, name = bar` for `Foo.bar`). I also checked that the sibling events listed in the same file do receive fully-qualified names, which is why they are untouched. The branch has been rebased onto current `master` and the change still applies cleanly.

Happy to adjust the wording if you would prefer different phrasing for either parameter.