### PR TITLE
Let the py:deco and py:const roles resolve through intersphinx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14564: Python domain: let the ``deco`` and ``const`` roles resolve
+  through intersphinx and in ``refspecific`` mode, by claiming them
+  from the object types that back them.
+  Patch by UlikGames
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/domains/python/__init__.py
+++ b/sphinx/domains/python/__init__.py
@@ -723,11 +723,11 @@ class PythonDomain(Domain):
     name = 'py'
     label = 'Python'
     object_types = {
-        'function': ObjType(_('function'), 'func', 'obj'),
-        'data': ObjType(_('data'), 'data', 'obj'),
+        'function': ObjType(_('function'), 'func', 'deco', 'obj'),
+        'data': ObjType(_('data'), 'data', 'const', 'obj'),
         'class': ObjType(_('class'), 'class', 'exc', 'obj'),
         'exception': ObjType(_('exception'), 'exc', 'class', 'obj'),
-        'method': ObjType(_('method'), 'meth', 'obj'),
+        'method': ObjType(_('method'), 'meth', 'deco', 'obj'),
         'classmethod': ObjType(_('class method'), 'meth', 'obj'),
         'staticmethod': ObjType(_('static method'), 'meth', 'obj'),
         'attribute': ObjType(_('attribute'), 'attr', 'obj'),

--- a/tests/test_domains/test_domain_py.py
+++ b/tests/test_domains/test_domain_py.py
@@ -1815,6 +1815,47 @@ def test_deco_role(app):
     assert doctree.astext() == '\n\n\n\n@bar'
 
 
+@pytest.mark.sphinx('html', testroot='root')
+def test_deco_and_const_object_types(app):
+    domain = app.env.domains.python_domain
+
+    # ``py:decorator`` is registered as a function and ``py:decoratormethod``
+    # as a method, so those are the types ``deco`` may resolve to
+    assert domain.objtypes_for_role('deco') == ['function', 'method']
+    assert domain.objtypes_for_role('const') == ['data']
+
+    # the roles used to *generate* references are unchanged
+    assert domain.role_for_objtype('function') == 'func'
+    assert domain.role_for_objtype('method') == 'meth'
+    assert domain.role_for_objtype('data') == 'data'
+
+
+@pytest.mark.sphinx('html', testroot='root')
+def test_deco_and_const_refspecific_lookup(app):
+    text = """\
+.. py:module:: m
+
+.. py:decorator:: dec
+
+.. py:decoratormethod:: Cls.meth
+
+.. py:data:: CONST
+"""
+    restructuredtext.parse(app, text)
+    domain = app.env.domains.python_domain
+
+    def find_obj(obj_name, obj_type):
+        return domain.find_obj(app.env, 'm', None, obj_name, obj_type, searchmode=1)
+
+    assert find_obj('dec', 'deco') == [('m.dec', ('index', 'm.dec', 'function', False))]
+    assert find_obj('Cls.meth', 'deco') == [
+        ('m.Cls.meth', ('index', 'm.Cls.meth', 'method', False))
+    ]
+    assert find_obj('CONST', 'const') == [
+        ('m.CONST', ('index', 'm.CONST', 'data', False))
+    ]
+
+
 def test_pytype_canonical(app):
     text = """\
 .. py:type:: A

--- a/tests/test_ext_intersphinx/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx/test_ext_intersphinx.py
@@ -287,6 +287,38 @@ def test_missing_reference_pydomain(tmp_path, app):
 
 
 @pytest.mark.sphinx('html', testroot='root')
+def test_missing_reference_pydomain_deco_const(tmp_path, app):
+    # the ``deco`` and ``const`` roles used to be claimed by no object type,
+    # so intersphinx had no candidate types to look for and gave up
+    inv_file = tmp_path / 'inventory'
+    inv_file.write_bytes(INVENTORY_V2)
+    set_config(
+        app,
+        {
+            'python': ('https://docs.python.org/', str(inv_file)),
+        },
+    )
+
+    validate_intersphinx_mapping(app, app.config)
+    load_mappings(app)
+
+    # ``deco`` resolves to a function, as ``py:decorator`` is a function
+    node, contnode = fake_node('py', 'deco', 'module1.func', 'module1.func')
+    rn = missing_reference(app, app.env, node, contnode)
+    assert rn['refuri'] == 'https://docs.python.org/sub/foo.html#module1.func'
+
+    # ... and to a method, as ``py:decoratormethod`` is a method
+    node, contnode = fake_node('py', 'deco', 'module1.Foo.bar', 'module1.Foo.bar')
+    rn = missing_reference(app, app.env, node, contnode)
+    assert rn['refuri'] == 'https://docs.python.org/index.html#foo.Bar.baz'
+
+    # ``const`` resolves to data
+    node, contnode = fake_node('py', 'const', 'module1.CONST', 'module1.CONST')
+    rn = missing_reference(app, app.env, node, contnode)
+    assert rn['refuri'] == 'https://docs.python.org/sub/foo.html#module1.CONST'
+
+
+@pytest.mark.sphinx('html', testroot='root')
 def test_missing_reference_stddomain(tmp_path, app):
     inv_file = tmp_path / 'inventory'
     inv_file.write_bytes(INVENTORY_V2)

--- a/tests/test_util/intersphinx_data.py
+++ b/tests/test_util/intersphinx_data.py
@@ -23,6 +23,7 @@ INVENTORY_V2: Final[bytes] = b"""\
 module1 py:module 0 foo.html#module-module1 Long Module desc
 module2 py:module 0 foo.html#module-$ -
 module1.func py:function 1 sub/foo.html#$ -
+module1.CONST py:data 1 sub/foo.html#$ -
 module1.Foo.bar py:method 1 index.html#foo.Bar.baz -
 CFunc c:function 2 cfunc.html#CFunc -
 std cpp:type 1 index.html#std -


### PR DESCRIPTION
Fixes #14564

Before, the `PythonDomain` added the `deco` and `const` roles without linking them to object types. This made `objtypes_for_role` return `None`. Because of that, Intersphinx couldn't follow these roles. The `find_obj()` function also skipped its `refspecific` check - only exact local matches worked. All other references showed up as plain text, with no warning unless `nitpicky` mode was on.

Now, `deco` links to function and method types (`py:decorator` registers as `func`, `py:decoratormethod` as `meth`). `const` now links to `data`, just like `_prop` does for `property`. Since each entry uses a consistent `roles[0]`, `role_for_objtype()` now correctly returns `func` for functions.

Three new tests check Intersphinx links, `refspecific` behavior, and role-to-type mapping. All three failed before the fix.

Tested on Windows: 2390 tests passed. Two failures (`test_ext_duration`, `test_util_display::test_status_iterator_verbosity_0`) existed before and are not related.


## AI usage disclosure

Tool used: Claude Opus 5
How it was used:  to run all of the tests, helping us ensure everything worked smoothly
Tool used: Codex Sol 5.6
How it was used: to refine the grammar and make the pull request description clearer. 

After suggestion from @jdillard asked(which I truly appreciated), I took the time to rewrite the description personally.