### PR TITLE
napoleon: Move Attributes/Methods directly below Parameters in NumPy-style docstrings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #13180: napoleon: Move the ``Attributes`` and ``Methods`` sections directly
+  below the ``Parameters`` section in NumPy-style docstrings, matching
+  numpydoc 1.8+.
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -373,6 +373,8 @@ class GoogleDocstring:
         self._parsed_lines: list[str] = []
         self._is_in_section = False
         self._section_indent = 0
+        if not hasattr(self, '_deferred_sections'):
+            self._deferred_sections: set[str] = set()
         if not hasattr(self, '_directive_sections'):
             self._directive_sections: list[str] = []
         if not hasattr(self, '_sections'):
@@ -839,6 +841,9 @@ class GoogleDocstring:
             self._parsed_lines.extend(res)
             return
 
+        insert_after_params: list[list[str]] = []
+        params_end: int | None = None
+        summary_end: int | None = None
         while self._lines:
             if self._is_section_header():
                 try:
@@ -852,12 +857,25 @@ class GoogleDocstring:
                 finally:
                     self._is_in_section = False
                     self._section_indent = 0
+
+                if summary_end is None:
+                    summary_end = len(self._parsed_lines)
+                if self._deferred_sections and section.lower() in self._deferred_sections:
+                    insert_after_params.append(lines)
+                    continue
+                self._parsed_lines.extend(lines)
+                if self._deferred_sections and section.lower() == 'parameters':
+                    params_end = len(self._parsed_lines)
             else:
                 if not self._parsed_lines:
                     lines = self._consume_contiguous() + self._consume_empty()
                 else:
                     lines = self._consume_to_next_section()
-            self._parsed_lines.extend(lines)
+                self._parsed_lines.extend(lines)
+        insert_at = params_end if params_end is not None else (summary_end or 0)
+        self._parsed_lines[insert_at:insert_at] = [
+            line for block in insert_after_params for line in block
+        ]
 
     def _parse_admonition(self, admonition: str, section: str) -> list[str]:
         # type (str, str) -> List[str]
@@ -1218,6 +1236,7 @@ class NumpyDocstring(GoogleDocstring):
         options: Any | None = None,
     ) -> None:
         self._directive_sections = ['.. index::']
+        self._deferred_sections = {'attributes', 'methods'}
         super().__init__(docstring, config, app, what, name, obj, options)
 
     def _escape_args_and_kwargs(self, name: str) -> str:

--- a/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
+++ b/tests/test_ext_napoleon/test_ext_napoleon_docstring.py
@@ -1847,6 +1847,98 @@ arg_ : type
 
         assert str(actual) == expected
 
+    def test_attributes_and_methods_follow_parameters(self):
+        docstring = """
+Summary.
+
+Parameters
+----------
+x : int
+    X desc.
+
+Notes
+-----
+Some notes.
+
+Attributes
+----------
+y : int
+    Y desc.
+
+Methods
+-------
+foo(i, j)
+    Method desc.
+
+Examples
+--------
+Some examples.
+"""
+
+        expected = """
+Summary.
+
+:param x: X desc.
+:type x: int
+
+.. attribute:: y
+
+   Y desc.
+
+   :type: int
+
+.. method:: foo(i, j)
+
+   Method desc.
+   
+
+.. rubric:: Notes
+
+Some notes.
+
+.. rubric:: Examples
+
+Some examples.
+"""  # ruff: ignore[blank-line-with-whitespace]
+
+        app = mock.Mock()
+        actual = NumpyDocstring(docstring, Config(), app, 'class')
+
+        assert str(actual) == expected
+
+    def test_attributes_follow_parameters_no_parameters(self):
+        docstring = """
+Summary.
+
+Notes
+-----
+Some notes.
+
+Attributes
+----------
+y : int
+    Y desc.
+"""
+
+        expected = """
+Summary.
+
+.. attribute:: y
+
+   Y desc.
+
+   :type: int
+
+.. rubric:: Notes
+
+Some notes.
+"""
+
+        app = mock.Mock()
+        actual = NumpyDocstring(docstring, Config(), app, 'class')
+
+        assert str(actual) == expected
+
     def test_underscore_in_attribute_strip_signature_backslash(self):
         docstring = """
 Attributes


### PR DESCRIPTION
Closes #13180

## Summary

numpydoc 1.8 moved the \Attributes\ and \Methods\ sections directly below the \Parameters\ section in the rendered output. Napoleon currently emits sections in the order they appear in the docstring, so \Attributes\/\Methods\ end up after \Notes\/\Examples\ for classes.

This change makes \NumpyDocstring\ match numpydoc's ordering: \Attributes\ and \Methods\ are moved directly below \Parameters\ (or below the summary when no Parameters section exists). Google-style docstrings are unaffected.

## Changes

- \sphinx/ext/napoleon/docstring.py\: \_parse()\ now defers \ttributes\/\methods\ sections (only active for \NumpyDocstring\) and reinserts them after the \Parameters\ section.
- Tests covering both orderings (attributes/methods after and before Parameters, and with no Parameters section).
- Changelog entry.

## Testing

\python -m pytest tests/test_ext_napoleon\ — 70 passed, 1 deselected (pre-existing failure, unrelated)