### PR TITLE
Fix autodoc restoring intentionally cleared annotations

### DIFF
--- a/sphinx/ext/autodoc/_dynamic/_type_comments.py
+++ b/sphinx/ext/autodoc/_dynamic/_type_comments.py
@@ -88,6 +88,12 @@ def _update_module_annotations_from_type_comments(mod: ModuleType) -> None:
                         cls = mod
                         for part in classname.split('.'):
                             cls = safe_getattr(cls, part)
+                        # Framework metaclasses may deliberately clear annotations
+                        # after consuming them. Respect an explicit empty mapping
+                        # instead of restoring source-level type comments.
+                        if cls.__dict__.get('__annotations__') == {}:
+                            class_annotations[classname] = {}
+                            continue
                         annotations = dict(inspect.getannotations(cls))
                         # Ignore errors setting __annotations__
                         with contextlib.suppress(TypeError, AttributeError):

--- a/tests/test_ext_autodoc/test_ext_autodoc_type_comments.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_type_comments.py
@@ -1,0 +1,32 @@
+from types import ModuleType
+
+from sphinx.ext.autodoc._dynamic._type_comments import (
+    ModuleAnalyzer,
+    _update_module_annotations_from_type_comments,
+)
+
+
+def test_explicit_empty_class_annotations_are_preserved(monkeypatch):
+    module = ModuleType('autodoc_type_comment_target')
+
+    class Model:
+        __annotations__ = {}
+
+    module.Model = Model
+
+    class Analyzer:
+        annotations = {('Model', 'field'): 'int'}
+
+        def analyze(self):
+            pass
+
+    analyzer = Analyzer()
+    monkeypatch.setattr(
+        ModuleAnalyzer,
+        'for_module',
+        classmethod(lambda cls, name: analyzer),
+    )
+
+    _update_module_annotations_from_type_comments(module)
+
+    assert Model.__annotations__ == {}


### PR DESCRIPTION
## Summary

Prevent autodoc's type-comment recovery from repopulating a class-level `__annotations__` mapping that a framework or metaclass deliberately cleared after consuming it.

## Changes

- distinguish a missing `__annotations__` mapping from an explicitly empty one
- preserve explicit empty mappings instead of restoring source type comments
- add a focused regression test around the type-comment analyzer

## Validation

Focused test:
`pytest -q tests/test_ext_autodoc/test_ext_autodoc_type_comments.py`

The change is intentionally limited to explicitly empty class annotations; ordinary classes that only use type comments still take the existing recovery path.

Fixes #14337

<!-- pr-relay-job relay-59-60f5477f9bfb74125ead -->