### PR TITLE
html: add dark mode to Haiku theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Release 9.1.1 (in development)
 ==============================
 
+Features added
+--------------
+
+* #13742: Add dark mode support to the Haiku HTML theme.
+
 Bugs fixed
 ----------
 

--- a/sphinx/themes/haiku/static/haiku.css.jinja
+++ b/sphinx/themes/haiku/static/haiku.css.jinja
@@ -324,6 +324,93 @@ hr {
     margin-top: 20px;
 }
 
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+    html {
+        background-color: #202124;
+        background-image: none;
+    }
+
+    body {
+        color: #e8eaed;
+    }
+
+    a:link {
+        color: #ff9d76;
+    }
+
+    a:visited {
+        color: #d6a8ff;
+    }
+
+    a:hover, a:active {
+        color: #ffb997;
+    }
+
+    h1, h2, h3, h4,
+    div.header h1,
+    div.header h1 a,
+    div.title {
+        color: #9cc9ff;
+    }
+
+    h1, h2, div.title {
+        border-color: #50545a;
+    }
+
+    div.header h2 {
+        color: #b4b4b4;
+    }
+
+    div.bottomnav {
+        background-color: #2d3136;
+    }
+
+    table.index {
+        border-color: #50545a;
+    }
+
+    table.index tr.heading {
+        background-color: #3a4046;
+    }
+
+    table.index tr.index {
+        background-color: #30343a;
+    }
+
+    div.admonition {
+        border-color: #666b72;
+    }
+
+    div.note, div.seealso {
+        background-color: #28432d;
+    }
+
+    div.warning {
+        background-color: #4a3e19;
+    }
+
+    code {
+        background-color: #3a3f44;
+        color: #f0f0f0;
+    }
+
+    pre {
+        background-color: #25282c;
+        border-color: #6ea8d8;
+    }
+
+    hr {
+        border-top-color: #60656b;
+    }
+
+    div.viewcode-block:target {
+        background-color: #4f402d;
+        border-top-color: #8aa878;
+        border-bottom-color: #8aa878;
+    }
+}
+
 /* printer only pretty stuff */
 @media print {
     .noprint {

--- a/tests/test_theming/test_theming.py
+++ b/tests/test_theming/test_theming.py
@@ -185,6 +185,23 @@ def test_dark_style(app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch) -> None
     ) in result
 
 
+@pytest.mark.sphinx(
+    'html',
+    testroot='theming',
+    confoverrides={'html_theme': 'haiku'},
+)
+def test_haiku_dark_mode_stylesheet(app: SphinxTestApp) -> None:
+    app.build()
+
+    stylesheet = app.outdir / '_static' / 'haiku.css'
+    assert stylesheet.exists()
+    result = stylesheet.read_text(encoding='utf8')
+    assert '@media (prefers-color-scheme: dark)' in result
+    assert 'background-image: none' in result
+    assert 'background-color: #202124' in result
+    assert 'background-color: #25282c' in result
+
+
 @pytest.mark.sphinx('html', testroot='theming')
 def test_theme_sidebars(app: SphinxTestApp) -> None:
     app.build()


### PR DESCRIPTION
## Summary

Add a prefers-color-scheme dark palette to the built-in Haiku HTML theme. The palette removes the light page texture, updates text and link contrast, and covers navigation, tables, admonitions, code blocks, and highlighted viewcode regions.

Adds a regression test that builds the Haiku stylesheet and checks the generated dark-mode rules.

Fixes #13742

## Validation

- uv run pytest tests/test_theming/test_theming.py -q (24 passed)
- uv run ruff check tests/test_theming/test_theming.py
- uv run ruff format --check tests/test_theming/test_theming.py
- git diff --check

This contribution was prepared with Codex (GPT-5) assistance and reviewed before publication.