### PR TITLE
Tests: adapt HTML escaping to pygments v2.21.0 change-in-behaviour

### DIFF
--- a/tests/test_builders/test_build_html_code.py
+++ b/tests/test_builders/test_build_html_code.py
@@ -57,7 +57,7 @@ def test_html_code_role(app: SphinxTestApp) -> None:
         '<span class="o">+</span> '
         '<span class="kc">None</span> '
         '<span class="o">+</span> '
-        '<span class="s2">&quot;abc&quot;</span>'
+        '<span class="s2">"abc"</span>'
         '<span class="p">):</span> '
         '<span class="k">pass</span>'
     )

--- a/tests/test_builders/test_build_html_code.py
+++ b/tests/test_builders/test_build_html_code.py
@@ -45,6 +45,11 @@ def test_html_code_role(app: SphinxTestApp) -> None:
     else:
         sp = ' '
 
+    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 21):
+        abc = '"abc"'
+    else:
+        abc = '&quot;abc&quot;'
+
     app.build()
     content = (app.outdir / 'index.html').read_text(encoding='utf8')
 
@@ -57,7 +62,7 @@ def test_html_code_role(app: SphinxTestApp) -> None:
         '<span class="o">+</span> '
         '<span class="kc">None</span> '
         '<span class="o">+</span> '
-        '<span class="s2">"abc"</span>'
+        f'<span class="s2">{abc}</span>'
         '<span class="p">):</span> '
         '<span class="k">pass</span>'
     )

--- a/tests/test_extensions/test_ext_viewcode.py
+++ b/tests/test_extensions/test_ext_viewcode.py
@@ -51,7 +51,7 @@ def check_viewcode_output(app: SphinxTestApp) -> str:
     assert f'<span>class</span>{sp}<span>Class1</span><span>:</span>\n' in result
     assert (
         '<span>    </span>'
-        '<span>&quot;&quot;&quot;this is Class1&quot;&quot;&quot;</span></div>\n'
+        '<span>"""this is Class1"""</span></div>\n'
     ) in result
 
     return result

--- a/tests/test_extensions/test_ext_viewcode.py
+++ b/tests/test_extensions/test_ext_viewcode.py
@@ -20,6 +20,11 @@ def check_viewcode_output(app: SphinxTestApp) -> str:
     else:
         sp = ' '
 
+    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 21):
+        ds = '"""this is Class1"""'
+    else:
+        ds = '&quot;&quot;&quot;this is Class1&quot;&quot;&quot;'
+
     warnings = re.sub(r'\\+', '/', app.warning.getvalue())
     assert re.findall(
         r"index.rst:\d+: WARNING: Object named 'func1' not found in include "
@@ -49,7 +54,7 @@ def check_viewcode_output(app: SphinxTestApp) -> str:
     ) in result
     assert '<span>@decorator</span>\n' in result
     assert f'<span>class</span>{sp}<span>Class1</span><span>:</span>\n' in result
-    assert '<span>    </span><span>"""this is Class1"""</span></div>\n' in result
+    assert f'<span>    </span><span>{ds}</span></div>\n' in result
 
     return result
 

--- a/tests/test_extensions/test_ext_viewcode.py
+++ b/tests/test_extensions/test_ext_viewcode.py
@@ -49,10 +49,7 @@ def check_viewcode_output(app: SphinxTestApp) -> str:
     ) in result
     assert '<span>@decorator</span>\n' in result
     assert f'<span>class</span>{sp}<span>Class1</span><span>:</span>\n' in result
-    assert (
-        '<span>    </span>'
-        '<span>"""this is Class1"""</span></div>\n'
-    ) in result
+    assert '<span>    </span><span>"""this is Class1"""</span></div>\n' in result
 
     return result
 

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -93,7 +93,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     ret = bridge.highlight_block('print "Hello sphinx world"', 'default')
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span> '
-        '<span class="s2">&quot;Hello sphinx world&quot;</span>\n</pre></div>\n'
+        '<span class="s2">"Hello sphinx world"</span>\n</pre></div>\n'
     )
 
     # default: fallbacks to none if highlighting failed
@@ -107,7 +107,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span>'
         '<span class="p">(</span>'
-        '<span class="s2">&quot;Hello sphinx world&quot;</span>'
+        '<span class="s2">"Hello sphinx world"</span>'
         '<span class="p">)</span>\n</pre></div>\n'
     )
 
@@ -116,7 +116,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span>'
         '<span class="p">(</span>'
-        '<span class="s2">&quot;Hello sphinx world&quot;</span>'
+        '<span class="s2">"Hello sphinx world"</span>'
         '<span class="p">)</span>\n</pre></div>\n'
     )
 

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -26,6 +26,11 @@ if tuple(map(int, pygments.__version__.split('.')[:2])) < (2, 18):
 
     Formatter.__class_getitem__ = classmethod(lambda cls, name: cls)  # type: ignore[attr-defined]
 
+if tuple(map(int, pygments.__version__.split('.')[:2])) < (2, 21):
+    hsw = '&quot;Hello sphinx world&quot;'
+else:
+    hsw = '"Hello sphinx world"'
+
 
 class MyLexer(RegexLexer):
     name = 'testlexer'
@@ -93,7 +98,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     ret = bridge.highlight_block('print "Hello sphinx world"', 'default')
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span> '
-        '<span class="s2">"Hello sphinx world"</span>\n</pre></div>\n'
+        f'<span class="s2">{hsw}</span>\n</pre></div>\n'
     )
 
     # default: fallbacks to none if highlighting failed
@@ -107,7 +112,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span>'
         '<span class="p">(</span>'
-        '<span class="s2">"Hello sphinx world"</span>'
+        f'<span class="s2">{hsw}</span>'
         '<span class="p">)</span>\n</pre></div>\n'
     )
 
@@ -116,7 +121,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span>'
         '<span class="p">(</span>'
-        '<span class="s2">"Hello sphinx world"</span>'
+        f'<span class="s2">{hsw}</span>'
         '<span class="p">)</span>\n</pre></div>\n'
     )
 

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -1647,7 +1647,7 @@ def test_additional_targets_should_not_be_translated(app: SphinxTestApp) -> None
     assert_count(expected_expr, result, 2)
 
     # ruby code block should not be translated but be highlighted
-    expected_expr = """<span class="s1">&#39;result&#39;</span>"""
+    expected_expr = """<span class="s1">'result'</span>"""
     assert_count(expected_expr, result, 1)
 
     # C code block without lang should not be translated and *ruby* highlighted
@@ -1738,7 +1738,7 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     assert_count(expected_expr, result, 1)
 
     # literalinclude should be translated
-    expected_expr = '<span class="s2">&quot;HTTPS://SPHINX-DOC.ORG&quot;</span>'
+    expected_expr = '<span class="s2">"HTTPS://SPHINX-DOC.ORG"</span>'
     assert_count(expected_expr, result, 1)
 
     # title should be translated
@@ -1746,7 +1746,7 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     assert_count(expected_expr, result, 2)
 
     # ruby code block should be translated and be highlighted
-    expected_expr = """<span class="s1">&#39;RESULT&#39;</span>"""
+    expected_expr = """<span class="s1">'RESULT'</span>"""
     assert_count(expected_expr, result, 1)
 
     # C code block without lang should be translated and *ruby* highlighted

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -1638,6 +1638,11 @@ def test_additional_targets_should_not_be_translated(app: SphinxTestApp) -> None
     else:
         sp = ' '
 
+    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 21):
+        res = "'result'"
+    else:
+        res = '&#39;result&#39;'
+
     app.build()
     # [literalblock.txt]
     result = (app.outdir / 'literalblock.html').read_text(encoding='utf8')
@@ -1647,7 +1652,7 @@ def test_additional_targets_should_not_be_translated(app: SphinxTestApp) -> None
     assert_count(expected_expr, result, 2)
 
     # ruby code block should not be translated but be highlighted
-    expected_expr = """<span class="s1">'result'</span>"""
+    expected_expr = f"""<span class="s1">{res}</span>"""
     assert_count(expected_expr, result, 1)
 
     # C code block without lang should not be translated and *ruby* highlighted
@@ -1726,6 +1731,13 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     else:
         sp = ' '
 
+    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 21):
+        home = '"HTTPS://SPHINX-DOC.ORG"'
+        res = "'RESULT'"
+    else:
+        home = '&quot;HTTPS://SPHINX-DOC.ORG&quot;'
+        res = '&#39;RESULT&#39;'
+
     app.build()
     # [literalblock.txt]
     result = (app.outdir / 'literalblock.html').read_text(encoding='utf8')
@@ -1738,7 +1750,7 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     assert_count(expected_expr, result, 1)
 
     # literalinclude should be translated
-    expected_expr = '<span class="s2">"HTTPS://SPHINX-DOC.ORG"</span>'
+    expected_expr = f'<span class="s2">{home}</span>'
     assert_count(expected_expr, result, 1)
 
     # title should be translated
@@ -1746,7 +1758,7 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     assert_count(expected_expr, result, 2)
 
     # ruby code block should be translated and be highlighted
-    expected_expr = """<span class="s1">'RESULT'</span>"""
+    expected_expr = f"""<span class="s1">{res}</span>"""
     assert_count(expected_expr, result, 1)
 
     # C code block without lang should be translated and *ruby* highlighted


### PR DESCRIPTION
## Purpose

This pull request should allow the Sphinx Python unit test suite to pass; it began failing recently following the release of Pygments v2.21.0 that included adjustments to HTML quote-escaping logic: https://github.com/pygments/pygments/issues/3185

This changeset adapts the relevant unit test expectations according to the runtime version of Pygments detected.

## References

- Resolves #14610

## AI Disclosure

I did not use any AI/LLM tooling for this pull request; neither to develop the changes locally, nor to create the pull request itself.

<hr />

Edit: correction: a different Pygments PR seems to have been the cause of this; the hyperlink has been updated
Edit: rephrase for conciseness/clarity