### PR TITLE
Doc: explain Napoleon configuration for import aliases

### DIFF
--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -607,6 +607,20 @@ sure that "sphinx.ext.napoleon" is enabled in ``conf.py``:
        :param arg2: Description of `arg2`
        :type arg2: :term:`dict-like <mapping>`
 
+   Import aliases used in type definitions can be translated to names present
+   in intersphinx inventories. For example, to translate ``np.ndarray`` to
+   ``numpy.ndarray``:
+
+   .. code-block:: python
+
+       napoleon_preprocess_types = True
+       napoleon_type_aliases = {
+           "np.ndarray": "numpy.ndarray",
+       }
+
+   Napoleon cannot infer module imports from type names written in docstrings,
+   so aliases must be configured explicitly.
+
    .. versionadded:: 3.2
 
 .. confval:: napoleon_attr_annotations


### PR DESCRIPTION
## Purpose

Explains how to translate import aliases used in docstring type definitions with `napoleon_preprocess_types` and `napoleon_type_aliases`. This adds an `np.ndarray` example and clarifies that Napoleon cannot infer module imports from docstring text.

The long-running discussion on #10151 attracted several affected users and proposed workarounds, indicating to me that the existing configuration was difficult to discover.

## References

- Follow-up to #10151

## AI Disclosure

AI was used to investigate #10151 and draft the documentation improvement.