### PR TITLE
Fix UnboundLocalError in read_svg_depth for empty SVG files (#14466)

### DIFF
--- a/sphinx/ext/imgmath.py
+++ b/sphinx/ext/imgmath.py
@@ -69,6 +69,10 @@ depthsvgcomment_re = re.compile(r'<!-- DEPTH=(-?\d+) -->')
 def read_svg_depth(filename: str | os.PathLike[str]) -> int | None:
     """Read the depth from comment at last line of SVG file"""
     with open(filename, encoding='utf-8') as f:
+        # An empty file (or one that was truncated mid-write by a concurrent
+        # build) yields no lines, so `line` stays unbound; treat that as "no
+        # depth" instead of raising UnboundLocalError.
+        line = ''
         for line in f:  # NoQA: B007
             pass
         # Only last line is checked

--- a/tests/test_extensions/test_ext_math.py
+++ b/tests/test_extensions/test_ext_math.py
@@ -625,3 +625,34 @@ def test_duplicate_equation_label_warning_type(app: SphinxTestApp) -> None:
     warnings = strip_escape_sequences(app.warning.getvalue())
     assert 'WARNING: duplicate label of equation duplicated' in warnings
     assert '[ref.equation]' in warnings
+
+
+def test_read_svg_depth(tmp_path):
+    """read_svg_depth returns the depth from the last line's comment."""
+    svg = tmp_path / 'math.svg'
+    svg.write_text('<svg></svg>\n<!-- DEPTH=42 -->\n', encoding='utf8')
+
+    from sphinx.ext.imgmath import read_svg_depth
+
+    assert read_svg_depth(svg) == 42
+
+
+def test_read_svg_depth_without_comment(tmp_path):
+    """read_svg_depth returns None when the last line has no DEPTH comment."""
+    svg = tmp_path / 'math.svg'
+    svg.write_text('<svg></svg>\n', encoding='utf8')
+
+    from sphinx.ext.imgmath import read_svg_depth
+
+    assert read_svg_depth(svg) is None
+
+
+def test_read_svg_depth_empty_file(tmp_path):
+    """read_svg_depth returns None for an empty (or truncated) file instead of
+    raising UnboundLocalError (#14466)."""
+    svg = tmp_path / 'math.svg'
+    svg.write_text('', encoding='utf8')
+
+    from sphinx.ext.imgmath import read_svg_depth
+
+    assert read_svg_depth(svg) is None


### PR DESCRIPTION
Closes #14466

## Problem

`read_svg_depth()` iterates the SVG file and matches the depth comment on the *last* line. When the file is empty — e.g. a parallel `imgmath` build catches an SVG mid-write — the loop body never runs, `line` stays unbound, and the match raises:

```
UnboundLocalError: cannot access local variable 'line' where it is not associated with a value
```

## Fix

Initialize `line` to `''` so an empty/truncated file reads as "no depth" (`None`) instead of crashing. Sporadic failures like #14466 (reported intermittently since Sphinx 5.3 on parallel builds) become a benign no-op.

## Tests

Added direct unit tests in `tests/test_extensions/test_ext_math.py`:
- empty file → `None` (the #14466 regression)
- no DEPTH comment → `None`
- normal file with `<!-- DEPTH=42 -->` on the last line → `42`

Verified the pre-fix code raises the reported `UnboundLocalError` on the empty-file case, and all three new tests pass after the fix.
