### PR TITLE
gettext: Remove obsolete source metadata workarounds

### DIFF
--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -177,12 +177,6 @@ def apply_source_workaround(node: Element) -> None:
         )
         node.source, node.line = node.parent.source, node.parent.line
 
-    # workaround: literal_block under bullet list
-    # See: https://github.com/sphinx-doc/sphinx/issues/4913
-    if isinstance(node, nodes.literal_block) and node.source is None:
-        with contextlib.suppress(ValueError):
-            node.source = get_node_source(node)
-
     # workaround: recommonmark-0.2.0 doesn't set rawsource attribute
     if not node.rawsource:
         node.rawsource = node.astext()

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -143,13 +143,6 @@ def apply_source_workaround(node: Element) -> None:
     elif isinstance(node, nodes.classifier) and not node.source:
         # docutils-0.15 fills in rawsource attribute, but not in source.
         node.source = node.parent.source
-    if isinstance(node, nodes.image) and node.source is None:
-        logger.debug(
-            '[i18n] PATCH: %r to have source, line: %s',
-            get_full_module_name(node),
-            repr_domxml(node),
-        )
-        node.source, node.line = node.parent.source, node.parent.line
     if isinstance(node, nodes.title) and node.source is None:
         logger.debug(
             '[i18n] PATCH: %r to have source: %s',
@@ -188,12 +181,8 @@ def apply_source_workaround(node: Element) -> None:
     if isinstance(
         node,
         (
-            # https://github.com/sphinx-doc/sphinx/issues/1305 rubric directive
-            nodes.rubric,
             # https://github.com/sphinx-doc/sphinx/issues/1477 line node
             nodes.line,
-            # https://github.com/sphinx-doc/sphinx/issues/3093 image directive in substitution
-            nodes.image,
             # https://github.com/sphinx-doc/sphinx/issues/3335 field list syntax
             nodes.field_name,
         ),

--- a/tests/test_util/test_util_nodes.py
+++ b/tests/test_util/test_util_nodes.py
@@ -13,7 +13,6 @@ from docutils.utils import new_document
 from sphinx.transforms import ApplySourceWorkaround
 from sphinx.util.nodes import (
     NodeMatcher,
-    apply_source_workaround,
     clean_astext,
     extract_messages,
     make_id,
@@ -253,23 +252,3 @@ def test_make_id_sequential(app):
 )
 def test_split_explicit_target(title: str, expected: tuple[bool, str, str]) -> None:
     assert split_explicit_title(title) == expected
-
-
-def test_apply_source_workaround_literal_block_no_source() -> None:
-    """Regression test for https://github.com/sphinx-doc/sphinx/issues/11091.
-
-    Test that apply_source_workaround doesn't raise.
-    """
-    literal_block = nodes.literal_block('', '')
-    list_item = nodes.list_item('', literal_block)
-    bullet_list = nodes.bullet_list('', list_item)
-
-    assert literal_block.source is None
-    assert list_item.source is None
-    assert bullet_list.source is None
-
-    apply_source_workaround(literal_block)
-
-    assert literal_block.source is None
-    assert list_item.source is None
-    assert bullet_list.source is None


### PR DESCRIPTION
## Purpose

Docutils now provides `source` and `line` metadata for the following nodes across all versions currently supported by Sphinx (`>=0.21,<0.23`):

- Literal blocks nested under bullet lists
- Rubric directives
- Images in substitutions and nested directives

This removes the corresponding obsolete source-metadata workarounds and the regression test that only exercised the removed literal-block fallback. Existing gettext and message-extraction tests continue to cover these cases.

The workarounds for line nodes and field names remain because supported Docutils versions still omit their metadata.

## References

- #1305
- #3093
- #4913
- #4943
- #11091
- [Docutils feature request #41: Not all Node instances have the source and line attributes set](https://sourceforge.net/p/docutils/feature-requests/41/)

## AI Disclosure

AI was used to investigate whether the workarounds remain necessary and draft the implementation. I reviewed and validated the changes.



