### PR TITLE
Fix crash when a section title contains a download role

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -79,6 +79,7 @@ Contributors
 * Juan Luis Cano Rodríguez -- new tutorial (2021)
 * Julien Palard -- Colspan and rowspan in text builder
 * Justus Magin -- napoleon improvements
+* Kayvan Zahiri -- toctree bug fix
 * Kazuya Take -- ``sphinx.testing.path`` bug fix
 * Kevin Dunn -- MathJax extension
 * KINEBUCHI Tomohiko -- typing Sphinx as well as docutils

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14514: Fix a build crash (``KeyError: 'refuri'`` or ``KeyError:
+  'anchorname'``) when a section title contains a :rst:role:`download` role.
+  Patch by Kayvan Zahiri
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/environment/adapters/toctree.py
+++ b/sphinx/environment/adapters/toctree.py
@@ -63,6 +63,9 @@ def document_toc(env: BuildEnvironment, docname: str, tags: Tags) -> Node:
         return nodes.paragraph()
 
     for node in toc.findall(nodes.reference):
+        if 'anchorname' not in node:
+            # not a ToC entry, but a reference nested within the entry's text
+            continue
         node['refuri'] = node['anchorname'] or '#'
     return toc
 
@@ -214,6 +217,9 @@ def _resolve_toctree(
     # set the target paths in the toctrees (they are not known at TOC
     # generation time)
     for refnode in newnode.findall(nodes.reference):
+        if 'anchorname' not in refnode:
+            # not a ToC entry, but a reference nested within the entry's text
+            continue
         if url_re.match(refnode['refuri']) is None:
             rel_uri = builder.get_relative_uri(docname, refnode['refuri'])
             refnode['refuri'] = rel_uri + refnode['anchorname']
@@ -447,7 +453,7 @@ def _toctree_standard_entry(
     if title and toc.children and len(toc.children) == 1:
         child = toc.children[0]
         for refnode in child.findall(nodes.reference):
-            if refnode['refuri'] == ref and not refnode['anchorname']:
+            if refnode.get('refuri') == ref and not refnode.get('anchorname'):
                 refnode.children[:] = [nodes.Text(title)]
     return toc, refdoc
 
@@ -465,8 +471,8 @@ def _toctree_add_classes(node: Element, depth: int, docname: str) -> None:
         elif isinstance(subnode, nodes.reference):
             # for <a>, identify which entries point to the current
             # document and therefore may not be collapsed
-            if subnode['refuri'] == docname:
-                if not subnode['anchorname']:
+            if subnode.get('refuri') == docname:
+                if not subnode.get('anchorname'):
                     # give the whole branch a 'current' class
                     # (useful for styling it differently)
                     branchnode: Element = subnode

--- a/sphinx/transforms/__init__.py
+++ b/sphinx/transforms/__init__.py
@@ -353,6 +353,10 @@ class SphinxContentsFilter(ContentsFilter):
     """
 
     visit_pending_xref = ContentsFilter.ignore_node_but_process_children
+    # ``download_reference`` subclasses ``reference``, but is created during
+    # parsing rather than during reference resolution, so it is not covered
+    # by ``ContentsFilter.visit_reference``.
+    visit_download_reference = ContentsFilter.ignore_node_but_process_children
 
     def visit_image(self, node: nodes.image) -> None:
         raise nodes.SkipNode

--- a/tests/roots/test-toctree-download/example.txt
+++ b/tests/roots/test-toctree-download/example.txt
@@ -1,0 +1,1 @@
+Example download file.

--- a/tests/roots/test-toctree-download/foo.rst
+++ b/tests/roots/test-toctree-download/foo.rst
@@ -1,0 +1,7 @@
+foo
+===
+
+Get :download:`example.txt` here
+--------------------------------
+
+Body text.

--- a/tests/roots/test-toctree-download/index.rst
+++ b/tests/roots/test-toctree-download/index.rst
@@ -1,0 +1,6 @@
+test-toctree-download
+=====================
+
+.. toctree::
+
+   foo

--- a/tests/test_environment/test_environment_toctree.py
+++ b/tests/test_environment/test_environment_toctree.py
@@ -1102,3 +1102,47 @@ def test_toctree_copy_only():
     assert isinstance(extract_node(toc, 0, 0, 0), nodes.reference)
     assert isinstance(extract_node(toc, 0, 0, 0, 0), nodes.literal)
     assert extract_node(toc, 0, 0, 0, 0, 0) == nodes.Text('lobster!')
+
+
+@pytest.mark.sphinx('html', testroot='toctree-download')
+def test_toctree_download_reference_in_section_title(app):
+    # regression test for https://github.com/sphinx-doc/sphinx/issues/14514
+    # ``download_reference`` subclasses ``reference`` and is created while
+    # parsing, so it used to be copied into the ToC entry without the
+    # ``anchorname`` and ``refuri`` attributes that ToC entries carry.
+    app.build()
+
+    toc = app.env.tocs['foo']
+    assert list(toc.findall(addnodes.download_reference)) == []
+    assert_node(
+        extract_node(toc, 0, 1, 0, 0),
+        [compact_paragraph, reference, ('Get ', [literal, 'example.txt'], ' here')],
+    )
+
+    # resolving the local and the global ToC no longer raises ``KeyError``
+    document_toc(app.env, 'foo', app.tags)
+    global_toctree_for_doc(app.env, 'foo', app.builder, tags=app.tags)
+
+
+@pytest.mark.sphinx('html', testroot='toctree-download')
+def test_toctree_nested_reference_is_left_alone(app):
+    # regression test for https://github.com/sphinx-doc/sphinx/issues/14514
+    # references nested within the text of a ToC entry (as extensions may add)
+    # are not ToC entries themselves, and must not be treated as such.
+    app.build()
+    entry = extract_node(app.env.tocs['foo'], 0, 1, 0, 0, 0)
+    assert isinstance(entry, reference)
+    entry += reference('', 'nested', refid='nested')
+
+    local_toc = document_toc(app.env, 'foo', app.tags)
+    nested = [node for node in local_toc.findall(reference) if 'anchorname' not in node]
+    assert len(nested) == 1
+    assert 'refuri' not in nested[0]
+
+    global_toc = global_toctree_for_doc(app.env, 'foo', app.builder, tags=app.tags)
+    assert global_toc is not None
+    nested = [
+        node for node in global_toc.findall(reference) if 'anchorname' not in node
+    ]
+    assert len(nested) == 1
+    assert 'refuri' not in nested[0]


### PR DESCRIPTION
Fixes #14514.

A `:download:` role in a section title crashes the build:

```
conf.py     (empty)
index.rst   Index\n=====\n\n.. toctree::\n\n   a\n
a.rst       Doc A\n=====\n\ndl :download:`a.rst` here\n-------------------------\n\nbody\n
```

```
dummy builder -> KeyError: 'refuri'      (_resolve_toctree)
html builder  -> KeyError: 'anchorname'  (document_toc)
```

`download_reference` subclasses `nodes.reference` but is built at parse time
rather than at reference resolution, since the download role is registered as
`XRefRole(nodeclass=...)`. Every other xref role leaves a `pending_xref` behind.
So it survives `SphinxContentsFilter` into `env.tocs` without a `refuri`, and the
toctree adapter reads that key unconditionally.

Fixed in the filter, with guards on the two unconditional reads in the adapter.
Reverting either half leaves one of the new tests failing.

Note the issue blames a monorepo layout with `root_doc` outside the conf.py
directory. I built that exactly and it works on main, so I think the real trigger
is the download role. Of eight other things I tried in a heading, only that one
breaks. Worth confirming with the reporter.

## AI Disclosure

An AI assistant helped investigate this and draft the change and tests. I
reproduced the crash and verified each half independently.
