### PR TITLE
autodoc: do not leak `__annotationlib_name_N__` placeholders into rendered annotations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,7 @@ Contributors
 * Alex Gaynor -- linkcheck retry on errors
 * Alexander Todorov -- inheritance_diagram tests and improvements
 * Andi Albrecht -- agogo theme
+* Anshul Singh -- autodoc deferred annotation fixes
 * Antonio Valentino -- qthelp builder, docstring inheritance
 * Antti Kaihola -- doctest extension (skipif option)
 * Barry Warsaw -- setup command improvements

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14457: autodoc: On Python 3.14, annotations that mix names only imported
+  under ``TYPE_CHECKING`` with resolvable ones (e.g. ``Mapping[str, int]``)
+  no longer render with ``__annotationlib_name_N__`` placeholders.
+  Patch by Anshul Singh
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -238,6 +238,39 @@ def _is_unpack_form(obj: Any) -> bool:
     return typing.get_origin(obj) is typing.Unpack
 
 
+def _forward_ref_arg(ref: typing.ForwardRef) -> str:
+    """Return the source text of a :class:`~typing.ForwardRef`.
+
+    On Python 3.14+, ``annotationlib``'s ``FORWARDREF`` format can store
+    placeholder names like ``__annotationlib_name_1__`` in
+    ``__forward_arg__`` when an annotation mixes undefined and defined
+    names (e.g. ``Mapping[str, int]`` with ``Mapping`` only imported under
+    ``TYPE_CHECKING``).  The real objects are kept in ``__extra_names__``.
+    Evaluating the reference in ``STRING`` format gives the clean text on
+    Python 3.14.5+ (python/cpython#148680); substituting ``__extra_names__``
+    by hand covers earlier 3.14 releases.
+    """
+    forward_arg: str = ref.__forward_arg__
+    if sys.version_info[:2] < (3, 14) or '__annotationlib_name_' not in forward_arg:
+        return forward_arg
+
+    import annotationlib  # type: ignore[import-not-found]
+
+    try:
+        evaluated = ref.evaluate(format=annotationlib.Format.STRING)
+    except Exception:
+        evaluated = forward_arg
+    if isinstance(evaluated, str) and '__annotationlib_name_' not in evaluated:
+        return evaluated
+
+    # Older 3.14 releases leave the placeholders in; substitute by hand.
+    extra_names: dict[str, Any] | None = getattr(ref, '__extra_names__', None)
+    if extra_names:
+        for name, value in extra_names.items():
+            forward_arg = forward_arg.replace(name, annotationlib.type_repr(value))
+    return forward_arg
+
+
 def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> str:
     """Convert a type-like object to a reST reference.
 
@@ -372,7 +405,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
         elif hasattr(cls, '__qualname__'):
             return f':py:class:`{module_prefix}{cls.__module__}.{cls.__qualname__}`'
         elif isinstance(cls, typing.ForwardRef):
-            return f':py:class:`{cls.__forward_arg__}`'
+            return f':py:class:`{_forward_ref_arg(cls)}`'
         else:
             # not a class (ex. TypeVar) but should have a __name__
             return f':py:obj:`{module_prefix}{cls.__module__}.{cls.__name__}`'
@@ -490,7 +523,9 @@ def stringify_annotation(
         pass
 
     module_prefix = f'{annotation_module}.'
-    annotation_forward_arg: str | None = getattr(annotation, '__forward_arg__', None)
+    annotation_forward_arg: str | None = None
+    if isinstance(annotation, typing.ForwardRef):
+        annotation_forward_arg = _forward_ref_arg(annotation)
     if annotation_qualname or (
         annotation_module_is_typing and not annotation_forward_arg
     ):

--- a/tests/roots/test-ext-autodoc/target/TYPE_CHECKING_pep649.py
+++ b/tests/roots/test-ext-autodoc/target/TYPE_CHECKING_pep649.py
@@ -1,0 +1,17 @@
+# NoQA: N999
+# Intentionally no ``from __future__ import annotations``: on Python 3.14+
+# these annotations are evaluated lazily (PEP 649), so ``Mapping`` and
+# ``Callable`` are only ever looked up by ``annotationlib``.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Deliberately only available for type checkers; see below.
+    from collections.abc import Callable, Mapping  # NoQA: TC004
+
+
+def convert_to_dict(x: Mapping[str, int]) -> Mapping[str, int]:
+    pass
+
+
+def apply(f: Callable[[str], int], s: str) -> int:
+    pass

--- a/tests/test_ext_autodoc/test_ext_autodoc.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc.py
@@ -2515,6 +2515,44 @@ def test_autodoc_TYPE_CHECKING() -> None:
     ]
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 14),
+    reason='annotations are only deferred from Python 3.14',
+)
+def test_autodoc_TYPE_CHECKING_deferred_annotations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # https://github.com/sphinx-doc/sphinx/issues/14457
+    # With deferred annotations, ``annotationlib`` represents the arguments
+    # of an unresolvable generic with ``__annotationlib_name_N__``
+    # placeholders; make sure those never reach the output.
+    #
+    # The test suite sets SPHINX_AUTODOC_RELOAD_MODULES, which re-imports
+    # modules with ``typing.TYPE_CHECKING = True`` and so makes the names
+    # resolvable.  Users do not normally have it set, so turn it off here
+    # to exercise the unresolved path.
+    monkeypatch.delenv('SPHINX_AUTODOC_RELOAD_MODULES', raising=False)
+    monkeypatch.delitem(sys.modules, 'target.TYPE_CHECKING_pep649', raising=False)
+    options = {
+        'members': None,
+        'undoc-members': None,
+    }
+    actual = do_autodoc('module', 'target.TYPE_CHECKING_pep649', options=options)
+    assert actual == [
+        '',
+        '.. py:module:: target.TYPE_CHECKING_pep649',
+        '',
+        '',
+        '.. py:function:: apply(f: Callable[[str], int], s: str) -> int',
+        '   :module: target.TYPE_CHECKING_pep649',
+        '',
+        '',
+        '.. py:function:: convert_to_dict(x: Mapping[str, int]) -> Mapping[str, int]',
+        '   :module: target.TYPE_CHECKING_pep649',
+        '',
+    ]
+
+
 def test_autodoc_TYPE_CHECKING_circular_import() -> None:
     options = {
         'members': None,

--- a/tests/test_util/test_util_typing.py
+++ b/tests/test_util/test_util_typing.py
@@ -75,6 +75,8 @@ from typing import (
 )
 from weakref import WeakSet
 
+import pytest
+
 from sphinx.ext.autodoc._dynamic._mock import mock
 from sphinx.util.typing import _INVALID_BUILTIN_CLASSES, restify, stringify_annotation
 
@@ -1011,6 +1013,38 @@ def test_stringify_type_ForwardRef():
         'smart',
     )
     assert ann_str == '~typing.Tuple[dict[MyInt, str], list[~typing.List[int]]]'
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 14),
+    reason='annotations are only deferred from Python 3.14',
+)
+def test_stringify_type_ForwardRef_annotationlib_placeholders():
+    # https://github.com/sphinx-doc/sphinx/issues/14457
+    import annotationlib
+
+    # This file uses ``from __future__ import annotations``, which would make
+    # the annotation a plain string; compile the function separately so that
+    # it gets a real PEP 649 deferred annotation instead.
+    ns: dict[str, Any] = {}
+    code = compile(
+        'def func(x: UndefinedMapping[str, int]) -> UndefinedMapping[str, int]: ...',
+        '<test>',
+        'exec',
+        dont_inherit=True,
+    )
+    exec(code, ns)  # NoQA: S102
+    func = ns['func']
+
+    ann = annotationlib.get_annotations(func, format=annotationlib.Format.FORWARDREF)
+    ref = ann['x']
+    assert isinstance(ref, ForwardRef)
+    # annotationlib stores the real objects under placeholder names
+    assert '__annotationlib_name_' in ref.__forward_arg__
+
+    assert stringify_annotation(ref) == 'UndefinedMapping[str, int]'
+    assert stringify_annotation(ref, 'smart') == 'UndefinedMapping[str, int]'
+    assert restify(ref) == ':py:class:`UndefinedMapping[str, int]`'
 
 
 def test_stringify_type_hints_paramspec():

--- a/tests/test_util/test_util_typing.py
+++ b/tests/test_util/test_util_typing.py
@@ -1021,7 +1021,7 @@ def test_stringify_type_ForwardRef():
 )
 def test_stringify_type_ForwardRef_annotationlib_placeholders():
     # https://github.com/sphinx-doc/sphinx/issues/14457
-    import annotationlib
+    import annotationlib  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
 
     # This file uses ``from __future__ import annotations``, which would make
     # the annotation a plain string; compile the function separately so that


### PR DESCRIPTION
## Purpose

Fixes #14457.

On Python 3.14, a function annotated `x: Mapping[str, int]` where `Mapping` is only imported under `TYPE_CHECKING` is rendered by autodoc as

```
Mapping[__annotationlib_name_1__, __annotationlib_name_2__]
```

Plain `s: str` and `-> int` are fine; only the subscript arguments of the unresolvable generic are mangled. `Callable[[str], int]` is affected the same way.

### Cause

`annotationlib`'s `FORWARDREF` format, which `sphinx.util.inspect.signature()` requests on 3.14+, builds the `ForwardRef` by running the annotation against fake globals. `Mapping` is undefined so it becomes a stringifier, and when that stringifier is subscripted with the *real* `str` and `int` objects, `annotationlib` has no source text for them and substitutes generated names, stashing the objects in `ForwardRef.__extra_names__`. Both `restify()` and `stringify_annotation()` in `sphinx/util/typing.py` read `__forward_arg__` directly and so print the placeholders.

CPython treats the leaked names as a bug and fixed `ForwardRef.evaluate(format=STRING)` in python/cpython#148680 (first in 3.14.5) and `typing.evaluate_forward_ref` in python/cpython#150641 (first in 3.14.7). Neither changes `__forward_arg__` itself, so Sphinx still rendered the placeholders on 3.14.7. I confirmed that on both 3.14.2 and 3.14.7 before changing anything.

### Fix

A small `_forward_ref_arg()` helper that both read sites use. If `__forward_arg__` contains a placeholder it asks the `ForwardRef` for its `STRING` evaluation, which is clean on 3.14.5+, and if that still contains placeholders (3.14.0 to 3.14.4) it substitutes `__extra_names__` by hand using `annotationlib.type_repr`, mirroring what CPython's fix does. Anything without a placeholder, and anything before 3.14, is untouched.

The `str.replace` fallback is safe against `__annotationlib_name_1__` being a prefix of `__annotationlib_name_10__` because the trailing `__` delimits each name; I checked with a 12-argument annotation on 3.14.2.

### Why the existing suite missed it

Two things, both worth knowing for future 3.14 work:

- `tests/roots/test-ext-autodoc/target/TYPE_CHECKING.py` has `from __future__ import annotations`, so its annotations are plain strings and never go through `annotationlib`'s deferred path. The new fixture `TYPE_CHECKING_pep649.py` deliberately omits the future import.
- `tests/conftest.py` sets `SPHINX_AUTODOC_RELOAD_MODULES=1` for the whole suite. That makes `_importer.py` re-import modules with `typing.TYPE_CHECKING = True`, so every `TYPE_CHECKING` import executes and every `ForwardRef` resolves, which is precisely the case where the bug cannot appear. The new autodoc test clears that variable to match a normal user environment.

### Tests

- `test_autodoc_TYPE_CHECKING_deferred_annotations`: end to end through `do_autodoc`. Fails on `master` with the exact mangled output from the issue, passes with the fix, on both 3.14.2 and 3.14.7.
- `test_stringify_type_ForwardRef_annotationlib_placeholders`: unit test for `stringify_annotation`/`restify` on a `ForwardRef` built with `Format.FORWARDREF`. Same before/after contract on both versions. Because `test_util_typing.py` itself uses the future import, the function under test is compiled with `dont_inherit=True`.
- Both skip on Python < 3.14.

Verified locally: `tests/test_util`, `tests/test_ext_autodoc`, `tests/test_ext_autosummary`, `tests/test_ext_napoleon`, `tests/test_domains` all pass on 3.14.7 (858 passed) and 3.14.2; on 3.12 the only failures are four that fail identically on pristine `master` in my environment. `ruff check`, `ruff format`, `mypy --strict` on `sphinx/util/typing.py`, pyright with the project config, and `sphinx-lint` on `CHANGES.rst`/`AUTHORS.rst` are all clean.

## References

- #14457
- python/cpython#148680, python/cpython#150641

## AI disclosure

This PR was written with Claude (Anthropic) operating as an autonomous coding agent under my account. The investigation, code, tests, and this description are AI-generated; I reviewed them before opening the PR and take responsibility for the change.