### PR TITLE
Correct formatting tests to match latest pygments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ test = [
     "defusedxml>=0.7.1",  # for secure XML/HTML parsing
     "setuptools>=70.0",  # for Cython compilation
     "typing_extensions>=4.9",  # for typing_extensions.Unpack
+    "pygments>=2.21.0",  # ensures the expected output of ' and " within HTML <span>
 ]
 translations = [
     "babel>=2.13",

--- a/tests/test_builders/test_build_html_code.py
+++ b/tests/test_builders/test_build_html_code.py
@@ -57,7 +57,7 @@ def test_html_code_role(app: SphinxTestApp) -> None:
         '<span class="o">+</span> '
         '<span class="kc">None</span> '
         '<span class="o">+</span> '
-        '<span class="s2">&quot;abc&quot;</span>'
+        '<span class="s2">"abc"</span>'
         '<span class="p">):</span> '
         '<span class="k">pass</span>'
     )

--- a/tests/test_extensions/test_ext_viewcode.py
+++ b/tests/test_extensions/test_ext_viewcode.py
@@ -49,10 +49,7 @@ def check_viewcode_output(app: SphinxTestApp) -> str:
     ) in result
     assert '<span>@decorator</span>\n' in result
     assert f'<span>class</span>{sp}<span>Class1</span><span>:</span>\n' in result
-    assert (
-        '<span>    </span>'
-        '<span>&quot;&quot;&quot;this is Class1&quot;&quot;&quot;</span></div>\n'
-    ) in result
+    assert ('<span>    </span><span>"""this is Class1"""</span></div>\n') in result
 
     return result
 

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -93,7 +93,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     ret = bridge.highlight_block('print "Hello sphinx world"', 'default')
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span> '
-        '<span class="s2">&quot;Hello sphinx world&quot;</span>\n</pre></div>\n'
+        '<span class="s2">"Hello sphinx world"</span>\n</pre></div>\n'
     )
 
     # default: fallbacks to none if highlighting failed
@@ -107,7 +107,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span>'
         '<span class="p">(</span>'
-        '<span class="s2">&quot;Hello sphinx world&quot;</span>'
+        '<span class="s2">"Hello sphinx world"</span>'
         '<span class="p">)</span>\n</pre></div>\n'
     )
 
@@ -116,7 +116,7 @@ def test_default_highlight(logger: mock.Mock) -> None:
     assert ret == (
         '<div class="highlight"><pre><span></span><span class="nb">print</span>'
         '<span class="p">(</span>'
-        '<span class="s2">&quot;Hello sphinx world&quot;</span>'
+        '<span class="s2">"Hello sphinx world"</span>'
         '<span class="p">)</span>\n</pre></div>\n'
     )
 

--- a/tests/test_intl/test_intl.py
+++ b/tests/test_intl/test_intl.py
@@ -1647,7 +1647,7 @@ def test_additional_targets_should_not_be_translated(app: SphinxTestApp) -> None
     assert_count(expected_expr, result, 2)
 
     # ruby code block should not be translated but be highlighted
-    expected_expr = """<span class="s1">&#39;result&#39;</span>"""
+    expected_expr = """<span class="s1">'result'</span>"""
     assert_count(expected_expr, result, 1)
 
     # C code block without lang should not be translated and *ruby* highlighted
@@ -1738,7 +1738,7 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     assert_count(expected_expr, result, 1)
 
     # literalinclude should be translated
-    expected_expr = '<span class="s2">&quot;HTTPS://SPHINX-DOC.ORG&quot;</span>'
+    expected_expr = '<span class="s2">"HTTPS://SPHINX-DOC.ORG"</span>'
     assert_count(expected_expr, result, 1)
 
     # title should be translated
@@ -1746,7 +1746,7 @@ def test_additional_targets_should_be_translated(app: SphinxTestApp) -> None:
     assert_count(expected_expr, result, 2)
 
     # ruby code block should be translated and be highlighted
-    expected_expr = """<span class="s1">&#39;RESULT&#39;</span>"""
+    expected_expr = """<span class="s1">'RESULT'</span>"""
     assert_count(expected_expr, result, 1)
 
     # C code block without lang should be translated and *ruby* highlighted


### PR DESCRIPTION
As of version 2.21.0, pygments doesn't escape quotation marks, single or double, when they appear between span tags like
`<span>"Hello sphinx world"</span>`.
This PR updates the test data to match the new behavior.

<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->


## References

<!--
Please add any relevant links here, especially including any 
GitHub issues or Pull Requests that this PR would resolve.
This helps to ensure that reviewers have context from
previous discussions or decisions.
-->

- https://github.com/pygments/pygments/pull/3185


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->
No AI tools used
