### PR TITLE
Make --no-color suppress cursor control sequences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14565: ``--no-color`` now also suppresses the cursor control sequences
+  used to redraw the progress line, matching ``NO_COLOR``.
+  Patch by Dipak Chaudhari
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/_cli/util/colour.py
+++ b/sphinx/_cli/util/colour.py
@@ -42,6 +42,17 @@ def terminal_supports_colour() -> bool:
     return _environ.get('TERM', 'unknown').lower() not in {'dumb', 'unknown'}
 
 
+def colour_enabled() -> bool:
+    """Return True if coloured terminal output is currently in effect.
+
+    This is :func:`terminal_supports_colour` narrowed by an explicit
+    :func:`disable_colour`, which ``--no-color`` triggers. Use it to decide
+    whether to emit any escape sequence, rather than asking only whether the
+    terminal is capable of showing one.
+    """
+    return not _COLOURING_DISABLED and terminal_supports_colour()
+
+
 def disable_colour() -> None:
     global _COLOURING_DISABLED  # NoQA: PLW0603
     _COLOURING_DISABLED = True

--- a/sphinx/util/display.py
+++ b/sphinx/util/display.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 
-from sphinx._cli.util.colour import bold, terminal_supports_colour
+from sphinx._cli.util.colour import bold, colour_enabled
 from sphinx.locale import __
 from sphinx.util import logging
 
@@ -31,8 +31,10 @@ def status_iterator[T](
     verbosity: int = 0,
     stringify_func: Callable[[Any], str] = display_chunk,
 ) -> Iterator[T]:
-    # printing on a single line requires ANSI control sequences
-    single_line = verbosity < 1 and terminal_supports_colour()
+    # printing on a single line requires ANSI control sequences, so it has
+    # to follow whether colouring is enabled -- not merely whether the
+    # terminal could support it -- or --no-color would still emit them
+    single_line = verbosity < 1 and colour_enabled()
     bold_summary = bold(summary)
     if length == 0:
         logger.info(bold_summary, nonl=True)

--- a/tests/test_util/test_util_display.py
+++ b/tests/test_util/test_util_display.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from sphinx._cli.util import colour
 from sphinx._cli.util.errors import strip_escape_sequences
 from sphinx.util import logging
 from sphinx.util.display import (
@@ -58,6 +59,59 @@ def test_status_iterator_verbosity_0(
     assert 'testing ... [ 33%] hello\r' in output
     assert 'testing ... [ 67%] sphinx\r' in output
     assert 'testing ... [100%] world\r\n' in output
+
+
+@pytest.mark.sphinx('dummy', testroot='root')
+def test_status_iterator_no_control_sequences_when_colour_disabled(
+    app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    r"""``--no-color`` must suppress the cursor control sequences too.
+
+    Regression for #14565: ``status_iterator`` asked whether the terminal
+    *supports* colour, which stays true after an explicit ``disable_colour()``,
+    so ``--no-color`` still emitted ``ESC[2K`` and ``\r`` while ``NO_COLOR``
+    did not.
+    """
+    monkeypatch.setenv('FORCE_COLOR', '1')
+    monkeypatch.setattr(colour, '_COLOURING_DISABLED', True)
+    logging.setup(app, app.status, app.warning)
+
+    app.status.seek(0)
+    app.status.truncate(0)
+    yields = status_iterator(
+        ['hello', 'sphinx', 'world'], 'testing ... ', length=3, verbosity=0
+    )
+    assert list(yields) == ['hello', 'sphinx', 'world']
+
+    output = app.status.getvalue()
+    assert '\x1b[' not in output
+    assert '\r' not in output
+    assert 'testing ... [ 33%] hello\n' in output
+
+
+def test_colour_enabled_follows_disable_colour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('FORCE_COLOR', '1')
+
+    monkeypatch.setattr(colour, '_COLOURING_DISABLED', False)
+    assert colour.terminal_supports_colour()
+    assert colour.colour_enabled()
+
+    monkeypatch.setattr(colour, '_COLOURING_DISABLED', True)
+    # the terminal is still capable; colouring is merely turned off
+    assert colour.terminal_supports_colour()
+    assert not colour.colour_enabled()
+
+
+def test_colour_enabled_follows_terminal_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(colour, '_COLOURING_DISABLED', False)
+    monkeypatch.setenv('NO_COLOR', '1')
+
+    assert not colour.terminal_supports_colour()
+    assert not colour.colour_enabled()
 
 
 @pytest.mark.sphinx('dummy', testroot='root')


### PR DESCRIPTION
Fixes #14565.

## Problem

`--no-color` and `NO_COLOR=1` behave differently: the flag still emits ANSI cursor control sequences (`ESC[2K`, carriage returns), the environment variable does not.

Running the reporter's matrix on Windows against `master`:

```text
default          ESC[2K=True  any-ANSI=True
--no-color       ESC[2K=True  any-ANSI=True
NO_COLOR=1       ESC[2K=False any-ANSI=False
```

## Cause

`status_iterator` decides whether to redraw the progress line in place with:

```python
single_line = verbosity < 1 and terminal_supports_colour()
```

`terminal_supports_colour()` reports terminal *capability*. `disable_colour()` — what `--no-color` triggers via `_validate_colour_support` — sets `_COLOURING_DISABLED`, which that function never consults. On Windows it returns `True` unconditionally, so the flag had no effect on this code path at all.

`NO_COLOR` happens to work only because it makes `terminal_supports_colour()` itself return `False`, before colouring is ever disabled.

## Fix

Add `colour_enabled()` next to the existing helpers — `terminal_supports_colour()` narrowed by an explicit `disable_colour()` — and use it for the `single_line` decision.

Keeping the terminal-support half matters: `status_iterator` is reachable from library use where the CLI never runs `_validate_colour_support`, so `_COLOURING_DISABLED` alone would start emitting escapes to non-terminals that previously got none.

After:

```text
default          ESC[2K=True  any-ANSI=True
--no-color       ESC[2K=False any-ANSI=False
NO_COLOR=1       ESC[2K=False any-ANSI=False
```

This takes the reporter's preferred reading — that `--no-color` should give fully ANSI-free output suitable for a log file — and makes the two mechanisms agree.

## Tests

- `test_status_iterator_no_control_sequences_when_colour_disabled` — with `FORCE_COLOR` set (so terminal support is not what is being measured) and colouring disabled, the output contains no `ESC[` and no `\r`, while the progress text itself is still present.
- `test_colour_enabled_follows_disable_colour` — the terminal stays capable while `colour_enabled()` goes false.
- `test_colour_enabled_follows_terminal_support` — the `NO_COLOR` half.

Full suite passes: 2387 passed, 35 skipped, 3 xfailed.

---

## AI disclosure

Per the [AI policy](https://www.sphinx-doc.org/en/master/internals/ai-policy.html):

- **Was AI used?** Yes.
- **Which tool?** Claude Code (Anthropic), model Claude Opus 5.
- **How was it used, and what is AI-generated?** The tool reproduced the issue locally, traced the `single_line` predicate to `terminal_supports_colour()`, and wrote the new `colour_enabled()` helper, the one-line change in `sphinx/util/display.py`, the three tests, the `CHANGES.rst` entry, and this description. All of the diff is AI-generated text.
- **Human oversight:** I reproduced the reported mismatch on Windows before and after the change using the script from the issue (output quoted above), and checked the three other callers of `terminal_supports_colour()` (`cmd/build.py`, `cmd/make_mode.py`, `cmd/quickstart.py`) — each uses it to decide whether to *call* `disable_colour()`, which is correct as-is, so `display.py` is the only site that needed changing. I also confirmed the full test suite passes rather than only the touched module.