### PR TITLE
Fix builder-specific translation handler fallback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #14587: Combine format-wide and builder-specific node translation handlers.
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -429,10 +429,8 @@ class SphinxComponentRegistry:
         translator = translator_class(*args)
 
         # transplant handlers for custom nodes to translator instance
-        handlers = self.translation_handlers.get(builder.name, None)
-        if handlers is None:
-            # retry with builder.format
-            handlers = self.translation_handlers.get(builder.format, {})
+        handlers = self.translation_handlers.get(builder.format, {}).copy()
+        handlers.update(self.translation_handlers.get(builder.name, {}))
 
         for name, (visit, depart) in handlers.items():
             setattr(translator, 'visit_' + name, MethodType(visit, translator))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,64 @@
+"""Test the Sphinx component registry."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from docutils import nodes
+
+from sphinx.registry import SphinxComponentRegistry
+
+
+class FormatNode(nodes.Element):
+    pass
+
+
+class BuilderNode(nodes.Element):
+    pass
+
+
+class OverrideNode(nodes.Element):
+    pass
+
+
+def test_create_translator_combines_builder_and_format_handlers() -> None:
+    registry = SphinxComponentRegistry()
+
+    def visit_format(translator: Mock, node: nodes.Element) -> None:
+        translator.visited.append(('format', node))
+
+    def visit_builder(translator: Mock, node: nodes.Element) -> None:
+        translator.visited.append(('builder', node))
+
+    registry.add_translation_handlers(
+        FormatNode,
+        html=(visit_format, None),
+    )
+    registry.add_translation_handlers(
+        BuilderNode,
+        dirhtml=(visit_builder, None),
+    )
+    registry.add_translation_handlers(
+        OverrideNode,
+        html=(visit_format, None),
+        dirhtml=(visit_builder, None),
+    )
+
+    translator = Mock(visited=[])
+    translator_class = Mock(return_value=translator)
+    builder = Mock(format='html', default_translator_class=translator_class)
+    builder.name = 'dirhtml'
+
+    registry.create_translator(builder)
+
+    format_node = FormatNode()
+    builder_node = BuilderNode()
+    override_node = OverrideNode()
+    translator.visit_FormatNode(format_node)
+    translator.visit_BuilderNode(builder_node)
+    translator.visit_OverrideNode(override_node)
+    assert translator.visited == [
+        ('format', format_node),
+        ('builder', builder_node),
+        ('builder', override_node),
+    ]


### PR DESCRIPTION
## Purpose

  Custom node handlers can be registered for both a general output format, such as `html`, and a specific builder, such as `dirhtml`. Previously, finding any builder-specific handlers caused all format-wide
  handlers to be discarded.

  This change starts with a copy of the handlers registered for `builder.format` and updates it with those registered for `builder.name`. This preserves format-wide handlers without mutating the registry,
  while allowing builder-specific handlers to take precedence when the same node is registered at both levels.

  The regression test covers nodes registered only for `html`, only for `dirhtml`, and for both, confirming that the `dirhtml` handler wins in the last case. A corresponding entry was added to `CHANGES.rst`.

  Validation:

  - Application and registry tests: 9 passed
  - DirHTML test: 1 passed
  - Full suite: 2388 passed, 35 skipped, 1 xfailed
  - Ruff formatting and checks
  - mypy
  - `git diff --check`

  Two unrelated full-suite errors remained in a Cython fixture and a timing-threshold test; neither involves the changed code.

  ## References

  - #14587