### PR TITLE
Pin Ty for reproducible type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ types = [
     "mypy==1.19.1",
     "pyrefly",
     "pyright==1.1.407",
-    "ty",
+    "ty==0.0.1a30",
     { include-group = "type-stubs" },
 ]
 type-stubs = [

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,7 @@ types = [
     { name = "mypy", specifier = "==1.19.0" },
     { name = "pyrefly" },
     { name = "pyright", specifier = "==1.1.407" },
-    { name = "ty" },
+    { name = "ty", specifier = "==0.0.1a30" },
     { name = "types-colorama", specifier = "==0.4.15.20250801" },
     { name = "types-defusedxml", specifier = "==0.7.0.20250822" },
     { name = "types-docutils", specifier = "==0.22.3.20251115" },


### PR DESCRIPTION
## Summary

- pin the experimental `ty` dependency to the version recorded in the lockfile
- keep the type-checking job reproducible while newer Ty releases report diagnostics across the existing codebase

## Checks

- `ty==0.0.1a30 check --color=never --python=.venv-ci/bin/python`
