### PR TITLE
docs: clarify include directive path semantics

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -399,8 +399,9 @@ Docutils supports the following directives:
   - :dudir:`include` (include reStructuredText from another file) -- in Sphinx,
     path handling differs from plain Docutils:
 
-    - A **relative** path is resolved from the directory of the file that
-      contains the directive.
+    - A **relative** path is resolved from the directory of the original Sphinx
+      source document. If C includes B and B includes A, relative includes in
+      both A and B resolve from C's directory.
     - A path that **starts with** ``/`` is *not* an operating-system absolute
       path. It is resolved from the top of the :term:`source directory`
       (the same rule as :rst:dir:`literalinclude` and :rst:dir:`toctree`).

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -397,8 +397,22 @@ Docutils supports the following directives:
 
   - :dudir:`raw <raw-data-pass-through>` (include raw target-format markup)
   - :dudir:`include` (include reStructuredText from another file) -- in Sphinx,
-    when given an absolute include file path, this directive takes it as
-    relative to the source directory
+    path handling differs from plain Docutils:
+
+    - A **relative** path is resolved from the directory of the file that
+      contains the directive.
+    - A path that **starts with** ``/`` is *not* an operating-system absolute
+      path. It is resolved from the top of the :term:`source directory`
+      (the same rule as :rst:dir:`literalinclude` and :rst:dir:`toctree`).
+
+    So ``.. include:: /generated/out.rst`` looks for
+    ``<source directory>/generated/out.rst``. If that file is missing, the
+    warning may show a path under the source tree (for example
+    ``source/generated/out.rst``) rather than an OS path under ``/``.
+
+    To pull in a file outside the source tree, prefer a path relative to the
+    including document (for example ``../build/generated.rst``). Relying on
+    OS-absolute paths is brittle and is not the intended model.
 
     .. _rstclass:
 

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -35,8 +35,7 @@ The ``toctree`` directive is the central element.
    Simple "inclusion" of one file in another can be done with the
    :dudir:`include` directive. In Sphinx, a path starting with ``/`` is
    relative to the :term:`source directory`, not the filesystem root.
-   See :doc:`/usage/restructuredtext/basics` (Special directives) for
-   details.
+   See :ref:`rst-directives` for details.
 
 .. note::
 

--- a/doc/usage/restructuredtext/directives.rst
+++ b/doc/usage/restructuredtext/directives.rst
@@ -33,7 +33,10 @@ The ``toctree`` directive is the central element.
 .. note::
 
    Simple "inclusion" of one file in another can be done with the
-   :dudir:`include` directive.
+   :dudir:`include` directive. In Sphinx, a path starting with ``/`` is
+   relative to the :term:`source directory`, not the filesystem root.
+   See :doc:`/usage/restructuredtext/basics` (Special directives) for
+   details.
 
 .. note::
 


### PR DESCRIPTION
## Summary

Relates to #11755.

A path starting with `/` on `.. include::` is resolved under the Sphinx
source directory. That is easy to misread as an OS absolute path, and the
missing-file warning can look like the wrong path was used.

### Changes
- Expand the include note under Special directives in basics.rst
- Cross-link from directives.rst

### Notes
Maintainer discussion on the issue treats this as a docs clarity problem
(not a code change to path resolution). Absolute OS paths remain brittle;
prefer paths relative to the including document for files outside srcdir.