### PR TITLE
fix(napoleon): order Attributes and Methods sections after Parameters for class docstrings

### DIFF
--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -1228,6 +1228,70 @@ class NumpyDocstring(GoogleDocstring):
         else:
             return func(name)
 
+    def _parse(self) -> None:
+        self._parsed_lines = self._consume_empty()
+
+        if self._name and self._what in {'attribute', 'data', 'property'}:
+            res: list[str] = []
+            with contextlib.suppress(StopIteration):
+                res = self._parse_attribute_docstring()
+            self._parsed_lines.extend(res)
+            return
+
+        # Buffer section outputs so we can reorder them for class docstrings.
+        sections: list[tuple[str, list[str]]] = []
+        while self._lines:
+            if self._is_section_header():
+                try:
+                    section = self._consume_section_header()
+                    self._is_in_section = True
+                    self._section_indent = self._get_current_indent()
+                    if _directive_regex.match(section):
+                        lines = [section, *self._consume_to_next_section()]
+                    else:
+                        lines = self._sections[section.lower()](section)
+                    sections.append((section, lines))
+                finally:
+                    self._is_in_section = False
+                    self._section_indent = 0
+            else:
+                if not self._parsed_lines:
+                    self._parsed_lines.extend(
+                        self._consume_contiguous() + self._consume_empty()
+                    )
+                else:
+                    self._parsed_lines.extend(self._consume_to_next_section())
+
+        # For class docstrings, reorder sections so that Attributes and Methods
+        # come right after Parameters, matching the numpydoc 1.8 conventions
+        # (https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring).
+        # This is the equivalent of numpydoc PR #571.
+        if self._what == 'class':
+            params_lines: list[list[str]] = []
+            attr_method_lines: list[list[str]] = []
+            other_lines: list[list[str]] = []
+            for name, lines in sections:
+                sl = name.lower()
+                if sl in (
+                    'parameters', 'args', 'arguments',
+                    'keyword args', 'keyword arguments',
+                    'other parameters',
+                ):
+                    params_lines.append(lines)
+                elif sl in ('attributes', 'methods'):
+                    attr_method_lines.append(lines)
+                else:
+                    other_lines.append(lines)
+            for lines in params_lines:
+                self._parsed_lines.extend(lines)
+            for lines in attr_method_lines:
+                self._parsed_lines.extend(lines)
+            for lines in other_lines:
+                self._parsed_lines.extend(lines)
+        else:
+            for _, lines in sections:
+                self._parsed_lines.extend(lines)
+
     def _consume_field(
         self, parse_type: bool = True, prefer_type: bool = False
     ) -> tuple[str, str, list[str]]:

--- a/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
@@ -2915,3 +2915,119 @@ int py:class 1 int.html -
         for a, uri in zip(a_, ('list.html', 'int.html'), strict=True):
             assert a.attrib['href'] == f'127.0.0.1:5555/{uri}'
             assert a.attrib['title'] == '(in Intersphinx Test v42)'
+
+
+class TestNumpyDocstringSectionOrder:
+    """NumpyDocstring section ordering for class docstrings.
+
+    numpydoc 1.8+ places Attributes and Methods sections directly below
+    Parameters for class docstrings.
+    """
+
+    config = Config(
+        napoleon_use_param=False,
+        napoleon_use_rtype=False,
+        napoleon_use_keyword=False,
+    )
+
+    def test_attributes_moved_before_notes_for_class(self):
+        docstring = dedent("""\
+            Summary line.
+
+            Parameters
+            ----------
+            param1 : int
+                First parameter.
+
+            Notes
+            -----
+            Some additional notes.
+
+            Attributes
+            ----------
+            attr1 : str
+                An attribute description.
+
+            Examples
+            --------
+            >>> example_code()
+        """)
+        actual = NumpyDocstring(docstring, self.config, what='class')
+        output = str(actual)
+        params_pos = output.find(':Parameters:')
+        attrs_pos = output.find('.. attribute::')
+        notes_pos = output.find('.. rubric:: Notes')
+        assert params_pos >= 0, 'Parameters section should exist'
+        assert attrs_pos >= 0, 'Attributes section should exist'
+        assert notes_pos >= 0, 'Notes section should exist'
+        assert params_pos < attrs_pos, (
+            'Attributes should come after Parameters'
+        )
+        assert attrs_pos < notes_pos, (
+            'Attributes should come before Notes for class docstrings'
+        )
+
+    def test_methods_moved_before_notes_for_class(self):
+        docstring = dedent("""\
+            Summary line.
+
+            Parameters
+            ----------
+            param1 : int
+                First parameter.
+
+            Notes
+            -----
+            Some notes.
+
+            Methods
+            -------
+            method1()
+                A method.
+        """)
+        actual = NumpyDocstring(docstring, self.config, what='class')
+        output = str(actual)
+        params_pos = output.find(':Parameters:')
+        methods_pos = output.find('.. method::')
+        notes_pos = output.find('.. rubric:: Notes')
+        assert params_pos >= 0, 'Parameters section should exist'
+        assert methods_pos >= 0, 'Methods section should exist'
+        assert notes_pos >= 0, 'Notes section should exist'
+        assert params_pos < methods_pos, (
+            'Methods should come after Parameters'
+        )
+        assert methods_pos < notes_pos, (
+            'Methods should come before Notes for class docstrings'
+        )
+
+    def test_no_reordering_for_non_class(self):
+        """Section order should be preserved for non-class objects."""
+        docstring = dedent("""\
+            Summary line.
+
+            Parameters
+            ----------
+            param1 : int
+                First parameter.
+
+            Notes
+            -----
+            Some notes.
+
+            Attributes
+            ----------
+            attr1 : str
+                An attribute description.
+        """)
+        actual = NumpyDocstring(docstring, self.config, what='function')
+        output = str(actual)
+        params_pos = output.find(':Parameters:')
+        notes_pos = output.find('.. rubric:: Notes')
+        attrs_pos = output.find('.. attribute::')
+        assert params_pos >= 0
+        assert notes_pos >= 0
+        assert attrs_pos >= 0
+        assert params_pos < notes_pos, 'Parameters should come before Notes'
+        assert notes_pos < attrs_pos, (
+            'Attributes should stay AFTER Notes for non-class objects'
+        )


### PR DESCRIPTION
Closes #13180

## Summary

When using NumPy-style docstrings for classes, the Attributes and Methods sections should appear right after the Parameters section, matching the [numpydoc 1.8 conventions](https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring) (numpydoc PR #571).

Before this change, Napoleon preserved the source order of sections, so Attributes and Methods could appear after Notes and Examples if that was how the user wrote the docstring.

## Changes

- Overrides `_parse()` in `NumpyDocstring` to buffer section outputs and reorder them for class docstrings
- Parameters (and related) sections first, then Attributes/Methods, then everything else in its original relative order
- 3 new tests confirming the reordering behavior
- All 69 existing Napoleon tests continue to pass