### PR TITLE
Fix autosummary CLI help typing on Python 3.15

### DIFF
--- a/sphinx/ext/autosummary/generate.py
+++ b/sphinx/ext/autosummary/generate.py
@@ -873,8 +873,9 @@ def find_autosummary_in_lines(
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         usage='%(prog)s [OPTIONS] <SOURCE_FILE>...',
-        epilog=__('For more information, visit <https://www.sphinx-doc.org/>.'),
-        description=__("""
+        epilog=str(__('For more information, visit <https://www.sphinx-doc.org/>.')),
+        description=str(
+            __("""
 Generate ReStructuredText using autosummary directives.
 
 sphinx-autogen is a frontend to sphinx.ext.autosummary.generate. It generates
@@ -885,7 +886,8 @@ The format of the autosummary directive is documented in the
 ``sphinx.ext.autosummary`` Python module and can be read using::
 
   pydoc sphinx.ext.autosummary
-"""),
+""")
+        ),
     )
 
     parser.add_argument(
@@ -896,7 +898,9 @@ The format of the autosummary directive is documented in the
     )
 
     parser.add_argument(
-        'source_file', nargs='+', help=__('source files to generate rST files for')
+        'source_file',
+        nargs='+',
+        help=str(__('source files to generate rST files for')),
     )
 
     parser.add_argument(
@@ -904,7 +908,7 @@ The format of the autosummary directive is documented in the
         '--output-dir',
         action='store',
         dest='output_dir',
-        help=__('directory to place all output in'),
+        help=str(__('directory to place all output in')),
     )
     parser.add_argument(
         '-s',
@@ -912,7 +916,7 @@ The format of the autosummary directive is documented in the
         action='store',
         dest='suffix',
         default='rst',
-        help=__('default suffix for files (default: %(default)s)'),
+        help=str(__('default suffix for files (default: %(default)s)')),
     )
     parser.add_argument(
         '-t',
@@ -920,7 +924,7 @@ The format of the autosummary directive is documented in the
         action='store',
         dest='templates',
         default=None,
-        help=__('custom template directory (default: %(default)s)'),
+        help=str(__('custom template directory (default: %(default)s)')),
     )
     parser.add_argument(
         '-i',
@@ -928,7 +932,7 @@ The format of the autosummary directive is documented in the
         action='store_true',
         dest='imported_members',
         default=False,
-        help=__('document imported members (default: %(default)s)'),
+        help=str(__('document imported members (default: %(default)s)')),
     )
     parser.add_argument(
         '-a',
@@ -936,9 +940,11 @@ The format of the autosummary directive is documented in the
         action='store_true',
         dest='respect_module_all',
         default=False,
-        help=__(
-            'document exactly the members in module __all__ attribute. '
-            '(default: %(default)s)'
+        help=str(
+            __(
+                'document exactly the members in module __all__ attribute. '
+                '(default: %(default)s)'
+            )
         ),
     )
     parser.add_argument(
@@ -946,8 +952,8 @@ The format of the autosummary directive is documented in the
         action='store_true',
         dest='remove_old',
         default=False,
-        help=__(
-            'Remove existing files in the output directory that were not generated'
+        help=str(
+            __('Remove existing files in the output directory that were not generated')
         ),
     )
 

--- a/tests/test_ext_autosummary/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary/test_ext_autosummary.py
@@ -23,6 +23,7 @@ from sphinx.ext.autosummary.generate import (
     AutosummaryEntry,
     generate_autosummary_content,
     generate_autosummary_docs,
+    get_parser,
 )
 from sphinx.ext.autosummary.generate import main as autogen_main
 from sphinx.testing.util import assert_node, etree_parse
@@ -998,3 +999,14 @@ def test_autogen_remove_old(rootdir, tmp_path):
         assert set(tmp_path.iterdir()) == {
             tmp_path / 'sphinx.application.TemplateBridge.rst'
         }
+
+
+def test_autogen_parser_help_is_str() -> None:
+    parser = get_parser()
+
+    assert isinstance(parser.description, str)
+    assert isinstance(parser.epilog, str)
+    assert all(
+        action.help is None or isinstance(action.help, str)
+        for action in parser._actions
+    )


### PR DESCRIPTION
## Summary

- ensure translated autosummary CLI help values are plain strings for Python 3.15's argparse typing
- add a regression test covering the parser description, epilog, and action help values

## Checks

- `pytest -q tests/test_ext_autosummary/test_ext_autosummary.py`
- `ty check --color=never --python=.venv-ci/bin/python`
- Ruff check and format validation for the changed files
