### PR TITLE
Fix suppression of duplicate glossary term warnings

### DIFF
--- a/sphinx/domains/std/__init__.py
+++ b/sphinx/domains/std/__init__.py
@@ -860,6 +860,7 @@ class StandardDomain(Domain):
                 name,
                 docname,
                 location=location,
+                type='ref', subtype=objtype,
             )
         self.objects[objtype, name] = (self.env.current_document.docname, labelid)
 

--- a/sphinx/domains/std/__init__.py
+++ b/sphinx/domains/std/__init__.py
@@ -860,7 +860,8 @@ class StandardDomain(Domain):
                 name,
                 docname,
                 location=location,
-                type='ref', subtype=objtype,
+                type='ref',
+                subtype=objtype,
             )
         self.objects[objtype, name] = (self.env.current_document.docname, labelid)
 


### PR DESCRIPTION

## Purpose


Tag duplicate standard-domain object warnings with `ref.<object type>` type/subtype metadata. This exposes:

- `ref.term`
- `ref.token`
- `ref.confval`
- `ref.envvar`
- `ref.<custom-type>` for types registered by extensions

and makes duplicate glossary term warnings use the `ref.term` warning code, allowing them to be suppressed with:
```python
suppress_warnings = ["ref.term"]
```

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Fixes https://github.com/sphinx-doc/sphinx/issues/13161


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->

I used AI to find where in the code base to apply the type/subtype