### PR TITLE
drop leftover setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ test = [
     "pytest-xdist[psutil]>=3.4",
     "cython>=3.0",  # for Cython compilation
     "defusedxml>=0.7.1",  # for secure XML/HTML parsing
-    "setuptools>=70.0",  # for Cython compilation
     "typing_extensions>=4.9",  # for typing_extensions.Unpack
 ]
 translations = [


### PR DESCRIPTION
setuptools support has been previously removed

I'm removing the dependency now from the Debian build:

https://salsa.debian.org/python-team/packages/sphinx/-/commit/a5ddc3fdc3e13eb3c1923f04872e51283e14bb78

https://salsa.debian.org/python-team/packages/sphinx/-/pipelines/1158325
