### PR TITLE
Fix #4248: exclude rst_prolog/rst_epilog from search index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #4248: Search: exclude ``rst_prolog`` and ``rst_epilog`` content from the
+  search index to prevent false matches across all pages.
+  Patch by harsh7733ai
+
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -612,6 +612,10 @@ def _feed_visit_nodes(
     elif isinstance(node, nodes.Element) and 'no-search' in node['classes']:
         # skip nodes marked with a 'no-search' class
         return
+    elif getattr(node, 'source', None) in {'<rst_prologue>', '<rst_epilogue>'}:
+        # skip nodes generated from the rst_prolog/rst_epilog config values,
+        # so their content isn't indexed on every page that includes them
+        return
     elif isinstance(node, nodes.raw):
         if 'html' in node.get('format', '').split():
             # Some people might put content in raw HTML that should be searched,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -442,6 +442,34 @@ def test_nosearch(app: SphinxTestApp) -> None:
 @pytest.mark.sphinx(
     'html',
     testroot='search',
+    confoverrides={
+        'rst_prolog': (
+            '.. |prologue_subst| replace:: rstprologuesubstituteterm\n'
+            '\n'
+            'rstprologueplainterm is not part of any page.\n'
+        ),
+        'rst_epilog': (
+            '.. |epilogue_subst| replace:: rstepiloguesubstituteterm\n'
+            '\n'
+            'rstepilogueplainterm is not part of any page.\n'
+        ),
+    },
+    freshenv=True,
+)
+def test_rst_prolog_and_epilog_are_not_indexed(app: SphinxTestApp) -> None:
+    # regression test for #4248: rst_prolog/rst_epilog content must not
+    # leak into the search index for every page
+    app.build()
+    index = load_searchindex(app.outdir / 'searchindex.js')
+    assert not is_registered_term(index, 'rstprologuesubstituteterm')
+    assert not is_registered_term(index, 'rstprologueplainterm')
+    assert not is_registered_term(index, 'rstepiloguesubstituteterm')
+    assert not is_registered_term(index, 'rstepilogueplainterm')
+
+
+@pytest.mark.sphinx(
+    'html',
+    testroot='search',
     parallel=3,
     freshenv=True,
 )


### PR DESCRIPTION
Fixes #4248

## Problem

When `rst_epilog` (or `rst_prolog`) defines substitutions or other content, that content ends up in every page's doctree, because it's textually injected into each document's source before parsing. The search indexer walks the whole doctree with no way to distinguish prolog/epilog nodes from the page's actual content, so every rst_prolog/rst_epilog term gets indexed against every page — even pages that never reference it.

## Fix

`_prepend_prologue`/`_append_epilogue` in `sphinx/util/rst.py` already tag inserted lines with a source of `<rst_prologue>` / `<rst_epilogue>`, and docutils preserves that on the resulting nodes (e.g. `substitution_definition`, `paragraph`). `_feed_visit_nodes` in `sphinx/search/__init__.py` now checks a node's `source` for those two tags and skips it (and its subtree), the same way it already skips `nodes.comment` and nodes with the `no-search` class.

This only touches the search indexer — rendering and the doctree itself are unchanged.

## Test plan

- Added `test_rst_prolog_and_epilog_are_not_indexed` in `tests/test_search.py`, which sets both `rst_prolog` and `rst_epilog` with a substitution definition plus a plain paragraph, builds, and asserts none of those terms are registered in `searchindex.js`.
- Confirmed the new test fails on master (reverting just the fix) and passes with the fix applied.
- `python -m pytest tests/test_search.py -v` — 21 passed.
- Manually reproduced the original bug with a minimal project (`rst_epilog` with two substitutions across three pages) and confirmed `searchindex.js` before the fix mapped both terms to all three pages, and after the fix only to the page that actually uses them.