### PR TITLE
Clarify the name passed to autodoc-skip-member

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -1480,7 +1480,8 @@ member should be included in the documentation by using the following event:
    :param obj_type: the type of the object which the docstring belongs to (one of
       ``'module'``, ``'class'``, ``'exception'``, ``'function'``, ``'decorator'``,
       ``'method'``, ``'property'``, ``'attribute'``, ``'data'``, or ``'type'``)
-   :param name: the fully qualified name of the object
+   :param name: the unqualified name of the member within the namespace of the
+      object being documented
    :param obj: the object itself
    :param skip: a boolean indicating if autodoc will skip this member if the
       user handler does not override the decision


### PR DESCRIPTION
## Purpose

This corrects the documentation for the `autodoc-skip-member` event. The `name` argument contains the member's name within the namespace of the object being documented, rather than its fully qualified name.

This documents the current behavior. Whether the event should provide a fully qualified name remains to be resolved in #12674.

## References

- Related to #12674

## AI Disclosure

AI was used to investigate the existing behavior and draft the documentation.