### PR TITLE
autosummary: fix name resolution when a class and module differ only by case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #11362: autosummary: Fix resolution failures on case-insensitive filesystems
+  (Windows and macOS) when a class and a module differ only by case, such as
+  a class ``pkg.Foo`` defined in ``pkg/foo.py``.  Names are now resolved by
+  attribute access where possible instead of importing ``pkg.Foo`` as a
+  module, which could clobber the class attribute with the mis-cased module.
+  Patch by Eric Larson
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/ext/autosummary/__init__.py
+++ b/sphinx/ext/autosummary/__init__.py
@@ -689,38 +689,49 @@ def _import_by_name(name: str, grouped_exception: bool = True) -> tuple[Any, Any
     try:
         name_parts = name.split('.')
 
-        # try first interpret `name` as MODNAME.OBJ
-        modname = '.'.join(name_parts[:-1])
-        if modname:
+        # Walk from the root module towards the target, preferring attribute
+        # access over submodule imports: importing e.g. ``pkg.Foo`` as a
+        # module may wrongly succeed on case-insensitive filesystems when a
+        # ``pkg/foo.py`` module exists, clobbering the ``Foo`` attribute of
+        # ``pkg`` with the mis-imported module (#11362).
+        modname = name_parts[0]
+        obj: Any = _import_module(modname)
+        parent: Any = None
+        for j, part in enumerate(name_parts[1:], start=2):
+            if parent is None and j < len(name_parts):
+                submod = sys.modules.get(f'{modname}.{part}')
+                if isinstance(submod, ModuleType):
+                    # for intermediate parts, an already-imported submodule
+                    # wins over a same-named attribute (e.g. a function
+                    # shadowing its own module), as with the import-first
+                    # resolution used previously
+                    modname = f'{modname}.{part}'
+                    obj = submod
+                    continue
             try:
-                mod = _import_module(modname)
-                return getattr(mod, name_parts[-1]), mod, modname
-            except (ImportError, IndexError, AttributeError) as exc:
-                errors.append(exc.__cause__ or exc)
-
-        # ... then as MODNAME, MODNAME.OBJ1, MODNAME.OBJ1.OBJ2, ...
-        last_j = 0
-        modname = ''
-        for j in reversed(range(1, len(name_parts) + 1)):
-            last_j = j
-            modname = '.'.join(name_parts[:j])
-            try:
-                _import_module(modname)
-            except ImportError as exc:
-                errors.append(exc.__cause__ or exc)
-
-            if modname in sys.modules:
-                break
-
-        if last_j < len(name_parts):
-            parent = None
-            obj = sys.modules[modname]
-            for obj_name in name_parts[last_j:]:
-                parent = obj
-                obj = getattr(obj, obj_name)
-            return obj, parent, modname
-        else:
-            return sys.modules[modname], None, modname
+                attr = getattr(obj, part)
+            except (AttributeError, ImportError) as exc:
+                if parent is not None:
+                    # ``obj`` was reached as an attribute; cannot fall back
+                    # to importing a submodule of it
+                    raise
+                errors.append(exc)
+                modname = f'{modname}.{part}'
+                obj = _import_module(modname)
+                continue
+            if (
+                j < len(name_parts)
+                and parent is None
+                and isinstance(attr, ModuleType)
+                and attr.__name__ == f'{modname}.{part}'
+            ):
+                # a genuine submodule reached via attribute access: keep
+                # treating the resolution as a module path
+                modname = f'{modname}.{part}'
+                obj = attr
+            else:
+                obj, parent = attr, obj
+        return obj, parent, modname
     except (ValueError, ImportError, AttributeError, KeyError) as exc:
         errors.append(exc)
         if grouped_exception:

--- a/tests/roots/test-ext-autosummary-case-insensitive/casefoo/__init__.py
+++ b/tests/roots/test-ext-autosummary-case-insensitive/casefoo/__init__.py
@@ -1,0 +1,1 @@
+from .foo import Foo

--- a/tests/roots/test-ext-autosummary-case-insensitive/casefoo/foo.py
+++ b/tests/roots/test-ext-autosummary-case-insensitive/casefoo/foo.py
@@ -1,0 +1,9 @@
+def find_foo():
+    """Find a foo."""
+
+
+class Foo:
+    """A class whose name collides with its module on case-insensitive FS."""
+
+    def crop(self):
+        """Crop it."""

--- a/tests/roots/test-ext-autosummary-case-insensitive/conf.py
+++ b/tests/roots/test-ext-autosummary-case-insensitive/conf.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path.cwd().resolve()))
+
+extensions = ['sphinx.ext.autosummary']
+autosummary_generate = True
+autosummary_filename_map = {'casefoo.foo': 'casefoo.foo-module'}

--- a/tests/roots/test-ext-autosummary-case-insensitive/index.rst
+++ b/tests/roots/test-ext-autosummary-case-insensitive/index.rst
@@ -1,0 +1,17 @@
+test-ext-autosummary-case-insensitive
+=====================================
+
+.. autosummary::
+   :toctree: generated
+
+   casefoo.Foo
+   casefoo.foo
+
+.. py:currentmodule:: casefoo
+
+.. py:class:: Foo
+   :no-index:
+
+   .. autosummary::
+
+      crop

--- a/tests/test_ext_autosummary/test_ext_autosummary.py
+++ b/tests/test_ext_autosummary/test_ext_autosummary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from contextlib import chdir
 from io import StringIO
@@ -821,6 +822,105 @@ def test_import_by_name() -> None:
     assert obj == sphinx.ext.autosummary.Autosummary.get_items
     assert parent is sphinx.ext.autosummary.Autosummary
     assert modname == 'sphinx.ext.autosummary'
+
+
+def _make_case_insensitive_finder(pkg_dir, package_name):
+    # emulate the Windows/macOS import behaviour from GH-11362: submodule
+    # names resolve case-insensitively, e.g. ``pkg.Foo`` finds ``pkg/foo.py``
+    class CaseInsensitiveFinder:
+        @staticmethod
+        def find_spec(fullname, path=None, target=None):  # NoQA: ARG004
+            parent_name, _, child = fullname.rpartition('.')
+            if parent_name != package_name or child == child.lower():
+                return None
+            location = pkg_dir / f'{child.lower()}.py'
+            if location.is_file():
+                return importlib.util.spec_from_file_location(fullname, location)
+            return None
+
+    return CaseInsensitiveFinder
+
+
+@pytest.mark.usefixtures('rollback_sysmodules')
+def test_import_by_name_class_shadowing_module(tmp_path, monkeypatch):
+    # https://github.com/sphinx-doc/sphinx/issues/11362
+    # ``case_pkg.Foo`` (class) and ``case_pkg/foo.py`` (module) collide on
+    # case-insensitive filesystems: importing ``case_pkg.Foo`` succeeds there,
+    # returning the mis-cased module and clobbering the class attribute.
+    pkg = tmp_path / 'case_pkg'
+    pkg.mkdir()
+    (pkg / '__init__.py').write_text('from .foo import Foo\n', encoding='utf-8')
+    (pkg / 'foo.py').write_text(
+        'class Foo:\n    def crop(self):\n        """Crop."""\n', encoding='utf-8'
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    finder = _make_case_insensitive_finder(pkg, 'case_pkg')
+    monkeypatch.setattr(sys, 'meta_path', [*sys.meta_path, finder])
+
+    prefixed_name, obj, parent, modname = import_by_name('case_pkg.Foo.crop')
+    case_pkg = sys.modules['case_pkg']
+    assert prefixed_name == 'case_pkg.Foo.crop'
+    assert obj is case_pkg.Foo.crop
+    assert parent is case_pkg.Foo
+    assert modname == 'case_pkg'
+    # the class must not have been shadowed by a mis-cased module import
+    assert isinstance(case_pkg.Foo, type)
+    assert 'case_pkg.Foo' not in sys.modules
+
+
+@pytest.mark.usefixtures('rollback_sysmodules')
+def test_import_by_name_attribute_shadows_module(tmp_path, monkeypatch):
+    # a function shadowing its own module (``from .util import util``) must
+    # not prevent resolving other members of the shadowed module
+    pkg = tmp_path / 'shadow_pkg'
+    pkg.mkdir()
+    (pkg / '__init__.py').write_text('from .util import util\n', encoding='utf-8')
+    (pkg / 'util.py').write_text(
+        'def util():\n    """Shadow."""\n\n\ndef helper():\n    """Help."""\n',
+        encoding='utf-8',
+    )
+    # a submodule not imported by __init__ at all
+    (pkg / 'bar.py').write_text('class Bar:\n    """Bar."""\n', encoding='utf-8')
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    _prefixed_name, obj, _parent, modname = import_by_name('shadow_pkg.util')
+    assert callable(obj)  # the attribute, not the module
+    assert modname == 'shadow_pkg'
+
+    _prefixed_name, obj, parent, modname = import_by_name('shadow_pkg.util.helper')
+    assert obj is sys.modules['shadow_pkg.util'].helper
+    assert parent is sys.modules['shadow_pkg.util']
+    assert modname == 'shadow_pkg.util'
+
+    _prefixed_name, obj, _parent, modname = import_by_name('shadow_pkg.bar.Bar')
+    assert obj is sys.modules['shadow_pkg.bar'].Bar
+    assert modname == 'shadow_pkg.bar'
+
+
+@pytest.mark.sphinx(
+    'dummy',
+    testroot='ext-autosummary-case-insensitive',
+    copy_test_root=True,
+)
+@pytest.mark.usefixtures('rollback_sysmodules')
+def test_autosummary_class_module_case_collision(app, monkeypatch):
+    # end to end: with the case-insensitive import behaviour emulated, a class
+    # and its same-named module can be documented together as long as
+    # autosummary_filename_map disambiguates the stub filenames
+    finder = _make_case_insensitive_finder(app.srcdir / 'casefoo', 'casefoo')
+    monkeypatch.setattr(sys, 'meta_path', [*sys.meta_path, finder])
+
+    app.build()
+    assert app.warning.getvalue() == ''
+
+    class_stub = (app.srcdir / 'generated' / 'casefoo.Foo.rst').read_text(
+        encoding='utf-8'
+    )
+    assert 'crop' in class_stub
+    module_stub = (app.srcdir / 'generated' / 'casefoo.foo-module.rst').read_text(
+        encoding='utf-8'
+    )
+    assert 'find_foo' in module_stub
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
## Purpose

Originally found this when trying to document the class `mne.Dipole` when there is also the `mne.dipole` module. Sphinx would try to import `mne.Dipole` *first*, which could succeed on a case-insensitive filesystem (and was observed on Windows) but errantly import `mne.dipole` (so all the class attributes etc. were missing). This PR changes the order: look for a (case-sensitive) `sys.modules` existence (for intermediate components), then an attribute `getattr(mne, "Dipole")`, and then try an import.

This PR mocks the case-insensitive import behavior via a `sys.meta_path` finder so it's reproducible on all platforms and more easily tested. It also does a combined test with `autosummary_filename_map`, which helps with a similar problem. Two tests are red on `master` but pass on this PR, and the third (`test_import_by_name_attribute_shadows_module`) is there to make sure an existing case on `master` (a function shadowing its own module like `from .util import util`) isn't broken.

## References

Closes #11362 (mine -- 3+ years ago, now I could finally look into it more deeply!)

## AI Disclosure

Claude Fable 5 was used to write the implementation, tests, and changelog entry. I reviewed and validated the implementation (e.g., suggesting a combined test to hit the `autosummary_filename_map` path as well).
