### PR TITLE
Only show category and message for SphinxError exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14543: Only print the category and message for :exc:`~sphinx.errors.SphinxError`
+  exceptions, such as those raised by extensions or ``conf.py``. The environment
+  details, loaded extension list, saved traceback and bug report prompt are again
+  reserved for unexpected exceptions.
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/_cli/util/errors.py
+++ b/sphinx/_cli/util/errors.py
@@ -211,14 +211,31 @@ def handle_exception(
         )
         print_err('\n    import sys\n    sys.setrecursionlimit(1_500)\n')
 
+    # ``SphinxError`` and its subclasses are the documented "nice" exceptions:
+    # the build failed for a reason the user or an extension can act on, so only
+    # the category and message are shown. The environment details, extension
+    # list, saved traceback and bug report prompt are reserved for unexpected
+    # exceptions, which is what they are useful for.
+    nice_error = isinstance(exception, SphinxError)
+
     print_err()
-    error_context = full_exception_context(
-        exception,
-        message_log=message_log,
-        extensions=extensions,
-        full_traceback=print_traceback or use_pdb,
-    )
-    print_err(error_context)
+    if nice_error:
+        print_err(str(exception))
+        # ``-T`` prints on the console the traceback that would otherwise be
+        # saved to a temporary file. Nice errors do not save one, so there is
+        # none to print; ``--pdb`` is honoured because it is a request to debug
+        # this exception.
+        if use_pdb:
+            print_err()
+            print_err(format_traceback(exception))
+    else:
+        error_context = full_exception_context(
+            exception,
+            message_log=message_log,
+            extensions=extensions,
+            full_traceback=print_traceback or use_pdb,
+        )
+        print_err(error_context)
     print_err()
 
     if use_pdb:
@@ -226,6 +243,9 @@ def handle_exception(
 
         print_red(__('Starting debugger:'))
         post_mortem(exception.__traceback__)
+        return
+
+    if nice_error:
         return
 
     # Save full traceback to log file

--- a/tests/test__cli/test__cli_util_errors.py
+++ b/tests/test__cli/test__cli_util_errors.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import itertools
 import operator
+from io import StringIO
 from typing import TYPE_CHECKING
 
+import pytest
+
 from sphinx._cli.util.colour import blue, reset
-from sphinx._cli.util.errors import strip_escape_sequences
+from sphinx._cli.util.errors import handle_exception, strip_escape_sequences
+from sphinx.errors import ConfigError, ExtensionError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Final
+
+    from sphinx.errors import SphinxError
 
 CURSOR_UP: Final[str] = '\x1b[2A'  # ignored ANSI code
 ERASE_LINE: Final[str] = '\x1b[2K'  # supported ANSI code
@@ -79,3 +85,84 @@ def test_strip_ansi_short_forms() -> None:
 
     # \x1b[K is equivalent to \x1b[0K
     assert strip_escape_sequences('\x1b[K') == ''
+
+
+def _handle(exception: BaseException, **kwargs: object) -> str:
+    stderr = StringIO()
+    handle_exception(exception, stderr=stderr, **kwargs)  # type: ignore[arg-type]
+    return stderr.getvalue()
+
+
+def _raised(exception: BaseException) -> BaseException:
+    """Return *exception* with a real traceback attached."""
+
+    def _raise() -> None:
+        raise exception
+
+    try:
+        _raise()
+    except BaseException as exc:
+        return exc
+    msg = 'unreachable'
+    raise AssertionError(msg)
+
+
+@pytest.mark.parametrize('exception', [ExtensionError('boom'), ConfigError('boom')])
+def test_handle_exception_nice_errors_are_short(exception: SphinxError) -> None:
+    # SphinxError subclasses are expected errors: only the category and the
+    # message are shown, so extensions and conf.py can report problems without
+    # implying that Sphinx itself is broken. Refs: #14543
+    out = _handle(_raised(exception))
+
+    assert exception.category in out
+    assert 'boom' in out
+    assert 'Versions' not in out
+    assert 'Loaded Extensions' not in out
+    assert 'Traceback' not in out
+    assert 'full traceback has been saved' not in out
+    assert 'report this error to the developers' not in out
+
+
+def test_handle_exception_nice_error_no_traceback_with_T() -> None:
+    # -T prints on the console the traceback that would otherwise be written to
+    # a temporary file. A nice error saves no such file, so -T must not print
+    # one either: an extension reporting a user error should not show a
+    # traceback.
+    out = _handle(_raised(ExtensionError('boom')), print_traceback=True)
+
+    assert 'boom' in out
+    assert 'in _raise' not in out
+    assert 'Traceback' not in out
+    assert 'full traceback has been saved' not in out
+    assert 'report this error to the developers' not in out
+
+
+def test_handle_exception_unexpected_error_traceback_with_T(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # For an unexpected exception -T does print the traceback it would have
+    # saved.
+    monkeypatch.setattr(
+        'sphinx._cli.util.errors.write_temporary_file',
+        lambda content: 'sphinx-err-fake.log',
+    )
+    out = _handle(_raised(RuntimeError('boom')), print_traceback=True)
+
+    assert 'in _raise' in out
+
+
+def test_handle_exception_unexpected_errors_are_verbose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Exceptions that are not SphinxError subclasses are unexpected, and keep
+    # the full context and the bug report prompt.
+    monkeypatch.setattr(
+        'sphinx._cli.util.errors.write_temporary_file',
+        lambda content: 'sphinx-err-fake.log',
+    )
+    out = _handle(_raised(RuntimeError('boom')))
+
+    assert 'Versions' in out
+    assert 'Loaded Extensions' in out
+    assert 'full traceback has been saved' in out
+    assert 'report this error to the developers' in out


### PR DESCRIPTION
Fixes #14543

### Feature or Bugfix

- Bugfix

### Purpose

An `ExtensionError` raised by an extension, or a `ConfigError` raised by `conf.py`, prints the version table, the loaded extension list, a saved traceback file and a prompt to report a bug in Sphinx. Those are expected errors the user can act on, so the output implied a Sphinx bug where there was none (a regression from ~7.2.6, and contrary to the intent of #7108).

This restores the documented behaviour of "nice" exceptions: only the category and message are shown.

### Detail

`SphinxError` is documented as the base class for "nice" exceptions — when one is raised, Sphinx aborts and presents just the category and message. `handle_exception` had stopped making that distinction and gave every exception the "unexpected" treatment (full context + saved traceback + bug report prompt).

Now:

| | nice error (`SphinxError`) | unexpected exception |
|---|---|---|
| default | `Extension error!` + message | context + short traceback + saved file + bug prompt |
| `-T` | unchanged | as above, with the full traceback on the console |

Because nice errors no longer save a traceback file, `-T` has nothing extra to print for them — which keeps the two halves consistent without special-casing, and matches the request in the issue thread. `--pdb` is still honoured (it is an explicit request to debug the exception). `SphinxParallelError` is also a `SphinxError`, so `-j auto` builds are covered as well.

### Testing

New tests in `tests/test__cli/test__cli_util_errors.py` cover the short output for `ExtensionError` and `ConfigError`, the `-T` opt-in for both nice and unexpected exceptions, and that unexpected exceptions keep the full context. Verified end to end with an extension raising `ExtensionError` and a `conf.py` raising `ConfigError`, including that no `sphinx-err-*.log` is written and that `-T` behaves as described. `tests/test__cli`, `tests/test_errors.py` and `tests/test_util` pass (the one failure, `test_restify_Unpack`, is a missing optional module and reproduces on a clean checkout).

### AI disclosure

Per the [AI policy](https://www.sphinx-doc.org/en/master/internals/ai-policy.html): this pull request was developed with AI assistance (the Codebuff coding agent). The AI was used to reproduce the issue, implement the fix described above, and write the accompanying tests and this description. The changes are small and I understand and can explain every part of them. No third-party copyrighted code is included.
