### PR TITLE
Show enum members in Annotated types like Literal does

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Release 9.1.1 (in development)
 Bugs fixed
 ----------
 
+* #14653: autodoc: Render enum members in ``Annotated`` metadata the same way
+  as ``Literal`` arguments, instead of dumping ``repr()``.
+  Patch by Gyanu
+
 * #14465: LaTeX: PDF build crash since LaTeX June 2026 release if tables are
   styled with ``'colorrows'`` (which is the default).
   Patch by Jean-François B.

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -298,7 +298,7 @@ def restify(cls: Any, mode: _RestifyMode = 'fully-qualified-except-typing') -> s
                     ])
                     meta_args.append(rf'{restify(type(m), mode)}\ ({d_fields})')
                 else:
-                    meta_args.append(repr(m))
+                    meta_args.append(_format_literal_arg_restify(m, mode=mode))
             meta = ', '.join(meta_args)
             return (
                 f':py:class:`{module_prefix}{cls.__module__}.{cls.__name__}`'
@@ -594,7 +594,7 @@ def stringify_annotation(
                         f'{stringify_annotation(type(m), mode=mode, short_literals=short_literals)}({d_fields})'  # NoQA: E501
                     )
                 else:
-                    meta_args.append(repr(m))
+                    meta_args.append(_format_literal_arg_stringify(m, mode=mode))
             meta = ', '.join(meta_args)
             return f'{module_prefix}Annotated[{args}, {meta}]'
         elif all(is_system_TypeVar(a) for a in annotation_args):

--- a/tests/test_util/test_util_typing.py
+++ b/tests/test_util/test_util_typing.py
@@ -289,6 +289,14 @@ def test_restify_Annotated() -> None:
     assert ann_rst == (
         ':py:class:`~typing.Annotated`\\ [:py:class:`float`, :py:class:`~tests.test_util.test_util_typing.Gt`\\ (gt=\\ -10.0)]'
     )
+    ann_rst = restify(Annotated[int, MyEnum.a], 'fully-qualified-except-typing')
+    assert ann_rst == (
+        ':py:class:`~typing.Annotated`\\ [:py:class:`int`, :py:attr:`tests.test_util.test_util_typing.MyEnum.a`]'
+    )
+    ann_rst = restify(Annotated[int, MyEnum.a], 'smart')
+    assert ann_rst == (
+        ':py:class:`~typing.Annotated`\\ [:py:class:`int`, :py:attr:`~tests.test_util.test_util_typing.MyEnum.a`]'
+    )
 
 
 def test_restify_type_hints_Callable() -> None:
@@ -730,6 +738,12 @@ def test_stringify_Annotated() -> None:
     assert ann_str == (
         '~typing.Annotated[float, ~tests.test_util.test_util_typing.Gt(gt=-10.0)]'
     )
+    ann_str = stringify_annotation(
+        Annotated[int, MyEnum.a], 'fully-qualified-except-typing'
+    )
+    assert ann_str == 'Annotated[int, tests.test_util.test_util_typing.MyEnum.a]'
+    ann_str = stringify_annotation(Annotated[int, MyEnum.a], 'smart')
+    assert ann_str == '~typing.Annotated[int, MyEnum.a]'
 
 
 def test_stringify_Unpack() -> None:


### PR DESCRIPTION
`Annotated[int, Color.red]` was going through `repr()`, so autodoc printed `<Color.red: 'red'>`. Literal already formats enum members as `:py:attr:` links — reused that for Annotated metadata.

Fixes #14653
