### PR TITLE
fix(i18n): fix fa/el translation placeholders for config value errors

### DIFF
--- a/sphinx/locale/el/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/el/LC_MESSAGES/sphinx.po
@@ -588,14 +588,14 @@ msgstr "Η τιμή παραμετροποίησης '{name}' πρέπει να 
 msgid ""
 "The config value `{name}' has type `{current.__name__}'; expected "
 "{permitted}."
-msgstr "Η τιμή παραμετροποίησης '{name]' έχει τύπο '[current__name__}'; αναμενόμενη {permitted}."
+msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current.__name__}'; αναμενόμενη {permitted}."
 
 #: config.py:846
 #, python-brace-format
 msgid ""
 "The config value `{name}' has type `{current.__name__}', defaults to "
 "`{default.__name__}'."
-msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current__name__}', αρχικοποίηση σε '{default__name__}'."
+msgstr "Η τιμή παραμετροποίησης '{name}' έχει τύπο '{current.__name__}', αρχικοποίηση σε '{default.__name__}'."
 
 #: config.py:858
 #, python-format

--- a/sphinx/locale/fa/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/fa/LC_MESSAGES/sphinx.po
@@ -596,7 +596,7 @@ msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name_
 msgid ""
 "The config value `{name}' has type `{current.__name__}', defaults to "
 "`{default.__name__}'."
-msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name__}' است، حالت پیش‌فرض {permitted} است."
+msgstr "مقدار پیکربندی '{name}' دارای نوع '{current.__name__}' است، حالت پیش‌فرض {default.__name__} است."
 
 #: config.py:858
 #, python-format


### PR DESCRIPTION
Fixes #14347

## Problem

`msgfmt -c` fails for Persian (`fa`) and Greek (`el`) locales, blocking `django-admin compilemessages` / `sphinx.locale` compilation for every user of those locales:

- `fa`: `"{permitted}"` should be `"{default.__name__}"` in the `defaults to` message (copy-paste from the `expected` message)
- `el`: unterminated `'{name]'` → `'{name}'`, `'[current__name__}'` → `'{current.__name__}'`, and `'{current__name__}'`/`'{default__name__}'` → `'{current.__name__}'`/`'{default.__name__}'` (missing dot)

Both are fatal `python-brace-format` errors.

## Change

- `sphinx/locale/fa/LC_MESSAGES/sphinx.po:599` — `{permitted}` → `{default.__name__}`
- `sphinx/locale/el/LC_MESSAGES/sphinx.po:591` — `'{name]'` → `'{name}'`, `'[current__name__}'` → `'{current.__name__}'`
- `sphinx/locale/el/LC_MESSAGES/sphinx.po:598` — `'{current__name__}'` → `'{current.__name__}'`, `'{default__name__}'` → `'{default.__name__}'`

Keep unrelated cleanup out of this PR.

## Why this approach

The `msgid` strings use `{name}`, `{current.__name__}`, `{permitted}`, `{default.__name__}`; the `msgstr` must use the same brace-format placeholders. Fixing the placeholders to match `msgid` makes `msgfmt -c` pass and restores the correct interpolated values. No code change needed.

## Testing

```text
command: msgfmt -c sphinx/locale/fa/LC_MESSAGES/sphinx.po -o /tmp/fa.mo
result: ok (was fatal before)

command: msgfmt -c sphinx/locale/el/LC_MESSAGES/sphinx.po -o /tmp/el.mo
result: ok (was fatal: "a format specification for argument 'default.__name__' doesn't exist")

command: git diff --check
result: clean
```

## Documentation and release impact

- [x] User-facing translation fixed
- [x] Changelog/release note needed: i18n fix
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none
- Follow-up issue, if any: none
- Security/licensing considerations: none
