### PR TITLE
Fix redundant parentheses in cross-reference titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Bugs fixed
   does not match the language name, such as Chinese (which reuses the
   English stemmer) and Dutch (which uses the Dutch Porter stemmer).
   Patch by Hugo van Kemenade
+* #11242: Avoid adding redundant parentheses to cross-reference titles that
+  already end with a parenthesized argument list.
+  Patch by Jared Dillard.
 
 
 Release 9.1.0 (released Dec 31, 2025)

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -87,7 +87,7 @@ class XRefRole(ReferenceRole):
     def update_title_and_target(self, title: str, target: str) -> tuple[str, str]:
         if not self.has_explicit_title:
             if self.config.add_function_parentheses:
-                if not title.endswith('()'):
+                if not title.endswith(')'):
                     # add parentheses to the title
                     title += '()'
             else:

--- a/tests/test_markup/test_markup.py
+++ b/tests/test_markup/test_markup.py
@@ -655,17 +655,25 @@ def test_XRefRole(app: SphinxTestApp) -> None:
 
     # fix_parens
     role = XRefRole(fix_parens=True)
-    doctrees, errors = role('ref', 'rawtext', 'text()', 5, inliner, {}, [])  # type: ignore[arg-type]
-    assert_node(doctrees[0], [addnodes.pending_xref, nodes.literal, 'text()'])
-    assert_node(
-        doctrees[0],
-        refdoc='dummy',
-        refdomain='',
-        reftype='ref',
-        reftarget='text',
-        refexplicit=False,
-        refwarn=False,
-    )
+    for text, title, target in (
+        ('text', 'text()', 'text'),
+        ('text()', 'text()', 'text'),
+        ('text(arg)', 'text(arg)', 'text(arg)'),
+    ):
+        doctrees, errors = role(  # type: ignore[arg-type]
+            'ref', 'rawtext', text, 5, inliner, {}, []
+        )
+        assert_node(doctrees[0], [addnodes.pending_xref, nodes.literal, title])
+        assert_node(
+            doctrees[0],
+            refdoc='dummy',
+            refdomain='',
+            reftype='ref',
+            reftarget=target,
+            refexplicit=False,
+            refwarn=False,
+        )
+        assert errors == []
 
     # lowercase
     role = XRefRole(lowercase=True)


### PR DESCRIPTION
## Purpose

Prevent `XRefRole(fix_parens=True)` from appending `()` to titles that already end with a parenthesized argument list. For example, `text(arg)` now remains `text(arg)` instead of becoming `text(arg)()`.

Added regression tests for `text` and `text(arg)`.

## References

- Fixes #11242

## AI Disclosure

AI was used to investigate the issue and generate the initial implementation.