### PR TITLE
Fix linkcheck uppercase scheme handling

### DIFF
--- a/sphinx/builders/linkcheck.py
+++ b/sphinx/builders/linkcheck.py
@@ -61,7 +61,7 @@ class _Status(StrEnum):
 logger = logging.getLogger(__name__)
 
 # matches to foo:// and // (a protocol relative URL)
-uri_re = re.compile('([a-z]+:)?//')
+uri_re = re.compile('([a-z]+:)?//', re.IGNORECASE)
 
 DEFAULT_REQUEST_HEADERS = {
     'Accept': 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
@@ -466,9 +466,9 @@ class HyperlinkAvailabilityCheckWorker(Thread):
                 )
                 return _Status.IGNORED, info, 0
 
-        if len(uri) == 0 or uri.startswith(('#', 'mailto:', 'tel:')):
+        if len(uri) == 0 or uri.lower().startswith(('#', 'mailto:', 'tel:')):
             return _Status.UNCHECKED, '', 0
-        if not uri.startswith(('http:', 'https:')):
+        if not uri.lower().startswith(('http:', 'https:')):
             if uri_re.match(uri):
                 # Non-supported URI schemes (ex. ftp)
                 return _Status.UNCHECKED, '', 0


### PR DESCRIPTION
## Problem

Sphinx's linkcheck builder uses a case-sensitive regex (`([a-z]+:)?//`) and case-sensitive `startswith` checks for `http:`/`https:` to detect external links. Per RFC 3986 §3.1, URI schemes are case-insensitive. URIs with uppercase schemes like `FTP://example.test/file` or `HTTP://example.com` are not recognized:

- `FTP://` fails `uri_re.match` (only lowercase `[a-z]`), so it falls through to the local-file existence check and is reported as `[broken]` instead of `[unchecked]`.
- `HTTP://`/`HTTPS://` fails `uri.startswith(('http:', 'https:'))`, also falling through to local-file logic.

Fixes #14541

Reproduction from the issue:

```python
import io, shutil
from pathlib import Path
from sphinx.application import Sphinx

root = Path("/tmp/sphinx_linkcheck_test")
shutil.rmtree(root, ignore_errors=True)
(root / "_build").mkdir(parents=True)
(root / "conf.py").write_text("")
(root / "index.rst").write_text("Test\n====\n\n`download <FTP://example.test/file>`_\n")

app = Sphinx(str(root), str(root), str(root / "_build"), str(root / "_doctree"),
             "linkcheck", status=io.StringIO(), warning=io.StringIO())
app.build(force_all=True)
print((root / "_build" / "output.txt").read_text())
# Before fix: index.rst:4: [broken] FTP://example.test/file:
# After fix: status unchecked (via output.json)
```

## Change

The smallest complete fix in `sphinx/builders/linkcheck.py`:

- `uri_re = re.compile('([a-z]+:)?//', re.IGNORECASE)` — recognize uppercase schemes
- `uri.lower().startswith(('http:', 'https:'))` — handle `HTTP://`/`HTTPS://` correctly
- `uri.lower().startswith(('#', 'mailto:', 'tel:'))` — consistent for `MAILTO:`/`TEL:` (also case-insensitive per RFC)

## Why this approach

- `re.IGNORECASE` preserves the existing pattern while matching uppercase per RFC 3986.
- `lower().startswith` is the standard case-insensitive prefix check and matches how `urlsplit`/`urlparse` normalize schemes.
- No behavioral change for lowercase URIs; only fixes the uppercase regression introduced by PR #7985.

## Testing

Manual reproduction with patched code:

```text
command: uv run --project /tmp/sphinx-l1-14541/repo python /tmp/test_sphinx2.py
result: FTP://example.test/file -> status unchecked (PASS), HTTP:// -> network check (redirected), MAILTO: -> unchecked
```

Existing linkcheck suite:

```text
command: uv run --project /tmp/sphinx-l1-14541/repo pytest /tmp/sphinx-l1-14541/repo/tests/test_builders/test_build_linkcheck.py -v
result: 48 passed in 4.39s
```

## Documentation and release impact

- [x] No documentation impact (bug fix only)
- [ ] Changelog/release note needed — will add if maintainer requests

## Review notes

- Known limitations: Single-slash URIs like `ftp:/archive.zip` still require `//` per maintainer discussion on #14541; not changed here.
- Security/licensing: No new dependencies

## AI disclosure

AI assistance was used (Muse Spark) for code analysis and fix drafting. All changes were manually reviewed, tested locally, and verified against the reproduction case. The contributor understands and can explain the submitted code.
