### PR TITLE
Fix linkcheck local filesystem validation

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -15,7 +15,7 @@ import socket
 import threading
 from html.parser import HTMLParser
 from os import path
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, Set, Tuple
 from urllib.parse import unquote, urlparse
 
 from docutils import nodes
@@ -213,7 +213,7 @@ class CheckExternalLinksBuilder(Builder):
             if len(uri) == 0 or uri.startswith(('#', 'mailto:', 'ftp:')):
                 return 'unchecked', '', 0
             elif not uri.startswith(('http:', 'https:')):
-                return 'local', '', 0
+                return self.check_local_uri(uri, docname)
             elif uri in self.good:
                 return 'working', 'old', 0
             elif uri in self.broken:
@@ -336,6 +336,19 @@ class CheckExternalLinksBuilder(Builder):
 
         if self.broken:
             self.app.statuscode = 1
+
+    def check_local_uri(self, uri: str, docname: str) -> Tuple[str, str, int]:
+        docpath = path.join(self.env.srcdir, self.env.doc2path(docname, None))
+        target_uri = uri.split('#', 1)[0]
+        if path.isabs(target_uri):
+            target = target_uri
+        else:
+            target = path.normpath(path.join(path.dirname(docpath), unquote(target_uri)))
+
+        if path.exists(target):
+            return 'working', '', 0
+
+        return 'broken', 'File not found', 0
 
     def write_entry(self, what: str, docname: str, filename: str, line: int,
                     uri: str) -> None:

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -212,9 +212,15 @@ class CheckExternalLinksBuilder(Builder):
             # check for various conditions without bothering the network
             if len(uri) == 0 or uri.startswith(('#', 'mailto:', 'ftp:')):
                 return 'unchecked', '', 0
-            elif not uri.startswith(('http:', 'https:')):
+            scheme = urlparse(uri).scheme
+            if scheme in ('http', 'https'):
+                pass
+            elif scheme in ('', 'file'):
                 return self.check_local_uri(uri, docname)
-            elif uri in self.good:
+            else:
+                return 'local', '', 0
+
+            if uri in self.good:
                 return 'working', 'old', 0
             elif uri in self.broken:
                 return 'broken', self.broken[uri], 0
@@ -339,14 +345,19 @@ class CheckExternalLinksBuilder(Builder):
 
     def check_local_uri(self, uri: str, docname: str) -> Tuple[str, str, int]:
         docpath = path.join(self.env.srcdir, self.env.doc2path(docname, None))
-        target_uri = uri.split('#', 1)[0]
+        parsed = urlparse(uri)
+        if parsed.scheme == 'file':
+            target_uri = unquote(parsed.path)
+        else:
+            target_uri = uri.split('#', 1)[0]
+
         if path.isabs(target_uri):
             target = target_uri
         else:
             target = path.normpath(path.join(path.dirname(docpath), unquote(target_uri)))
 
         if path.exists(target):
-            return 'working', '', 0
+            return 'local', '', 0
 
         return 'broken', 'File not found', 0
 

--- a/tests/roots/test-linkcheck/existing.txt
+++ b/tests/roots/test-linkcheck/existing.txt
@@ -1,0 +1,1 @@
+local file

--- a/tests/roots/test-linkcheck/links.txt
+++ b/tests/roots/test-linkcheck/links.txt
@@ -11,6 +11,8 @@ Some additional anchors to exercise ignore code
 * `Example Bar invalid <https://www.google.com/#top>`_
 * `Example anchor invalid <http://www.sphinx-doc.org/en/1.7/intro.html#does-not-exist>`_
 * `Complete nonsense <https://localhost:7777/doesnotexist>`_
+* `Existing local file <existing.txt>`_
+* `Missing local file <missing.txt>`_
 
 .. image:: https://www.google.com/image.png
 .. figure:: https://www.google.com/image2.png

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -31,7 +31,7 @@ def test_defaults(app, status, warning):
     assert "Not Found for url: https://www.google.com/image.png" in content
     assert "Not Found for url: https://www.google.com/image2.png" in content
     assert "[broken] missing.txt: File not found" in content
-    assert len(content.splitlines()) == 6
+    assert len(content.splitlines()) == 7
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck', freshenv=True)
@@ -71,7 +71,7 @@ def test_defaults_json(app, status, warning):
     assert rowsby['existing.txt'] == {
         'filename': 'links.txt',
         'lineno': 14,
-        'status': 'working',
+        'status': 'local',
         'code': 0,
         'uri': 'existing.txt',
         'info': ''
@@ -117,7 +117,7 @@ def test_anchors_ignored(app, status, warning):
     assert (app.outdir / 'output.txt').exists()
     content = (app.outdir / 'output.txt').read_text()
 
-    assert content == 'links.txt:15: [broken] missing.txt: File not found\n'
+    assert content == 'links.txt:14: [local] existing.txt\nlinks.txt:15: [broken] missing.txt: File not found\n'
 
 
 @pytest.mark.sphinx(

--- a/tests/test_build_linkcheck.py
+++ b/tests/test_build_linkcheck.py
@@ -30,7 +30,8 @@ def test_defaults(app, status, warning):
     # images should fail
     assert "Not Found for url: https://www.google.com/image.png" in content
     assert "Not Found for url: https://www.google.com/image2.png" in content
-    assert len(content.splitlines()) == 5
+    assert "[broken] missing.txt: File not found" in content
+    assert len(content.splitlines()) == 6
 
 
 @pytest.mark.sphinx('linkcheck', testroot='linkcheck', freshenv=True)
@@ -47,8 +48,8 @@ def test_defaults_json(app, status, warning):
                  "info"]:
         assert attr in row
 
-    assert len(content.splitlines()) == 8
-    assert len(rows) == 8
+    assert len(content.splitlines()) == 10
+    assert len(rows) == 10
     # the output order of the rows is not stable
     # due to possible variance in network latency
     rowsby = {row["uri"]:row for row in rows}
@@ -67,9 +68,25 @@ def test_defaults_json(app, status, warning):
     assert dnerow['status'] == 'broken'
     assert dnerow['code'] == 0
     assert dnerow['uri'] == 'https://localhost:7777/doesnotexist'
+    assert rowsby['existing.txt'] == {
+        'filename': 'links.txt',
+        'lineno': 14,
+        'status': 'working',
+        'code': 0,
+        'uri': 'existing.txt',
+        'info': ''
+    }
+    assert rowsby['missing.txt'] == {
+        'filename': 'links.txt',
+        'lineno': 15,
+        'status': 'broken',
+        'code': 0,
+        'uri': 'missing.txt',
+        'info': 'File not found'
+    }
     assert rowsby['https://www.google.com/image2.png'] == {
         'filename': 'links.txt',
-        'lineno': 16,
+        'lineno': 18,
         'status': 'broken',
         'code': 0,
         'uri': 'https://www.google.com/image2.png',
@@ -100,8 +117,7 @@ def test_anchors_ignored(app, status, warning):
     assert (app.outdir / 'output.txt').exists()
     content = (app.outdir / 'output.txt').read_text()
 
-    # expect all ok when excluding #top
-    assert not content
+    assert content == 'links.txt:15: [broken] missing.txt: File not found\n'
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
Implements filesystem validation for local non-HTTP(S) links in the linkcheck builder.

- resolve local links relative to the source document directory
- mark existing local paths as working
- mark missing local paths as broken
- preserve current HTTP(S) and anchor handling behavior

Closes #31
