### PR TITLE
Add colour to status progress percentage

### DIFF
--- a/sphinx/util/display.py
+++ b/sphinx/util/display.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 import functools
 
-from sphinx._cli.util.colour import bold, terminal_supports_colour
+from sphinx._cli.util.colour import (
+    bold,
+    brown,
+    darkgreen,
+    green,
+    red,
+    terminal_supports_colour,
+    yellow,
+)
 from sphinx.locale import __
 from sphinx.util import logging
 
@@ -21,6 +29,18 @@ def display_chunk(chunk: Any) -> str:
             return str(chunk[0])
         return f'{chunk[0]} .. {chunk[-1]}'
     return str(chunk)
+
+
+def _progress_colour(percent: int) -> Callable[[str], str]:
+    if percent >= 100:
+        return green
+    if percent >= 75:
+        return darkgreen
+    if percent >= 50:
+        return yellow
+    if percent >= 25:
+        return brown
+    return red
 
 
 def status_iterator[T](
@@ -44,7 +64,9 @@ def status_iterator[T](
             if single_line:
                 # clear the entire line ('Erase in Line')
                 logger.info('\x1b[2K', nonl=True)
-            logger.info(f'{bold_summary}[{i / length: >4.0%}] ', nonl=True)  # NoQA: G004
+            percent = round(100 * i / length)
+            percentage = _progress_colour(percent)(f'[{percent: >3}%] ')
+            logger.info(bold_summary + percentage, nonl=True)  # NoQA: G003
             # Emit the string representation of ``item``
             logger.info(stringify_func(item), nonl=True, color=color)
             # If in single-line mode, emit a carriage return to move the cursor


### PR DESCRIPTION
<!--
Thank you for creating this pull request and for spending time to help Sphinx!
Our contributors' guide can be found online: https://www.sphinx-doc.org/en/master/internals/contributing.html
Ask any questions at https://github.com/sphinx-doc/sphinx/discussions
-->


## Purpose

<!--
A description of the purpose of this pull request.
Ensure that all relevant information is included for reviewers,
including any environment-specific details.

* If you plan to add tests or documentation after opening this PR,
  please note it here.
* For user-visible changes, remember to add an entry to CHANGES.rst.
* Please add your name to AUTHORS.rst if you haven't already!
-->

Add more colour to the logs, so the "[XX%]" bit is shown in a different colour based on percentage, from red to green:

```
reading sources... [ 49%] extdev/nodes
...
writing output... [ 97%] usage/restructuredtext/directives
...
highlighting module code... [100%] sphinxcontrib.websupport.storage
...
copying images... [100%] _static/themes/bizstyle.png
```

Demo using:

```sh
uv run --group docs --no-group package make -C doc clean html
```

I verified no colour is shown when disabling via env var:

```sh
NO_COLOR=1 uv run --group docs --no-group package make -C doc clean html
```


## AI Disclosure

<!--
If AI was used in the preparation of this pull request, please disclose the
tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section.
Please read our policy on AI generated code:
https://www.sphinx-doc.org/en/master/internals/ai-policy.html

In particular, all interaction is to be done by humans, including submission
of pull requests.
-->
Initial code by Claude, improved by me.
