### PR TITLE
Fix Russian translation for documentation heading string

### DIFF
--- a/sphinx/locale/ru/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/ru/LC_MESSAGES/sphinx.po
@@ -4193,7 +4193,7 @@ msgstr "HTML 4 больше не поддерживается Sphinx. (стро�
 #: builders/html/__init__.py:1454
 #, python-format
 msgid "%s %s documentation"
-msgstr "документация %s %s"
+msgstr "Документация %s %s"
 
 #: builders/latex/theming.py:87
 #, python-format


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

This is to fix display of a russian translation of [docs.python.org](https://docs.python.org/ru/3.14/index.html) index page.
<img width="646" height="130" alt="image" src="https://github.com/user-attachments/assets/8598eea0-6552-4133-bbbe-70a52afb0ba8" />
The title needs to be capitalized.


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- https://docs.python.org/ru/3.14/index.html


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->
