### PR TITLE
Store a handler-supplied signature for objects that have none

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugs fixed
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
 
+* #14576: autodoc: Fix ``IndexError`` when an ``autodoc-process-signature``
+  handler returns a signature for a data or type object, which are documented
+  without one. The object was then rendered without its docstring.
+  Patch by Jhon Alvarez
+
 
 Release 9.1.0 (released Dec 31, 2025)
 =====================================

--- a/sphinx/ext/autodoc/_dynamic/_signatures.py
+++ b/sphinx/ext/autodoc/_dynamic/_signatures.py
@@ -125,7 +125,10 @@ def _format_signatures(
     ):
         if len(result) == 2 and isinstance(result[0], str):
             args, retann = result
-            signatures[0] = (args, retann if isinstance(retann, str) else '')
+            # Data and type objects skip signature extraction, so *signatures*
+            # may still be empty here. A handler is free to return a signature
+            # for them anyway, and slice assignment stores it either way.
+            signatures[:1] = [(args, retann if isinstance(retann, str) else '')]
 
     if props.obj_type in {'module', 'data', 'type'}:
         signatures[1:] = ()  # discard all signatures save the first

--- a/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
+++ b/tests/test_ext_autodoc/test_ext_autodoc_signatures.py
@@ -289,6 +289,24 @@ def test_format_signatures_event_handler() -> None:
     assert format_sig('method', 'bar', H.foo1, events=events) == ('42', '')
 
 
+def test_format_signatures_event_handler_on_data() -> None:
+    # A data object skips signature extraction, so *signatures* is still empty
+    # when the event fires. A handler may return a signature for it anyway.
+    def process_signature(*args: Any) -> tuple[str, str | None]:
+        return '()', None
+
+    events = FakeEvents()
+    events.connect('autodoc-process-signature', process_signature)
+
+    class CallableData:
+        class_var: Any
+
+        def __call__(self) -> None:
+            pass
+
+    assert format_sig('data', 'sig_bug', CallableData(), events=events) == ('()', '')
+
+
 def test_format_functools_partial_signatures() -> None:
     # test functions created via functools.partial
     from functools import partial


### PR DESCRIPTION
Closes #14576.

## The problem

`_format_signatures` reads `signatures[0]` defensively when emitting `autodoc-process-signature`:

```python
        signatures[0][0] if signatures else None,  # args
        signatures[0][1] if signatures else '',  # retann
    ):
        if len(result) == 2 and isinstance(result[0], str):
            args, retann = result
            signatures[0] = (args, retann if isinstance(retann, str) else '')
```

and then writes `signatures[0]` unconditionally. Data and type objects skip signature extraction, so for them that list is empty and the write raises `IndexError`. It is caught and logged, and the object loses its docstring:

```
WARNING: error while formatting signature for mod.sig_bug:
list assignment index out of range [autodoc]
```

The reporter diagnosed this precisely in the issue; I reproduced it with their module and a `conf.py` handler, which is the documented way to use the event:

```python
def process_signature(app, objtype, name, obj, options, args, retann):
    if objtype != "data":
        return None
    return ("()", None)

def setup(app):
    app.connect("autodoc-process-signature", process_signature)
```

Before: the warning above, and `trigger` (the `#:` docstring) appears **0** times in the built HTML.
After: `build succeeded.`, and `trigger` appears **1** time.

## The change

`signatures[:1] = [...]` instead of `signatures[0] = ...`. Slice assignment stores the signature whether or not one was already extracted, and is identical to the old behaviour when the list is non-empty.

The `if props.obj_type in {'module', 'data', 'type'}: signatures[1:] = ()` a few lines below already uses the same idiom for the same reason.

## Tests

`test_format_signatures_event_handler_on_data` in `tests/test_ext_autodoc/test_ext_autodoc_signatures.py`. On `master` it fails with the exact error from the issue:

```
E               IndexError: list assignment index out of range
sphinx/ext/autodoc/_dynamic/_signatures.py:128: IndexError
```

`tests/test_ext_autodoc/` goes from `4 failed, 222 passed` to `4 failed, 223 passed`. The four failures are present on unmodified `master` here as well — they are Python 3.14 import failures in `test_autodoc_pep695_type_alias`, `test_final`, `test_overload3` and `test_import_native_module_stubs`, unrelated to this change. `ruff check` reports the same 9 pre-existing findings before and after; `ruff format --check` is clean.

## AI disclosure

Claude (Opus 5) was used to locate the code, draft the change and the test, and write this description. I built the reproducer and ran the before/after builds myself, checked that the four suite failures predate the change by running the suite on a clean checkout, and confirmed the new test fails without the fix. Happy to answer questions on it.