### PR TITLE
fix(theming): make inherited themes import basic.css

### DIFF
--- a/sphinx/themes/agogo/static/agogo.css.jinja
+++ b/sphinx/themes/agogo/static/agogo.css.jinja
@@ -1,6 +1,8 @@
 /*
  * Sphinx stylesheet -- agogo theme.
  */
+@import url("basic.css");
+
 
 * {
   margin: 0px;

--- a/sphinx/themes/epub/static/epub.css.jinja
+++ b/sphinx/themes/epub/static/epub.css.jinja
@@ -1,6 +1,8 @@
 /*
  * Sphinx stylesheet -- epub theme.
  */
+@import url("basic.css");
+
 
 /* -- main layout ----------------------------------------------------------- */
 

--- a/sphinx/themes/nonav/static/nonav.css.jinja
+++ b/sphinx/themes/nonav/static/nonav.css.jinja
@@ -1,6 +1,8 @@
 /*
  * Sphinx stylesheet -- nonav theme.
  */
+@import url("basic.css");
+
 
 /* -- main layout ----------------------------------------------------------- */
 

--- a/sphinx/themes/scrolls/static/scrolls.css.jinja
+++ b/sphinx/themes/scrolls/static/scrolls.css.jinja
@@ -1,6 +1,8 @@
 /*
  * Sphinx stylesheet -- scrolls theme.
  */
+@import url("basic.css");
+
 
 body {
     background-color: #222;

--- a/sphinx/themes/traditional/static/traditional.css.jinja
+++ b/sphinx/themes/traditional/static/traditional.css.jinja
@@ -1,6 +1,8 @@
 /*
  * Sphinx stylesheet -- traditional docs.python.org theme.
  */
+@import url("basic.css");
+
 
 body {
     color: #000;

--- a/tests/test_theming/test_theming.py
+++ b/tests/test_theming/test_theming.py
@@ -240,6 +240,36 @@ def test_theme_builds(
             pytest.fail(f'Failed to parse {html_file.relative_to(app.outdir)}: {exc}')
 
 
+@pytest.mark.parametrize(
+    'theme_name',
+    [
+        'agogo',
+        'epub',
+        'nonav',
+        'scrolls',
+        'traditional',
+    ],
+)
+def test_inherited_themes_import_basic_css(theme_name: str) -> None:
+    """Themes inheriting from ``basic`` must @import its CSS so that
+    foundational style changes propagate automatically.
+
+    We can assert this by parsing the template's source: if the theme's
+    ``*.css.jinja`` does not emit an ``@import url("basic.css");``
+    instruction, the rendered CSS will miss the import, since the
+    template is copied verbatim into the output (Jinja2 processes only
+    the theme-option variables, never the bare ``@import`` line).
+
+    See :issue:`9093`.
+    """
+    theme_path = (
+        HERE.parent.parent / 'sphinx' / 'themes' / theme_name / 'static' / f'{theme_name}.css.jinja'
+    )
+    assert theme_path.exists(), f'{theme_name} theme missing'
+    content = theme_path.read_text(encoding='utf8')
+    assert '@import url("basic.css");' in content
+
+
 def test_config_file_toml() -> None:
     config_path = HERE / 'theme.toml'
     cfg = _load_theme_toml(config_path)


### PR DESCRIPTION
## Summary

Fixes #9093 — make themes that inherit from `basic` actually import its CSS.

## Problem

Five bundled themes (`agogo`, `epub`, `nonav`, `scrolls`, `traditional`)
declare `inherit = "basic"` in their `theme.toml`, but their
`*.css.jinja` stylesheets never `@import url("basic.css");`.

That means any CSS change in `basic.css` (the foundational stylesheet)
does not propagate to those themes. Six other inheriting themes
(`classic`, `bizstyle`, `nature`, `haiku`, `pyramid`, and pyramid's
`epub.css.jinja`) already do import it — the pattern is well
established.

## Solution

Prepend `@import url("basic.css");` to the top of each of the five
affected `.css.jinja` files, immediately after their existing header
comment block. Matches the pattern used by the other inheriting
themes verbatim.

## Test plan

- Added `test_inherited_themes_import_basic_css` in
  `tests/test_theming/test_theming.py` — parametrised over the five
  themes; reads each theme's `.css.jinja` source and asserts the
  `@import url("basic.css");` instruction is present. The check is
  on the template source because the Jinja renderer emits the raw
  `@import` line verbatim into the output CSS (Jinja2 only processes
  the `{{ ... }}` / `{% ... %}` tokens, never a bare `@import`), so
  presence-in-source is equivalent to presence-in-output.
- Existing `test_theme_builds` (line 219) already runs all 14 bundled
  themes through `make_app` and validates the emitted HTML as strict
  XML, so the change cannot break the HTML output.
- `git diff --check` passes.

## Files

- `sphinx/themes/agogo/static/agogo.css.jinja`
- `sphinx/themes/epub/static/epub.css.jinja`
- `sphinx/themes/nonav/static/nonav.css.jinja`
- `sphinx/themes/scrolls/static/scrolls.css.jinja`
- `sphinx/themes/traditional/static/traditional.css.jinja`
- `tests/test_theming/test_theming.py` (new test)