### PR TITLE
autodoc: fix IndexError when an event handler supplies a signature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14576: autodoc: Fix ``IndexError`` when an ``autodoc-process-signature``
+  handler returns a signature for an object that has none, such as a
+  module, a data object, a type alias, or an attribute.
+  Patch by UlikGames
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/ext/autodoc/_dynamic/_signatures.py
+++ b/sphinx/ext/autodoc/_dynamic/_signatures.py
@@ -125,7 +125,9 @@ def _format_signatures(
     ):
         if len(result) == 2 and isinstance(result[0], str):
             args, retann = result
-            signatures[0] = (args, retann if isinstance(retann, str) else '')
+            # a slice assignment, as there may be no signature to replace:
+            # data, modules and type aliases skip signature extraction
+            signatures[:1] = [(args, retann if isinstance(retann, str) else '')]
 
     if props.obj_type in {'module', 'data', 'type'}:
         signatures[1:] = ()  # discard all signatures save the first

--- a/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
@@ -289,6 +289,25 @@ def test_format_signatures_event_handler() -> None:
     assert format_sig('method', 'bar', H.foo1, events=events) == ('42', '')
 
 
+@pytest.mark.parametrize('obj_type', ['data', 'module', 'type', 'attribute'])
+def test_format_signatures_event_handler_without_signature(
+    obj_type: _AutodocObjType,
+) -> None:
+    # these object types never have a signature to introspect,
+    # so a handler's return value has nothing to replace
+    def process_signature(*args: Any) -> tuple[str, None]:
+        return '(spam)', None
+
+    events = FakeEvents()
+    events.connect('autodoc-process-signature', process_signature)
+
+    class Callable_:
+        def __call__(self) -> None:
+            pass
+
+    assert format_sig(obj_type, 'bar', Callable_(), events=events) == ('(spam)', '')
+
+
 def test_format_functools_partial_signatures() -> None:
     # test functions created via functools.partial
     from functools import partial

--- a/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
@@ -308,6 +308,18 @@ def test_format_signatures_event_handler_without_signature(
     assert format_sig(obj_type, 'bar', Callable_(), events=events) == ('(spam)', '')
 
 
+def test_format_signatures_event_handler_for_builtin_without_signature() -> None:
+    events = FakeEvents()
+    events.connect('autodoc-process-signature', _process_signature)
+    config = _AutodocConfig(autodoc_docstring_signature=False)
+
+    assert format_sig('function', 'int', int, config=config) == ()
+    assert format_sig('function', 'bar', int, config=config, events=events) == (
+        '42',
+        '',
+    )
+
+
 def test_format_functools_partial_signatures() -> None:
     # test functions created via functools.partial
     from functools import partial


### PR DESCRIPTION
Fixes #14576

Previously, `_format_signatures` would run into trouble when it received an empty `signatures` list - something that naturally occurs with data, modules, type aliases, and attributes, since `_get_signature_object` doesn’t process these types.

When a custom event handler supplied a signature for one of these items, the code tried to update the first entry using `signatures[0] = ...`. But if the list was empty, this triggered an `IndexError`, resulting in a warning and leaving both signature and docstring ungenerated.

This update replaces that approach with `signatures[:1] = ...`, a more flexible method that either adds the signature when the list is empty or replaces the first item if one exists - handling both cases smoothly.

Also worth noting: while the original report pointed to annotated class variables, they may not be the core issue. The same problem can occur with objects that have no annotations at all, or when a signature is provided via an event handler for something that previously had none.

New tests covering data, modules, type aliases, and attributes have been included, and everything runs successfully in local testing.

## AI usage disclosure

Tool used: Claude Opus 5
How it was used:  to run all of the tests, helping us ensure everything worked smoothly
Tool used: Codex Sol 5.6
How it was used: to refine the grammar and make the pull request description clearer. 

After suggestion from @jdillard asked(which I truly appreciated), I took the time to rewrite the description personally.