### PR TITLE
docs: clarify autodoc skip-member parameters

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -1477,10 +1477,10 @@ member should be included in the documentation by using the following event:
    autodoc and other enabled extensions.
 
    :param app: the Sphinx application object
-   :param obj_type: the type of the object which the docstring belongs to (one of
-      ``'module'``, ``'class'``, ``'exception'``, ``'function'``, ``'decorator'``,
-      ``'method'``, ``'property'``, ``'attribute'``, ``'data'``, or ``'type'``)
-   :param name: the fully qualified name of the object
+   :param obj_type: for autodoc, the type of the object containing the member
+      (e.g. ``'class'``); for autosummary, the type of the object being
+      documented.
+   :param name: the unqualified name of the member
    :param obj: the object itself
    :param skip: a boolean indicating if autodoc will skip this member if the
       user handler does not override the decision


### PR DESCRIPTION
Fixes #14555.

Clarify that `obj_type` describes the containing object for autodoc, that autosummary reports the documented object type, and that `name` is the member name rather than a fully qualified name.