### PR TITLE
Add inline todo role

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Release 9.1.1 (in development)
 ==============================
 
+Features added
+--------------
+
+* #6689: todo: Add the :rst:role:`todo` role for inline todo items.
+  Patch by Lem0nTea2002.
+
 Bugs fixed
 ----------
 

--- a/doc/usage/extensions/todo.rst
+++ b/doc/usage/extensions/todo.rst
@@ -10,7 +10,18 @@
 .. role:: code-py(code)
    :language: Python
 
-There are two additional directives when using this extension:
+This extension provides two directives and an inline role:
+
+.. rst:role:: todo
+
+   Use this role for short todo items within a paragraph.  For example,
+   ``:todo:`add a reference here``` displays the todo text inline.
+
+   Inline todo items are included in :rst:dir:`todolist`, emit the
+   :event:`todo-defined` event, and honor the same configuration values as the
+   :rst:dir:`todo` directive.
+
+   .. versionadded:: 9.1.1
 
 .. rst:directive:: todo
 
@@ -40,14 +51,15 @@ Configuration
    :type: :code-py:`bool`
    :default: :code-py:`False`
 
-   If this is ``True``, :rst:dir:`todo` and :rst:dir:`todolist` produce output,
-   else they produce nothing.
+   If this is ``True``, :rst:role:`todo`, :rst:dir:`todo`, and
+   :rst:dir:`todolist` produce output, else they produce nothing.
 
 .. confval:: todo_emit_warnings
    :type: :code-py:`bool`
    :default: :code-py:`False`
 
-   If this is ``True``, :rst:dir:`todo` emits a warning for each TODO entries.
+   If this is ``True``, :rst:role:`todo` and :rst:dir:`todo` emit a warning for
+   each TODO entry.
 
    .. versionadded:: 1.5
 
@@ -60,11 +72,11 @@ Configuration
 
    .. versionadded:: 1.4
 
-autodoc provides the following an additional event:
+The extension provides the following additional event:
 
 .. event:: todo-defined (app, node)
 
    .. versionadded:: 1.5
 
    Emitted when a todo is defined. *node* is the defined
-   ``sphinx.ext.todo.todo_node`` node.
+   ``sphinx.ext.todo.todo_node`` or ``sphinx.ext.todo.todo_inline_node`` node.

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -7,8 +7,6 @@ with a backlink to the original location.
 
 from __future__ import annotations
 
-import functools
-import operator
 from typing import TYPE_CHECKING, cast
 
 from docutils import nodes
@@ -20,13 +18,13 @@ from sphinx.domains import Domain
 from sphinx.errors import NoUri
 from sphinx.locale import _, __
 from sphinx.util import logging, texescape
-from sphinx.util.docutils import SphinxDirective, new_document
+from sphinx.util.docutils import SphinxDirective, SphinxRole, new_document
 
 if TYPE_CHECKING:
     from collections.abc import Set
     from typing import Any, ClassVar
 
-    from docutils.nodes import Element, Node
+    from docutils.nodes import Element, Node, system_message
 
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
@@ -38,6 +36,10 @@ logger = logging.getLogger(__name__)
 
 
 class todo_node(nodes.Admonition, nodes.Element):
+    pass
+
+
+class todo_inline_node(nodes.inline):
     pass
 
 
@@ -66,12 +68,28 @@ class Todo(SphinxAdmonition):
         return [todo]
 
 
+class TodoRole(SphinxRole):
+    """A todo entry displayed inline with the surrounding text."""
+
+    def run(self) -> tuple[list[Node], list[system_message]]:
+        todo = todo_inline_node(
+            self.rawtext,
+            nodes.Text(self.text),
+            classes=['todo-inline'],
+            ids=[f'todo-{self.env.new_serialno("todo")}'],
+        )
+        todo['docname'] = self.env.current_document.docname
+        self.set_source_info(todo)
+        self.inliner.document.note_explicit_target(todo)
+        return [todo], []
+
+
 class TodoDomain(Domain):
     name = 'todo'
     label = 'todo'
 
     @property
-    def todos(self) -> dict[str, list[todo_node]]:
+    def todos(self) -> dict[str, list[todo_node | todo_inline_node]]:
         return self.data.setdefault('todos', {})
 
     def clear_doc(self, docname: str) -> None:
@@ -85,14 +103,19 @@ class TodoDomain(Domain):
         self, env: BuildEnvironment, docname: str, document: nodes.document
     ) -> None:
         todos = self.todos.setdefault(docname, [])
-        for todo in document.findall(todo_node):
+        for node in document.findall(
+            lambda node: isinstance(node, (todo_node, todo_inline_node))
+        ):
+            todo = cast('todo_node | todo_inline_node', node)
             env.events.emit('todo-defined', todo)
             todos.append(todo)
 
             if env.config.todo_emit_warnings:
-                logger.warning(
-                    __('TODO entry found: %s'), todo[1].astext(), location=todo
-                )
+                if isinstance(todo, todo_node):
+                    message = todo[1].astext()
+                else:
+                    message = todo.astext()
+                logger.warning(__('TODO entry found: %s'), message, location=todo)
 
 
 class TodoList(SphinxDirective):
@@ -121,9 +144,11 @@ class TodoListProcessor:
         self.process(doctree, docname)
 
     def process(self, doctree: nodes.document, docname: str) -> None:
-        todos: list[todo_node] = functools.reduce(
-            operator.iadd, self.domain.todos.values(), []
-        )
+        todos = [
+            todo
+            for document_todos in self.domain.todos.values()
+            for todo in document_todos
+        ]
         for node in list(doctree.findall(todolist)):
             if not self.config.todo_include_todos:
                 node.parent.remove(node)
@@ -136,7 +161,7 @@ class TodoListProcessor:
 
             for todo in todos:
                 # Create a copy of the todo node
-                new_todo = todo.deepcopy()
+                new_todo = self.create_todo_copy(todo)
                 new_todo['ids'].clear()
 
                 self.resolve_reference(new_todo, docname)
@@ -147,7 +172,25 @@ class TodoListProcessor:
 
             node.replace_self(content)
 
-    def create_todo_reference(self, todo: todo_node, docname: str) -> nodes.paragraph:
+    @staticmethod
+    def create_todo_copy(todo: todo_node | todo_inline_node) -> todo_node:
+        if isinstance(todo, todo_node):
+            return todo.deepcopy()
+
+        inline = todo.deepcopy()
+        inline['ids'].clear()
+        inline['names'].clear()
+
+        new_todo = todo_node(classes=['admonition-todo'])
+        new_todo.source = todo.source
+        new_todo.line = todo.line
+        new_todo += nodes.title(text=_('Todo'))
+        new_todo += nodes.paragraph('', '', inline)
+        return new_todo
+
+    def create_todo_reference(
+        self, todo: todo_node | todo_inline_node, docname: str
+    ) -> nodes.paragraph:
         if self.config.todo_link_only:
             description = _('<<original entry>>')
         else:
@@ -202,6 +245,17 @@ def depart_todo_node(self: HTML5Translator, node: todo_node) -> None:
     self.depart_admonition(node)
 
 
+def visit_todo_inline_node(self: HTML5Translator, node: todo_inline_node) -> None:
+    if self.config.todo_include_todos:
+        self.visit_inline(node)
+    else:
+        raise nodes.SkipNode
+
+
+def depart_todo_inline_node(self: HTML5Translator, node: todo_inline_node) -> None:
+    self.depart_inline(node)
+
+
 def latex_visit_todo_node(self: LaTeXTranslator, node: todo_node) -> None:
     if self.config.todo_include_todos:
         self.body.append('\n\\begin{sphinxtodo}{')
@@ -223,6 +277,20 @@ def latex_depart_todo_node(self: LaTeXTranslator, node: todo_node) -> None:
     self.no_latex_floats -= 1
 
 
+def latex_visit_todo_inline_node(self: LaTeXTranslator, node: todo_inline_node) -> None:
+    if self.config.todo_include_todos:
+        self.body.append(self.hypertarget_to(node))
+        self.visit_inline(node)
+    else:
+        raise nodes.SkipNode
+
+
+def latex_depart_todo_inline_node(
+    self: LaTeXTranslator, node: todo_inline_node
+) -> None:
+    self.depart_inline(node)
+
+
 def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_event('todo-defined')
     app.add_config_value('todo_include_todos', False, 'html', types=frozenset({bool}))
@@ -230,6 +298,14 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value('todo_emit_warnings', False, 'html', types=frozenset({bool}))
 
     app.add_node(todolist)
+    app.add_node(
+        todo_inline_node,
+        html=(visit_todo_inline_node, depart_todo_inline_node),
+        latex=(latex_visit_todo_inline_node, latex_depart_todo_inline_node),
+        text=(visit_todo_inline_node, depart_todo_inline_node),
+        man=(visit_todo_inline_node, depart_todo_inline_node),
+        texinfo=(visit_todo_inline_node, depart_todo_inline_node),
+    )
     app.add_node(
         todo_node,
         html=(visit_todo_node, depart_todo_node),
@@ -241,6 +317,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
     app.add_directive('todo', Todo)
     app.add_directive('todolist', TodoList)
+    app.add_role('todo', TodoRole())
     app.add_domain(TodoDomain)
     app.connect('doctree-resolved', TodoListProcessor)
     return {

--- a/tests/roots/test-ext-todo/foo.rst
+++ b/tests/roots/test-ext-todo/foo.rst
@@ -3,6 +3,8 @@ foo
 
 .. todo:: todo in foo
 
+An inline :todo:`todo inline in foo` appears here.
+
 .. py:function:: hello()
 
    :param bug: https://github.com/sphinx-doc/sphinx/pull/5800

--- a/tests/test_extensions/test_ext_todo.py
+++ b/tests/test_extensions/test_ext_todo.py
@@ -9,7 +9,7 @@ import pytest
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
-    from sphinx.ext.todo import todo_node
+    from sphinx.ext.todo import todo_inline_node, todo_node
     from sphinx.testing.util import SphinxTestApp
 
 
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
     confoverrides={'todo_include_todos': True, 'todo_emit_warnings': True},
 )
 def test_todo(app: SphinxTestApp) -> None:
-    todos = []
+    todos: list[todo_node | todo_inline_node] = []
 
-    def on_todo_defined(app: Sphinx, node: todo_node) -> None:
+    def on_todo_defined(app: Sphinx, node: todo_node | todo_inline_node) -> None:
         todos.append(node)
 
     app.connect('todo-defined', on_todo_defined)
@@ -34,9 +34,18 @@ def test_todo(app: SphinxTestApp) -> None:
 
     assert '<p class="admonition-title">Todo</p>\n<p>todo in bar</p>' in content
 
+    inline_todo = (
+        '<p class="admonition-title">Todo</p>\n'
+        '<p><span class="todo-inline">todo inline in foo</span></p>'
+    )
+    assert content.count(inline_todo) == 2
+
     # check todo
     content = (app.outdir / 'foo.html').read_text(encoding='utf8')
     assert '<p class="admonition-title">Todo</p>\n<p>todo in foo</p>' in content
+
+    assert '<span class="todo-inline"' in content
+    assert 'todo inline in foo</span>' in content
 
     assert (
         '<p class="admonition-title">Todo</p>\n<p>todo in param field</p>'
@@ -45,14 +54,20 @@ def test_todo(app: SphinxTestApp) -> None:
     # check emitted warnings
     assert 'WARNING: TODO entry found: todo in foo' in app.warning.getvalue()
     assert 'WARNING: TODO entry found: todo in bar' in app.warning.getvalue()
+    assert 'WARNING: TODO entry found: todo inline in foo' in app.warning.getvalue()
 
     # check handled event
-    assert len(todos) == 3
-    assert {todo[1].astext() for todo in todos} == {
+    from sphinx.ext.todo import todo_inline_node
+
+    block_todos = [todo for todo in todos if not isinstance(todo, todo_inline_node)]
+    inline_todos = [todo for todo in todos if isinstance(todo, todo_inline_node)]
+    assert len(todos) == 4
+    assert {todo[1].astext() for todo in block_todos} == {
         'todo in foo',
         'todo in bar',
         'todo in param field',
     }
+    assert [todo.astext() for todo in inline_todos] == ['todo inline in foo']
 
 
 @pytest.mark.sphinx(
@@ -62,9 +77,9 @@ def test_todo(app: SphinxTestApp) -> None:
     confoverrides={'todo_include_todos': False, 'todo_emit_warnings': True},
 )
 def test_todo_not_included(app: SphinxTestApp) -> None:
-    todos = []
+    todos: list[todo_node | todo_inline_node] = []
 
-    def on_todo_defined(app: Sphinx, node: todo_node) -> None:
+    def on_todo_defined(app: Sphinx, node: todo_node | todo_inline_node) -> None:
         todos.append(node)
 
     app.connect('todo-defined', on_todo_defined)
@@ -75,22 +90,30 @@ def test_todo_not_included(app: SphinxTestApp) -> None:
     assert '<p class="admonition-title">Todo</p>\n<p>todo in foo</p>' not in content
 
     assert '<p class="admonition-title">Todo</p>\n<p>todo in bar</p>' not in content
+    assert 'todo inline in foo' not in content
 
     # check todo
     content = (app.outdir / 'foo.html').read_text(encoding='utf8')
     assert '<p class="admonition-title">Todo</p>\n<p>todo in foo</p>' not in content
+    assert 'todo inline in foo' not in content
 
     # check emitted warnings
     assert 'WARNING: TODO entry found: todo in foo' in app.warning.getvalue()
     assert 'WARNING: TODO entry found: todo in bar' in app.warning.getvalue()
+    assert 'WARNING: TODO entry found: todo inline in foo' in app.warning.getvalue()
 
     # check handled event
-    assert len(todos) == 3
-    assert {todo[1].astext() for todo in todos} == {
+    from sphinx.ext.todo import todo_inline_node
+
+    block_todos = [todo for todo in todos if not isinstance(todo, todo_inline_node)]
+    inline_todos = [todo for todo in todos if isinstance(todo, todo_inline_node)]
+    assert len(todos) == 4
+    assert {todo[1].astext() for todo in block_todos} == {
         'todo in foo',
         'todo in bar',
         'todo in param field',
     }
+    assert [todo.astext() for todo in inline_todos] == ['todo inline in foo']
 
 
 @pytest.mark.sphinx(
@@ -117,7 +140,7 @@ def test_todo_valid_link(app: SphinxTestApp) -> None:
         r'\\sphinxstyleemphasis{original entry}}}}'
     )
     m = re.findall(link, content)
-    assert len(m) == 4
+    assert len(m) == 6
     target = m[0]
 
     # Look for the targets of this link.


### PR DESCRIPTION
Resolves #6689

### Description
This PR addresses the feature request to add an inline `:todo:` role to the `sphinx.ext.todo` extension, complementing the existing block-level `.. todo::` directive.

**Implementation Details:**
- The new inline todo role is fully integrated with the existing todo domain: it emits the `todo-defined` event, triggers optional warnings if configured, and is successfully collected into the `todolist` output.
- Within the `todolist`, inline todos are smoothly converted into standard Todo admonitions while preserving a backlink to their original inline location.
- HTML and LaTeX rendering correctly preserve the inline representation and target links. (Support is also maintained for text, man, and texinfo formats).
- As expected, all inline todo items are hidden when `todo_include_todos` is set to `False`.

**Local Verification:**
- Targeted todo extension integration tests: 3/3 passed.
- Mypy validation for `sphinx/ext/todo.py` passed.
- Ruff check and format passed.
- The complete 155-source dummy documentation build passed with warnings treated as errors. 

**Declaration:**
This pull request includes code written with the assistance of AI. The code has been reviewed and tested by a human.