### PR TITLE
Remove outdated HTML-only note for modindex_common_prefix

### DIFF
--- a/doc/usage/configuration.rst
+++ b/doc/usage/configuration.rst
@@ -4172,9 +4172,6 @@ Options for the Python domain
    This can be handy if you document a project that consists of a
    single package.
 
-   .. caution::
-      Works only for the HTML builder currently.
-
    .. versionadded:: 0.6
 
 .. confval:: python_display_short_literal_types


### PR DESCRIPTION
## Purpose

Remove the outdated HTML-only caution for `modindex_common_prefix`.

The setting is applied when Sphinx generates the Python module index, independently of the output builder. Builders that do not generate this index simply ignore the setting, so configuring it causes no error or unsupported behavior.

## References

- Closes #1371

## AI Disclosure

AI was used to investigate builder support and prepare this documentation change.