### PR TITLE
docs: clarify autodoc-skip-member arguments

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ Contributors
 * Erik Bedard -- config options for :mod:`sphinx.ext.duration`
 * Etienne Desautels -- apidoc module
 * Ezio Melotti -- collapsible sidebar JavaScript
+* Fhatuwani Sikhwari -- autodoc documentation
 * Filip Vavera -- napoleon todo directive
 * Florian Best -- log improvements
 * Glenn Matthews -- python domain signature improvements

--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -1477,10 +1477,11 @@ member should be included in the documentation by using the following event:
    autodoc and other enabled extensions.
 
    :param app: the Sphinx application object
-   :param obj_type: the type of the object which the docstring belongs to (one of
-      ``'module'``, ``'class'``, ``'exception'``, ``'function'``, ``'decorator'``,
-      ``'method'``, ``'property'``, ``'attribute'``, ``'data'``, or ``'type'``)
-   :param name: the fully qualified name of the object
+   :param obj_type: the type of the object whose member is being considered (one
+      of ``'module'``, ``'class'``, ``'exception'``, ``'function'``,
+      ``'decorator'``, ``'method'``, ``'property'``, ``'attribute'``,
+      ``'data'``, or ``'type'``)
+   :param name: the unqualified name of the member
    :param obj: the object itself
    :param skip: a boolean indicating if autodoc will skip this member if the
       user handler does not override the decision

--- a/doc/usage/extensions/autosummary.rst
+++ b/doc/usage/extensions/autosummary.rst
@@ -214,8 +214,9 @@ also use these config values:
 
    .. versionchanged:: 2.3
 
-      Emits :event:`autodoc-skip-member` event as :mod:`~sphinx.ext.autodoc`
-      does.
+      Emits the :event:`autodoc-skip-member` event.  Unlike
+      :mod:`~sphinx.ext.autodoc`, the ``obj_type`` argument is the type of the
+      candidate member.
 
    .. versionchanged:: 4.0
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

The `autodoc-skip-member` documentation incorrectly described the `obj_type` and `name` arguments. When autodoc evaluates `bar`, the event receives `obj_type="class"` and `name="bar"`. Autodoc passes the enclosing object's `obj_type` together with the member's unqualified name.

The previous description of `name` as a fully qualified name was incorrect, because a fully qualified name would be something like `Foo.bar`, while the event receives only `bar`. I also clarified the different `obj_type` behaviour in autosummary.


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

Closes #14555


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->

I used the Codex CLI extension in VS Code. Codex helped me inspect the relevant Sphinx source, draft the documentation changes in `autodoc.rst` and `autosummary.rst`, and run the local validation. It also assisted with the contributor entry in `AUTHORS.rst`, commit preparation, fork setup, and branch push.

I reviewed the changes, checked that I understood the documented behaviour, and I am taking responsibility for the submission and handling the PR and maintainer communication myself.

I also used ChatGPT only to review the grammar and clarity of PR text that I wrote myself.
