### PR TITLE
DOC: document the translatable node

### DIFF
--- a/doc/extdev/nodes.rst
+++ b/doc/extdev/nodes.rst
@@ -83,6 +83,7 @@ New inline nodes
 ----------------
 
 .. autoclass:: index
+.. autoclass:: translatable
 .. autoclass:: pending_xref
 .. autoclass:: pending_xref_condition
 .. autoclass:: literal_emphasis


### PR DESCRIPTION
This adds `translatable` to the Sphinx documentation page that lists the doctree nodes provided by Sphinx. The class is already part of `sphinx.addnodes`, so the API page now points extension authors to it.

Fixes #9409