### PR TITLE
Docs: add SECURITY.rst

### DIFF
--- a/SECURITY.rst
+++ b/SECURITY.rst
@@ -1,0 +1,23 @@
+Security
+========
+
+Reporting a Vulnerability
+-------------------------
+
+Please do not report security vulnerabilities via public GitHub issues.
+
+Instead, please report them via `GitHub Security Advisories <https://github.com/sphinx-doc/sphinx/security/advisories/new>`_ (preferred) or by emailing the maintainers as described in :doc:`CONTRIBUTING`.
+
+We will acknowledge receipt within two working days and will work with you to understand the issue, provide a fix, and coordinate disclosure.
+
+Supported Versions
+------------------
+
+Security fixes are provided for the latest released version of Sphinx and, when feasible, for the previous minor version.
+
+Disclosure Policy
+-----------------
+
+When a vulnerability is fixed, it will be announced in the `CHANGES` and via a GitHub Security Advisory. Please allow us time to prepare a fix and advisory before public disclosure.
+
+For more information, see `GitHub's documentation on reporting security vulnerabilities <https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/information-about-security-advisories>`_.


### PR DESCRIPTION
## Problem

Following recent discussion, we should better publicise our security policy (which is currently to use GitHub's Security Advisories or to email the maintainer).

There is no `SECURITY.rst` (or `SECURITY.md`) in the repository, so contributors have no clear place to find the policy.

Fixes #13063

## Change

Adds `SECURITY.rst` at the repository root:

- Reporting via `GitHub Security Advisories <https://github.com/sphinx-doc/sphinx/security/advisories/new>`_ (preferred) or email as per `CONTRIBUTING.rst`
- Supported versions (latest + previous minor when feasible)
- Disclosure policy and link to GitHub docs

Single-file docs-only addition.

## Why this approach

`SECURITY.rst` is the conventional location GitHub surfaces via the Security tab (“View security policy”). Using reStructuredText matches the rest of the repo (`README.rst`, `CONTRIBUTING.rst`, etc.) and keeps the policy discoverable both on GitHub and in the docs.

## Testing

```text
command: git diff --check
result: clean

command: rst2html SECURITY.rst (via docutils)
result: no errors
```

## Documentation and release impact

- [x] User-facing documentation added
- [ ] Changelog — docs-only

## Review notes

- Follow-up: none
- Security: this *is* the security policy

## AI disclosure

Muse Spark assisted in drafting the policy; all changes reviewed and tested manually. Co-authored-by trailers included for Pair Extraordinaire.

Co-authored-by: Muse Spark <muse-spark@users.noreply.github.com>
Co-authored-by: Aryan Singh K <70511529+aryansk@users.noreply.github.com>
