### PR TITLE
Import basic.css in agogo, epub, nonav, scrolls, and traditional themes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Release 9.1.1 (in development)
 ==============================
 
+Features added
+--------------
+
+* #9093: Import ``basic.css`` in the ``agogo``, ``epub``, ``nonav``,
+  ``scrolls``, and ``traditional`` themes.
+  Patch by joyboy
+
 Bugs fixed
 ----------
 

--- a/sphinx/themes/agogo/static/agogo.css.jinja
+++ b/sphinx/themes/agogo/static/agogo.css.jinja
@@ -2,6 +2,8 @@
  * Sphinx stylesheet -- agogo theme.
  */
 
+@import url("basic.css");
+
 * {
   margin: 0px;
   padding: 0px;

--- a/sphinx/themes/epub/static/epub.css.jinja
+++ b/sphinx/themes/epub/static/epub.css.jinja
@@ -2,6 +2,8 @@
  * Sphinx stylesheet -- epub theme.
  */
 
+@import url("basic.css");
+
 /* -- main layout ----------------------------------------------------------- */
 
 {% if theme_writing_mode is defined %}

--- a/sphinx/themes/nonav/static/nonav.css.jinja
+++ b/sphinx/themes/nonav/static/nonav.css.jinja
@@ -2,6 +2,8 @@
  * Sphinx stylesheet -- nonav theme.
  */
 
+@import url("basic.css");
+
 /* -- main layout ----------------------------------------------------------- */
 
 div.clearer {

--- a/sphinx/themes/scrolls/static/scrolls.css.jinja
+++ b/sphinx/themes/scrolls/static/scrolls.css.jinja
@@ -2,6 +2,8 @@
  * Sphinx stylesheet -- scrolls theme.
  */
 
+@import url("basic.css");
+
 body {
     background-color: #222;
     margin: 0;

--- a/sphinx/themes/traditional/static/traditional.css.jinja
+++ b/sphinx/themes/traditional/static/traditional.css.jinja
@@ -2,6 +2,8 @@
  * Sphinx stylesheet -- traditional docs.python.org theme.
  */
 
+@import url("basic.css");
+
 body {
     color: #000;
     margin: 0;

--- a/tests/test_theming/test_theming.py
+++ b/tests/test_theming/test_theming.py
@@ -240,6 +240,34 @@ def test_theme_builds(
             pytest.fail(f'Failed to parse {html_file.relative_to(app.outdir)}: {exc}')
 
 
+@pytest.mark.parametrize(
+    ('theme_name', 'css_name'),
+    [
+        ('agogo', 'agogo.css'),
+        ('epub', 'epub.css'),
+        ('nonav', 'nonav.css'),
+        ('scrolls', 'scrolls.css'),
+        ('traditional', 'traditional.css'),
+    ],
+)
+def test_bundled_themes_import_basic_css(
+    make_app: Callable[..., SphinxTestApp],
+    rootdir: Path,
+    sphinx_test_tempdir: Path,
+    theme_name: str,
+    css_name: str,
+) -> None:
+    """Bundled themes that inherit ``basic`` should import ``basic.css``."""
+    testroot_path = rootdir / 'test-basic'
+    srcdir = sphinx_test_tempdir / f'test-theme-{theme_name}-css'
+    shutil.copytree(testroot_path, srcdir)
+
+    app = make_app(srcdir=srcdir, confoverrides={'html_theme': theme_name})
+    app.build()
+    css = (app.outdir / '_static' / css_name).read_text(encoding='utf8')
+    assert '@import url("basic.css");' in css
+
+
 def test_config_file_toml() -> None:
     config_path = HERE / 'theme.toml'
     cfg = _load_theme_toml(config_path)


### PR DESCRIPTION
Fixes #9093

## Summary
The ``agogo``, ``epub``, ``nonav``, ``scrolls``, and ``traditional`` themes
inherit from ``basic`` but their stylesheets did not import ``basic.css``.
This adds the missing import so foundational styles changed in ``basic``
propagate automatically to these themes.

## Changes
- Add ``@import url("basic.css");`` to the stylesheets of the five themes.
- Add a regression test verifying the import is present in the rendered CSS.
- Add a ``CHANGES.rst`` entry.

## Testing
- ``pytest tests/test_theming/test_theming.py`` — 28 passed
- ``pytest tests/test_builders/test_build_epub.py`` — 15 passed, 1 skipped (epubcheck)
