### PR TITLE
linkcheck: treat URI schemes as case-insensitive (RFC 3986) (#14541)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #14541: linkcheck: Treat URI schemes as case-insensitive (RFC 3986), so
+  uppercase schemes such as ``FTP://`` are no longer reported as ``broken``.
+
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -61,7 +61,9 @@ class _Status(StrEnum):
 logger = logging.getLogger(__name__)
 
 # matches to foo:// and // (a protocol relative URL)
-uri_re = re.compile('([a-z]+:)?//')
+# URI schemes are case-insensitive per RFC 3986, so the pattern is
+# case-insensitive (e.g. ``FTP://`` is treated the same as ``ftp://``).
+uri_re = re.compile('([a-z]+:)?//', re.IGNORECASE)
 
 DEFAULT_REQUEST_HEADERS = {
     'Accept': 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1522,3 +1522,30 @@ def test_linkcheck_case_sensitivity(
     assert rowsby[f'http://{address}/path1']['status'] == expected_path1
     assert rowsby[f'http://{address}/path2']['status'] == expected_path2
     assert rowsby[f'http://{address}/PATH3']['status'] == expected_path3
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        'FTP://example.test/file',
+        'ftp://example.test/file',
+        'SSH://example.test/file',
+    ],
+)
+def test_linkcheck_uppercase_scheme_is_unchecked(
+    make_app: Callable[..., SphinxTestApp], tmp_path: Path, uri: str
+) -> None:
+    """Non-http URI schemes are case-insensitive (RFC 3986).
+
+    Uppercase schemes such as ``FTP://`` must be treated like their
+    lowercase equivalents and reported as ``unchecked`` rather than
+    ``broken``.
+    """
+    tmp_path.joinpath('conf.py').write_text('')
+    tmp_path.joinpath('index.rst').write_text(f'Test\n====\n\n`download <{uri}>`_\n')
+    app = make_app('linkcheck', srcdir=tmp_path)
+    app.build()
+    content = (app.outdir / 'output.json').read_text(encoding='utf8')
+    rows = [json.loads(x) for x in content.splitlines()]
+    rowsby = {row['uri']: row for row in rows}
+    assert rowsby[uri]['status'] == 'unchecked'


### PR DESCRIPTION
Hi,

This fixes a `linkcheck` bug where URIs with an uppercase scheme (e.g. `FTP://example.test/file`) were reported as `[broken]`, while the lowercase form `ftp://` was correctly reported as `[unchecked]`.

**AI assistance disclosure (per the AI policy):** I used an AI coding assistant to help produce the initial patch and the regression test. I have reviewed the diff, understand exactly what it does, and can explain it below. I am opening this PR myself after checking it.

**What's going on / why I think this is the right fix**

Per RFC 3986 §3.1, URI schemes are case-insensitive, so `FTP://` and `ftp://` are the same scheme. Sphinx's `linkcheck` decides whether a link is "external" (a non-HTTP scheme) with this regex in `sphinx/builders/linkcheck.py`:

    uri_re = re.compile('([a-z]+:)?//')

Because the character class is `[a-z]` only, an uppercase scheme like `FTP://` never matches, so `linkcheck` does not recognise it as an external link. It then falls through to the local-file existence check and reports `[broken]` for a URI that is actually a remote FTP link.

The fix is a one-liner: make the regex case-insensitive.

    uri_re = re.compile('([a-z]+:)?//', re.IGNORECASE)

Now `FTP://`, `SSH://`, etc. are treated exactly like their lowercase forms and reported as `[unchecked]`. `http:`/`https:` links are unaffected (they are still checked normally), and nothing else in the matching logic changes.

**How I verified it**

- Added a regression test `tests/test_builders/test_build_linkcheck.py::test_linkcheck_uppercase_scheme_is_unchecked` covering `FTP://`, `ftp://`, and `SSH://`. It reports `broken` on the unpatched code and `unchecked` with the fix.
- `pytest tests/test_builders/test_build_linkcheck.py` → 51 passed, no regressions.
- `ruff check` / `ruff format --check` clean on the changed files.

Fixes #14541.