### PR TITLE
intersphinx: make inventory load warnings suppressible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #14341: intersphinx: classify the warning emitted when inventory location
+  fails to load as ``intersphinx.inventory``.
+
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -1424,6 +1424,7 @@ Options for warning control
    * ``autosummary.import_cycle``
    * ``duration``
    * ``intersphinx.external``
+   * ``intersphinx.inventory``
 
    You can choose from these types.  You can also give only the first
    component to exclude all warnings attached to it.
@@ -1490,6 +1491,9 @@ Options for warning control
 
    .. versionadded:: 9.0
       ``duration``.
+
+   .. versionadded:: 9.1.1
+      ``intersphinx.inventory``.
 
 
 Builder options

--- a/sphinx/ext/intersphinx/_load.py
+++ b/sphinx/ext/intersphinx/_load.py
@@ -331,6 +331,8 @@ def _fetch_inventory_group(
         LOGGER.warning(
             __('failed to reach any of the inventories with the following issues:\n%s'),
             _display_failures(failures),
+            type='intersphinx',
+            subtype='inventory',
         )
     return updated
 


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

Classify inventory loading failures as `intersphinx.inventory`, which allows these warnings to be suppressed through `suppress_warnings`.

`intersphinx.inventory` was picked, because `intersphinx.external` is already used for cross-reference resolution and I didn't want it overloaded.

## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- Closes #14341


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->

I used AI to find the location in the code to add the type and subtype.
