### PR TITLE
Fix duplicate nested admonition titles on todolist pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #14623: todo: Nested admonitions no longer get a duplicate title on the
+  todolist page when the source document is written first.
+  Patch by Burak Keskin
+
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/ext/todo.py
+++ b/sphinx/ext/todo.py
@@ -87,7 +87,12 @@ class TodoDomain(Domain):
         todos = self.todos.setdefault(docname, [])
         for todo in document.findall(todo_node):
             env.events.emit('todo-defined', todo)
-            todos.append(todo)
+            # Store an independent copy. The HTML writer mutates admonition
+            # nodes in place (inserting title children). If the domain kept
+            # the document's own nodes, writing the source page first would
+            # leave those titles in place; deepcopying them into a later
+            # todolist would then add a second title.
+            todos.append(todo.deepcopy())
 
             if env.config.todo_emit_warnings:
                 logger.warning(

--- a/tests/roots/test-ext-todo-nested-admonition/a.rst
+++ b/tests/roots/test-ext-todo-nested-admonition/a.rst
@@ -1,0 +1,10 @@
+Doc A
+=====
+
+.. todo::
+
+   A todo entry.
+
+   .. danger::
+
+      Danger inside a todo.

--- a/tests/roots/test-ext-todo-nested-admonition/b.rst
+++ b/tests/roots/test-ext-todo-nested-admonition/b.rst
@@ -1,0 +1,4 @@
+Doc B
+=====
+
+.. todolist::

--- a/tests/roots/test-ext-todo-nested-admonition/conf.py
+++ b/tests/roots/test-ext-todo-nested-admonition/conf.py
@@ -1,0 +1,2 @@
+extensions = ['sphinx.ext.todo']
+todo_include_todos = True

--- a/tests/roots/test-ext-todo-nested-admonition/index.rst
+++ b/tests/roots/test-ext-todo-nested-admonition/index.rst
@@ -1,0 +1,7 @@
+Index
+=====
+
+.. toctree::
+
+   a
+   b

--- a/tests/test_extensions/test_ext_todo.py
+++ b/tests/test_extensions/test_ext_todo.py
@@ -126,3 +126,25 @@ def test_todo_valid_link(app: SphinxTestApp) -> None:
 
     # If everything is correct we should have exactly one target.
     assert len(matched) == 1
+
+
+@pytest.mark.sphinx(
+    'html',
+    testroot='ext-todo-nested-admonition',
+    freshenv=True,
+    confoverrides={'todo_include_todos': True},
+)
+def test_nested_admonition_title_not_duplicated_on_todolist(
+    app: SphinxTestApp,
+) -> None:
+    """Nested named admonitions inside a todo must keep a single title on both
+    the source page and the todolist page, even when the source document is
+    written first (alphabetical order a.rst then b.rst).
+    """
+    app.build(force_all=True)
+
+    source = (app.outdir / 'a.html').read_text(encoding='utf8')
+    todolist_page = (app.outdir / 'b.html').read_text(encoding='utf8')
+
+    assert source.count('<p class="admonition-title">Danger</p>') == 1
+    assert todolist_page.count('<p class="admonition-title">Danger</p>') == 1


### PR DESCRIPTION
Fixes #14623.

The HTML writer inserts title nodes into named admonitions in place. The todo domain previously stored those same node objects, so writing the source document first left extra titles on the stored todos. Copying them into a later `todolist` then produced a second title bar for nested admonitions such as `danger`.

Store a deepcopy when collecting todos so the source write cannot mutate the copies used on the todolist page. Regression test writes `a.rst` (the todo) before `b.rst` (the todolist) and asserts a single Danger title on both pages.
