### PR TITLE
Fix dirhtml builder ignoring html-format node handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #14587: ``dirhtml`` builder: custom node handlers registered for the shared
+  ``html`` format are no longer ignored when an extension also registers a
+  handler for the ``dirhtml`` builder name.
+
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -429,10 +429,13 @@ class SphinxComponentRegistry:
         translator = translator_class(*args)
 
         # transplant handlers for custom nodes to translator instance
-        handlers = self.translation_handlers.get(builder.name, None)
-        if handlers is None:
-            # retry with builder.format
-            handlers = self.translation_handlers.get(builder.format, {})
+        handlers = {}
+        # Merge format-level handlers (e.g. ``html``) first so builders that
+        # share a format but use a distinct name (e.g. ``dirhtml``) still get
+        # the format's handlers. Builder-name-specific handlers take
+        # precedence and are overlaid on top.
+        handlers.update(self.translation_handlers.get(builder.format, {}))
+        handlers.update(self.translation_handlers.get(builder.name, {}))
 
         for name, (visit, depart) in handlers.items():
             setattr(translator, 'visit_' + name, MethodType(visit, translator))

--- a/tests/test_builders/test_build_dirhtml.py
+++ b/tests/test_builders/test_build_dirhtml.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import posixpath
 from typing import TYPE_CHECKING
 
+import docutils
 import pytest
+from docutils.parsers import rst
+from docutils.readers import standalone
+from docutils.writers import html5_polyglot
 
+from sphinx.util.docutils import _get_settings, new_document
 from sphinx.util.inventory import InventoryFile, _InventoryItem
 
 if TYPE_CHECKING:
@@ -65,3 +70,33 @@ def test_dirhtml(app: SphinxTestApp) -> None:
         uri='path/to/foo/#foo',
         display_name='foo/index',
     )
+
+
+@pytest.mark.sphinx('dirhtml', testroot='builder-dirhtml')
+def test_dirhtml_inherits_format_translation_handlers(app: SphinxTestApp) -> None:
+    # A custom node with a dirhtml-specific handler must not hide handlers
+    # registered for the shared ``html`` format (e.g. graphviz nodes).
+    # See https://github.com/sphinx-doc/sphinx/issues/14587
+    class DirhtmlOnlyNode(docutils.nodes.General, docutils.nodes.Element):
+        pass
+
+    class HtmlOnlyNode(docutils.nodes.General, docutils.nodes.Element):
+        pass
+
+    def visit_custom(self, node: docutils.nodes.Node) -> None:
+        raise docutils.nodes.SkipNode
+
+    app.add_node(
+        DirhtmlOnlyNode, html=(visit_custom, None), dirhtml=(visit_custom, None)
+    )
+    app.registry.add_translation_handlers(
+        HtmlOnlyNode, html=(visit_custom, None)
+    )
+
+    settings = _get_settings(
+        standalone.Reader, rst.Parser, html5_polyglot.Writer, defaults={}
+    )
+    document = new_document('test', settings)
+    translator = app.builder.create_translator(document, app.builder)
+    assert hasattr(translator, 'visit_DirhtmlOnlyNode')
+    assert hasattr(translator, 'visit_HtmlOnlyNode')


### PR DESCRIPTION
### Feature or bugfix
- Bugfix

### Purpose
Fix ``NotImplementedError`` in the ``dirhtml`` builder when an extension registers node handlers for both the ``dirhtml`` builder name and the shared ``html`` format (e.g. combining a custom node with ``sphinx.ext.graphviz``).

### Detail
``Registry.create_translator`` looked up translation handlers by ``builder.name`` and only fell back to ``builder.format`` when no name-specific handlers existed. A builder like ``dirhtml`` (name ``dirhtml``, format ``html``) therefore lost every handler registered for the shared ``html`` format as soon as any extension registered a ``dirhtml``-specific handler — causing ``NotImplementedError: departing unknown node type`` for nodes such as ``graphviz``.

The fix merges the format-level handlers first and overlays the builder-name handlers, so both sets are transplanted onto the translator.

### Additional info
- Fixes #14587
- Regression test added in ``tests/test_builders/test_build_dirhtml.py``
- Tested: ``pytest tests/test_builders/test_build_dirhtml.py tests/test_builders/test_build_html.py tests/test_builders/test_build_texinfo.py tests/test_builders/test_build_epub.py`` (89 passed)

### AI disclosure
This PR was developed with assistance from Claude (via Command Code). The changes were fully reviewed and verified by a human contributor.
