### PR TITLE
Suppress ANSI control sequences when colour is disabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14565: Do not emit ANSI control sequences in progress output when
+  colouring is disabled with ``--no-color``, matching ``NO_COLOR``.
+  Patch by Ali Asgher
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/_cli/util/colour.py
+++ b/sphinx/_cli/util/colour.py
@@ -52,6 +52,16 @@ def enable_colour() -> None:
     _COLOURING_DISABLED = False
 
 
+def colour_enabled() -> bool:
+    """Return True if coloured output is currently enabled.
+
+    Unlike :func:`terminal_supports_colour`, which only reports whether the
+    terminal is capable of colour, this also honours colouring having been
+    turned off explicitly (``--no-color``).
+    """
+    return not _COLOURING_DISABLED and terminal_supports_colour()
+
+
 def colourise(colour_name: str, text: str, /) -> str:
     if _COLOURING_DISABLED:
         return text
@@ -61,6 +71,7 @@ def colourise(colour_name: str, text: str, /) -> str:
         'terminal_supports_colour',
         'disable_colour',
         'enable_colour',
+        'colour_enabled',
         'colourise',
     }:
         msg = f'Invalid colour name: {colour_name!r}'

--- a/sphinx/util/display.py
+++ b/sphinx/util/display.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 
-from sphinx._cli.util.colour import bold, terminal_supports_colour
+from sphinx._cli.util.colour import bold, colour_enabled
 from sphinx.locale import __
 from sphinx.util import logging
 
@@ -32,7 +32,7 @@ def status_iterator[T](
     stringify_func: Callable[[Any], str] = display_chunk,
 ) -> Iterator[T]:
     # printing on a single line requires ANSI control sequences
-    single_line = verbosity < 1 and terminal_supports_colour()
+    single_line = verbosity < 1 and colour_enabled()
     bold_summary = bold(summary)
     if length == 0:
         logger.info(bold_summary, nonl=True)

--- a/tests/test_util/test_util_display.py
+++ b/tests/test_util/test_util_display.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from sphinx._cli.util.colour import disable_colour, enable_colour
 from sphinx._cli.util.errors import strip_escape_sequences
 from sphinx.util import logging
 from sphinx.util.display import (
@@ -78,6 +79,32 @@ def test_status_iterator_verbosity_1(
     assert 'testing ... [ 33%] hello\n' in output
     assert 'testing ... [ 67%] sphinx\n' in output
     assert 'testing ... [100%] world\n\n' in output
+
+
+@pytest.mark.sphinx('dummy', testroot='root')
+def test_status_iterator_colour_disabled(
+    app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``--no-color`` disables colouring without setting NO_COLOR, so the
+    # terminal still reports colour support. The single-line progress output
+    # must not emit ANSI control sequences in that case.
+    monkeypatch.setenv('FORCE_COLOR', '1')
+    logging.setup(app, app.status, app.warning)
+
+    app.status.seek(0)
+    app.status.truncate(0)
+    disable_colour()
+    try:
+        yields = status_iterator(
+            ['hello', 'sphinx', 'world'], 'testing ... ', length=3, verbosity=0
+        )
+        assert list(yields) == ['hello', 'sphinx', 'world']
+    finally:
+        enable_colour()
+
+    output = app.status.getvalue()
+    assert 'testing ... [100%] world' in output
+    assert output == strip_escape_sequences(output)
 
 
 @pytest.mark.sphinx('html', testroot='root')


### PR DESCRIPTION
Closes #14565

### Feature or Bugfix

- Bugfix

### Purpose

`--no-color` and `NO_COLOR` disagreed: `NO_COLOR=1` produced ANSI-free output, but `--no-color` still emitted cursor/erase control sequences (`\x1b[2K`), so `--no-color` output was not usable for log files.

### Detail

The two mechanisms take different paths:

- `NO_COLOR` is read by `terminal_supports_colour()`, so it suppresses everything gated on that probe.
- `--no-color` goes through `_validate_colour_support()` → `disable_colour()`, which only sets the module-level `_COLOURING_DISABLED` flag.

`terminal_supports_colour()` never consults `_COLOURING_DISABLED`, so `status_iterator()` (`sphinx/util/display.py`) still considered the terminal ANSI-capable and emitted the "erase in line" sequence for single-line progress, even though `colourise()` was correctly returning uncoloured text.

This adds `colour_enabled()`, which combines the capability probe with the explicit disable flag, and uses it for the `single_line` check.

`terminal_supports_colour()` is deliberately left as a pure capability probe rather than being taught about the flag: `_parse_command()` in `sphinx/_cli/__init__.py` does `if terminal_supports_colour(): enable_colour() else: disable_colour()`, so folding the flag into the probe would make colouring impossible to re-enable once disabled. `term_width_line()` in `sphinx/util/console.py` already gates its control-sequence output on `_COLOURING_DISABLED`, so this brings `status_iterator()` in line with that.

### Verification

Using the reproduction script from the issue (with `FORCE_COLOR=1` so a colour-capable terminal is simulated in a non-tty environment):

Before:

```
default        -> contains ESC[2K: True
--no-color     -> contains ESC[2K: True
NO_COLOR=1     -> contains ESC[2K: False
```

After:

```
default        -> contains ESC[2K: True
--no-color     -> contains ESC[2K: False
NO_COLOR=1     -> contains ESC[2K: False
```

Default output is unchanged. `tests/test_util/test_util_display.py::test_status_iterator_colour_disabled` covers this and fails without the change. `tests/test_util`, `tests/test__cli`, `tests/test_quickstart.py` and `tests/test_command_line.py` pass (the one failure in my environment, `test_restify_Unpack`, is a missing optional module and reproduces on a clean checkout).

### Relates

- #14565