### PR TITLE
linkcheck: stop reporting local file links with query/fragment as [broken]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14542: linkcheck: Stop reporting local file links that include a query
+  (``?``) or fragment (``#``) component as ``[broken]``. The query and
+  fragment are now stripped before the filesystem existence check.
+  Patch by sudorm-rf0
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -473,7 +473,11 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                 # Non-supported URI schemes (ex. ftp)
                 return _Status.UNCHECKED, '', 0
 
-            if (hyperlink.docpath.parent / uri).exists():
+            # Strip any query (?) and fragment (#) components before
+            # checking the filesystem, since they are not part of the
+            # filename. Regression test for #14542.
+            uri_path = urlsplit(uri).path
+            if (hyperlink.docpath.parent / uri_path).exists():
                 return _Status.WORKING, '', 0
             return _Status.BROKEN, '', 0
 

--- a/tests/test_builders/test_build_linkcheck.py
+++ b/tests/test_builders/test_build_linkcheck.py
@@ -1522,3 +1522,30 @@ def test_linkcheck_case_sensitivity(
     assert rowsby[f'http://{address}/path1']['status'] == expected_path1
     assert rowsby[f'http://{address}/path2']['status'] == expected_path2
     assert rowsby[f'http://{address}/PATH3']['status'] == expected_path3
+
+
+def test_linkcheck_local_uri_with_query_or_fragment(
+    make_app: Callable[..., SphinxTestApp], tmp_path: Path
+) -> None:
+    # Regression test for #14542: a local file referenced with a query (?)
+    # or fragment (#) should still be reported as working, because those
+    # components are not part of the filename.
+    tmp_path.joinpath('conf.py').write_text('')
+    tmp_path.joinpath('target.html').write_text('Target')
+    tmp_path.joinpath('index.rst').write_text(
+        'Test\n====\n\n'
+        '`query <target.html?view=full>`_\n'
+        '`fragment <target.html#section>`_\n'
+        '`plain <target.html>`_\n'
+    )
+
+    app = make_app('linkcheck', srcdir=tmp_path)
+    app.build()
+
+    with open(app.outdir / 'output.json', encoding='utf-8') as fp:
+        rows = [json.loads(l) for l in fp]
+
+    records = {row['uri']: row for row in rows}
+    assert records['target.html']['status'] == 'working'
+    assert records['target.html?view=full']['status'] == 'working'
+    assert records['target.html#section']['status'] == 'working'


### PR DESCRIPTION
Hi,

`linkcheck` currently marks local-file links that carry a query or fragment — e.g. `target.html?view=full` or `target.html#section` — as `[broken]`, even though the file `target.html` exists on disk.

**AI assistance disclosure (per the AI policy):** An AI coding assistant helped me draft the first version of the patch and the test. I reviewed the change and understand it; I am opening this PR myself.

**Root cause**

In `sphinx/builders/linkcheck.py`, the local-file branch checks whether the target exists by joining the URI straight onto the doc directory:

    if (hyperlink.docpath.parent / uri).exists():

The `?` and `#` parts are not part of the filename, so the joined path (`.../target.html?view=full`) never matches the real file and the link is reported broken. This was introduced in #7985.

**Fix**

Strip the query/fragment before the existence check:

    # Strip any query (?) and fragment (#) components before
    # checking the filesystem, since they are not part of the
    # filename. Regression test for #14542.
    uri_path = urlsplit(uri).path
    if (hyperlink.docpath.parent / uri_path).exists():
        return _Status.WORKING, '', 0

`urlsplit` is already imported in the module. The `http(s)://` branch that handles remote links is earlier and untouched.

**Verification**

- Added `tests/test_builders/test_build_linkcheck.py::test_linkcheck_local_uri_with_query_or_fragment`, which builds a tiny project linking to `target.html`, `target.html?view=full`, and `target.html#section`. It fails (reports `broken`) without the fix and passes with it.
- Full `tests/test_builders/test_build_linkcheck.py` passes, no regressions.
- Added a CHANGES.rst entry.

Fixes #14542.
