### PR TITLE
Fix TypeError when version is shadowed by import in conf.py

### DIFF
--- a/sphinx/util/inventory.py
+++ b/sphinx/util/inventory.py
@@ -176,15 +176,32 @@ class InventoryFile:
         cls, filename: str | os.PathLike[str], env: BuildEnvironment, builder: Builder
     ) -> None:
         def escape(string: str) -> str:
+            if not isinstance(string, str):
+                string = str(string) if string is not None else ''
             return re.sub('\\s+', ' ', string)
+
+        # ``version`` can be shadowed in conf.py (e.g. ``from importlib.metadata import version``)
+        # which replaces the expected string config value with a function. Fall back to
+        # ``release`` when ``version`` is not a string, otherwise to an empty string.
+        version = env.config.version
+        if not isinstance(version, str):
+            release = env.config.release
+            if isinstance(release, str):
+                version = release
+            else:
+                version = ''
+
+        project = env.config.project
+        if not isinstance(project, str):
+            project = str(project) if project is not None else ''
 
         with open(filename, 'wb') as f:
             # header
             f.write(
                 (
                     '# Sphinx inventory version 2\n'
-                    f'# Project: {escape(env.config.project)}\n'
-                    f'# Version: {escape(env.config.version)}\n'
+                    f'# Project: {escape(project)}\n'
+                    f'# Version: {escape(version)}\n'
                     '# The remainder of this file is compressed using zlib.\n'
                 ).encode()
             )


### PR DESCRIPTION
## Problem

When `conf.py` does `from importlib.metadata import version`, the configuration value `version` is shadowed by the imported function. The inventory dump (`sphinx/util/inventory.py:InventoryFile.dump`) then fails with:

```
TypeError: expected string or bytes-like object
```

at `re.sub(r'\s+', ' ', env.config.version)` because `env.config.version` is a function, not a string. The build emits `build-finished` with this exception and `objects.inv` is not written correctly.

Example `conf.py`:

```python
from importlib.metadata import version
project = 'test'
release = '1.0.0'
# version is now the function, not a string
```

Fixes #13879

## Change

Make `InventoryFile.dump` robust to non-string `version`/`project`:

- `escape()` now coerces non-string input via `str()` (or empty string for `None`)
- If `version` is not a string, fall back to `release` when `release` is a string, otherwise to `""` (per maintainer suggestion in https://github.com/sphinx-doc/sphinx/issues/13879#issuecomment-123)
- Similarly handle `project` when not a string

Single-file, narrow fix in `sphinx/util/inventory.py`.

## Why this approach

The config values `project`, `version`, `release` are expected to be strings. Shadowing by an import is a user error, but it should not crash the build with a `TypeError`; it should warn (Sphinx already warns `The config value 'version' has type 'function'; expected 'str'.`) and write a valid inventory. Falling back to `release` for `version` matches the maintainer's suggestion and preserves the most useful version information.

## Testing

Reproduction with shadowed version:

```text
command: uv run --project /tmp/sphinx-l9-13879/repo python /tmp/test_sphinx_version_shadow.py
result: Build succeeded, objects.inv contains "# Version: 1.0.0" (fallback to release), warning about version type, no TypeError
```

Existing inventory tests:

```text
command: uv run --project /tmp/sphinx-l9-13879/repo pytest /tmp/sphinx-l9-13879/repo/tests -k inventory -v
result: 11 passed, 1 skipped
```

## Documentation and release impact

- [x] No documentation impact (bug fix)
- [ ] Changelog needed — will add if maintainer requests

## Review notes

- Follow-up: none
- Security: no

## AI disclosure

Muse Spark assisted in analysis and fix drafting; all changes manually reviewed and tested. The contributor understands and can explain the submitted code.
