### PR TITLE
Document include-only reStructuredText files

### DIFF
--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -400,6 +400,24 @@ Docutils supports the following directives:
     when given an absolute include file path, this directive takes it as
     relative to the source directory
 
+    Sphinx considers each file whose suffix is listed in
+    :confval:`source_suffix` to be a standalone source document, even if the
+    file is also included in another document.  To use a file only as reusable
+    content, either give it a suffix that is not listed in ``source_suffix``,
+    such as :file:`.inc` or :file:`.rst.inc`, or exclude it from source
+    discovery.  For example, to store reusable content in an
+    :file:`_includes` directory, add the following to :file:`conf.py`:
+
+    .. code-block:: python
+
+       exclude_patterns = ['_includes/**']
+
+    Files excluded by :confval:`exclude_patterns` can still be included, and
+    included content is parsed as reStructuredText regardless of its filename
+    extension.  Without one of these measures, labels in an included file can
+    be registered both in the standalone document and in the including
+    document, resulting in duplicate-label warnings.
+
     .. _rstclass:
 
   - :dudir:`class <setting-class-attributes>`

--- a/doc/usage/restructuredtext/basics.rst
+++ b/doc/usage/restructuredtext/basics.rst
@@ -402,11 +402,11 @@ Docutils supports the following directives:
 
     Sphinx considers each file whose suffix is listed in
     :confval:`source_suffix` to be a standalone source document, even if the
-    file is also included in another document.  To use a file only as reusable
+    file is also included in another document. To use a file only as reusable
     content, either give it a suffix that is not listed in ``source_suffix``,
-    such as :file:`.inc` or :file:`.rst.inc`, or exclude it from source
-    discovery.  For example, to store reusable content in an
-    :file:`_includes` directory, add the following to :file:`conf.py`:
+    such as :file:`.rsti`, or exclude it from source discovery. For example,
+    to store reusable content in an :file:`_includes` directory, add the
+    following to :file:`conf.py`:
 
     .. code-block:: python
 
@@ -414,9 +414,7 @@ Docutils supports the following directives:
 
     Files excluded by :confval:`exclude_patterns` can still be included, and
     included content is parsed as reStructuredText regardless of its filename
-    extension.  Without one of these measures, labels in an included file can
-    be registered both in the standalone document and in the including
-    document, resulting in duplicate-label warnings.
+    extension.
 
     .. _rstclass:
 


### PR DESCRIPTION
## Purpose

Explain that files matching `source_suffix` are treated as standalone documents, even when used with `include` and document best practices for creating reusable include-only content using a different suffix or `exclude_patterns`, preventing duplicate-label warnings.

The reactions and related reports indicate that this has been a recurring source of confusion for users, so thought it was worth making an improvement.

## References

- Relates to #9707
- Relates to #8515

## AI Disclosure

AI was used to investigate the issue and draft the documentation change. I reviewed and validated the text.