### PR TITLE
Fix #4248: searchindex.js contains rst_epilog matches for all pages in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #4248: Do not include content injected via :confval:`rst_prolog` and
+  :confval:`rst_epilog` in the search index, so that a term appearing
+  only in a prologue or epilogue substitution definition no longer
+  matches every page.
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/search/__init__.py
+++ b/sphinx/search/__init__.py
@@ -185,6 +185,11 @@ class _JavaScriptIndex:
 
 js_index = _JavaScriptIndex()
 
+#: Source names given to content injected by ``rst_prolog``/``rst_epilog``
+#: (see ``sphinx.util.rst``); such content appears in every document
+#: and must not pollute the per-page search index.
+_INJECTED_SOURCES = frozenset({'<rst_prologue>', '<rst_epilogue>'})
+
 
 def _is_meta_keywords(
     node: nodes.meta,
@@ -218,6 +223,10 @@ class WordCollector(nodes.NodeVisitor):
 
     def dispatch_visit(self, node: Node) -> None:
         if isinstance(node, nodes.comment):
+            raise nodes.SkipNode
+        elif node.source in _INJECTED_SOURCES:
+            # skip content injected via rst_prolog/rst_epilog,
+            # which would otherwise be indexed on every page
             raise nodes.SkipNode
         elif isinstance(node, nodes.Element) and 'no-search' in node['classes']:
             # skip nodes marked with a 'no-search' class
@@ -608,6 +617,10 @@ def _feed_visit_nodes(
     language: str,
 ) -> None:
     if isinstance(node, nodes.comment):
+        return
+    elif node.source in _INJECTED_SOURCES:
+        # skip content injected via rst_prolog/rst_epilog,
+        # which would otherwise be indexed on every page
         return
     elif isinstance(node, nodes.Element) and 'no-search' in node['classes']:
         # skip nodes marked with a 'no-search' class

--- a/tests/roots/test-search-rst-prolog-epilog/conf.py
+++ b/tests/roots/test-search-rst-prolog-epilog/conf.py
@@ -1,0 +1,8 @@
+exclude_patterns = ['_build']
+html_search_language = 'en'
+rst_prolog = """
+.. |subst_prolog| replace:: prologword
+"""
+rst_epilog = """
+.. |subst_epilog| replace:: epilogword
+"""

--- a/tests/roots/test-search-rst-prolog-epilog/index.rst
+++ b/tests/roots/test-search-rst-prolog-epilog/index.rst
@@ -1,0 +1,7 @@
+index
+=====
+
+.. toctree::
+
+   uses
+   plain

--- a/tests/roots/test-search-rst-prolog-epilog/plain.rst
+++ b/tests/roots/test-search-rst-prolog-epilog/plain.rst
@@ -1,0 +1,4 @@
+plain
+=====
+
+This page does not use any substitution.

--- a/tests/roots/test-search-rst-prolog-epilog/uses.rst
+++ b/tests/roots/test-search-rst-prolog-epilog/uses.rst
@@ -1,0 +1,4 @@
+uses
+====
+
+This page uses |subst_prolog| and |subst_epilog|.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -181,6 +181,24 @@ def test_term_in_raw_directive(app: SphinxTestApp) -> None:
     assert not is_registered_term(searchindex, 'latex_keyword')
 
 
+@pytest.mark.sphinx(
+    'html',
+    testroot='search',
+    confoverrides={
+        'rst_prolog': '.. |subst_prolog| replace:: prologword\n',
+        'rst_epilog': '.. |subst_epilog| replace:: epilogword\n',
+    },
+    freshenv=True,
+)
+def test_rst_prolog_epilog_not_indexed(app: SphinxTestApp) -> None:
+    app.build(force_all=True)
+    searchindex = load_searchindex(app.outdir / 'searchindex.js')
+    # words from rst_prolog/rst_epilog are injected into every document
+    # and must not be indexed
+    assert not is_registered_term(searchindex, 'prologword')
+    assert not is_registered_term(searchindex, 'epilogword')
+
+
 def test_IndexBuilder():
     settings = frontend.get_default_settings(rst.Parser)
     parser = rst.Parser()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -181,22 +181,22 @@ def test_term_in_raw_directive(app: SphinxTestApp) -> None:
     assert not is_registered_term(searchindex, 'latex_keyword')
 
 
-@pytest.mark.sphinx(
-    'html',
-    testroot='search',
-    confoverrides={
-        'rst_prolog': '.. |subst_prolog| replace:: prologword\n',
-        'rst_epilog': '.. |subst_epilog| replace:: epilogword\n',
-    },
-    freshenv=True,
-)
+@pytest.mark.sphinx('html', testroot='search-rst-prolog-epilog', freshenv=True)
 def test_rst_prolog_epilog_not_indexed(app: SphinxTestApp) -> None:
     app.build(force_all=True)
     searchindex = load_searchindex(app.outdir / 'searchindex.js')
-    # words from rst_prolog/rst_epilog are injected into every document
-    # and must not be indexed
-    assert not is_registered_term(searchindex, 'prologword')
-    assert not is_registered_term(searchindex, 'epilogword')
+
+    def docs_for_term(term: str) -> set[str]:
+        files = searchindex['terms'].get(term, [])
+        if isinstance(files, int):
+            files = [files]
+        return {searchindex['docnames'][file] for file in files}
+
+    # the substitution definitions from rst_prolog/rst_epilog are injected
+    # into every document; only the page actually using the substitutions
+    # must match, not every page
+    assert docs_for_term('prologword') == {'uses'}
+    assert docs_for_term('epilogword') == {'uses'}
 
 
 def test_IndexBuilder():


### PR DESCRIPTION
Resolves #4248.