### PR TITLE
Allow suppressing unmatched toctree glob warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,8 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
-* #14625: Fix issue that prevented empty TOC entry warnings from being
-  suppressed.
+* #14625: Allow suppressing warnings for unmatched toctree glob patterns using
+  `toc.empty_glob`.
   Patch by Michel Albert
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14625: Fix issue that prevented empty TOC entry warnings from being
+  suppressed.
+  Patch by Michel Albert
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Bugs fixed
   Patch by Hugo van Kemenade
 
 * #14625: Allow suppressing warnings for unmatched toctree glob patterns using
-  `toc.empty_glob`.
+  ``toc.empty_glob``.
   Patch by Michel Albert
 
 

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -119,8 +119,8 @@ class TocTree(SphinxDirective):
                         __("toctree glob pattern %r didn't match any documents"),
                         entry,
                         location=toctree,
-                        subtype='empty_glob',
                         type='toc',
+                        subtype='empty_glob',
                     )
 
                 for docname in doc_names:

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -120,6 +120,7 @@ class TocTree(SphinxDirective):
                         entry,
                         location=toctree,
                         subtype='empty_glob',
+                        type='toc',
                     )
 
                 for docname in doc_names:


### PR DESCRIPTION
This fixed an issue that prevented these log-messages from being suppressed via `suppress_warnings`.

Fixes #14625

## Purpose

Currently, "empty-glob" warnings cannot be suppressed. This blocks us from using the "--fail-on-warning" option while also having "placeholder" glob-entries for future documents. 

## References

See #14625 

## AI Disclosure

The changes have been made manually (100% human) but AI helped to _discover_ the bug. OpenCode with GPT5.5-Terra was used to pinpoint the root-cause. The code edit, bug-report and PR were all made by hand.
