### PR TITLE
linkcheck reports uppercase-scheme URIs as broken

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -61,7 +61,7 @@ class _Status(StrEnum):
 logger = logging.getLogger(__name__)
 
 # matches to foo:// and // (a protocol relative URL)
-uri_re = re.compile('([a-z]+:)?//')
+uri_re = re.compile('([a-zA-Z]+:)?//', re.IGNORECASE)
 
 DEFAULT_REQUEST_HEADERS = {
     'Accept': 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',


### PR DESCRIPTION
## Purpose

This PR fixes the documentation issue reported in #14541: corrects `uri_re = re.compile('([a-z]+:)?//')` to `uri_re = re.compile('([a-zA-Z]+:)?//', re.IGNORECASE)` in `sphinx/builders/linkcheck.py`.

Fixes #14541

## References

- <...>
- <...>
- <...>

## AI Disclosure

Fixes #14541