### PR TITLE
docs: complete add_js_file and add_css_file documentation

### DIFF
--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -1461,13 +1461,25 @@ class Sphinx:
         Example::
 
             app.add_js_file('example.js')
-            # => <script src="_static/example.js"></script>
+            # => <script src="_static/example.js?v=a1b2c3d4"></script>
 
             app.add_js_file('example.js', loading_method='async')
-            # => <script src="_static/example.js" async="async"></script>
+            # => <script src="_static/example.js?v=a1b2c3d4" async="async"></script>
 
             app.add_js_file(None, body="var myVariable = 'foo';")
             # => <script>var myVariable = 'foo';</script>
+
+        The ``?v=a1b2c3d4`` query parameter is an 8-digit CRC32 checksum of
+        the file contents.  It is omitted for remote URIs, empty files, and
+        files that are not present in the build output when the HTML page
+        is written.
+
+        This method only emits the ``<script>`` tag.  A local file must
+        already be available under the output ``_static`` directory:
+        extensions should register a directory with :meth:`add_static_dir`,
+        and site authors can list a directory in :confval:`html_static_path`.
+        Site authors who only need to include extra scripts can use
+        :confval:`html_js_files` instead of writing an extension.
 
         .. list-table:: priority range for JavaScript files
            :widths: 20,80
@@ -1485,7 +1497,8 @@ class Sphinx:
         calls this method on :event:`html-page-context` event.
 
         .. seealso::
-           :meth:`add_static_dir` for copying static files to the output directory
+           :meth:`add_static_dir`, :confval:`html_js_files`,
+           :confval:`html_static_path`
 
         .. versionadded:: 0.5
 
@@ -1498,6 +1511,9 @@ class Sphinx:
         .. versionchanged:: 4.4
            Take loading_method argument.  Allow to change the loading method of the
            JavaScript file.
+        .. versionchanged:: 7.1
+           Local asset URIs include a CRC32 checksum query parameter
+           (``?v=...``) for cache busting.
         """
         if loading_method == 'async':
             kwargs['async'] = 'async'
@@ -1527,15 +1543,28 @@ class Sphinx:
         Example::
 
             app.add_css_file('custom.css')
-            # => <link rel="stylesheet" href="_static/custom.css" type="text/css" />
+            # => <link rel="stylesheet" href="_static/custom.css?v=a1b2c3d4"
+            #          type="text/css" />
 
             app.add_css_file('print.css', media='print')
-            # => <link rel="stylesheet" href="_static/print.css"
+            # => <link rel="stylesheet" href="_static/print.css?v=a1b2c3d4"
             #          type="text/css" media="print" />
 
             app.add_css_file('fancy.css', rel='alternate stylesheet', title='fancy')
-            # => <link rel="alternate stylesheet" href="_static/fancy.css"
+            # => <link rel="alternate stylesheet" href="_static/fancy.css?v=a1b2c3d4"
             #          type="text/css" title="fancy" />
+
+        The ``?v=a1b2c3d4`` query parameter is an 8-digit CRC32 checksum of
+        the file contents.  It is omitted for remote URIs, empty files, and
+        files that are not present in the build output when the HTML page
+        is written.
+
+        This method only emits the ``<link>`` tag.  A local file must
+        already be available under the output ``_static`` directory:
+        extensions should register a directory with :meth:`add_static_dir`,
+        and site authors can list a directory in :confval:`html_static_path`.
+        Site authors who only need to include extra stylesheets can use
+        :confval:`html_css_files` instead of writing an extension.
 
         .. list-table:: priority range for CSS files
            :widths: 20,80
@@ -1553,7 +1582,8 @@ class Sphinx:
         this method on :event:`html-page-context` event.
 
         .. seealso::
-           :meth:`add_static_dir` for copying static files to the output directory
+           :meth:`add_static_dir`, :confval:`html_css_files`,
+           :confval:`html_static_path`
 
         .. versionadded:: 1.0
 
@@ -1570,6 +1600,10 @@ class Sphinx:
 
         .. versionchanged:: 3.5
            Take priority argument.  Allow to add a CSS file to the specific page.
+
+        .. versionchanged:: 7.1
+           Local asset URIs include a CRC32 checksum query parameter
+           (``?v=...``) for cache busting.
         """
         logger.debug('[app] adding stylesheet: %r', filename)
         self.registry.add_css_files(filename, priority=priority, **kwargs)


### PR DESCRIPTION
## Purpose

Fill the remaining gaps in the `Sphinx.add_js_file()` and `Sphinx.add_css_file()` docstrings reported in #12223:

- Show the CRC32 cache-busting query parameter (`?v=`) in the examples (added in #11415 / Sphinx 7.1).
- Add `versionchanged:: 7.1` notes for that checksum.
- Explain that these methods only emit the HTML tag; local files still have to land in `_static` via `add_static_dir()` (extensions) or `html_static_path` (site authors).
- Point site authors at `html_js_files` / `html_css_files` with `html_static_path`.

This is a new PR, not a continuation of #14322.

No `CHANGES.rst` entry (documentation-only).

## References

- https://github.com/sphinx-doc/sphinx/issues/12223
- https://github.com/sphinx-doc/sphinx/pull/11415

Closes #12223.

## AI Disclosure

A Cursor Cloud Agent prepared this change at the requester's instruction.

- Tools: Cursor Cloud Agent. Used to read #12223, the current add_js_file / add_css_file docstrings, the HTML builder checksum implementation, add_static_dir, and the html_js_files / html_css_files / html_static_path confvals, then draft the docstring additions.
- What is AI-generated: the new paragraphs, example `?v=` suffixes, versionchanged 7.1 notes, expanded seealso lines in sphinx/application.py, and this pull request body.
- What is not: no runtime code was changed. The wording was checked against the implementation.
- #14322 was read only to avoid duplicating it; this text was written separately.

I have read https://www.sphinx-doc.org/en/master/internals/ai-policy.html.
